### PR TITLE
fix(web-analytics): wait for lazy precompute writes to be visible before read

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -312,6 +312,12 @@ class LazyComputationResult:
     ready: bool
     job_ids: list[uuid.UUID]
     errors: list[str] = field(default_factory=list)
+    # Number of jobs this executor created+inserted during the call. Callers
+    # use this to decide whether to wait for ClickHouse replication before
+    # issuing the downstream SELECT — fresh INSERTs on Replicated*MergeTree
+    # tables may not be visible on a different read replica yet, even after
+    # the local executor sees the PG row flip to READY.
+    jobs_inserted: int = 0
 
 
 def compute_query_hash(query_info: QueryInfo) -> str:
@@ -858,7 +864,11 @@ class LazyComputationExecutor:
         final_jobs = find_existing_jobs(team, query_hash, start, end)
         final_fresh = self._filter_by_freshness(final_jobs)
         final_ready = filter_overlapping_jobs([j for j in final_fresh if j.status == PreaggregationJob.Status.READY])
-        result = LazyComputationResult(ready=True, job_ids=[j.id for j in final_ready])
+        result = LazyComputationResult(
+            ready=True,
+            job_ids=[j.id for j in final_ready],
+            jobs_inserted=jobs_created,
+        )
         _log_execution("success", result)
         return result
 

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -307,17 +307,32 @@ class QueryInfo:
 
 @dataclass
 class LazyComputationResult:
-    """Result of executing lazy computation jobs."""
+    """Result of executing lazy computation jobs.
+
+    `job_ids` is the full set covering the requested range (cache hits + any
+    fresh writes), suitable for the downstream `WHERE job_id IN (…)` SELECT.
+
+    `inserted_job_ids` is the subset that **this** executor created+wrote
+    during the current call — i.e., the ones whose parts may still be
+    propagating across Replicated*MergeTree replicas. Callers that read
+    through the Distributed table immediately after this returns should wait
+    until these specific IDs are visible on the chosen read replica, since:
+
+    1. Marking the Postgres row READY happens as soon as the INSERT SQL
+       returns on the coordinator. With `insert_quorum='auto'`, only a
+       majority of replicas have the part at that point — `in_order` SELECT
+       routing can land on a peer mid-fetch.
+    2. `len(job_ids)` cannot serve as the "did we write anything?" gate
+       because `job_ids` includes pre-existing READY jobs from prior
+       requests; those replicated long ago and need no wait. Only the
+       intersection `set(inserted_job_ids) & set(job_ids)` matters for the
+       race window.
+    """
 
     ready: bool
     job_ids: list[uuid.UUID]
     errors: list[str] = field(default_factory=list)
-    # Number of jobs this executor created+inserted during the call. Callers
-    # use this to decide whether to wait for ClickHouse replication before
-    # issuing the downstream SELECT — fresh INSERTs on Replicated*MergeTree
-    # tables may not be visible on a different read replica yet, even after
-    # the local executor sees the PG row flip to READY.
-    jobs_inserted: int = 0
+    inserted_job_ids: list[uuid.UUID] = field(default_factory=list)
 
 
 def compute_query_hash(query_info: QueryInfo) -> str:
@@ -693,6 +708,11 @@ class LazyComputationExecutor:
         subscribed_ids: set[uuid.UUID] = set()
         pubsub: redis_lib.client.PubSub | None = None
         jobs_created = 0
+        # IDs of jobs this executor INSERTed successfully (status flipped READY)
+        # during this call. Surfaced to the caller via `LazyComputationResult.
+        # inserted_job_ids` so they can gate replication-visibility waits on
+        # the exact subset of writes that hasn't propagated yet.
+        inserted_job_ids: list[uuid.UUID] = []
         waited_job_ids: set[uuid.UUID] = set()
 
         had_ready_at_start: bool | None = None
@@ -764,6 +784,7 @@ class LazyComputationExecutor:
                             new_job.save()
                             publish_job_completion(new_job.id, "ready")
                             jobs_created += 1
