### PR TITLE
feat(funnels): add funnel→hog-charts series transforms

### DIFF
--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/funnelChartTransforms.test.ts
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/funnelChartTransforms.test.ts
@@ -1,0 +1,139 @@
+import type { FunnelStepWithNestedBreakdown } from '~/types'
+
+import { buildFunnelLineSeries, buildFunnelLineTimeSeriesConfig, type IndexedFunnelStep } from './funnelChartTransforms'
+
+const RED = '#ff0000'
+
+const makeStep = (overrides: Partial<IndexedFunnelStep> = {}): IndexedFunnelStep =>
+    ({
+        id: 0,
+        seriesIndex: 0,
+        action_id: 'pageview',
+        average_conversion_time: null,
+        median_conversion_time: null,
+        count: 100,
+        name: 'Step 1',
+        order: 0,
+        type: 'events',
+        converted_people_url: '',
+        dropped_people_url: null,
+        data: [10, 20, 30, 40, 50],
+        days: ['2024-06-10', '2024-06-11', '2024-06-12', '2024-06-13', '2024-06-14'],
+        labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+        ...overrides,
+    }) as IndexedFunnelStep
+
+describe('funnelChartTransforms', () => {
+    describe('buildFunnelLineSeries', () => {
+        it('builds a series per indexed step with days and breakdown_value carried in meta', () => {
+            const steps: IndexedFunnelStep[] = [
+                makeStep({ id: 0, order: 0, name: 'Step 1', breakdown_value: 'spike' }),
+                makeStep({ id: 1, order: 1, name: 'Step 2', breakdown_value: 'spike' }),
+            ]
+            const series = buildFunnelLineSeries(steps, { getColor: () => RED })
+
+            expect(series).toHaveLength(2)
+            expect(series[0]).toMatchObject({
+                key: '0',
+                label: 'Step 1',
+                data: [10, 20, 30, 40, 50],
+                color: RED,
+            })
+            expect(series[0].meta).toEqual({
+                days: ['2024-06-10', '2024-06-11', '2024-06-12', '2024-06-13', '2024-06-14'],
+                breakdown_value: 'spike',
+                order: 0,
+                label: 'Step 1',
+            })
+        })
+
+        it('normalises missing data to an empty array so the trends transform accepts it', () => {
+            const step = makeStep({ data: undefined as unknown as number[] })
+            const [series] = buildFunnelLineSeries([step], { getColor: () => RED })
+
+            expect(series.data).toEqual([])
+        })
+
+        it('sets a dashed in-progress tail when incompletenessOffsetFromEnd is negative', () => {
+            const step = makeStep({ data: [1, 2, 3, 4, 5, 6, 7] })
+            const [series] = buildFunnelLineSeries([step], {
+                getColor: () => RED,
+                incompletenessOffsetFromEnd: -2,
+            })
+
+            expect(series.stroke).toEqual({ partial: { fromIndex: 5 } })
+        })
+
+        it('passes the original IndexedFunnelStep to getColor (not the normalized shape)', () => {
+            const step = makeStep({ breakdown_value: 'spike' })
+            const getColor = jest.fn(() => RED)
+            buildFunnelLineSeries([step], { getColor })
+
+            expect(getColor).toHaveBeenCalledWith(step, 0)
+        })
+    })
+
+    describe('buildFunnelLineTimeSeriesConfig', () => {
+        it('produces a percentage y-axis tick formatter', () => {
+            const config = buildFunnelLineTimeSeriesConfig({
+                indexedSteps: [makeStep()],
+                interval: 'day',
+                timezone: 'UTC',
+                allDays: ['2024-06-10'],
+                showTrendLines: false,
+            })
+
+            expect(config.yAxis).toMatchObject({ format: 'percentage' })
+        })
+
+        it('passes through goal lines, trend lines, and value labels', () => {
+            const config = buildFunnelLineTimeSeriesConfig({
+                indexedSteps: [makeStep()],
+                interval: 'day',
+                timezone: 'UTC',
+                allDays: ['2024-06-10'],
+                showTrendLines: true,
+                goalLines: [{ label: 'Goal', value: 75, displayIfCrossed: true }],
+                valueLabels: { formatter: (v) => `${v}%` },
+            })
+
+            expect(config.trendLines).not.toBeUndefined()
+            expect(config.trendLines).not.toHaveLength(0)
+            expect(config.goalLines).toHaveLength(1)
+            expect(config.valueLabels).toBeTruthy()
+        })
+
+        it('omits confidence intervals and moving average (funnels do not surface either)', () => {
+            const config = buildFunnelLineTimeSeriesConfig({
+                indexedSteps: [makeStep()],
+                interval: 'day',
+                timezone: 'UTC',
+                allDays: ['2024-06-10'],
+                showTrendLines: false,
+            })
+
+            expect(config.confidenceIntervals).toBeUndefined()
+            expect(config.movingAverage).toBeUndefined()
+        })
+
+        it('omits the trendLines field when showTrendLines is false', () => {
+            const config = buildFunnelLineTimeSeriesConfig({
+                indexedSteps: [makeStep()],
+                interval: 'day',
+                timezone: 'UTC',
+                allDays: ['2024-06-10'],
+                showTrendLines: false,
+            })
+
+            expect(config.trendLines).toBeUndefined()
+        })
+    })
+
+    describe('type contracts', () => {
+        it('IndexedFunnelStep is assignable from FunnelStepWithNestedBreakdown', () => {
+            const step: FunnelStepWithNestedBreakdown = makeStep()
+            const indexed: IndexedFunnelStep = { ...step, id: 0, seriesIndex: 0 }
+            expect(indexed.id).toBe(0)
+        })
+    })
+})

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/funnelChartTransforms.ts
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/funnelChartTransforms.ts
@@ -1,0 +1,92 @@
+import type { Series, TimeSeriesLineChartConfig, TooltipConfig } from 'lib/hog-charts'
+import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import {
+    buildTrendsLineTimeSeriesConfig,
+    buildTrendsSeries,
+} from 'scenes/trends/viz/trends-line-chart/trendsChartTransforms'
+
+import type { GoalLine as SchemaGoalLine, TrendsFilter } from '~/queries/schema/schema-general'
+import type { FunnelStepWithNestedBreakdown, IntervalType } from '~/types'
+
+import type { FunnelSeriesMeta } from '../shared/funnelSeriesMeta'
+
+export type IndexedFunnelStep = FunnelStepWithNestedBreakdown & { id: number; seriesIndex: number }
+
+// The API populates `data`/`days`, but the base FunnelStep type marks them optional —
+// normalize so the trends transform never receives undefined.
+interface NormalizedFunnelStep {
+    id: string | number
+    label: string | null
+    data: number[]
+    days?: string[]
+    breakdown_value?: SeriesDatum['breakdown_value']
+    order: number
+}
+
+function normalizeStep(step: IndexedFunnelStep): NormalizedFunnelStep {
+    return {
+        id: step.id,
+        label: step.name ?? null,
+        data: step.data ?? [],
+        days: step.days,
+        breakdown_value: step.breakdown_value as SeriesDatum['breakdown_value'],
+        order: step.order,
+    }
+}
+
+export interface BuildFunnelLineSeriesOpts {
+    incompletenessOffsetFromEnd?: number
+    getColor: (step: IndexedFunnelStep, index: number) => string
+}
+
+export function buildFunnelLineSeries(
+    indexedSteps: IndexedFunnelStep[],
+    opts: BuildFunnelLineSeriesOpts
+): Series<FunnelSeriesMeta>[] {
+    const normalized = indexedSteps.map(normalizeStep)
+    return buildTrendsSeries<NormalizedFunnelStep, FunnelSeriesMeta>(normalized, {
+        getColor: (_, index) => opts.getColor(indexedSteps[index], index),
+        incompletenessOffsetFromEnd: opts.incompletenessOffsetFromEnd,
+        buildMeta: (step) => ({
+            days: step.days,
+            breakdown_value: step.breakdown_value,
+            order: step.order,
+            label: step.label,
+        }),
+    })
+}
+
+export interface BuildFunnelLineConfigOpts {
+    indexedSteps: IndexedFunnelStep[]
+    interval?: IntervalType | null
+    timezone?: string
+    allDays?: string[]
+    goalLines?: SchemaGoalLine[] | null
+    incompletenessOffsetFromEnd?: number
+    showTrendLines: boolean
+    valueLabels?: TimeSeriesLineChartConfig['valueLabels']
+    tooltip?: TooltipConfig
+    showCrosshair?: boolean
+}
+
+// Funnel trends always use a percentage y-axis; this drives the shared trends config builder.
+const PERCENTAGE_TRENDS_FILTER: TrendsFilter = { aggregationAxisFormat: 'percentage' }
+
+export function buildFunnelLineTimeSeriesConfig(opts: BuildFunnelLineConfigOpts): TimeSeriesLineChartConfig {
+    const normalized = opts.indexedSteps.map(normalizeStep)
+    return buildTrendsLineTimeSeriesConfig<NormalizedFunnelStep>({
+        results: normalized,
+        trendsFilter: PERCENTAGE_TRENDS_FILTER,
+        isPercentStackView: false,
+        isStickiness: false,
+        interval: opts.interval,
+        timezone: opts.timezone,
+        allDays: opts.allDays,
+        goalLines: opts.goalLines,
+        incompletenessOffsetFromEnd: opts.incompletenessOffsetFromEnd,
+        showTrendLines: opts.showTrendLines,
+        valueLabels: opts.valueLabels,
+        tooltip: opts.tooltip,
+        showCrosshair: opts.showCrosshair,
+    })
+}

