### PR TITLE
fix(web-analytics): SYNC REPLICA before lazy precompute compare read

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -312,6 +312,12 @@ class LazyComputationResult:
     ready: bool
     job_ids: list[uuid.UUID]
     errors: list[str] = field(default_factory=list)
+    # Number of jobs this executor created+inserted during the call. Callers
+    # use this to decide whether to wait for ClickHouse replication before
+    # issuing the downstream SELECT — fresh INSERTs on Replicated*MergeTree
+    # tables may not be visible on a different read replica yet, even after
+    # the local executor sees the PG row flip to READY.
+    jobs_inserted: int = 0
 
 
 def compute_query_hash(query_info: QueryInfo) -> str:
@@ -858,7 +864,11 @@ class LazyComputationExecutor:
         final_jobs = find_existing_jobs(team, query_hash, start, end)
         final_fresh = self._filter_by_freshness(final_jobs)
         final_ready = filter_overlapping_jobs([j for j in final_fresh if j.status == PreaggregationJob.Status.READY])
-        result = LazyComputationResult(ready=True, job_ids=[j.id for j in final_ready])
+        result = LazyComputationResult(
+            ready=True,
+            job_ids=[j.id for j in final_ready],
+            jobs_inserted=jobs_created,
+        )
         _log_execution("success", result)
         return result
 

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -307,17 +307,24 @@ class QueryInfo:
 
 @dataclass
 class LazyComputationResult:
-    """Result of executing lazy computation jobs."""
+    """Result of executing lazy computation jobs.
+
+    `job_ids` is the full set covering the requested range (cache hits + any
+    fresh writes), suitable for the downstream `WHERE job_id IN (…)` SELECT.
+
+    `inserted_job_ids` is the subset that **this** executor created+wrote
+    during the current call — i.e., the ones whose parts may still be
+    propagating across Replicated*MergeTree replicas. Callers that read
+    through the Distributed table immediately after this returns can use
+    this to decide whether to wait for replication; `len(job_ids)` cannot
+    serve that purpose because it includes pre-existing READY jobs from
+    prior requests, which replicated long ago and need no wait.
+    """
 
     ready: bool
     job_ids: list[uuid.UUID]
     errors: list[str] = field(default_factory=list)
-    # Number of jobs this executor created+inserted during the call. Callers
-    # use this to decide whether to wait for ClickHouse replication before
-    # issuing the downstream SELECT — fresh INSERTs on Replicated*MergeTree
-    # tables may not be visible on a different read replica yet, even after
-    # the local executor sees the PG row flip to READY.
-    jobs_inserted: int = 0
+    inserted_job_ids: list[uuid.UUID] = field(default_factory=list)
 
 
 def compute_query_hash(query_info: QueryInfo) -> str:
@@ -693,6 +700,11 @@ class LazyComputationExecutor:
         subscribed_ids: set[uuid.UUID] = set()
         pubsub: redis_lib.client.PubSub | None = None
         jobs_created = 0
+        # IDs of jobs this executor INSERTed successfully (status flipped READY)
+        # during this call. Surfaced to the caller via `LazyComputationResult.
+        # inserted_job_ids` so they can gate replication-visibility waits on
+        # the exact subset of writes that hasn't propagated yet.
+        inserted_job_ids: list[uuid.UUID] = []
         waited_job_ids: set[uuid.UUID] = set()
 
         had_ready_at_start: bool | None = None
@@ -764,6 +776,7 @@ class LazyComputationExecutor:
                             new_job.save()
                             publish_job_completion(new_job.id, "ready")
                             jobs_created += 1
