### PR TITLE
fix(max): close upstream connection if synthesize response construction fails

### DIFF
--- a/ee/api/hands_free.py
+++ b/ee/api/hands_free.py
@@ -218,15 +218,24 @@ class MaxHandsFreeViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             upstream.close()
             raise HandsFreeProviderError(f"Hands-free provider returned {upstream.status_code}.")
 
-        HANDS_FREE_SYNTHESIZE_COUNTER.labels(outcome="ok").inc()
-        HANDS_FREE_SYNTHESIZE_CHARS_COUNTER.inc(len(text))
+        # Anything between the upstream 200 and returning the StreamingHttpResponse can
+        # raise (a counter labels() call, the StreamingHttpResponse constructor, the
+        # header assignment). Without an explicit close on those paths the connection
+        # only releases when the unconsumed generator is garbage collected — which is
+        # not guaranteed to be prompt under load. Guard the whole block.
+        try:
+            HANDS_FREE_SYNTHESIZE_COUNTER.labels(outcome="ok").inc()
+            HANDS_FREE_SYNTHESIZE_CHARS_COUNTER.inc(len(text))
 
-        def stream_and_close() -> Any:
-            try:
-                yield from upstream.iter_content(chunk_size=4096)
-            finally:
-                upstream.close()
+            def stream_and_close() -> Any:
+                try:
+                    yield from upstream.iter_content(chunk_size=4096)
+                finally:
+                    upstream.close()
 
-        response = StreamingHttpResponse(stream_and_close(), content_type="audio/mpeg")
-        response["Cache-Control"] = "no-store"
+            response = StreamingHttpResponse(stream_and_close(), content_type="audio/mpeg")
+            response["Cache-Control"] = "no-store"
+        except Exception:
+            upstream.close()
+            raise
         return response

--- a/ee/api/test/test_hands_free.py
+++ b/ee/api/test/test_hands_free.py
@@ -128,3 +128,22 @@ class TestMaxHandsFreeAPI(APIBaseTest):
         self.client.logout()
         response = self.client.post(self._synthesize_url(), data={"text": "hello"}, format="json")
         assert response.status_code in (401, 403)
+
+    @patch("ee.api.hands_free.StreamingHttpResponse")
+    @patch("ee.api.hands_free.requests.post")
+    def test_synthesize_closes_upstream_when_response_construction_fails(
+        self, mock_post: MagicMock, mock_streaming_response: MagicMock
+    ) -> None:
+        # Upstream returns 200 (so close isn't called on the error-status path) but the
+        # StreamingHttpResponse constructor blows up before we can return. Without the
+        # try/except in synthesize the upstream connection would leak — Django would
+        # surface a 500 to the client and the requests connection would only release on
+        # GC of the unconsumed iter_content generator.
+        upstream = MagicMock(status_code=200)
+        mock_post.return_value = upstream
+        mock_streaming_response.side_effect = RuntimeError("django blew up")
+
+        response = self.client.post(self._synthesize_url(), data={"text": "hello"}, format="json")
+
+        assert response.status_code == 500
+        upstream.close.assert_called_once()


### PR DESCRIPTION
## Problem

The hands-free synthesize endpoint streams ElevenLabs TTS bytes back to the browser via `StreamingHttpResponse`. The current implementation has a small window between the upstream 200 and returning the response:

\`\`\`python
HANDS_FREE_SYNTHESIZE_COUNTER.labels(outcome=\"ok\").inc()  # ← can raise
HANDS_FREE_SYNTHESIZE_CHARS_COUNTER.inc(len(text))         # ← can raise
def stream_and_close(): ...
response = StreamingHttpResponse(...)                       # ← can raise
response[\"Cache-Control\"] = \"no-store\"                    # ← can raise
return response
\`\`\`

If any of those raise, the upstream connection only releases when the unconsumed \`iter_content\` generator is garbage collected — not guaranteed prompt under load. Surfaced as a follow-up by the merge reviewer on #59188.

## Fix

Wrap the success path in try/except so \`upstream.close()\` runs explicitly on any exception:

\`\`\`python
try:
    HANDS_FREE_SYNTHESIZE_COUNTER.labels(outcome=\"ok\").inc()
    ...
    response = StreamingHttpResponse(stream_and_close(), content_type=\"audio/mpeg\")
    response[\"Cache-Control\"] = \"no-store\"
except Exception:
    upstream.close()
    raise
return response
\`\`\`

Regression test patches \`StreamingHttpResponse\` to raise and asserts \`upstream.close()\` is called exactly once.

## 🤖 Agent context

Cherry-picked from the #59188 review feedback as a single-file follow-up. No behavioural change on the happy path; the existing \`stream_and_close()\` finally block still handles the normal stream lifecycle.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*