### PR TITLE
fix(error-tracking): add default MSW mocks for organization integrations and quick filters

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -248,6 +248,8 @@ export const defaultMocks: Mocks = {
         'api/projects/:team_id/surveys': EMPTY_PAGINATED_RESPONSE,
         'api/projects/:team_id/surveys/responses_count': {},
         'api/environments/:team_id/integrations': EMPTY_PAGINATED_RESPONSE,
+        '/api/organizations/:organization_id/integrations/': EMPTY_PAGINATED_RESPONSE,
+        '/api/environments/:team_id/quick_filters/': EMPTY_PAGINATED_RESPONSE,
         'api/environments/:team_id/error_tracking/assignment_rules': EMPTY_PAGINATED_RESPONSE,
         'api/environments/:team_id/error_tracking/grouping_rules': EMPTY_PAGINATED_RESPONSE,
         'api/environments/:team_id/error_tracking/suppression_rules': EMPTY_PAGINATED_RESPONSE,


### PR DESCRIPTION
## Problem

The Error Tracking storybook scene currently shows two error toasts on load:

- *Load quick filters failed: URL not found* — the `quickFiltersLogic.loadQuickFilters` loader hits `api/environments/:team_id/quick_filters/`, which has no MSW default.
- *Load organization integrations failed: URL not found* — `organizationIntegrationsLogic.loadOrganizationIntegrations` hits `api/organizations/:organization_id/integrations/`, also unmocked.

These toasts pollute the rendered story (and any visual snapshot) and obscure real issues.

## Changes

Adds two empty paginated defaults to `defaultMocks` in `frontend/src/mocks/handlers.ts`:

```ts
'/api/organizations/:organization_id/integrations/': EMPTY_PAGINATED_RESPONSE,
'/api/environments/:team_id/quick_filters/': EMPTY_PAGINATED_RESPONSE,
```

These match the pattern already used for the project-scoped `integrations` endpoint right next to them.

## How did you test this code?

I'm an agent — I checked the loader and api wiring to confirm the failing URLs (`frontend/src/lib/components/QuickFilters/quickFiltersLogic.ts:44` → `api.quickFilters.list()` → `api/environments/:team_id/quick_filters/`, and `frontend/src/scenes/settings/organization/organizationIntegrationsLogic.ts:25` → `api.organizationIntegrations.list()` → `api/organizations/:organization_id/integrations/`). Have not run storybook with this change.

Manual verification:
- Open `Scenes-App/ErrorTracking` story — the two "URL not found" toasts should no longer appear.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) — Paul spotted the toast in Storybook and asked for a separate PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*