### PR TITLE
fix(logs-ingestion): honor filter_group on rate_limit drop rules

### DIFF
--- a/nodejs/src/logs-ingestion/sampling/compile-rules.ts
+++ b/nodejs/src/logs-ingestion/sampling/compile-rules.ts
@@ -241,6 +241,11 @@ export function compileRuleSet(rows: SamplingRuleRow[]): CompiledRuleSet {
             if (rateLimit) {
                 hasRateLimitRules = true
             }
+            // rate_limit rules also accept config.filter_group as a universal scope (the
+            // drop-rule UI now writes service-scoping there instead of scope_service).
+            // The path_drop branch above already parsed any filter_group on path_drop rows;
+            // do the same parse for rate_limit so the evaluator can honor it.
+            filterGroup = parseFilterGroup(row.config?.filter_group)
         }
         rules.push({
             id: row.id,

--- a/nodejs/src/logs-ingestion/sampling/evaluate.test.ts
+++ b/nodejs/src/logs-ingestion/sampling/evaluate.test.ts
@@ -207,6 +207,87 @@ describe('evaluateLogRecord', () => {
         expect(classifySamplingRecord(rules, rec).kind).toBe('resolved')
     })
 
+    describe('rate_limit with config.filter_group', () => {
+        // Same outer envelope shape the drop-rules UI emits, matching the path_drop tests below.
+        const wrap = (inner: object): object => ({ type: 'AND', values: [inner] })
+
+        it('classifySamplingRecord returns rate_limit when filter_group matches', () => {
+            const rules = compileRuleSet([
+                {
+                    id: 'rl-fg',
+                    rule_type: 'rate_limit',
+                    scope_service: null,
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: {
+                        logs_per_second: 10,
+                        filter_group: wrap({
+                            type: 'AND',
+                            values: [{ key: 'service.name', operator: 'exact', value: 'api' }],
+                        }),
+                    },
+                },
+            ])
+            const rec = baseRecord()
+            rec.service_name = 'api'
+            expect(classifySamplingRecord(rules, rec)).toEqual({ kind: 'rate_limit', ruleId: 'rl-fg' })
+        })
+
+        it('classifySamplingRecord skips rate_limit when filter_group does not match', () => {
+            const rules = compileRuleSet([
+                {
+                    id: 'rl-fg',
+                    rule_type: 'rate_limit',
+                    scope_service: null,
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: {
+                        logs_per_second: 10,
+                        filter_group: wrap({
+                            type: 'AND',
+                            values: [{ key: 'service.name', operator: 'exact', value: 'api' }],
+                        }),
+                    },
+                },
+            ])
+            const rec = baseRecord()
+            rec.service_name = 'other'
+            // Rule has no other scoping, so without filter_group honor, this would return rate_limit
+            // and rate-limit every log on the team. With the fix, it falls through to keep.
+            expect(classifySamplingRecord(rules, rec).kind).toBe('resolved')
+        })
+
+        it('classifySamplingRecord still requires scope_service AND filter_group when both set', () => {
+            const rules = compileRuleSet([
+                {
+                    id: 'rl-both',
+                    rule_type: 'rate_limit',
+                    scope_service: 'api',
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: {
+                        logs_per_second: 10,
+                        filter_group: wrap({
+                            type: 'AND',
+                            values: [{ key: 'severity_text', operator: 'exact', value: 'error' }],
+                        }),
+                    },
+                },
+            ])
+            const apiInfo = baseRecord()
+            apiInfo.service_name = 'api'
+            apiInfo.severity_text = 'info'
+            // scope_service matches but filter_group doesn't → skip.
+            expect(classifySamplingRecord(rules, apiInfo).kind).toBe('resolved')
+
+            const apiError = baseRecord()
+            apiError.service_name = 'api'
+            apiError.severity_text = 'error'
+            // Both match → rate_limit.
+            expect(classifySamplingRecord(rules, apiError)).toEqual({ kind: 'rate_limit', ruleId: 'rl-both' })
+        })
+    })
+
     it('path_drop match runs before rate_limit in rule order', () => {
         const rules = compileRuleSet([
             {

--- a/nodejs/src/logs-ingestion/sampling/evaluate.ts
+++ b/nodejs/src/logs-ingestion/sampling/evaluate.ts
@@ -231,10 +231,16 @@ export function classifySamplingRecord(teamRuleSet: CompiledRuleSet | null, reco
             return { kind: 'resolved', decision: SAMPLING_DECISION_SAMPLE_DROPPED, ruleId: rule.id }
         }
         if (rule.ruleType === 'rate_limit') {
-            if (rule.rateLimit) {
-                return { kind: 'rate_limit', ruleId: rule.id }
+            if (!rule.rateLimit) {
+                continue
             }
-            continue
+            // Mirror path_drop: filter_group must match if set. scope_service was
+            // already checked by matchesScope; this adds the modern scoping that
+            // the drop-rule UI now writes for rate_limit rules.
+            if (rule.filterGroup && !matchFilterGroup(rule.filterGroup, record)) {
+                continue
+            }
+            return { kind: 'rate_limit', ruleId: rule.id }
         }
     }
     return { kind: 'resolved', decision: SAMPLING_DECISION_KEEP, ruleId: null }


### PR DESCRIPTION
## Problem

When the drop-rules UI form moved to `filter_group` as the universal matcher (#59424), the rate_limit code path in the ingestion worker was not updated to read it. As a result, a rate_limit rule whose service-scope was set via `filter_group` (the new shape the UI now writes) — rather than the legacy top-level `scope_service` column — is accepted by the API, looks correct in the UI, and then **rate-limits every log on the team** because the worker sees `scope_service = null` and never reads the filter_group.

This was observed in dev: a rule scoped to `service_name = contour/contour` via the filter chip dropped ~226K log lines/24h that did not belong to `contour/contour`. The legacy `scope_service` workaround (set the column directly via API) restored the intended scoping, confirming the diagnosis.

`path_drop` rules already honor `filter_group` and were unaffected.

## Changes

Two-half fix to bring rate_limit in line with path_drop:

| File | Change |
|---|---|
| `nodejs/src/logs-ingestion/sampling/compile-rules.ts` | Parse `config.filter_group` for `rate_limit` rows. Previously only `path_drop` rows had `parseFilterGroup` called, so rate_limit rules always compiled with `filterGroup = null` — the evaluator never had a chance to honor a filter_group. Same depth + breadth caps already enforced at compile time apply. |
| `nodejs/src/logs-ingestion/sampling/evaluate.ts` | In `classifySamplingRecord`, when a rate_limit rule has a `filterGroup`, require `matchFilterGroup` to return true before returning `{ kind: 'rate_limit' }`. `evaluateLogRecord`'s rate_limit branch already `continue`s unconditionally (stateless eval doesn't drop rate-limited rows in any path), so no change there. |
| `nodejs/src/logs-ingestion/sampling/evaluate.test.ts` | Three new classify tests: filter_group match returns rate_limit; filter_group miss falls through to `resolved`; scope_service AND filter_group both set behave as logical AND. |

**Scope of the fix:**

- Rules that use only `scope_service` (legacy) keep working — `matchesScope` runs first and is unchanged.
- Rules with both `scope_service` AND `filter_group` set: both must match (AND semantics) — matches the path_drop behaviour where both are checked.
- Rules with only `filter_group`: now honored. Previously rate-limited everything on the team.

## How did you test this code?

**Agent-authored PR.** I am PostHog Code. Manual local testing not performed; only automated tests below.

- `pnpm --filter=@posthog/nodejs jest src/logs-ingestion/sampling/` → **81 / 81 pass** (3 new cases).
- `pnpm --filter=@posthog/nodejs exec tsc --noEmit -p tsconfig.json` → clean.
- Lint-staged formatter ran successfully on the three modified files.

Manual end-to-end on dev would be: configure a rate_limit rule whose only scoping is a filter_group chip (e.g. `service_name = svc-X`), wait 30s for the sampling cache to refresh, send sustained traffic for both `svc-X` and another service, then query `default.app_metrics2 WHERE metric_name='sampling_records_dropped_by_rule'` — pre-fix would attribute drops across both services, post-fix only `svc-X`. The dev reproducer the author hit when this bug was originally reported is the gold-standard validation here.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs (internal bug fix, no documented surface change — the UI behaviour was already supposed to work this way).

## 🤖 Agent context

- **Tool:** Claude Code (PostHog Code harness), Opus 4.7. Bug uncovered while testing PR #59520 in dev — the author created a rate_limit rule scoped only via filter_group and observed it dropping ~226K log lines across unrelated services in 24h.
- **Diagnosis trail:**
  - Confirmed the rate_limit branch in `classifySamplingRecord` had no filter_group check (line 233-238 on the pre-fix master).
  - Traced the regression to #59424 (Frank's drop-rules form refactor + `feat(logs): drop scope_service requirement for rate_limit rules`): the backend validator was loosened to make filter_group sufficient, but the symmetric Node ingestion-worker change was missed.
  - On the way to the evaluator fix, discovered `compile-rules.ts` also never parsed `filter_group` for rate_limit rows, so the evaluator's new check would have read `null` regardless. Both halves needed to change for the fix to actually take effect — caught by the tests failing on the first patch.
- **Reuse:** `parseFilterGroup` + `matchFilterGroup` are the same helpers `path_drop` already uses. The fix is symmetry-restoring, not a new mechanism.
- **Out of scope (deliberately):** the analogous "active_rules per service" UI computation in `products/logs/backend/services_query_runner.py:72` also reads only `scope_service` and ignores filter_group, leading to filter-group-scoped rules appearing as active on every service in the Services tab. That's a display-only bug and lives in a separate codebase boundary; it should be a follow-up PR rather than be bundled here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*