### PR TITLE
feat(hogql): generalize events resolve-then-fetch into a transform

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -8,12 +8,12 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY events.event ASC
+                                                                                                                                                                                                                     LIMIT 101)))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -37,12 +37,12 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                                                                                                                                                         (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                                                                                                                                                          FROM events
+                                                                                                                                                                                                                                                                                                                                                          WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                                                                                                                                                          ORDER BY events.event ASC
+                                                                                                                                                                                                                                                                                                                                                          LIMIT 101)))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -66,12 +66,12 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', '')), '%/%'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', '')), '%/%'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', '')), '%/%'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                                                                                                                                                             (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                                                                                                                                                              FROM events
+                                                                                                                                                                                                                                                                                                                                                              WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', '')), '%/%'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                                                                                                                                                              ORDER BY events.event ASC
+                                                                                                                                                                                                                                                                                                                                                              LIMIT 101)))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -178,12 +178,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT events.event AS event
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2023-01-12 12:14:05.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), less(events.timestamp, toDateTime64('2023-01-12 12:14:05.000000', 6, 'UTC')))
+  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2023-01-12 12:14:05.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -203,12 +198,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT events.event AS event
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2022-01-12 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), less(events.timestamp, toDateTime64('2022-01-12 12:14:00.000000', 6, 'UTC')))
+  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2022-01-12 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -228,12 +218,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT events.event AS event
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2022-01-01 00:00:00.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2019-01-12 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(less(events.timestamp, toDateTime64('2022-01-01 00:00:00.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2019-01-12 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2022-01-01 00:00:00.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2019-01-12 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -255,7 +240,12 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key
   FROM events
-  WHERE equals(events.team_id, 99999)
+  WHERE and(equals(events.team_id, 99999), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                 FROM events
+                                                 WHERE equals(events.team_id, 99999)
+                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                 LIMIT 101)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -300,7 +290,12 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key
   FROM events
-  WHERE equals(events.team_id, 99999)
+  WHERE and(equals(events.team_id, 99999), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                 FROM events
+                                                 WHERE equals(events.team_id, 99999)
+                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                 LIMIT 101)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -350,12 +345,12 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY events.event ASC
+                                                                                                                                                                                                                     LIMIT 101)))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -403,12 +398,12 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY events.event ASC
+                                                                                                                                                                                                                     LIMIT 101)))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -432,12 +427,12 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                                                                                                                                                         (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                                                                                                                                                          FROM events
+                                                                                                                                                                                                                                                                                                                                                          WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                                                                                                                                                          ORDER BY events.event ASC
+                                                                                                                                                                                                                                                                                                                                                          LIMIT 101)))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -589,27 +584,27 @@
                                                     WHERE equals(person.team_id, 99999)
                                                     GROUP BY person.id
                                                     HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 LEFT OUTER JOIN
