### PR TITLE
chore: rename team-llm-gateway to team-ai-gateway

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -162,18 +162,18 @@ services/mcp/src/tools/generated/llm_analytics.ts @PostHog/team-ai-observability
 services/mcp/src/tools/llmAnalytics/ @PostHog/team-ai-observability
 services/mcp/src/ui-apps/apps/generated/llm-costs.tsx @PostHog/team-ai-observability
 
-# LLM Gateway - owned by @PostHog/team-llm-gateway
-nodejs/src/ingestion/ai/costs/ @PostHog/team-ai-observability @PostHog/team-llm-gateway
-products/llm_analytics/backend/api/proxy.py @PostHog/team-llm-gateway
-products/llm_analytics/backend/api/test/test_proxy.py @PostHog/team-llm-gateway
-products/llm_analytics/frontend/playground/ @PostHog/team-llm-gateway
-services/llm-gateway/ @PostHog/team-llm-gateway
+# LLM Gateway - owned by @PostHog/team-ai-gateway
+nodejs/src/ingestion/ai/costs/ @PostHog/team-ai-observability @PostHog/team-ai-gateway
+products/llm_analytics/backend/api/proxy.py @PostHog/team-ai-gateway
+products/llm_analytics/backend/api/test/test_proxy.py @PostHog/team-ai-gateway
+products/llm_analytics/frontend/playground/ @PostHog/team-ai-gateway
+services/llm-gateway/ @PostHog/team-ai-gateway
 
 # DevEx-adjacent files - owned by @PostHog/team-devex
 .github/workflows/** @PostHog/team-devex
-.github/workflows/ci-llm-gateway.yml @PostHog/team-devex @PostHog/team-llm-gateway
-.github/workflows/llm-gateway-cd.yml @PostHog/team-devex @PostHog/team-llm-gateway
-.github/workflows/update-ai-costs.yml @PostHog/team-devex @PostHog/team-llm-gateway
+.github/workflows/ci-llm-gateway.yml @PostHog/team-devex @PostHog/team-ai-gateway
+.github/workflows/llm-gateway-cd.yml @PostHog/team-devex @PostHog/team-ai-gateway
+.github/workflows/update-ai-costs.yml @PostHog/team-devex @PostHog/team-ai-gateway
 .github/workflows/cd-llm-analytics-image.yml @PostHog/team-devex @PostHog/team-ai-observability
 .github/actions/** @PostHog/team-devex
 .github/dependabot.yml @PostHog/team-devex
@@ -188,7 +188,7 @@ tools/hogli-commands/ @PostHog/team-devex
 hogli.yaml @PostHog/team-devex
 tach.toml @PostHog/team-devex
 bin/ @PostHog/team-devex
-bin/start-llm-gateway @PostHog/team-devex @PostHog/team-llm-gateway
+bin/start-llm-gateway @PostHog/team-devex @PostHog/team-ai-gateway
 CODEOWNERS-soft @PostHog/team-devex
 CODEOWNERS @PostHog/team-devex
 CLAUDE.md @PostHog/team-devex

--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -163,7 +163,7 @@ jobs:
                     --head chore/llma-update-ai-costs \
                     --label "automated" --label "llm-analytics" \
                     --reviewer "PostHog/team-ai-observability" \
-                    --reviewer "PostHog/team-llm-gateway")
+                    --reviewer "PostHog/team-ai-gateway")
                   echo "Created $new_pr_url"
 
                   # If the previously open PR on this branch got auto-closed by the


### PR DESCRIPTION
## TL;DR

Rename the GitHub team `@PostHog/team-llm-gateway` to `@PostHog/team-ai-gateway` across CODEOWNERS and CI workflow files to better reflect the team's broader AI product responsibilities.

## Problem

The team previously named `team-llm-gateway` has expanded its scope beyond just LLM Gateway functionality to cover broader AI product areas. Renaming the team improves clarity and alignment with the team's actual responsibilities.

## Changes

- Updated all references to `@PostHog/team-llm-gateway` to `@PostHog/team-ai-gateway` in `.github/CODEOWNERS-soft`
- Updated team mentions in `.github/workflows/update-ai-costs.yml` to use the new team name
- Updated comments referencing "LLM Gateway - owned by" to reflect the new team name while keeping the service name unchanged

## How did you test this code?

As an agent, I verified that:
- All references to the old team name have been consistently replaced with the new name across the modified files
- The changes are isolated to team ownership and reviewer assignments only
- No functional code changes are included in this refactoring

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*