### PR TITLE
fix(logs): poll drop-rule impact every 30s so the table stays in sync

### DIFF
--- a/products/logs/frontend/components/LogsSampling/logsSamplingSectionLogic.ts
+++ b/products/logs/frontend/components/LogsSampling/logsSamplingSectionLogic.ts
@@ -15,6 +15,12 @@ import { LogsSamplingRuleApi } from 'products/logs/frontend/generated/api.schema
 import type { logsSamplingSectionLogicType } from './logsSamplingSectionLogicType'
 import { fetchSamplingRuleDropTotalsLast24h } from './samplingRuleDropImpact'
 
+// Background refresh cadence for the per-rule 24h drop counts. The underlying
+// `app_metrics2` table flushes every ~1 min, so a 30s tick is fast enough that
+// the user sees the new numbers shortly after they arrive without spamming
+// HogQL. The disposables plugin pauses the timer while the tab is hidden.
+const IMPACT_POLL_INTERVAL_MS = 30_000
+
 export const logsSamplingSectionLogic = kea<logsSamplingSectionLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsSampling', 'logsSamplingSectionLogic']),
 
@@ -155,7 +161,13 @@ export const logsSamplingSectionLogic = kea<logsSamplingSectionLogicType>([
         },
     })),
 
-    afterMount(({ actions }) => {
+    afterMount(({ actions, cache }) => {
         actions.loadRules()
+        cache.disposables.add(() => {
+            const pollTimer = window.setInterval(() => {
+                actions.loadRuleDropImpact(undefined)
+            }, IMPACT_POLL_INTERVAL_MS)
+            return () => clearInterval(pollTimer)
+        }, 'impactPoller')
     }),
 ])


### PR DESCRIPTION
## Problem

The per-rule 24h drop counts on the drop-rules settings table only refreshed when the section component re-mounted (`afterMount` → `loadRules` → `loadRulesSuccess` → `loadRuleDropImpact`). A user who landed on the settings page, enabled or edited a rule, and stayed on the page could watch the impact column stay stuck on the pre-change number indefinitely — until they hit the manual "Refresh list" button or navigated away and back.

This was especially confusing alongside the rule detail page, which exposes its own manual refresh button on its 24h-impact panel. After saving on the detail page and navigating back to the table, the table impact column was easily several minutes behind reality even though the underlying metric had updated.

## Changes

`products/logs/frontend/components/LogsSampling/logsSamplingSectionLogic.ts`: poll `loadRuleDropImpact` every 30s while the `LogsSamplingSection` is mounted. The interval is registered through `cache.disposables.add(...)` so:

- Cleanup runs automatically on unmount — no `beforeUnmount` needed.
- The disposables plugin pauses the timer while the browser tab is hidden and resumes it when the tab is visible again, so background tabs cost nothing.

30s is chosen against the `app_metrics2` flush cadence (~1 min): the table catches up within roughly one flush period, matching how often the data itself can change.

No changes to the backend, the HogQL query, or any other component.

## How did you test this code?

I'm an agent.

- `pnpm exec tsc --noEmit` — clean (after `pnpm typegen:write` to refresh kea-generated logic types stale from #59544).
- Verified the change by inspection against the pattern in `frontend/src/layout/navigation/noEventsBannerLogic.ts` and the `using-kea-disposables` skill.
- No automated tests exist for `logsSamplingSectionLogic`; not adding one for a 30s timer.
- No manual testing — would require a running PostHog with active ingestion. Behavior is mechanical: the loader's existing `breakpoint(1)` already de-dupes back-to-back calls.

## Publish to changelog?

no

## Docs update

No docs change — this is invisible to operators except as a UX improvement.

## 🤖 Agent context

Agent-authored via PostHog Code (Claude Opus 4.7).

Decision notes:

- Considered also wiring a cross-logic call from the rule detail page's save action into `logsSamplingSectionLogic.loadRules()` so the table refreshes immediately on save. Rejected as redundant: when the detail scene unmounts and the settings scene re-mounts, `afterMount` already triggers `loadRules`. The only stale-data case left after that was "user stays on the settings page" — which the 30s poll covers.
- Considered shorter intervals (5s / 10s). Rejected: `app_metrics2` itself flushes every ~1 min, so anything faster than ~30s would just re-fetch unchanged numbers and spam HogQL.
- Considered adding a "Last refreshed" timestamp to the table to make the lag visible. Out of scope — the user's request was to make the data sync, not to visualize the sync state. Easy follow-up if it's still confusing.
- Used `cache.disposables.add(...)` per `.claude/rules/kea-disposables.md` rather than a bare `setInterval` + `beforeUnmount` cleanup.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*