### PR TITLE
feat(logs): show bytes dropped alongside records in drop-rules table

### DIFF
--- a/products/logs/frontend/components/LogsSampling/LogsSamplingRulesSortableTable.tsx
+++ b/products/logs/frontend/components/LogsSampling/LogsSamplingRulesSortableTable.tsx
@@ -25,15 +25,18 @@ import { LemonButton, LemonSwitch } from '@posthog/lemon-ui'
 
 import { SortableDragIcon } from 'lib/lemon-ui/icons'
 import { Tooltip } from 'lib/lemon-ui/Tooltip/Tooltip'
-import { compactNumber } from 'lib/utils'
+import { compactNumber, humanizeBytes } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
 import { LogsSamplingRuleApi } from 'products/logs/frontend/generated/api.schemas'
 
 import { logsSamplingSectionLogic } from './logsSamplingSectionLogic'
 import { ruleTypeLabel } from './ruleTypeLabel'
+import { type SamplingRuleDropTotals } from './samplingRuleDropImpact'
 
 type RuleDropImpactCellState = 'loading' | 'ok' | 'error' | 'unknown'
+
+const EMPTY_IMPACT: SamplingRuleDropTotals = { records: 0, bytes: 0 }
 
 interface SortableRowProps {
     row: LogsSamplingRuleApi
@@ -42,7 +45,7 @@ interface SortableRowProps {
     ruleEnabledTogglePendingId: string | null
     saveRulesOrderPending: boolean
     ruleDropImpactCellState: RuleDropImpactCellState
-    dropped24h: number
+    impact24h: SamplingRuleDropTotals
     onSetRuleEnabled: (ruleId: string, enabled: boolean) => void
 }
 
@@ -53,7 +56,7 @@ function SortableRow({
     ruleEnabledTogglePendingId,
     saveRulesOrderPending,
     ruleDropImpactCellState,
-    dropped24h,
+    impact24h,
     onSetRuleEnabled,
 }: SortableRowProps): JSX.Element {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -105,7 +108,11 @@ function SortableRow({
                     <span className="text-muted">…</span>
                 ) : ruleDropImpactCellState === 'ok' ? (
                     <span>
-                        ~{compactNumber(dropped24h)} dropped <span className="text-muted">(24h)</span>
+                        ~{compactNumber(impact24h.records)} dropped
+                        {impact24h.bytes > 0 && (
+                            <span className="text-muted"> · ~{humanizeBytes(impact24h.bytes)}</span>
+                        )}{' '}
+                        <span className="text-muted">(24h)</span>
                     </span>
                 ) : (
                     <span
@@ -240,8 +247,10 @@ export function LogsSamplingRulesSortableTable(): JSX.Element {
                                         <Tooltip
                                             title={
                                                 <>
-                                                    Log lines dropped by this rule in ingestion metrics. Rules scoped to
-                                                    a service only affect that service; others count across the project.
+                                                    Log lines and bytes dropped by this rule in ingestion metrics. Bytes
+                                                    appear once any drops have been attributed by the current producer
+                                                    (older drops show records only). Rules scoped to a service only
+                                                    affect that service; others count across the project.
                                                 </>
                                             }
                                         >
@@ -275,7 +284,7 @@ export function LogsSamplingRulesSortableTable(): JSX.Element {
                                             ruleEnabledTogglePendingId={ruleEnabledTogglePendingId}
                                             saveRulesOrderPending={saveRulesOrderPending}
                                             ruleDropImpactCellState={ruleDropImpactCellState}
-                                            dropped24h={ruleDropImpact[row.id] ?? 0}
+                                            impact24h={ruleDropImpact[row.id] ?? EMPTY_IMPACT}
                                             onSetRuleEnabled={setRuleEnabled}
                                         />
                                     ))}

--- a/products/logs/frontend/components/LogsSampling/logsSamplingSectionLogic.ts
+++ b/products/logs/frontend/components/LogsSampling/logsSamplingSectionLogic.ts
@@ -13,7 +13,7 @@ import {
 import { LogsSamplingRuleApi } from 'products/logs/frontend/generated/api.schemas'
 
 import type { logsSamplingSectionLogicType } from './logsSamplingSectionLogicType'
-import { fetchSamplingRuleDropTotalsLast24h } from './samplingRuleDropImpact'
+import { type SamplingRuleDropTotals, fetchSamplingRuleDropTotalsLast24h } from './samplingRuleDropImpact'
 
 // Background refresh cadence for the per-rule 24h drop counts. The underlying
 // `app_metrics2` table flushes every ~1 min, so a 30s tick is fast enough that
@@ -64,7 +64,7 @@ export const logsSamplingSectionLogic = kea<logsSamplingSectionLogicType>([
             },
         ],
         ruleDropImpact: [
-            {} as Record<string, number>,
+            {} as Record<string, SamplingRuleDropTotals>,
             {
                 loadRuleDropImpact: async (_, breakpoint) => {
                     const rules = values.rules
@@ -73,15 +73,7 @@ export const logsSamplingSectionLogic = kea<logsSamplingSectionLogicType>([
                         return {}
                     }
                     await breakpoint(1)
-                    const totals = await fetchSamplingRuleDropTotalsLast24h(ids)
-                    // The list-view cell only renders record count (column space is tight).
-                    // Byte totals are surfaced on the rule detail page; here we collapse
-                    // back to the records number this loader has always exposed.
-                    const out: Record<string, number> = {}
-                    for (const [id, { records }] of Object.entries(totals)) {
-                        out[id] = records
-                    }
-                    return out
+                    return await fetchSamplingRuleDropTotalsLast24h(ids)
                 },
             },
         ],


### PR DESCRIPTION
## Problem

The drop-rules settings table's 24h impact cell shows just the record count: "~76 dropped (24h)". With the producer now attributing per-row bytes (#59480) and the consumer summing `bytes_dropped_by_rule` (#59499), the detail page already shows both records and bytes — but the table doesn't, so an operator scanning the list to find their biggest savers still has to click into each rule to see how much volume was dropped.

## Changes

- `LogsSamplingRulesSortableTable.tsx`: the impact cell now renders `~76 dropped · ~37 KB (24h)` when the per-rule byte counter is non-zero. Rules whose drops all happened before the per-row byte producer landed have a zero byte total and render unchanged (`~76 dropped (24h)`). Uses `humanizeBytes` from `lib/utils`, matching the format the detail page already uses.
- `logsSamplingSectionLogic.ts`: the `ruleDropImpact` loader passes through the full `SamplingRuleDropTotals` shape (`{records, bytes}`) that `fetchSamplingRuleDropTotalsLast24h` already returned. The previous unwrap-to-records step is gone.
- Column header tooltip updated to mention bytes and explain the old-producer behavior.

No backend changes, no schema changes, no new queries.

## How did you test this code?

I'm an agent.

- `pnpm exec tsc --noEmit` — clean (after `pnpm typegen:write` to refresh kea-generated logic types).
- No automated tests exist for this table or the section logic; not adding one for a render branch.
- No manual testing — would require a running PostHog with active drops on a rule. The render is mechanical: cell pulls `impact24h.records` and conditionally appends `humanizeBytes(impact24h.bytes)`.

## Publish to changelog?

no

## Docs update

No docs change — the panel is feature-flagged and undocumented externally.

## 🤖 Agent context

Agent-authored via PostHog Code (Claude Opus 4.7).

Decision notes:

- Considered showing bytes always (rendering `~0 B` for old-producer rows). Rejected: visually distracting and misleading, since the byte total isn't actually zero — it's just unattributed. The detail page already uses "hide bytes when zero"; I mirrored that.
- Considered a two-line cell `~76 dropped\n~37 KB` to keep the original line short. Rejected: the cell already has `whitespace-nowrap` and a single-line `~76 dropped · ~37 KB (24h)` reads naturally and matches the detail page's "X log lines (~Y KB) dropped" treatment.
- Considered keeping the loader's unwrap-to-records step and reading bytes from a sibling selector. Rejected: needless indirection — the loader already had the full shape; the unwrap was a leftover from when the table didn't render bytes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*