### PR TITLE
chore: remove duplicate-word typos across frontend and backend comments

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -119,7 +119,7 @@ class FunnelCorrelation:
             if not key.startswith("funnel_correlation_")
         }
         # NOTE: we always use the final matching event for the recording because this
-        # is the the right event for both drop off and successful funnels
+        # is the right event for both drop off and successful funnels
         filter_data.update({"include_final_matching_events": self._filter.include_recordings})
         filter = Filter(data=filter_data, hogql_context=self._filter.hogql_context)
 

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -22,7 +22,7 @@ type SceneLayoutProps = {
 export function ScenePanel({ children }: { children: React.ReactNode }): JSX.Element {
     const { scenePanelElement } = useValues(sceneLayoutLogic)
     const { setScenePanelIsPresent } = useActions(sceneLayoutLogic)
-    // HACKY: Show the panel only if this element in in the DOM
+    // HACKY: Show the panel only if this element is in the DOM
     useEffect(() => {
         setScenePanelIsPresent(true)
         return () => {

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -74,7 +74,7 @@ export function SceneTabs(): JSX.Element {
                 </ButtonPrimitive>
             )}
 
-            {/* Line below tabs to to complete border on <main> element */}
+            {/* Line below tabs to complete border on <main> element */}
             <div className="absolute bottom-0 w-full px-[5px] lg:pr-2">
                 <div className="w-full bottom-0 h-px border-b border-primary z-10" />
             </div>

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -471,7 +471,7 @@ export function LemonInputSelect<T = string>({
             let indexOfValue = values.indexOf(typedValue)
             if (indexOfValue > -1) {
                 if (itemBeingEditedIndex !== null && itemBeingEditedIndex < indexOfValue) {
-                    // If already editing an item that's earlier in the list the the one we're about to edit,
+                    // If already editing an item that's earlier in the list than the one we're about to edit,
                     // we need to adjust the index by 1
                     indexOfValue += 1
                 }

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -166,7 +166,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
 
     const parsedHref = typeof href === 'function' ? href(attributes) : href
 
-    // Element is resizable if resizable is set to true. If expandable is set to true then is is only resizable if expanded is true
+    // Element is resizable if resizable is set to true. If expandable is set to true then it is only resizable if expanded is true
     const isResizeable = resizeable && (!expandable || expanded)
     const isDraggable = !!(isEditable && getPos)
     const isPythonNode = nodeType === NotebookNodeType.Python

--- a/frontend/src/scenes/persons/person-utils.ts
+++ b/frontend/src/scenes/persons/person-utils.ts
@@ -100,7 +100,7 @@ export function asDisplay(
 
     // Force return of the UUID truncated to 22 characters (unless maxLength is specified)
     // 0199ed4a-5c03-0000-3220-df21df612e95 => 0199ed4a-5c…21df612e95
-    // Which keeps the the timestamp at the beginning of the UUID and a unique identifier at the end.
+    // Which keeps the timestamp at the beginning of the UUID and a unique identifier at the end.
     if (truncateIdUUID && display && isUUIDLike(display)) {
         return midEllipsis(display, maxLength || 22)
     }

--- a/nodejs/tests/worker/ingestion/postgres-parity.test.ts
+++ b/nodejs/tests/worker/ingestion/postgres-parity.test.ts
@@ -497,7 +497,7 @@ describe('postgres parity', () => {
 
         await clickhouse.delayUntilEventIngested(() => clickhouse.fetchDistinctIdValues(postgresPerson), 1)
 
-        // move distinct ids from person to to anotherPerson
+        // move distinct ids from person to anotherPerson
         const moveDistinctIdsResult = await personRepository.moveDistinctIds(person, anotherPerson, undefined)
         expect(moveDistinctIdsResult.success).toEqual(true)
 

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -159,7 +159,7 @@ async def wait_for_schema_or_producer(queue: RecordBatchQueue, producer_task: as
 
     if get_schema_task.done():
         # The schema is available, and the queue is not empty, so we can continue
-        # with the rest of the the batch export.
+        # with the rest of the batch export.
         record_batch_schema = get_schema_task.result()
     else:
         # We finished producing without putting anything in the queue and there is

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -338,7 +338,7 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
     def _calculate(self) -> TraceSpansQueryResponse:
         limit_by_n = self.query.prefetchSpans or 1
         query = self.to_query()
-        # original pagination settings are locked in in the trace id subquery already
+        # original pagination settings are locked in the trace id subquery already
         # override limit to allow for N * limit for the trace spans
         self.paginator = HogQLHasMorePaginator.from_limit_context(
             limit_context=LimitContext.QUERY,


### PR DESCRIPTION
## Problem

Nine duplicate-word typos in code comments / test labels across products, frontend, and backend. None are user-facing strings, but several distort the meaning (e.g. \`earlier in the list the the one\` → \`earlier in the list than the one\`, \`then is is only resizable\` → \`then it is only resizable\`).

## Changes

| File:line | Fix |
|---|---|
| \`products/batch_exports/backend/temporal/spmc.py:162\` | \`the rest of the the batch export\` → \`the rest of the batch export\` |
| \`products/tracing/backend/logic.py:341\` | \`locked in in the trace id subquery\` → \`locked in the trace id subquery\` |
| \`frontend/src/scenes/persons/person-utils.ts:103\` | \`keeps the the timestamp\` → \`keeps the timestamp\` |
| \`frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx:169\` | \`then is is only resizable\` → \`then it is only resizable\` |
| \`frontend/src/layout/scenes/SceneTabs.tsx:77\` | \`Line below tabs to to complete border\` → \`Line below tabs to complete border\` |
| \`frontend/src/layout/scenes/SceneLayout.tsx:25\` | \`if this element in in the DOM\` → \`if this element is in the DOM\` |
| \`frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx:474\` | \`earlier in the list the the one we're about to edit\` → \`earlier in the list than the one we're about to edit\` |
| \`ee/clickhouse/queries/funnels/funnel_correlation.py:122\` | \`is the the right event\` → \`is the right event\` |
| \`nodejs/tests/worker/ingestion/postgres-parity.test.ts:500\` | \`from person to to anotherPerson\` → \`from person to anotherPerson\` |

Diff is exactly 9 lines, all in comments. Distinct from the open typo-sweep PR #57409 (different files; verified by inspecting its diff).

## How did you test this code?

I'm an automated agent — no manual testing claimed. All edits are inside \`#\` / \`//\` / \`{/* */}\` comments, so no runtime behaviour changes. Verified with:

\`\`\`bash
grep -rn 'the the \\|in in \\|to to \\|is is \\|or or ' <changed files>
\`\`\`

…returns no matches after the fix.

## 🤖 Agent context

Submitted by an automated contribution pass. Changes are scoped to comment text only — no API, schema, or runtime change. Each typo location was cross-checked against open PR #57409 (which touches a disjoint set of files) before submitting.