### PR TITLE
fix(clickhouse): fix trends query usage in new analyzer

### DIFF
--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -694,31 +694,28 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
                         },
                     ),
                     parse_expr(
-                        "arrayMap((max_num, min_num) -> max_num - min_num, arrayZip(max_nums, min_nums)) as diff"
-                    ),
-                    ast.Alias(
-                        alias="bins",
-                        expr=ast.Array(
-                            exprs=[
-                                ast.Constant(value=alias["histogram_bin_count"])
-                                for alias in breakdown_aliases_with_histograms
-                            ]
-                        ),
-                    ),
-                    parse_expr(
                         """
                             arrayMap(
-                                i -> arrayMap(x -> [
-                                        ((diff[i] / bins[i]) * x) + min_nums[i],
-                                        ((diff[i] / bins[i]) * (x + 1)) + min_nums[i] + if(x + 1 = bins[i], 0.01, 0)
+                                (max_num, min_num, bin_count) -> arrayMap(x -> [
+                                        (((max_num - min_num) / bin_count) * x) + min_num,
+                                        (((max_num - min_num) / bin_count) * (x + 1))
+                                            + min_num
+                                            + if(x + 1 = bin_count, 0.01, 0)
                                     ],
-                                    range(bins[i])
+                                    range(bin_count)
                                 ),
-                                range(1, {breakdown_count})
+                                max_nums,
+                                min_nums,
+                                {bin_counts}
                             ) as buckets
                         """,
                         placeholders={
-                            "breakdown_count": ast.Constant(value=len(breakdown_aliases_with_histograms) + 1),
+                            "bin_counts": ast.Array(
+                                exprs=[
+                                    ast.Constant(value=alias["histogram_bin_count"])
+                                    for alias in breakdown_aliases_with_histograms
+                                ]
+                            ),
                         },
                     ),
                 ]


### PR DESCRIPTION
## Problem

Trends queries with histogram breakdowns could generate ClickHouse SQL that referenced same-select aliases from inside nested lambdas. Newer ClickHouse analysis can fail to resolve those aliases, producing an unknown identifier error for `bins`.

https://us.posthog.com/project/2/error_tracking/019e0773-7bba-7872-94f8-020345cfdaa0?timestamp=2026-05-22%2001%3A37%3A10.013000-07%3A00&dateRange=%7B%22date_from%22%3A%22-1h%22%2C%22date_to%22%3Anull%7D

## Changes

Reworked histogram bucket generation in `TrendsQueryBuilder` to pass `max_num`, `min_num`, and `bin_count` directly into `arrayMap` lambdas instead of creating and referencing outer `diff` and `bins` aliases.

This keeps the generated SQL equivalent while avoiding alias-resolution issues inside nested lambda scopes.

## How did you test this code?

Agent-authored.

- `./bin/ruff.sh check posthog/hogql_queries/insights/trends/trends_query_builder.py`
- `flox activate -- bash -c "./bin/hogli test posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py::TestTrendsQueryRunner::test_trends_event_multiple_numeric_breakdowns_into_bins"` passed

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 Agent context

Codex investigated a ClickHouse `Unknown identifier bins` failure from a trends query stack trace. The failing SQL came from histogram breakdown bucket generation in `posthog/hogql_queries/insights/trends/trends_query_builder.py`.

The chosen fix was to keep the change local and avoid broader query refactors: bucket ranges are now generated by passing the histogram values as lambda arguments, which avoids relying on ClickHouse resolving same-select aliases inside nested lambdas. This preserves the existing bucket behavior while addressing the root alias-scoping issue.