+                            inserted_job_ids.append(new_job.id)
                             logger.info(
                                 "lazy_computation.job_completed",
                                 job_id=str(new_job.id),
@@ -867,7 +880,7 @@ class LazyComputationExecutor:
         result = LazyComputationResult(
             ready=True,
             job_ids=[j.id for j in final_ready],
-            jobs_inserted=jobs_created,
+            inserted_job_ids=inserted_job_ids,
         )
         _log_execution("success", result)
         return result

--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
@@ -607,3 +607,122 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             result = execute_lazy_precomputed_read(runner)
 
         assert result is None, f"expected fall-back to raw when current precompute not ready, got {result!r}"
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_sync_replica_fires_when_jobs_were_inserted(self):
+        # When `ensure_*` reports it INSERTed something, the read must wait for
+        # those parts to replicate (`_wait_for_replication`) before issuing the
+        # SELECT — otherwise the SELECT can land on a replica mid-fetch and
+        # silently under-count, which is the bug this whole flow was added for.
+        from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
+        from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
+
+        with (
+            self._enable_lazy(),
+            patch.object(
+                mod,
+                "ensure_web_overview_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=1),
+            ),
+            patch.object(mod, "_wait_for_replication", return_value=True) as wait_mock,
+            patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
+        ):
+            runner = WebOverviewQueryRunner(team=self.team, query=self._build_query())
+            result = execute_lazy_precomputed_read(runner)
+
+        assert wait_mock.call_count == 1, f"_wait_for_replication should fire exactly once, got {wait_mock.call_count}"
+        assert result is not None, "successful sync should not fall back"
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_sync_replica_skipped_on_warm_cache_hit(self):
+        # The warm-cache path (`ensure_*` returns ready=True, jobs_inserted=0)
+        # must skip `_wait_for_replication` so reads stay fast — every part is
+        # already on every replica from previous calls.
+        from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
+        from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
+
+        with (
+            self._enable_lazy(),
+            patch.object(
+                mod,
+                "ensure_web_overview_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=0),
+            ),
+            patch.object(mod, "_wait_for_replication", return_value=True) as wait_mock,
+            patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
+        ):
+            runner = WebOverviewQueryRunner(team=self.team, query=self._build_query())
+            result = execute_lazy_precomputed_read(runner)
+
+        assert wait_mock.call_count == 0, (
+            f"_wait_for_replication must not fire when no new INSERTs were made, got {wait_mock.call_count}"
+        )
+        assert result is not None, "warm-cache read should succeed"
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_sync_replica_failure_falls_back(self):
+        # If `_wait_for_replication` returns False (timeout, missing privilege,
+        # cluster unreachable, etc.) we MUST NOT read the partial state — fall
+        # through to the live path so the caller gets correct numbers even if
+        # slow. Better to be slow once than to return wrong numbers.
+        from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
+        from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
+
+        read_mock_called = {"n": 0}
+
+        def fake_read(**kwargs):
+            read_mock_called["n"] += 1
+            return [[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]
+
+        with (
+            self._enable_lazy(),
+            patch.object(
+                mod,
+                "ensure_web_overview_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=3),
+            ),
+            patch.object(mod, "_wait_for_replication", return_value=False),
+            patch.object(mod, "execute_read_query", side_effect=fake_read),
+        ):
+            runner = WebOverviewQueryRunner(team=self.team, query=self._build_query())
+            result = execute_lazy_precomputed_read(runner)
+
+        assert result is None, f"sync failure must fall back to live path, got {result!r}"
+        assert read_mock_called["n"] == 0, (
+            f"read query must NOT fire when sync failed, fired {read_mock_called['n']} time(s)"
+        )
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_sync_replica_fires_when_only_previous_period_inserted(self):
+        # Common compareFilter race: current period is warm (no INSERTs) but
+        # the previous period is cold (fresh INSERTs). We MUST sync before the
+        # read or the previous-period buckets won't be visible yet.
+        from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
+        from posthog.hogql_queries.web_analytics.web_overview_lazy_precompute import execute_lazy_precomputed_read
+
+        call_count = {"n": 0}
+
+        def fake_ensure(runner, time_range_start, time_range_end):
+            call_count["n"] += 1
+            # First call (current period): warm cache, nothing inserted.
+            # Second call (previous period): cold, INSERTed 5 jobs.
+            return LazyComputationResult(
+                ready=True,
+                job_ids=[uuid.uuid4()],
+                jobs_inserted=0 if call_count["n"] == 1 else 5,
+            )
+
+        with (
+            self._enable_lazy(),
+            patch.object(mod, "ensure_web_overview_precomputed", side_effect=fake_ensure),
+            patch.object(mod, "_wait_for_replication", return_value=True) as wait_mock,
+            patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
+        ):
+            runner = WebOverviewQueryRunner(team=self.team, query=self._build_query(compare=True))
+            result = execute_lazy_precomputed_read(runner)
+
+        assert call_count["n"] == 2, f"expected 2 ensure calls (current+previous), got {call_count['n']}"
+        assert wait_mock.call_count == 1, (
+            f"sync must still fire when only the previous-period call inserted, got {wait_mock.call_count}"
+        )
+        assert result is not None

--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
@@ -622,7 +622,7 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             patch.object(
                 mod,
                 "ensure_web_overview_precomputed",
-                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=1),
+                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], inserted_job_ids=[uuid.uuid4()]),
             ),
             patch.object(mod, "_wait_for_replication", return_value=True) as wait_mock,
             patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
