### PR TITLE
feat(funnels): migrate FunnelLineGraph to hog-charts TimeSeriesLineChart

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1157,9 +1157,9 @@ snapshots:
     components-search--product-recents-and-starred--light:
         hash: v1.k794b7964.093365121259b79e33584b3e0042ad3813b0e77f2af285369ab7b2bf98bd9c79.-imuS481bcvyD7kDEeyJ4mfKoQcmD451n4Lxv2IrE3g
     components-search--searching--dark:
-        hash: v1.k794b7964.ad396839fe9f33932049672506634e20d59d18b3fadd0a777f40e83ac714698a.xmQ67eu1qjN6DIEu36qXgff2UHGSMhozO_-renm2CRw
+        hash: v1.k794b7964.5640d6ceda1c0c42d11d0830ce6f99d435ed755f675c7bcf189625c50c6fb77e.y1r9bx5WquHigHMTHREsnNCKkDLi0SluFC9L48L6NxM
     components-search--searching--light:
-        hash: v1.k794b7964.09f7821d34292ac6ae488cf6e77283ee604f033dbffd6c91bf7ae2b5ffe9c4f2.o44oJ2GJt3eMDzIWZJJDLpWSHM8fL3aR2hN22PD1UpU
+        hash: v1.k794b7964.00eec8365eb2b8e99781a485440555fdde5a1ed86e73254e927075b30d97a8cb.Vo_QisoIzatCT6K0G9D63ScY4y_-Y22PxQMJ4Kv64S4
     components-sentencelist--full-sentence--dark:
         hash: v1.k794b7964.9d72ed5224f75be3f53f1ba8edc2547978e519aa46a57cc97eef9087b403cb7d.3yHHiA7NW-p6vVSlM-2nPx7Nbk7wuTr5SA9Av2nW--g
     components-sentencelist--full-sentence--light:
@@ -1864,6 +1864,18 @@ snapshots:
         hash: v1.k794b7964.85a7028e6729988dedf767a52640b16c94aa48baf0ab9c89b1085c38d4e8cc8e.wDERvaZQvyEVwZsoj2q7nTwZSDswGOq-6dnRNcvuRpw
     insights-funnelcorrelationtable--default--light:
         hash: v1.k794b7964.a5ccf40b74b63001bb7383ff53cb81b8f4f4a07308e0b6a2ad590ff821efc3ee.wCJ8wpYAyHJfnQB7k7qNZZKqiPtIq2sppx3qVS4IGQQ
+    insights-funnellinechart--default--dark:
+        hash: v1.k794b7964.88b532c89fa992eac628ca0a779b0889d74e00e650284960e1d935f5e7e8704c.9XjpRbnpuvI56K35oITlbW-Z4_d8VXboPy03ork9yaY
+    insights-funnellinechart--default--light:
+        hash: v1.k794b7964.bc3e2e9caee13301c07d79564d2c7e01a29c748a1f382496585f58f2ac283389.SDhk8kXtp9imHhdiYpRwgQfwSXvcH_oeQ8m1K729q0Q
+    insights-funnellinechart--goal-line--dark:
+        hash: v1.k794b7964.bda4551694dc54902b3e46ffb327e0d713af760b1a53ae7b7453779fa1e26bbf.pFfUWaxERw1KCaA9ZcqwB0R8TKC4CDiD5ift8kApZM4
+    insights-funnellinechart--goal-line--light:
+        hash: v1.k794b7964.35b2f6e08b22e8b95c561f10f4a3eeee0ec5355d91aa166db2cc3595f2acc4ae.iqDGpipKH0res85GZFCYszkpygWdzEM7lweEmg62j6M
+    insights-funnellinechart--value-labels--dark:
+        hash: v1.k794b7964.0c55587cfcea1fc34a6aede2eccbaac54ac296aa405d1272fc3c09efc1d02a6b.7kVLiv-W7Mk_5t8YKcXB2IM_ikwvMm5ssyT_uxoJvfw
+    insights-funnellinechart--value-labels--light:
+        hash: v1.k794b7964.746ea8a29d8e924baa6e7384d7a3a4a357727d37877668d15caae4fe2fcb4398.NoQWMVJ_C7Tw-ejmNiYdWnToUC5v0SdTi7OL5e6TrIo
     insights-funnelpropertycorrelationtable--default--dark:
         hash: v1.k794b7964.49a465be8c619b1b05298a08904f554cb8636e8080dece84b8a37f85e1fefa8f.XYyBv_BrMjUV6Vqt_JHcot038t7pXgyS7FSXNBV7wJs
     insights-funnelpropertycorrelationtable--default--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -417,6 +417,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_HOG_CHARTS: 'product-analytics-hog-charts', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_HOG_CHARTS_BAR: 'product-analytics-hog-charts-bar', // owner: @sampennington #team-product-analytics
+    PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL: 'product-analytics-hog-charts-funnel', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics

--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -3,6 +3,7 @@ import './Funnel.scss'
 import { useValues } from 'kea'
 
 import { FunnelLayout } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { FunnelLineGraph } from 'scenes/funnels/FunnelLineGraph'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
@@ -13,15 +14,17 @@ import { FunnelBarVertical } from './FunnelBarVertical/FunnelBarVertical'
 import { funnelDataLogic } from './funnelDataLogic'
 import { FunnelFlowGraph } from './FunnelFlowGraph/FunnelFlowGraph'
 import { FunnelHistogram } from './FunnelHistogram'