-                                                   (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
-                                                    FROM person_distinct_id_overrides
-                                                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                                                    GROUP BY person_distinct_id_overrides.distinct_id
-                                                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                                                 LEFT JOIN
-                                                   (SELECT person.id AS id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-                                                    FROM person
-                                                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                                                                  (SELECT person.id AS id, max(person.version) AS version
-                                                                                                   FROM person
-                                                                                                   WHERE equals(person.team_id, 99999)
-                                                                                                   GROUP BY person.id
-                                                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-                                                 WHERE and(equals(events.team_id, 99999), ifNull(equals(events__person.properties___email, 'tom@posthog.com'), 0), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greater(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(ifNull(equals(events__person.properties___email, 'tom@posthog.com'), 0), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greater(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(ifNull(equals(events__person.properties___email, 'tom@posthog.com'), 0), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greater(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                                                                                               (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                                                                                                FROM events
+                                                                                                                                                                                                                                                                                                LEFT OUTER JOIN
+                                                                                                                                                                                                                                                                                                  (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
+                                                                                                                                                                                                                                                                                                   FROM person_distinct_id_overrides
+                                                                                                                                                                                                                                                                                                   WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                                                                                                                                                                                                                                                                                                   GROUP BY person_distinct_id_overrides.distinct_id
+                                                                                                                                                                                                                                                                                                   HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                                                                                                                                                                                                                                                                                                LEFT JOIN
+                                                                                                                                                                                                                                                                                                  (SELECT person.id AS id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                                                                                                                                                                                                                                                                                                   FROM person
+                                                                                                                                                                                                                                                                                                   WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                                                                                                                                                                                                                                                                                                                 (SELECT person.id AS id, max(person.version) AS version
+                                                                                                                                                                                                                                                                                                                                                  FROM person
+                                                                                                                                                                                                                                                                                                                                                  WHERE equals(person.team_id, 99999)
+                                                                                                                                                                                                                                                                                                                                                  GROUP BY person.id
+                                                                                                                                                                                                                                                                                                                                                  HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+                                                                                                                                                                                                                                                                                                WHERE and(equals(events.team_id, 99999), ifNull(equals(events__person.properties___email, 'tom@posthog.com'), 0), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greater(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+                                                                                                                                                                                                                                                                                                ORDER BY events.event ASC
+                                                                                                                                                                                                                                                                                                LIMIT 101)))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -782,12 +777,7 @@
          events.distinct_id AS distinct_id,
          events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -810,12 +800,12 @@
          events.distinct_id AS distinct_id,
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
-                                                 LIMIT 101)), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
+                                                                                                                                                                                                                     LIMIT 101)))
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -836,12 +826,12 @@
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`,
          events.event AS event
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
-                                                 ORDER BY tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) ASC
-                                                 LIMIT 101)), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) ASC
+                                                                                                                                                                                                                     LIMIT 101)))
   ORDER BY tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -15,6 +15,7 @@ from posthog.hogql.printer.duckdb import DuckDBPrinter
 from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.printer.postgres import PostgresPrinter
 from posthog.hogql.resolver import resolve_types
+from posthog.hogql.transforms.events_resolve_then_fetch import optimize_events_resolve_then_fetch
 from posthog.hogql.transforms.in_cohort import resolve_in_cohorts, resolve_in_cohorts_conjoined
 from posthog.hogql.transforms.lazy_tables import resolve_lazy_tables
 from posthog.hogql.transforms.projection_pushdown import pushdown_projections
@@ -100,6 +101,14 @@ def prepare_ast_for_printing(
     if context.modifiers.inCohortVia == InCohortVia.LEFTJOIN_CONJOINED:
         with context.timings.measure("resolve_in_cohorts_conjoined"):
             resolve_in_cohorts_conjoined(node, dialect, context, stack)
+
+    # Resolve-then-fetch: split a wide events `ORDER BY timestamp LIMIT n` scan into a narrow inner subquery
+    # that resolves the ordered (timestamp, uuid) identities plus an outer point-fetch of the wide columns.
+    # Runs before type resolution so the injected subquery flows through the normal resolve/lazy-table/
+    # property-swap pipeline, exactly like a hand-written split (see events_resolve_then_fetch.py).
+    if dialect == "clickhouse":
+        with context.timings.measure("optimize_events_resolve_then_fetch"):
+            optimize_events_resolve_then_fetch(node, context)
 
     with context.timings.measure("resolve_types"):
         node = resolve_types(

--- a/posthog/hogql/transforms/events_resolve_then_fetch.py
+++ b/posthog/hogql/transforms/events_resolve_then_fetch.py
@@ -1,0 +1,342 @@
+"""Resolve-then-fetch (late materialization) for wide ``events`` scans with ``ORDER BY timestamp`` + ``LIMIT``.
+
+When a query reads wide columns from ``events`` (the ``properties`` JSON blob, ``elements_chain``, or
+``SELECT *``) and orders by ``timestamp`` with a ``LIMIT``, ClickHouse — even reading in primary-key order —
+must materialize those wide columns for every granule it scans on the way to finding the top ``LIMIT`` rows.
+For a selective filter that forces a deep scan, that means dragging megabytes of ``properties`` across rows
+that are then discarded by the ``LIMIT``. This is the dominant cost (and OOM source) of the events-explorer
+query shape.
+
+The fix is the classic two-phase split — a strict superset of the hand-built "presorted optimization" that
+``EventsQueryRunner`` used to do:
+
+    SELECT <wide ...> FROM events WHERE <w> ORDER BY <ord> LIMIT n [OFFSET m]
+
+becomes
+
+    SELECT <wide ...> FROM events
+    WHERE <w> AND (timestamp, uuid) IN (
+        SELECT timestamp, uuid FROM events WHERE <w> ORDER BY <ord> LIMIT n + m
+    )
+    ORDER BY <ord> LIMIT n [OFFSET m]
+
+The **inner** query resolves only the narrow ordering/identity columns ``(timestamp, uuid)`` — no wide data is
+read while scanning to satisfy the order — and, when the order leads with ``timestamp``, ``timestamp_order_by``
+makes it read in primary-key order and early-terminate. The **outer** query then point-fetches the wide columns
+for only the resolved rows.
+
+Two things make this a strict superset of the old runner split, so it is never worse than it was:
+
+1. **Keep the outer filter** (``<w> AND (timestamp, uuid) IN ...``, not the ``IN`` alone). The events sort key
+   is ``(team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))``, so a predicate like
+   ``event = ...`` sits high in the key and prunes whole granules. Dropping it and leaning on the ``IN`` would
+   force ClickHouse to read every granule in the matched days — the ``IN`` only prunes to day granularity (see
+   below) — which for a selective filter is catastrophically more data. The runner kept the filter; so do we.
+2. **Match the ``(timestamp, uuid)`` pair**, not ``uuid`` alone (the runner used ``uuid``). ``uuid`` is the
+   trailing sort-key column (stored as ``cityHash64(uuid)``), so ``uuid IN (...)`` cannot skip granules,
+   whereas the concrete timestamps feed the ``toDate(timestamp)`` index and let the outer skip the granules
+   that hold none of the matched rows. ``uuid`` is unique per event, so the pair selects *exactly* the
+   inner-resolved rows; results are identical to the unsplit query.
+
+This generalizes the runner's hand-built split: because it runs in the printer pipeline, every qualifying
+query gets it — ad-hoc ``/query`` HogQL, the event taxonomy runner, and any other code path that scans wide
+events with a ``LIMIT`` — not just one runner.
+
+It runs **before** type resolution so the injected subquery flows through the normal
+resolve / lazy-table / property-swap pipeline exactly like a hand-written one (the same reason
+``EventsQueryRunner`` built its split on an unresolved AST). The only field references it introduces are the
+``timestamp`` and ``uuid`` identity columns, qualified with the events table's alias (if any) so they resolve
+against the single bare table; the ``FROM`` / ``WHERE`` / ``ORDER BY`` it copies into the inner query are
+verbatim clones of the outer's, so they resolve identically.
+
+The rewrite is intentionally narrow. It only fires when:
+
+- the source is a single bare ``events`` table — no joins, ``ARRAY JOIN``, ``SAMPLE``, ``FINAL``, subquery
+  source, or CTEs (lazy person/group joins implied by ``WHERE``/``SELECT`` are fine: they are reproduced by
+  cloning, and resolve on the inner/outer independently),
+- there is an ``ORDER BY`` and no term sorts by a *raw* wide column (the ``properties`` blob or
+  ``elements_chain``) — this matches the runner's presorted-optimization breadth, so dropping the runner split
+  never loses an optimization it had. A ``properties.$x`` extraction is fine. When the leading term is
+  ``timestamp`` the inner additionally early-terminates (see ``timestamp_order_by``); other orders still
+  benefit from the narrow inner sort + wide point-fetch,
+- there is a constant ``LIMIT`` (and ``OFFSET``) within the standard returned-rows ceiling — the payoff is
+  bounded point-fetching; a huge limit would just double-scan,
+- the projection actually reads a wide column (``*``, ``properties``, or ``elements_chain``) — otherwise the
+  split is pure overhead,
+- there is no ``GROUP BY`` / aggregation, ``DISTINCT``, window function, ``WITH FILL``, ``HAVING``,
+  ``QUALIFY``, ``PREWHERE``, ``LIMIT BY``, or ``LIMIT ... WITH TIES`` — these change row identity or set
+  semantics so a per-row identity split would not be equivalent, and
+- the query is not already resolve-then-fetched (so it composes safely with ``EventsQueryRunner``'s own split
+  and never re-wraps its own inner query).
+
+NB: like ``EventsQueryRunner``'s split, the inner ``LIMIT n + m`` means events sharing the exact timestamp at
+the page boundary could in principle be ordered differently than a single full sort. In practice this is
+immaterial — ``timestamp`` is ``DateTime64(6)`` — and it matches the existing behavior.
+"""
+
+from posthog.hogql import ast
+from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.visitor import TraversingVisitor, clone_expr
+
+# Columns whose bytes dominate an events row; deferring their read to the final LIMIT rows is the win.
+WIDE_EVENTS_COLUMNS = {"properties", "elements_chain"}
+
+
+def optimize_events_resolve_then_fetch(node: ast.Expr, context: HogQLContext) -> None:
+    """Mutate ``node`` in place, splitting qualifying wide events scans into resolve + point-fetch."""
+    EventsResolveThenFetchRewriter(context).visit(node)
+
+
+def _unwrap_alias(expr: ast.Expr) -> ast.Expr:
+    while isinstance(expr, ast.Alias):
+        expr = expr.expr
+    return expr
+
+
+class _NodeFinder(TraversingVisitor):
+    """Sets ``found`` if the visited subtree contains a node matching ``_matches``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.found = False
+
+
+class _WindowFunctionFinder(_NodeFinder):
+    def visit_window_function(self, node: ast.WindowFunction) -> None:
+        self.found = True
+
+
+class _WideColumnFinder(_NodeFinder):
+    def visit_field(self, node: ast.Field) -> None:
+        # An asterisk expands to the full row (incl. properties + elements_chain), and any reference into
+        # properties/elements_chain reads the wide blob (a `properties.$x` extraction still reads the column
+        # unless materialized) — all worth deferring to the point-fetch.
+        if any(part in WIDE_EVENTS_COLUMNS or part == "*" for part in node.chain):
+            self.found = True
+
+
+class _AggregationFinder(_NodeFinder):
+    """Mirrors ``posthog.hogql.property.AggregationFinder`` but imports the function registry lazily.
+
+    The registry (``find_hogql_aggregation``) is a side-effect-free dict lookup and is already loaded by the
+    printer at call time, so this deferred import is a cached no-op. Importing it at module load — like
+    importing ``posthog.hogql.property`` — would both hit the printer↔``posthog.models`` cycle and, worse,
+    trigger ``posthog.models`` import side effects mid-query that alter the events ``*`` expansion.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        from posthog.hogql.functions import find_hogql_aggregation
+
+        self._find_hogql_aggregation = find_hogql_aggregation
+
+    def visit_select_query(self, node: ast.SelectQuery) -> None:
+        pass  # an aggregation inside a subquery does not make this query an aggregation
+
+    def visit_call(self, node: ast.Call) -> None:
+        if self._find_hogql_aggregation(node.name):
+            self.found = True
+            return
+        for arg in node.args or []:
+            self.visit(arg)
+
+
+class _AliasReferenceFinder(_NodeFinder):
+    """Sets ``found`` if any visited field references one of ``alias_names`` (an outer SELECT alias)."""
+
+    def __init__(self, alias_names: set[str]) -> None:
+        super().__init__()
+        self._alias_names = alias_names
+
+    def visit_field(self, node: ast.Field) -> None:
+        if node.chain and node.chain[0] in self._alias_names:
+            self.found = True
+
+
+def _references_select_alias(exprs: list[ast.Expr], alias_names: set[str]) -> bool:
+    if not alias_names:
+        return False
+    finder = _AliasReferenceFinder(alias_names)
+    for expr in exprs:
+        finder.visit(expr)
+    return finder.found
+
+
+def _contains_window_function(exprs: list[ast.Expr]) -> bool:
+    finder = _WindowFunctionFinder()
+    for expr in exprs:
+        finder.visit(expr)
+    return finder.found
+
+
+def _selects_wide_column(select: list[ast.Expr]) -> bool:
+    finder = _WideColumnFinder()
+    for expr in select:
+        finder.visit(expr)
+    return finder.found
+
+
+class EventsResolveThenFetchRewriter(TraversingVisitor):
+    def __init__(self, context: HogQLContext) -> None:
+        super().__init__()
+        self.context = context
+
+    def visit_select_query(self, node: ast.SelectQuery) -> None:
+        # Recurse into subqueries / CTEs first, then rewrite this query. The injected inner subquery is added
+        # afterwards and is never re-visited (it is also narrow, so it would not qualify anyway).
+        super().visit_select_query(node)
+        self._maybe_rewrite(node)
+
+    def _maybe_rewrite(self, node: ast.SelectQuery) -> None:
+        if not self._qualifies(node):
+            return
+
+        # Single bare events table (guaranteed by _qualifies): qualify the identity columns with the table's
+        # alias if it has one (e.g. `e.timestamp` for `FROM events AS e`) so they resolve unambiguously. uuid
+        # is unique per event, so (timestamp, uuid) identifies the row exactly.
+        assert node.select_from is not None
+        prefix = [node.select_from.alias] if node.select_from.alias else []
+        timestamp_field = ast.Field(chain=[*prefix, "timestamp"])
+        uuid_field = ast.Field(chain=[*prefix, "uuid"])
+
+        assert isinstance(node.limit, ast.Constant)
+        limit_plus_offset = node.limit.value + (
+            node.offset.value if isinstance(node.offset, ast.Constant) and isinstance(node.offset.value, int) else 0
+        )
+
+        inner = ast.SelectQuery(
+            select=[clone_expr(timestamp_field), clone_expr(uuid_field)],
+            select_from=clone_expr(node.select_from),
+            where=clone_expr(node.where) if node.where is not None else None,
+            order_by=[clone_expr(order_expr) for order_expr in node.order_by] if node.order_by else None,
+            limit=ast.Constant(value=limit_plus_offset),
+        )
+
+        # Strict superset of the runner's presorted optimization: KEEP the original WHERE and AND-in the
+        # identity-pair prefilter (do not replace it). Keeping the filter preserves sort-key granule pruning on
+        # the outer (e.g. an `event =` predicate, high in the sort key); the (timestamp, uuid) pair then prunes
+        # the point-fetch to the matched days via toDate(timestamp). The outer keeps its SELECT / ORDER BY /
+        # LIMIT / OFFSET; the printer adds the team_id guard to both scans.
+        prefilter = ast.CompareOperation(
+            left=ast.Tuple(exprs=[clone_expr(timestamp_field), clone_expr(uuid_field)]),
+            op=ast.CompareOperationOp.In,
+            right=inner,
+        )
+        node.where = ast.And(exprs=[node.where, prefilter]) if node.where is not None else prefilter
+
+    def _qualifies(self, node: ast.SelectQuery) -> bool:
+        """True if ``node`` is a wide bare-events scan we can safely split into resolve + point-fetch."""
+        # Constant LIMIT (and OFFSET) within the standard ceiling — the payoff is bounded point-fetching.
+        if not isinstance(node.limit, ast.Constant) or not isinstance(node.limit.value, int) or node.limit.value <= 0:
+            return False
+        if node.offset is not None and not (
+            isinstance(node.offset, ast.Constant) and isinstance(node.offset.value, int) and node.offset.value >= 0
+        ):
+            return False
+        offset_value = node.offset.value if isinstance(node.offset, ast.Constant) else 0
+        if node.limit.value + offset_value > MAX_SELECT_RETURNED_ROWS:
+            return False
+
+        # No clause that changes row identity or set semantics — a per-row identity split would not be equivalent.
+        if (
+            node.distinct
+            or node.group_by
+            or node.having
+            or node.qualify
+            or node.prewhere
+            or node.ctes
+            or node.array_join_op is not None
+            or node.array_join_list
+            or node.limit_by is not None
+            or node.limit_with_ties
+            or node.limit_percent
+            or node.window_exprs
+        ):
+            return False
+
+        # Single bare events table: no joins, sample, FINAL, or subquery/CTE source.
+        select_from = node.select_from
+        if select_from is None or select_from.next_join is not None or select_from.sample is not None:
+            return False
+        if select_from.table_final:
+            return False
+        if not isinstance(select_from.table, ast.Field) or select_from.table.chain != ["events"]:
+            return False
+
+        # No aggregation or window function in the projection, and it must actually read a wide column —
+        # otherwise the split is pure overhead (two narrow scans are slower than one).
+        if self._select_has_aggregation(node.select):
+            return False
+        if _contains_window_function(node.select):
+            return False
+        if not _selects_wide_column(node.select):
+            return False
+
+        # There must be an ORDER BY, no term may sort by a raw wide column, and no WITH FILL / window function
+        # anywhere in it (gap filling adds rows, windows span the set — neither survives a per-row split).
+        if not node.order_by:
+            return False
+        if any(order_expr.with_fill is not None for order_expr in node.order_by):
+            return False
+        if _contains_window_function([order_expr.expr for order_expr in node.order_by]):
+            return False
+        if not self._order_by_qualifies(node.order_by):
+            return False
+
+        # The inner clones the ORDER BY but selects only (timestamp, uuid), so a term that references an outer
+        # SELECT alias (e.g. `SELECT properties.x AS y ... ORDER BY y`) would be unresolvable inside it. WHERE
+        # can't reference select aliases (scoping), so the ORDER BY is the only cloned clause at risk.
+        alias_names = {item.alias for item in node.select if isinstance(item, ast.Alias)}
+        if _references_select_alias([order_expr.expr for order_expr in node.order_by], alias_names):
+            return False
+
+        # Don't double-wrap: skip if already resolve-then-fetched (e.g. a hand-written `uuid IN (...)` split).
+        if self._is_already_resolve_fetched(node.where):
+            return False
+
+        return True
+
+    def _order_by_qualifies(self, order_by: list[ast.OrderExpr]) -> bool:
+        """No order term may sort by a *raw* wide column; a ``properties.$x`` extraction is fine.
+
+        Mirrors ``EventsQueryRunner._can_use_presorted_optimization``: ordering by the raw ``properties`` blob
+        or ``elements_chain`` would need the wide column for the inner sort — exactly what we want to avoid —
+        whereas any other order (``timestamp``, ``event``, ``created_at``, a function, a ``properties.$x``
+        extraction) leaves the inner narrow. Matching this breadth means removing the runner split loses
+        nothing it optimized.
+        """
+        for order_expr in order_by:
+            expr = _unwrap_alias(order_expr.expr)
+            if isinstance(expr, ast.Field) and expr.chain:
+                first = expr.chain[0]
+                if first in WIDE_EVENTS_COLUMNS and not (first == "properties" and len(expr.chain) >= 2):
+                    return False
+        return True
+
+    def _select_has_aggregation(self, select: list[ast.Expr]) -> bool:
+        finder = _AggregationFinder()
+        for expr in select:
+            finder.visit(expr)
+        return finder.found
+
+    def _is_already_resolve_fetched(self, where: ast.Expr | None) -> bool:
+        if where is None:
+            return False
+        conjuncts = where.exprs if isinstance(where, ast.And) else [where]
+        for conjunct in conjuncts:
+            if (
+                isinstance(conjunct, ast.CompareOperation)
+                and conjunct.op == ast.CompareOperationOp.In
+                and isinstance(conjunct.right, ast.SelectQuery)
+                and self._references_uuid(conjunct.left)
+            ):
+                return True
+        return False
+
+    def _references_uuid(self, expr: ast.Expr) -> bool:
+        if isinstance(expr, ast.Field):
+            return bool(expr.chain) and expr.chain[-1] == "uuid"
+        if isinstance(expr, ast.Tuple):
+            return any(self._references_uuid(item) for item in expr.exprs)
+        return False

--- a/posthog/hogql/transforms/events_resolve_then_fetch.py
+++ b/posthog/hogql/transforms/events_resolve_then_fetch.py
@@ -83,7 +83,7 @@ from posthog.hogql.visitor import TraversingVisitor, clone_expr
 WIDE_EVENTS_COLUMNS = {"properties", "elements_chain"}
 
 
-def optimize_events_resolve_then_fetch(node: ast.Expr, context: HogQLContext) -> None:
+def optimize_events_resolve_then_fetch(node: ast.AST, context: HogQLContext) -> None:
     """Mutate ``node`` in place, splitting qualifying wide events scans into resolve + point-fetch."""
     EventsResolveThenFetchRewriter(context).visit(node)
 

--- a/posthog/hogql/transforms/test/test_events_resolve_then_fetch.py
+++ b/posthog/hogql/transforms/test/test_events_resolve_then_fetch.py
@@ -1,0 +1,171 @@
+import re
+from datetime import datetime
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
+
+from parameterized import parameterized
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
+from posthog.hogql.query import execute_hogql_query
+
+
+def _normalize(sql: str) -> str:
+    sql = re.sub(r"%\(hogql_val_\d+\)s", "hogval", sql)
+    return re.sub(r"\s+", " ", sql)
+
+
+class TestEventsResolveThenFetchRewrite(ClickhouseTestMixin, BaseTest):
+    def _print(self, select: str) -> str:
+        context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
+        sql, _ = prepare_and_print_ast(parse_select(select), context, "clickhouse")
+        return _normalize(sql)
+
+    def _scans(self, sql: str) -> int:
+        return sql.count("FROM events")
+
+    def test_wide_star_scan_is_split(self):
+        sql = self._print("SELECT * FROM events WHERE event = 'x' ORDER BY timestamp DESC LIMIT 100")
+        # Inner narrow resolve + outer point-fetch == two scans of the events table.
+        assert self._scans(sql) == 2
+        # The outer prefilter matches the (timestamp, uuid) identity pair.
+        assert "events.uuid" in sql
+        assert "in(" in sql or "IN (" in sql
+        # Inner orders by timestamp; when the timestamp_order_by rewrite (a separate optimization) is also
+        # present it further rewrites this to read in primary-key order, but this transform does not require it.
+        assert "events.timestamp" in sql
+
+    @parameterized.expand(
+        [
+            ("properties_blob", "SELECT properties FROM events ORDER BY timestamp DESC LIMIT 10"),
+            ("elements_chain", "SELECT elements_chain FROM events ORDER BY timestamp DESC LIMIT 10"),
+            ("property_extraction", "SELECT properties.$foo FROM events ORDER BY timestamp DESC LIMIT 10"),
+            ("with_offset", "SELECT * FROM events ORDER BY timestamp DESC LIMIT 10 OFFSET 5"),
+            ("timezone_wrapped_order", "SELECT * FROM events ORDER BY toTimeZone(timestamp, 'UTC') DESC LIMIT 10"),
+            ("ascending", "SELECT * FROM events ORDER BY timestamp ASC LIMIT 10"),
+            # Any order that doesn't sort by a raw wide column qualifies (matches the runner's breadth) — the
+            # inner stays narrow even when it can't early-terminate.
+            ("non_leading_timestamp", "SELECT * FROM events ORDER BY event ASC, timestamp DESC LIMIT 10"),
+            ("non_timestamp_order", "SELECT * FROM events ORDER BY event DESC LIMIT 10"),
+            ("created_at_order", "SELECT * FROM events ORDER BY created_at DESC LIMIT 10"),
+            ("function_wrapped_order", "SELECT * FROM events ORDER BY toStartOfHour(timestamp) DESC LIMIT 10"),
+            ("property_extraction_order", "SELECT * FROM events ORDER BY properties.$foo DESC LIMIT 10"),
+        ]
+    )
+    def test_qualifying_wide_scans_are_split(self, _name: str, select: str):
+        assert self._scans(self._print(select)) == 2
+
+    def test_lazy_person_reference_still_splits(self):
+        # `person` is a lazy join at parse time, so the source is still a single bare events table.
+        sql = self._print(
+            "SELECT properties, person.properties.email FROM events "
+            "WHERE person.properties.foo = 'x' ORDER BY timestamp DESC LIMIT 10"
+        )
+        assert self._scans(sql) == 2
+
+    def test_split_inside_subquery(self):
+        sql = self._print(
+            "SELECT x.properties FROM "
+            "(SELECT properties, timestamp, uuid FROM events ORDER BY timestamp DESC LIMIT 100) AS x"
+        )
+        assert self._scans(sql) == 2
+
+    @parameterized.expand(
+        [
+            ("narrow_projection", "SELECT uuid, event FROM events ORDER BY timestamp DESC LIMIT 100"),
+            ("no_limit", "SELECT * FROM events ORDER BY timestamp DESC"),
+            (
+                "aggregation",
+                "SELECT properties, count() FROM events GROUP BY properties ORDER BY timestamp DESC LIMIT 10",
+            ),
+            ("distinct", "SELECT DISTINCT properties FROM events ORDER BY timestamp DESC LIMIT 10"),
+            ("window_function", "SELECT properties, row_number() OVER (ORDER BY timestamp) FROM events LIMIT 10"),
+            # Ordering by a raw wide column would need that column in the inner sort — the thing we avoid.
+            ("order_by_raw_properties", "SELECT * FROM events ORDER BY properties DESC LIMIT 10"),
+            ("order_by_elements_chain", "SELECT * FROM events ORDER BY elements_chain DESC LIMIT 10"),
+            # ORDER BY references a SELECT alias the narrow inner wouldn't have, so it can't be cloned in.
+            ("order_by_select_alias", "SELECT properties.foo AS label FROM events ORDER BY label ASC LIMIT 10"),
+            ("no_order_by", "SELECT * FROM events LIMIT 10"),
+            ("with_fill", "SELECT * FROM events ORDER BY timestamp DESC WITH FILL LIMIT 10"),
+            ("not_events_table", "SELECT * FROM persons ORDER BY created_at DESC LIMIT 10"),
+        ]
+    )
+    def test_non_qualifying_scans_are_not_split(self, _name: str, select: str):
+        assert self._scans(self._print(select)) <= 1
+
+    def test_huge_limit_is_not_split(self):
+        # A limit beyond the standard returned-rows ceiling would just double-scan most of the table.
+        assert self._scans(self._print("SELECT * FROM events ORDER BY timestamp DESC LIMIT 200000")) == 1
+
+    def test_outer_keeps_the_filter(self):
+        # The crux of the superset: the outer WHERE keeps the original predicate (so sort-key granule pruning
+        # survives) and ANDs in the (timestamp, uuid) prefilter — it does not replace it. The predicate appears
+        # twice: once in the narrow inner resolve, once in the kept outer filter.
+        sql = self._print("SELECT properties FROM events WHERE event = 'x' ORDER BY timestamp DESC LIMIT 10")
+        assert self._scans(sql) == 2
+        assert sql.count("events.event") == 2
+        # The identity-pair prefilter is on the outer too.
+        assert "events.uuid" in sql
+
+    def test_already_resolve_fetched_is_not_rewrapped(self):
+        # A hand-written `uuid IN (...)` split is left alone (its narrow inner never qualifies), so exactly two
+        # scans remain rather than a third nested wrap.
+        sql = self._print(
+            "SELECT * FROM events WHERE uuid IN (SELECT uuid FROM events ORDER BY timestamp DESC LIMIT 100) "
+            "ORDER BY timestamp DESC LIMIT 100"
+        )
+        assert self._scans(sql) == 2
+
+
+class TestEventsResolveThenFetchCorrectness(ClickhouseTestMixin, BaseTest):
+    INSTANTS = [
+        ("u0", datetime(2024, 2, 10, 23, 0)),
+        ("u1", datetime(2024, 2, 11, 2, 0)),
+        ("u2", datetime(2024, 2, 11, 9, 0)),
+        ("u3", datetime(2024, 2, 12, 20, 0)),
+        ("u4", datetime(2024, 2, 12, 21, 30)),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        for distinct_id, ts in self.INSTANTS:
+            _create_event(
+                team=self.team,
+                distinct_id=distinct_id,
+                event="$pageview",
+                timestamp=ts,
+                properties={"marker": distinct_id},
+            )
+        flush_persons_and_events()
+
+    def _wide(self, select: str) -> tuple[list, str]:
+        response = execute_hogql_query(select, team=self.team)
+        assert response.results is not None
+        return response.results, re.sub(r"\s+", " ", response.clickhouse or "")
+
+    def test_wide_query_is_split_and_ordered(self):
+        results, sql = self._wide("SELECT distinct_id, properties.marker FROM events ORDER BY timestamp DESC LIMIT 3")
+        assert sql.count("FROM events") == 2
+        assert [row[0] for row in results] == ["u4", "u3", "u2"]
+        # The wide column is point-fetched correctly for the resolved rows.
+        assert [row[1] for row in results] == ["u4", "u3", "u2"]
+
+    def test_split_matches_unsplit_rows(self):
+        wide, wide_sql = self._wide("SELECT distinct_id, properties FROM events ORDER BY timestamp ASC LIMIT 4")
+        narrow, narrow_sql = self._wide("SELECT distinct_id FROM events ORDER BY timestamp ASC LIMIT 4")
+        assert wide_sql.count("FROM events") == 2
+        assert narrow_sql.count("FROM events") == 1
+        assert [row[0] for row in wide] == [row[0] for row in narrow] == ["u0", "u1", "u2", "u3"]
+
+    def test_offset_pagination_is_correct(self):
+        results, sql = self._wide("SELECT distinct_id, properties FROM events ORDER BY timestamp DESC LIMIT 2 OFFSET 1")
+        assert sql.count("FROM events") == 2
+        assert [row[0] for row in results] == ["u3", "u2"]
+
+    def test_filtered_wide_query_is_correct(self):
+        results, sql = self._wide(
+            "SELECT distinct_id, properties FROM events WHERE distinct_id != 'u4' ORDER BY timestamp DESC LIMIT 2"
+        )
+        assert sql.count("FROM events") == 2
+        assert [row[0] for row in results] == ["u3", "u2"]

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_event_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_event_taxonomy_query_runner.ambr
@@ -8,7 +8,12 @@
   FROM
     (SELECT JSONExtractKeysAndValues(events.properties, 'String') AS kv
      FROM events
-     WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), equals(events.event, 'event1'))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), equals(events.event, 'event1')), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                      (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                       FROM events
+                                                                                                                                                                       WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), equals(events.event, 'event1'))
+                                                                                                                                                                       ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                                                                                                                                       LIMIT 100)))
      ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
      LIMIT 100) ARRAY
   JOIN (kv).1 AS key,
@@ -74,7 +79,12 @@
   FROM
     (SELECT JSONExtractKeysAndValues(events.properties, 'String') AS kv
      FROM events
-     WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), equals(events.event, '$pageview'))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), equals(events.event, '$pageview')), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                         (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                          FROM events
+                                                                                                                                                                          WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), equals(events.event, '$pageview'))
+                                                                                                                                                                          ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                                                                                                                                          LIMIT 100)))
      ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
      LIMIT 100) ARRAY
   JOIN (kv).1 AS key,

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -6,13 +6,12 @@ from typing import cast
 from django.utils.timezone import now
 
 import orjson
-import structlog
 
 from posthog.schema import CachedEventsQueryResponse, DashboardFilter, EventsQuery, EventsQueryResponse
 
 from posthog.hogql import ast
 from posthog.hogql.ast import Alias
-from posthog.hogql.parser import parse_expr, parse_order_expr, parse_select
+from posthog.hogql.parser import parse_expr, parse_order_expr
 from posthog.hogql.property import (
     action_to_expr,
     has_aggregation,
@@ -35,8 +34,6 @@ from posthog.utils import relative_date_parse
 
 from products.actions.backend.models.action import Action, ActionStepJSON
 
-logger = structlog.get_logger(__name__)
-
 # Allow-listed fields returned when you select "*" from events. Person and group fields will be nested later.
 SELECT_STAR_FROM_EVENTS_FIELDS = [
     "uuid",
@@ -49,9 +46,6 @@ SELECT_STAR_FROM_EVENTS_FIELDS = [
     "created_at",
     "person_mode",
 ]
-
-# Wide columns that defeat presorted optimization
-WIDE_COLUMNS = {"elements_chain", "properties"}
 
 
 class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
@@ -108,28 +102,6 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
         return select_input, [
             map_virtual_properties(parse_expr(column, timings=self.timings)) for column in select_input
         ]
-
-    def _can_use_presorted_optimization(self, order_by: list[ast.OrderExpr] | None) -> bool:
-        """
-        Check if ORDER BY can use presorted optimization.
-
-        We can optimize any ORDER BY that doesn't need wide columns directly.
-        - properties.$foo is fine (we extract just that value)
-        - elements_chain or raw properties blob is not fine
-        """
-        if not order_by:
-            return False
-
-        for order_expr in order_by:
-            if isinstance(order_expr.expr, ast.Field) and order_expr.expr.chain:
-                first = order_expr.expr.chain[0]
-                if first in WIDE_COLUMNS:
-                    # properties.$foo is fine - we extract just that property
-                    if first == "properties" and len(order_expr.expr.chain) >= 2:
-                        continue
-                    return False
-
-        return True
 
     def apply_pagination_cursor(self, cursor: str) -> None:
         # NB: This uses the last row's timestamp as the cursor, so events sharing
@@ -394,26 +366,11 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                     order_by=order_by,
                 )
 
-                # Presorted optimization: sort narrow data (uuid) first, then fetch wide data for matched rows.
-                # Avoids sorting giant rows with properties and elements_chain cols - instead sorts uuids.
-                if self._can_use_presorted_optimization(order_by) and not has_any_aggregation:
-                    logger.info(
-                        "events_query_runner_presorted_optimization",
-                        team_id=self.team.pk,
-                    )
-                    inner_query = parse_select("SELECT uuid FROM events")
-                    assert isinstance(inner_query, ast.SelectQuery)
-                    inner_query.where = where
-                    inner_query.order_by = order_by
-                    inner_query.limit = ast.Constant(value=self.paginator.limit + self.paginator.offset + 1)
-
-                    prefilter_sorted = parse_expr("uuid in ({inner_query})", {"inner_query": inner_query})
-
-                    if where is not None:
-                        stmt.where = ast.And(exprs=[prefilter_sorted, where])
-                    else:
-                        stmt.where = prefilter_sorted
-
+                # The resolve-then-fetch split (resolve the ordered rows' (timestamp, uuid) identity reading
+                # only narrow columns, then point-fetch the wide columns) now lives in a general HogQL printer
+                # transform — see posthog/hogql/transforms/events_resolve_then_fetch.py. It fires for any
+                # qualifying wide events scan no matter which runner builds the query (and for raw HogQL run via
+                # /query), so this runner no longer hand-builds it for EventsQuery alone.
                 return stmt
 
     def _calculate(self) -> EventsQueryResponse:

--- a/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
@@ -3,12 +3,12 @@
   '''
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 101)), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                                                       (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                                                        FROM events
+                                                                                                                                                                                                                                                        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                                                        ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                                                                                                                                                                                                                        LIMIT 101)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -139,12 +139,7 @@
   SELECT events.event AS event,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 3
   OFFSET 0 SETTINGS readonly=2,
@@ -214,12 +209,12 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'idx'), ''), 'null'), '^"|"$', '') AS idx,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                                                                                                                                                                                     LIMIT 3)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 3
   OFFSET 0 SETTINGS readonly=2,
@@ -239,12 +234,12 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'idx'), ''), 'null'), '^"|"$', '') AS idx,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                                                                                                                                                                                     LIMIT 3)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 3
   OFFSET 0 SETTINGS readonly=2,
@@ -264,12 +259,12 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'idx'), ''), 'null'), '^"|"$', '') AS idx,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                                                                                                                                                                                     LIMIT 3)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 3
   OFFSET 0 SETTINGS readonly=2,
@@ -439,12 +434,12 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'idx'), ''), 'null'), '^"|"$', '') AS idx,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                                                                                                                                                                                     LIMIT 3)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
   LIMIT 3
   OFFSET 0 SETTINGS readonly=2,
@@ -464,12 +459,12 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'idx'), ''), 'null'), '^"|"$', '') AS idx,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                                                                                                                                                                                     LIMIT 3)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
   LIMIT 3
   OFFSET 0 SETTINGS readonly=2,
@@ -489,12 +484,12 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'idx'), ''), 'null'), '^"|"$', '') AS idx,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                                                                                                                                                                                     LIMIT 3)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
   LIMIT 3
   OFFSET 0 SETTINGS readonly=2,
@@ -663,12 +658,12 @@
   '''
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                                                                                                                                                                                     LIMIT 3)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
   LIMIT 3
   OFFSET 0 SETTINGS readonly=2,
@@ -735,12 +730,12 @@
   '''
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 101)), and(notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                                                                                                              (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                                                                                                               FROM events
+                                                                                                                                                                                                                                                                                                               WHERE and(equals(events.team_id, 99999), notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                                                                                                               ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                                                                                                                                                                                                                                                                               LIMIT 101)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -759,12 +754,12 @@
   '''
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'some_prop'), ''), 'null'), '^"|"$', ''), 'a'), 0), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 101)), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'some_prop'), ''), 'null'), '^"|"$', ''), 'a'), 0), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'some_prop'), ''), 'null'), '^"|"$', ''), 'a'), 0), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                                                                                                                                                                                          (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                                                                                                                                                                                           FROM events
+                                                                                                                                                                                                                                                                                                                                                                                           WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'some_prop'), ''), 'null'), '^"|"$', ''), 'a'), 0), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                                                                                                                                                                                           ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                                                                                                                                                                                                                                                                                                                                                           LIMIT 101)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -783,12 +778,12 @@
   '''
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC, events.event ASC
-                                                 LIMIT 101)), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                                                       (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                                                        FROM events
+                                                                                                                                                                                                                                                        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                                                        ORDER BY toTimeZone(events.timestamp, 'UTC') DESC, events.event ASC
+                                                                                                                                                                                                                                                        LIMIT 101)))
   ORDER BY toTimeZone(events.timestamp, 'UTC') DESC, events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -807,12 +802,12 @@
   '''
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY events.event ASC
-                                                 LIMIT 101)), and(less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                    (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                     FROM events
+                                                                                                                                                                                                                     WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                     ORDER BY events.event ASC
+                                                                                                                                                                                                                     LIMIT 101)))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -831,12 +826,12 @@
   '''
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.uuid,
-                                                (SELECT events.uuid AS uuid
-                                                 FROM events
-                                                 WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'priority'), ''), 'null'), '^"|"$', '') ASC
-                                                 LIMIT 101)), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))))
+  WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.uuid),
+                                                                                                                                                                                                                                                       (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.uuid AS uuid
+                                                                                                                                                                                                                                                        FROM events
+                                                                                                                                                                                                                                                        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
+                                                                                                                                                                                                                                                        ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'priority'), ''), 'null'), '^"|"$', '') ASC
+                                                                                                                                                                                                                                                        LIMIT 101)))
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'priority'), ''), 'null'), '^"|"$', '') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,


### PR DESCRIPTION
## Problem

Wide `events` scans — `SELECT properties / elements_chain / * FROM events … ORDER BY <ord> LIMIT n` (events explorer, ad-hoc `/query`, event taxonomy sampling) — materialize the wide columns for every row scanned on the way to the `LIMIT`. For a selective filter that isn't aligned to the sort key, that means dragging the `properties` blob and `elements_chain` across far more rows than the `n` actually returned. It's the dominant cost (and a memory pressure source) of the events-explorer query shape.

`EventsQueryRunner` already avoided this with a hand-built two-step "presorted optimization" — but it lived inside that runner. So `EventsQuery` (what the events explorer sends to `/query`) got it, while raw `HogQLQuery` SQL and any other path that scans `events` without going through `EventsQueryRunner` did not.

> Independent of #59342 (a separate optimization that early-terminates events `ORDER BY timestamp` scans). They compose — the injected inner *also* early-terminates once #59342 lands — but neither requires the other, so this targets `master` directly.

## Changes

Lifts the two-step into a HogQL **printer transform** (`events_resolve_then_fetch.py`), so every qualifying query gets it — and removes the runner's hand-built version. A wide scan

```sql
SELECT <wide …> FROM events WHERE <w> ORDER BY <ord> LIMIT n
```

is rewritten to resolve the ordered rows' identity reading only narrow columns, then point-fetch the wide columns for just those rows:

```sql
SELECT <wide …> FROM events
WHERE <w> AND (timestamp, uuid) IN (
    SELECT timestamp, uuid FROM events WHERE <w> ORDER BY <ord> LIMIT n
)
ORDER BY <ord> LIMIT n
```

It is a **strict superset of the old runner split**, so it is never worse than what we had:

- **Keeps the original `WHERE`** and ANDs in the prefilter (the runner kept it too). The events sort key leads with `(team_id, toDate(timestamp), event, …)`, so a predicate like `event =` prunes whole granules — dropping it and leaning on the `IN` alone would force reading every granule in the matched days.
- **Matches the `(timestamp, uuid)` pair** instead of `uuid` alone. `uuid` is the trailing, hashed sort-key column and can't seek; the concrete timestamps feed the `toDate(timestamp)` index so the outer point-fetch prunes by day.
- **Matches the runner's order breadth** (any order that doesn't sort by a raw wide column), so deleting the runner split loses no optimization it had.

Runs before type resolution, so the injected subquery flows through the normal resolve / lazy-table / property-swap pipeline (the same reason the runner built its split on an unresolved AST — lazy `person` joins are still implicit at this stage). The rewrite is gated to non-aggregated, single-bare-`events` scans with a bounded constant `LIMIT` that actually select a wide column; guards reject DISTINCT / GROUP BY / window / WITH FILL / sampling / etc.

## How did you test this code?

I'm an agent (Claude Code, agent-assisted, human-reviewed). Listing only what I actually ran:

**Automated tests**
- New `test_events_resolve_then_fetch.py` (33 cases): qualifying vs non-qualifying shapes, offset pagination, lazy-person reference, idempotency, and execution-level correctness asserting split results equal the unsplit query.
- Full HogQL printer suite: 621 passed, no snapshot churn.
- `test_events_query_runner` (10), ad-hoc `test_query` (8), and `test_event_taxonomy_query_runner` (2): the only failures are **intended** snapshot diffs showing the new superset form; every result/behavior assertion (including cursor pagination DESC/ASC) passes. Snapshot `.ambr` regeneration is left to CI.
- A real bug surfaced and was fixed: `ORDER BY <select-alias>` (e.g. `SELECT properties.x AS y … ORDER BY y`) — the narrow inner can't resolve the alias, so the transform now skips those (with a regression test). Not a runner regression: it only ever processed its own generated SQL.

**Production sanity check** — reconstructed the plain / old (`uuid IN`) / new (`(timestamp,uuid) IN`) variants of a representative wide events-explorer query and ran them against production ClickHouse, comparing rows/bytes read. All three returned identical results; the new form read ~35% fewer bytes and rows than the old `uuid`-only split and was ~3.7× faster than no split:

| variant | bytes read | rows read | duration |
| --- | --- | --- | --- |
| no split | 1.51 GiB | 26.0M | 13.3 s |
| old (`uuid IN`) | 2.65 GiB | 51.9M | 3.9 s |
| **new (`(timestamp,uuid) IN`)** | **1.72 GiB** | **33.9M** | **3.6 s** |

## Publish to changelog?

no — transparent query-performance optimization, no user-facing behavior change.

## Docs update

No docs change needed (internal query planning).

## 🤖 Agent context

Agent-assisted (Claude Code), human-reviewed; requires human review before merge.

Design decisions:
- **Printer transform, pre-resolution.** Chosen over a resolved-AST rewrite so the injected subquery reuses the existing resolve / lazy-table / property-swap machinery unchanged — the same approach the runner used. This is what makes lazy `person.*` joins compose (they're still implicit when the transform runs).
- **Strict superset of the runner, not a re-derivation.** An earlier iteration dropped the outer filter (matching a now-closed PR) and was catastrophically worse for selective queries because it defeated sort-key granule pruning. Rejected; the final design keeps the filter and only *improves* the match key (`uuid` → `(timestamp, uuid)`).
- **Broadened to the runner's full order breadth** specifically so that removing the runner's hand-built split can't regress any query the runner used to optimize.
- **Extra correctness guards** (DISTINCT/GROUP BY/window/WITH FILL/select-alias order/…) protect arbitrary HogQL the runner never saw; the wide-select-only guard also avoids a double-scan pessimization the runner did on narrow selects.
