### PR TITLE
chore(funnels): add e2e test for trends funnel compare-to-previous toggle

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4538,6 +4538,10 @@ snapshots:
         hash: v1.k794b7964.b7b66559dccb763f858ee380c0d40d53762513df15f578847fb7d9e4d895bac8.6oo4h2VarntGAxWHNR2JnaPQL3-aBA8yjSewpfh1nK8
     scenes-app-insights-funnels--funnel-historical-trends--light:
         hash: v1.k794b7964.9fe64ca28742cf7dfb240b6aa406aaa4a2f432c37ee9bb8f48226288a0cc211a.cBV0X_j0CpIsQmxGgG-npGLQE1GhEHECWbdfi3lrviY
+    scenes-app-insights-funnels--funnel-historical-trends-compare--dark:
+        hash: v1.k794b7964.51f9e17a891ee9e734b149f3d3e0d75a17efed2739fca34b2a60303707df663a.ILben9P-htPVE30EG-LMY2AmDKjaCcboMcsAm88a5gc
+    scenes-app-insights-funnels--funnel-historical-trends-compare--light:
+        hash: v1.k794b7964.0c262649d9cccd6e0db23747e5dea4d4c6482ec8c39a843f85dc3d57e353dca8.WlfMvGeOV7nIb2BT5eLjcx5gG3UhzUIXXknUZ6p5xgw
     scenes-app-insights-funnels--funnel-historical-trends-edit--dark:
         hash: v1.k794b7964.e299dd20eac9d0a05dc0735c1bd6144ff5a4d0769184c7658494e175e77bb5fa.Og5dgfHwNhZgIcYUVdf6ZWqvUT32DDufl3iT_rDI4x0
     scenes-app-insights-funnels--funnel-historical-trends-edit--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -193,6 +193,7 @@ export const FEATURE_FLAGS = {
     /* The below flag is used to activate unmounting charts outside the viewport, as we're currently investigating frontend performance
     issues related to this and want to know the impact of having it on vs. off. */
     EXPERIMENTAL_DASHBOARD_ITEM_RENDERING: 'experimental-dashboard-item-rendering', // owner: @thmsobrmlr #team-product-analytics
+    FUNNELS_COMPARE: 'funnels-compare', // owner: #team-product-analytics, gates "Compare to previous" toggle on funnel insights
     GATEWAY_PERSONAL_API_KEY: 'gateway-personal-api-key', // owner: #team-platform-features
     IMPROVED_COOKIELESS_MODE: 'improved-cookieless-mode', // owner: #team-web-analytics
     LINEAGE_DEPENDENCY_VIEW: 'lineage-dependency-view', // owner: #team-data-modeling

--- a/frontend/src/mocks/fixtures/api/projects/team_id/insights/funnelHistoricalTrendsCompare.json
+++ b/frontend/src/mocks/fixtures/api/projects/team_id/insights/funnelHistoricalTrendsCompare.json
@@ -1,0 +1,137 @@
+{
+    "id": 52,
+    "short_id": "funnelTrendsCompare",
+    "name": null,
+    "derived_name": "Pageview → Pageview → Pageview user conversion trend (compare)",
+    "filters": {},
+    "filters_hash": "cache_funnel_trends_compare",
+    "order": null,
+    "deleted": false,
+    "dashboard": null,
+    "layouts": {},
+    "color": null,
+    "last_refresh": null,
+    "refreshing": false,
+    "result": [
+        {
+            "count": 8,
+            "data": [14.05, 15.61, 16.66, 3.08, 0, 0, 1.85, 0],
+            "days": [
+                "2022-03-08",
+                "2022-03-09",
+                "2022-03-10",
+                "2022-03-11",
+                "2022-03-12",
+                "2022-03-13",
+                "2022-03-14",
+                "2022-03-15"
+            ],
+            "labels": [
+                "8-Mar-2022",
+                "9-Mar-2022",
+                "10-Mar-2022",
+                "11-Mar-2022",
+                "12-Mar-2022",
+                "13-Mar-2022",
+                "14-Mar-2022",
+                "15-Mar-2022"
+            ],
+            "compare": true,
+            "compare_label": "current"
+        },
+        {
+            "count": 5,
+            "data": [8.4, 9.9, 6.2, 2.0, 0, 0, 0, 0],
+            "days": [
+                "2022-03-01",
+                "2022-03-02",
+                "2022-03-03",
+                "2022-03-04",
+                "2022-03-05",
+                "2022-03-06",
+                "2022-03-07",
+                "2022-03-08"
+            ],
+            "labels": [
+                "1-Mar-2022",
+                "2-Mar-2022",
+                "3-Mar-2022",
+                "4-Mar-2022",
+                "5-Mar-2022",
+                "6-Mar-2022",
+                "7-Mar-2022",
+                "8-Mar-2022"
+            ],
+            "compare": true,
+            "compare_label": "previous"
+        }
+    ],
+    "created_at": "2022-03-15T21:31:00.192917Z",
+    "created_by": {
+        "id": 1,
+        "uuid": "017f7913-c1ee-0000-faff-0fe5ace3849a",
+        "distinct_id": "Q1OD2NmnqqbqrLR45mYm2p1VNNbSO9DBFsMig90GWkK",
+        "first_name": "Marius",
+        "email": "marius@posthog.com"
+    },
+    "description": "",
+    "updated_at": "2022-03-15T21:48:00.105822Z",
+    "tags": [],
+    "favorited": false,
+    "saved": true,
+    "last_modified_at": "2022-03-15T21:48:00.096438Z",
+    "last_modified_by": {
+        "id": 1,
+        "uuid": "017f7913-c1ee-0000-faff-0fe5ace3849a",
+        "distinct_id": "Q1OD2NmnqqbqrLR45mYm2p1VNNbSO9DBFsMig90GWkK",
+        "first_name": "Marius",
+        "email": "marius@posthog.com"
+    },
+    "is_sample": false,
+    "query": {
+        "kind": "InsightVizNode",
+        "source": {
+            "compareFilter": {
+                "compare": true
+            },
+            "dateRange": {
+                "date_from": "2022-03-08",
+                "date_to": "2022-03-15"
+            },
+            "funnelsFilter": {
+                "exclusions": [],
+                "funnelVizType": "trends",
+                "layout": "horizontal"
+            },
+            "interval": "day",
+            "kind": "FunnelsQuery",
+            "properties": {
+                "type": "AND",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": []
+                    }
+                ]
+            },
+            "series": [
+                {
+                    "event": "$pageview",
+                    "kind": "EventsNode",
+                    "name": "$pageview"
+                },
+                {
+                    "event": "$pageview",
+                    "kind": "EventsNode",
+                    "name": "$pageview"
+                },
+                {
+                    "event": "$pageview",
+                    "kind": "EventsNode",
+                    "name": "$pageview"
+                }
+            ]
+        },
+        "full": true
+    }
+}

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -83,13 +83,15 @@ export function InsightDisplayConfig(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const hideWeekendsEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS]
 