+import { FunnelLineChart } from './viz/funnel-line-chart/FunnelLineChart'
 
 export function Funnel(props: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { funnelsFilter } = useValues(funnelDataLogic(insightProps))
+    const hogChartsFunnelEnabled = useFeatureFlag('PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL')
     const { funnelVizType, layout } = funnelsFilter || {}
 
     let viz: JSX.Element | null = null
     if (funnelVizType == FunnelVizType.Trends) {
-        viz = <FunnelLineGraph {...props} />
+        viz = hogChartsFunnelEnabled ? <FunnelLineChart {...props} /> : <FunnelLineGraph {...props} />
     } else if (funnelVizType == FunnelVizType.TimeToConvert) {
         viz = <FunnelHistogram />
     } else if (funnelVizType === FunnelVizType.Flow) {

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.stories.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.stories.tsx
@@ -1,0 +1,83 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { BindLogic } from 'kea'
+import { useState } from 'react'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { getCachedResults } from '~/queries/nodes/InsightViz/utils'
+import type { FunnelsFilter } from '~/queries/schema/schema-general'
+import { InsightLogicProps, InsightShortId } from '~/types'
+
+import { FunnelLineChart } from './FunnelLineChart'
+
+type Story = StoryObj<{}>
+
+const meta: Meta = {
+    title: 'Insights/FunnelLineChart',
+    component: FunnelLineChart,
+    parameters: {
+        layout: 'centered',
+        mockDate: '2022-03-12',
+        testOptions: { snapshotBrowsers: ['chromium'] },
+    },
+}
+export default meta
+
+let uniqueNode = 0
+
+function Stage({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ height: 360, width: 720, display: 'flex', flexDirection: 'column' }}>{children}</div>
+    )
+}
+
+function renderFunnelLineChart(insightFixture: any, funnelsFilterOverrides?: Partial<FunnelsFilter>): JSX.Element {
+    const [dashboardItemId] = useState(() => `FunnelLineChartStory.${uniqueNode++}` as InsightShortId)
+    const source = {
+        ...insightFixture.query.source,
+        funnelsFilter: { ...insightFixture.query.source.funnelsFilter, ...funnelsFilterOverrides },
+    }
+    const cachedInsight = { ...insightFixture, short_id: dashboardItemId, query: { ...insightFixture.query, source } }
+
+    const insightProps: InsightLogicProps = { dashboardItemId, doNotLoad: true, cachedInsight }
+    const dataNodeLogicProps: DataNodeLogicProps = {
+        query: source,
+        key: insightVizDataNodeKey(insightProps),
+        cachedResults: getCachedResults(cachedInsight, source),
+        doNotLoad: true,
+    }
+
+    return (
+        <BindLogic logic={insightLogic} props={insightProps}>
+            <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+                <Stage>
+                    <FunnelLineChart />
+                </Stage>
+            </BindLogic>
+        </BindLogic>
+    )
+}
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const funnelTrendsInsight = (): any =>
+    require('../../../../mocks/fixtures/api/projects/team_id/insights/funnelHistoricalTrends.json')
+
+export const Default: Story = {
+    render: () => renderFunnelLineChart(funnelTrendsInsight()),
+}
+
+export const ValueLabels: Story = {
+    render: () => renderFunnelLineChart(funnelTrendsInsight(), { showValuesOnSeries: true }),
+}
+
+export const GoalLine: Story = {
+    render: () =>
+        renderFunnelLineChart(funnelTrendsInsight(), {
+            goalLines: [{ label: 'Target', value: 10, displayIfCrossed: true }],
+        }),
+}
+/* eslint-enable @typescript-eslint/no-var-requires */

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.stories.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
 
+import { mswDecorator } from '~/mocks/browser'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
@@ -23,6 +24,37 @@ const meta: Meta = {
         mockDate: '2022-03-12',
         testOptions: { snapshotBrowsers: ['chromium'] },
     },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/annotations/': {
+                    count: 1,
+                    next: null,
+                    previous: null,
+                    results: [
+                        {
+                            id: 1,
+                            content: 'Funnel optimization shipped',
+                            date_marker: '2022-03-10T12:00:00Z',
+                            creation_type: 'USR',
+                            dashboard_item: null,
+                            created_by: {
+                                id: 1,
+                                uuid: '0188cbcf-2391-0000-1868-14fb987285c5',
+                                distinct_id: 'storybook-user',
+                                first_name: 'Story',
+                                email: 'story@posthog.com',
+                            },
+                            created_at: '2022-03-10T12:00:00Z',
+                            updated_at: '2022-03-10T12:00:00Z',
+                            deleted: false,
+                            scope: 'project',
+                        },
+                    ],
+                },
+            },
+        }),
+    ],
 }
 export default meta
 

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
@@ -7,6 +7,8 @@ import { ensureJsdom, waitForHogChartTooltip } from 'lib/hog-charts/testing'
 import { FUNNEL_CONVERSION_SERIES_LABEL } from 'scenes/funnels/viz/shared/funnelSeriesMeta'
 
 import { buildFunnelsQuery, chart, getHogChart, personsModal, renderInsight } from '~/test/insight-testing'
+import { buildAnnotation } from '~/test/insight-testing/test-data'
+import { AnnotationScope } from '~/types'
 
 ensureJsdom()
 
@@ -140,6 +142,48 @@ describe('FunnelLineChart', () => {
             await waitFor(() => {
                 expect(getHogChart().valueLabels()).toHaveLength(5)
             })
+        })
+    })
+
+    describe('annotations', () => {
+        it('renders an annotation badge when an annotation exists', async () => {
+            renderInsight({
+                query: buildFunnelsQuery(),
+                featureFlags: HOG_CHARTS_FUNNEL_FLAG,
+                mocks: {
+                    annotations: [
+                        buildAnnotation({
+                            scope: AnnotationScope.Project,
+                            content: 'Hedgehog spotted',
+                            date_marker: '2024-06-12T12:00:00Z',
+                        }),
+                    ],
+                },
+            })
+
+            await waitFor(() => {
+                expect(document.querySelectorAll('.AnnotationsBadge').length).toBeGreaterThan(0)
+            })
+        })
+
+        it('does not render annotations when inSharedMode is true', async () => {
+            renderInsight({
+                query: buildFunnelsQuery(),
+                featureFlags: HOG_CHARTS_FUNNEL_FLAG,
+                inSharedMode: true,
+                mocks: {
+                    annotations: [
+                        buildAnnotation({
+                            scope: AnnotationScope.Project,
+                            content: 'Hidden in shared mode',
+                            date_marker: '2024-06-12T12:00:00Z',
+                        }),
+                    ],
+                },
+            })
+
+            await screen.findByRole('img', { name: /chart with/i })
+            expect(document.querySelectorAll('.AnnotationsBadge')).toHaveLength(0)
         })
     })
 })

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
@@ -24,8 +24,9 @@ describe('FunnelLineChart', () => {
 
             const tooltip = await chart.hoverTooltip(2)
 
+            expect(getHogChart().seriesCount).toBe(1)
             expect(tooltip.element.textContent).toContain(FUNNEL_CONVERSION_SERIES_LABEL)
-            expect(tooltip.element.textContent).toMatch(/40%/)
+            expect(tooltip.element.textContent).toContain('40%')
         })
 
         it('renders a series per breakdown variant', async () => {
@@ -37,7 +38,7 @@ describe('FunnelLineChart', () => {
             })
 
             await waitFor(() => {
-                expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
+                expect(getHogChart().seriesCount).toBe(2)
             })
         })
 
