### PR TITLE
feat(mcp-analytics): explain session id origin

### DIFF
--- a/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
@@ -4,6 +4,7 @@ import { IconBolt, IconClock, IconSparkles, IconUser, IconWarning } from '@posth
 import { LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
 
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { mcpSessionsLogic } from './mcpSessionsLogic'
 import { formatDuration, formatRelativeOffset, sessionDurationMs, shortenSessionId } from './utils'
@@ -73,19 +74,29 @@ export function MCPSessionDetail(): JSX.Element {
                     ) : null}
                     <MetaBadge icon={<IconBolt />} label={`${calls} tool call${calls === 1 ? '' : 's'}`} />
                     <MetaBadge icon={<IconClock />} label={formatDuration(durationMs)} />
-                    <span
-                        className="inline-flex items-center gap-1 rounded-full bg-surface-secondary px-2 py-0.5 text-[11px] text-secondary font-mono"
-                        title={selectedSession.session_id}
+                    <Tooltip
+                        title={
+                            <div className="flex flex-col gap-1 max-w-xs">
+                                <span className="font-mono break-all">{selectedSession.session_id}</span>
+                                <span>
+                                    Streamable-HTTP transport session id, minted by the MCP server and sent on each
+                                    request via the <span className="font-mono">Mcp-Session-Id</span> header. Used to
+                                    group every tool call from one client connection.
+                                </span>
+                            </div>
+                        }
                     >
-                        <CopyToClipboardInline
-                            explicitValue={selectedSession.session_id}
-                            description="session id"
-                            iconSize="xsmall"
-                            className="font-mono"
-                        >
-                            {shortenSessionId(selectedSession.session_id)}
-                        </CopyToClipboardInline>
-                    </span>
+                        <span className="inline-flex items-center gap-1 rounded-full bg-surface-secondary px-2 py-0.5 text-[11px] text-secondary font-mono">
+                            <CopyToClipboardInline
+                                explicitValue={selectedSession.session_id}
+                                description="session id"
+                                iconSize="xsmall"
+                                className="font-mono"
+                            >
+                                {shortenSessionId(selectedSession.session_id)}
+                            </CopyToClipboardInline>
+                        </span>
+                    </Tooltip>
                 </div>
             </header>
 


### PR DESCRIPTION
## Problem

`session_id` shown in the MCP analytics Sessions tab is the MCP Streamable-HTTP `Mcp-Session-Id` header value — not the PostHog session uuid7 most engineers expect. There was nothing in the UI explaining that. Likewise, anyone writing HogQL against MCP events has to reconstruct the `$mcp_*` schema and the two-session-id distinction from scratch every time.

## Changes

- Wrap the session-id pill in `MCPSessionDetail` with a tooltip that names the `Mcp-Session-Id` header it comes from and what it groups. The full id is preserved in the tooltip body.
- Add a `querying-mcp-analytics-data` skill covering the event vocabulary, the `$mcp_session_id` vs `$session_id` distinction, the `$mcp_*` property namespace, the ClickHouse-events vs `posthog_mcp_session` storage split, intent clustering quirks, and a code map back into the product.

## How did you test this code?

I'm an agent. Automated checks only:

- `hogli lint:skills` — pass (42 skills)
- `hogli build:skills` — new skill listed in build output
- `pnpm --filter=@posthog/frontend format` — clean on `MCPSessionDetail.tsx`

Did not exercise the tooltip in a browser.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Two commits kept separate so the skill addition (chore) is reviewable independently of the UI tweak (feat). Considered putting the explainer as a banner above the sessions table instead of a tooltip on the pill, but the pill is the only place in the UI where the raw `Mcp-Session-Id` value is shown, so co-locating the explanation with it felt more discoverable.