### PR TITLE
fix(logs): services tab respects filter_group when listing active rules

### DIFF
--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -100,7 +100,6 @@ def _evaluate_service_leaf(leaf: dict, service_name: str) -> int:
         # For positive match operators, empty string can't match
         return _FALSE
 
-
     if operator in ("exact", "in"):
         return _TRUE if _matches_any(value, sn) else _FALSE
     if operator in ("is_not", "not_in"):

--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -1,3 +1,6 @@
+import re
+from typing import Any
+
 from posthog.schema import CachedLogsQueryResponse, LogsQuery
 
 from posthog.hogql import ast
@@ -9,6 +12,114 @@ from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 
 from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQueryRunnerMixin
 from products.logs.backend.models import LogsExclusionRule
+
+# Three-valued logic for evaluating a rule's filter_group against a partial record
+# at query time. We only know the row's `service_name`; everything else (severity,
+# attributes) varies per log line. A leaf returning INDETERMINATE means we can't
+# decide without seeing the full row, so the answer at the group level depends on
+# how children combine: AND × INDETERMINATE → INDETERMINATE, OR × INDETERMINATE
+# → INDETERMINATE (unless another child resolves it). The Services page treats
+# INDETERMINATE as "rule might apply, show it" and only excludes when the result
+# is provably FALSE — i.e. the rule cannot match any row from this service.
+_FALSE, _INDETERMINATE, _TRUE = -1, 0, 1
+_SERVICE_NAME_KEYS = {"service_name", "service.name"}
+
+
+def rule_could_apply_to_service(filter_group: Any, service_name: str) -> bool:
+    """
+    Return True iff the rule's `config.filter_group` could match some log line
+    with this `service_name`. Returns True for an absent/empty filter_group
+    (no scoping → applies to everything). Returns False only when the filter
+    group provably cannot match — e.g. an `AND` containing
+    `service.name exact "other"` against `service_name == "api"`.
+
+    Operates on three-valued logic so non-service-name predicates (severity,
+    arbitrary attributes) remain INDETERMINATE and conservatively keep the rule
+    visible in the Services tab. The Node ingestion worker remains the source
+    of truth for per-record drop decisions; this helper only filters the
+    display list of "rules active on each service".
+    """
+    if filter_group is None or not isinstance(filter_group, dict):
+        return True
+    return _evaluate_node(filter_group, service_name) != _FALSE
+
+
+def _evaluate_node(node: Any, service_name: str) -> int:
+    if not isinstance(node, dict):
+        return _INDETERMINATE
+    if _is_group(node):
+        children = node.get("values") or []
+        if not children:
+            # Empty group: conservative — keep the rule visible (mirrors the
+            # ingestion worker's "empty group → no match → don't drop" logic;
+            # for display, "might apply" is the safer default).
+            return _INDETERMINATE
+        results = [_evaluate_node(child, service_name) for child in children]
+        if str(node.get("type", "")).upper() == "OR":
+            if _TRUE in results:
+                return _TRUE
+            if _INDETERMINATE in results:
+                return _INDETERMINATE
+            return _FALSE
+        # AND (default for any unrecognised operator).
+        if _FALSE in results:
+            return _FALSE
+        if _INDETERMINATE in results:
+            return _INDETERMINATE
+        return _TRUE
+    # Property-filter leaf.
+    key = str(node.get("key") or "").lower()
+    if key not in _SERVICE_NAME_KEYS:
+        # Any other key depends on per-row data we don't have at services-tab time.
+        return _INDETERMINATE
+    return _evaluate_service_leaf(node, service_name)
+
+
+def _is_group(node: dict) -> bool:
+    type_ = str(node.get("type", "")).upper()
+    return type_ in ("AND", "OR") and isinstance(node.get("values"), list)
+
+
+def _evaluate_service_leaf(leaf: dict, service_name: str) -> int:
+    operator = str(leaf.get("operator") or "exact").lower()
+    value = leaf.get("value")
+    sn = service_name or ""
+
+    if operator == "is_set":
+        return _TRUE if sn else _FALSE
+    if operator == "is_not_set":
+        return _TRUE if not sn else _FALSE
+    # Every remaining operator requires both an override and a filter value.
+    if not sn or value is None:
+        return _INDETERMINATE if value is None else _FALSE
+
+    if operator in ("exact", "in"):
+        return _TRUE if _matches_any(value, sn) else _FALSE
+    if operator in ("is_not", "not_in"):
+        return _FALSE if _matches_any(value, sn) else _TRUE
+    if operator == "icontains":
+        return _TRUE if str(value).lower() in sn.lower() else _FALSE
+    if operator == "not_icontains":
+        return _FALSE if str(value).lower() in sn.lower() else _TRUE
+    if operator in ("regex", "not_regex"):
+        try:
+            matched = bool(re.search(str(value), sn, re.IGNORECASE | re.DOTALL))
+        except re.error:
+            # Invalid regex permanently no-matches, mirroring the ingestion worker.
+            return _FALSE
+        if operator == "regex":
+            return _TRUE if matched else _FALSE
+        return _FALSE if matched else _TRUE
+    # Numeric / semver / date operators don't apply to service_name strings —
+    # unknown for our purposes, so be conservative and keep the rule visible.
+    return _INDETERMINATE
+
+
+def _matches_any(value: Any, sn: str) -> bool:
+    sn_lower = sn.lower()
+    if isinstance(value, list):
+        return any(str(v).lower() == sn_lower for v in value)
+    return str(value).lower() == sn_lower
 
 
 def _sampling_rule_summary(rule: LogsExclusionRule) -> str:
@@ -69,7 +180,15 @@ class ServicesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
             error_rate = error_count / log_count if log_count > 0 else 0.0
             active_rules = []
             for rule in enabled_rules:
+                # Legacy scope_service column (still honored for rules that predate
+                # the universal filter_group).
                 if rule.scope_service and rule.scope_service != service_name:
+                    continue
+                # Modern: scope via `config.filter_group`. Three-valued evaluation
+                # against the partial record (we only know service_name at this
+                # point); INDETERMINATE keeps the rule visible.
+                filter_group = (rule.config or {}).get("filter_group")
+                if not rule_could_apply_to_service(filter_group, service_name):
                     continue
                 active_rules.append(
                     {

--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -1,5 +1,6 @@
-import re
 from typing import Any
+
+import re2
 
 from posthog.schema import CachedLogsQueryResponse, LogsQuery
 
@@ -109,9 +110,16 @@ def _evaluate_service_leaf(leaf: dict, service_name: str) -> int:
     if operator == "not_icontains":
         return _FALSE if str(value).lower() in sn.lower() else _TRUE
     if operator in ("regex", "not_regex"):
+        # RE2 (linear-time, no catastrophic backtracking) — same engine the Node
+        # ingestion worker uses via `tracked-re2`. A project member can pick the
+        # regex operator on the drop-rule form, so a pathological pattern run
+        # through Python's backtracking `re` engine here would be a ReDoS vector
+        # on every Services-tab request.
         try:
-            matched = bool(re.search(str(value), sn, re.IGNORECASE | re.DOTALL))
-        except re.error:
+            # `(?is)` inline flags = case-insensitive + DOTALL, matching the worker's
+            # `re.IGNORECASE | re.DOTALL` and `compileLeafRegex`'s `is` flags.
+            matched = re2.compile(f"(?is){str(value)}").search(sn) is not None
+        except re2.error:
             # Invalid regex: for `regex` it can never match → FALSE.
             # For `not_regex` it trivially never matches → the "not" condition is
             # always satisfied → INDETERMINATE (shown on every service row), which

--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -90,8 +90,16 @@ def _evaluate_service_leaf(leaf: dict, service_name: str) -> int:
     if operator == "is_not_set":
         return _TRUE if not sn else _FALSE
     # Every remaining operator requires both an override and a filter value.
-    if not sn or value is None:
-        return _INDETERMINATE if value is None else _FALSE
+
+    if value is None:
+        return _INDETERMINATE
+    if not sn:
+        # For negation operators, empty string doesn't match non-empty values
+        if operator in ("is_not", "not_in", "not_icontains", "not_regex"):
+            return _TRUE
+        # For positive match operators, empty string can't match
+        return _FALSE
+
 
     if operator in ("exact", "in"):
         return _TRUE if _matches_any(value, sn) else _FALSE

--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -105,8 +105,12 @@ def _evaluate_service_leaf(leaf: dict, service_name: str) -> int:
         try:
             matched = bool(re.search(str(value), sn, re.IGNORECASE | re.DOTALL))
         except re.error:
-            # Invalid regex permanently no-matches, mirroring the ingestion worker.
-            return _FALSE
+            # Invalid regex: for `regex` it can never match → FALSE.
+            # For `not_regex` it trivially never matches → the "not" condition is
+            # always satisfied → INDETERMINATE (shown on every service row), which
+            # is the conservative choice and consistent with the PR's invariant that
+            # only a provably-FALSE result hides the rule.
+            return _FALSE if operator == "regex" else _INDETERMINATE
         if operator == "regex":
             return _TRUE if matched else _FALSE
         return _FALSE if matched else _TRUE

--- a/products/logs/backend/test/test_services_query_runner.py
+++ b/products/logs/backend/test/test_services_query_runner.py
@@ -62,6 +62,7 @@ class TestRuleCouldApplyToService:
             ("is_not_set_with_value", "is_not_set", None, "api", False),
             ("is_not_set_blank", "is_not_set", None, "", True),
             ("invalid_regex_never_matches", "regex", "[unclosed", "api", False),
+            ("invalid_not_regex_is_indeterminate", "not_regex", "[unclosed", "api", True),
         ]
     )
     def test_service_leaf_operators(

--- a/products/logs/backend/test/test_services_query_runner.py
+++ b/products/logs/backend/test/test_services_query_runner.py
@@ -1,0 +1,156 @@
+from typing import Any
+
+import pytest
+
+from parameterized import parameterized
+
+from products.logs.backend.services_query_runner import rule_could_apply_to_service
+
+
+def _wrap(inner: dict) -> dict:
+    """Mirror the outer-AND envelope the drop-rules UI emits."""
+    return {"type": "AND", "values": [inner]}
+
+
+def _leaf(key: str, operator: str, value: Any) -> dict:
+    return {"key": key, "operator": operator, "value": value, "type": "log_resource_attribute"}
+
+
+class TestRuleCouldApplyToService:
+    """
+    Unit tests for the three-valued evaluator that backs the Services tab's
+    `active_rules` list. The Node ingestion worker remains the source of truth
+    for actual per-record drop decisions; this helper only filters the display
+    list so a rule scoped via `filter_group` to one service doesn't appear on
+    every service's row.
+    """
+
+    def test_empty_or_missing_filter_group_applies_to_every_service(self) -> None:
+        assert rule_could_apply_to_service(None, "api") is True
+        assert rule_could_apply_to_service({}, "api") is True
+        assert rule_could_apply_to_service({"type": "AND", "values": []}, "api") is True
+
+    def test_exact_service_name_match(self) -> None:
+        rule = _wrap({"type": "AND", "values": [_leaf("service.name", "exact", "api")]})
+        assert rule_could_apply_to_service(rule, "api") is True
+        assert rule_could_apply_to_service(rule, "other") is False
+
+    def test_underscore_key_matches_dotted_key(self) -> None:
+        # The Node consumer treats `service_name` and `service.name` as aliases;
+        # services-page evaluation should too, so the UI's choice of key doesn't
+        # silently change the display semantics.
+        rule = _wrap({"type": "AND", "values": [_leaf("service_name", "exact", "api")]})
+        assert rule_could_apply_to_service(rule, "api") is True
+        assert rule_could_apply_to_service(rule, "other") is False
+
+    @parameterized.expand(
+        [
+            ("icontains_match", "icontains", "ap", "api", True),
+            ("icontains_no_match", "icontains", "redis", "api", False),
+            ("not_icontains_match", "not_icontains", "redis", "api", True),
+            ("not_icontains_excludes", "not_icontains", "ap", "api", False),
+            ("regex_anchor_match", "regex", "^api$", "api", True),
+            ("regex_prefix_match", "regex", "^api", "api-v2", True),
+            ("regex_no_match", "regex", "^kafka", "api", False),
+            ("not_regex_match", "not_regex", "^kafka", "api", True),
+            ("in_list_match", "in", ["api", "kafka"], "api", True),
+            ("in_list_no_match", "in", ["redis", "kafka"], "api", False),
+            ("not_in_match", "not_in", ["redis", "kafka"], "api", True),
+            ("not_in_excludes", "not_in", ["api", "kafka"], "api", False),
+            ("is_set_with_value", "is_set", None, "api", True),
+            ("is_set_blank", "is_set", None, "", False),
+            ("is_not_set_with_value", "is_not_set", None, "api", False),
+            ("is_not_set_blank", "is_not_set", None, "", True),
+            ("invalid_regex_never_matches", "regex", "[unclosed", "api", False),
+        ]
+    )
+    def test_service_leaf_operators(
+        self, _label: str, operator: str, value: Any, service_name: str, expected: bool
+    ) -> None:
+        rule = _wrap({"type": "AND", "values": [_leaf("service.name", operator, value)]})
+        assert rule_could_apply_to_service(rule, service_name) is expected
+
+    def test_non_service_leaf_is_indeterminate(self) -> None:
+        # A rule scoped only by attributes can match some logs on any service —
+        # we can't know without seeing the row. Keep the rule visible.
+        rule = _wrap({"type": "AND", "values": [_leaf("severity_text", "exact", "error")]})
+        assert rule_could_apply_to_service(rule, "api") is True
+        assert rule_could_apply_to_service(rule, "anything") is True
+
+    def test_and_excludes_when_service_predicate_fails(self) -> None:
+        # `service.name = api AND severity = error` → for `other` the service
+        # predicate is FALSE, so the AND is FALSE regardless of severity.
+        rule = _wrap(
+            {
+                "type": "AND",
+                "values": [
+                    _leaf("service.name", "exact", "api"),
+                    _leaf("severity_text", "exact", "error"),
+                ],
+            }
+        )
+        assert rule_could_apply_to_service(rule, "api") is True  # might apply (error subset)
+        assert rule_could_apply_to_service(rule, "other") is False  # cannot apply
+
+    def test_or_keeps_rule_visible_when_one_branch_indeterminate(self) -> None:
+        # `service.name = api OR severity = error` → on `other`, service branch
+        # is FALSE but severity branch is INDETERMINATE → INDETERMINATE → keep.
+        rule = _wrap(
+            {
+                "type": "OR",
+                "values": [
+                    _leaf("service.name", "exact", "api"),
+                    _leaf("severity_text", "exact", "error"),
+                ],
+            }
+        )
+        assert rule_could_apply_to_service(rule, "api") is True
+        assert rule_could_apply_to_service(rule, "other") is True  # error logs of `other` would match
+
+    def test_or_all_service_predicates_resolve_negatively(self) -> None:
+        # `service.name = api OR service.name = kafka` → on `redis`, both branches
+        # FALSE, OR = FALSE, rule excluded.
+        rule = _wrap(
+            {
+                "type": "OR",
+                "values": [
+                    _leaf("service.name", "exact", "api"),
+                    _leaf("service.name", "exact", "kafka"),
+                ],
+            }
+        )
+        assert rule_could_apply_to_service(rule, "api") is True
+        assert rule_could_apply_to_service(rule, "kafka") is True
+        assert rule_could_apply_to_service(rule, "redis") is False
+
+    def test_nested_groups(self) -> None:
+        # `service.name = api AND (severity = error OR severity = fatal)` —
+        # the inner OR is INDETERMINATE (severity unknown), AND with TRUE service
+        # match yields INDETERMINATE → keep on `api`. On `other`, the outer AND
+        # short-circuits to FALSE.
+        rule = _wrap(
+            {
+                "type": "AND",
+                "values": [
+                    _leaf("service.name", "exact", "api"),
+                    {
+                        "type": "OR",
+                        "values": [
+                            _leaf("severity_text", "exact", "error"),
+                            _leaf("severity_text", "exact", "fatal"),
+                        ],
+                    },
+                ],
+            }
+        )
+        assert rule_could_apply_to_service(rule, "api") is True
+        assert rule_could_apply_to_service(rule, "other") is False
+
+    def test_malformed_node_falls_back_to_indeterminate(self) -> None:
+        # Conservative default: anything we can't parse keeps the rule visible.
+        assert rule_could_apply_to_service({"type": "AND", "values": ["oops"]}, "api") is True
+        assert rule_could_apply_to_service({"not_a_group": True}, "api") is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

The Services tab's per-row \`active_rules\` list only checked the legacy top-level \`scope_service\` column. Rules scoped via \`config.filter_group\` (which the drop-rule UI has been writing exclusively since #59424) all have \`scope_service = NULL\`, so they appeared as active on **every** service row.

For an operator looking at the Services tab, a rule scoped to \`service.name = api\` shows up next to \`kafka\`, \`redis\`, \`nginx\`, and every other service — directly contradicting the actual ingestion-time behaviour (which, after #59533, correctly drops only \`api\` logs).

Symmetric story to #59533: the UI form moved to \`filter_group\`-only scoping in #59424; the Node ingestion worker side of that change was missed (and fixed in #59533); this PR fixes the Python display side.

## Changes

Three-valued evaluator that walks the filter_group AND/OR tree at services-query time, evaluating leaves keyed on \`service_name\` / \`service.name\` against the row's service. Non-service leaves remain \`INDETERMINATE\` (severity / attributes vary per log, can't decide without seeing the full row). AND/OR aggregation propagates the third value:

| Leaf | Result for this service |
|---|---|
| \`service.name exact "api"\` against \`api\` | TRUE |
| \`service.name exact "api"\` against \`other\` | FALSE |
| \`service.name regex "^api"\` against \`api-v2\` | TRUE |
| \`severity_text exact "error"\` against any service | INDETERMINATE |

| Group | Result |
|---|---|
| AND with any FALSE child | FALSE (excluded from row) |
| AND with INDETERMINATE child and no FALSE | INDETERMINATE (shown) |
| OR with any TRUE child | TRUE (shown) |
| OR with all FALSE children | FALSE (excluded) |
| OR with INDETERMINATE child and no TRUE | INDETERMINATE (shown) |

A rule is hidden from a service's \`active_rules\` only when the tree provably evaluates to FALSE; INDETERMINATE keeps the rule visible so attribute-scoped rules (which can match some subset of logs on any service) don't silently disappear from the Services tab.

Supported operators match what the Node ingestion worker already evaluates: \`exact\`, \`is_not\`, \`in\`, \`not_in\`, \`icontains\`, \`not_icontains\`, \`regex\`, \`not_regex\`, \`is_set\`, \`is_not_set\`. Numeric / semver / date operators don't apply to service-name strings and remain \`INDETERMINATE\`.

**Out of scope:**
- The Node ingestion worker's per-record drop evaluation. Fixed in #59533; that PR is the source of truth for what actually gets dropped at ingest time.
- Removing the legacy \`scope_service\` column. Kept for backward-compat with rules that predate filter_group; that's a follow-up cleanup PR.

## How did you test this code?

**Agent-authored PR.** No manual testing performed; only the automated tests below.

- \`hogli test products/logs/backend/test/test_services_query_runner.py\` → **26 / 26 pass** (one fresh test file, parameterised across operator classes and AND/OR/nested shapes).
- Pre-commit lint-staged ran ruff fix, \`uv run ty check\`, and the Python formatter successfully on the two modified files.

Manual validation reviewers can run on dev: pick a service that has logs and create a rule scoped to a different service via the filter chip. Today's behaviour: the rule appears on every service's \`active_rules\` row. With this PR: the rule appears only on the scoped service.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs (internal bug fix; the UI behaviour was always supposed to work this way).

## 🤖 Agent context

- **Tool:** Claude Code (PostHog Code harness), Opus 4.7. Bug surfaced while planning the broader drop-rules cleanup — the author asked how the services page handles filter_group, and the evaluator-side bug (#59533) implied a symmetric display-side problem.
- **Key decisions:**
  - **Three-valued logic, not boolean.** A two-valued evaluator that returned FALSE for "I can't decide" would silently hide rules that have a real chance of dropping logs on the service (attribute-only rules). FALSE → hidden is the worse failure mode (operator thinks rule is inactive when it isn't). Three-valued logic with INDETERMINATE → shown is conservative and aligned with how the page is used.
  - **No reuse of \`posthog.queries.base.match_property\`.** It requires a \`Property\` class instance with many optional fields; the leaf-key recognition and dotted-vs-underscore key aliasing are bespoke to logs. A small focused evaluator in \`services_query_runner.py\` is clearer and keeps the display-only logic out of the broader property-matching layer.
  - **Python \`re\` instead of RE2.** This is query-time code (services tab), not ingestion-time. ReDoS concern is much lower because regexes are admin-authored (not user-controlled at request time) and the engine matches against a single service-name string, not arbitrary log content. If a malicious regex gets through, the API query timeout catches it. Matches the broader pattern of "ingestion uses RE2 for safety, query-time uses Python \`re\`."
  - **Legacy \`scope_service\` check kept.** Existing rules that scoped via the legacy column continue to work; the new filter_group check is additive.
- **Reuse:** the wire shape of filter_group leaves is the same one the Node ingestion worker reads from (\`{key, operator, value, type}\`), and the operator semantics match \`nodejs/src/logs-ingestion/sampling/property-filter-match.ts\`. The aliasing of \`service_name\` ↔ \`service.name\` matches \`filter-group-match.ts:76\` in the worker.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*