@@ -98,8 +99,8 @@ describe('FunnelLineChart', () => {
                 const texts = getHogChart()
                     .valueLabels()
                     .map((l) => l.text)
-                expect(texts.length).toBeGreaterThan(0)
-                expect(texts.every((t) => t.endsWith('%'))).toBe(true)
+                // default fixture data [10, 25, 40, 60, 35] rendered as percentages
+                expect([...texts].sort()).toEqual(['10%', '25%', '35%', '40%', '60%'])
             })
         })
     })
@@ -126,8 +127,9 @@ describe('FunnelLineChart', () => {
                 featureFlags: HOG_CHARTS_FUNNEL_FLAG,
             })
 
+            // main series + trend-line series = 2
             await waitFor(() => {
-                expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
+                expect(getHogChart().seriesCount).toBe(2)
             })
         })
     })

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
@@ -124,15 +124,21 @@ describe('FunnelLineChart', () => {
     })
 
     describe('trend lines overlay', () => {
-        it('adds a trend-line series when showTrendLines is enabled', async () => {
+        it('adds a trend-line overlay when showTrendLines is enabled', async () => {
             renderInsight({
-                query: buildFunnelsQuery({ funnelsFilter: { showTrendLines: true } }),
+                query: buildFunnelsQuery({ funnelsFilter: { showTrendLines: true, showValuesOnSeries: true } }),
                 featureFlags: HOG_CHARTS_FUNNEL_FLAG,
             })
 
-            // main series + trend-line series = 2
+            // main series + trend-line series = 2 rendered series
             await waitFor(() => {
                 expect(getHogChart().seriesCount).toBe(2)
+            })
+
+            // the trend line is an overlay — excluded from value labels, so the 5 data
+            // points yield 5 labels, not 10 (a regular 2nd series would double them)
+            await waitFor(() => {
+                expect(getHogChart().valueLabels()).toHaveLength(5)
             })
         })
     })

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
@@ -42,7 +42,7 @@ describe('FunnelLineChart', () => {
             })
         })
 
