### PR TITLE
chore(product-analytics): add retention domain context and dwh rollout adr

### DIFF
--- a/products/product_analytics/CONTEXT.md
+++ b/products/product_analytics/CONTEXT.md
@@ -1,0 +1,55 @@
+# Product analytics
+
+Insights built on event data — trends, funnels, retention, paths, stickiness, lifecycle. This context covers the language used across these insight types and their query runners.
+
+## Language
+
+### Retention
+
+**Retention insight**:
+An insight that tracks how many actors who performed a _start event_ within a period later perform a _return event_ in subsequent periods.
+_Avoid_: cohort retention (we already use "cohort" to mean a saved set of users)
+
+**Start event**:
+The event (or data warehouse row) that places an actor into a retention cohort for a given period.
+_Avoid_: target event, anchor event, cohorting event
+
+**Return event**:
+The event (or data warehouse row) that counts an actor as retained in a later period.
+_Avoid_: returning event, retention event
+
+**Strict-calendar-date retention**:
+The default retention time mode. Intervals are aligned to calendar boundaries — start of day, start of week, start of month. Driven by `timeWindowMode == "strict_calendar_dates"`. Implemented by `RetentionFixedIntervalBaseQueryBuilder`.
+_Avoid_: fixed-interval retention (the class name only — confusing because the user-visible mode is "calendar dates"), default retention
+
+**24-hour-window retention**:
+The alternative retention time mode. Intervals are 24-hour windows anchored to each actor's first qualifying start event (`t_0`), regardless of calendar boundaries. Driven by `timeWindowMode == "24_hour_windows"`. Implemented by `RetentionRollingIntervalBaseQueryBuilder`.
+_Avoid_: rolling-interval retention (the class name only — "rolling" is also used informally to describe how retention itself rolls over time), rolling retention
+
+### Flagged ambiguities
+
+- **"Rolling" is overloaded in this codebase.** `RetentionRollingIntervalBaseQueryBuilder` does _not_ implement "rolling retention" in the general sense — it implements the 24-hour-window time mode only. Use **24-hour-window retention** to refer to the mode; only use "rolling interval" when discussing the class name itself.
+- **"Fixed interval" is misleading.** `RetentionFixedIntervalBaseQueryBuilder` handles the strict-calendar-date mode, which is the _default_ and most common path — not a special "fixed" alternative. Use **strict-calendar-date retention** when discussing behavior; reserve "fixed interval" for the class name.
+
+### Data warehouse
+
+**Data warehouse series**:
+A start or return event sourced from a data warehouse table rather than the `events` table. Identified by `entity.type == EntityType.DATA_WAREHOUSE`.
+_Avoid_: DW series, warehouse event (the row isn't an event)
+
+**DWH variant**:
+The data-warehouse-capable base-query implementation that lives alongside the legacy events-only path during the parity rollout. Currently exists for strict-calendar-date retention only (`RetentionFixedIntervalBaseQueryBuilder.build_base_query_dwh`).
+_Avoid_: new query, v2 query
+
+**Parity gap**:
+A query shape where the DWH variant does not yet produce results identical to the legacy events-only path. Tracked in `_query_uses_known_retention_base_query_variant_gap`.
+
+## Example dialogue
+
+> **Dev:** "Customer is on 24-hour-window retention with a Stripe table as the return event — does that work?"
+>
+> **Domain:** "Today no — the DWH variant only exists for strict-calendar-date retention. 24-hour-window retention runs through `RetentionRollingIntervalBaseQueryBuilder`, which has no data warehouse series support yet."
+>
+> **Dev:** "So if I want a Stripe-table return, the user has to pick strict calendar dates?"
+>
+> **Domain:** "Right. And once we retrofit 24-hour-window retention for data warehouse series, that constraint drops — there's no separate variant flag for that path, the retrofit goes directly."

--- a/products/product_analytics/docs/adr/0001-dwh-retention-rollout-strategy.md
+++ b/products/product_analytics/docs/adr/0001-dwh-retention-rollout-strategy.md
@@ -1,0 +1,21 @@
+# Data warehouse retention: dual-builder for strict-calendar-date, direct retrofit for 24-hour-window
+
+We're adding data warehouse series support to two retention time modes with deliberately different rollout strategies.
+
+- **Strict-calendar-date retention** (`RetentionFixedIntervalBaseQueryBuilder`, the default mode) uses a **dual-builder approach**. The legacy `build_base_query_legacy` (events-only, unchanged) and the new DWH-capable `build_base_query_dwh` live side by side. Events-only routing through the DWH path is gated per team by the `retention-fixed-interval-base-query-dwh-variant` feature flag, and `RetentionBaseQueryVariantComparisonMixin` runs both branches against every supported test input and asserts result parity. Once parity is verified for every supported query shape, `build_base_query_legacy` is deleted.
+- **24-hour-window retention** (`RetentionRollingIntervalBaseQueryBuilder`, gated by `timeWindowMode == "24_hour_windows"`) is **retrofitted directly** — DWH support is added in place, with no parallel implementation, feature flag, or parity comparison harness.
+
+The asymmetry exists because the two legacy implementations have very different blast radius. Strict-calendar-date retention is ~700 lines including memory-sensitive `groupArrayIf` paths over millions of events and is the highest-traffic retention insight; a behavior regression there is expensive to roll back without a parallel implementation. The 24-hour-window legacy is ~100 lines, not memory-sensitive, and carries comparatively little traffic — a parity-flag scaffold buys less than it costs.
+
+## Consequences
+
+- The variant flag is the **only** parity gate for the strict-calendar-date variant. Closing a parity gap (breakdowns, first-time retention types, `minimumOccurrences > 1`, sampling) and forgetting to remove the corresponding branch from `_query_uses_known_retention_base_query_variant_gap` silently re-disables parity testing for that shape. Reviewers must check this on every gap-closure PR.
+- Deletion criteria for `build_base_query_legacy`: (a) the variant flag is enabled at 100% for ≥ 2 weeks with no parity-related incident, AND (b) `_query_uses_known_retention_base_query_variant_gap` returns `False` for every input — i.e. all known gaps are closed.
+- 24-hour-window retention has no rollback hatch. The retrofit must be covered by tests pre-merge; any regression ships to production immediately when the PR merges.
+- Data warehouse series with global property filters, test-account filters, or `samplingFactor` continue to be rejected by `DisallowUnsupportedDataWarehouseSettings`. Sampling for events-only retention through the variant is closed as a parity gap; sampling on a DWH series stays rejected.
+
+## Considered alternatives
+
+- **Direct rewrite of strict-calendar-date `build_base_query`** (no parallel implementation). Rejected: too risky given the legacy's traffic share and memory profile. A bug that only manifests in production data shape would have no easy rollback.
+- **Dual-builder for 24-hour-window too.** Rejected: the dual-implementation tax is not justified by the legacy's size or traffic, and the existing comparison harness is structured around the strict-calendar-date builder's per-side UNION ALL shape — reusing it for 24-hour-window would force a non-trivial generalization.
+- **Translate DWH sources into synthetic `events`-shaped subqueries to keep the legacy path unchanged.** Rejected: forces every DWH retention query to wrap a UNION or CTE around the source table even for simple single-table cases, blowing up query plans and hiding the actual table read in execution traces.


### PR DESCRIPTION
## Problem

Product analytics lacked a shared vocabulary for retention concepts, and the in-flight data warehouse retention work had no written record of why the two retention time modes are being rolled out with different strategies. New contributors (human or agent) had to reverse-engineer the asymmetry from `RetentionFixedIntervalBaseQueryBuilder` vs `RetentionRollingIntervalBaseQueryBuilder` and the variant-flag scaffolding.

## Changes

Documentation only — no code changes.

- `products/product_analytics/CONTEXT.md`: Establishes canonical terminology for retention insights (start event, return event, strict-calendar-date vs 24-hour-window retention, DWH variant, parity gap). Flags two ambiguities in the code: "rolling" is overloaded, and "fixed interval" is misleading for what is actually the default mode.
- `products/product_analytics/docs/adr/0001-dwh-retention-rollout-strategy.md`: Records the decision to use a dual-builder + variant flag + parity comparison for strict-calendar-date retention, but a direct retrofit for 24-hour-window retention. Documents the blast-radius reasoning, the deletion criteria for the legacy builder, and the rejected alternatives.

## How did you test this code?

Agent-authored PR — no manual or automated testing required for documentation-only changes. Markdown was auto-formatted by the repo's lint-staged hook on commit.

## Publish to changelog?

no

## Docs update

Internal-only context and ADR — no public docs change.

## 🤖 Agent context

Authored by PostHog Code. The CONTEXT.md was drafted by reading the retention query-builder code (`RetentionFixedIntervalBaseQueryBuilder`, `RetentionRollingIntervalBaseQueryBuilder`, `RetentionBaseQueryVariantComparisonMixin`, `_query_uses_known_retention_base_query_variant_gap`) and noting the terminology clashes between class names and the user-facing time-mode labels. The ADR captures the rollout asymmetry that's already implicit in the codebase — the work is to make the rationale legible to future contributors rather than to introduce any new convention.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*