### PR TITLE
fix: apply organization-level sharing to exported assets

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -781,10 +781,8 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
         if not resource:
             return custom_404_response(self.request)
 
-        # Check if organization allows publicly shared resources
         if (
-            isinstance(resource, SharingConfiguration)
-            and resource.team.organization.is_feature_available(AvailableFeature.ORGANIZATION_SECURITY_SETTINGS)
+            resource.team.organization.is_feature_available(AvailableFeature.ORGANIZATION_SECURITY_SETTINGS)
             and not resource.team.organization.allow_publicly_shared_resources
         ):
             return custom_404_response(self.request)

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -1023,6 +1023,86 @@ class TestSharingConfigurationSerializerValidation(APIBaseTest):
         response = self.client.get(f"/shared/{access_token}")
         assert response.status_code == 404
 
+    @patch("posthog.models.exported_asset.object_storage.get_presigned_url")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
+    def test_exported_asset_public_url_blocked_when_organization_disallows_public_sharing(
+        self, _patched_exporter_task: Mock, patched_get_presigned_url: Mock
+    ):
+        """
+        Regression test: previously, disabling org-level public sharing only blocked
+        `/shared/<token>` (SharingConfiguration path) but left `/exporter/...?token=<jwt>`
+        (ExportedAsset public token path) returning content. Both surfaces must respect
+        the kill switch.
+        """
+        patched_get_presigned_url.return_value = "https://s3.example.com/presigned-url"
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ORGANIZATION_SECURITY_SETTINGS, "name": "organization_security_settings"},
+        ]
+        self.organization.save()
+
+        # Enable sharing and create a publicly-accessible ExportedAsset for the dashboard.
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing",
+            {"enabled": True},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        asset = ExportedAsset.objects.create(
+            team=self.team,
+            dashboard=self.dashboard,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            content_location="some object url",
+        )
+        exporter_url = asset.get_public_content_url()
+
+        # Sanity check: public token URL works while public sharing is allowed.
+        response = self.client.get(exporter_url)
+        assert response.status_code == 302
+
+        # Disable public sharing at the org level.
+        self.organization.allow_publicly_shared_resources = False
+        self.organization.save()
+
+        # ExportedAsset public token URL must now be blocked, same as /shared/...
+        response = self.client.get(exporter_url)
+        assert response.status_code == 404
+
+    @patch("posthog.models.exported_asset.object_storage.get_presigned_url")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
+    def test_exported_asset_public_url_blocked_for_password_protected_share_when_disallowed(
+        self, _patched_exporter_task: Mock, patched_get_presigned_url: Mock
+    ):
+        """
+        A known ExportedAsset public token URL must not bypass the org-level kill switch even
+        when the underlying SharingConfiguration is password-protected.
+        """
+        patched_get_presigned_url.return_value = "https://s3.example.com/presigned-url"
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ORGANIZATION_SECURITY_SETTINGS, "name": "organization_security_settings"},
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": "access_control"},
+        ]
+        self.organization.save()
+
+        SharingConfiguration.objects.create(
+            team=self.team,
+            dashboard=self.dashboard,
+            enabled=True,
+            password_required=True,
+        )
+        asset = ExportedAsset.objects.create(
+            team=self.team,
+            dashboard=self.dashboard,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            content_location="some object url",
+        )
+        exporter_url = asset.get_public_content_url()
+
+        self.organization.allow_publicly_shared_resources = False
+        self.organization.save()
+
+        response = self.client.get(exporter_url)
+        assert response.status_code == 404
+
 
 class TestSharePasswordLogging(APIBaseTest):
     """Test the _log_share_password_attempt function for activity logging"""


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Exported assets are exempt from the organization-level allow public resource sharing setting.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Remove exported asset gate for public resource sharing

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