--- a/frontend/src/scenes/funnels/viz/shared/funnelSeriesMeta.ts
+++ b/frontend/src/scenes/funnels/viz/shared/funnelSeriesMeta.ts
@@ -1,0 +1,9 @@
+import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+
+export type FunnelSeriesMeta = {
+    days?: string[]
+    // Narrower than BreakdownKeyType — matches SeriesDatum so the tooltip adapter needs no cast.
+    breakdown_value?: SeriesDatum['breakdown_value']
+    order: number
+    label?: string | null
+}


### PR DESCRIPTION
> **Stack:** this is the precursor; the `FunnelLineChart` component that consumes these transforms is #59541.

## Problem

The funnel **Trends** viz is being migrated from the legacy Chart.js `LineGraph` to the canvas-based `lib/hog-charts` library. That migration needs a transform layer to turn funnel data into hog-charts inputs. Splitting it out keeps the component PR focused.

## Changes

- `funnelChartTransforms.ts` — pure functions (`buildFunnelLineSeries`, `buildFunnelLineTimeSeriesConfig`) that adapt `funnelDataLogic`'s indexed steps into the hog-charts `Series` / `TimeSeriesLineChartConfig` shapes. They wrap the existing trends builders (`buildTrendsSeries`, `buildTrendsLineTimeSeriesConfig`) — pinned to a percentage y-axis, with no confidence intervals or moving average (funnels surface neither).
- `funnelSeriesMeta.ts` — the shared `FunnelSeriesMeta` type carried on each series.
- `funnelChartTransforms.test.ts` — unit tests for the transforms.

No production code consumes these yet — that's the stacked follow-up #59541 (the `FunnelLineChart` component). This PR is pure functions plus their tests, reviewable in isolation.

## How did you test this code?

Authored and verified by an agent. `funnelChartTransforms.test.ts` — 9 unit tests, all passing. `oxlint` clean.

## Publish to changelog?

no — no user-visible change; this is internal scaffolding for the funnel hog-charts migration.

## 🤖 Agent context

Authored with Claude Code (Anthropic) at the request of the human reviewer. Requires human review before merge.

First of a two-PR stack splitting the funnel hog-charts line-chart migration: this PR is the pure transform layer; #59541 is the `FunnelLineChart` component, tooltip, click handler, feature flag, tests, and Storybook stories.