@@ -635,7 +635,7 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2024-01-15T12:00:00Z")
     def test_sync_replica_skipped_on_warm_cache_hit(self):
-        # The warm-cache path (`ensure_*` returns ready=True, jobs_inserted=0)
+        # The warm-cache path (`ensure_*` returns ready=True, inserted_job_ids=[])
         # must skip `_wait_for_replication` so reads stay fast — every part is
         # already on every replica from previous calls.
         from posthog.hogql_queries.web_analytics import web_overview_lazy_precompute as mod
@@ -646,7 +646,7 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             patch.object(
                 mod,
                 "ensure_web_overview_precomputed",
-                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=0),
+                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], inserted_job_ids=[]),
             ),
             patch.object(mod, "_wait_for_replication", return_value=True) as wait_mock,
             patch.object(mod, "execute_read_query", return_value=[[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]]),
@@ -679,7 +679,11 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             patch.object(
                 mod,
                 "ensure_web_overview_precomputed",
-                return_value=LazyComputationResult(ready=True, job_ids=[uuid.uuid4()], jobs_inserted=3),
+                return_value=LazyComputationResult(
+                    ready=True,
+                    job_ids=[uuid.uuid4()],
+                    inserted_job_ids=[uuid.uuid4(), uuid.uuid4(), uuid.uuid4()],
+                ),
             ),
             patch.object(mod, "_wait_for_replication", return_value=False),
             patch.object(mod, "execute_read_query", side_effect=fake_read),