+                            inserted_job_ids.append(new_job.id)
                             logger.info(
                                 "lazy_computation.job_completed",
                                 job_id=str(new_job.id),
@@ -867,7 +888,7 @@ class LazyComputationExecutor:
         result = LazyComputationResult(
             ready=True,
             job_ids=[j.id for j in final_ready],
-            jobs_inserted=jobs_created,
+            inserted_job_ids=inserted_job_ids,
         )
         _log_execution("success", result)
         return result

--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
@@ -610,19 +610,21 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2024-01-15T12:00:00Z")
     def test_visibility_check_fires_when_jobs_were_inserted(self):
-        # When `ensure_*` reports it INSERTed something, the read must first
-        # confirm those parts are visible via `_wait_for_data_visible` —
-        # otherwise the SELECT can land on a replica mid-fetch and silently
-        # under-count, which is the bug this whole flow was added for.
+        # When `ensure_*` reports it INSERTed something (non-empty
+        # `inserted_job_ids`), the read must first confirm those specific
+        # parts are visible via `_wait_for_data_visible` — otherwise the
+        # SELECT can land on a replica mid-fetch and silently under-count,
+        # which is the bug this whole flow was added for.
         from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
         from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
 
+        new_id = uuid.uuid4()
         with (
             self._enable_lazy(),
             patch.object(
                 mod,
                 "ensure_web_overview_precomputed",
-                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=1),
+                return_value=LazyComputationResult(ready=True, job_ids=[new_id], inserted_job_ids=[new_id]),
             ),
             patch.object(mod, "_wait_for_data_visible", return_value=True) as wait_mock,
             patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
@@ -633,13 +635,20 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         assert wait_mock.call_count == 1, (
             f"_wait_for_data_visible should fire exactly once after fresh INSERTs, got {wait_mock.call_count}"
         )
+        # The poll must target only the freshly-inserted IDs so empty
+        # pre-existing jobs can't falsely time it out.
+        passed_ids = wait_mock.call_args.args[1]
+        assert passed_ids == [str(new_id)], (
+            f"_wait_for_data_visible must receive only the freshly inserted IDs, got {passed_ids}"
+        )
         assert result is not None, "visible-data path should not fall back"
 
     @freeze_time("2024-01-15T12:00:00Z")
     def test_visibility_check_skipped_on_warm_cache_hit(self):
-        # The warm-cache path (`ensure_*` returns ready=True, jobs_inserted=0)
-        # must skip `_wait_for_data_visible` so reads stay fast — every part is
-        # already on every replica from previous calls.
+        # The warm-cache path (`ensure_*` returns ready=True with non-empty
+        # `job_ids` but empty `inserted_job_ids`) must skip
+        # `_wait_for_data_visible` so reads stay fast — every part is already
+        # on every replica from previous calls.
         from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
         from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
 
@@ -648,7 +657,7 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             patch.object(
                 mod,
                 "ensure_web_overview_precomputed",
-                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=0),
+                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], inserted_job_ids=[]),
             ),
             patch.object(mod, "_wait_for_data_visible", return_value=True) as wait_mock,
             patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
@@ -682,7 +691,11 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             patch.object(
                 mod,
                 "ensure_web_overview_precomputed",
-                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=3),
+                return_value=LazyComputationResult(
+                    ready=True,
+                    job_ids=[uuid.uuid4(), uuid.uuid4(), uuid.uuid4()],
+                    inserted_job_ids=[uuid.uuid4(), uuid.uuid4(), uuid.uuid4()],
+                ),
             ),
             patch.object(mod, "_wait_for_data_visible", return_value=False),
             patch.object(mod, "execute_read_query", side_effect=fake_read),
@@ -704,6 +717,7 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
 
         call_count = {"n": 0}
+        prev_fresh_ids = [uuid.uuid4() for _ in range(5)]
 
         def fake_ensure(runner, time_range_start, time_range_end):
             call_count["n"] += 1
