### PR TITLE
fix(notebooks): sync embedded sql editor attributes

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.test.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.test.tsx
@@ -1,0 +1,182 @@
+import { renderHook } from '@testing-library/react'
+import { useActions, useValues } from 'kea'
+
+import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
+import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
+
+import { DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
+import { ChartDisplayType } from '~/types'
+
+import { useNotebookCodeSQLEditorSync, useNotebookQuerySQLEditorSync } from './NotebookSQLEditor'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useActions: jest.fn(),
+    useValues: jest.fn(),
+}))
+
+jest.mock('scenes/data-warehouse/editor/SQLEditor', () => ({
+    SQLEditor: () => null,
+    SQLEditorPanel: {
+        Output: 'output',
+        Query: 'query',
+    },
+}))
+
+jest.mock('scenes/data-warehouse/editor/sqlEditorLogic', () => ({
+    sqlEditorLogic: jest.fn((props) => ({ type: 'sqlEditorLogic', props })),
+}))
+
+const mockedUseActions = useActions as jest.Mock
+const mockedUseValues = useValues as jest.Mock
+const mockedSqlEditorLogic = sqlEditorLogic as jest.Mock
+
+const setQueryInput = jest.fn()
+const setSourceQuery = jest.fn()
+const updateAttributes = jest.fn()
+const initialize = jest.fn()
+const runQuery = jest.fn()
+
+let queryInput: string | null
+let sourceQuery: DataVisualizationNode
+
+function buildSourceQuery(query: string): DataVisualizationNode {
+    return {
+        kind: NodeKind.DataVisualizationNode,
+        source: {
+            kind: NodeKind.HogQLQuery,
+            query,
+        },
+        display: ChartDisplayType.ActionsTable,
+    }
+}
+
+describe('NotebookSQLEditor sync hooks', () => {
+    beforeEach(() => {
+        queryInput = 'select old'
+        sourceQuery = buildSourceQuery('select old')
+
+        mockedUseValues.mockImplementation(() => ({ queryInput, sourceQuery }))
+        mockedUseActions.mockImplementation(() => ({ initialize, runQuery, setQueryInput, setSourceQuery }))
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('seeds code-node SQL on initial mount without writing attributes', () => {
+        queryInput = null
+        sourceQuery = buildSourceQuery('')
+
+        renderHook(() =>
+            useNotebookCodeSQLEditorSync({
+                attributes: { nodeId: 'node-1', code: 'select old' },
+                updateAttributes,
+                tabId: 'tab-1',
+            })
+        )
+
+        expect(setQueryInput).toHaveBeenCalledWith('select old')
+        expect(setSourceQuery).toHaveBeenCalledWith(buildSourceQuery('select old'))
+        expect(updateAttributes).not.toHaveBeenCalled()
+    })
+
+    it('syncs code-node SQL from changed attributes without writing stale SQL back', () => {
+        const { rerender } = renderHook(
+            ({ code }) =>
+                useNotebookCodeSQLEditorSync({
+                    attributes: { nodeId: 'node-1', code },
+                    updateAttributes,
+                    tabId: 'tab-1',
+                }),
+            {
+                initialProps: { code: 'select old' },
+            }
+        )
+
+        expect(setQueryInput).not.toHaveBeenCalled()
+        expect(updateAttributes).not.toHaveBeenCalled()
+
+        rerender({ code: 'select remote' })
+
+        expect(setQueryInput).toHaveBeenCalledWith('select remote')
+        expect(setSourceQuery).toHaveBeenCalledWith(buildSourceQuery('select remote'))
+        expect(updateAttributes).not.toHaveBeenCalled()
+        expect(mockedSqlEditorLogic).toHaveBeenCalledWith({ tabId: 'tab-1', mode: SQLEditorMode.Embedded })
+    })
+
+    it('writes local code-node SQL edits back to attributes', () => {
+        const { rerender } = renderHook(() =>
+            useNotebookCodeSQLEditorSync({
+                attributes: { nodeId: 'node-1', code: 'select old' },
+                updateAttributes,
+                tabId: 'tab-1',
+            })
+        )
+
+        queryInput = 'select local'
+        rerender()
+
+        expect(updateAttributes).toHaveBeenCalledWith({ code: 'select local' })
+        expect(setSourceQuery).toHaveBeenCalledWith(buildSourceQuery('select local'))
+    })
+
+    it('ignores equal query-node attribute rerenders', () => {
+        const { rerender } = renderHook(
+            ({ query }) =>
+                useNotebookQuerySQLEditorSync({
+                    attributes: { nodeId: 'node-1', query },
+                    updateAttributes,
+                    tabId: 'tab-1',
+                }),
+            {
+                initialProps: { query: buildSourceQuery('select old') },
+            }
+        )
+
+        jest.clearAllMocks()
+        rerender({ query: buildSourceQuery('select old') })
+
+        expect(setQueryInput).not.toHaveBeenCalled()
+        expect(setSourceQuery).not.toHaveBeenCalled()
+        expect(updateAttributes).not.toHaveBeenCalled()
+    })
+
+    it('syncs query-node SQL from changed attributes without writing stale SQL back', () => {
+        const { rerender } = renderHook(
+            ({ query }) =>
+                useNotebookQuerySQLEditorSync({
+                    attributes: { nodeId: 'node-1', query },
+                    updateAttributes,
+                    tabId: 'tab-1',
+                }),
+            {
+                initialProps: { query: buildSourceQuery('select old') },
+            }
+        )
+
+        const remoteQuery = buildSourceQuery('select remote')
+        rerender({ query: remoteQuery })
+
+        expect(setQueryInput).toHaveBeenCalledWith('select remote')
+        expect(setSourceQuery).toHaveBeenCalledWith(remoteQuery)
+        expect(runQuery).not.toHaveBeenCalled()
+        expect(updateAttributes).not.toHaveBeenCalled()
+    })
+
+    it('writes local query-node SQL edits back to attributes', () => {
+        const { rerender } = renderHook(() =>
+            useNotebookQuerySQLEditorSync({
+                attributes: { nodeId: 'node-1', query: buildSourceQuery('select old') },
+                updateAttributes,
+                tabId: 'tab-1',
+            })
+        )
+
+        queryInput = 'select local'
+        sourceQuery = buildSourceQuery('select local')
+        rerender()
+
+        expect(updateAttributes).toHaveBeenCalledWith({ query: buildSourceQuery('select local') })
+    })
+})

--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
@@ -1,6 +1,6 @@
 import equal from 'fast-deep-equal'
 import { useActions, useValues } from 'kea'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import { SQLEditor, SQLEditorPanel } from 'scenes/data-warehouse/editor/SQLEditor'
 import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
@@ -54,22 +54,45 @@ export function useNotebookQuerySQLEditorSync<T extends { query: QuerySchema }>(
     const logic = sqlEditorLogic({ tabId, mode: SQLEditorMode.Embedded })
     const { queryInput, sourceQuery } = useValues(logic)
     const { initialize, runQuery, setQueryInput, setSourceQuery } = useActions(logic)
+    const lastAttributeQuery = useRef<DataVisualizationNode | null>(null)
+    const suppressNextWriteback = useRef(false)
 
     useEffect(() => {
         initialize()
     }, [initialize])
 
     useEffect(() => {
-        if (!editorSourceQuery || queryInput !== null) {
+        if (!editorSourceQuery) {
+            lastAttributeQuery.current = null
             return
         }
 
-        setQueryInput(editorSourceQuery.source.query)
-        setSourceQuery(editorSourceQuery)
-        runQuery(editorSourceQuery.source.query)
-    }, [editorSourceQuery, queryInput, runQuery, setQueryInput, setSourceQuery])
+        if (lastAttributeQuery.current && equal(lastAttributeQuery.current, editorSourceQuery)) {
+            return
+        }
+
+        lastAttributeQuery.current = editorSourceQuery
+        suppressNextWriteback.current = true
+
+        if (queryInput !== editorSourceQuery.source.query) {
+            setQueryInput(editorSourceQuery.source.query)
+
+            if (queryInput === null) {
+                runQuery(editorSourceQuery.source.query)
+            }
+        }
+
+        if (!equal(sourceQuery, editorSourceQuery)) {
+            setSourceQuery(editorSourceQuery)
+        }
+    }, [editorSourceQuery, queryInput, runQuery, setQueryInput, setSourceQuery, sourceQuery])
 
     useEffect(() => {
+        if (suppressNextWriteback.current) {
+            suppressNextWriteback.current = false
+            return
+        }
+
         if (!editorSourceQuery || queryInput === null) {
             return
         }
@@ -100,32 +123,42 @@ export function useNotebookCodeSQLEditorSync<T extends { code: string }>({
     const logic = sqlEditorLogic({ tabId, mode: SQLEditorMode.Embedded })
     const { queryInput, sourceQuery } = useValues(logic)
     const { initialize, setQueryInput, setSourceQuery } = useActions(logic)
+    const lastAttributeCode = useRef<string | null>(null)
+    const suppressNextWriteback = useRef(false)
 
     useEffect(() => {
         initialize()
     }, [initialize])
 
     useEffect(() => {
-        if (queryInput !== null) {
+        if (lastAttributeCode.current === code) {
             return
         }
 
-        setQueryInput(code)
-        setSourceQuery(buildSourceQuery(code))
-    }, [code, queryInput, setQueryInput, setSourceQuery])
+        lastAttributeCode.current = code
+        suppressNextWriteback.current = true
+
+        if (queryInput !== code) {
+            setQueryInput(code)
+        }
+
+        const nextSourceQuery = buildSourceQuery(code)
+        if (!equal(nextSourceQuery, sourceQuery)) {
+            setSourceQuery(nextSourceQuery)
+        }
+    }, [code, queryInput, setQueryInput, setSourceQuery, sourceQuery])
 
     useEffect(() => {
+        if (suppressNextWriteback.current) {
+            suppressNextWriteback.current = false
+            return
+        }
+
         if (queryInput === null || queryInput === code) {
             return
         }
 
         updateAttributes({ code: queryInput } as Partial<NotebookNodeAttributes<T>>)
-    }, [code, queryInput, updateAttributes])
-
-    useEffect(() => {
-        if (queryInput === null) {
-            return
-        }
 
         const nextSourceQuery = {
             ...sourceQuery,
@@ -139,7 +172,7 @@ export function useNotebookCodeSQLEditorSync<T extends { code: string }>({
         if (!equal(nextSourceQuery, sourceQuery)) {
             setSourceQuery(nextSourceQuery)
         }
-    }, [queryInput, setSourceQuery, sourceQuery])
+    }, [code, queryInput, setSourceQuery, sourceQuery, updateAttributes])
 }
 
 export function NotebookSQLEditorOutput<T extends { query: QuerySchema }>({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Notebook SQL cells could keep rendering stale SQL after the underlying Tiptap node attributes changed from another browser tab. The stale embedded SQL editor state could then write the old SQL back into the node attributes and overwrite the remote edit without a collab conflict.

## Changes

- Reconcile embedded SQL editor state from notebook node attributes whenever `attrs.code` or `attrs.query.source.query` changes after mount.
- Suppress the immediate reverse writeback for incoming attribute changes so stale `queryInput` cannot clobber remote edits.
- Add focused hook regression tests for code-backed SQL nodes and query-backed SQL nodes.

## How did you test this code?

Agent-tested with:

- `pnpm --filter=@posthog/frontend exec jest frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.test.tsx --runInBand`
- `pnpm --filter=@posthog/frontend exec oxlint --quiet "src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx" "src/scenes/notebooks/Nodes/components/NotebookSQLEditor.test.tsx"`

Also attempted browser-level local app testing, but the dev bootstrap is blocked in this environment because `./bin/start --help` runs setup and fails while downloading GeoLite data due to missing `brotli`.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Implemented by Cursor cloud agent. The fix keeps Tiptap node attributes as the source of truth for notebook SQL content while preserving local SQL editor writeback behavior. Automated tests cover initial seeding, remote attribute sync without stale writeback, equal-value rerenders, and local edit writeback for both SQL storage shapes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59f6d1c6-6fe1-4e61-9b66-c8848cb4cd30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59f6d1c6-6fe1-4e61-9b66-c8848cb4cd30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