-        it('shows breakdown labels (not "Conversion") in the tooltip when broken down', async () => {
+        it('shows the breakdown label on each tooltip row when broken down', async () => {
             renderInsight({
                 query: buildFunnelsQuery({
                     breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
@@ -54,7 +54,6 @@ describe('FunnelLineChart', () => {
             const tooltip = await waitForHogChartTooltip()
             expect(tooltip.textContent).toContain('Spike')
             expect(tooltip.textContent).toContain('Bramble')
-            expect(tooltip.textContent).not.toContain(FUNNEL_CONVERSION_SERIES_LABEL)
         })
     })
 

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
@@ -1,0 +1,134 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, screen, waitFor } from '@testing-library/react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { ensureJsdom, waitForHogChartTooltip } from 'lib/hog-charts/testing'
+import { FUNNEL_CONVERSION_SERIES_LABEL } from 'scenes/funnels/viz/shared/funnelSeriesMeta'
+
+import { buildFunnelsQuery, chart, getHogChart, personsModal, renderInsight } from '~/test/insight-testing'
+
+ensureJsdom()
+
+afterEach(() => {
+    personsModal.cleanupAll()
+    cleanup()
+})
+
+const HOG_CHARTS_FUNNEL_FLAG = { [FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL]: true }
+
+describe('FunnelLineChart', () => {
+    describe('series rendering', () => {
+        it('renders a single conversion series with percentage values in the tooltip', async () => {
+            renderInsight({ query: buildFunnelsQuery(), featureFlags: HOG_CHARTS_FUNNEL_FLAG })
+
+            const tooltip = await chart.hoverTooltip(2)
+
+            expect(tooltip.element.textContent).toContain(FUNNEL_CONVERSION_SERIES_LABEL)
+            expect(tooltip.element.textContent).toMatch(/40%/)
+        })
+
+        it('renders a series per breakdown variant', async () => {
+            renderInsight({
+                query: buildFunnelsQuery({
+                    breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+                }),
+                featureFlags: HOG_CHARTS_FUNNEL_FLAG,
+            })
+
+            await waitFor(() => {
+                expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
+            })
+        })
+
+        it('shows breakdown labels (not "Conversion") in the tooltip when broken down', async () => {
+            renderInsight({
+                query: buildFunnelsQuery({
+                    breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+                }),
+                featureFlags: HOG_CHARTS_FUNNEL_FLAG,
+            })
+
+            await chart.clickAtIndex(2)
+            const tooltip = await waitForHogChartTooltip()
+            expect(tooltip.textContent).toContain('Spike')
+            expect(tooltip.textContent).toContain('Bramble')
+            expect(tooltip.textContent).not.toContain(FUNNEL_CONVERSION_SERIES_LABEL)
+        })
+    })
+
+    describe('click → persons modal', () => {
+        it('opens the persons modal with the day-scoped actors for a single-series chart', async () => {
+            renderInsight({ query: buildFunnelsQuery(), featureFlags: HOG_CHARTS_FUNNEL_FLAG })
+
+            await chart.clickAtIndex(2)
+
+            await waitFor(() => {
+                expect(personsModal.actorNames()).toEqual(['funnel-wed-a@example.com', 'funnel-wed-b@example.com'])
+            })
+            expect(personsModal.title()).toMatch(/12 Jun/)
+        })
+
+        it('opens the persons modal scoped to the clicked breakdown row', async () => {
+            renderInsight({
+                query: buildFunnelsQuery({
+                    breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+                }),
+                featureFlags: HOG_CHARTS_FUNNEL_FLAG,
+            })
+
+            await chart.clickAtIndex(2)
+            await chart.clickTooltipRow('Spike')
+
+            await waitFor(() => {
+                expect(personsModal.actorNames()).toEqual(['funnel-spike@example.com'])
+            })
+        })
+    })
+
+    describe('value labels overlay', () => {
+        it('renders percentage value labels when showValuesOnSeries is enabled', async () => {
+            renderInsight({
+                query: buildFunnelsQuery({ funnelsFilter: { showValuesOnSeries: true } }),
+                featureFlags: HOG_CHARTS_FUNNEL_FLAG,
+            })
+
+            await screen.findByRole('img', { name: /chart with/i })
+            await waitFor(() => {
+                const texts = getHogChart()
+                    .valueLabels()
+                    .map((l) => l.text)
+                expect(texts.length).toBeGreaterThan(0)
+                expect(texts.every((t) => t.endsWith('%'))).toBe(true)
+            })
+        })
+    })
+
+    describe('goal lines', () => {
+        it('renders configured goal lines on the chart', async () => {
+            renderInsight({
+                query: buildFunnelsQuery({
+                    funnelsFilter: { goalLines: [{ label: 'Target', value: 30, displayIfCrossed: true }] },
+                }),
+                featureFlags: HOG_CHARTS_FUNNEL_FLAG,
+            })
+
+            await screen.findByRole('img', { name: /chart with/i })
+            const lines = getHogChart().referenceLines()
+            expect(lines.map((l) => l.label)).toEqual(['Target'])
+        })
+    })
+
+    describe('trend lines overlay', () => {
+        it('adds a trend-line series when showTrendLines is enabled', async () => {
+            renderInsight({
+                query: buildFunnelsQuery({ funnelsFilter: { showTrendLines: true } }),
+                featureFlags: HOG_CHARTS_FUNNEL_FLAG,
+            })
+
+            await waitFor(() => {
+                expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
+            })
+        })
+    })
+})

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.test.tsx
@@ -115,7 +115,11 @@ describe('FunnelLineChart', () => {
 
             await screen.findByRole('img', { name: /chart with/i })
             const lines = getHogChart().referenceLines()
-            expect(lines.map((l) => l.label)).toEqual(['Target'])
+            // value→pixel isn't recoverable from the DOM; assert the line is labelled,
+            // drawn horizontally (across the value axis), and actually positioned.
+            expect(lines).toEqual([
+                expect.objectContaining({ label: 'Target', orientation: 'horizontal', position: expect.any(Number) }),
+            ])
         })
     })
 

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.tsx
@@ -1,0 +1,176 @@
+import { useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useMemo, type ErrorInfo } from 'react'
+
+import { buildTheme } from 'lib/charts/utils/theme'
+import { TimeSeriesLineChart } from 'lib/hog-charts'
+import type { PointClickData, TimeSeriesLineChartConfig, TooltipConfig, TooltipContext } from 'lib/hog-charts'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import { teamLogic } from 'scenes/teamLogic'
+import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
+
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+import { cohortsModel } from '~/models/cohortsModel'
+import type { Noun } from '~/models/groupsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { isFunnelsQuery } from '~/queries/utils'
+import { ChartParams } from '~/types'
+
+import { funnelDataLogic } from '../../funnelDataLogic'
+import { funnelPersonsModalLogic } from '../../funnelPersonsModalLogic'
+import type { FunnelSeriesMeta } from '../shared/funnelSeriesMeta'
+import { buildFunnelLineSeries, buildFunnelLineTimeSeriesConfig, type IndexedFunnelStep } from './funnelChartTransforms'
+import { FunnelLineTooltip } from './FunnelLineTooltip'
+import { type FunnelLineChartClickDeps, handleFunnelLineChartClick } from './handleFunnelLineChartClick'
+
+const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
+const EMPTY_LABELS: string[] = []
+
+const handleChartError = (error: Error, info: ErrorInfo): void => {
+    posthog.captureException(error, {
+        feature: 'funnels-line-chart',
+        componentStack: info.componentStack ?? undefined,
+    })
+}
+
+function resolveGroupTypeLabel(
+    labelGroupType: 'people' | 'none' | number,
+    aggregationLabel: (groupTypeIndex: number) => Noun
+): string {
+    if (labelGroupType === 'people') {
+        return 'people'
+    }
+    if (labelGroupType === 'none') {
+        return ''
+    }
+    return aggregationLabel(labelGroupType).plural
+}
+
+export function FunnelLineChart({
+    showPersonsModal: showPersonsModalProp = true,
+}: Omit<ChartParams, 'filters'>): JSX.Element | null {
+    const { isDarkModeOn } = useValues(themeLogic)
+    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const { insightProps } = useValues(insightLogic)
+
+    const {
+        indexedSteps,
+        goalLines,
+        aggregationTargetLabel,
+        incompletenessOffsetFromEnd,
+        querySource,
+        interval,
+        insightData,
+        showValuesOnSeries,
+        funnelsFilter,
+        breakdownFilter,
+        labelGroupType,
+        getFunnelsColor,
+    } = useValues(funnelDataLogic(insightProps))
+    const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
+    const { timezone, weekStartDay } = useValues(teamLogic)
+    const { allCohorts } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+    const { aggregationLabel } = useValues(groupsModel)
+
+    const showPersonsModal = canOpenPersonModal && showPersonsModalProp
+    const steps = useMemo(() => (indexedSteps ?? []) as IndexedFunnelStep[], [indexedSteps])
+
+    const series = useMemo(
+        () =>
+            buildFunnelLineSeries(steps, {
+                incompletenessOffsetFromEnd,
+                getColor: (step) => getFunnelsColor(step),
+            }),
+        [steps, incompletenessOffsetFromEnd, getFunnelsColor]
+    )
+
+    const chartConfig: TimeSeriesLineChartConfig = useMemo(
+        () =>
+            buildFunnelLineTimeSeriesConfig({
+                indexedSteps: steps,
+                interval,
+                timezone,
+                allDays: steps[0]?.days ?? [],
+                goalLines,
+                incompletenessOffsetFromEnd,
+                showTrendLines: funnelsFilter?.showTrendLines ?? false,
+                valueLabels: showValuesOnSeries ? { formatter: (value) => `${value}%` } : false,
+                showCrosshair: true,
+                tooltip: TOOLTIP_CONFIG,
+            }),
+        [
+            steps,
+            interval,
+            timezone,
+            goalLines,
+            incompletenessOffsetFromEnd,
+            funnelsFilter?.showTrendLines,
+            showValuesOnSeries,
+        ]
+    )
+
+    if (!isFunnelsQuery(querySource)) {
+        return null
+    }
+
+    const resolvedGroupTypeLabel = resolveGroupTypeLabel(labelGroupType, aggregationLabel)
+    const labels = steps[0]?.labels ?? EMPTY_LABELS
+
+    const clickDeps: FunnelLineChartClickDeps = {
+        hasPersonsModal: showPersonsModal,
+        querySource,
+        interval,
+        timezone,
+        weekStartDay,
+        resolvedDateRange: insightData?.resolved_date_range ?? null,
+        breakdownFilter,
+        aggregationTargetLabel,
+        cohorts: allCohorts.results,
+        formatPropertyValueForDisplay,
+        openPersonsModal,
+    }
+
+    const onPointClick = (clickData: PointClickData<FunnelSeriesMeta>): void => {
+        if (clickData.series.meta) {
+            handleFunnelLineChartClick(clickData.series.meta, clickData.dataIndex, clickDeps)
+        }
+    }
+
+    const renderTooltip = (ctx: TooltipContext<FunnelSeriesMeta>): JSX.Element => (
+        <FunnelLineTooltip
+            context={ctx}
+            timezone={timezone}
+            interval={interval ?? undefined}
+            breakdownFilter={breakdownFilter ?? undefined}
+            dateRange={insightData?.resolved_date_range ?? undefined}
+            groupTypeLabel={resolvedGroupTypeLabel}
+            onRowClick={
+                showPersonsModal
+                    ? (datum: SeriesDatum) => {
+                          const meta = ctx.seriesData[datum.datasetIndex]?.series.meta
+                          if (meta) {
+                              handleFunnelLineChartClick(meta, datum.dataIndex, clickDeps)
+                          }
+                      }
+                    : undefined
+            }
+        />
+    )
+
+    return (
+        <TimeSeriesLineChart<FunnelSeriesMeta>
+            series={series}
+            labels={labels}
+            theme={theme}
+            config={chartConfig}
+            tooltip={renderTooltip}
+            onPointClick={showPersonsModal ? onPointClick : undefined}
+            className="LineGraph"
+            dataAttr="trend-line-graph-funnel"
+            onError={handleChartError}
+        />
+    )
+}

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.tsx
@@ -17,7 +17,7 @@ import type { Noun } from '~/models/groupsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { isFunnelsQuery } from '~/queries/utils'
-import { ChartParams } from '~/types'
+import { ChartParams, type FunnelStepWithConversionMetrics } from '~/types'
 
 import { funnelDataLogic } from '../../funnelDataLogic'
 import { funnelPersonsModalLogic } from '../../funnelPersonsModalLogic'
@@ -84,7 +84,9 @@ export function FunnelLineChart({
         () =>
             buildFunnelLineSeries(steps, {
                 incompletenessOffsetFromEnd,
-                getColor: (step) => getFunnelsColor(step),
+                // getFunnelsColor is typed for the steps-viz datasets; for the trends viz it
+                // only reads `breakdown_value`, which IndexedFunnelStep carries.
+                getColor: (step) => getFunnelsColor(step as unknown as FunnelStepWithConversionMetrics),
             }),
         [steps, incompletenessOffsetFromEnd, getFunnelsColor]
     )

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.tsx
@@ -9,6 +9,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
+import { AnnotationsLayer } from 'scenes/trends/viz/shared/AnnotationsLayer'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { cohortsModel } from '~/models/cohortsModel'
@@ -26,7 +27,7 @@ import { FunnelLineTooltip } from './FunnelLineTooltip'
 import { type FunnelLineChartClickDeps, handleFunnelLineChartClick } from './handleFunnelLineChartClick'
 
 const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
-const EMPTY_LABELS: string[] = []
+const EMPTY_STRINGS: string[] = []
 
 const handleChartError = (error: Error, info: ErrorInfo): void => {
     posthog.captureException(error, {
@@ -49,11 +50,12 @@ function resolveGroupTypeLabel(
 }
 
 export function FunnelLineChart({
+    inSharedMode,
     showPersonsModal: showPersonsModalProp = true,
 }: Omit<ChartParams, 'filters'>): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, insight } = useValues(insightLogic)
 
     const {
         indexedSteps,
@@ -117,7 +119,8 @@ export function FunnelLineChart({
     }
 
     const resolvedGroupTypeLabel = resolveGroupTypeLabel(labelGroupType, aggregationLabel)
-    const labels = steps[0]?.labels ?? EMPTY_LABELS
+    const labels = steps[0]?.labels ?? EMPTY_STRINGS
+    const annotationDates = steps[0]?.days ?? EMPTY_STRINGS
 
     const clickDeps: FunnelLineChartClickDeps = {
         hasPersonsModal: showPersonsModal,
@@ -171,6 +174,8 @@ export function FunnelLineChart({
             className="LineGraph"
             dataAttr="trend-line-graph-funnel"
             onError={handleChartError}
-        />
+        >
+            {!inSharedMode && <AnnotationsLayer insightNumericId={insight.id || 'new'} dates={annotationDates} />}
+        </TimeSeriesLineChart>
     )
 }

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineTooltip.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineTooltip.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useMemo } from 'react'
+
+import type { TooltipContext } from 'lib/hog-charts'
+import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
+import { getDatumTitle, type SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+
+import type { BreakdownFilter, DateRange } from '~/queries/schema/schema-general'
+import type { IntervalType } from '~/types'
+
+import { hasBreakdown } from '../../funnelUtils'
+import { FUNNEL_CONVERSION_SERIES_LABEL, type FunnelSeriesMeta } from '../shared/funnelSeriesMeta'
+
+const NOOP = (): void => {}
+
+interface FunnelLineTooltipProps {
+    context: TooltipContext<FunnelSeriesMeta>
+    timezone?: string
+    interval?: IntervalType
+    breakdownFilter?: BreakdownFilter
+    dateRange?: DateRange
+    groupTypeLabel?: string
+    onRowClick?: (datum: SeriesDatum) => void
+}
+
+export function FunnelLineTooltip({
+    context,
+    timezone,
+    interval,
+    breakdownFilter,
+    dateRange,
+    groupTypeLabel,
+    onRowClick,
+}: FunnelLineTooltipProps): React.ReactElement {
+    const seriesData = useMemo<SeriesDatum[]>(
+        () =>
+            context.seriesData.map((entry, idx) => {
+                const meta = entry.series.meta ?? ({} as FunnelSeriesMeta)
+                return {
+                    id: idx,
+                    dataIndex: context.dataIndex,
+                    datasetIndex: idx,
+                    order: meta.order ?? idx,
+                    label: entry.series.label,
+                    color: entry.color,
+                    count: entry.value,
+                    breakdown_value: meta.breakdown_value,
+                    date_label: meta.days?.[context.dataIndex],
+                }
+            }),
+        [context.seriesData, context.dataIndex]
+    )
+
+    const date = context.seriesData[0]?.series.meta?.days?.[context.dataIndex]
+
+    const renderCount = useCallback((value: number): string => `${value}%`, [])
+
+    const renderSeries = useCallback(
+        (_value: React.ReactNode, datum: SeriesDatum): React.ReactElement => {
+            if (hasBreakdown(datum.breakdown_value)) {
+                return <div className="datum-label-column">{getDatumTitle(datum, breakdownFilter)}</div>
+            }
+            return <div className="datum-label-column">{FUNNEL_CONVERSION_SERIES_LABEL}</div>
+        },
+        [breakdownFilter]
+    )
+
+    return (
+        <InsightTooltip
+            date={date}
+            timezone={timezone}
+            seriesData={seriesData}
+            breakdownFilter={breakdownFilter}
+            interval={interval}
+            dateRange={dateRange}
+            groupTypeLabel={groupTypeLabel}
+            onClose={context.onUnpin ?? NOOP}
+            renderSeries={renderSeries}
+            renderCount={renderCount}
+            onRowClick={onRowClick}
+            hideInspectActorsSection={!onRowClick}
+        />
+    )
+}

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/handleFunnelLineChartClick.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/handleFunnelLineChartClick.tsx
@@ -1,0 +1,82 @@
+import { DateDisplay } from 'lib/components/DateDisplay'
+import { dayjs } from 'lib/dayjs'
+import { capitalizeFirstLetter } from 'lib/utils'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
+import type { OpenPersonsModalProps } from 'scenes/trends/persons-modal/PersonsModal'
+
+import type { Noun } from '~/models/groupsModel'
+import type { FormatPropertyValueForDisplayFunction } from '~/models/propertyDefinitionsModel'
+import {
+    type BreakdownFilter,
+    type FunnelsActorsQuery,
+    type FunnelsQuery,
+    NodeKind,
+    type ResolvedDateRangeResponse,
+} from '~/queries/schema/schema-general'
+import type { CohortType, IntervalType } from '~/types'
+
+import { hasBreakdown } from '../../funnelUtils'
+import type { FunnelSeriesMeta } from '../shared/funnelSeriesMeta'
+
+export interface FunnelLineChartClickDeps {
+    hasPersonsModal: boolean
+    querySource: FunnelsQuery | null | undefined
+    interval: IntervalType | null | undefined
+    timezone?: string
+    weekStartDay: number | null | undefined
+    resolvedDateRange: ResolvedDateRangeResponse | null | undefined
+    breakdownFilter: BreakdownFilter | null | undefined
+    aggregationTargetLabel: Noun
+    cohorts: CohortType[]
+    formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction | undefined
+    openPersonsModal: (props: OpenPersonsModalProps) => void
+}
+
+export function handleFunnelLineChartClick(
+    meta: FunnelSeriesMeta,
+    dataIndex: number,
+    deps: FunnelLineChartClickDeps
+): void {
+    if (!deps.hasPersonsModal || !deps.querySource) {
+        return
+    }
+
+    const day = meta.days?.[dataIndex]
+    if (day == null || day === '') {
+        return
+    }
+
+    const breakdownValue = meta.breakdown_value
+    const breakdownLabel = hasBreakdown(breakdownValue)
+        ? formatBreakdownLabel(
+              breakdownValue,
+              deps.breakdownFilter ?? null,
+              deps.cohorts,
+              deps.formatPropertyValueForDisplay
+          )
+        : null
+
+    const title = (
+        <>
+            {capitalizeFirstLetter(deps.aggregationTargetLabel.plural)} converted on{' '}
+            <DateDisplay
+                interval={deps.interval || 'day'}
+                resolvedDateRange={deps.resolvedDateRange ?? undefined}
+                timezone={deps.timezone}
+                weekStartDay={deps.weekStartDay ?? undefined}
+                date={day.toString()}
+            />
+            {breakdownLabel ? <> • {breakdownLabel}</> : null}
+        </>
+    )
+
+    const query: FunnelsActorsQuery = {
+        kind: NodeKind.FunnelsActorsQuery,
+        source: deps.querySource,
+        funnelTrendsDropOff: false,
+        includeRecordings: true,
+        funnelTrendsEntrancePeriodStart: dayjs(day).format('YYYY-MM-DD HH:mm:ss'),
+        ...(hasBreakdown(breakdownValue) ? { funnelStepBreakdown: breakdownValue } : {}),
+    }
+    deps.openPersonsModal({ title, query })
+}

--- a/frontend/src/scenes/funnels/viz/shared/funnelSeriesMeta.ts
+++ b/frontend/src/scenes/funnels/viz/shared/funnelSeriesMeta.ts
@@ -1,5 +1,7 @@
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
+export const FUNNEL_CONVERSION_SERIES_LABEL = 'Conversion'
+
 export type FunnelSeriesMeta = {
     days?: string[]
     // Narrower than BreakdownKeyType — matches SeriesDatum so the tooltip adapter needs no cast.

--- a/frontend/src/test/insight-testing/index.ts
+++ b/frontend/src/test/insight-testing/index.ts
@@ -5,12 +5,13 @@ export type { HogChart } from 'lib/hog-charts/testing'
 export { createInsightTooltipAccessor } from './tooltip-helpers'
 export type { InsightTooltipAccessor } from './tooltip-helpers'
 export {
+    buildFunnelsQuery,
     buildTrendsQuery,
     renderInsight,
     renderInsight as renderInsightPage,
     renderWithInsights,
 } from './render-insight'
-export type { RenderInsightProps, RenderWithInsightsProps } from './render-insight'
+export type { InsightQuery, RenderInsightProps, RenderWithInsightsProps } from './render-insight'
 export {
     breakdown,
     chart,

--- a/frontend/src/test/insight-testing/mocks.ts
+++ b/frontend/src/test/insight-testing/mocks.ts
@@ -7,8 +7,11 @@ import { EventDefinition, PropertyDefinition, RawAnnotationType } from '~/types'
 import {
     actionDefinitions,
     eventDefinitions as defaultEventDefs,
+    type FunnelStepData,
+    funnelTrendsSteps,
     lookupActors,
     lookupCompareSeries,
+    lookupFunnelActors,
     lookupSeries,
     personProperties,
     propertyDefinitions as defaultPropDefs,
@@ -27,12 +30,17 @@ export interface QueryBody {
     [key: string]: unknown
 }
 
+interface FunnelsQueryResponseLike {
+    results: FunnelStepData[]
+}
+
 export interface MockResponse {
     match: (query: QueryBody) => boolean
     response:
         | TrendsQueryResponse
         | ActorsQueryResponse
-        | ((query: QueryBody) => TrendsQueryResponse | ActorsQueryResponse)
+        | FunnelsQueryResponseLike
+        | ((query: QueryBody) => TrendsQueryResponse | ActorsQueryResponse | FunnelsQueryResponseLike)
 }
 
 /** Build an ActorsQueryResponse shaped like the server response, with one row
@@ -99,6 +107,35 @@ function resolveActors(query: QueryBody): Array<{ email: string }> {
     })
 }
 
+/** Funnels in trends-viz mode return a flat `FunnelStep[]` — one entry per series, or per breakdown value. */
+function buildFunnelsResponse(query: QueryBody): FunnelsQueryResponseLike {
+    const breakdownProp = query.breakdownFilter?.breakdowns?.[0]?.property ?? query.breakdownFilter?.breakdown
+    if (breakdownProp && funnelTrendsSteps.byBreakdown[breakdownProp]) {
+        return { results: funnelTrendsSteps.byBreakdown[breakdownProp] }
+    }
+    return { results: [funnelTrendsSteps.default] }
+}
+
+interface FunnelsActorsQueryShape {
+    kind?: string
+    funnelTrendsEntrancePeriodStart?: string | null
+    funnelStepBreakdown?: string | number | null
+}
+
+// PersonsModalLogic wraps the FunnelsActorsQuery in an ActorsQuery, so the funnel fields
+// sit one level deeper at body.source.*.
+function isFunnelsActorsQuery(query: QueryBody): boolean {
+    const source = (query as { source?: FunnelsActorsQueryShape }).source
+    return source?.kind === NodeKind.FunnelsActorsQuery
+}
+
+function resolveFunnelActors(query: QueryBody): Array<{ email: string }> {
+    const source = (query as { source?: FunnelsActorsQueryShape }).source ?? {}
+    // Actors are keyed by calendar date; the query sends a full 'YYYY-MM-DD HH:mm:ss' timestamp.
+    const day = source.funnelTrendsEntrancePeriodStart?.split(' ')[0] ?? null
+    return lookupFunnelActors({ day, breakdown: source.funnelStepBreakdown ?? null })
+}
+
 function resolveSeriesData(query: QueryBody): SeriesData[] {
     const breakdownProp = query.breakdownFilter?.breakdowns?.[0]?.property ?? query.breakdownFilter?.breakdown ?? null
     const isCompare = !!(query as Record<string, unknown>).compareFilter
@@ -153,6 +190,15 @@ export function setupInsightMocks({
         {
             match: (query) => query.kind === NodeKind.TrendsQuery,
             response: (query) => buildTrendsResponse(resolveSeriesData(query)),
+        },
+        {
+            match: (query) => query.kind === NodeKind.FunnelsQuery,
+            response: (query) => buildFunnelsResponse(query),
+        },
+        // Must precede the generic ActorsQuery matcher so funnel actor queries route to lookupFunnelActors.
+        {
+            match: (query) => query.kind === NodeKind.ActorsQuery && isFunnelsActorsQuery(query),
+            response: (query) => buildActorsResponse(resolveFunnelActors(query)),
         },
         {
             match: (query) => query.kind === NodeKind.ActorsQuery,

--- a/frontend/src/test/insight-testing/render-insight.tsx
+++ b/frontend/src/test/insight-testing/render-insight.tsx
@@ -5,8 +5,9 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { actionsModel } from '~/models/actionsModel'
 import { groupsModel } from '~/models/groupsModel'
-import { InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { FunnelsQuery, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
+import { FunnelVizType } from '~/types'
 
 import { initKeaTests } from '../init'
 import { resetCapturedCharts } from './chartjs-mock'
@@ -15,11 +16,28 @@ import { setupInsightMocks, type SetupMocksOptions } from './mocks'
 export const INSIGHT_TEST_KEY = 'test-harness'
 export const INSIGHT_TEST_ID = `new-AdHoc.InsightViz.${INSIGHT_TEST_KEY}`
 
+export type InsightQuery = TrendsQuery | FunnelsQuery
+
 export function buildTrendsQuery(overrides?: Partial<TrendsQuery>): TrendsQuery {
     return {
         kind: NodeKind.TrendsQuery,
         series: [{ kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' }],
         ...overrides,
+    }
+}
+
+export function buildFunnelsQuery(overrides?: Partial<FunnelsQuery>): FunnelsQuery {
+    return {
+        kind: NodeKind.FunnelsQuery,
+        series: [
+            { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
+            { kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' },
+        ],
+        ...overrides,
+        funnelsFilter: {
+            funnelVizType: FunnelVizType.Trends,
+            ...overrides?.funnelsFilter,
+        },
     }
 }
 
@@ -53,7 +71,7 @@ export function renderWithInsights(props: RenderWithInsightsProps): ReturnType<t
 }
 
 export interface RenderInsightProps {
-    query?: TrendsQuery
+    query?: InsightQuery
     showFilters?: boolean
     mocks?: SetupMocksOptions
     featureFlags?: Record<string, string | boolean>
@@ -67,7 +85,7 @@ function InsightWrapper({
     context,
     inSharedMode,
 }: {
-    query: TrendsQuery
+    query: InsightQuery
     showFilters: boolean
     context?: QueryContext<InsightVizNode>
     inSharedMode?: boolean

--- a/frontend/src/test/insight-testing/test-data.ts
+++ b/frontend/src/test/insight-testing/test-data.ts
@@ -254,3 +254,70 @@ export function lookupActors({ event, breakdown, day }: ActorsLookupQuery): Acto
     const breakdownKey = breakdown == null ? '__none__' : String(breakdown)
     return actorsByEventBreakdownDay[event]?.[breakdownKey]?.[String(day)] ?? []
 }
+
+// Funnel trends-viz response shape: `data` holds the conversion percentage over time.
+export interface FunnelStepData {
+    count: number
+    data: number[]
+    days: string[]
+    labels: string[]
+    name?: string
+    breakdown_value?: string | number
+}
+
+export const funnelTrendsSteps = {
+    default: {
+        count: 50,
+        data: [10, 25, 40, 60, 35],
+        days,
+        labels,
+        name: '$pageview → Napped',
+    } satisfies FunnelStepData,
+    byBreakdown: {
+        hedgehog: [
+            {
+                count: 30,
+                data: [20, 35, 50, 70, 45],
+                days,
+                labels,
+                name: '$pageview → Napped',
+                breakdown_value: 'Spike',
+            },
+            {
+                count: 20,
+                data: [5, 15, 30, 50, 25],
+                days,
+                labels,
+                name: '$pageview → Napped',
+                breakdown_value: 'Bramble',
+            },
+        ] satisfies FunnelStepData[],
+    } as Record<string, FunnelStepData[]>,
+}
+
+// Keyed by breakdown value (or '__none__'), then by calendar date.
+const funnelActorsByBreakdownDay: Record<string, Record<string, ActorFixture[]>> = {
+    __none__: {
+        '2024-06-12': [{ email: 'funnel-wed-a@example.com' }, { email: 'funnel-wed-b@example.com' }],
+        '2024-06-13': [{ email: 'funnel-thu-a@example.com' }],
+    },
+    Spike: {
+        '2024-06-12': [{ email: 'funnel-spike@example.com' }],
+    },
+    Bramble: {
+        '2024-06-12': [{ email: 'funnel-bramble@example.com' }],
+    },
+}
+
+export interface FunnelActorsLookupQuery {
+    day?: string | null
+    breakdown?: string | number | null
+}
+
+export function lookupFunnelActors({ day, breakdown }: FunnelActorsLookupQuery): ActorFixture[] {
+    if (!day) {
+        return []
+    }
+    const breakdownKey = breakdown == null ? '__none__' : String(breakdown)
+    return funnelActorsByBreakdownDay[breakdownKey]?.[day] ?? []
+}


### PR DESCRIPTION
## Problem

Want to use hog-charts for funnels line cahrts

## Changes

There should be no actually visible changes to the current funnels line chart

- New `frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineChart.tsx` rendering `TimeSeriesLineChart<FunnelSeriesMeta>` with the existing funnel selectors. Click → persons modal preserves the `FunnelsActorsQuery` shape (`funnelTrendsEntrancePeriodStart` + optional `funnelStepBreakdown`).
- The pure transform layer it consumes (`funnelChartTransforms.ts`, `funnelSeriesMeta.ts`) lands in the stacked precursor #59558.
- Custom minimal `FunnelLineTooltip` (Conversion / breakdown label + `${value}%`) reusing `InsightTooltip` for layout.
- Feature flag `PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL`. Default off — `Funnel.tsx` falls back to the legacy `FunnelLineGraph` until the flag flips.
- `test/insight-testing/` infra extended to support `FunnelsQuery`: `buildFunnelsQuery`, generalized `RenderInsightProps`, a canned funnel response, and actor lookups. Future funnel tests can use the same `renderInsight` harness as trends.
- `FunnelLineChart.stories.tsx` adds Storybook snapshot coverage (Default / ValueLabels / GoalLine). The chart is flag-gated, so existing insight stories render the legacy component and never reach it — and canvas output can't be asserted in jsdom, so Storybook is the only visual-regression surface.

## How did you test this code?

Authored and verified by an agent — no manual click-through; the checks below are the automated tests run locally.

- Integration tests for `FunnelLineChart` (`FunnelLineChart.test.tsx`): tooltip / breakdown rendering, click → persons modal (single-series and breakdown row), goal lines, trend lines overlay, value labels overlay — all passing alongside the transform unit tests from #59558 (17 tests total across the stack).
- New Storybook snapshot stories give visual-regression coverage of the canvas output (generated on the first CI run).
- Re-ran the existing trends suites (`trends-line-chart`, `trends-bar-chart`, `test/insight-testing`) to confirm no regression from extending the shared insight-testing infra.
- `oxlint` clean on the new and touched files.

## Publish to changelog?

no — the feature is flag-gated and not user-visible until rollout.

## 🤖 Agent context

Authored with Claude Code (Anthropic) at the request of the human reviewer. Requires human review before merge.

Approach decisions:

- **Reuse trends transforms over forking them.** `FunnelStepWithNestedBreakdown` already satisfies trends' `TrendsResultLike` shape (id, label, data, days, breakdown_value). Wrapping the trends builders avoids duplication and means future trends improvements (in-progress dashing, trend lines) reach funnels for free.
- **Feature flag instead of swap-and-delete.** Trends rolled out behind `PRODUCT_ANALYTICS_HOG_CHARTS`; this matches that pattern — consistent, and lets us A/B and revert without code changes.
- **Custom tooltip over `TrendsTooltip`.** `TrendsTooltip` is tightly coupled to `TrendsSeriesMeta` (action, compare_label, filter, formula). The funnel tooltip needs only "Conversion or breakdown label" plus a percentage, so a minimal `FunnelLineTooltip` reusing `InsightTooltip` is cleaner than bridging through `TrendsTooltip`.
- **No wrapper element.** `FunnelLineChart` renders `TimeSeriesLineChart` directly; the `.FunnelInsight--type-trends` scene container already supplies flex sizing and `min-height`, and hog-charts sets its own `position: relative`. This matches `TrendsLineChart`.
- **Infra extension in this PR, not separately.** `test/insight-testing/` was trends-only; generalizing it to also accept `FunnelsQuery` keeps the call sites and the generalization in one reviewable diff. One landmine to flag: `personsModalLogic` wraps the inner query inside an `ActorsQuery`, so the funnel-specific mock matcher checks `query.source.kind === FunnelsActorsQuery` and is ordered before the generic `ActorsQuery` matcher.