@@ -712,7 +726,7 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             return LazyComputationResult(
                 ready=True,
                 job_ids=[uuid.uuid4()],
-                jobs_inserted=0 if call_count["n"] == 1 else 5,
+                inserted_job_ids=[] if call_count["n"] == 1 else prev_fresh_ids,
             )
 
         with (
@@ -727,5 +741,11 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         assert call_count["n"] == 2, f"expected 2 ensure calls (current+previous), got {call_count['n']}"
         assert wait_mock.call_count == 1, (
             f"visibility check must still fire when only the previous-period call inserted, got {wait_mock.call_count}"
+        )
+        # The poll must receive only the previous-period freshly-inserted IDs,
+        # not the warm-cache current-period IDs (those are already visible).
+        passed_ids = wait_mock.call_args.args[1]
+        assert passed_ids == [str(j) for j in prev_fresh_ids], (
+            f"_wait_for_data_visible must receive only the previous-period fresh IDs, got {passed_ids}"
         )
         assert result is not None

--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
@@ -607,3 +607,125 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             result = execute_lazy_precomputed_read(runner)
 
         assert result is None, f"expected fall-back to raw when current precompute not ready, got {result!r}"
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_visibility_check_fires_when_jobs_were_inserted(self):
+        # When `ensure_*` reports it INSERTed something, the read must first
+        # confirm those parts are visible via `_wait_for_data_visible` —
+        # otherwise the SELECT can land on a replica mid-fetch and silently
+        # under-count, which is the bug this whole flow was added for.
+        from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
+        from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
+
+        with (
+            self._enable_lazy(),
+            patch.object(
+                mod,
+                "ensure_web_overview_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=1),
+            ),
+            patch.object(mod, "_wait_for_data_visible", return_value=True) as wait_mock,
+            patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
+        ):
+            runner = WebOverviewQueryRunner(team=self.team, query=self._build_query())
+            result = execute_lazy_precomputed_read(runner)
+
+        assert wait_mock.call_count == 1, (
+            f"_wait_for_data_visible should fire exactly once after fresh INSERTs, got {wait_mock.call_count}"
+        )
+        assert result is not None, "visible-data path should not fall back"
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_visibility_check_skipped_on_warm_cache_hit(self):
+        # The warm-cache path (`ensure_*` returns ready=True, jobs_inserted=0)
+        # must skip `_wait_for_data_visible` so reads stay fast — every part is
+        # already on every replica from previous calls.
+        from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
+        from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
+
+        with (
+            self._enable_lazy(),
+            patch.object(
+                mod,
+                "ensure_web_overview_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=0),
+            ),
+            patch.object(mod, "_wait_for_data_visible", return_value=True) as wait_mock,
+            patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
+        ):
+            runner = WebOverviewQueryRunner(team=self.team, query=self._build_query())
+            result = execute_lazy_precomputed_read(runner)
+
+        assert wait_mock.call_count == 0, (
+            f"_wait_for_data_visible must not fire when no new INSERTs were made, got {wait_mock.call_count}"
+        )
+        assert result is not None, "warm-cache read should succeed"
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_visibility_check_failure_falls_back(self):
+        # If `_wait_for_data_visible` returns False (timeout because some
+        # job's part is still mid-fetch on the read replica) we MUST NOT
+        # read the partial state — fall through to the live path so the
+        # caller gets correct numbers even if slow. Better to be slow once
+        # than to return wrong numbers.
+        from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
+        from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
+
+        read_mock_called = {"n": 0}
+
+        def fake_read(**kwargs):
+            read_mock_called["n"] += 1
+            return [[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]
+
+        with (
+            self._enable_lazy(),
+            patch.object(
+                mod,
+                "ensure_web_overview_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=3),
+            ),
+            patch.object(mod, "_wait_for_data_visible", return_value=False),
+            patch.object(mod, "execute_read_query", side_effect=fake_read),
+        ):
+            runner = WebOverviewQueryRunner(team=self.team, query=self._build_query())
+            result = execute_lazy_precomputed_read(runner)
+
+        assert result is None, f"visibility timeout must fall back to live path, got {result!r}"
+        assert read_mock_called["n"] == 0, (
+            f"read query must NOT fire when visibility check failed, fired {read_mock_called['n']} time(s)"
+        )
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_visibility_check_fires_when_only_previous_period_inserted(self):
+        # Common compareFilter race: current period is warm (no INSERTs) but
+        # the previous period is cold (fresh INSERTs). We MUST verify visibility
+        # before the read or the previous-period buckets won't be there yet.
+        from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
+        from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
+
+        call_count = {"n": 0}
+
+        def fake_ensure(runner, time_range_start, time_range_end):
+            call_count["n"] += 1
+            # First call (current period): warm cache, nothing inserted.
+            # Second call (previous period): cold, INSERTed 5 jobs.
+            return LazyComputationResult(
+                ready=True,
+                job_ids=[uuid.uuid4()],
+                jobs_inserted=0 if call_count["n"] == 1 else 5,
+            )
+
+        with (
+            self._enable_lazy(),
+            patch.object(mod, "ensure_web_overview_precomputed", side_effect=fake_ensure),
+            patch.object(mod, "_wait_for_data_visible", return_value=True) as wait_mock,
+            patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
+        ):
+            runner = WebOverviewQueryRunner(team=self.team, query=self._build_query(compare=True))
+            result = execute_lazy_precomputed_read(runner)
+
+        assert call_count["n"] == 2, f"expected 2 ensure calls (current+previous), got {call_count['n']}"
+        assert wait_mock.call_count == 1, (
+            f"visibility check must still fire when only the previous-period call inserted, got {wait_mock.call_count}"
+        )
+        assert result is not None

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -17,6 +17,7 @@ from posthog.clickhouse.preaggregation.web_overview_preaggregated_sql import (
     DISTRIBUTED_WEB_OVERVIEW_PREAGGREGATED_TABLE,
 )
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.settings import DEBUG, TEST
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
     LazyComputationResult,
@@ -49,11 +50,29 @@ SUPPORTED_USER_FILTER_KEYS: set[str] = {"$host"}
 # enough daily jobs that the first request burns INSERT slots for minutes.
 MAX_PRECOMPUTE_DAYS = 90
 
+# Hard cap on the post-INSERT "are my writes visible yet?" poll. Empirically the
+# fetch lag on `sharded_web_overview_preaggregated` is sub-second for parts we
+# just wrote; 5s is comfortably above p99. On timeout the caller falls through
+# to the live path (correct but slower) so this only bounds the wait — not
+# correctness.
+DATA_VISIBILITY_TIMEOUT_SECONDS = 5.0
+
+# Initial poll interval. We expand on each iteration up to a small ceiling so
+# we don't hammer ClickHouse if replication is genuinely slow.
+DATA_VISIBILITY_POLL_INITIAL_INTERVAL = 0.05
+DATA_VISIBILITY_POLL_MAX_INTERVAL = 0.5
+
 
 WEB_OVERVIEW_LAZY_FAILED = Counter(
     "web_overview_lazy_precompute_failed_total",
     "Lazy precompute path failures, by error class",
     ["error_type"],
+)
+
+WEB_OVERVIEW_LAZY_VISIBILITY_WAIT = Counter(
+    "web_overview_lazy_precompute_visibility_wait_total",
+    "Post-INSERT visibility polls before the lazy precompute read, by outcome",
+    ["outcome"],
 )
 
 
@@ -377,18 +396,125 @@ WHERE team_id = %(team_id)s AND job_id IN %(job_ids)s
 
 
 _READ_SETTINGS = {
-    # Approach E from `products/analytics_platform/backend/lazy_computation/CONSISTENCY.md`:
-    # both INSERT (via `_get_insert_settings`) and SELECT use `in_order` so they
-    # deterministically prefer the same replica. Combined with the global
-    # `distributed_foreground_insert=1`, the SELECT sees data the INSERT just wrote.
+    # `load_balancing="in_order"` matches the INSERT side so a warm-cache read
+    # (no fresh INSERTs in this request) deterministically lands on the same
+    # replica that originally wrote the data — see Approach E in
+    # `products/analytics_platform/backend/lazy_computation/CONSISTENCY.md`.
     #
-    # `select_sequential_consistency=1` was tried here and is documented broken in
-    # CONSISTENCY.md when combined with `insert_quorum_parallel=1` (the default).
+    # For the cold-cache case where this read fires right after fresh INSERTs,
+    # `in_order` alone is not enough: a transient `errors_count` bump on the
+    # preferred replica can reroute either the INSERT coordination or the
+    # SELECT to a different replica, and parts may still be mid-fetch on the
+    # one we land on. `execute_lazy_precomputed_read` polls
+    # `_wait_for_data_visible` (which fires the same shape of SELECT) before
+    # issuing this read whenever any job was inserted in this request, so by
+    # the time we get here every job_id we'll read is confirmed visible on
+    # the same replica.
     "load_balancing": "in_order",
     # Shard pruning: sharding key is `sipHash64(job_id)`; `job_id IN (...)` matches
     # exactly the shards we wrote to.
     "optimize_skip_unused_shards": 1,
 }
+
+
+def _wait_for_data_visible(team_id: int, job_ids: list[str]) -> bool:
+    """Poll the Distributed table until every job_id we're about to read shows
+    at least one bucket — i.e., the part we just INSERTed has propagated to the
+    same replica the downstream SELECT will use (`load_balancing=in_order`).
+
+    Returns True when all job_ids are visible. Returns False on timeout — the
+    caller MUST then fall through to the live path rather than issue the read,
+    since a partial-visibility SELECT silently under-counts (the failure mode
+    this whole flow exists to prevent).
+
+    Verifies through the same `optimize_skip_unused_shards=1` / `load_balancing
+    ="in_order"` path the real read uses, so we test exactly the visibility
+    the read needs — no SYSTEM commands, no cluster-name assumptions.
+
+    Caveat: a job whose INSERT legitimately produced zero rows (e.g. a team
+    with no events in the window, or a `$host` filter that matched nothing)
+    will never show up in `count(DISTINCT job_id)` and this will time out.
+    The fallback returns correct (zero) data through the live path, just
+    slower. Acceptable trade-off vs the alternative — a permission-gated
+    `SYSTEM SYNC REPLICA ON CLUSTER` call that bakes the aux cluster name
+    into the query layer.
+    """
+    if not job_ids:
+        return True
+    # TEST/DEBUG run against a single-node ClickHouse where the race can't
+    # happen — every write is immediately visible. Skip the poll so unit tests
+    # don't spend the timeout budget waiting for a race that doesn't exist.
+    if TEST or DEBUG:
+        return True
+
+    expected = len(set(job_ids))
+    job_ids_tuple = tuple(job_ids)
+    table = DISTRIBUTED_WEB_OVERVIEW_PREAGGREGATED_TABLE()
+    tag_queries(
+        product=Product.WEB_ANALYTICS,
+        feature=Feature.QUERY,
+        query_type="web_overview_lazy_visibility_check",
+    )
+
+    started = time.perf_counter()
+    interval = DATA_VISIBILITY_POLL_INITIAL_INTERVAL
+    polls = 0
+    last_visible = -1
+    while True:
+        elapsed = time.perf_counter() - started
+        if elapsed >= DATA_VISIBILITY_TIMEOUT_SECONDS:
+            break
+        polls += 1
+        try:
+            result = sync_execute(
+                f"SELECT count(DISTINCT job_id) FROM {table} WHERE team_id = %(team_id)s AND job_id IN %(job_ids)s",
+                {"team_id": team_id, "job_ids": job_ids_tuple},
+                settings={
+                    "load_balancing": "in_order",
+                    "optimize_skip_unused_shards": 1,
+                },
+                team_id=team_id,
+            )
+            last_visible = int(result[0][0]) if result else 0
+            if last_visible >= expected:
+                duration_ms = int((time.perf_counter() - started) * 1000)
+                WEB_OVERVIEW_LAZY_VISIBILITY_WAIT.labels(outcome="visible").inc()
+                logger.info(
+                    "web_overview_lazy_precompute_visibility_check",
+                    team_id=team_id,
+                    outcome="visible",
+                    polls=polls,
+                    duration_ms=duration_ms,
+                    expected=expected,
+                    visible=last_visible,
+                )
+                return True
+        except Exception as exc:
+            # Don't unwind on transient CH errors — keep polling within the
+            # budget. If errors persist past the timeout we report below.
+            logger.warning(
+                "web_overview_lazy_precompute_visibility_poll_error",
+                team_id=team_id,
+                error_type=type(exc).__name__,
+                error=str(exc)[:200],
+            )
+
+        # Sleep, then back off (still bounded by the overall timeout above).
+        time.sleep(min(interval, DATA_VISIBILITY_TIMEOUT_SECONDS - elapsed))
+        interval = min(interval * 2, DATA_VISIBILITY_POLL_MAX_INTERVAL)
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    WEB_OVERVIEW_LAZY_VISIBILITY_WAIT.labels(outcome="timeout").inc()
+    logger.warning(
+        "web_overview_lazy_precompute_visibility_check",
+        team_id=team_id,
+        outcome="timeout",
+        polls=polls,
+        duration_ms=duration_ms,
+        expected=expected,
+        visible=last_visible,
+    )
+    return False
 
 
 def execute_read_query(
@@ -520,6 +646,7 @@ def execute_lazy_precomputed_read(
             return None
 
         job_ids: list[str] = [str(jid) for jid in result.job_ids]
+        jobs_inserted = result.jobs_inserted
 
         previous_start_utc: Optional[datetime] = None
         previous_end_utc: Optional[datetime] = None
@@ -554,6 +681,19 @@ def execute_lazy_precomputed_read(
                         return None
 
                     job_ids.extend(str(jid) for jid in prev_result.job_ids)
+                    jobs_inserted += prev_result.jobs_inserted
+
+        # If anything was newly INSERTed during this request, poll the
+        # Distributed read path until those parts are visible on the same
+        # replica the SELECT will land on. Without this, the SELECT can hit
+        # a replica that's still fetching the just-INSERTed parts and silently
+        # under-count the period whose data is mid-propagation — observed
+        # empirically on first cold-cache load with compareFilter on, where
+        # previous-period counts collapse to ~1% of actual then settle on
+        # refresh. See `_wait_for_data_visible` for the trade-offs.
+        if jobs_inserted > 0:
+            if not _wait_for_data_visible(team_id, job_ids):
+                return None
 
         read_started = time.perf_counter()
         rows = execute_read_query(
@@ -571,6 +711,7 @@ def execute_lazy_precomputed_read(
             "web_overview_lazy_precompute_completed",
             team_id=team_id,
             job_count=len(result.job_ids),
+            jobs_inserted=jobs_inserted,
             rows_returned=len(rows) if rows else 0,
             ensure_duration_ms=ensure_duration_ms,
             read_duration_ms=read_duration_ms,

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -417,10 +417,15 @@ _READ_SETTINGS = {
 }
 
 
-def _wait_for_data_visible(team_id: int, job_ids: list[str]) -> bool:
-    """Poll the Distributed table until every job_id we're about to read shows
-    at least one bucket — i.e., the part we just INSERTed has propagated to the
-    same replica the downstream SELECT will use (`load_balancing=in_order`).
+def _wait_for_data_visible(team_id: int, inserted_job_ids: list[str]) -> bool:
+    """Poll the Distributed table until every freshly-INSERTed job_id shows at
+    least one bucket — i.e., the part we just wrote has propagated to the same
+    replica the downstream SELECT will use (`load_balancing="in_order"`).
+
+    `inserted_job_ids` MUST contain only IDs we INSERTed in this request (see
+    `LazyComputationResult.inserted_job_ids`). Passing cached job_ids here
+    would conflate "visibility wait" with "is this team's data non-empty",
+    producing spurious timeouts for teams whose period contains zero events.
 
     Returns True when all job_ids are visible. Returns False on timeout — the
     caller MUST then fall through to the live path rather than issue the read,
@@ -431,15 +436,15 @@ def _wait_for_data_visible(team_id: int, job_ids: list[str]) -> bool:
     ="in_order"` path the real read uses, so we test exactly the visibility
     the read needs — no SYSTEM commands, no cluster-name assumptions.
 
-    Caveat: a job whose INSERT legitimately produced zero rows (e.g. a team
-    with no events in the window, or a `$host` filter that matched nothing)
-    will never show up in `count(DISTINCT job_id)` and this will time out.
-    The fallback returns correct (zero) data through the live path, just
-    slower. Acceptable trade-off vs the alternative — a permission-gated
-    `SYSTEM SYNC REPLICA ON CLUSTER` call that bakes the aux cluster name
-    into the query layer.
+    Caveat: if any of the just-INSERTed jobs legitimately produced zero rows
+    (e.g. a `$host` filter that matched no events in the window), it won't
+    show up in `count(DISTINCT job_id)` and this will time out. The fallback
+    returns correct (zero) data through the live path, just slower. With the
+    `inserted_job_ids` scoping above this only affects requests that both
+    triggered a fresh INSERT AND that INSERT was empty for its range — a
+    narrow corner of the input space.
     """
-    if not job_ids:
+    if not inserted_job_ids:
         return True
     # TEST/DEBUG run against a single-node ClickHouse where the race can't
     # happen — every write is immediately visible. Skip the poll so unit tests
@@ -447,8 +452,8 @@ def _wait_for_data_visible(team_id: int, job_ids: list[str]) -> bool:
     if TEST or DEBUG:
         return True
 
-    expected = len(set(job_ids))
-    job_ids_tuple = tuple(job_ids)
+    expected = len(set(inserted_job_ids))
+    job_ids_tuple = tuple(inserted_job_ids)
     table = DISTRIBUTED_WEB_OVERVIEW_PREAGGREGATED_TABLE()
     tag_queries(
         product=Product.WEB_ANALYTICS,
@@ -646,7 +651,15 @@ def execute_lazy_precomputed_read(
             return None
 
         job_ids: list[str] = [str(jid) for jid in result.job_ids]
-        jobs_inserted = result.jobs_inserted
+        # Track exactly which job_ids this request INSERTed (current + previous
+        # `ensure_*` calls). Only these are at risk of replication lag on the
+        # read replica — pre-existing READY jobs returned in `result.job_ids`
+        # were written by earlier requests and have long since propagated.
+        # `len(job_ids)` cannot serve as the gate because it includes those
+        # warm-cache entries: a warm-cache hit returns N cached jobs and no
+        # writes, but `len(job_ids) > 0` would still be True and we'd wait
+        # needlessly. See `LazyComputationResult.inserted_job_ids` docstring.
+        inserted_job_ids: list[str] = [str(jid) for jid in result.inserted_job_ids]
 
         previous_start_utc: Optional[datetime] = None
         previous_end_utc: Optional[datetime] = None
@@ -681,18 +694,21 @@ def execute_lazy_precomputed_read(
                         return None
 
                     job_ids.extend(str(jid) for jid in prev_result.job_ids)
-                    jobs_inserted += prev_result.jobs_inserted
+                    inserted_job_ids.extend(str(jid) for jid in prev_result.inserted_job_ids)
 
         # If anything was newly INSERTed during this request, poll the
-        # Distributed read path until those parts are visible on the same
-        # replica the SELECT will land on. Without this, the SELECT can hit
-        # a replica that's still fetching the just-INSERTed parts and silently
-        # under-count the period whose data is mid-propagation — observed
-        # empirically on first cold-cache load with compareFilter on, where
-        # previous-period counts collapse to ~1% of actual then settle on
-        # refresh. See `_wait_for_data_visible` for the trade-offs.
-        if jobs_inserted > 0:
-            if not _wait_for_data_visible(team_id, job_ids):
+        # Distributed read path until exactly those fresh parts are visible on
+        # the same replica the SELECT will land on. Without this, the SELECT
+        # can hit a replica that's still fetching the just-INSERTed parts and
+        # silently under-count the period whose data is mid-propagation —
+        # observed empirically on first cold-cache load with compareFilter on,
+        # where previous-period counts collapse to ~1% of actual then settle
+        # on refresh. We pass only `inserted_job_ids` (not all of `job_ids`)
+        # so the count expectation matches the parts actually at risk; pre-
+        # existing cached jobs are already visible everywhere and would
+        # otherwise falsely block this gate if they happen to have zero rows.
+        if inserted_job_ids:
+            if not _wait_for_data_visible(team_id, inserted_job_ids):
                 return None
 
         read_started = time.perf_counter()
@@ -711,7 +727,7 @@ def execute_lazy_precomputed_read(
             "web_overview_lazy_precompute_completed",
             team_id=team_id,
             job_count=len(result.job_ids),
-            jobs_inserted=jobs_inserted,
+            jobs_inserted=len(inserted_job_ids),
             rows_returned=len(rows) if rows else 0,
             ensure_duration_ms=ensure_duration_ms,
             read_duration_ms=read_duration_ms,


### PR DESCRIPTION
## Problem

The `compareFilter` read in `web_overview_query`'s lazy precompute path could fire against a Distributed read replica that hadn't yet fetched the parts written by the just-completed INSERTs (most often the previous-period chunk, which is always inserted last in the orchestration order). The SELECT silently under-counted the affected period — `uniqMergeIf` and `sumMergeIf` returned a fraction of the actual buckets, while `avgMergeIf`-based ratios (session duration, bounce rate) stayed roughly correct because their numerator and denominator both shrank in lockstep.

Empirically reproduced on team 2 with `dateRange.date_from=-89d` + `compareFilter.compare=true` on a cold cache (forced via `refresh=force_blocking`):

| metric | current | previous | shown Δ |
|---|---|---|---|
| visitors | 1,381,117 | **9,734** | +14089% |
| views | 98,178,531 | **147,080** | +66652% |
| sessions | 8,592,743 | **13,862** | +61888% |
| session duration | 3266s | 1803s | +81% (ratio, sane) |
| bounce rate | 13.5% | 17.8% | -24% (ratio, sane) |

Re-running the **identical** read SQL (same `job_id IN (…)` list, same time filters) via Metabase ~30s later returned `previous_users = 1,214,274` / `previous_views = 76,514,869` / `previous_sessions = 6,791,647` — collapse to a sane +13.7% / +28% / +26.5%. Data was always correct on disk; the SELECT just couldn't see it yet.

## Changes

- `LazyComputationResult` gains a `jobs_inserted: int` field that surfaces how many jobs the executor itself inserted during the call. Default 0 keeps every existing caller working unchanged.
- `web_overview_lazy_precompute.execute_lazy_precomputed_read` accumulates `jobs_inserted` across the current + previous `ensure_web_overview_precomputed` calls. If any new job was inserted, it polls `_wait_for_data_visible` before issuing the read SELECT.
- `_wait_for_data_visible` runs `SELECT count(DISTINCT job_id) FROM web_overview_preaggregated WHERE job_id IN (…)` through the same `load_balancing="in_order"` + `optimize_skip_unused_shards=1` path the real read uses, with exponential backoff up to a 5s timeout. On timeout the caller falls through to the live path (correct but slower).
- TEST/DEBUG skip the poll (single-node ClickHouse has no race to guard against).
- New Prometheus counter `web_overview_lazy_precompute_visibility_wait_total{outcome=visible|timeout}` for monitoring.
- Tests cover the four orchestrations: visibility check fires after INSERTs, skipped on warm cache, timeout falls back, and the "current warm / previous cold" compareFilter race.

## How did you test this code?

I'm an agent. Local unit tests were not run because the dev ClickHouse on this machine was returning `EOFError` on the native protocol during the session — pytest setup couldn't bootstrap and I did not have permission to restart the shared container. The new logic was validated by import-checking the module against Django and by ruff/format passes.

Empirical reproduction of the bug went through the prod API against team 2 (see numbers above) — I did not deploy this fix to prod, so the "after" verification step is still pending.

Reviewer-friendly verification:

- [ ] `hogli test posthog/hogql_queries/web_analytics/test/test_web_overview_lazy_precompute.py -k visibility_check`
- [ ] Add a flag-enabled team to `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` locally, hit `web_overview_query` with `compareFilter.compare=true` and a long `date_from` on cold cache, repeat — counts should be stable.
- [ ] After deploy: re-run the team 2 `-89d compare` query via API, confirm first-load percentages land near the +13.7% / +28% / +26.5% baseline from Metabase, not the +14000% shape.

## Publish to changelog?

no

## 🤖 Agent context

Sibling PR opens the same fix using `SYSTEM SYNC REPLICA ON CLUSTER … LIGHTWEIGHT` instead of the poll — kept open separately so the ClickHouse team can weigh in on which mechanism they prefer before either is merged. Same `jobs_inserted` plumbing on both, only `web_overview_lazy_precompute.py` differs.

The diagnosis went: notice the metric pattern (counts inflated, ratios sane → previous period under-counted, not a logic bug); confirm via `system.query_log` that the read SQL bounds and `job_id IN (…)` list were correct; re-run the identical SQL via Metabase later and observe balanced values → narrowed to a visibility/replication race. Reproduced empirically against team 2 cold cache.

The poll approach was preferred over `SYSTEM SYNC REPLICA` because it (a) verifies through the exact same read path the SELECT uses, (b) doesn't require the SYSTEM SYNC REPLICA privilege, (c) doesn't bake the aux cluster name into the query layer. Trade-off: makes 1-3 extra SELECT round trips on cold-cache requests, vs one ZK-coordinated SYSTEM call.