### PR TITLE
fix(logs): deterministic drops outrank rate_limit regardless of priority

### DIFF
--- a/nodejs/src/logs-ingestion/sampling/evaluate.test.ts
+++ b/nodejs/src/logs-ingestion/sampling/evaluate.test.ts
@@ -453,4 +453,199 @@ describe('evaluateLogRecord', () => {
             })
         })
     })
+
+    describe('deterministic drops outrank rate_limit regardless of priority', () => {
+        // A rate-limit bucket is a finite shared resource; if a record was going to be
+        // dropped anyway by a deterministic rule, charging the bucket for it just
+        // starves legitimate traffic for no reason. So path_drop / severity_sampling
+        // ALWAYS resolve a record before rate_limit can claim it, even when rate_limit
+        // appears first in the priority-ordered rule list.
+
+        it('path_drop wins when rate_limit appears earlier in rule order', () => {
+            const rules = compileRuleSet([
+                {
+                    id: 'rl-first',
+                    rule_type: 'rate_limit',
+                    scope_service: 'api',
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { logs_per_second: 10 },
+                },
+                {
+                    id: 'pd-second',
+                    rule_type: 'path_drop',
+                    scope_service: null,
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { patterns: ['/healthz'] },
+                },
+            ])
+            const rec = baseRecord()
+            rec.service_name = 'api'
+            expect(classifySamplingRecord(rules, rec)).toEqual({
+                kind: 'resolved',
+                decision: SAMPLING_DECISION_DROP,
+                ruleId: 'pd-second',
+            })
+        })
+
+        it('severity_sampling drop wins when rate_limit appears earlier in rule order', () => {
+            const rules = compileRuleSet([
+                {
+                    id: 'rl-first',
+                    rule_type: 'rate_limit',
+                    scope_service: 'api',
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { logs_per_second: 10 },
+                },
+                {
+                    id: 'ss-second',
+                    rule_type: 'severity_sampling',
+                    scope_service: null,
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: {
+                        actions: {
+                            DEBUG: { type: 'keep' },
+                            INFO: { type: 'drop' },
+                            WARN: { type: 'keep' },
+                            ERROR: { type: 'keep' },
+                        },
+                    },
+                },
+            ])
+            const rec = baseRecord()
+            rec.service_name = 'api'
+            rec.severity_text = 'info'
+            expect(classifySamplingRecord(rules, rec)).toEqual({
+                kind: 'resolved',
+                decision: SAMPLING_DECISION_DROP,
+                ruleId: 'ss-second',
+            })
+        })
+
+        it('severity_sampling keep wins over later rate_limit (record is preserved, bucket not charged)', () => {
+            const rules = compileRuleSet([
+                {
+                    id: 'rl-first',
+                    rule_type: 'rate_limit',
+                    scope_service: 'api',
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { logs_per_second: 10 },
+                },
+                {
+                    id: 'ss-second',
+                    rule_type: 'severity_sampling',
+                    scope_service: null,
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: {
+                        actions: {
+                            DEBUG: { type: 'keep' },
+                            INFO: { type: 'keep' },
+                            WARN: { type: 'keep' },
+                            ERROR: { type: 'keep' },
+                        },
+                    },
+                },
+            ])
+            const rec = baseRecord()
+            rec.service_name = 'api'
+            expect(classifySamplingRecord(rules, rec)).toEqual({
+                kind: 'resolved',
+                decision: 'keep',
+                ruleId: 'ss-second',
+            })
+        })
+
+        it('rate_limit still wins when no deterministic rule resolves the record', () => {
+            const rules = compileRuleSet([
+                {
+                    id: 'rl-first',
+                    rule_type: 'rate_limit',
+                    scope_service: 'api',
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { logs_per_second: 10 },
+                },
+                {
+                    id: 'pd-noop',
+                    rule_type: 'path_drop',
+                    scope_service: null,
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { patterns: ['/never-matches'] },
+                },
+            ])
+            const rec = baseRecord()
+            rec.service_name = 'api'
+            expect(classifySamplingRecord(rules, rec)).toEqual({ kind: 'rate_limit', ruleId: 'rl-first' })
+        })
+
+        it('first matching rate_limit rule wins when multiple rate_limit rules apply and no deterministic rule resolves', () => {
+            const rules = compileRuleSet([
+                {
+                    id: 'rl-a',
+                    rule_type: 'rate_limit',
+                    scope_service: 'api',
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { logs_per_second: 10 },
+                },
+                {
+                    id: 'rl-b',
+                    rule_type: 'rate_limit',
+                    scope_service: 'api',
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { logs_per_second: 100 },
+                },
+            ])
+            const rec = baseRecord()
+            rec.service_name = 'api'
+            expect(classifySamplingRecord(rules, rec)).toEqual({ kind: 'rate_limit', ruleId: 'rl-a' })
+        })
+
+        it('alwaysKeep on a later rule still pre-empts an earlier rate_limit match', () => {
+            // alwaysKeep already short-circuits to KEEP today; this guards against a
+            // future refactor accidentally letting rate_limit win over an explicit
+            // alwaysKeep that sits after it in the priority order.
+            const rules = compileRuleSet([
+                {
+                    id: 'rl-first',
+                    rule_type: 'rate_limit',
+                    scope_service: 'api',
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { logs_per_second: 10 },
+                },
+                {
+                    id: 'keep-errors',
+                    rule_type: 'severity_sampling',
+                    scope_service: null,
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: {
+                        actions: {
+                            DEBUG: { type: 'drop' },
+                            INFO: { type: 'drop' },
+                            WARN: { type: 'keep' },
+                            ERROR: { type: 'keep' },
+                        },
+                        always_keep: { status_gte: 500 },
+                    },
+                },
+            ])
+            const rec = baseRecord()
+            rec.service_name = 'api'
+            rec.attributes = { 'http.status_code': '503' }
+            expect(classifySamplingRecord(rules, rec)).toEqual({
+                kind: 'resolved',
+                decision: 'keep',
+                ruleId: 'keep-errors',
+            })
+        })
+    })
 })