+    const funnelsCompareEnabled = !!featureFlags[FEATURE_FLAGS.FUNNELS_COMPARE]
     const showCompare =
         (isTrends &&
             display !== ChartDisplayType.ActionsAreaGraph &&
             display !== ChartDisplayType.CalendarHeatmap &&
             display !== ChartDisplayType.BoxPlot) ||
         isStickiness ||
-        isWebAnalyticsInsightQuery(querySource)
+        isWebAnalyticsInsightQuery(querySource) ||
+        (funnelsCompareEnabled && isTrendsFunnel)
     const showInterval =
         isTrendsFunnel ||
         isLifecycle ||

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -19960,6 +19960,10 @@
                     "$ref": "#/definitions/BreakdownFilter",
                     "description": "Breakdown of the events and actions"
                 },
+                "compareFilter": {
+                    "$ref": "#/definitions/CompareFilter",
+                    "description": "Compare to date range"
+                },
                 "dataColorTheme": {
                     "description": "Colors used in the insight's visualization",
                     "type": ["number", "null"]

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1634,6 +1634,8 @@ export interface FunnelsQuery extends InsightsQueryBase<FunnelsQueryResponse> {
     funnelsFilter?: FunnelsFilter
     /** Breakdown of the events and actions */
     breakdownFilter?: BreakdownFilter
+    /** Compare to date range */
+    compareFilter?: CompareFilter
 }
 
 /** @asType integer */

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -411,8 +411,14 @@ export function isInsightQueryWithBreakdown(
 
 export function isInsightQueryWithCompare(
     node?: Record<string, any> | null
-): node is TrendsQuery | StickinessQuery | WebStatsTableQuery | WebOverviewQuery {
-    return isTrendsQuery(node) || isStickinessQuery(node) || isWebStatsTableQuery(node) || isWebOverviewQuery(node)
+): node is TrendsQuery | StickinessQuery | WebStatsTableQuery | WebOverviewQuery | FunnelsQuery {
+    return (
+        isTrendsQuery(node) ||
+        isStickinessQuery(node) ||
+        isWebStatsTableQuery(node) ||
+        isWebOverviewQuery(node) ||
+        isFunnelsQuery(node)
+    )
 }
 
 export function isDatabaseSchemaQuery(node?: Node): node is DatabaseSchemaQuery {

--- a/frontend/src/scenes/insights/Funnels.stories.tsx
+++ b/frontend/src/scenes/insights/Funnels.stories.tsx
@@ -4,6 +4,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import { waitFor } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { createInsightStory } from 'scenes/insights/__mocks__/createInsightScene'
 
 import { mswDecorator } from '~/mocks/browser'
@@ -116,13 +117,9 @@ export const FunnelHistoricalTrendsCompare: Story = createInsightStory(
     require('../../mocks/fixtures/api/projects/team_id/insights/funnelHistoricalTrendsCompare.json')
 )
 FunnelHistoricalTrendsCompare.parameters = {
-    testOptions: { waitForSelector: '[data-attr=trend-line-graph-funnel] > canvas' },
-}
-export const FunnelHistoricalTrendsCompareEdit: Story = createInsightStory(
-    require('../../mocks/fixtures/api/projects/team_id/insights/funnelHistoricalTrendsCompare.json'),
-    'edit'
-)
-FunnelHistoricalTrendsCompareEdit.parameters = {
+    // funnels-compare gates the Compare-to-previous toggle on funnel trends — without this the
+    // dual-period chart degrades back to the single-period rendering and the snapshot is wrong.
+    featureFlags: [FEATURE_FLAGS.FUNNELS_COMPARE],
     testOptions: { waitForSelector: '[data-attr=trend-line-graph-funnel] > canvas' },
 }
 

--- a/frontend/src/scenes/insights/Funnels.stories.tsx
+++ b/frontend/src/scenes/insights/Funnels.stories.tsx
@@ -112,6 +112,19 @@ export const FunnelHistoricalTrendsEdit: Story = createInsightStory(
 FunnelHistoricalTrendsEdit.parameters = {
     testOptions: { waitForSelector: '[data-attr=trend-line-graph-funnel] > canvas' },
 }
+export const FunnelHistoricalTrendsCompare: Story = createInsightStory(
+    require('../../mocks/fixtures/api/projects/team_id/insights/funnelHistoricalTrendsCompare.json')
+)
+FunnelHistoricalTrendsCompare.parameters = {
+    testOptions: { waitForSelector: '[data-attr=trend-line-graph-funnel] > canvas' },
+}
+export const FunnelHistoricalTrendsCompareEdit: Story = createInsightStory(
+    require('../../mocks/fixtures/api/projects/team_id/insights/funnelHistoricalTrendsCompare.json'),
+    'edit'
+)
+FunnelHistoricalTrendsCompareEdit.parameters = {
+    testOptions: { waitForSelector: '[data-attr=trend-line-graph-funnel] > canvas' },
+}
 
 export const FunnelTimeToConvert: Story = createInsightStory(
     require('../../mocks/fixtures/api/projects/team_id/insights/funnelTimeToConvert.json')

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -9,8 +9,9 @@ import {
 } from 'lib/components/InsightLegend/utils'
 import { Intervals, intervals } from 'lib/components/IntervalFilter/intervals'
 import { parseProperties } from 'lib/components/PropertyFilters/utils'
-import { NON_TIME_SERIES_DISPLAY_TYPES, NON_VALUES_ON_SERIES_DISPLAY_TYPES } from 'lib/constants'
+import { FEATURE_FLAGS, NON_TIME_SERIES_DISPLAY_TYPES, NON_VALUES_ON_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { dateMapping, is12HoursOrLess, isLessThan2Days } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
@@ -96,7 +97,14 @@ import {
     nodeKindToFilterProperty,
     supportsPercentStackView,
 } from '~/queries/utils'
-import { BaseMathType, ChartDisplayType, InsightLogicProps, LabelGroupType, SlowQueryPossibilities } from '~/types'
+import {
+    BaseMathType,
+    ChartDisplayType,
+    FunnelVizType,
+    InsightLogicProps,
+    LabelGroupType,
+    SlowQueryPossibilities,
+} from '~/types'
 
 import type { insightVizDataLogicType } from './insightVizDataLogicType'
 
@@ -119,6 +127,8 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
             ['dataWarehouseTablesMap'],
             dataThemeLogic,
             ['getTheme'],
+            featureFlagLogic,
+            ['featureFlags'],
         ],
         actions: [insightDataLogic, ['setQuery', 'setInsightData', 'loadData', 'loadDataSuccess', 'loadDataFailure']],
     })),
@@ -206,12 +216,24 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         isTrendsLike: [(s) => [s.querySource], (q) => isTrendsQuery(q) || isLifecycleQuery(q) || isStickinessQuery(q)], // this is for filtering out world map
         supportsDisplay: [(s) => [s.querySource], (q) => isTrendsQuery(q) || isStickinessQuery(q)],
         supportsCompare: [
-            (s) => [s.querySource, s.display, s.dateRange],
-            (q, display, dateRange) =>
-                (isTrendsQuery(q) || isStickinessQuery(q) || isWebAnalyticsInsightQuery(q)) &&
-                display !== ChartDisplayType.WorldMap &&
-                display !== ChartDisplayType.CalendarHeatmap &&
-                dateRange?.date_from !== 'all',
+            (s) => [s.querySource, s.display, s.dateRange, s.featureFlags],
+            (q, display, dateRange, featureFlags) => {
+                if (dateRange?.date_from === 'all') {
+                    return false
+                }
+                if (isTrendsQuery(q) || isStickinessQuery(q) || isWebAnalyticsInsightQuery(q)) {
+                    return display !== ChartDisplayType.WorldMap && display !== ChartDisplayType.CalendarHeatmap
+                }
+                // Funnel compare ships behind a flag, and only for the TRENDS viz mode in slice 1.
+                if (
+                    isFunnelsQuery(q) &&
+                    !!featureFlags[FEATURE_FLAGS.FUNNELS_COMPARE] &&
+                    q.funnelsFilter?.funnelVizType === FunnelVizType.Trends
+                ) {
+                    return true
+                }
+                return false
+            },
         ],
         supportsPercentStackView: [(s) => [s.querySource], (q) => supportsPercentStackView(q)],
         supportsValueOnSeries: [

--- a/playwright/e2e/product-analytics/insights/funnels.spec.ts
+++ b/playwright/e2e/product-analytics/insights/funnels.spec.ts
@@ -3,6 +3,7 @@ import { InsightShortId, InsightType } from '~/types'
 import { InsightPage } from '../../../page-models/insightPage'
 import { randomString } from '../../../utils'
 import { createEvent, daysAgo } from '../../../utils/event-data'
+import { mockFeatureFlags } from '../../../utils/mockApi'
 import { PlaywrightSetupEvent } from '../../../utils/playwright-setup'
 import { PlaywrightWorkspaceSetupResult, expect, test } from '../../../utils/workspace-test-base'
 
@@ -166,6 +167,35 @@ test.describe('Funnel insights', () => {
             await expect(insight.funnels.stepLegend(0)).toContainText('20')
             await expect(insight.funnels.stepLegend(1)).toContainText('10')
             await expect(insight.funnels.stepLegend(2)).toContainText('5')
+        })
+    })
+
+    test('Compare to previous period toggle is gated to Historical trends + funnels-compare flag', async ({ page }) => {
+        // Seeded funnel uses date_from '-7d' so the supportsCompare date guard is satisfied.
+        await mockFeatureFlags(page, { 'funnels-compare': true })
+
+        const insight = await goToSeededFunnel(page)
+
+        await test.step('compare-filter is hidden in default Conversion steps viz', async () => {
+            await expect(insight.funnels.comparisonButton).not.toBeVisible()
+        })
+
+        await test.step('switch to Historical trends — compare-filter becomes visible', async () => {
+            await insight.funnels.selectVizType('Historical trends')
+            await insight.funnels.waitForTrendsLineGraph()
+            await expect(insight.funnels.comparisonButton).toBeVisible()
+        })
+
+        await test.step('enable Compare to previous period — button label updates and chart still renders', async () => {
+            await insight.funnels.selectComparison('Compare to previous period')
+            await expect(insight.funnels.comparisonButton).toContainText('Previous')
+            await expect(insight.funnels.trendsLineGraph).toBeVisible()
+        })
+
+        await test.step('switch back to Conversion steps — compare-filter is gated off again', async () => {
+            await insight.funnels.selectVizType('Conversion steps')
+            await insight.funnels.waitForChart()
+            await expect(insight.funnels.comparisonButton).not.toBeVisible()
         })
     })
 

--- a/playwright/page-models/insights/funnelsInsight.ts
+++ b/playwright/page-models/insights/funnelsInsight.ts
@@ -14,6 +14,7 @@ export class FunnelsInsight {
     readonly tooltip: Locator
     readonly taxonomicFilter: TaxonomicFilter
     readonly conversionWindowInput: Locator
+    readonly comparisonButton: Locator
     private readonly conversionWindowSection: Locator
 
     constructor(private readonly page: Page) {
@@ -29,6 +30,7 @@ export class FunnelsInsight {
         this.taxonomicFilter = new TaxonomicFilter(page)
         this.conversionWindowSection = page.getByTestId('funnel-conversion-window-filter')
         this.conversionWindowInput = this.conversionWindowSection.getByRole('spinbutton')
+        this.comparisonButton = page.getByTestId('compare-filter')
     }
 
     async waitForChart(): Promise<void> {
@@ -119,6 +121,12 @@ export class FunnelsInsight {
         await this.expandFunnelSettings()
         await this.page.getByTestId('funnel-aggregation-filter').getByTestId('retention-aggregation-selector').click()
         await this.page.getByRole('menuitem', { name: label }).click()
+    }
+
+    async selectComparison(text: string): Promise<void> {
+        await this.comparisonButton.click()
+        await this.page.getByText(text).click()
+        await this.waitForTrendsLineGraph()
     }
 
     stepLegend(index: number): Locator {

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from django.conf import settings
 
 import posthoganalytics
+import structlog
 
 from posthog.schema import (
     CachedFunnelsQueryResponse,
@@ -44,6 +45,8 @@ from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWareho
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
 from posthog.models.filters.mixins.utils import cached_property
+
+logger = structlog.get_logger(__name__)
 
 
 class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
@@ -104,8 +107,13 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
             return self._calculate_compare()
         return self._calculate_single_period(self.funnel_class)
 
-    def _calculate_single_period(self, funnel_class) -> FunnelsQueryResponse:
+    def _calculate_single_period(
+        self, funnel_class, timings_override: Optional[HogQLTimings] = None
+    ) -> FunnelsQueryResponse:
         query = funnel_class.get_query()
+        # Compare runs subqueries in parallel threads; each worker passes its own clone since
+        # HogQLTimings is not thread-safe. Single-period runs fall back to the shared instance.
+        effective_timings = timings_override if timings_override is not None else self.timings
         timings = []
 
         # TODO: can we get this from execute_hogql_query as well?
@@ -115,7 +123,7 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
             query_type="FunnelsQuery",
             query=query,
             team=self.team,
-            timings=self.timings,
+            timings=effective_timings,
             modifiers=self.modifiers,
             limit_context=self.limit_context,
             settings=HogQLGlobalSettings(
@@ -153,13 +161,13 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         errors: list[Exception] = []
         funnels = [self.funnel_class, previous_funnel]
 
-        def run(index: int, query_tags: Optional[QueryTags] = None) -> None:
+        def run(index: int, timings: HogQLTimings, query_tags: Optional[QueryTags] = None) -> None:
             try:
                 # Worker threads start with an empty QueryTags ContextVar — restore the parent's
                 # snapshot so execute_hogql_query has the required feature/product tags.
                 if query_tags is not None:
                     query_tagging.update_tags(query_tags)
-                responses[index] = self._calculate_single_period(funnels[index])
+                responses[index] = self._calculate_single_period(funnels[index], timings_override=timings)
             except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
             finally:
@@ -172,11 +180,15 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         if settings.IN_UNIT_TESTING:
             # Django + threads in tests is flaky; trends compare uses the same bypass.
             for index in range(len(funnels)):
-                run(index)
+                run(index, self.timings.clone_for_subquery(index))
         else:
             parent_tags = query_tagging.get_query_tags().model_copy(deep=True)
             jobs = [
-                threading.Thread(target=run, args=(index, parent_tags)) for index in range(len(funnels))
+                threading.Thread(
+                    target=run,
+                    args=(index, self.timings.clone_for_subquery(index), parent_tags),
+                )
+                for index in range(len(funnels))
             ]
             for job in jobs:
                 job.start()
@@ -184,6 +196,10 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
                 job.join()
 
         if errors:
+            # Surface every secondary error with its traceback before re-raising the first,
+            # so dual-query failures don't disappear into the void.
+            for dropped in errors[1:]:
+                logger.exception("funnels_compare_secondary_error", exc_info=dropped)
             raise errors[0]
 
         current_response, previous_response = responses

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -1,10 +1,16 @@
+import threading
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from math import ceil
 from typing import Any, Optional
 
+from django.conf import settings
+
+import posthoganalytics
+
 from posthog.schema import (
     CachedFunnelsQueryResponse,
+    DateRange,
     FunnelsQuery,
     FunnelsQueryResponse,
     FunnelVizType,
@@ -29,7 +35,9 @@ from posthog.hogql_queries.insights.funnels.funnel_validation_rules import (
     ValidateOptionalFunnelSteps,
 )
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
+from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
 from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
@@ -90,7 +98,12 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         return self.funnel_actor_class.actor_query()
 
     def _calculate(self):
-        query = self.to_query()
+        if self._is_compare_active():
+            return self._calculate_compare()
+        return self._calculate_single_period(self.funnel_class)
+
+    def _calculate_single_period(self, funnel_class) -> FunnelsQueryResponse:
+        query = funnel_class.get_query()
         timings = []
 
         # TODO: can we get this from execute_hogql_query as well?
@@ -109,7 +122,7 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
             ),
         )
 
-        results = self.funnel_class._format_results(response.results)
+        results = funnel_class._format_results(response.results)
 
         if response.timings is not None:
             timings.extend(response.timings)
@@ -123,6 +136,122 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
             ),
+        )
+
+    def _calculate_compare(self) -> FunnelsQueryResponse:
+        """Run current + previous period queries and merge tagged rows.
+
+        Each row in `results: Any` is tagged with `compare_label: 'current' | 'previous'`. The
+        response shape is otherwise identical to a single-period response — this is the contract
+        the frontend (and later viz-mode slices) rely on. Two parallel queries instead of a UNION
+        because funnel queries are CTE/UDF-heavy; doubling cost is the explicit trade-off.
+        """
+        previous_funnel = self._build_previous_funnel()
+        responses: list[Optional[FunnelsQueryResponse]] = [None, None]
+        errors: list[Exception] = []
+        funnels = [self.funnel_class, previous_funnel]
+
+        def run(index: int) -> None:
+            try:
+                responses[index] = self._calculate_single_period(funnels[index])
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                if not settings.IN_UNIT_TESTING:
+                    # Close the per-thread DB connection so this thread doesn't leak it.
+                    from django.db import connection
+
+                    connection.close()
+
+        if settings.IN_UNIT_TESTING:
+            # Django + threads in tests is flaky; trends compare uses the same bypass.
+            for index in range(len(funnels)):
+                run(index)
+        else:
+            jobs = [threading.Thread(target=run, args=(index,)) for index in range(len(funnels))]
+            for job in jobs:
+                job.start()
+            for job in jobs:
+                job.join()
+
+        if errors:
+            raise errors[0]
+
+        current_response, previous_response = responses
+        assert current_response is not None and previous_response is not None
+
+        merged_results = []
+        for row in current_response.results or []:
+            row["compare_label"] = "current"
+            merged_results.append(row)
+        for row in previous_response.results or []:
+            row["compare_label"] = "previous"
+            merged_results.append(row)
+
+        timings = list(current_response.timings or []) + list(previous_response.timings or [])
+
+        return FunnelsQueryResponse(
+            results=merged_results,
+            timings=timings,
+            hogql=current_response.hogql,
+            modifiers=self.modifiers,
+            resolved_date_range=ResolvedDateRangeResponse(
+                date_from=self.query_date_range.date_from(),
+                date_to=self.query_date_range.date_to(),
+            ),
+        )
+
+    def _build_previous_funnel(self) -> FunnelTrendsUDF:
+        """Construct a FunnelTrendsUDF pinned to the previous-period date range.
+
+        The previous query is a clone of `self.query` with its `dateRange` swapped for the
+        shifted range and `compareFilter` cleared (to prevent infinite recursion if the cloned
+        query ever flows back through this runner).
+        """
+        prev_date_from = self.query_previous_date_range.date_from()
+        prev_date_to = self.query_previous_date_range.date_to()
+        previous_query = self.query.model_copy(
+            update={
+                "dateRange": DateRange(
+                    date_from=prev_date_from.isoformat() if prev_date_from else None,
+                    date_to=prev_date_to.isoformat() if prev_date_to else None,
+                    explicitDate=True,
+                ),
+                "compareFilter": None,
+            }
+        )
+        previous_context = FunnelQueryContext(
+            query=previous_query,
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+        )
+        return FunnelTrendsUDF(context=previous_context, just_summarize=self.just_summarize)
+
+    def _is_compare_active(self) -> bool:
+        compare_filter = self.query.compareFilter
+        if compare_filter is None or not compare_filter.compare:
+            return False
+        # Slice 1 ships compare only for the TRENDS viz mode. Other viz modes land in later slices.
+        if self.context.funnelsFilter.funnelVizType != FunnelVizType.TRENDS:
+            return False
+        return self._team_flag_funnels_compare()
+
+    def _team_flag_funnels_compare(self) -> bool:
+        return posthoganalytics.feature_enabled(
+            "funnels-compare",
+            str(self.team.uuid),
+            groups={
+                "organization": str(self.team.organization_id),
+                "project": str(self.team.id),
+            },
+            group_properties={
+                "organization": {"id": str(self.team.organization_id)},
+                "project": {"id": str(self.team.id)},
+            },
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
         )
 
     @cached_property
@@ -159,4 +288,22 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
             interval=self.query.interval,
             now=datetime.now(),
             exact_timerange=self.exact_timerange,
+        )
+
+    @cached_property
+    def query_previous_date_range(self) -> QueryDateRange:
+        compare_filter = self.query.compareFilter
+        if compare_filter is not None and compare_filter.compare_to:
+            return QueryCompareToDateRange(
+                date_range=self.query.dateRange,
+                team=self.team,
+                interval=self.query.interval,
+                now=datetime.now(),
+                compare_to=compare_filter.compare_to,
+            )
+        return QueryPreviousPeriodDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=self.query.interval,
+            now=datetime.now(),
         )

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -18,6 +18,8 @@ from posthog.schema import (
     ResolvedDateRangeResponse,
 )
 
+from posthog.clickhouse import query_tagging
+from posthog.clickhouse.query_tagging import QueryTags
 from posthog.hogql import ast
 from posthog.hogql.constants import MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY, HogQLGlobalSettings, LimitContext
 from posthog.hogql.printer import to_printed_hogql
@@ -151,8 +153,12 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         errors: list[Exception] = []
         funnels = [self.funnel_class, previous_funnel]
 
-        def run(index: int) -> None:
+        def run(index: int, query_tags: Optional[QueryTags] = None) -> None:
             try:
+                # Worker threads start with an empty QueryTags ContextVar — restore the parent's
+                # snapshot so execute_hogql_query has the required feature/product tags.
+                if query_tags is not None:
+                    query_tagging.update_tags(query_tags)
                 responses[index] = self._calculate_single_period(funnels[index])
             except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
@@ -168,7 +174,10 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
             for index in range(len(funnels)):
                 run(index)
         else:
-            jobs = [threading.Thread(target=run, args=(index,)) for index in range(len(funnels))]
+            parent_tags = query_tagging.get_query_tags().model_copy(deep=True)
+            jobs = [
+                threading.Thread(target=run, args=(index, parent_tags)) for index in range(len(funnels))
+            ]
             for job in jobs:
                 job.start()
             for job in jobs:

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -6,8 +6,8 @@ from typing import Any, Optional
 
 from django.conf import settings
 
-import posthoganalytics
 import structlog
+import posthoganalytics
 
 from posthog.schema import (
     CachedFunnelsQueryResponse,
@@ -19,8 +19,6 @@ from posthog.schema import (
     ResolvedDateRangeResponse,
 )
 
-from posthog.clickhouse import query_tagging
-from posthog.clickhouse.query_tagging import QueryTags
 from posthog.hogql import ast
 from posthog.hogql.constants import MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY, HogQLGlobalSettings, LimitContext
 from posthog.hogql.printer import to_printed_hogql
@@ -28,6 +26,8 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
+from posthog.clickhouse import query_tagging
+from posthog.clickhouse.query_tagging import QueryTags
 from posthog.hogql_queries.insights.funnels import FunnelTrendsUDF, FunnelUDF
 from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
 from posthog.hogql_queries.insights.funnels.funnel_time_to_convert import FunnelTimeToConvertUDF

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -10,12 +10,16 @@ from posthog.test.base import (
     _create_person,
     snapshot_clickhouse_queries,
 )
+from unittest.mock import patch
+
+from django.test import override_settings
 
 from parameterized import parameterized
 
 from posthog.schema import (
     BreakdownAttributionType,
     BreakdownFilter,
+    CompareFilter,
     DateRange,
     EventPropertyFilter,
     EventsNode,
@@ -3384,3 +3388,184 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(1, results[0]["reached_from_step_count"])
         self.assertEqual(0, results[0]["reached_to_step_count"])
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
+    """Compare-to-previous on funnel TRENDS viz. Tagged-row contract that later viz modes will reuse."""
+
+    maxDiff = None
+
+    def _build_query(
+        self,
+        date_from: str = "2021-06-07 00:00:00",
+        date_to: str = "2021-06-13 23:59:59",
+        compare: bool = True,
+        compare_to: Optional[str] = None,
+    ) -> FunnelsQuery:
+        return FunnelsQuery(
+            dateRange=DateRange(date_from=date_from, date_to=date_to),
+            interval="day",
+            series=[EventsNode(event="step one"), EventsNode(event="step two")],
+            funnelsFilter=FunnelsFilter(
+                funnelVizType="trends",
+                funnelWindowInterval=7,
+                funnelWindowIntervalUnit="day",
+            ),
+            compareFilter=CompareFilter(compare=compare, compare_to=compare_to),
+        )
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_compare_default_previous_period_tags_rows(self, _feature_enabled):
+        # Current period 2021-06-07 .. 2021-06-13. Default previous is the prior 7-day window
+        # (2021-05-31 .. 2021-06-06). One conversion lands in each window.
+        journeys_for(
+            {
+                "current_user": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 8, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 8, 11)},
+                ],
+                "previous_user": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 1, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 1, 11)},
+                ],
+            },
+            self.team,
+        )
+
+        results = FunnelsQueryRunner(query=self._build_query(), team=self.team).calculate().results
+
+        # Frontend-facing shape: one summarized series per period, tagged with compare_label.
+        # This is the same contract STEPS and TIME_TO_CONVERT slices will reuse.
+        labels = [row.get("compare_label") for row in results]
+        self.assertEqual(labels, ["current", "previous"])
+
+        current_series = next(r for r in results if r["compare_label"] == "current")
+        previous_series = next(r for r in results if r["compare_label"] == "previous")
+
+        # Each series carries the standard summarized funnel-trends payload (count is interval count).
+        self.assertEqual(len(current_series["data"]), 7)
+        self.assertEqual(len(previous_series["data"]), 7)
+        # Conversion happened on day index 1 (June 8) in current and day index 1 (June 1) in previous.
+        # Conversion rate is 100% (1/1) so the data point is 100.0.
+        self.assertIn(100.0, current_series["data"])
+        self.assertIn(100.0, previous_series["data"])
+        # Day labels for current period start at 2021-06-07; previous at 2021-05-31.
+        self.assertEqual(current_series["days"][0], "2021-06-07")
+        self.assertEqual(previous_series["days"][0], "2021-05-31")
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_compare_with_custom_offset_shifts_previous_window(self, _feature_enabled):
+        # Custom offset `-30d` puts the previous window 30 days before the current window's start
+        # regardless of the current window's length.
+        journeys_for(
+            {
+                "current_user": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 8, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 8, 11)},
+                ],
+                "previous_user": [
+                    # 2021-05-08 = 30 days before 2021-06-07
+                    {"event": "step one", "timestamp": datetime(2021, 5, 8, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 5, 8, 11)},
+                ],
+                "noise_user": [
+                    # Falls in the *default* previous window but NOT in the -30d window: must be ignored.
+                    {"event": "step one", "timestamp": datetime(2021, 6, 1, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 1, 11)},
+                ],
+            },
+            self.team,
+        )
+
+        results = FunnelsQueryRunner(query=self._build_query(compare_to="-30d"), team=self.team).calculate().results
+
+        previous_series = next(r for r in results if r["compare_label"] == "previous")
+        # Previous window starts 30 days before the current window's start (2021-06-07 - 30d = 2021-05-08).
+        self.assertEqual(previous_series["days"][0], "2021-05-08")
+        # The conversion on 2021-05-08 lands inside the previous window.
+        self.assertIn(100.0, previous_series["data"])
+        # The 2021-06-01 conversion (default-previous window) does NOT contribute here.
+        self.assertEqual(previous_series["data"].count(100.0), 1)
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_compare_with_empty_previous_period(self, _feature_enabled):
+        # Only the current period has events; previous-period series must still be returned (zeroed).
+        journeys_for(
+            {
+                "current_user": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 8, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 8, 11)},
+                ],
+            },
+            self.team,
+        )
+
+        results = FunnelsQueryRunner(query=self._build_query(), team=self.team).calculate().results
+
+        labels = [row["compare_label"] for row in results]
+        self.assertEqual(labels, ["current", "previous"])
+
+        previous_series = next(r for r in results if r["compare_label"] == "previous")
+        # Skeleton intact: 7 days, no conversions.
+        self.assertEqual(len(previous_series["data"]), 7)
+        self.assertEqual(len(previous_series["days"]), 7)
+        self.assertEqual(set(previous_series["data"]), {0.0})
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_compare_holds_funnel_window_constant(self, _feature_enabled):
+        # The previous-period sub-runner must use the same funnel window as the current-period one.
+        # Only the date range shifts when compare is on; funnelWindowInterval / funnelWindowIntervalUnit
+        # stay put. This is what keeps current and previous comparable.
+        runner = FunnelsQueryRunner(query=self._build_query(), team=self.team)
+        previous_funnel = runner._build_previous_funnel()
+
+        # Structural contract: previous funnel inherits the same funnelsFilter (window, attribution, etc.)
+        self.assertEqual(previous_funnel.context.funnelsFilter, runner.context.funnelsFilter)
+        # Sanity: compareFilter is cleared on the previous query so it can't recurse.
+        self.assertIsNone(previous_funnel.context.query.compareFilter)
+        # Sanity: previous query's dateRange differs from current.
+        self.assertNotEqual(previous_funnel.context.query.dateRange, runner.query.dateRange)
+
+    @patch("posthoganalytics.feature_enabled", return_value=False)
+    def test_compare_feature_flag_off_returns_single_period(self, _feature_enabled):
+        # When the `funnels-compare` flag is off, the runner ignores compareFilter and behaves
+        # as if compare=False — saved-funnel safety.
+        journeys_for(
+            {
+                "u": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 8, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 8, 11)},
+                ],
+            },
+            self.team,
+        )
+
+        results = FunnelsQueryRunner(query=self._build_query(), team=self.team).calculate().results
+
+        # Single-period response: one summarized series, no compare_label tagging.
+        self.assertEqual(len(results), 1)
+        self.assertNotIn("compare_label", results[0])
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_compare_with_all_time_date_range(self, _feature_enabled):
+        # When date_from='all', mirror trends' behavior: the runner does not reject the query;
+        # the previous period is whatever QueryPreviousPeriodDateRange resolves to and rows are
+        # tagged accordingly. The frontend toggle hides "compare" when date_from='all', but the
+        # backend stays tolerant of stale clients.
+        journeys_for(
+            {
+                "u": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 8, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 8, 11)},
+                ],
+            },
+            self.team,
+        )
+
+        query = self._build_query(date_from="all", date_to="2021-06-13 23:59:59")
+        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
+
+        labels = {row.get("compare_label") for row in results}
+        # The orchestrator still emits both tags; the data may be empty / overlapping — that's expected.
+        self.assertEqual(labels, {"current", "previous"})

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -21756,6 +21756,7 @@ class FunnelsQuery(BaseModel):
     )
     aggregation_group_type_index: int | None = Field(default=None, description="Groups aggregation")
     breakdownFilter: BreakdownFilter | None = Field(default=None, description="Breakdown of the events and actions")
