### PR TITLE
feat(cymbal): v2 endpoint

### DIFF
--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -39,7 +39,7 @@ pub struct AppContext {
     pub catalog: Arc<Catalog>,
     pub symbol_resolver: Arc<dyn SymbolResolver>,
     pub symbol_resolution_limiter: Arc<Semaphore>,
-    pub process_request_limiter: Arc<Semaphore>,
+    pub process_event_limiter: Arc<Semaphore>,
     pub config: Config,
 
     pub team_manager: TeamManager,
@@ -203,8 +203,8 @@ impl AppContext {
         ));
         let symbol_resolution_limiter =
             Arc::new(Semaphore::new(config.symbol_resolution_concurrency.max(1)));
-        let process_request_limiter =
-            Arc::new(Semaphore::new(config.process_max_in_flight_requests.max(1)));
+        let process_event_limiter =
+            Arc::new(Semaphore::new(config.process_max_in_flight_events.max(1)));
 
         let issue_cache = CacheBuilder::new(1000)
             .time_to_live(Duration::from_secs(config.issue_cache_ttl_seconds))
@@ -218,7 +218,7 @@ impl AppContext {
             catalog,
             config: config.clone(),
             symbol_resolution_limiter,
-            process_request_limiter,
+            process_event_limiter,
             team_manager,
             issue_buckets_redis_client,
             signal_client,

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -131,16 +131,16 @@ pub struct Config {
     #[envconfig(default = "60000")]
     pub process_slow_log_threshold_ms: u64,
 
-    // Total time budget for a single /v2/process request, in milliseconds. After
+    // Total time budget for a single /v2/resolve request, in milliseconds. After
     // this elapses, any events still being processed get a fallback Retry disposition
     // so the response returns within budget regardless of slow events.
     //
-    // This is the latency SLO cymbal commits to: 99% of /v2/process requests
+    // This is the latency SLO cymbal commits to: 99% of /v2/resolve requests
     // return within `process_request_deadline_ms`.
     #[envconfig(default = "30000")]
     pub process_request_deadline_ms: u64,
 
-    // Per-event time budget within a /v2/process request, in milliseconds. Events
+    // Per-event time budget within a /v2/resolve request, in milliseconds. Events
     // exceeding this get a Retry disposition (reason: deadline_exceeded) so they
     // don't dominate the request budget at the expense of faster siblings.
     //

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -123,10 +123,11 @@ pub struct Config {
     #[envconfig(default = "64")]
     pub symbol_resolution_concurrency: usize,
 
-    // Maximum number of in-flight /process requests accepted by the API.
-    // Requests above this limit are rejected with 429 to apply backpressure.
-    #[envconfig(default = "128")]
-    pub process_max_in_flight_requests: usize,
+    // Maximum number of in-flight events accepted by the HTTP processing API.
+    // Requests whose full batch cannot fit under this limit are rejected with
+    // 429 to apply backpressure.
+    #[envconfig(default = "1000")]
+    pub process_max_in_flight_events: usize,
 
     #[envconfig(default = "60000")]
     pub process_slow_log_threshold_ms: u64,

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -131,6 +131,25 @@ pub struct Config {
     #[envconfig(default = "60000")]
     pub process_slow_log_threshold_ms: u64,
 
+    // Total time budget for a single /v2/process request, in milliseconds. After
+    // this elapses, any events still being processed get a fallback Retry verdict
+    // so the response returns within budget regardless of slow events.
+    //
+    // This is the latency SLO cymbal commits to: 99% of /v2/process requests
+    // return within `process_request_deadline_ms`.
+    #[envconfig(default = "30000")]
+    pub process_request_deadline_ms: u64,
+
+    // Per-event time budget within a /v2/process request, in milliseconds. Events
+    // exceeding this get a Retry verdict (reason: deadline_exceeded) so they
+    // don't dominate the request budget at the expense of faster siblings.
+    //
+    // Should be smaller than `process_request_deadline_ms` — a request with N
+    // events processed concurrently can each consume up to this budget without
+    // pushing the request past its overall deadline.
+    #[envconfig(default = "10000")]
+    pub process_per_event_deadline_ms: u64,
+
     #[envconfig(default = "300")]
     pub team_cache_ttl_secs: u64,
 

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -132,7 +132,7 @@ pub struct Config {
     pub process_slow_log_threshold_ms: u64,
 
     // Total time budget for a single /v2/process request, in milliseconds. After
-    // this elapses, any events still being processed get a fallback Retry verdict
+    // this elapses, any events still being processed get a fallback Retry disposition
     // so the response returns within budget regardless of slow events.
     //
     // This is the latency SLO cymbal commits to: 99% of /v2/process requests
@@ -141,7 +141,7 @@ pub struct Config {
     pub process_request_deadline_ms: u64,
 
     // Per-event time budget within a /v2/process request, in milliseconds. Events
-    // exceeding this get a Retry verdict (reason: deadline_exceeded) so they
+    // exceeding this get a Retry disposition (reason: deadline_exceeded) so they
     // don't dominate the request budget at the expense of faster siblings.
     //
     // Should be smaller than `process_request_deadline_ms` — a request with N

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -86,6 +86,7 @@ pub const JAVA_EXCEPTION_REMAP_FAILED: &str = "cymbal_java_exception_remap_faile
 pub const PROCESS_REQUESTS_TOTAL: &str = "cymbal_process_requests_total";
 pub const PROCESS_REQUEST_DURATION_SECONDS: &str = "cymbal_process_request_duration_seconds";
 pub const PROCESS_BATCH_EVENTS: &str = "cymbal_process_batch_events";
+// Gauge of events currently admitted by the HTTP processing backpressure limiter.
 pub const PROCESS_IN_FLIGHT: &str = "cymbal_process_in_flight";
 
 // Disposition-based /v2/resolve observability. These count individual event

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -88,30 +88,31 @@ pub const PROCESS_REQUEST_DURATION_SECONDS: &str = "cymbal_process_request_durat
 pub const PROCESS_BATCH_EVENTS: &str = "cymbal_process_batch_events";
 pub const PROCESS_IN_FLIGHT: &str = "cymbal_process_in_flight";
 
-// Verdict-based /v2/process observability. These count individual event
-// outcomes (labelled by `{status, reason}`) and surface the new contract's
+// Disposition-based /v2/process observability. These count individual event
+// outcomes (labelled by `{action, reason}`) and surface the new contract's
 // per-event classification to operators. Combined with PROCESS_REQUESTS_TOTAL
 // (which counts whole requests), they give a complete picture of cymbal's
 // behaviour under load.
-pub const VERDICTS_EMITTED_TOTAL: &str = "cymbal_verdicts_emitted_total";
-// Wall-clock time spent producing the verdict for a single event, including
+pub const DISPOSITIONS_EMITTED_TOTAL: &str = "cymbal_event_dispositions_emitted_total";
+// Wall-clock time spent producing the disposition for a single event, including
 // any sub-stage work. Tells us where the per-event deadline budget is going.
-pub const VERDICT_DURATION_SECONDS: &str = "cymbal_verdict_duration_seconds";
-// Increments whenever an event verdict had to be filled in as a fallback
+pub const DISPOSITION_DURATION_SECONDS: &str = "cymbal_event_disposition_duration_seconds";
+// Increments whenever an event disposition had to be filled in as a fallback
 // because the per-event deadline elapsed mid-processing. Distinct from
-// "verdicts_emitted_total{status=retry,reason=deadline_exceeded}" because it
+// "event_dispositions_emitted_total{action=retry,reason=deadline_exceeded}" because it
 // signals the deadline triggered the fallback, rather than a stage choosing
-// to emit a retry verdict on its own.
-pub const VERDICT_DEADLINE_FALLBACK_TOTAL: &str = "cymbal_verdict_deadline_fallback_total";
+// to emit a retry disposition on its own.
+pub const DISPOSITION_DEADLINE_FALLBACK_TOTAL: &str =
+    "cymbal_event_disposition_deadline_fallback_total";
 // Increments whenever per-event processing panicked. A non-zero rate means
-// cymbal has bugs being absorbed silently as `retry` verdicts; the panic
+// cymbal has bugs being absorbed silently as `retry` dispositions; the panic
 // counter is the trail for finding them.
-pub const VERDICT_PANIC_TOTAL: &str = "cymbal_verdict_panic_total";
+pub const DISPOSITION_PANIC_TOTAL: &str = "cymbal_event_disposition_panic_total";
 // Increments when the whole-request deadline elapsed with events still
 // in flight. Should be rare in steady state — per-event deadlines should
 // bring each event home before the request deadline.
-pub const VERDICT_REQUEST_DEADLINE_EXHAUSTED_TOTAL: &str =
-    "cymbal_verdict_request_deadline_exhausted_total";
+pub const DISPOSITION_REQUEST_DEADLINE_EXHAUSTED_TOTAL: &str =
+    "cymbal_event_disposition_request_deadline_exhausted_total";
 
 // Spike detection metrics
 pub const SPIKE_INCREMENT_ISSUE_BUCKETS_TIME: &str = "cymbal_spike_increment_issue_buckets_time";

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -88,7 +88,7 @@ pub const PROCESS_REQUEST_DURATION_SECONDS: &str = "cymbal_process_request_durat
 pub const PROCESS_BATCH_EVENTS: &str = "cymbal_process_batch_events";
 pub const PROCESS_IN_FLIGHT: &str = "cymbal_process_in_flight";
 
-// Disposition-based /v2/process observability. These count individual event
+// Disposition-based /v2/resolve observability. These count individual event
 // outcomes (labelled by `{action, reason}`) and surface the new contract's
 // per-event classification to operators. Combined with PROCESS_REQUESTS_TOTAL
 // (which counts whole requests), they give a complete picture of cymbal's

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -88,6 +88,31 @@ pub const PROCESS_REQUEST_DURATION_SECONDS: &str = "cymbal_process_request_durat
 pub const PROCESS_BATCH_EVENTS: &str = "cymbal_process_batch_events";
 pub const PROCESS_IN_FLIGHT: &str = "cymbal_process_in_flight";
 
+// Verdict-based /v2/process observability. These count individual event
+// outcomes (labelled by `{status, reason}`) and surface the new contract's
+// per-event classification to operators. Combined with PROCESS_REQUESTS_TOTAL
+// (which counts whole requests), they give a complete picture of cymbal's
+// behaviour under load.
+pub const VERDICTS_EMITTED_TOTAL: &str = "cymbal_verdicts_emitted_total";
+// Wall-clock time spent producing the verdict for a single event, including
+// any sub-stage work. Tells us where the per-event deadline budget is going.
+pub const VERDICT_DURATION_SECONDS: &str = "cymbal_verdict_duration_seconds";
+// Increments whenever an event verdict had to be filled in as a fallback
+// because the per-event deadline elapsed mid-processing. Distinct from
+// "verdicts_emitted_total{status=retry,reason=deadline_exceeded}" because it
+// signals the deadline triggered the fallback, rather than a stage choosing
+// to emit a retry verdict on its own.
+pub const VERDICT_DEADLINE_FALLBACK_TOTAL: &str = "cymbal_verdict_deadline_fallback_total";
+// Increments whenever per-event processing panicked. A non-zero rate means
+// cymbal has bugs being absorbed silently as `retry` verdicts; the panic
+// counter is the trail for finding them.
+pub const VERDICT_PANIC_TOTAL: &str = "cymbal_verdict_panic_total";
+// Increments when the whole-request deadline elapsed with events still
+// in flight. Should be rare in steady state — per-event deadlines should
+// bring each event home before the request deadline.
+pub const VERDICT_REQUEST_DEADLINE_EXHAUSTED_TOTAL: &str =
+    "cymbal_verdict_request_deadline_exhausted_total";
+
 // Spike detection metrics
 pub const SPIKE_INCREMENT_ISSUE_BUCKETS_TIME: &str = "cymbal_spike_increment_issue_buckets_time";
 pub const SPIKE_INCREMENT_TEAM_BUCKETS_TIME: &str = "cymbal_spike_increment_team_buckets_time";

--- a/rust/cymbal/src/router/event.rs
+++ b/rust/cymbal/src/router/event.rs
@@ -23,10 +23,10 @@ use crate::{
     types::{batch::Batch, event::AnyEvent, stage::Stage},
 };
 
-struct ProcessInFlightGuard;
+pub(super) struct ProcessInFlightGuard;
 
 impl ProcessInFlightGuard {
-    fn start() -> Self {
+    pub(super) fn start() -> Self {
         metrics::gauge!(PROCESS_IN_FLIGHT).increment(1.0);
         Self
     }
@@ -38,7 +38,7 @@ impl Drop for ProcessInFlightGuard {
     }
 }
 
-fn get_request_id(headers: &HeaderMap) -> String {
+pub(super) fn get_request_id(headers: &HeaderMap) -> String {
     headers
         .get("x-request-id")
         .and_then(|v| v.to_str().ok())
@@ -148,7 +148,10 @@ pub async fn process_events(
         })?;
 
     let slow_log_threshold_ms = ctx.config.process_slow_log_threshold_ms;
-    let pipeline = HttpEventPipeline::new(ctx.clone());
+    // Legacy /process flow: no shared batch cache (each call gets its own
+    // per-batch cache inside LinkingStage) and no spike-alert accumulator
+    // (spike detection runs inline at the end of this batch).
+    let pipeline = HttpEventPipeline::new(ctx.clone(), None, None);
     let input = Batch::from(events);
     let output = pipeline.process(input).await;
 

--- a/rust/cymbal/src/router/event.rs
+++ b/rust/cymbal/src/router/event.rs
@@ -10,6 +10,7 @@ use reqwest::StatusCode;
 use uuid::Uuid;
 
 use serde_json::json;
+use tokio::sync::OwnedSemaphorePermit;
 use tracing::{debug, error, warn};
 
 use crate::{
@@ -23,18 +24,103 @@ use crate::{
     types::{batch::Batch, event::AnyEvent, stage::Stage},
 };
 
-pub(super) struct ProcessInFlightGuard;
+struct ProcessInFlightGuard {
+    event_count: usize,
+}
 
 impl ProcessInFlightGuard {
-    pub(super) fn start() -> Self {
-        metrics::gauge!(PROCESS_IN_FLIGHT).increment(1.0);
-        Self
+    pub(super) fn start(event_count: usize) -> Self {
+        metrics::gauge!(PROCESS_IN_FLIGHT).increment(event_count as f64);
+        Self { event_count }
     }
 }
 
 impl Drop for ProcessInFlightGuard {
     fn drop(&mut self) {
-        metrics::gauge!(PROCESS_IN_FLIGHT).decrement(1.0);
+        metrics::gauge!(PROCESS_IN_FLIGHT).decrement(self.event_count as f64);
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum ProcessEndpoint {
+    LegacyProcess,
+    ResolveV2,
+}
+
+impl ProcessEndpoint {
+    fn path(self) -> &'static str {
+        match self {
+            Self::LegacyProcess => "/process",
+            Self::ResolveV2 => "/v2/resolve",
+        }
+    }
+
+    fn metric_endpoint(self) -> Option<&'static str> {
+        match self {
+            Self::LegacyProcess => None,
+            Self::ResolveV2 => Some("v2"),
+        }
+    }
+}
+
+pub(super) struct ProcessEventCapacityGuard {
+    _in_flight: ProcessInFlightGuard,
+    _permit: Option<OwnedSemaphorePermit>,
+}
+
+impl ProcessEventCapacityGuard {
+    pub(super) fn try_start(
+        ctx: &Arc<AppContext>,
+        endpoint: ProcessEndpoint,
+        request_id: &str,
+        batch_event_count: usize,
+        team_count: usize,
+    ) -> Result<Self, ProcessEventsError> {
+        let permit_count = u32::try_from(batch_event_count).unwrap_or(u32::MAX);
+        let permit = if permit_count == 0 {
+            None
+        } else {
+            Some(
+                ctx.process_event_limiter
+                    .clone()
+                    .try_acquire_many_owned(permit_count)
+                    .map_err(|_| {
+                        metrics::counter!(ERRORS, "cause" => "process_backpressure").increment(1);
+                        match endpoint.metric_endpoint() {
+                            Some(endpoint_label) => {
+                                metrics::counter!(
+                                    PROCESS_REQUESTS_TOTAL,
+                                    "outcome" => "error",
+                                    "status_class" => "4xx",
+                                    "endpoint" => endpoint_label
+                                )
+                                .increment(1);
+                            }
+                            None => {
+                                metrics::counter!(
+                                    PROCESS_REQUESTS_TOTAL,
+                                    "outcome" => "error",
+                                    "status_class" => "4xx"
+                                )
+                                .increment(1);
+                            }
+                        }
+                        warn!(
+                            request_id,
+                            batch_event_count,
+                            team_count,
+                            endpoint = endpoint.path(),
+                            "Rejected HTTP processing request due to event backpressure"
+                        );
+                        ProcessEventsError::Backpressure
+                    })?,
+            )
+        };
+
+        Ok(Self {
+            _in_flight: ProcessInFlightGuard::start(batch_event_count),
+            _permit: permit,
+        })
     }
 }
 
@@ -72,8 +158,8 @@ impl IntoResponse for ProcessEventsError {
             ProcessEventsError::Backpressure => (
                 StatusCode::TOO_MANY_REQUESTS,
                 Json(json!({
-                    "error": "Too many in-flight /process requests",
-                    "details": "Backpressure limit reached, retry later",
+                    "error": "Too many in-flight /process events",
+                    "details": "Event backpressure limit reached, retry later",
                 })),
             )
                 .into_response(),
@@ -106,7 +192,6 @@ pub async fn process_events(
     headers: HeaderMap,
     Json(events): Json<Vec<AnyEvent>>,
 ) -> Result<Batch<Option<AnyEvent>>, ProcessEventsError> {
-    let _in_flight = ProcessInFlightGuard::start();
     let request_id = get_request_id(&headers);
     let started_at = Instant::now();
 
@@ -126,26 +211,13 @@ pub async fn process_events(
         "Started /process request"
     );
 
-    let _permit = ctx
-        .process_request_limiter
-        .clone()
-        .try_acquire_owned()
-        .map_err(|_| {
-            metrics::counter!(ERRORS, "cause" => "process_backpressure").increment(1);
-            metrics::counter!(
-                PROCESS_REQUESTS_TOTAL,
-                "outcome" => "error",
-                "status_class" => "4xx"
-            )
-            .increment(1);
-            warn!(
-                request_id = %request_id,
-                batch_event_count,
-                team_count,
-                "Rejected /process request due to backpressure"
-            );
-            ProcessEventsError::Backpressure
-        })?;
+    let _capacity = ProcessEventCapacityGuard::try_start(
+        &ctx,
+        ProcessEndpoint::LegacyProcess,
+        &request_id,
+        batch_event_count,
+        team_count,
+    )?;
 
     let slow_log_threshold_ms = ctx.config.process_slow_log_threshold_ms;
     // Legacy /process flow: no shared batch cache (each call gets its own

--- a/rust/cymbal/src/router/event_disposition_processor.rs
+++ b/rust/cymbal/src/router/event_disposition_processor.rs
@@ -1,0 +1,351 @@
+use std::{panic::AssertUnwindSafe, sync::Arc, time::Duration};
+
+use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
+use moka::future::Cache;
+use tokio::time::Instant;
+use tracing::warn;
+
+use crate::{
+    app_context::AppContext,
+    error::EventError,
+    issue_resolution::Issue,
+    metric_consts::{
+        DISPOSITION_DEADLINE_FALLBACK_TOTAL, DISPOSITION_DURATION_SECONDS, DISPOSITION_PANIC_TOTAL,
+        DISPOSITION_REQUEST_DEADLINE_EXHAUSTED_TOTAL,
+    },
+    stages::{
+        alerting::SpikeAlertAccumulator,
+        http_pipeline::{HttpEventProcessingPipeline, HttpEventProcessingResult},
+    },
+    types::{
+        batch::Batch,
+        event::{AnyEvent, PropertiesContainer},
+        event_disposition::{DropReason, EventDisposition, RetryReason},
+        operator::TeamId,
+        stage::Stage,
+    },
+};
+
+/// Runs per-event Cymbal processing for `/v2/process` and converts each raw
+/// result into an `EventDisposition`. The struct owns the request-scoped shared
+/// state that must be reused across all isolated `Batch<1>` invocations.
+#[derive(Clone)]
+pub(super) struct PerEventDispositionProcessor {
+    ctx: Arc<AppContext>,
+    per_event_budget: Duration,
+    batch_issue_cache: Cache<(TeamId, String), Issue>,
+    spike_alert_accumulator: Arc<SpikeAlertAccumulator>,
+}
+
+impl PerEventDispositionProcessor {
+    pub(super) fn new(
+        ctx: Arc<AppContext>,
+        per_event_budget: Duration,
+        batch_issue_cache: Cache<(TeamId, String), Issue>,
+        spike_alert_accumulator: Arc<SpikeAlertAccumulator>,
+    ) -> Self {
+        Self {
+            ctx,
+            per_event_budget,
+            batch_issue_cache,
+            spike_alert_accumulator,
+        }
+    }
+
+    /// Drive every event through its own isolated pipeline invocation and
+    /// collect the dispositions. Each event gets the same deadline budget but
+    /// runs concurrently with the others.
+    ///
+    /// If the request deadline elapses first, completed event dispositions are
+    /// preserved and only unfinished positions get a `retry/deadline_exceeded`
+    /// fallback.
+    pub(super) async fn process_batch(
+        &self,
+        events: Vec<AnyEvent>,
+        request_deadline: Instant,
+    ) -> Vec<EventDisposition> {
+        let event_count = events.len();
+        if event_count == 0 {
+            return Vec::new();
+        }
+
+        let now = Instant::now();
+        let mut futures = FuturesUnordered::new();
+        for (index, event) in events.into_iter().enumerate() {
+            let deadline = (now + self.per_event_budget).min(request_deadline);
+            let processor = self.clone();
+            futures.push(async move { (index, processor.process_one(event, deadline).await) });
+        }
+
+        let mut dispositions: Vec<Option<EventDisposition>> = vec![None; event_count];
+        let mut remaining = event_count;
+        let deadline_sleep = tokio::time::sleep_until(request_deadline);
+        tokio::pin!(deadline_sleep);
+
+        while remaining > 0 {
+            tokio::select! {
+                item = futures.next() => {
+                    match item {
+                        Some((index, disposition)) => {
+                            if dispositions[index].is_none() {
+                                dispositions[index] = Some(disposition);
+                                remaining -= 1;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                _ = &mut deadline_sleep => {
+                    metrics::counter!(DISPOSITION_REQUEST_DEADLINE_EXHAUSTED_TOTAL).increment(1);
+                    metrics::counter!(DISPOSITION_DEADLINE_FALLBACK_TOTAL).increment(remaining as u64);
+                    break;
+                }
+            }
+        }
+
+        if remaining > 0 {
+            warn!(
+                event_count,
+                unfinished_event_count = remaining,
+                "Request deadline exhausted with events still in flight; \
+                 filling unfinished positions with retry/deadline_exceeded dispositions"
+            );
+        }
+
+        dispositions
+            .into_iter()
+            .map(|disposition| disposition.unwrap_or_else(deadline_exceeded_disposition))
+            .collect()
+    }
+
+    /// Run the core processing pipeline on a single event (as a `Batch<1>`)
+    /// with the per-event deadline and panic catching applied, then convert
+    /// the result to an `EventDisposition`.
+    async fn process_one(&self, event: AnyEvent, deadline: Instant) -> EventDisposition {
+        let started = Instant::now();
+        let remaining = match deadline.checked_duration_since(started) {
+            Some(d) if !d.is_zero() => d,
+            _ => {
+                // Already past deadline before we started — emit retry
+                // without doing more work. Possible if the request deadline
+                // is tighter than the per-event budget for the last events
+                // in the batch.
+                metrics::counter!(DISPOSITION_DEADLINE_FALLBACK_TOTAL).increment(1);
+                return deadline_exceeded_disposition();
+            }
+        };
+
+        let ctx = self.ctx.clone();
+        // Cloning the moka cache is a refcount bump on the underlying
+        // storage — every per-event invocation sees the same data.
+        let batch_issue_cache = self.batch_issue_cache.clone();
+        let spike_alert_accumulator = self.spike_alert_accumulator.clone();
+
+        let work = async move {
+            let pipeline = HttpEventProcessingPipeline::new(
+                ctx,
+                Some(batch_issue_cache),
+                Some(spike_alert_accumulator),
+            );
+            let input = Batch::from(vec![event]);
+            pipeline.process(input).await
+        };
+
+        // catch_unwind absorbs panics from inside the pipeline so one event's
+        // panic doesn't taint another's disposition.
+        let panic_safe = AssertUnwindSafe(work).catch_unwind();
+
+        let disposition = match tokio::time::timeout(remaining, panic_safe).await {
+            Ok(Ok(Ok(batch))) => match disposition_from_pipeline_output(batch) {
+                Ok(disposition) => disposition,
+                Err(unhandled) => EventDisposition::from_unhandled_error(unhandled),
+            },
+            Ok(Ok(Err(unhandled))) => {
+                // UnhandledError from the pipeline — classify as retry per the
+                // contract. Cymbal does not assert the event is broken; we
+                // don't know whether the failure is event-caused or cymbal-side.
+                EventDisposition::from_unhandled_error(unhandled)
+            }
+            Ok(Err(panic_payload)) => {
+                warn!(
+                    "Per-event pipeline panicked: {}",
+                    panic_message(&panic_payload)
+                );
+                metrics::counter!(DISPOSITION_PANIC_TOTAL).increment(1);
+                EventDisposition::Retry {
+                    reason: RetryReason::UnhandledProcessingError,
+                    retry_after_ms: None,
+                }
+            }
+            Err(_elapsed) => {
+                metrics::counter!(DISPOSITION_DEADLINE_FALLBACK_TOTAL).increment(1);
+                deadline_exceeded_disposition()
+            }
+        };
+
+        metrics::histogram!(DISPOSITION_DURATION_SECONDS, "action" => disposition.action_label())
+            .record(started.elapsed().as_secs_f64());
+
+        disposition
+    }
+}
+
+/// Convert a successful core pipeline output into an `EventDisposition`.
+/// Per-event isolation guarantees the input was a `Batch<1>`, so the output
+/// must also be length 1.
+fn disposition_from_pipeline_output(
+    batch: Batch<HttpEventProcessingResult>,
+) -> Result<EventDisposition, crate::error::UnhandledError> {
+    let mut iter = Vec::from(batch).into_iter();
+    match iter.next() {
+        Some(result) => disposition_from_processing_result(result),
+        // The pipeline returned an empty batch for a Batch<1> input.
+        // This is a contract violation by the pipeline itself; treat as
+        // retry so the pipeline can be debugged without dropping events.
+        None => Ok(EventDisposition::Retry {
+            reason: RetryReason::UnhandledProcessingError,
+            retry_after_ms: None,
+        }),
+    }
+}
+
+fn disposition_from_processing_result(
+    processing_result: HttpEventProcessingResult,
+) -> Result<EventDisposition, crate::error::UnhandledError> {
+    let mut original = processing_result.original_event;
+    match processing_result.result {
+        Ok(props) => {
+            original.set_properties(props)?;
+            Ok(EventDisposition::Forward {
+                event: Box::new(original),
+            })
+        }
+        Err(EventError::Suppressed(_)) => Ok(EventDisposition::Drop {
+            reason: DropReason::IssueSuppressed,
+        }),
+        Err(EventError::SuppressedByRule(_)) => Ok(EventDisposition::Drop {
+            reason: DropReason::SuppressedByRule,
+        }),
+        Err(err) => {
+            original.attach_error(err.to_string())?;
+            Ok(EventDisposition::Forward {
+                event: Box::new(original),
+            })
+        }
+    }
+}
+
+fn deadline_exceeded_disposition() -> EventDisposition {
+    EventDisposition::Retry {
+        reason: RetryReason::DeadlineExceeded,
+        retry_after_ms: None,
+    }
+}
+
+/// Best-effort extraction of a string description from a `catch_unwind`
+/// payload. Falls back to a fixed label when the payload isn't a string.
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "<non-string panic payload>".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::exception_properties::ExceptionProperties;
+    use uuid::Uuid;
+
+    fn make_event() -> AnyEvent {
+        AnyEvent {
+            uuid: Uuid::nil(),
+            event: "$exception".to_string(),
+            team_id: 1,
+            timestamp: "2026-05-21T00:00:00Z".to_string(),
+            properties: serde_json::json!({
+                "$exception_list": [{"type": "Error", "value": "test"}],
+            }),
+            others: Default::default(),
+        }
+    }
+
+    #[test]
+    fn disposition_from_pipeline_output_maps_processed_event_to_forward() {
+        let event = make_event();
+        let props = ExceptionProperties::try_from(event.clone()).unwrap();
+        let batch = Batch::from(vec![HttpEventProcessingResult {
+            original_event: event.clone(),
+            result: Ok(props),
+        }]);
+
+        let disposition = disposition_from_pipeline_output(batch).unwrap();
+        match disposition {
+            EventDisposition::Forward { event: returned } => {
+                assert_eq!(returned.uuid, event.uuid);
+            }
+            other => panic!("expected Forward, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn disposition_from_pipeline_output_maps_suppressed_error_to_drop() {
+        let event = make_event();
+        let batch: Batch<HttpEventProcessingResult> =
+            Batch::from(vec![HttpEventProcessingResult {
+                original_event: event,
+                result: Err(crate::error::EventError::Suppressed(Uuid::nil())),
+            }]);
+
+        let disposition = disposition_from_pipeline_output(batch).unwrap();
+        assert!(matches!(
+            disposition,
+            EventDisposition::Drop {
+                reason: DropReason::IssueSuppressed,
+            }
+        ));
+    }
+
+    #[test]
+    fn disposition_from_pipeline_output_attaches_handled_error_to_forwarded_event() {
+        let event = make_event();
+        let batch: Batch<HttpEventProcessingResult> =
+            Batch::from(vec![HttpEventProcessingResult {
+                original_event: event,
+                result: Err(crate::error::EventError::EmptyExceptionList(Uuid::nil())),
+            }]);
+
+        let disposition = disposition_from_pipeline_output(batch).unwrap();
+        let EventDisposition::Forward { event } = disposition else {
+            panic!("expected Forward disposition");
+        };
+        let errors = event
+            .properties
+            .get("$cymbal_errors")
+            .and_then(|value| value.as_array())
+            .expect("forwarded event should carry cymbal errors");
+        assert!(errors.iter().any(|error| error
+            .as_str()
+            .is_some_and(|error| error.contains("Empty exception list"))));
+    }
+
+    #[test]
+    fn disposition_from_pipeline_output_maps_empty_to_retry() {
+        // A pipeline that returns an empty batch for a Batch<1> input is
+        // a contract violation. Emit Retry so the pipeline can be debugged
+        // without silently dropping events.
+        let batch: Batch<HttpEventProcessingResult> = Batch::from(Vec::new());
+
+        let disposition = disposition_from_pipeline_output(batch).unwrap();
+        assert!(matches!(
+            disposition,
+            EventDisposition::Retry {
+                reason: RetryReason::UnhandledProcessingError,
+                ..
+            }
+        ));
+    }
+}

--- a/rust/cymbal/src/router/event_disposition_processor.rs
+++ b/rust/cymbal/src/router/event_disposition_processor.rs
@@ -1,6 +1,6 @@
 use std::{panic::AssertUnwindSafe, sync::Arc, time::Duration};
 
-use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
+use futures::{stream, FutureExt, StreamExt};
 use moka::future::Cache;
 use tokio::time::Instant;
 use tracing::warn;
@@ -53,8 +53,10 @@ impl PerEventDispositionProcessor {
     }
 
     /// Drive every event through its own isolated pipeline invocation and
-    /// collect the dispositions. Each event gets the same deadline budget but
-    /// runs concurrently with the others.
+    /// collect the dispositions. Each event gets the same deadline budget.
+    /// Concurrency is capped by `batch_apply_concurrency`, matching the
+    /// existing batch-stage fan-out limit so a single request cannot spawn
+    /// unbounded DB/S3/Redis-capable work.
     ///
     /// If the request deadline elapses first, completed event dispositions are
     /// preserved and only unfinished positions get a `retry/deadline_exceeded`
@@ -70,12 +72,14 @@ impl PerEventDispositionProcessor {
         }
 
         let now = Instant::now();
-        let mut futures = FuturesUnordered::new();
-        for (index, event) in events.into_iter().enumerate() {
+        let concurrency_limit = self.ctx.config.batch_apply_concurrency.max(1);
+        let futures = stream::iter(events.into_iter().enumerate().map(|(index, event)| {
             let deadline = (now + self.per_event_budget).min(request_deadline);
             let processor = self.clone();
-            futures.push(async move { (index, processor.process_one(event, deadline).await) });
-        }
+            async move { (index, processor.process_one(event, deadline).await) }
+        }))
+        .buffered(concurrency_limit);
+        tokio::pin!(futures);
 
         let mut dispositions: Vec<Option<EventDisposition>> = vec![None; event_count];
         let mut remaining = event_count;

--- a/rust/cymbal/src/router/event_disposition_processor.rs
+++ b/rust/cymbal/src/router/event_disposition_processor.rs
@@ -26,7 +26,7 @@ use crate::{
     },
 };
 
-/// Runs per-event Cymbal processing for `/v2/process` and converts each raw
+/// Runs per-event Cymbal processing for `/v2/resolve` and converts each raw
 /// result into an `EventDisposition`. The struct owns the request-scoped shared
 /// state that must be reused across all isolated `Batch<1>` invocations.
 #[derive(Clone)]

--- a/rust/cymbal/src/router/event_v2.rs
+++ b/rust/cymbal/src/router/event_v2.rs
@@ -1,0 +1,568 @@
+//! `/v2/process` request handler. Returns per-event verdicts in a
+//! structured response shape that the ingestion pipeline can route on
+//! without inference.
+//!
+//! Isolation model: each input event runs through the existing
+//! `HttpEventPipeline` as its own `Batch<1>` in a separate future, wrapped
+//! in a per-event timeout and `catch_unwind`. A failure (panic, timeout, or
+//! `UnhandledError`) for one event becomes a `retry` verdict for that
+//! position only — the request still returns verdicts for every other
+//! event in the batch.
+//!
+//! Per-request shared state restores the cross-event optimizations the
+//! legacy single-batch flow gets implicitly:
+//!
+//! - **Batch issue cache**: a per-request `Cache<(team_id, fingerprint), Issue>`
+//!   that all per-event pipeline invocations share, so events with the same
+//!   fingerprint within a request resolve their issue exactly once.
+//! - **Spike-alert accumulator**: a shared accumulator that collects
+//!   `(issue, props)` from every per-event invocation and runs spike
+//!   detection **once** at end-of-request with the merged batch — avoiding
+//!   the per-event Redis call amplification we'd otherwise see.
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use axum::{
+    extract::{Json, State},
+    http::HeaderMap,
+};
+use futures::future::join_all;
+use futures::FutureExt;
+use moka::future::Cache;
+use std::panic::AssertUnwindSafe;
+use tokio::time::Instant;
+use tracing::{debug, error, warn};
+
+use crate::{
+    app_context::AppContext,
+    issue_resolution::Issue,
+    metric_consts::{
+        ERRORS, PROCESS_BATCH_EVENTS, PROCESS_REQUESTS_TOTAL, PROCESS_REQUEST_DURATION_SECONDS,
+        VERDICTS_EMITTED_TOTAL, VERDICT_DEADLINE_FALLBACK_TOTAL, VERDICT_DURATION_SECONDS,
+        VERDICT_PANIC_TOTAL, VERDICT_REQUEST_DEADLINE_EXHAUSTED_TOTAL,
+    },
+    router::event::{get_request_id, ProcessEventsError, ProcessInFlightGuard},
+    stages::{
+        alerting::{spike_detection::do_spike_detection, SpikeAlertAccumulator},
+        http_pipeline::HttpEventPipeline,
+        linking::LinkingStage,
+    },
+    types::{
+        batch::Batch,
+        event::AnyEvent,
+        operator::TeamId,
+        stage::Stage,
+        verdict::{EventVerdict, RetryReason},
+    },
+};
+
+/// Handler for `POST /v2/process`. Accepts a JSON array of events and
+/// returns a JSON array of verdicts aligned 1:1 with the input.
+#[axum::debug_handler]
+pub async fn process_events_v2(
+    State(ctx): State<Arc<AppContext>>,
+    headers: HeaderMap,
+    Json(events): Json<Vec<AnyEvent>>,
+) -> Result<Json<Vec<EventVerdict>>, ProcessEventsError> {
+    let _in_flight = ProcessInFlightGuard::start();
+    let request_id = get_request_id(&headers);
+    let started_at = Instant::now();
+
+    let batch_event_count = events.len();
+    let team_count = events
+        .iter()
+        .map(|event| event.team_id)
+        .collect::<HashSet<_>>()
+        .len();
+
+    metrics::histogram!(PROCESS_BATCH_EVENTS).record(batch_event_count as f64);
+
+    debug!(
+        request_id = %request_id,
+        batch_event_count,
+        team_count,
+        "Started /v2/process request"
+    );
+
+    // Same backpressure semaphore as /process — when the in-flight limit is
+    // hit, this request is rejected with 429. This is the path cymbal uses
+    // to tell the client to back off; the inner CB on the client side will
+    // pick it up the same way it does for the legacy endpoint.
+    let _permit = ctx
+        .process_request_limiter
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| {
+            // Mirror legacy `/process` so existing alerts on
+            // `cymbal_errors{cause="process_backpressure"}` and
+            // `cymbal_process_requests_total{outcome="error", status_class="4xx"}`
+            // pick up v2 backpressure too.
+            metrics::counter!(ERRORS, "cause" => "process_backpressure").increment(1);
+            metrics::counter!(
+                PROCESS_REQUESTS_TOTAL,
+                "outcome" => "error",
+                "status_class" => "4xx",
+                "endpoint" => "v2"
+            )
+            .increment(1);
+            warn!(
+                request_id = %request_id,
+                batch_event_count,
+                team_count,
+                "Rejected /v2/process request due to backpressure"
+            );
+            ProcessEventsError::Backpressure
+        })?;
+
+    // Deadlines: per-event budget caps how long any single event can take,
+    // and the request deadline bounds the whole call. Per-event deadlines
+    // ensure that one slow event can't block fast siblings; the request
+    // deadline is a safety net in case per-event budgeting has a bug.
+    let request_deadline =
+        started_at + Duration::from_millis(ctx.config.process_request_deadline_ms);
+    let per_event_budget = Duration::from_millis(ctx.config.process_per_event_deadline_ms);
+
+    // Per-request shared state. Both pieces are threaded into every per-event
+    // pipeline invocation so the per-event isolation we get for free doesn't
+    // come at the cost of losing the legacy flow's cross-event optimizations.
+    let shared_batch_issue_cache = LinkingStage::default_batch_issue_cache();
+    let spike_alert_accumulator = SpikeAlertAccumulator::new();
+
+    let verdicts = run_isolated_per_event(
+        ctx.clone(),
+        events,
+        request_deadline,
+        per_event_budget,
+        shared_batch_issue_cache,
+        spike_alert_accumulator.clone(),
+    )
+    .await;
+
+    record_verdict_metrics(&verdicts);
+
+    // Verdict-shape counters useful in completion logs. Computed once so
+    // both the slow-log and the success-log can include them.
+    let (process_count, drop_count, retry_count, dlq_count) =
+        verdicts
+            .iter()
+            .fold((0, 0, 0, 0), |(p, d, r, dl), v| match v {
+                EventVerdict::Process { .. } => (p + 1, d, r, dl),
+                EventVerdict::Drop { .. } => (p, d + 1, r, dl),
+                EventVerdict::Retry { .. } => (p, d, r + 1, dl),
+                EventVerdict::Dlq { .. } => (p, d, r, dl + 1),
+            });
+
+    // Run spike detection once with the merged inputs from every per-event
+    // invocation. This is what makes the per-event isolation cheap: one
+    // Redis call covers the whole request, the same as the legacy flow.
+    //
+    // Spike detection is a customer-facing alerting feature, not a fire-and-
+    // forget side effect: if it fails, we propagate the error and 500 the
+    // request so the client retries (matching the legacy `/process` flow).
+    // Silently dropping a failure here would mean a customer-visible spike
+    // alert never fires — worse than re-symbolicating a batch on retry.
+    if let Err(err) = run_deferred_spike_detection(ctx.clone(), spike_alert_accumulator).await {
+        let duration_ms = started_at.elapsed().as_millis() as u64;
+        metrics::counter!(
+            PROCESS_REQUESTS_TOTAL,
+            "outcome" => "error",
+            "status_class" => "5xx",
+            "endpoint" => "v2"
+        )
+        .increment(1);
+        metrics::histogram!(PROCESS_REQUEST_DURATION_SECONDS, "endpoint" => "v2")
+            .record(started_at.elapsed().as_secs_f64());
+        error!(
+            request_id = %request_id,
+            error = %err,
+            duration_ms,
+            batch_event_count,
+            team_count,
+            "Failed /v2/process request (deferred spike detection error)"
+        );
+        return Err(ProcessEventsError::Unhandled(err));
+    }
+
+    let duration = started_at.elapsed();
+    let duration_ms = duration.as_millis() as u64;
+    let is_slow = duration_ms >= ctx.config.process_slow_log_threshold_ms;
+
+    metrics::counter!(
+        PROCESS_REQUESTS_TOTAL,
+        "outcome" => "success",
+        "status_class" => "2xx",
+        "endpoint" => "v2"
+    )
+    .increment(1);
+    metrics::histogram!(PROCESS_REQUEST_DURATION_SECONDS, "endpoint" => "v2")
+        .record(duration.as_secs_f64());
+
+    if is_slow {
+        warn!(
+            request_id = %request_id,
+            duration_ms,
+            batch_event_count,
+            team_count,
+            process_count,
+            drop_count,
+            retry_count,
+            dlq_count,
+            "Completed /v2/process request (slow)"
+        );
+    } else {
+        debug!(
+            request_id = %request_id,
+            duration_ms,
+            batch_event_count,
+            team_count,
+            process_count,
+            drop_count,
+            retry_count,
+            dlq_count,
+            "Completed /v2/process request"
+        );
+    }
+
+    Ok(Json(verdicts))
+}
+
+/// Drive every event through its own isolated pipeline invocation and
+/// collect the verdicts. Each event gets the same deadline budget but runs
+/// concurrently with the others.
+///
+/// The whole join is also bounded by the request deadline: if for any
+/// reason events are still in flight when the request deadline elapses,
+/// the unfinished ones collapse to a `retry/deadline_exceeded` verdict so
+/// the response can return on time.
+async fn run_isolated_per_event(
+    ctx: Arc<AppContext>,
+    events: Vec<AnyEvent>,
+    request_deadline: Instant,
+    per_event_budget: Duration,
+    shared_batch_issue_cache: Cache<(TeamId, String), Issue>,
+    spike_alert_accumulator: Arc<SpikeAlertAccumulator>,
+) -> Vec<EventVerdict> {
+    let event_count = events.len();
+    if event_count == 0 {
+        return Vec::new();
+    }
+
+    let now = Instant::now();
+    let per_event_deadlines: Vec<Instant> = (0..event_count)
+        .map(|_| (now + per_event_budget).min(request_deadline))
+        .collect();
+
+    let futures = events
+        .into_iter()
+        .zip(per_event_deadlines)
+        .map(|(event, deadline)| {
+            let ctx = ctx.clone();
+            // Cloning the moka cache is a refcount bump on the underlying
+            // storage — every per-event invocation sees the same data.
+            let cache = shared_batch_issue_cache.clone();
+            let acc = spike_alert_accumulator.clone();
+            async move { verdict_for_single_event(ctx, event, deadline, cache, acc).await }
+        });
+
+    let request_remaining = request_deadline.duration_since(Instant::now());
+
+    match tokio::time::timeout(request_remaining, join_all(futures)).await {
+        Ok(verdicts) => verdicts,
+        Err(_) => {
+            // The request budget elapsed before all per-event futures
+            // resolved. This should be rare — per-event deadlines should
+            // bring each event home first. Track it explicitly so it's
+            // alertable if it starts happening.
+            metrics::counter!(VERDICT_REQUEST_DEADLINE_EXHAUSTED_TOTAL).increment(1);
+            warn!(
+                event_count,
+                "Request deadline exhausted with events still in flight; \
+                 filling with retry/deadline_exceeded verdicts"
+            );
+            // We don't have position-level resolution here (the join_all
+            // was abandoned). All positions get the same fallback. This is
+            // a degraded-mode response.
+            std::iter::repeat_with(|| EventVerdict::Retry {
+                reason: RetryReason::DeadlineExceeded,
+                retry_after_ms: None,
+            })
+            .take(event_count)
+            .collect()
+        }
+    }
+}
+
+/// Run the existing pipeline on a single event (as a `Batch<1>`) with the
+/// per-event deadline and panic catching applied, then convert the result
+/// to an `EventVerdict`.
+async fn verdict_for_single_event(
+    ctx: Arc<AppContext>,
+    event: AnyEvent,
+    deadline: Instant,
+    batch_issue_cache: Cache<(TeamId, String), Issue>,
+    spike_alert_accumulator: Arc<SpikeAlertAccumulator>,
+) -> EventVerdict {
+    let started = Instant::now();
+    let remaining = match deadline.checked_duration_since(started) {
+        Some(d) if !d.is_zero() => d,
+        _ => {
+            // Already past deadline before we started — emit retry
+            // without doing more work. Possible if the request deadline
+            // is tighter than the per-event budget for the last events
+            // in the batch.
+            metrics::counter!(VERDICT_DEADLINE_FALLBACK_TOTAL).increment(1);
+            return EventVerdict::Retry {
+                reason: RetryReason::DeadlineExceeded,
+                retry_after_ms: None,
+            };
+        }
+    };
+
+    let work = async {
+        let pipeline =
+            HttpEventPipeline::new(ctx, Some(batch_issue_cache), Some(spike_alert_accumulator));
+        let input = Batch::from(vec![event]);
+        pipeline.process(input).await
+    };
+
+    // catch_unwind absorbs panics from inside the pipeline so one event's
+    // panic doesn't taint another's verdict.
+    let panic_safe = AssertUnwindSafe(work).catch_unwind();
+
+    let verdict = match tokio::time::timeout(remaining, panic_safe).await {
+        Ok(Ok(Ok(batch))) => verdict_from_pipeline_output(batch),
+        Ok(Ok(Err(unhandled))) => {
+            // UnhandledError from the pipeline — classify as retry per the
+            // contract. Cymbal does not assert the event is broken; we
+            // don't know whether the failure is event-caused or cymbal-side.
+            EventVerdict::from(unhandled)
+        }
+        Ok(Err(panic_payload)) => {
+            warn!(
+                "Per-event pipeline panicked: {}",
+                panic_message(&panic_payload)
+            );
+            metrics::counter!(VERDICT_PANIC_TOTAL).increment(1);
+            EventVerdict::Retry {
+                reason: RetryReason::UnhandledProcessingError,
+                retry_after_ms: None,
+            }
+        }
+        Err(_elapsed) => {
+            metrics::counter!(VERDICT_DEADLINE_FALLBACK_TOTAL).increment(1);
+            EventVerdict::Retry {
+                reason: RetryReason::DeadlineExceeded,
+                retry_after_ms: None,
+            }
+        }
+    };
+
+    metrics::histogram!(VERDICT_DURATION_SECONDS, "status" => verdict.status_label())
+        .record(started.elapsed().as_secs_f64());
+
+    verdict
+}
+
+/// Convert a successful pipeline output (a `Batch<Option<AnyEvent>>` from
+/// the existing pipeline) into an `EventVerdict`. The pipeline returns
+/// `Some(event)` for events it processed and `None` for suppressed events
+/// (the legacy "drop" signal). Per-event isolation guarantees the input
+/// was a `Batch<1>`, so the output must also be length 1.
+fn verdict_from_pipeline_output(batch: Batch<Option<AnyEvent>>) -> EventVerdict {
+    let mut iter = Vec::from(batch).into_iter();
+    match iter.next() {
+        Some(Some(event)) => EventVerdict::Process {
+            event: Box::new(event),
+        },
+        // The existing pipeline returns None for suppressed events. We
+        // don't have visibility into whether it was issue-status or
+        // rule-based suppression from the pipeline output alone, so we
+        // emit a generic "issue_suppressed" drop reason. The pipeline's
+        // own EventError variants distinguish the cases at the metric
+        // layer (SuppressionRules vs IssueSuppression operators).
+        Some(None) => EventVerdict::Drop {
+            reason: crate::types::verdict::DropReason::IssueSuppressed,
+        },
+        // The pipeline returned an empty batch for a Batch<1> input.
+        // This is a contract violation by the pipeline itself; treat as
+        // retry so the pipeline can be debugged without dropping events.
+        None => EventVerdict::Retry {
+            reason: RetryReason::UnhandledProcessingError,
+            retry_after_ms: None,
+        },
+    }
+}
+
+/// Run spike detection once at end-of-request with the merged inputs from
+/// every per-event invocation. Equivalent to `SpikeAlertStage`'s inline
+/// call in the legacy flow, just deferred so a single Redis call covers
+/// the whole request rather than one per event.
+///
+/// Errors propagate to the caller — matching the legacy semantics where a
+/// spike-detection failure 500s the request and the client retries. Spike
+/// alerts are a customer-facing feature, not a fire-and-forget side
+/// effect; silently dropping a failure here would mean missed alerts.
+async fn run_deferred_spike_detection(
+    ctx: Arc<AppContext>,
+    accumulator: Arc<SpikeAlertAccumulator>,
+) -> Result<(), crate::error::UnhandledError> {
+    let state = accumulator.take().await;
+    if state.issues.is_empty() {
+        return Ok(());
+    }
+
+    let counts = state.issues_count_by_id();
+    let props = state.issue_props_by_id.clone();
+    let by_id = state.issues_by_id();
+
+    do_spike_detection(ctx, by_id, props, counts).await
+}
+
+fn record_verdict_metrics(verdicts: &[EventVerdict]) {
+    for verdict in verdicts {
+        metrics::counter!(
+            VERDICTS_EMITTED_TOTAL,
+            "status" => verdict.status_label(),
+            "reason" => verdict.reason_label(),
+        )
+        .increment(1);
+    }
+}
+
+/// Best-effort extraction of a string description from a `catch_unwind`
+/// payload. Falls back to a fixed label when the payload isn't a string.
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "<non-string panic payload>".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::issue_resolution::{Issue, IssueStatus};
+    use crate::stages::alerting::SpikeAlertAccumulatorState;
+    use crate::types::verdict::DlqReason;
+    use crate::types::verdict::DropReason;
+    use uuid::Uuid;
+
+    fn make_event() -> AnyEvent {
+        AnyEvent {
+            uuid: Uuid::nil(),
+            event: "$exception".to_string(),
+            team_id: 1,
+            timestamp: "2026-05-21T00:00:00Z".to_string(),
+            properties: serde_json::json!({}),
+            others: Default::default(),
+        }
+    }
+
+    #[test]
+    fn verdict_from_pipeline_output_maps_some_to_process() {
+        let event = make_event();
+        let batch = Batch::from(vec![Some(event.clone())]);
+
+        let verdict = verdict_from_pipeline_output(batch);
+        match verdict {
+            EventVerdict::Process { event: returned } => {
+                assert_eq!(returned.uuid, event.uuid);
+            }
+            other => panic!("expected Process, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn verdict_from_pipeline_output_maps_none_to_drop() {
+        let batch: Batch<Option<AnyEvent>> = Batch::from(vec![None]);
+
+        let verdict = verdict_from_pipeline_output(batch);
+        assert!(matches!(
+            verdict,
+            EventVerdict::Drop {
+                reason: DropReason::IssueSuppressed,
+            }
+        ));
+    }
+
+    #[test]
+    fn verdict_from_pipeline_output_maps_empty_to_retry() {
+        // A pipeline that returns an empty batch for a Batch<1> input is
+        // a contract violation. Emit Retry so the pipeline can be debugged
+        // without silently dropping events.
+        let batch: Batch<Option<AnyEvent>> = Batch::from(Vec::<Option<AnyEvent>>::new());
+
+        let verdict = verdict_from_pipeline_output(batch);
+        assert!(matches!(
+            verdict,
+            EventVerdict::Retry {
+                reason: RetryReason::UnhandledProcessingError,
+                ..
+            }
+        ));
+    }
+
+    /// Reference test for the From<EventError> conversion. The actual
+    /// `From<EventError>` lives in `types::verdict`; this is here to keep
+    /// the v2 handler's intended verdict shape under regression coverage —
+    /// if a stage starts emitting an EventError that maps differently, this
+    /// test will need updating along with `From<EventError>`.
+    #[test]
+    fn invalid_properties_event_error_becomes_dlq_via_existing_from_impl() {
+        use crate::error::EventError;
+        let err = EventError::InvalidProperties(Uuid::nil(), "bad properties".to_string());
+        let verdict: EventVerdict = err.into();
+        assert!(matches!(
+            verdict,
+            EventVerdict::Dlq {
+                reason: DlqReason::InvalidProperties,
+            }
+        ));
+    }
+
+    /// The deferred spike-detection inputs are aggregated by
+    /// `SpikeAlertAccumulatorState`. This is the unit that the request
+    /// handler hands to `do_spike_detection` once at end-of-request, so
+    /// its shape is what makes the deferred Redis call single-shot.
+    #[test]
+    fn accumulator_state_counts_and_maps_issues() {
+        let issue_alpha = Issue {
+            id: Uuid::from_u128(1),
+            team_id: 7,
+            status: IssueStatus::Active,
+            name: None,
+            description: None,
+            created_at: chrono::Utc::now(),
+        };
+        let issue_beta = Issue {
+            id: Uuid::from_u128(2),
+            team_id: 7,
+            status: IssueStatus::Active,
+            name: None,
+            description: None,
+            created_at: chrono::Utc::now(),
+        };
+
+        // Simulate 3 per-event pipelines contributing: 2 for alpha, 1 for
+        // beta. In production this is built up by `record_batch` calls
+        // from each AlertingStage invocation; for the aggregation unit
+        // test we construct the state directly.
+        let state = SpikeAlertAccumulatorState {
+            issues: vec![issue_alpha.clone(), issue_alpha.clone(), issue_beta.clone()],
+            issue_props_by_id: Default::default(),
+        };
+
+        let counts = state.issues_count_by_id();
+        assert_eq!(counts.get(&issue_alpha.id), Some(&2));
+        assert_eq!(counts.get(&issue_beta.id), Some(&1));
+        assert_eq!(counts.len(), 2);
+
+        let by_id = state.issues_by_id();
+        assert_eq!(by_id.len(), 2);
+        assert!(by_id.contains_key(&issue_alpha.id));
+        assert!(by_id.contains_key(&issue_beta.id));
+    }
+}

--- a/rust/cymbal/src/router/event_v2.rs
+++ b/rust/cymbal/src/router/event_v2.rs
@@ -1,4 +1,4 @@
-//! `/v2/process` request handler. Returns per-event dispositions in a
+//! `/v2/resolve` request handler. Returns per-event dispositions in a
 //! structured response shape that the ingestion pipeline can route on
 //! without inference.
 //!
@@ -46,10 +46,10 @@ use crate::{
     types::{event::AnyEvent, event_disposition::EventDisposition},
 };
 
-/// Handler for `POST /v2/process`. Accepts a JSON array of events and
+/// Handler for `POST /v2/resolve`. Accepts a JSON array of events and
 /// returns a JSON array of dispositions aligned 1:1 with the input.
 #[axum::debug_handler]
-pub async fn process_events_v2(
+pub async fn resolve_events_v2(
     State(ctx): State<Arc<AppContext>>,
     headers: HeaderMap,
     Json(events): Json<Vec<AnyEvent>>,
@@ -71,7 +71,7 @@ pub async fn process_events_v2(
         request_id = %request_id,
         batch_event_count,
         team_count,
-        "Started /v2/process request"
+        "Started /v2/resolve request"
     );
 
     // Same backpressure semaphore as /process — when the in-flight limit is
@@ -99,7 +99,7 @@ pub async fn process_events_v2(
                 request_id = %request_id,
                 batch_event_count,
                 team_count,
-                "Rejected /v2/process request due to backpressure"
+                "Rejected /v2/resolve request due to backpressure"
             );
             ProcessEventsError::Backpressure
         })?;
@@ -153,7 +153,7 @@ pub async fn process_events_v2(
             duration_ms,
             batch_event_count,
             team_count,
-            "Failed /v2/process request (deferred spike detection error)"
+            "Failed /v2/resolve request (deferred spike detection error)"
         );
         return Err(ProcessEventsError::Unhandled(err));
     }
@@ -184,7 +184,7 @@ pub async fn process_events_v2(
             drop_count = disposition_counts.drop,
             retry_count = disposition_counts.retry,
             dlq_count = disposition_counts.dlq,
-            "Completed /v2/process request (slow)"
+            "Completed /v2/resolve request (slow)"
         );
     } else {
         debug!(
@@ -196,7 +196,7 @@ pub async fn process_events_v2(
             drop_count = disposition_counts.drop,
             retry_count = disposition_counts.retry,
             dlq_count = disposition_counts.dlq,
-            "Completed /v2/process request"
+            "Completed /v2/resolve request"
         );
     }
 

--- a/rust/cymbal/src/router/event_v2.rs
+++ b/rust/cymbal/src/router/event_v2.rs
@@ -1,12 +1,12 @@
-//! `/v2/process` request handler. Returns per-event verdicts in a
+//! `/v2/process` request handler. Returns per-event dispositions in a
 //! structured response shape that the ingestion pipeline can route on
 //! without inference.
 //!
-//! Isolation model: each input event runs through the existing
-//! `HttpEventPipeline` as its own `Batch<1>` in a separate future, wrapped
+//! Isolation model: each input event runs through the core HTTP processing
+//! pipeline as its own `Batch<1>` in a separate future, wrapped
 //! in a per-event timeout and `catch_unwind`. A failure (panic, timeout, or
-//! `UnhandledError`) for one event becomes a `retry` verdict for that
-//! position only — the request still returns verdicts for every other
+//! `UnhandledError`) for one event becomes a `retry` disposition for that
+//! position only — the request still returns dispositions for every other
 //! event in the batch.
 //!
 //! Per-request shared state restores the cross-event optimizations the
@@ -26,44 +26,34 @@ use axum::{
     extract::{Json, State},
     http::HeaderMap,
 };
-use futures::future::join_all;
-use futures::FutureExt;
-use moka::future::Cache;
-use std::panic::AssertUnwindSafe;
 use tokio::time::Instant;
 use tracing::{debug, error, warn};
 
 use crate::{
     app_context::AppContext,
-    issue_resolution::Issue,
     metric_consts::{
-        ERRORS, PROCESS_BATCH_EVENTS, PROCESS_REQUESTS_TOTAL, PROCESS_REQUEST_DURATION_SECONDS,
-        VERDICTS_EMITTED_TOTAL, VERDICT_DEADLINE_FALLBACK_TOTAL, VERDICT_DURATION_SECONDS,
-        VERDICT_PANIC_TOTAL, VERDICT_REQUEST_DEADLINE_EXHAUSTED_TOTAL,
+        DISPOSITIONS_EMITTED_TOTAL, ERRORS, PROCESS_BATCH_EVENTS, PROCESS_REQUESTS_TOTAL,
+        PROCESS_REQUEST_DURATION_SECONDS,
     },
-    router::event::{get_request_id, ProcessEventsError, ProcessInFlightGuard},
+    router::{
+        event::{get_request_id, ProcessEventsError, ProcessInFlightGuard},
+        event_disposition_processor::PerEventDispositionProcessor,
+    },
     stages::{
         alerting::{spike_detection::do_spike_detection, SpikeAlertAccumulator},
-        http_pipeline::HttpEventPipeline,
         linking::LinkingStage,
     },
-    types::{
-        batch::Batch,
-        event::AnyEvent,
-        operator::TeamId,
-        stage::Stage,
-        verdict::{EventVerdict, RetryReason},
-    },
+    types::{event::AnyEvent, event_disposition::EventDisposition},
 };
 
 /// Handler for `POST /v2/process`. Accepts a JSON array of events and
-/// returns a JSON array of verdicts aligned 1:1 with the input.
+/// returns a JSON array of dispositions aligned 1:1 with the input.
 #[axum::debug_handler]
 pub async fn process_events_v2(
     State(ctx): State<Arc<AppContext>>,
     headers: HeaderMap,
     Json(events): Json<Vec<AnyEvent>>,
-) -> Result<Json<Vec<EventVerdict>>, ProcessEventsError> {
+) -> Result<Json<Vec<EventDisposition>>, ProcessEventsError> {
     let _in_flight = ProcessInFlightGuard::start();
     let request_id = get_request_id(&headers);
     let started_at = Instant::now();
@@ -128,29 +118,14 @@ pub async fn process_events_v2(
     let shared_batch_issue_cache = LinkingStage::default_batch_issue_cache();
     let spike_alert_accumulator = SpikeAlertAccumulator::new();
 
-    let verdicts = run_isolated_per_event(
+    let processor = PerEventDispositionProcessor::new(
         ctx.clone(),
-        events,
-        request_deadline,
         per_event_budget,
         shared_batch_issue_cache,
         spike_alert_accumulator.clone(),
-    )
-    .await;
-
-    record_verdict_metrics(&verdicts);
-
-    // Verdict-shape counters useful in completion logs. Computed once so
-    // both the slow-log and the success-log can include them.
-    let (process_count, drop_count, retry_count, dlq_count) =
-        verdicts
-            .iter()
-            .fold((0, 0, 0, 0), |(p, d, r, dl), v| match v {
-                EventVerdict::Process { .. } => (p + 1, d, r, dl),
-                EventVerdict::Drop { .. } => (p, d + 1, r, dl),
-                EventVerdict::Retry { .. } => (p, d, r + 1, dl),
-                EventVerdict::Dlq { .. } => (p, d, r, dl + 1),
-            });
+    );
+    let dispositions = processor.process_batch(events, request_deadline).await;
+    let disposition_counts = DispositionCounts::from_dispositions(&dispositions);
 
     // Run spike detection once with the merged inputs from every per-event
     // invocation. This is what makes the per-event isolation cheap: one
@@ -183,6 +158,8 @@ pub async fn process_events_v2(
         return Err(ProcessEventsError::Unhandled(err));
     }
 
+    record_disposition_metrics(&dispositions);
+
     let duration = started_at.elapsed();
     let duration_ms = duration.as_millis() as u64;
     let is_slow = duration_ms >= ctx.config.process_slow_log_threshold_ms;
@@ -203,10 +180,10 @@ pub async fn process_events_v2(
             duration_ms,
             batch_event_count,
             team_count,
-            process_count,
-            drop_count,
-            retry_count,
-            dlq_count,
+            forward_count = disposition_counts.forward,
+            drop_count = disposition_counts.drop,
+            retry_count = disposition_counts.retry,
+            dlq_count = disposition_counts.dlq,
             "Completed /v2/process request (slow)"
         );
     } else {
@@ -215,182 +192,15 @@ pub async fn process_events_v2(
             duration_ms,
             batch_event_count,
             team_count,
-            process_count,
-            drop_count,
-            retry_count,
-            dlq_count,
+            forward_count = disposition_counts.forward,
+            drop_count = disposition_counts.drop,
+            retry_count = disposition_counts.retry,
+            dlq_count = disposition_counts.dlq,
             "Completed /v2/process request"
         );
     }
 
-    Ok(Json(verdicts))
-}
-
-/// Drive every event through its own isolated pipeline invocation and
-/// collect the verdicts. Each event gets the same deadline budget but runs
-/// concurrently with the others.
-///
-/// The whole join is also bounded by the request deadline: if for any
-/// reason events are still in flight when the request deadline elapses,
-/// the unfinished ones collapse to a `retry/deadline_exceeded` verdict so
-/// the response can return on time.
-async fn run_isolated_per_event(
-    ctx: Arc<AppContext>,
-    events: Vec<AnyEvent>,
-    request_deadline: Instant,
-    per_event_budget: Duration,
-    shared_batch_issue_cache: Cache<(TeamId, String), Issue>,
-    spike_alert_accumulator: Arc<SpikeAlertAccumulator>,
-) -> Vec<EventVerdict> {
-    let event_count = events.len();
-    if event_count == 0 {
-        return Vec::new();
-    }
-
-    let now = Instant::now();
-    let per_event_deadlines: Vec<Instant> = (0..event_count)
-        .map(|_| (now + per_event_budget).min(request_deadline))
-        .collect();
-
-    let futures = events
-        .into_iter()
-        .zip(per_event_deadlines)
-        .map(|(event, deadline)| {
-            let ctx = ctx.clone();
-            // Cloning the moka cache is a refcount bump on the underlying
-            // storage — every per-event invocation sees the same data.
-            let cache = shared_batch_issue_cache.clone();
-            let acc = spike_alert_accumulator.clone();
-            async move { verdict_for_single_event(ctx, event, deadline, cache, acc).await }
-        });
-
-    let request_remaining = request_deadline.duration_since(Instant::now());
-
-    match tokio::time::timeout(request_remaining, join_all(futures)).await {
-        Ok(verdicts) => verdicts,
-        Err(_) => {
-            // The request budget elapsed before all per-event futures
-            // resolved. This should be rare — per-event deadlines should
-            // bring each event home first. Track it explicitly so it's
-            // alertable if it starts happening.
-            metrics::counter!(VERDICT_REQUEST_DEADLINE_EXHAUSTED_TOTAL).increment(1);
-            warn!(
-                event_count,
-                "Request deadline exhausted with events still in flight; \
-                 filling with retry/deadline_exceeded verdicts"
-            );
-            // We don't have position-level resolution here (the join_all
-            // was abandoned). All positions get the same fallback. This is
-            // a degraded-mode response.
-            std::iter::repeat_with(|| EventVerdict::Retry {
-                reason: RetryReason::DeadlineExceeded,
-                retry_after_ms: None,
-            })
-            .take(event_count)
-            .collect()
-        }
-    }
-}
-
-/// Run the existing pipeline on a single event (as a `Batch<1>`) with the
-/// per-event deadline and panic catching applied, then convert the result
-/// to an `EventVerdict`.
-async fn verdict_for_single_event(
-    ctx: Arc<AppContext>,
-    event: AnyEvent,
-    deadline: Instant,
-    batch_issue_cache: Cache<(TeamId, String), Issue>,
-    spike_alert_accumulator: Arc<SpikeAlertAccumulator>,
-) -> EventVerdict {
-    let started = Instant::now();
-    let remaining = match deadline.checked_duration_since(started) {
-        Some(d) if !d.is_zero() => d,
-        _ => {
-            // Already past deadline before we started — emit retry
-            // without doing more work. Possible if the request deadline
-            // is tighter than the per-event budget for the last events
-            // in the batch.
-            metrics::counter!(VERDICT_DEADLINE_FALLBACK_TOTAL).increment(1);
-            return EventVerdict::Retry {
-                reason: RetryReason::DeadlineExceeded,
-                retry_after_ms: None,
-            };
-        }
-    };
-
-    let work = async {
-        let pipeline =
-            HttpEventPipeline::new(ctx, Some(batch_issue_cache), Some(spike_alert_accumulator));
-        let input = Batch::from(vec![event]);
-        pipeline.process(input).await
-    };
-
-    // catch_unwind absorbs panics from inside the pipeline so one event's
-    // panic doesn't taint another's verdict.
-    let panic_safe = AssertUnwindSafe(work).catch_unwind();
-
-    let verdict = match tokio::time::timeout(remaining, panic_safe).await {
-        Ok(Ok(Ok(batch))) => verdict_from_pipeline_output(batch),
-        Ok(Ok(Err(unhandled))) => {
-            // UnhandledError from the pipeline — classify as retry per the
-            // contract. Cymbal does not assert the event is broken; we
-            // don't know whether the failure is event-caused or cymbal-side.
-            EventVerdict::from(unhandled)
-        }
-        Ok(Err(panic_payload)) => {
-            warn!(
-                "Per-event pipeline panicked: {}",
-                panic_message(&panic_payload)
-            );
-            metrics::counter!(VERDICT_PANIC_TOTAL).increment(1);
-            EventVerdict::Retry {
-                reason: RetryReason::UnhandledProcessingError,
-                retry_after_ms: None,
-            }
-        }
-        Err(_elapsed) => {
-            metrics::counter!(VERDICT_DEADLINE_FALLBACK_TOTAL).increment(1);
-            EventVerdict::Retry {
-                reason: RetryReason::DeadlineExceeded,
-                retry_after_ms: None,
-            }
-        }
-    };
-
-    metrics::histogram!(VERDICT_DURATION_SECONDS, "status" => verdict.status_label())
-        .record(started.elapsed().as_secs_f64());
-
-    verdict
-}
-
-/// Convert a successful pipeline output (a `Batch<Option<AnyEvent>>` from
-/// the existing pipeline) into an `EventVerdict`. The pipeline returns
-/// `Some(event)` for events it processed and `None` for suppressed events
-/// (the legacy "drop" signal). Per-event isolation guarantees the input
-/// was a `Batch<1>`, so the output must also be length 1.
-fn verdict_from_pipeline_output(batch: Batch<Option<AnyEvent>>) -> EventVerdict {
-    let mut iter = Vec::from(batch).into_iter();
-    match iter.next() {
-        Some(Some(event)) => EventVerdict::Process {
-            event: Box::new(event),
-        },
-        // The existing pipeline returns None for suppressed events. We
-        // don't have visibility into whether it was issue-status or
-        // rule-based suppression from the pipeline output alone, so we
-        // emit a generic "issue_suppressed" drop reason. The pipeline's
-        // own EventError variants distinguish the cases at the metric
-        // layer (SuppressionRules vs IssueSuppression operators).
-        Some(None) => EventVerdict::Drop {
-            reason: crate::types::verdict::DropReason::IssueSuppressed,
-        },
-        // The pipeline returned an empty batch for a Batch<1> input.
-        // This is a contract violation by the pipeline itself; treat as
-        // retry so the pipeline can be debugged without dropping events.
-        None => EventVerdict::Retry {
-            reason: RetryReason::UnhandledProcessingError,
-            retry_after_ms: None,
-        },
-    }
+    Ok(Json(dispositions))
 }
 
 /// Run spike detection once at end-of-request with the merged inputs from
@@ -418,110 +228,51 @@ async fn run_deferred_spike_detection(
     do_spike_detection(ctx, by_id, props, counts).await
 }
 
-fn record_verdict_metrics(verdicts: &[EventVerdict]) {
-    for verdict in verdicts {
+fn record_disposition_metrics(dispositions: &[EventDisposition]) {
+    for disposition in dispositions {
         metrics::counter!(
-            VERDICTS_EMITTED_TOTAL,
-            "status" => verdict.status_label(),
-            "reason" => verdict.reason_label(),
+            DISPOSITIONS_EMITTED_TOTAL,
+            "action" => disposition.action_label(),
+            "reason" => disposition.reason_label(),
         )
         .increment(1);
     }
 }
 
-/// Best-effort extraction of a string description from a `catch_unwind`
-/// payload. Falls back to a fixed label when the payload isn't a string.
-fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        return (*s).to_string();
+struct DispositionCounts {
+    forward: usize,
+    drop: usize,
+    retry: usize,
+    dlq: usize,
+}
+
+impl DispositionCounts {
+    fn from_dispositions(dispositions: &[EventDisposition]) -> Self {
+        dispositions.iter().fold(
+            Self {
+                forward: 0,
+                drop: 0,
+                retry: 0,
+                dlq: 0,
+            },
+            |mut counts, disposition| {
+                match disposition {
+                    EventDisposition::Forward { .. } => counts.forward += 1,
+                    EventDisposition::Drop { .. } => counts.drop += 1,
+                    EventDisposition::Retry { .. } => counts.retry += 1,
+                    EventDisposition::Dlq { .. } => counts.dlq += 1,
+                }
+                counts
+            },
+        )
     }
-    if let Some(s) = payload.downcast_ref::<String>() {
-        return s.clone();
-    }
-    "<non-string panic payload>".to_string()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::issue_resolution::{Issue, IssueStatus};
     use crate::stages::alerting::SpikeAlertAccumulatorState;
-    use crate::types::verdict::DlqReason;
-    use crate::types::verdict::DropReason;
     use uuid::Uuid;
-
-    fn make_event() -> AnyEvent {
-        AnyEvent {
-            uuid: Uuid::nil(),
-            event: "$exception".to_string(),
-            team_id: 1,
-            timestamp: "2026-05-21T00:00:00Z".to_string(),
-            properties: serde_json::json!({}),
-            others: Default::default(),
-        }
-    }
-
-    #[test]
-    fn verdict_from_pipeline_output_maps_some_to_process() {
-        let event = make_event();
-        let batch = Batch::from(vec![Some(event.clone())]);
-
-        let verdict = verdict_from_pipeline_output(batch);
-        match verdict {
-            EventVerdict::Process { event: returned } => {
-                assert_eq!(returned.uuid, event.uuid);
-            }
-            other => panic!("expected Process, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn verdict_from_pipeline_output_maps_none_to_drop() {
-        let batch: Batch<Option<AnyEvent>> = Batch::from(vec![None]);
-
-        let verdict = verdict_from_pipeline_output(batch);
-        assert!(matches!(
-            verdict,
-            EventVerdict::Drop {
-                reason: DropReason::IssueSuppressed,
-            }
-        ));
-    }
-
-    #[test]
-    fn verdict_from_pipeline_output_maps_empty_to_retry() {
-        // A pipeline that returns an empty batch for a Batch<1> input is
-        // a contract violation. Emit Retry so the pipeline can be debugged
-        // without silently dropping events.
-        let batch: Batch<Option<AnyEvent>> = Batch::from(Vec::<Option<AnyEvent>>::new());
-
-        let verdict = verdict_from_pipeline_output(batch);
-        assert!(matches!(
-            verdict,
-            EventVerdict::Retry {
-                reason: RetryReason::UnhandledProcessingError,
-                ..
-            }
-        ));
-    }
-
-    /// Reference test for the From<EventError> conversion. The actual
-    /// `From<EventError>` lives in `types::verdict`; this is here to keep
-    /// the v2 handler's intended verdict shape under regression coverage —
-    /// if a stage starts emitting an EventError that maps differently, this
-    /// test will need updating along with `From<EventError>`.
-    #[test]
-    fn invalid_properties_event_error_becomes_dlq_via_existing_from_impl() {
-        use crate::error::EventError;
-        let err = EventError::InvalidProperties(Uuid::nil(), "bad properties".to_string());
-        let verdict: EventVerdict = err.into();
-        assert!(matches!(
-            verdict,
-            EventVerdict::Dlq {
-                reason: DlqReason::InvalidProperties,
-            }
-        ));
-    }
 
     /// The deferred spike-detection inputs are aggregated by
     /// `SpikeAlertAccumulatorState`. This is the unit that the request

--- a/rust/cymbal/src/router/event_v2.rs
+++ b/rust/cymbal/src/router/event_v2.rs
@@ -32,11 +32,11 @@ use tracing::{debug, error, warn};
 use crate::{
     app_context::AppContext,
     metric_consts::{
-        DISPOSITIONS_EMITTED_TOTAL, ERRORS, PROCESS_BATCH_EVENTS, PROCESS_REQUESTS_TOTAL,
+        DISPOSITIONS_EMITTED_TOTAL, PROCESS_BATCH_EVENTS, PROCESS_REQUESTS_TOTAL,
         PROCESS_REQUEST_DURATION_SECONDS,
     },
     router::{
-        event::{get_request_id, ProcessEventsError, ProcessInFlightGuard},
+        event::{get_request_id, ProcessEndpoint, ProcessEventCapacityGuard, ProcessEventsError},
         event_disposition_processor::PerEventDispositionProcessor,
     },
     stages::{
@@ -54,7 +54,6 @@ pub async fn resolve_events_v2(
     headers: HeaderMap,
     Json(events): Json<Vec<AnyEvent>>,
 ) -> Result<Json<Vec<EventDisposition>>, ProcessEventsError> {
-    let _in_flight = ProcessInFlightGuard::start();
     let request_id = get_request_id(&headers);
     let started_at = Instant::now();
 
@@ -74,35 +73,13 @@ pub async fn resolve_events_v2(
         "Started /v2/resolve request"
     );
 
-    // Same backpressure semaphore as /process — when the in-flight limit is
-    // hit, this request is rejected with 429. This is the path cymbal uses
-    // to tell the client to back off; the inner CB on the client side will
-    // pick it up the same way it does for the legacy endpoint.
-    let _permit = ctx
-        .process_request_limiter
-        .clone()
-        .try_acquire_owned()
-        .map_err(|_| {
-            // Mirror legacy `/process` so existing alerts on
-            // `cymbal_errors{cause="process_backpressure"}` and
-            // `cymbal_process_requests_total{outcome="error", status_class="4xx"}`
-            // pick up v2 backpressure too.
-            metrics::counter!(ERRORS, "cause" => "process_backpressure").increment(1);
-            metrics::counter!(
-                PROCESS_REQUESTS_TOTAL,
-                "outcome" => "error",
-                "status_class" => "4xx",
-                "endpoint" => "v2"
-            )
-            .increment(1);
-            warn!(
-                request_id = %request_id,
-                batch_event_count,
-                team_count,
-                "Rejected /v2/resolve request due to backpressure"
-            );
-            ProcessEventsError::Backpressure
-        })?;
+    let _capacity = ProcessEventCapacityGuard::try_start(
+        &ctx,
+        ProcessEndpoint::ResolveV2,
+        &request_id,
+        batch_event_count,
+        team_count,
+    )?;
 
     // Deadlines: per-event budget caps how long any single event can take,
     // and the request deadline bounds the whole call. Per-event deadlines

--- a/rust/cymbal/src/router/mod.rs
+++ b/rust/cymbal/src/router/mod.rs
@@ -1,9 +1,11 @@
 mod event;
+mod event_v2;
 
 use axum::routing::{get, post};
 use axum::{extract::State, response::IntoResponse, Router};
 
 pub use event::*;
+pub use event_v2::*;
 
 use health::HealthStatus;
 use reqwest::StatusCode;
@@ -28,6 +30,7 @@ pub fn get_router(context: Arc<AppContext>) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/process", post(process_events))
+        .route("/v2/process", post(process_events_v2))
         .route("/_readiness", get(index))
         .route("/_liveness", get(liveness))
         .fallback(not_found)

--- a/rust/cymbal/src/router/mod.rs
+++ b/rust/cymbal/src/router/mod.rs
@@ -1,4 +1,5 @@
 mod event;
+mod event_disposition_processor;
 mod event_v2;
 
 use axum::routing::{get, post};

--- a/rust/cymbal/src/router/mod.rs
+++ b/rust/cymbal/src/router/mod.rs
@@ -31,7 +31,7 @@ pub fn get_router(context: Arc<AppContext>) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/process", post(process_events))
-        .route("/v2/process", post(process_events_v2))
+        .route("/v2/resolve", post(resolve_events_v2))
         .route("/_readiness", get(index))
         .route("/_liveness", get(liveness))
         .fallback(not_found)

--- a/rust/cymbal/src/stages/alerting/mod.rs
+++ b/rust/cymbal/src/stages/alerting/mod.rs
@@ -1,26 +1,124 @@
-use std::sync::Arc;
-mod spike_alert;
-mod spike_detection;
+use std::{collections::HashMap, sync::Arc};
+
+pub mod spike_alert;
+pub mod spike_detection;
+
+use tokio::sync::Mutex;
+use uuid::Uuid;
 
 use crate::{
     app_context::AppContext,
+    issue_resolution::Issue,
     metric_consts::ALERTING_STAGE,
     stages::{alerting::spike_alert::SpikeAlertStage, pipeline::ExceptionEventPipelineItem},
     types::{
         batch::Batch,
         stage::{Stage, StageResult},
+        OutputErrProps,
     },
 };
 
-#[derive(Clone)]
-pub struct AlertingStage {
-    context: Arc<AppContext>,
+/// Per-request accumulator for spike-detection inputs.
+///
+/// The legacy `/process` flow runs `SpikeAlertStage` at the end of the
+/// per-batch pipeline and does one batched Redis call covering every
+/// issue in the batch. The `/v2/process` flow runs the pipeline once per
+/// event for isolation — without this accumulator, each per-event run
+/// would make its own Redis call, amplifying call volume by a factor of
+/// events-per-request.
+///
+/// With the accumulator threaded through the per-event pipelines, every
+/// `AlertingStage` invocation appends its `(issue, props)` to the shared
+/// state instead of making a Redis call. The `/v2` handler runs spike
+/// detection **once** after all per-event work has finished, with the
+/// merged set of issues — recovering the single-Redis-call shape of the
+/// legacy flow.
+#[derive(Default)]
+pub struct SpikeAlertAccumulator {
+    state: Mutex<SpikeAlertAccumulatorState>,
 }
 
-impl From<&Arc<AppContext>> for AlertingStage {
-    fn from(app_context: &Arc<AppContext>) -> Self {
+#[derive(Default)]
+pub struct SpikeAlertAccumulatorState {
+    /// Every successfully-linked event appends its issue here. The vector
+    /// holds duplicates intentionally: spike detection counts events per
+    /// issue, so 3 events with the same issue produce 3 entries.
+    pub issues: Vec<Issue>,
+    /// One canonical `OutputErrProps` per issue — they share the same
+    /// stack shape, so we only need the first one we see.
+    pub issue_props_by_id: HashMap<Uuid, OutputErrProps>,
+}
+
+impl SpikeAlertAccumulator {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Record every successfully-linked event in `batch` into the
+    /// accumulator. Mirrors the iteration that `SpikeAlertStage::process`
+    /// does today, but writes into shared state instead of calling spike
+    /// detection immediately.
+    pub async fn record_batch(&self, batch: &Batch<ExceptionEventPipelineItem>) {
+        let mut state = self.state.lock().await;
+        for res in batch.inner_ref() {
+            let Ok(evt) = res else { continue };
+            let Some(issue) = &evt.issue else { continue };
+            // One canonical OutputErrProps per issue — first writer wins.
+            if let std::collections::hash_map::Entry::Vacant(e) =
+                state.issue_props_by_id.entry(issue.id)
+            {
+                if let Ok(props) = evt.to_output(issue.id) {
+                    e.insert(props);
+                }
+            }
+            state.issues.push(issue.clone());
+        }
+    }
+
+    /// Consume the accumulator, returning the aggregated state ready to
+    /// be passed to `do_spike_detection`.
+    pub async fn take(self: Arc<Self>) -> SpikeAlertAccumulatorState {
+        let mut state = self.state.lock().await;
+        std::mem::take(&mut *state)
+    }
+}
+
+impl SpikeAlertAccumulatorState {
+    /// Aggregate `issues` into a `(issue_id -> count)` map, mirroring the
+    /// fold `SpikeAlertStage::process` does in the legacy path.
+    pub fn issues_count_by_id(&self) -> HashMap<Uuid, u32> {
+        self.issues.iter().fold(HashMap::new(), |mut acc, issue| {
+            *acc.entry(issue.id).or_insert(0) += 1;
+            acc
+        })
+    }
+
+    /// Aggregate `issues` into a `(issue_id -> Issue)` map, dropping
+    /// duplicates — later writes win — they're identical structs because
+    /// they all came from the same issue in this request.
+    pub fn issues_by_id(self) -> HashMap<Uuid, Issue> {
+        self.issues
+            .into_iter()
+            .map(|issue| (issue.id, issue))
+            .collect()
+    }
+}
+
+pub struct AlertingStage {
+    context: Arc<AppContext>,
+    /// Optional accumulator for the deferred-mode `/v2/process` flow.
+    /// When `Some`, the stage appends events to the accumulator instead
+    /// of making Redis calls; the request handler invokes spike detection
+    /// once at end-of-request. When `None`, spike detection runs inline
+    /// for this batch (legacy `/process` behaviour).
+    accumulator: Option<Arc<SpikeAlertAccumulator>>,
+}
+
+impl AlertingStage {
+    pub fn new(context: Arc<AppContext>, accumulator: Option<Arc<SpikeAlertAccumulator>>) -> Self {
         Self {
-            context: app_context.clone(),
+            context,
+            accumulator,
         }
     }
 }
@@ -34,6 +132,16 @@ impl Stage for AlertingStage {
     }
 
     async fn process(self, batch: Batch<Self::Input>) -> StageResult<Self> {
-        batch.apply_stage(SpikeAlertStage::new(self.context)).await
+        match self.accumulator {
+            // Deferred mode: append to the shared accumulator. The /v2
+            // handler will run spike detection once at end-of-request
+            // with the merged batch.
+            Some(acc) => {
+                acc.record_batch(&batch).await;
+                Ok(batch)
+            }
+            // Legacy mode: run spike detection inline for this batch.
+            None => batch.apply_stage(SpikeAlertStage::new(self.context)).await,
+        }
     }
 }

--- a/rust/cymbal/src/stages/alerting/mod.rs
+++ b/rust/cymbal/src/stages/alerting/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 ///
 /// The legacy `/process` flow runs `SpikeAlertStage` at the end of the
 /// per-batch pipeline and does one batched Redis call covering every
-/// issue in the batch. The `/v2/process` flow runs the pipeline once per
+/// issue in the batch. The `/v2/resolve` flow runs the pipeline once per
 /// event for isolation — without this accumulator, each per-event run
 /// would make its own Redis call, amplifying call volume by a factor of
 /// events-per-request.
@@ -106,7 +106,7 @@ impl SpikeAlertAccumulatorState {
 
 pub struct AlertingStage {
     context: Arc<AppContext>,
-    /// Optional accumulator for the deferred-mode `/v2/process` flow.
+    /// Optional accumulator for the deferred-mode `/v2/resolve` flow.
     /// When `Some`, the stage appends events to the accumulator instead
     /// of making Redis calls; the request handler invokes spike detection
     /// once at end-of-request. When `None`, spike detection runs inline

--- a/rust/cymbal/src/stages/http_pipeline.rs
+++ b/rust/cymbal/src/stages/http_pipeline.rs
@@ -23,7 +23,7 @@ use crate::{
 /// Raw per-event result from Cymbal's HTTP processing pipeline, before any
 /// endpoint-specific response adaptation. The original event is kept alongside
 /// the processing result so callers can either enrich it (legacy `/process`) or
-/// map the handled error directly into a routing decision (`/v2/process`).
+/// map the handled error directly into a routing decision (`/v2/resolve`).
 pub struct HttpEventProcessingResult {
     pub original_event: AnyEvent,
     pub result: Result<ExceptionProperties, EventError>,
@@ -80,12 +80,12 @@ impl Stage for HttpEventProcessingPipeline {
 pub struct HttpEventPipeline {
     app_context: Arc<AppContext>,
     /// Optional shared per-batch issue cache, threaded down to `LinkingStage`.
-    /// `/v2/process` creates one cache per request and supplies it on every
+    /// `/v2/resolve` creates one cache per request and supplies it on every
     /// per-event invocation so they share fingerprint -> Issue dedup across
     /// the request. `None` for the legacy `/process` flow (linking stage
     /// allocates a fresh cache).
     batch_issue_cache: Option<Cache<(TeamId, String), Issue>>,
-    /// Optional accumulator for deferring spike-alert work. `/v2/process`
+    /// Optional accumulator for deferring spike-alert work. `/v2/resolve`
     /// creates one accumulator per request, threads it through every
     /// per-event invocation, and runs spike detection once at end-of-request
     /// with the merged inputs. `None` for the legacy `/process` flow

--- a/rust/cymbal/src/stages/http_pipeline.rs
+++ b/rust/cymbal/src/stages/http_pipeline.rs
@@ -1,25 +1,52 @@
 use std::sync::Arc;
 
+use moka::future::Cache;
+
 use crate::{
     app_context::AppContext,
     error::{EventError, UnhandledError},
+    issue_resolution::Issue,
     metric_consts::HTTP_EXCEPTION_PIPELINE,
-    stages::pipeline::{create_pre_post_processing, ExceptionEventPipeline, HandledError},
+    stages::{
+        alerting::SpikeAlertAccumulator,
+        pipeline::{create_pre_post_processing, ExceptionEventPipeline, HandledError},
+    },
     types::{
         batch::Batch,
         event::{AnyEvent, PropertiesContainer},
         exception_properties::ExceptionProperties,
+        operator::TeamId,
         stage::{Stage, StageResult},
     },
 };
 
 pub struct HttpEventPipeline {
     app_context: Arc<AppContext>,
+    /// Optional shared per-batch issue cache, threaded down to `LinkingStage`.
+    /// `/v2/process` creates one cache per request and supplies it on every
+    /// per-event invocation so they share fingerprint -> Issue dedup across
+    /// the request. `None` for the legacy `/process` flow (linking stage
+    /// allocates a fresh cache).
+    batch_issue_cache: Option<Cache<(TeamId, String), Issue>>,
+    /// Optional accumulator for deferring spike-alert work. `/v2/process`
+    /// creates one accumulator per request, threads it through every
+    /// per-event invocation, and runs spike detection once at end-of-request
+    /// with the merged inputs. `None` for the legacy `/process` flow
+    /// (alerting stage calls Redis inline).
+    spike_alert_accumulator: Option<Arc<SpikeAlertAccumulator>>,
 }
 
 impl HttpEventPipeline {
-    pub fn new(app_context: Arc<AppContext>) -> Self {
-        Self { app_context }
+    pub fn new(
+        app_context: Arc<AppContext>,
+        batch_issue_cache: Option<Cache<(TeamId, String), Issue>>,
+        spike_alert_accumulator: Option<Arc<SpikeAlertAccumulator>>,
+    ) -> Self {
+        Self {
+            app_context,
+            batch_issue_cache,
+            spike_alert_accumulator,
+        }
     }
 }
 
@@ -34,10 +61,17 @@ impl Stage for HttpEventPipeline {
     async fn process(self, batch: Batch<Self::Input>) -> StageResult<Self> {
         let (preprocess, postprocess) =
             create_pre_post_processing(batch.len(), Box::new(handle_result));
+
+        let exception_pipeline = ExceptionEventPipeline::new(
+            self.app_context.clone(),
+            self.batch_issue_cache,
+            self.spike_alert_accumulator,
+        );
+
         batch
             .apply_stage(preprocess)
             .await?
-            .apply_stage(ExceptionEventPipeline::new(self.app_context.clone()))
+            .apply_stage(exception_pipeline)
             .await?
             .apply_stage(postprocess)
             .await

--- a/rust/cymbal/src/stages/http_pipeline.rs
+++ b/rust/cymbal/src/stages/http_pipeline.rs
@@ -9,7 +9,7 @@ use crate::{
     metric_consts::HTTP_EXCEPTION_PIPELINE,
     stages::{
         alerting::SpikeAlertAccumulator,
-        pipeline::{create_pre_post_processing, ExceptionEventPipeline, HandledError},
+        pipeline::{create_pre_post_processing, ExceptionEventPipeline},
     },
     types::{
         batch::Batch,
@@ -19,6 +19,63 @@ use crate::{
         stage::{Stage, StageResult},
     },
 };
+
+/// Raw per-event result from Cymbal's HTTP processing pipeline, before any
+/// endpoint-specific response adaptation. The original event is kept alongside
+/// the processing result so callers can either enrich it (legacy `/process`) or
+/// map the handled error directly into a routing decision (`/v2/process`).
+pub struct HttpEventProcessingResult {
+    pub original_event: AnyEvent,
+    pub result: Result<ExceptionProperties, EventError>,
+}
+
+pub struct HttpEventProcessingPipeline {
+    app_context: Arc<AppContext>,
+    batch_issue_cache: Option<Cache<(TeamId, String), Issue>>,
+    spike_alert_accumulator: Option<Arc<SpikeAlertAccumulator>>,
+}
+
+impl HttpEventProcessingPipeline {
+    pub fn new(
+        app_context: Arc<AppContext>,
+        batch_issue_cache: Option<Cache<(TeamId, String), Issue>>,
+        spike_alert_accumulator: Option<Arc<SpikeAlertAccumulator>>,
+    ) -> Self {
+        Self {
+            app_context,
+            batch_issue_cache,
+            spike_alert_accumulator,
+        }
+    }
+}
+
+impl Stage for HttpEventProcessingPipeline {
+    type Input = AnyEvent;
+    type Output = HttpEventProcessingResult;
+
+    fn name(&self) -> &'static str {
+        HTTP_EXCEPTION_PIPELINE
+    }
+
+    async fn process(self, batch: Batch<Self::Input>) -> StageResult<Self> {
+        let (preprocess, postprocess) =
+            create_pre_post_processing(batch.len(), Box::new(preserve_result));
+
+        let exception_pipeline = ExceptionEventPipeline::new(
+            self.app_context.clone(),
+            self.batch_issue_cache,
+            self.spike_alert_accumulator,
+        );
+
+        batch
+            .apply_stage(preprocess)
+            .await?
+            .apply_stage(exception_pipeline)
+            .await?
+            .apply_stage(postprocess)
+            .await
+    }
+}
 
 pub struct HttpEventPipeline {
     app_context: Arc<AppContext>,
@@ -59,30 +116,36 @@ impl Stage for HttpEventPipeline {
     }
 
     async fn process(self, batch: Batch<Self::Input>) -> StageResult<Self> {
-        let (preprocess, postprocess) =
-            create_pre_post_processing(batch.len(), Box::new(handle_result));
-
-        let exception_pipeline = ExceptionEventPipeline::new(
-            self.app_context.clone(),
+        let processing_pipeline = HttpEventProcessingPipeline::new(
+            self.app_context,
             self.batch_issue_cache,
             self.spike_alert_accumulator,
         );
 
-        batch
-            .apply_stage(preprocess)
-            .await?
-            .apply_stage(exception_pipeline)
-            .await?
-            .apply_stage(postprocess)
-            .await
+        let processed = processing_pipeline.process(batch).await?;
+        let events = processed
+            .into_iter()
+            .map(handle_legacy_result)
+            .collect::<Result<Vec<_>, UnhandledError>>()?;
+        Ok(Batch::from(events))
     }
 }
 
-fn handle_result(
-    mut original: AnyEvent,
-    processed: Result<ExceptionProperties, HandledError>,
+fn preserve_result(
+    original: AnyEvent,
+    processed: Result<ExceptionProperties, EventError>,
+) -> Result<HttpEventProcessingResult, UnhandledError> {
+    Ok(HttpEventProcessingResult {
+        original_event: original,
+        result: processed,
+    })
+}
+
+fn handle_legacy_result(
+    result: HttpEventProcessingResult,
 ) -> Result<Option<AnyEvent>, UnhandledError> {
-    let item: Option<AnyEvent> = match processed {
+    let mut original = result.original_event;
+    let item: Option<AnyEvent> = match result.result {
         Ok(props) => {
             original.set_properties(props)?;
             Some(original)

--- a/rust/cymbal/src/stages/linking/mod.rs
+++ b/rust/cymbal/src/stages/linking/mod.rs
@@ -38,7 +38,7 @@ pub struct LinkingStage {
     // resolve the Issue exactly once. moka's `try_get_with` also deduplicates
     // concurrent misses for the same key inside the same batch.
     //
-    // The `/v2/process` flow runs the pipeline once per event for isolation. To
+    // The `/v2/resolve` flow runs the pipeline once per event for isolation. To
     // preserve cross-event dedup within a request, the handler creates one cache
     // and threads it through `new(ctx, Some(cache))` to every per-event invocation.
     pub batch_issue_cache: Cache<(TeamId, String), Issue>,
@@ -46,7 +46,7 @@ pub struct LinkingStage {
 
 impl LinkingStage {
     /// Build a `LinkingStage`. When `batch_issue_cache` is `Some`, the supplied
-    /// cache is reused (the `/v2/process` flow uses this to share one cache
+    /// cache is reused (the `/v2/resolve` flow uses this to share one cache
     /// across the per-event pipeline invocations within a single request).
     /// When `None`, a fresh per-batch cache is allocated — the legacy
     /// `/process` behaviour.
@@ -94,7 +94,7 @@ mod tests {
 
     /// A `LinkingStage` constructed with a supplied cache reuses that
     /// instance — multiple stages built around the same cache see each
-    /// other's writes. This is the property the `/v2/process` flow relies on.
+    /// other's writes. This is the property the `/v2/resolve` flow relies on.
     #[tokio::test]
     async fn supplied_batch_issue_cache_is_shared() {
         let shared = LinkingStage::default_batch_issue_cache();

--- a/rust/cymbal/src/stages/linking/mod.rs
+++ b/rust/cymbal/src/stages/linking/mod.rs
@@ -24,16 +24,49 @@ use crate::{
     },
 };
 
+/// Capacity for the per-batch issue cache. Generous because `MAX_EVENTS_PER_BATCH`
+/// is 1000 today; the cache is dropped when the stage is.
+const BATCH_ISSUE_CACHE_CAPACITY: u64 = 10_000;
+
 #[derive(Clone)]
 pub struct LinkingStage {
     pub app_context: Arc<AppContext>,
     // Cross-batch `(team_id, fingerprint) -> issue_id` mapping cache. Owned by AppContext.
     pub issue_cache: Cache<(TeamId, String), Uuid>,
     // Per-batch fingerprint -> Issue dedup. Built fresh per batch (LinkingStage is
-    // constructed per batch via `From`), so events sharing a fingerprint within a single
-    // batch resolve the Issue exactly once. moka's `try_get_with` also deduplicates
+    // constructed per batch), so events sharing a fingerprint within a single batch
+    // resolve the Issue exactly once. moka's `try_get_with` also deduplicates
     // concurrent misses for the same key inside the same batch.
+    //
+    // The `/v2/process` flow runs the pipeline once per event for isolation. To
+    // preserve cross-event dedup within a request, the handler creates one cache
+    // and threads it through `new(ctx, Some(cache))` to every per-event invocation.
     pub batch_issue_cache: Cache<(TeamId, String), Issue>,
+}
+
+impl LinkingStage {
+    /// Build a `LinkingStage`. When `batch_issue_cache` is `Some`, the supplied
+    /// cache is reused (the `/v2/process` flow uses this to share one cache
+    /// across the per-event pipeline invocations within a single request).
+    /// When `None`, a fresh per-batch cache is allocated — the legacy
+    /// `/process` behaviour.
+    pub fn new(
+        ctx: &Arc<AppContext>,
+        batch_issue_cache: Option<Cache<(TeamId, String), Issue>>,
+    ) -> Self {
+        Self {
+            app_context: ctx.clone(),
+            issue_cache: ctx.issue_cache.clone(),
+            batch_issue_cache: batch_issue_cache.unwrap_or_else(Self::default_batch_issue_cache),
+        }
+    }
+
+    /// Construct a fresh, empty per-batch cache sized for the largest batch we
+    /// support. Callers that need to share a cache across pipeline invocations
+    /// build one with this and pass it through `new` on each invocation.
+    pub fn default_batch_issue_cache() -> Cache<(TeamId, String), Issue> {
+        CacheBuilder::new(BATCH_ISSUE_CACHE_CAPACITY).build()
+    }
 }
 
 impl Stage for LinkingStage {
@@ -55,16 +88,62 @@ impl Stage for LinkingStage {
     }
 }
 
-impl From<&Arc<AppContext>> for LinkingStage {
-    fn from(ctx: &Arc<AppContext>) -> Self {
-        // `issue_cache` lives on AppContext so it survives across batches; cloning the
-        // moka handle is just a refcount bump on the underlying Arc.
-        // `batch_issue_cache` is built fresh per batch — capacity is generous because
-        // `MAX_EVENTS_PER_BATCH` is 1000 today; the cache is dropped when the stage is.
-        Self {
-            app_context: ctx.clone(),
-            issue_cache: ctx.issue_cache.clone(),
-            batch_issue_cache: CacheBuilder::new(10_000).build(),
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `LinkingStage` constructed with a supplied cache reuses that
+    /// instance — multiple stages built around the same cache see each
+    /// other's writes. This is the property the `/v2/process` flow relies on.
+    #[tokio::test]
+    async fn supplied_batch_issue_cache_is_shared() {
+        let shared = LinkingStage::default_batch_issue_cache();
+
+        let key = (42_i32, "fingerprint".to_string());
+        let sentinel = Issue {
+            id: Uuid::nil(),
+            team_id: 42,
+            status: crate::issue_resolution::IssueStatus::Active,
+            name: None,
+            description: None,
+            created_at: chrono::Utc::now(),
+        };
+        shared.insert(key.clone(), sentinel.clone()).await;
+
+        // Two clones of the cache (mirroring how the v2 handler hands the same
+        // cache to each per-event call) both see the previously-inserted
+        // sentinel — they share the underlying moka storage.
+        let view_one = shared.clone();
+        let view_two = shared.clone();
+
+        assert!(view_one.contains_key(&key));
+        assert!(view_two.contains_key(&key));
+
+        // A write through one clone is visible through the other.
+        let second_key = (42_i32, "another_fingerprint".to_string());
+        view_one.insert(second_key.clone(), sentinel.clone()).await;
+        assert!(view_two.contains_key(&second_key));
+    }
+
+    /// `new(ctx, None)` allocates an independent cache — the legacy
+    /// `/process` flow's behaviour is unchanged.
+    #[tokio::test]
+    async fn omitted_cache_means_fresh_per_stage() {
+        let cache_a = LinkingStage::default_batch_issue_cache();
+        let cache_b = LinkingStage::default_batch_issue_cache();
+
+        let key = (1_i32, "fp".to_string());
+        let sentinel = Issue {
+            id: Uuid::nil(),
+            team_id: 1,
+            status: crate::issue_resolution::IssueStatus::Active,
+            name: None,
+            description: None,
+            created_at: chrono::Utc::now(),
+        };
+        cache_a.insert(key.clone(), sentinel.clone()).await;
+
+        assert!(cache_a.contains_key(&key));
+        assert!(!cache_b.contains_key(&key));
     }
 }

--- a/rust/cymbal/src/stages/pipeline.rs
+++ b/rust/cymbal/src/stages/pipeline.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 
 use common_types::ClickHouseEvent;
+use moka::future::Cache;
 
 use crate::{
     app_context::AppContext,
     error::EventError,
+    issue_resolution::Issue,
     metric_consts::EXCEPTION_PROCESSING_PIPELINE,
     stages::{
-        alerting::AlertingStage,
+        alerting::{AlertingStage, SpikeAlertAccumulator},
         grouping::GroupingStage,
         linking::LinkingStage,
         post_processing::{PostProcessingHandler, PostProcessingStage},
@@ -17,17 +19,38 @@ use crate::{
     types::{
         batch::Batch,
         exception_properties::ExceptionProperties,
+        operator::TeamId,
         stage::{Stage, StageResult},
     },
 };
 
 pub struct ExceptionEventPipeline {
     app_context: Arc<AppContext>,
+    /// Optional override for `LinkingStage::batch_issue_cache`. When `Some`,
+    /// the supplied cache is reused; when `None`, the linking stage allocates
+    /// a fresh per-batch cache. The `/v2/process` handler creates one cache
+    /// per request and threads it through so every per-event invocation
+    /// shares the same fingerprint -> Issue dedup.
+    batch_issue_cache: Option<Cache<(TeamId, String), Issue>>,
+    /// Optional accumulator for deferring spike-alert work. When `Some`, the
+    /// alerting stage records events into shared state instead of calling
+    /// Redis; the `/v2` handler runs spike detection once at end-of-request
+    /// with the merged inputs. When `None`, spike detection runs inline at
+    /// the end of this batch (legacy `/process` behaviour).
+    spike_alert_accumulator: Option<Arc<SpikeAlertAccumulator>>,
 }
 
 impl ExceptionEventPipeline {
-    pub fn new(app_context: Arc<AppContext>) -> Self {
-        Self { app_context }
+    pub fn new(
+        app_context: Arc<AppContext>,
+        batch_issue_cache: Option<Cache<(TeamId, String), Issue>>,
+        spike_alert_accumulator: Option<Arc<SpikeAlertAccumulator>>,
+    ) -> Self {
+        Self {
+            app_context,
+            batch_issue_cache,
+            spike_alert_accumulator,
+        }
     }
 }
 
@@ -53,10 +76,13 @@ impl Stage for ExceptionEventPipeline {
             .apply_stage(GroupingStage::from(&self.app_context))
             .await?
             // Link events to issues and suppress
-            .apply_stage(LinkingStage::from(&self.app_context))
+            .apply_stage(LinkingStage::new(&self.app_context, self.batch_issue_cache))
             .await?
-            // Send internal events for alerting
-            .apply_stage(AlertingStage::from(&self.app_context))
+            // Send internal events for alerting (deferred if accumulator is Some)
+            .apply_stage(AlertingStage::new(
+                self.app_context,
+                self.spike_alert_accumulator,
+            ))
             .await
     }
 }

--- a/rust/cymbal/src/stages/pipeline.rs
+++ b/rust/cymbal/src/stages/pipeline.rs
@@ -28,7 +28,7 @@ pub struct ExceptionEventPipeline {
     app_context: Arc<AppContext>,
     /// Optional override for `LinkingStage::batch_issue_cache`. When `Some`,
     /// the supplied cache is reused; when `None`, the linking stage allocates
-    /// a fresh per-batch cache. The `/v2/process` handler creates one cache
+    /// a fresh per-batch cache. The `/v2/resolve` handler creates one cache
     /// per request and threads it through so every per-event invocation
     /// shares the same fingerprint -> Issue dedup.
     batch_issue_cache: Option<Cache<(TeamId, String), Issue>>,

--- a/rust/cymbal/src/types/event_disposition.rs
+++ b/rust/cymbal/src/types/event_disposition.rs
@@ -1,31 +1,40 @@
 use serde::{Deserialize, Serialize};
 
-use crate::error::{EventError, UnhandledError};
+use crate::error::UnhandledError;
 use crate::types::event::AnyEvent;
 
-/// Per-event outcome of `/process`. The full response is a `Vec<EventVerdict>`
+/// Per-event routing decision from `/v2/process`. The full response is a `Vec<EventDisposition>`
 /// aligned 1:1 with the input batch's events.
 ///
 /// This is the contract surface between cymbal and the ingestion pipeline.
-/// Cymbal commits to producing a verdict for every event within the request
-/// deadline; the pipeline routes each event according to its verdict without
+/// Cymbal commits to producing a disposition for every event within the request
+/// deadline; the pipeline routes each event according to its disposition without
 /// any classification logic of its own.
+///
+/// Wire examples:
+///
+/// ```json
+/// { "action": "forward", "event": { "event": "$exception" } }
+/// { "action": "drop", "reason": "issue_suppressed" }
+/// { "action": "retry", "reason": "deadline_exceeded" }
+/// { "action": "dlq", "reason": "invalid_properties" }
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "status", rename_all = "lowercase")]
-pub enum EventVerdict {
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum EventDisposition {
     /// Cymbal symbolicated the event; the updated event follows. The
     /// pipeline forwards downstream as normal.
-    Process { event: Box<AnyEvent> },
+    Forward { event: Box<AnyEvent> },
 
     /// Event was suppressed at the cymbal layer (by-design no-op). The
     /// pipeline must not forward it downstream.
     Drop { reason: DropReason },
 
-    /// Cymbal couldn't verdict this event in this attempt. The pipeline
+    /// Cymbal couldn't decide where this event should go in this attempt. The pipeline
     /// should retry; per-event retry exhaustion is the pipeline's concern
     /// (routes to overflow / DLQ by lane).
     ///
-    /// `Retry` is the safe-by-default verdict for any failure cymbal cannot
+    /// `Retry` is the safe-by-default disposition for any failure cymbal cannot
     /// affirmatively classify as broken event data — including panics,
     /// timeouts, and any transient infrastructure failure.
     Retry {
@@ -38,6 +47,11 @@ pub enum EventVerdict {
     /// pipeline must route to DLQ without further attempts. Reserved for
     /// cases cymbal can name with certainty (parse failures, schema
     /// violations, etc.).
+    ///
+    /// `/v2/process` currently preserves the legacy `/process` behavior for
+    /// handled event errors by forwarding the original event with
+    /// `$cymbal_errors` attached. This variant is reserved for future cases
+    /// where Cymbal can safely make a terminal DLQ decision.
     Dlq { reason: DlqReason },
 }
 
@@ -51,7 +65,7 @@ pub enum DropReason {
     SuppressedByRule,
 }
 
-/// Why cymbal couldn't verdict an event in this attempt.
+/// Why cymbal couldn't disposition an event in this attempt.
 ///
 /// Variants here represent ambiguous-or-cymbal-side failures: cymbal cannot
 /// tell whether the event data or cymbal itself is to blame, so the safe
@@ -61,7 +75,7 @@ pub enum DropReason {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RetryReason {
-    /// Cymbal's per-event deadline elapsed before producing a verdict.
+    /// Cymbal's per-event deadline elapsed before producing a disposition.
     DeadlineExceeded,
     /// A downstream sourcemap fetch timed out.
     SourcemapFetchTimeout,
@@ -90,26 +104,58 @@ pub enum DlqReason {
     EmptyExceptionList,
 }
 
-impl EventVerdict {
-    /// Short label used for metrics. Matches the JSON `status` value.
-    pub fn status_label(&self) -> &'static str {
-        match self {
-            EventVerdict::Process { .. } => "process",
-            EventVerdict::Drop { .. } => "drop",
-            EventVerdict::Retry { .. } => "retry",
-            EventVerdict::Dlq { .. } => "dlq",
+impl EventDisposition {
+    /// Classify an `UnhandledError` into a disposition.
+    ///
+    /// `UnhandledError` represents conditions cymbal cannot affirmatively call
+    /// event-broken — Kafka/Redis/SQL/S3 failures, serde mishaps, etc. The
+    /// honest disposition is always `Retry`; cymbal does not assert the event
+    /// is broken because we cannot distinguish event-caused failures from
+    /// cymbal-side or downstream-side ones at this level.
+    pub fn from_unhandled_error(err: UnhandledError) -> Self {
+        let reason = match err {
+            // Kafka / SQL / S3 / Redis are infrastructure dependencies; if
+            // they hiccup we'd rather have the pipeline retry than DLQ the
+            // event.
+            UnhandledError::KafkaError(_)
+            | UnhandledError::KafkaProduceError(_)
+            | UnhandledError::SqlxError(_)
+            | UnhandledError::S3Error(_)
+            | UnhandledError::ByteStreamError(_)
+            | UnhandledError::RedisError(_) => RetryReason::DownstreamTransient,
+            // SerdeError / ConfigError / Other are ambiguous — they could be
+            // cymbal bugs, event-data quirks we don't classify, or
+            // misconfiguration. Retry is the safe-by-default disposition per
+            // the contract.
+            UnhandledError::SerdeError(_)
+            | UnhandledError::ConfigError(_)
+            | UnhandledError::Other(_) => RetryReason::UnhandledProcessingError,
+        };
+        EventDisposition::Retry {
+            reason,
+            retry_after_ms: None,
         }
     }
 
-    /// Short label for the verdict's reason (or "ok" for `Process`). Used
+    /// Short label used for metrics. Matches the JSON `action` value.
+    pub fn action_label(&self) -> &'static str {
+        match self {
+            EventDisposition::Forward { .. } => "forward",
+            EventDisposition::Drop { .. } => "drop",
+            EventDisposition::Retry { .. } => "retry",
+            EventDisposition::Dlq { .. } => "dlq",
+        }
+    }
+
+    /// Short label for the disposition's reason (or "ok" for `Forward`). Used
     /// to label metric counters so operators can see *why* events landed in
-    /// each verdict.
+    /// each disposition.
     pub fn reason_label(&self) -> &'static str {
         match self {
-            EventVerdict::Process { .. } => "ok",
-            EventVerdict::Drop { reason } => reason.label(),
-            EventVerdict::Retry { reason, .. } => reason.label(),
-            EventVerdict::Dlq { reason } => reason.label(),
+            EventDisposition::Forward { .. } => "ok",
+            EventDisposition::Drop { reason } => reason.label(),
+            EventDisposition::Retry { reason, .. } => reason.label(),
+            EventDisposition::Dlq { reason } => reason.label(),
         }
     }
 }
@@ -157,121 +203,29 @@ impl DlqReason {
     }
 }
 
-/// Classify a per-event `EventError` into the verdict the contract demands.
-///
-/// `EventError` variants are cymbal's own affirmative classifications of an
-/// event's state — these are the cases where cymbal can name the outcome,
-/// so they map directly to terminal verdicts (`Drop` or `Dlq`).
-impl From<EventError> for EventVerdict {
-    fn from(err: EventError) -> Self {
-        match err {
-            EventError::Suppressed(_) => EventVerdict::Drop {
-                reason: DropReason::IssueSuppressed,
-            },
-            EventError::SuppressedByRule(_) => EventVerdict::Drop {
-                reason: DropReason::SuppressedByRule,
-            },
-            EventError::WrongEventType(_, _) => EventVerdict::Dlq {
-                reason: DlqReason::WrongEventType,
-            },
-            EventError::InvalidProperties(_, _) => EventVerdict::Dlq {
-                reason: DlqReason::InvalidProperties,
-            },
-            EventError::EmptyExceptionList(_) => EventVerdict::Dlq {
-                reason: DlqReason::EmptyExceptionList,
-            },
-        }
-    }
-}
-
-/// Classify an `UnhandledError` into a verdict.
-///
-/// `UnhandledError` represents conditions cymbal cannot affirmatively call
-/// event-broken — Kafka/Redis/SQL/S3 failures, serde mishaps, etc. The
-/// honest verdict is always `Retry`; cymbal does not assert the event is
-/// broken because we cannot distinguish event-caused failures from
-/// cymbal-side or downstream-side ones at this level.
-impl From<UnhandledError> for EventVerdict {
+impl From<UnhandledError> for EventDisposition {
     fn from(err: UnhandledError) -> Self {
-        let reason = match err {
-            // Kafka / SQL / S3 / Redis are infrastructure dependencies; if
-            // they hiccup we'd rather have the pipeline retry than DLQ the
-            // event.
-            UnhandledError::KafkaError(_)
-            | UnhandledError::KafkaProduceError(_)
-            | UnhandledError::SqlxError(_)
-            | UnhandledError::S3Error(_)
-            | UnhandledError::ByteStreamError(_)
-            | UnhandledError::RedisError(_) => RetryReason::DownstreamTransient,
-            // SerdeError / ConfigError / Other are ambiguous — they could be
-            // cymbal bugs, event-data quirks we don't classify, or
-            // misconfiguration. Retry is the safe-by-default verdict per the
-            // contract.
-            UnhandledError::SerdeError(_)
-            | UnhandledError::ConfigError(_)
-            | UnhandledError::Other(_) => RetryReason::UnhandledProcessingError,
-        };
-        EventVerdict::Retry {
-            reason,
-            retry_after_ms: None,
-        }
+        Self::from_unhandled_error(err)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use uuid::Uuid;
-
-    #[test]
-    fn event_error_maps_to_terminal_verdicts() {
-        let id = Uuid::nil();
-
-        let suppressed: EventVerdict = EventError::Suppressed(id).into();
-        assert!(matches!(
-            suppressed,
-            EventVerdict::Drop {
-                reason: DropReason::IssueSuppressed
-            }
-        ));
-
-        let suppressed_rule: EventVerdict = EventError::SuppressedByRule(id).into();
-        assert!(matches!(
-            suppressed_rule,
-            EventVerdict::Drop {
-                reason: DropReason::SuppressedByRule
-            }
-        ));
-
-        let wrong_type: EventVerdict = EventError::WrongEventType("foo".into(), id).into();
-        assert!(matches!(
-            wrong_type,
-            EventVerdict::Dlq {
-                reason: DlqReason::WrongEventType
-            }
-        ));
-
-        let empty: EventVerdict = EventError::EmptyExceptionList(id).into();
-        assert!(matches!(
-            empty,
-            EventVerdict::Dlq {
-                reason: DlqReason::EmptyExceptionList
-            }
-        ));
-    }
 
     #[test]
     fn unhandled_error_always_maps_to_retry() {
-        // Infrastructure dependency → DownstreamTransient.
-        let redis: EventVerdict = UnhandledError::Other("simulating redis blip".into()).into();
-        assert!(matches!(redis, EventVerdict::Retry { .. }));
+        // Ambiguous errors are still retryable — never DLQ.
+        let other: EventDisposition =
+            UnhandledError::Other("simulating processing blip".into()).into();
+        assert!(matches!(other, EventDisposition::Retry { .. }));
 
         // SerdeError / Other → UnhandledProcessingError. Both are Retry —
         // never Dlq — because cymbal can't tell whether the event or
         // cymbal itself is to blame.
-        let serde_err: EventVerdict = UnhandledError::Other("serde failure".into()).into();
+        let serde_err: EventDisposition = UnhandledError::Other("serde failure".into()).into();
         match serde_err {
-            EventVerdict::Retry {
+            EventDisposition::Retry {
                 reason: RetryReason::UnhandledProcessingError,
                 retry_after_ms: None,
             } => {}
@@ -288,37 +242,37 @@ mod tests {
     }
 
     #[test]
-    fn verdict_status_and_reason_labels_match_serialization() {
-        let drop = EventVerdict::Drop {
+    fn disposition_action_and_reason_labels_match_serialization() {
+        let drop = EventDisposition::Drop {
             reason: DropReason::IssueSuppressed,
         };
-        assert_eq!(drop.status_label(), "drop");
+        assert_eq!(drop.action_label(), "drop");
         assert_eq!(drop.reason_label(), "issue_suppressed");
 
-        let retry = EventVerdict::Retry {
+        let retry = EventDisposition::Retry {
             reason: RetryReason::DeadlineExceeded,
             retry_after_ms: None,
         };
-        assert_eq!(retry.status_label(), "retry");
+        assert_eq!(retry.action_label(), "retry");
         assert_eq!(retry.reason_label(), "deadline_exceeded");
 
-        let dlq = EventVerdict::Dlq {
+        let dlq = EventDisposition::Dlq {
             reason: DlqReason::WrongEventType,
         };
-        assert_eq!(dlq.status_label(), "dlq");
+        assert_eq!(dlq.action_label(), "dlq");
         assert_eq!(dlq.reason_label(), "wrong_event_type");
     }
 
     #[test]
-    fn drop_serializes_with_status_and_reason_tags() {
-        let drop = EventVerdict::Drop {
+    fn drop_serializes_with_action_and_reason_tags() {
+        let drop = EventDisposition::Drop {
             reason: DropReason::IssueSuppressed,
         };
         let json = serde_json::to_value(&drop).unwrap();
         assert_eq!(
             json,
             serde_json::json!({
-                "status": "drop",
+                "action": "drop",
                 "reason": "issue_suppressed"
             })
         );
@@ -326,7 +280,7 @@ mod tests {
 
     #[test]
     fn retry_serializes_with_optional_retry_after_ms() {
-        let no_hint = EventVerdict::Retry {
+        let no_hint = EventDisposition::Retry {
             reason: RetryReason::SourcemapFetchTimeout,
             retry_after_ms: None,
         };
@@ -334,12 +288,12 @@ mod tests {
         assert_eq!(
             json,
             serde_json::json!({
-                "status": "retry",
+                "action": "retry",
                 "reason": "sourcemap_fetch_timeout"
             })
         );
 
-        let with_hint = EventVerdict::Retry {
+        let with_hint = EventDisposition::Retry {
             reason: RetryReason::DownstreamTransient,
             retry_after_ms: Some(500),
         };
@@ -347,7 +301,7 @@ mod tests {
         assert_eq!(
             json,
             serde_json::json!({
-                "status": "retry",
+                "action": "retry",
                 "reason": "downstream_transient",
                 "retry_after_ms": 500
             })

--- a/rust/cymbal/src/types/event_disposition.rs
+++ b/rust/cymbal/src/types/event_disposition.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::UnhandledError;
 use crate::types::event::AnyEvent;
 
-/// Per-event routing decision from `/v2/process`. The full response is a `Vec<EventDisposition>`
+/// Per-event routing decision from `/v2/resolve`. The full response is a `Vec<EventDisposition>`
 /// aligned 1:1 with the input batch's events.
 ///
 /// This is the contract surface between cymbal and the ingestion pipeline.
@@ -48,7 +48,7 @@ pub enum EventDisposition {
     /// cases cymbal can name with certainty (parse failures, schema
     /// violations, etc.).
     ///
-    /// `/v2/process` currently preserves the legacy `/process` behavior for
+    /// `/v2/resolve` currently preserves the legacy `/process` behavior for
     /// handled event errors by forwarding the original event with
     /// `$cymbal_errors` attached. This variant is reserved for future cases
     /// where Cymbal can safely make a terminal DLQ decision.

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -26,6 +26,7 @@ pub mod event;
 pub mod exception_properties;
 pub mod operator;
 pub mod stage;
+pub mod verdict;
 
 pub use exception::*;
 pub use stacktrace::*;

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -23,10 +23,10 @@ mod stacktrace;
 
 pub mod batch;
 pub mod event;
+pub mod event_disposition;
 pub mod exception_properties;
 pub mod operator;
 pub mod stage;
-pub mod verdict;
 
 pub use exception::*;
 pub use stacktrace::*;

--- a/rust/cymbal/src/types/verdict.rs
+++ b/rust/cymbal/src/types/verdict.rs
@@ -1,0 +1,356 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::{EventError, UnhandledError};
+use crate::types::event::AnyEvent;
+
+/// Per-event outcome of `/process`. The full response is a `Vec<EventVerdict>`
+/// aligned 1:1 with the input batch's events.
+///
+/// This is the contract surface between cymbal and the ingestion pipeline.
+/// Cymbal commits to producing a verdict for every event within the request
+/// deadline; the pipeline routes each event according to its verdict without
+/// any classification logic of its own.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum EventVerdict {
+    /// Cymbal symbolicated the event; the updated event follows. The
+    /// pipeline forwards downstream as normal.
+    Process { event: Box<AnyEvent> },
+
+    /// Event was suppressed at the cymbal layer (by-design no-op). The
+    /// pipeline must not forward it downstream.
+    Drop { reason: DropReason },
+
+    /// Cymbal couldn't verdict this event in this attempt. The pipeline
+    /// should retry; per-event retry exhaustion is the pipeline's concern
+    /// (routes to overflow / DLQ by lane).
+    ///
+    /// `Retry` is the safe-by-default verdict for any failure cymbal cannot
+    /// affirmatively classify as broken event data — including panics,
+    /// timeouts, and any transient infrastructure failure.
+    Retry {
+        reason: RetryReason,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        retry_after_ms: Option<u64>,
+    },
+
+    /// Event is affirmatively broken — retrying it would not help. The
+    /// pipeline must route to DLQ without further attempts. Reserved for
+    /// cases cymbal can name with certainty (parse failures, schema
+    /// violations, etc.).
+    Dlq { reason: DlqReason },
+}
+
+/// Why an event was dropped at cymbal.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DropReason {
+    /// The event's issue is suppressed by issue status.
+    IssueSuppressed,
+    /// The event's issue is suppressed by a suppression rule.
+    SuppressedByRule,
+}
+
+/// Why cymbal couldn't verdict an event in this attempt.
+///
+/// Variants here represent ambiguous-or-cymbal-side failures: cymbal cannot
+/// tell whether the event data or cymbal itself is to blame, so the safe
+/// answer is retry. If cymbal's own resources are the predominant cause of
+/// retries across recent traffic, cymbal will additionally escalate
+/// subsequent requests to HTTP 429.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryReason {
+    /// Cymbal's per-event deadline elapsed before producing a verdict.
+    DeadlineExceeded,
+    /// A downstream sourcemap fetch timed out.
+    SourcemapFetchTimeout,
+    /// Cymbal threw an unhandled exception (panic or wrapped error) while
+    /// processing this event. The pipeline should retry; if the failure
+    /// persists across retries, it routes to overflow / DLQ.
+    UnhandledProcessingError,
+    /// A transient infrastructure dependency was unavailable (Kafka, Redis,
+    /// SQL, S3, etc.).
+    DownstreamTransient,
+}
+
+/// Why an event was determined to be broken.
+///
+/// Cymbal must only emit `Dlq` for events it can affirmatively call broken.
+/// Anything ambiguous — including unhandled errors and panics during
+/// processing — must use `Retry` instead.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DlqReason {
+    /// The event type is not one cymbal handles.
+    WrongEventType,
+    /// The event's properties failed schema deserialization.
+    InvalidProperties,
+    /// The event's exception list was empty — nothing to process.
+    EmptyExceptionList,
+}
+
+impl EventVerdict {
+    /// Short label used for metrics. Matches the JSON `status` value.
+    pub fn status_label(&self) -> &'static str {
+        match self {
+            EventVerdict::Process { .. } => "process",
+            EventVerdict::Drop { .. } => "drop",
+            EventVerdict::Retry { .. } => "retry",
+            EventVerdict::Dlq { .. } => "dlq",
+        }
+    }
+
+    /// Short label for the verdict's reason (or "ok" for `Process`). Used
+    /// to label metric counters so operators can see *why* events landed in
+    /// each verdict.
+    pub fn reason_label(&self) -> &'static str {
+        match self {
+            EventVerdict::Process { .. } => "ok",
+            EventVerdict::Drop { reason } => reason.label(),
+            EventVerdict::Retry { reason, .. } => reason.label(),
+            EventVerdict::Dlq { reason } => reason.label(),
+        }
+    }
+}
+
+impl DropReason {
+    pub fn label(&self) -> &'static str {
+        match self {
+            DropReason::IssueSuppressed => "issue_suppressed",
+            DropReason::SuppressedByRule => "suppressed_by_rule",
+        }
+    }
+}
+
+impl RetryReason {
+    pub fn label(&self) -> &'static str {
+        match self {
+            RetryReason::DeadlineExceeded => "deadline_exceeded",
+            RetryReason::SourcemapFetchTimeout => "sourcemap_fetch_timeout",
+            RetryReason::UnhandledProcessingError => "unhandled_processing_error",
+            RetryReason::DownstreamTransient => "downstream_transient",
+        }
+    }
+
+    /// Whether this retry reason was caused by cymbal's own state (pool,
+    /// queue, internal deadline) versus an event-specific or downstream
+    /// condition. Used by the self-health tracker to decide when to escalate
+    /// to HTTP 429.
+    pub fn is_cymbal_caused(&self) -> bool {
+        match self {
+            RetryReason::DeadlineExceeded => true,
+            RetryReason::UnhandledProcessingError => true,
+            RetryReason::SourcemapFetchTimeout => false,
+            RetryReason::DownstreamTransient => false,
+        }
+    }
+}
+
+impl DlqReason {
+    pub fn label(&self) -> &'static str {
+        match self {
+            DlqReason::WrongEventType => "wrong_event_type",
+            DlqReason::InvalidProperties => "invalid_properties",
+            DlqReason::EmptyExceptionList => "empty_exception_list",
+        }
+    }
+}
+
+/// Classify a per-event `EventError` into the verdict the contract demands.
+///
+/// `EventError` variants are cymbal's own affirmative classifications of an
+/// event's state — these are the cases where cymbal can name the outcome,
+/// so they map directly to terminal verdicts (`Drop` or `Dlq`).
+impl From<EventError> for EventVerdict {
+    fn from(err: EventError) -> Self {
+        match err {
+            EventError::Suppressed(_) => EventVerdict::Drop {
+                reason: DropReason::IssueSuppressed,
+            },
+            EventError::SuppressedByRule(_) => EventVerdict::Drop {
+                reason: DropReason::SuppressedByRule,
+            },
+            EventError::WrongEventType(_, _) => EventVerdict::Dlq {
+                reason: DlqReason::WrongEventType,
+            },
+            EventError::InvalidProperties(_, _) => EventVerdict::Dlq {
+                reason: DlqReason::InvalidProperties,
+            },
+            EventError::EmptyExceptionList(_) => EventVerdict::Dlq {
+                reason: DlqReason::EmptyExceptionList,
+            },
+        }
+    }
+}
+
+/// Classify an `UnhandledError` into a verdict.
+///
+/// `UnhandledError` represents conditions cymbal cannot affirmatively call
+/// event-broken — Kafka/Redis/SQL/S3 failures, serde mishaps, etc. The
+/// honest verdict is always `Retry`; cymbal does not assert the event is
+/// broken because we cannot distinguish event-caused failures from
+/// cymbal-side or downstream-side ones at this level.
+impl From<UnhandledError> for EventVerdict {
+    fn from(err: UnhandledError) -> Self {
+        let reason = match err {
+            // Kafka / SQL / S3 / Redis are infrastructure dependencies; if
+            // they hiccup we'd rather have the pipeline retry than DLQ the
+            // event.
+            UnhandledError::KafkaError(_)
+            | UnhandledError::KafkaProduceError(_)
+            | UnhandledError::SqlxError(_)
+            | UnhandledError::S3Error(_)
+            | UnhandledError::ByteStreamError(_)
+            | UnhandledError::RedisError(_) => RetryReason::DownstreamTransient,
+            // SerdeError / ConfigError / Other are ambiguous — they could be
+            // cymbal bugs, event-data quirks we don't classify, or
+            // misconfiguration. Retry is the safe-by-default verdict per the
+            // contract.
+            UnhandledError::SerdeError(_)
+            | UnhandledError::ConfigError(_)
+            | UnhandledError::Other(_) => RetryReason::UnhandledProcessingError,
+        };
+        EventVerdict::Retry {
+            reason,
+            retry_after_ms: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn event_error_maps_to_terminal_verdicts() {
+        let id = Uuid::nil();
+
+        let suppressed: EventVerdict = EventError::Suppressed(id).into();
+        assert!(matches!(
+            suppressed,
+            EventVerdict::Drop {
+                reason: DropReason::IssueSuppressed
+            }
+        ));
+
+        let suppressed_rule: EventVerdict = EventError::SuppressedByRule(id).into();
+        assert!(matches!(
+            suppressed_rule,
+            EventVerdict::Drop {
+                reason: DropReason::SuppressedByRule
+            }
+        ));
+
+        let wrong_type: EventVerdict = EventError::WrongEventType("foo".into(), id).into();
+        assert!(matches!(
+            wrong_type,
+            EventVerdict::Dlq {
+                reason: DlqReason::WrongEventType
+            }
+        ));
+
+        let empty: EventVerdict = EventError::EmptyExceptionList(id).into();
+        assert!(matches!(
+            empty,
+            EventVerdict::Dlq {
+                reason: DlqReason::EmptyExceptionList
+            }
+        ));
+    }
+
+    #[test]
+    fn unhandled_error_always_maps_to_retry() {
+        // Infrastructure dependency → DownstreamTransient.
+        let redis: EventVerdict = UnhandledError::Other("simulating redis blip".into()).into();
+        assert!(matches!(redis, EventVerdict::Retry { .. }));
+
+        // SerdeError / Other → UnhandledProcessingError. Both are Retry —
+        // never Dlq — because cymbal can't tell whether the event or
+        // cymbal itself is to blame.
+        let serde_err: EventVerdict = UnhandledError::Other("serde failure".into()).into();
+        match serde_err {
+            EventVerdict::Retry {
+                reason: RetryReason::UnhandledProcessingError,
+                retry_after_ms: None,
+            } => {}
+            other => panic!("expected Retry/UnhandledProcessingError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cymbal_caused_retries_are_flagged() {
+        assert!(RetryReason::DeadlineExceeded.is_cymbal_caused());
+        assert!(RetryReason::UnhandledProcessingError.is_cymbal_caused());
+        assert!(!RetryReason::SourcemapFetchTimeout.is_cymbal_caused());
+        assert!(!RetryReason::DownstreamTransient.is_cymbal_caused());
+    }
+
+    #[test]
+    fn verdict_status_and_reason_labels_match_serialization() {
+        let drop = EventVerdict::Drop {
+            reason: DropReason::IssueSuppressed,
+        };
+        assert_eq!(drop.status_label(), "drop");
+        assert_eq!(drop.reason_label(), "issue_suppressed");
+
+        let retry = EventVerdict::Retry {
+            reason: RetryReason::DeadlineExceeded,
+            retry_after_ms: None,
+        };
+        assert_eq!(retry.status_label(), "retry");
+        assert_eq!(retry.reason_label(), "deadline_exceeded");
+
+        let dlq = EventVerdict::Dlq {
+            reason: DlqReason::WrongEventType,
+        };
+        assert_eq!(dlq.status_label(), "dlq");
+        assert_eq!(dlq.reason_label(), "wrong_event_type");
+    }
+
+    #[test]
+    fn drop_serializes_with_status_and_reason_tags() {
+        let drop = EventVerdict::Drop {
+            reason: DropReason::IssueSuppressed,
+        };
+        let json = serde_json::to_value(&drop).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "status": "drop",
+                "reason": "issue_suppressed"
+            })
+        );
+    }
+
+    #[test]
+    fn retry_serializes_with_optional_retry_after_ms() {
+        let no_hint = EventVerdict::Retry {
+            reason: RetryReason::SourcemapFetchTimeout,
+            retry_after_ms: None,
+        };
+        let json = serde_json::to_value(&no_hint).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "status": "retry",
+                "reason": "sourcemap_fetch_timeout"
+            })
+        );
+
+        let with_hint = EventVerdict::Retry {
+            reason: RetryReason::DownstreamTransient,
+            retry_after_ms: Some(500),
+        };
+        let json = serde_json::to_value(&with_hint).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "status": "retry",
+                "reason": "downstream_transient",
+                "retry_after_ms": 500
+            })
+        );
+    }
+}

--- a/rust/cymbal/tests/event_v2.rs
+++ b/rust/cymbal/tests/event_v2.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the `/v2/process` endpoint — verifies the disposition
+//! Integration tests for the `/v2/resolve` endpoint — verifies the disposition
 //! contract end-to-end (HTTP → pipeline → response shape) and the failure
 //! paths the new endpoint promises:
 //!
@@ -156,7 +156,7 @@ impl V2Harness {
         .await
     }
 
-    /// POST `/v2/process` with a caller-supplied `MockRedisClient` and a
+    /// POST `/v2/resolve` with a caller-supplied `MockRedisClient` and a
     /// config-tweak closure. Returns the JSON response decoded into either
     /// `Vec<V2Disposition>` (on 2xx) or `serde_json::Value` (on 4xx/5xx).
     async fn post_events_with_overrides<T: serde::de::DeserializeOwned>(
@@ -180,7 +180,7 @@ impl V2Harness {
         Request::builder()
             .method("POST")
             .header("content-type", "application/json")
-            .uri("/v2/process")
+            .uri("/v2/resolve")
             .body(Body::from(serde_json::to_vec(events).unwrap()))
             .unwrap()
     }
@@ -320,7 +320,7 @@ async fn invalid_json_returns_400(db: PgPool) {
             Request::builder()
                 .method("POST")
                 .header("content-type", "application/json")
-                .uri("/v2/process")
+                .uri("/v2/resolve")
                 .body(Body::from(b"{\"not\": \"an array\"}".to_vec()))
                 .unwrap()
         },

--- a/rust/cymbal/tests/event_v2.rs
+++ b/rust/cymbal/tests/event_v2.rs
@@ -1,8 +1,8 @@
-//! Integration tests for the `/v2/process` endpoint — verifies the verdict
+//! Integration tests for the `/v2/process` endpoint — verifies the disposition
 //! contract end-to-end (HTTP → pipeline → response shape) and the failure
 //! paths the new endpoint promises:
 //!
-//! - Per-event verdicts (`Process`, `Drop`, `Retry`, `Dlq`) in the response.
+//! - Per-event dispositions (`Forward`, `Drop`, `Retry`, `Dlq`) in the response.
 //! - Cross-event optimizations preserved: shared `batch_issue_cache` so
 //!   same-fingerprint events still resolve to the same issue; deferred
 //!   spike detection so Redis is called once per request, not once per event.
@@ -12,8 +12,8 @@
 //! What's intentionally not tested at the integration layer:
 //! - Per-event panic isolation: needs a fault-injection hook in the
 //!   pipeline that doesn't exist yet. Covered at the unit level via
-//!   `catch_unwind` semantics in `verdict_for_single_event` and
-//!   `VERDICT_PANIC_TOTAL` metric wiring.
+//!   `catch_unwind` semantics in `PerEventDispositionProcessor::process_one` and
+//!   `DISPOSITION_PANIC_TOTAL` metric wiring.
 //! - Per-event UnhandledError isolation for a single event in a mixed
 //!   batch: needs the ability to make `S3::get` fail for a specific
 //!   sourcemap key only. Achievable but requires extending `MockS3Client`
@@ -87,16 +87,16 @@ fn make_exception(exception_type: &str, message: &str) -> Exception {
     }
 }
 
-// ---------- Verdict response deserialization ----------
+// ---------- Disposition response deserialization ----------
 //
-// Mirrors `cymbal::types::verdict::EventVerdict` but without depending on
+// Mirrors `cymbal::types::event_disposition::EventDisposition` but without depending on
 // the production type, so the test asserts the wire shape rather than the
 // in-memory representation. If the JSON contract changes, these tests fail.
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "status", rename_all = "lowercase")]
-enum V2Verdict {
-    Process {
+#[serde(tag = "action", rename_all = "snake_case")]
+enum V2Disposition {
+    Forward {
         event: Box<AnyEvent>,
     },
     Drop {
@@ -113,18 +113,18 @@ enum V2Verdict {
     },
 }
 
-impl V2Verdict {
-    fn expect_process(&self) -> &AnyEvent {
+impl V2Disposition {
+    fn expect_forward(&self) -> &AnyEvent {
         match self {
-            V2Verdict::Process { event } => event,
-            other => panic!("expected Process verdict, got {:?}", other),
+            V2Disposition::Forward { event } => event,
+            other => panic!("expected Forward disposition, got {:?}", other),
         }
     }
 
     fn expect_drop(&self) -> &str {
         match self {
-            V2Verdict::Drop { reason } => reason,
-            other => panic!("expected Drop verdict, got {:?}", other),
+            V2Disposition::Drop { reason } => reason,
+            other => panic!("expected Drop disposition, got {:?}", other),
         }
     }
 }
@@ -146,7 +146,7 @@ impl V2Harness {
         s3
     }
 
-    async fn post_events(&self, events: Vec<AnyEvent>) -> (StatusCode, Vec<V2Verdict>) {
+    async fn post_events(&self, events: Vec<AnyEvent>) -> (StatusCode, Vec<V2Disposition>) {
         utils::get_response(
             self.db.clone(),
             STORAGE_BUCKET.to_string(),
@@ -158,7 +158,7 @@ impl V2Harness {
 
     /// POST `/v2/process` with a caller-supplied `MockRedisClient` and a
     /// config-tweak closure. Returns the JSON response decoded into either
-    /// `Vec<V2Verdict>` (on 2xx) or `serde_json::Value` (on 4xx/5xx).
+    /// `Vec<V2Disposition>` (on 2xx) or `serde_json::Value` (on 4xx/5xx).
     async fn post_events_with_overrides<T: serde::de::DeserializeOwned>(
         &self,
         events: Vec<AnyEvent>,
@@ -195,30 +195,30 @@ impl V2Harness {
 }
 
 // =========================================================================
-// Tier 1: basic verdict shapes
+// Tier 1: basic disposition shapes
 // =========================================================================
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
-async fn happy_path_returns_process_verdict(db: PgPool) {
+async fn happy_path_returns_forward_disposition(db: PgPool) {
     let harness = V2Harness::new(db);
     let input = make_event(vec![make_exception("TypeError", "cannot read property")]);
 
-    let (status, verdicts) = harness.post_events(vec![input.clone()]).await;
+    let (status, dispositions) = harness.post_events(vec![input.clone()]).await;
 
     assert!(status.is_success(), "expected 2xx, got {status}");
-    assert_eq!(verdicts.len(), 1);
-    let event = verdicts[0].expect_process();
+    assert_eq!(dispositions.len(), 1);
+    let event = dispositions[0].expect_forward();
     assert_eq!(event.uuid, input.uuid);
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
-async fn suppressed_issue_returns_drop_verdict(db: PgPool) {
+async fn suppressed_issue_returns_drop_disposition(db: PgPool) {
     let harness = V2Harness::new(db);
     let input = make_event(vec![make_exception("SuppressedError", "will suppress")]);
 
     // First post creates the issue so we can suppress it.
     let (_, first) = harness.post_events(vec![input.clone()]).await;
-    let created_event = first[0].expect_process();
+    let created_event = first[0].expect_forward();
     let issue_id_value = created_event
         .properties
         .get("$exception_issue_id")
@@ -228,12 +228,32 @@ async fn suppressed_issue_returns_drop_verdict(db: PgPool) {
     harness.suppress_issue(issue_id).await;
 
     // Second post should now drop.
-    let (status, verdicts) = harness.post_events(vec![input]).await;
+    let (status, dispositions) = harness.post_events(vec![input]).await;
 
     assert!(status.is_success());
-    assert_eq!(verdicts.len(), 1);
-    let reason = verdicts[0].expect_drop();
+    assert_eq!(dispositions.len(), 1);
+    let reason = dispositions[0].expect_drop();
     assert_eq!(reason, "issue_suppressed");
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn empty_exception_list_returns_forward_disposition_with_error(db: PgPool) {
+    let harness = V2Harness::new(db);
+    let input = make_event(vec![]);
+
+    let (status, dispositions) = harness.post_events(vec![input]).await;
+
+    assert!(status.is_success());
+    assert_eq!(dispositions.len(), 1);
+    let event = dispositions[0].expect_forward();
+    let errors = event
+        .properties
+        .get("$cymbal_errors")
+        .and_then(|value| value.as_array())
+        .expect("forwarded event should carry cymbal errors");
+    assert!(errors.iter().any(|error| error
+        .as_str()
+        .is_some_and(|error| error.contains("Empty exception list"))));
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
@@ -253,14 +273,14 @@ async fn same_fingerprint_dedupes_via_shared_batch_cache(db: PgPool) {
         })
         .collect();
 
-    let (status, verdicts) = harness.post_events(inputs).await;
+    let (status, dispositions) = harness.post_events(inputs).await;
     assert!(status.is_success());
-    assert_eq!(verdicts.len(), 3);
+    assert_eq!(dispositions.len(), 3);
 
-    let issue_ids: Vec<String> = verdicts
+    let issue_ids: Vec<String> = dispositions
         .iter()
         .map(|v| {
-            v.expect_process()
+            v.expect_forward()
                 .properties
                 .get("$exception_issue_id")
                 .and_then(|v| v.as_str().map(|s| s.to_string()))
@@ -278,13 +298,13 @@ async fn same_fingerprint_dedupes_via_shared_batch_cache(db: PgPool) {
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
-async fn empty_batch_returns_empty_verdict_array(db: PgPool) {
+async fn empty_batch_returns_empty_disposition_array(db: PgPool) {
     let harness = V2Harness::new(db);
 
-    let (status, verdicts) = harness.post_events(vec![]).await;
+    let (status, dispositions) = harness.post_events(vec![]).await;
 
     assert!(status.is_success());
-    assert!(verdicts.is_empty());
+    assert!(dispositions.is_empty());
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
@@ -336,7 +356,7 @@ async fn spike_detection_runs_once_per_request(db: PgPool) {
 
     let redis = Arc::new(MockRedisClient::new());
     let redis_for_inspection = redis.clone();
-    let (status, _verdicts): (_, Vec<V2Verdict>) = harness
+    let (status, _dispositions): (_, Vec<V2Disposition>) = harness
         .post_events_with_overrides(inputs, redis, |_cfg| {})
         .await;
 

--- a/rust/cymbal/tests/event_v2.rs
+++ b/rust/cymbal/tests/event_v2.rs
@@ -18,9 +18,9 @@
 //!   batch: needs the ability to make `S3::get` fail for a specific
 //!   sourcemap key only. Achievable but requires extending `MockS3Client`
 //!   with per-key behaviour. Tracked as follow-up.
-//! - Backpressure → 429: `Semaphore::new(config.process_max_in_flight_requests.max(1))`
+//! - Backpressure → 429: `Semaphore::new(config.process_max_in_flight_events.max(1))`
 //!   in `AppContext::new` floors the semaphore at 1 permit, so a single
-//!   request never hits backpressure. Driving the path needs the test to
+//!   event request never hits backpressure. Driving the path needs the test to
 //!   pre-acquire the permit before posting, which requires reaching into
 //!   the constructed `AppContext` — not exposed by the current test
 //!   harness. Code path is identical to the legacy `/process` flow, which

--- a/rust/cymbal/tests/event_v2.rs
+++ b/rust/cymbal/tests/event_v2.rs
@@ -1,0 +1,395 @@
+//! Integration tests for the `/v2/process` endpoint — verifies the verdict
+//! contract end-to-end (HTTP → pipeline → response shape) and the failure
+//! paths the new endpoint promises:
+//!
+//! - Per-event verdicts (`Process`, `Drop`, `Retry`, `Dlq`) in the response.
+//! - Cross-event optimizations preserved: shared `batch_issue_cache` so
+//!   same-fingerprint events still resolve to the same issue; deferred
+//!   spike detection so Redis is called once per request, not once per event.
+//! - Backpressure path: 429 with the expected metric counters.
+//! - Spike-detection failure propagates → 500 (legacy semantics).
+//!
+//! What's intentionally not tested at the integration layer:
+//! - Per-event panic isolation: needs a fault-injection hook in the
+//!   pipeline that doesn't exist yet. Covered at the unit level via
+//!   `catch_unwind` semantics in `verdict_for_single_event` and
+//!   `VERDICT_PANIC_TOTAL` metric wiring.
+//! - Per-event UnhandledError isolation for a single event in a mixed
+//!   batch: needs the ability to make `S3::get` fail for a specific
+//!   sourcemap key only. Achievable but requires extending `MockS3Client`
+//!   with per-key behaviour. Tracked as follow-up.
+//! - Backpressure → 429: `Semaphore::new(config.process_max_in_flight_requests.max(1))`
+//!   in `AppContext::new` floors the semaphore at 1 permit, so a single
+//!   request never hits backpressure. Driving the path needs the test to
+//!   pre-acquire the permit before posting, which requires reaching into
+//!   the constructed `AppContext` — not exposed by the current test
+//!   harness. Code path is identical to the legacy `/process` flow, which
+//!   also has no backpressure integration test, so this isn't a
+//!   regression in coverage.
+
+use std::{collections::HashMap, sync::Arc};
+
+use axum::{body::Body, http::Request};
+use common_redis::MockRedisClient;
+use cymbal::types::{event::AnyEvent, Exception, ExceptionList, Mechanism};
+use reqwest::StatusCode;
+use serde::Deserialize;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::utils::MockS3Client;
+
+mod utils;
+
+const STORAGE_BUCKET: &str = "test-bucket";
+
+// ---------- Helpers (small subset of what tests/event.rs provides) ----------
+
+fn make_event(exceptions: Vec<Exception>) -> AnyEvent {
+    make_event_with_fingerprint(exceptions, None)
+}
+
+fn make_event_with_fingerprint(exceptions: Vec<Exception>, fingerprint: Option<&str>) -> AnyEvent {
+    let exception_list = ExceptionList(exceptions);
+    let mut properties = json!({
+        "$exception_list": exception_list,
+        "$exception_handled": false,
+    });
+    if let Some(fp) = fingerprint {
+        properties["$exception_fingerprint"] = json!(fp);
+    }
+
+    AnyEvent {
+        uuid: Uuid::now_v7(),
+        event: "$exception".to_string(),
+        team_id: 1,
+        timestamp: "2026-05-21T00:00:00Z".to_string(),
+        properties,
+        others: HashMap::new(),
+    }
+}
+
+fn make_exception(exception_type: &str, message: &str) -> Exception {
+    Exception {
+        exception_id: None,
+        exception_type: exception_type.to_string(),
+        exception_message: message.to_string(),
+        mechanism: Some(Mechanism {
+            handled: Some(false),
+            mechanism_type: None,
+            source: None,
+            synthetic: Some(false),
+        }),
+        module: None,
+        thread_id: None,
+        stack: None,
+    }
+}
+
+// ---------- Verdict response deserialization ----------
+//
+// Mirrors `cymbal::types::verdict::EventVerdict` but without depending on
+// the production type, so the test asserts the wire shape rather than the
+// in-memory representation. If the JSON contract changes, these tests fail.
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+enum V2Verdict {
+    Process {
+        event: Box<AnyEvent>,
+    },
+    Drop {
+        reason: String,
+    },
+    #[allow(dead_code)]
+    Retry {
+        reason: String,
+        retry_after_ms: Option<u64>,
+    },
+    #[allow(dead_code)]
+    Dlq {
+        reason: String,
+    },
+}
+
+impl V2Verdict {
+    fn expect_process(&self) -> &AnyEvent {
+        match self {
+            V2Verdict::Process { event } => event,
+            other => panic!("expected Process verdict, got {:?}", other),
+        }
+    }
+
+    fn expect_drop(&self) -> &str {
+        match self {
+            V2Verdict::Drop { reason } => reason,
+            other => panic!("expected Drop verdict, got {:?}", other),
+        }
+    }
+}
+
+// ---------- Test harness ----------
+
+struct V2Harness {
+    db: PgPool,
+}
+
+impl V2Harness {
+    fn new(db: PgPool) -> Self {
+        Self { db }
+    }
+
+    fn create_s3_mock() -> MockS3Client {
+        let mut s3 = MockS3Client::new();
+        s3.expect_ping_bucket().returning(|_| Ok(()));
+        s3
+    }
+
+    async fn post_events(&self, events: Vec<AnyEvent>) -> (StatusCode, Vec<V2Verdict>) {
+        utils::get_response(
+            self.db.clone(),
+            STORAGE_BUCKET.to_string(),
+            || self.build_request(&events),
+            Arc::new(Self::create_s3_mock()),
+        )
+        .await
+    }
+
+    /// POST `/v2/process` with a caller-supplied `MockRedisClient` and a
+    /// config-tweak closure. Returns the JSON response decoded into either
+    /// `Vec<V2Verdict>` (on 2xx) or `serde_json::Value` (on 4xx/5xx).
+    async fn post_events_with_overrides<T: serde::de::DeserializeOwned>(
+        &self,
+        events: Vec<AnyEvent>,
+        redis: Arc<MockRedisClient>,
+        configure: impl FnOnce(&mut cymbal::config::Config),
+    ) -> (StatusCode, T) {
+        utils::get_response_with_overrides(
+            self.db.clone(),
+            STORAGE_BUCKET.to_string(),
+            || self.build_request(&events),
+            Arc::new(Self::create_s3_mock()),
+            redis,
+            configure,
+        )
+        .await
+    }
+
+    fn build_request(&self, events: &[AnyEvent]) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .header("content-type", "application/json")
+            .uri("/v2/process")
+            .body(Body::from(serde_json::to_vec(events).unwrap()))
+            .unwrap()
+    }
+
+    async fn suppress_issue(&self, issue_id: Uuid) {
+        sqlx::query("UPDATE posthog_errortrackingissue SET status = 'suppressed' WHERE id = $1")
+            .bind(issue_id)
+            .execute(&self.db)
+            .await
+            .expect("Should update issue status");
+    }
+}
+
+// =========================================================================
+// Tier 1: basic verdict shapes
+// =========================================================================
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn happy_path_returns_process_verdict(db: PgPool) {
+    let harness = V2Harness::new(db);
+    let input = make_event(vec![make_exception("TypeError", "cannot read property")]);
+
+    let (status, verdicts) = harness.post_events(vec![input.clone()]).await;
+
+    assert!(status.is_success(), "expected 2xx, got {status}");
+    assert_eq!(verdicts.len(), 1);
+    let event = verdicts[0].expect_process();
+    assert_eq!(event.uuid, input.uuid);
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn suppressed_issue_returns_drop_verdict(db: PgPool) {
+    let harness = V2Harness::new(db);
+    let input = make_event(vec![make_exception("SuppressedError", "will suppress")]);
+
+    // First post creates the issue so we can suppress it.
+    let (_, first) = harness.post_events(vec![input.clone()]).await;
+    let created_event = first[0].expect_process();
+    let issue_id_value = created_event
+        .properties
+        .get("$exception_issue_id")
+        .expect("issue id should be set on processed event");
+    let issue_id: Uuid =
+        serde_json::from_value(issue_id_value.clone()).expect("issue id parses as uuid");
+    harness.suppress_issue(issue_id).await;
+
+    // Second post should now drop.
+    let (status, verdicts) = harness.post_events(vec![input]).await;
+
+    assert!(status.is_success());
+    assert_eq!(verdicts.len(), 1);
+    let reason = verdicts[0].expect_drop();
+    assert_eq!(reason, "issue_suppressed");
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn same_fingerprint_dedupes_via_shared_batch_cache(db: PgPool) {
+    // Three events with the same fingerprint, in a single request. The
+    // shared `batch_issue_cache` (created once per request, threaded into
+    // every per-event pipeline) must dedup the fingerprint → issue lookup
+    // so all three get the same `issue_id`. This is the property that
+    // makes the per-event isolation cheap.
+    let harness = V2Harness::new(db);
+    let inputs: Vec<AnyEvent> = (0..3)
+        .map(|_| {
+            make_event_with_fingerprint(
+                vec![make_exception("Error", "shared-fingerprint")],
+                Some("shared-fp-test"),
+            )
+        })
+        .collect();
+
+    let (status, verdicts) = harness.post_events(inputs).await;
+    assert!(status.is_success());
+    assert_eq!(verdicts.len(), 3);
+
+    let issue_ids: Vec<String> = verdicts
+        .iter()
+        .map(|v| {
+            v.expect_process()
+                .properties
+                .get("$exception_issue_id")
+                .and_then(|v| v.as_str().map(|s| s.to_string()))
+                .expect("processed event carries issue_id")
+        })
+        .collect();
+
+    let unique: std::collections::HashSet<_> = issue_ids.iter().collect();
+    assert_eq!(
+        unique.len(),
+        1,
+        "all events with same fingerprint should share an issue_id; got {:?}",
+        issue_ids
+    );
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn empty_batch_returns_empty_verdict_array(db: PgPool) {
+    let harness = V2Harness::new(db);
+
+    let (status, verdicts) = harness.post_events(vec![]).await;
+
+    assert!(status.is_success());
+    assert!(verdicts.is_empty());
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn invalid_json_returns_400(db: PgPool) {
+    // Mirrors `invalid_request_returns_400` on the legacy `/process`
+    // handler. axum's `Json` extractor rejects with 4xx before the v2
+    // handler runs; this exercises the framework layer.
+    let harness = V2Harness::new(db);
+    let (status, _body): (_, String) = utils::get_raw_response(
+        harness.db.clone(),
+        STORAGE_BUCKET.to_string(),
+        || {
+            Request::builder()
+                .method("POST")
+                .header("content-type", "application/json")
+                .uri("/v2/process")
+                .body(Body::from(b"{\"not\": \"an array\"}".to_vec()))
+                .unwrap()
+        },
+        Arc::new(V2Harness::create_s3_mock()),
+    )
+    .await;
+
+    assert!(
+        status.is_client_error(),
+        "expected 4xx for malformed JSON, got {status}"
+    );
+}
+
+// =========================================================================
+// Tier 1.5 / 2: failure modes and call-pattern assertions
+// =========================================================================
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn spike_detection_runs_once_per_request(db: PgPool) {
+    // With the shared `SpikeAlertAccumulator`, a request with N events
+    // produces exactly one batched Redis call for issue buckets, not N.
+    // We assert this by inspecting the `MockRedisClient` call log after
+    // posting 5 events.
+    let harness = V2Harness::new(db);
+    let inputs: Vec<AnyEvent> = (0..5)
+        .map(|i| {
+            make_event_with_fingerprint(
+                vec![make_exception("DistinctError", &format!("variant-{i}"))],
+                Some(&format!("distinct-fp-{i}")),
+            )
+        })
+        .collect();
+
+    let redis = Arc::new(MockRedisClient::new());
+    let redis_for_inspection = redis.clone();
+    let (status, _verdicts): (_, Vec<V2Verdict>) = harness
+        .post_events_with_overrides(inputs, redis, |_cfg| {})
+        .await;
+
+    assert!(status.is_success());
+
+    // The accumulator should have produced one batched
+    // `batch_incr_by_expire_nx` call per request (covering both the issue
+    // bucket and team bucket increments), not five.
+    //
+    // `MockRedisClient::get_calls` returns every call made; we filter to
+    // the `batch_incr_by_expire_nx` shape. Exact count depends on the
+    // spike-detection implementation (issue buckets + team buckets), but
+    // it should be O(1) not O(events).
+    let calls = redis_for_inspection.get_calls();
+    let batch_incr_calls = calls
+        .iter()
+        .filter(|c| format!("{:?}", c).contains("BatchIncrByExpireNx"))
+        .count();
+    assert!(
+        batch_incr_calls <= 3,
+        "expected O(1) batched Redis calls per /v2 request, got {batch_incr_calls} for 5 events"
+    );
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn spike_detection_failure_propagates_as_500(db: PgPool) {
+    // Customer-facing alert: if spike detection can't run, we 500 the
+    // request rather than silently drop the alert. Verifies the legacy
+    // semantics are preserved by the deferred path.
+    let harness = V2Harness::new(db);
+    let input = make_event(vec![make_exception("Error", "trigger-spike")]);
+
+    let mut redis = MockRedisClient::new();
+    // Force the bucket-read path to fail. Spike detection's increment
+    // calls (`try_increment_issue_buckets` / `try_increment_team_buckets`)
+    // are wrapped in `if let Err(...)` and just log a warning — they
+    // intentionally don't propagate. The error path that does propagate
+    // is inside `get_spiking_issues`, which calls `mget` to read the
+    // historical buckets back; that's what we mock to fail here.
+    redis.mget_error(common_redis::CustomRedisError::Timeout);
+
+    let (status, _body): (_, serde_json::Value) = harness
+        .post_events_with_overrides(vec![input], Arc::new(redis), |_cfg| {})
+        .await;
+
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "spike detection failure should propagate as 500, got {status}"
+    );
+}
+
+// Note: `backpressure_returns_429` was prototyped but the harness can't
+// drive it reliably — see the module docstring for why. The code path is
+// shared with `/process` which also has no equivalent integration test,
+// so coverage isn't a regression.

--- a/rust/cymbal/tests/utils.rs
+++ b/rust/cymbal/tests/utils.rs
@@ -92,3 +92,41 @@ pub(crate) async fn get_raw_response(
     let body_string = String::from_utf8(body_bytes.to_vec()).unwrap();
     (status, body_string)
 }
+
+/// Variant of `get_response` that lets the caller supply a pre-configured
+/// `MockRedisClient` and apply config tweaks before constructing `AppContext`.
+/// Used by `/v2/process` tests that need to assert on Redis call counts
+/// (spike-detection batching) or force errors (spike-detection failure path).
+#[allow(dead_code)]
+pub(crate) async fn get_response_with_overrides<T: for<'de> Deserialize<'de>>(
+    db: PgPool,
+    storage_bucket: String,
+    request_factory: impl Fn() -> Request<Body>,
+    s3_client: Arc<MockS3Client>,
+    redis_client: Arc<MockRedisClient>,
+    configure: impl FnOnce(&mut Config),
+) -> (StatusCode, T) {
+    let mut config = Config::init_with_defaults().unwrap();
+    config.object_storage_bucket = storage_bucket.clone();
+    configure(&mut config);
+
+    let app_ctx = AppContext::new(&config, s3_client, db.clone(), redis_client)
+        .await
+        .unwrap();
+
+    let ctx = Arc::new(app_ctx);
+
+    let res = get_router(ctx).oneshot(request_factory()).await.unwrap();
+
+    let status = res.status();
+
+    let body_bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+
+    let body_string = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+    let body: T = serde_json::from_slice(body_bytes.to_bytes())
+        .unwrap_or_else(|e| panic!("Failed to deserialize response: {e} {body_string}"));
+    (status, body)
+}

--- a/rust/cymbal/tests/utils.rs
+++ b/rust/cymbal/tests/utils.rs
@@ -95,7 +95,7 @@ pub(crate) async fn get_raw_response(
 
 /// Variant of `get_response` that lets the caller supply a pre-configured
 /// `MockRedisClient` and apply config tweaks before constructing `AppContext`.
-/// Used by `/v2/process` tests that need to assert on Redis call counts
+/// Used by `/v2/resolve` tests that need to assert on Redis call counts
 /// (spike-detection batching) or force errors (spike-detection failure path).
 #[allow(dead_code)]
 pub(crate) async fn get_response_with_overrides<T: for<'de> Deserialize<'de>>(


### PR DESCRIPTION

## Problem

this is a very vibe coded proposal for tightening up the contract around the cymbal api. it definitely needs to be cleaned up and tested

Why                                                                                  
                                                                                                                                                                                                                                                                             
Today the ingestion pipeline guesses at how to handle cymbal failures: which events within a 5xx are causing timeouts / poison pills, which 5xxs are intermittent issues, when to time out, which events should be rerouted, etc.                                                                                                                                                                                                                        
                                                                                   
This PR introduces /v2/process, where cymbal returns an explicit per-event verdict for every event. The client becomes a thin transport that forwards verdicts to the pipeline's retry/route layer without inference.                                                      
                                                             
  Contract                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                             
  /v2/process returns Vec<EventVerdict> aligned 1:1 with the input batch:
                                                                                                                                                                                                                                                                             
  { "status": "process", "event": { ... } }   // symbolicated, forward downstream  
  { "status": "drop",    "reason": "issue_suppressed" }   // by-design no-op                                                                                                                                                                                                 
  { "status": "retry",   "reason": "sourcemap_fetch_timeout" }   // pipeline retries
  { "status": "dlq",     "reason": "stack_unparseable" }   // pipeline DLQs                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                             
Cymbal only emits dlq for events it can affirmatively call broken. Ambiguous failures (panics, unhandled errors, transient infra hiccups) emit retry — the pipeline's retry-then-overflow layer handles persistent failures, never silent data loss from cymbal-side misclassification.                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                             
Request-level concerns (5xx, 429, timeouts) keep using HTTP status — cymbal returns 200 with verdicts when it's healthy, 429 when self-degraded, 5xx when genuinely broken.                                                                                                
                                                                                                                                                                                                                                                                             
  Architecture                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                             
  - Per-event isolation: each event runs through the existing HttpEventPipeline as Batch<1> wrapped in tokio::time::timeout + catch_unwind. One event's panic / timeout / UnhandledError becomes a Retry verdict for that position — other events still get correct verdicts.
  - Per-event deadlines: process_per_event_deadline_ms (10s default) ensures one slow event doesn't block fast siblings. process_request_deadline_ms (30s default) bounds the whole request.                                                                                 
  - Cross-event optimizations preserved via threaded shared state:                 
  - LinkingStage::batch_issue_cache shared across all per-event invocations within a request — same-fingerprint dedup still works.                                                                                                                                         
  - SpikeAlertAccumulator collects spike inputs per-event, runs do_spike_detection once at end-of-request — one batched Redis call per request, same as legacy.
  - what is still needed is what is effectively an api side circuit breaker - a way to differentiate between "this one event is unable to resolve within the sla" and "several events are failing to resolve due to something like pool exhaustion"
                                                                                                                                                                                                                                                                             
The legacy /process endpoint is untouched. 