--- a/nodejs/src/logs-ingestion/sampling/evaluate.test.ts
+++ b/nodejs/src/logs-ingestion/sampling/evaluate.test.ts
@@ -461,7 +461,41 @@ describe('evaluateLogRecord', () => {
         // ALWAYS resolve a record before rate_limit can claim it, even when rate_limit
         // appears first in the priority-ordered rule list.
 
-        it('path_drop wins when rate_limit appears earlier in rule order', () => {
+        it.each([
+            {
+                label: 'path_drop wins when rate_limit appears earlier in rule order',
+                extraRule: {
+                    id: 'pd-second',
+                    rule_type: 'path_drop' as const,
+                    scope_service: null,
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: { patterns: ['/healthz'] },
+                },
+                patchRecord: (_rec: LogRecord) => {},
+                expected: { kind: 'resolved', decision: SAMPLING_DECISION_DROP, ruleId: 'pd-second' },
+            },
+            {
+                label: 'severity_sampling drop wins when rate_limit appears earlier in rule order',
+                extraRule: {
+                    id: 'ss-second',
+                    rule_type: 'severity_sampling' as const,
+                    scope_service: null,
+                    scope_path_pattern: null,
+                    scope_attribute_filters: [],
+                    config: {
+                        actions: {
+                            DEBUG: { type: 'keep' },
+                            INFO: { type: 'drop' },
+                            WARN: { type: 'keep' },
+                            ERROR: { type: 'keep' },
+                        },
+                    },
+                },
+                patchRecord: (rec: LogRecord) => { rec.severity_text = 'info' },
+                expected: { kind: 'resolved', decision: SAMPLING_DECISION_DROP, ruleId: 'ss-second' },
+            },
+        ])('$label', ({ extraRule, patchRecord, expected }) => {
             const rules = compileRuleSet([
                 {
                     id: 'rl-first',
@@ -471,22 +505,12 @@ describe('evaluateLogRecord', () => {
                     scope_attribute_filters: [],
                     config: { logs_per_second: 10 },
                 },
-                {
-                    id: 'pd-second',
-                    rule_type: 'path_drop',
-                    scope_service: null,
-                    scope_path_pattern: null,
-                    scope_attribute_filters: [],
-                    config: { patterns: ['/healthz'] },
-                },
+                extraRule,
             ])
             const rec = baseRecord()
             rec.service_name = 'api'
-            expect(classifySamplingRecord(rules, rec)).toEqual({
-                kind: 'resolved',
-                decision: SAMPLING_DECISION_DROP,
-                ruleId: 'pd-second',
-            })
+            patchRecord(rec)
+            expect(classifySamplingRecord(rules, rec)).toEqual(expected)
         })
 
         it('severity_sampling drop wins when rate_limit appears earlier in rule order', () => {

--- a/nodejs/src/logs-ingestion/sampling/evaluate.test.ts
+++ b/nodejs/src/logs-ingestion/sampling/evaluate.test.ts
@@ -492,7 +492,9 @@ describe('evaluateLogRecord', () => {
                         },
                     },
                 },
-                patchRecord: (rec: LogRecord) => { rec.severity_text = 'info' },
+                patchRecord: (rec: LogRecord) => {
+                    rec.severity_text = 'info'
+                },
                 expected: { kind: 'resolved', decision: SAMPLING_DECISION_DROP, ruleId: 'ss-second' },
             },
         ])('$label', ({ extraRule, patchRecord, expected }) => {

--- a/nodejs/src/logs-ingestion/sampling/evaluate.ts
+++ b/nodejs/src/logs-ingestion/sampling/evaluate.ts
@@ -199,14 +199,18 @@ export type SamplingClassifyResult =
 export type RateLimitPendingByRule = Map<string, number[]>
 
 /**
- * Stateless rule walk for ingestion. When the first applicable rule is `rate_limit` with a compiled
- * bucket, returns `rate_limit` so the caller can batch Redis checks. Otherwise matches `evaluateLogRecord`.
+ * Stateless rule walk for ingestion. Deterministic rules (`path_drop`, `severity_sampling`)
+ * always win over `rate_limit` regardless of priority order: a record that any deterministic
+ * rule resolves never charges the rate-limit bucket. The first applicable `rate_limit` match
+ * is remembered while the walk continues; it is only returned when no deterministic rule
+ * resolves the record. Otherwise matches `evaluateLogRecord`.
  */
 export function classifySamplingRecord(teamRuleSet: CompiledRuleSet | null, record: LogRecord): SamplingClassifyResult {
     if (!teamRuleSet || teamRuleSet.rules.length === 0) {
         return { kind: 'resolved', decision: SAMPLING_DECISION_KEEP, ruleId: null }
     }
     const ord = severityOrdinalFromRecord(record)
+    let pendingRateLimitRuleId: string | null = null
     for (const rule of teamRuleSet.rules) {
         if (!matchesScope(rule, record)) {
             continue
@@ -244,8 +248,14 @@ export function classifySamplingRecord(teamRuleSet: CompiledRuleSet | null, reco
             if (rule.filterGroup && !matchFilterGroup(rule.filterGroup, record)) {
                 continue
             }
-            return { kind: 'rate_limit', ruleId: rule.id }
+            if (pendingRateLimitRuleId === null) {
+                pendingRateLimitRuleId = rule.id
+            }
+            continue
         }
+    }
+    if (pendingRateLimitRuleId !== null) {
+        return { kind: 'rate_limit', ruleId: pendingRateLimitRuleId }
     }
     return { kind: 'resolved', decision: SAMPLING_DECISION_KEEP, ruleId: null }
 }


### PR DESCRIPTION
## Problem

A record that any deterministic drop rule (`path_drop` or `severity_sampling`) would resolve was being charged against a `rate_limit` rule's token bucket whenever the rate-limit rule sat earlier in the priority-ordered rule list. That was wasted bucket capacity — the record was always going to be dropped (or explicitly kept) — and it starved legitimate traffic for no reason.

The previous policy let _any_ first applicable rule win, including `rate_limit`. Operators had to know to lower the priority of every rate-limit rule below every deterministic rule to get sensible behavior. The new policy makes the precedence intrinsic: deterministic rules always resolve a record before `rate_limit` can claim it.

## Changes

`classifySamplingRecord` (`nodejs/src/logs-ingestion/sampling/evaluate.ts`) now walks every rule. The first matching `rate_limit` rule's id is remembered but the walk continues. If any later rule deterministically resolves the record (`path_drop` matches, `severity_sampling` returns keep/drop/sample, or `alwaysKeep` triggers), that decision wins. Only when the walk finishes without a deterministic resolution does the deferred `rate_limit` match get returned so the caller can do its Redis-bucket check.

`evaluateLogRecord` is unchanged — it's the stateless variant used outside ingestion and never produced a rate-limit decision in the first place.

No schema, config, or API changes. No frontend changes.

## How did you test this code?

I'm an agent. I added six new tests under a `deterministic drops outrank rate_limit regardless of priority` describe block in `evaluate.test.ts`:

- `path_drop` wins when `rate_limit` is listed first
- `severity_sampling` drop wins when `rate_limit` is listed first
- `severity_sampling` keep wins over a later `rate_limit` (record preserved, bucket not charged)
- `rate_limit` still wins when no deterministic rule resolves the record
- First matching `rate_limit` rule wins when multiple `rate_limit` rules apply
- `alwaysKeep` on a later rule still pre-empts an earlier `rate_limit` match

Existing tests still pass:

- `pnpm exec jest src/logs-ingestion/sampling/` — 89/89 pass (4 suites)
- `pnpm exec tsc --noEmit -p tsconfig.json` — clean

No manual testing performed.

## Publish to changelog?

no

## Docs update

No docs change — this is a stateless evaluator semantics fix invisible to operators except via correct rate-limit accounting.

## 🤖 Agent context

Agent-authored via PostHog Code (Claude Opus 4.7).

Decision notes:

- Considered enforcing precedence at compile time by reordering the rules array so deterministic rules sort before rate-limit rules. Rejected: it would silently override operator-visible priority order, which is more confusing than the runtime precedence we have now.
- Considered returning the deterministic decision but still tracking the rate-limit match for accounting. Rejected: the whole point is to not charge the bucket for records the rule was never going to actually drop. The matched rate-limit rule id is forgotten if a deterministic rule resolves the record.
- Kept the iteration semantics (first-matching rate_limit wins among rate_limit rules) consistent with the old behavior — only the deterministic-rule precedence is new.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*