@@ -709,7 +713,7 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             return LazyComputationResult(
                 ready=True,
                 job_ids=[uuid.uuid4()],
-                jobs_inserted=0 if call_count["n"] == 1 else 5,
+                inserted_job_ids=[] if call_count["n"] == 1 else [uuid.uuid4() for _ in range(5)],
             )
 
         with (

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -2,6 +2,8 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Optional
 
+from django.conf import settings
+
 import structlog
 import posthoganalytics
 from prometheus_client import Counter
@@ -15,8 +17,10 @@ from posthog.hogql.transforms.preaggregated_table_transformation import is_integ
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.preaggregation.web_overview_preaggregated_sql import (
     DISTRIBUTED_WEB_OVERVIEW_PREAGGREGATED_TABLE,
+    SHARDED_WEB_OVERVIEW_PREAGGREGATED_TABLE,
 )
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.settings import DEBUG, TEST
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
     LazyComputationResult,
@@ -49,11 +53,23 @@ SUPPORTED_USER_FILTER_KEYS: set[str] = {"$host"}
 # enough daily jobs that the first request burns INSERT slots for minutes.
 MAX_PRECOMPUTE_DAYS = 90
 
+# Hard cap on `SYSTEM SYNC REPLICA … LIGHTWEIGHT` before the read. Bounded so a
+# wedged replication queue doesn't turn a query into a hung HTTP request.
+# Empirically the fetch lag on `sharded_web_overview_preaggregated` is sub-second
+# for parts we just wrote; 10s is comfortably above p99.
+SYNC_REPLICA_TIMEOUT_SECONDS = 10
+
 
 WEB_OVERVIEW_LAZY_FAILED = Counter(
     "web_overview_lazy_precompute_failed_total",
     "Lazy precompute path failures, by error class",
     ["error_type"],
+)
+
+WEB_OVERVIEW_LAZY_SYNC_REPLICA = Counter(
+    "web_overview_lazy_precompute_sync_replica_total",
+    "SYSTEM SYNC REPLICA calls fired before the lazy precompute read, by outcome",
+    ["outcome"],
 )
 
 
@@ -377,18 +393,95 @@ WHERE team_id = %(team_id)s AND job_id IN %(job_ids)s
 
 
 _READ_SETTINGS = {
-    # Approach E from `products/analytics_platform/backend/lazy_computation/CONSISTENCY.md`:
-    # both INSERT (via `_get_insert_settings`) and SELECT use `in_order` so they
-    # deterministically prefer the same replica. Combined with the global
-    # `distributed_foreground_insert=1`, the SELECT sees data the INSERT just wrote.
+    # `load_balancing="in_order"` matches the INSERT side so a warm-cache read
+    # (no fresh INSERTs in this request) deterministically lands on the same
+    # replica that originally wrote the data — see Approach E in
+    # `products/analytics_platform/backend/lazy_computation/CONSISTENCY.md`.
     #
-    # `select_sequential_consistency=1` was tried here and is documented broken in
-    # CONSISTENCY.md when combined with `insert_quorum_parallel=1` (the default).
+    # For the cold-cache case where this read fires right after fresh INSERTs,
+    # `in_order` alone is not enough: a transient `errors_count` bump on the
+    # preferred replica can reroute either the INSERT coordination or the
+    # SELECT to a different replica, and parts may still be mid-fetch on the
+    # one we land on. `execute_lazy_precomputed_read` runs `SYSTEM SYNC REPLICA
+    # … LIGHTWEIGHT` before issuing this SELECT whenever any job was inserted
+    # during the request to close that race.
     "load_balancing": "in_order",
     # Shard pruning: sharding key is `sipHash64(job_id)`; `job_id IN (...)` matches
     # exactly the shards we wrote to.
     "optimize_skip_unused_shards": 1,
 }
+
+
+def _wait_for_replication(team_id: int) -> bool:
+    """Block until all replicas of `sharded_web_overview_preaggregated` have
+    pulled the parts we just INSERTed, so the downstream SELECT can't land on a
+    replica that's still mid-fetch.
+
+    Returns True on success, False on timeout / error / privilege issue — the
+    caller MUST treat False as "fall through to the live path" rather than
+    issue the read, since the whole point of this call is to avoid serving the
+    partial-data shape that triggered this fix.
+
+    `LIGHTWEIGHT` ignores merges/mutations and only waits for replication-queue
+    fetches (GET_PART / ATTACH_PART entries), so it returns quickly when the
+    queue is short — exactly the entries created by our INSERTs.
+
+    NOTE: this uses `ON CLUSTER` to broadcast to every shard's replicas (the
+    read goes through the Distributed table and can land anywhere). That
+    requires the SYSTEM SYNC REPLICA privilege on the runtime user, the aux
+    cluster name to match what's configured in CH, and adds 1 ZK round-trip
+    per shard. **This approach should be reviewed with the ClickHouse team
+    before deploying.**
+    """
+    # TEST/DEBUG run against a single-node ClickHouse without the `aux` cluster
+    # defined. The race we're guarding against can't happen there (no peer
+    # replicas to fall behind), and `ON CLUSTER aux` would raise on the
+    # missing cluster. Skip and report success so the read proceeds normally.
+    if TEST or DEBUG:
+        return True
+
+    table = SHARDED_WEB_OVERVIEW_PREAGGREGATED_TABLE()
+    cluster = settings.CLICKHOUSE_AUX_CLUSTER
+    tag_queries(
+        product=Product.WEB_ANALYTICS,
+        feature=Feature.QUERY,
+        query_type="web_overview_lazy_sync_replica",
+    )
+    started = time.perf_counter()
+    try:
+        # `readonly=0` because SYSTEM commands aren't allowed under the HogQL
+        # default `readonly=2`. `receive_timeout` bounds how long the local
+        # node waits for peer ACKs before failing the statement.
+        sync_execute(
+            f"SYSTEM SYNC REPLICA ON CLUSTER {cluster} {table} LIGHTWEIGHT",
+            {},
+            settings={
+                "receive_timeout": SYNC_REPLICA_TIMEOUT_SECONDS,
+                "readonly": 0,
+            },
+            team_id=team_id,
+        )
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        WEB_OVERVIEW_LAZY_SYNC_REPLICA.labels(outcome="success").inc()
+        logger.info(
+            "web_overview_lazy_precompute_sync_replica",
+            team_id=team_id,
+            outcome="success",
+            duration_ms=duration_ms,
+        )
+        return True
+    except Exception as exc:
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        WEB_OVERVIEW_LAZY_SYNC_REPLICA.labels(outcome="failed").inc()
+        logger.warning(
+            "web_overview_lazy_precompute_sync_replica",
+            team_id=team_id,
+            outcome="failed",
+            duration_ms=duration_ms,
+            error_type=type(exc).__name__,
+            error=str(exc)[:200],
+        )
+        return False
 
 
 def execute_read_query(
@@ -520,6 +613,7 @@ def execute_lazy_precomputed_read(
             return None
 
         job_ids: list[str] = [str(jid) for jid in result.job_ids]
+        jobs_inserted = result.jobs_inserted
 
         previous_start_utc: Optional[datetime] = None
         previous_end_utc: Optional[datetime] = None
@@ -554,6 +648,17 @@ def execute_lazy_precomputed_read(
                         return None
 
                     job_ids.extend(str(jid) for jid in prev_result.job_ids)
+                    jobs_inserted += prev_result.jobs_inserted
+
+        # If anything was newly INSERTed during this request, wait for fresh
+        # parts to replicate before reading. Without this, the SELECT can hit
+        # a replica that's mid-fetch and silently under-count the period whose
+        # parts are still propagating — observed empirically as previous-period
+        # counts dropping to <1% of actual on first cold-cache load with
+        # compareFilter on (parts settle within a second or two on refresh).
+        if jobs_inserted > 0:
+            if not _wait_for_replication(team_id):
+                return None
 
         read_started = time.perf_counter()
         rows = execute_read_query(
@@ -571,6 +676,7 @@ def execute_lazy_precomputed_read(
             "web_overview_lazy_precompute_completed",
             team_id=team_id,
             job_count=len(result.job_ids),
+            jobs_inserted=jobs_inserted,
             rows_returned=len(rows) if rows else 0,
             ensure_duration_ms=ensure_duration_ms,
             read_duration_ms=read_duration_ms,

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -613,7 +613,14 @@ def execute_lazy_precomputed_read(
             return None
 
         job_ids: list[str] = [str(jid) for jid in result.job_ids]
-        jobs_inserted = result.jobs_inserted
+        # Track which job_ids this request actually INSERTed across current +
+        # previous `ensure_*` calls. Only these are at risk of replication lag —
+        # pre-existing READY jobs in `result.job_ids` were written by earlier
+        # requests and have long since propagated. `len(job_ids)` can't tell
+        # us "did we write anything in this request?" because warm-cache hits
+        # also return non-empty `job_ids`. See `LazyComputationResult.
+        # inserted_job_ids`.
+        inserted_job_ids: list[str] = [str(jid) for jid in result.inserted_job_ids]
 
         previous_start_utc: Optional[datetime] = None
         previous_end_utc: Optional[datetime] = None
@@ -648,7 +655,7 @@ def execute_lazy_precomputed_read(
                         return None
 
                     job_ids.extend(str(jid) for jid in prev_result.job_ids)
-                    jobs_inserted += prev_result.jobs_inserted
+                    inserted_job_ids.extend(str(jid) for jid in prev_result.inserted_job_ids)
 
         # If anything was newly INSERTed during this request, wait for fresh
         # parts to replicate before reading. Without this, the SELECT can hit
@@ -656,7 +663,7 @@ def execute_lazy_precomputed_read(
         # parts are still propagating — observed empirically as previous-period
         # counts dropping to <1% of actual on first cold-cache load with
         # compareFilter on (parts settle within a second or two on refresh).
-        if jobs_inserted > 0:
+        if inserted_job_ids:
             if not _wait_for_replication(team_id):
                 return None
 
@@ -676,7 +683,7 @@ def execute_lazy_precomputed_read(
             "web_overview_lazy_precompute_completed",
             team_id=team_id,
             job_count=len(result.job_ids),
-            jobs_inserted=jobs_inserted,
+            jobs_inserted=len(inserted_job_ids),
             rows_returned=len(rows) if rows else 0,
             ensure_duration_ms=ensure_duration_ms,
             read_duration_ms=read_duration_ms,


### PR DESCRIPTION
## Problem

Same bug as [#59551](https://github.com/PostHog/posthog/pull/59551): `compareFilter` reads in `web_overview_query`'s lazy precompute path silently under-count the period whose parts are still mid-fetch on the chosen Distributed read replica. See that PR's Problem section for the full evidence (counts inflated 14000%+ on cold cache; ratios stay sane; identical SQL re-run later returns balanced values).

This PR is the alternative implementation we'd like to discuss with the ClickHouse team before picking between the two.

## Changes

- `LazyComputationResult.jobs_inserted` is added the same way as in [#59551](https://github.com/PostHog/posthog/pull/59551) so the lazy path knows whether the current request did any fresh writes.
- `web_overview_lazy_precompute.execute_lazy_precomputed_read` calls `_wait_for_replication(team_id)` when any job was inserted in this request, before issuing the read SELECT.
- `_wait_for_replication` runs `SYSTEM SYNC REPLICA ON CLUSTER {aux_cluster} sharded_web_overview_preaggregated LIGHTWEIGHT` with `receive_timeout = 10s` and `readonly=0` (SYSTEM commands aren't allowed under HogQL's default `readonly=2`). On error/timeout the caller falls back to the live path.
- TEST/DEBUG short-circuit to success (single-node CH has no `aux` cluster and no race to fix).
- New Prometheus counter `web_overview_lazy_precompute_sync_replica_total{outcome=success|failed}`.
- Tests mirror the polling PR's coverage (fires after INSERTs, skipped on warm cache, failure falls back, fires when only previous-period chunk was cold).

## Trade-offs versus [#59551](https://github.com/PostHog/posthog/pull/59551) (poll-based fix)

| Aspect | This PR (SYNC REPLICA) | [#59551](https://github.com/PostHog/posthog/pull/59551) (poll) |
|---|---|---|
| Round trips on cold cache | 1 ClickHouse SYSTEM call | 1–N `SELECT count(DISTINCT job_id)` polls (typically 1–2) |
| ClickHouse-side cost | ZK roundtrip + fetch wait, broadcast to every replica in the aux cluster | Regular SELECT per poll, only touches shards holding our `job_id`s |
| Coordination layer | ZK (LIGHTWEIGHT skips merges/mutations) | Same Distributed/`in_order` path the real read uses |
| Privilege requirement | `SYSTEM SYNC REPLICA` on the runtime user | None beyond the existing read user |
| Cluster name coupling | Hardcoded `settings.CLICKHOUSE_AUX_CLUSTER` in the query | None |
| Failure modes | Whole-cluster lock if the SYNC REPLICA itself hangs (bounded by `receive_timeout`); fails closed → live path | Poll loop guarded by 5s budget; fails closed → live path |
| Verifies the read | No — trusts replicas catch up by the time the SELECT runs | Yes — count is asserted via the exact same `load_balancing=in_order` path |

Both approaches share `jobs_inserted` plumbing and the fall-back-to-live-on-failure contract.

## How did you test this code?

I'm an agent. Local unit tests were not run — the dev ClickHouse on my machine was returning `EOFError` on the native protocol during the session and I did not have permission to restart the shared container. The new logic was validated by import-checking the module against Django and by ruff/format passes.

Reviewer-friendly verification:

- [ ] **Discuss with the ClickHouse team** whether the broadcast `SYSTEM SYNC REPLICA ON CLUSTER … LIGHTWEIGHT` is acceptable on the aux cluster from the read user, or whether we should prefer the polling approach in [#59551](https://github.com/PostHog/posthog/pull/59551).
- [ ] `hogli test posthog/hogql_queries/web_analytics/test/test_web_overview_lazy_precompute.py -k sync_replica`
- [ ] Local repro with the relevant team in `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS`, `compareFilter.compare=true`, long `date_from`, cold cache.

## Publish to changelog?

no

## 🤖 Agent context

This PR exists alongside [#59551](https://github.com/PostHog/posthog/pull/59551) so the ClickHouse team can weigh in on which mechanism they prefer before either is merged. Only `web_overview_lazy_precompute.py` differs between the two; the `LazyComputationResult.jobs_inserted` plumbing is identical.

The `LIGHTWEIGHT` variant was picked over a full `SYSTEM SYNC REPLICA` so it only waits for `GET_PART` / `ATTACH_PART` entries (i.e., the entries our INSERTs just created) and skips merges/mutations, per the framework's existing `CONSISTENCY.md` discussion.