+    compareFilter: CompareFilter | None = Field(default=None, description="Compare to date range")
     dataColorTheme: float | None = Field(default=None, description="Colors used in the insight's visualization")
     dateRange: DateRange | None = Field(default=None, description="Date range for the query")
     filterTestAccounts: bool | None = Field(

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1949,6 +1949,8 @@ export interface FunnelsQueryApi {
     aggregation_group_type_index?: number | null
     /** Breakdown of the events and actions */
     breakdownFilter?: BreakdownFilterApi | null
+    /** Compare to date range */
+    compareFilter?: CompareFilterApi | null
     /** Colors used in the insight's visualization */
     dataColorTheme?: number | null
     /** Date range for the query */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2281,6 +2281,8 @@ export namespace Schemas {
       aggregation_group_type_index?: number | null;
       /** Breakdown of the events and actions */
       breakdownFilter?: BreakdownFilter | null;
+      /** Compare to date range */
+      compareFilter?: CompareFilter | null;
       /** Colors used in the insight's visualization */
       dataColorTheme?: number | null;
       /** Date range for the query */


### PR DESCRIPTION
## Problem

PR #59536 adds the backend orchestration and frontend gating for a "Compare to previous" toggle on funnel insights (Historical trends viz mode, behind the `funnels-compare` feature flag), but there's no automated UI test covering the new gating predicates. A reviewer cannot tell from the diff alone whether the toggle actually appears in the right places and stays hidden in the wrong ones.

This PR adds a Playwright end-to-end test that captures the intended behavior, so the gating logic in `insightVizDataLogic.supportsCompare` and `InsightDisplayConfig.showCompare` is exercised by CI.

Stacked on top of #59536 — once that merges, this PR auto-retargets master.

## Changes

`playwright/page-models/insights/funnelsInsight.ts`
- Adds `comparisonButton` locator (`data-testid=compare-filter`) and a `selectComparison(text)` helper, mirroring `TrendsInsight`.

`playwright/e2e/product-analytics/insights/funnels.spec.ts`
- One new test in the existing `Funnel insights` describe block: `Compare to previous period toggle is gated to Historical trends + funnels-compare flag`.
- Steps:
  1. With the seeded funnel in default `Conversion steps` viz, the compare-filter is hidden.
  2. Switching to `Historical trends` surfaces the toggle.
  3. Clicking `Compare to previous period` updates the button label and the funnel-trends line graph still renders.
  4. Switching back to `Conversion steps` re-hides the toggle.
- The `funnels-compare` flag is mocked locally at the top of the test via `mockFeatureFlags` — not in `beforeEach` — so the other 7 funnels tests are unaffected.

Deliberately **not** asserting two-line series rendering: per #59536's description, frontend splitting of compare-tagged results into paired `indexedSteps` is deferred to a follow-up PR. A test for that belongs with the follow-up.

## How did you test this code?

I'm an agent; I have not manually run the Playwright suite. To run locally:

```
pnpm --filter @posthog/playwright exec playwright test \
  e2e/product-analytics/insights/funnels.spec.ts \
  -g "Compare to previous period toggle"
```

Sanity check: temporarily flip `'funnels-compare': true` to `false` and confirm step 2 fails (toggle should be hidden on Historical trends without the flag).

## Publish to changelog?

no

## Docs update

No docs change.

## 🤖 Agent context

Authored by PostHog Code (Claude Code).

Approach:

- Verified PR #59536's branch tip frontend gating via `git diff` rather than trusting a research-agent summary — initial summary incorrectly reported the gating had been reverted. The actual branch state: flag in `constants.tsx`, `isInsightQueryWithCompare` extended to include `FunnelsQuery`, `supportsCompare` extended with funnel-trends + flag + non-`all` date guard, `showCompare` extended likewise. The test is written against that confirmed state.
- Chose to stack the test PR on the feature branch (base = `posthog-code/slice-1-funnels-trends-compare`) rather than target master directly. Reasons: the test asserts behavior that doesn't exist on master and would fail CI; a single revert removes both; reviewers of the parent PR see the test as ground-truth of intent.
- Considered putting the flag mock in `beforeEach`. Rejected — the other 7 funnels tests don't need `funnels-compare` and shouldn't carry it.
- Considered asserting on the exact button label `'Previous period'`. Used the looser `toContainText('Previous')` to be forgiving of label variants while still catching genuine regressions.
- Considered asserting two-line series rendering. Rejected per the parent PR's explicit scope deferral.

Known risk: the compare-on path triggers two parallel ClickHouse queries; if that's slower than the default `expect` timeout in CI, `waitForTrendsLineGraph` may flake. If observed in CI, raise the timeout on the page-model helper rather than burying a sleep in the test.