### PR TITLE
feat(funnels): use lighter shade for compare-to-previous line on funnel trends

### DIFF
--- a/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
+++ b/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
@@ -324,6 +324,8 @@ export const funnelResultTrends = {
 // 1. Add step "Pageview"
 // 2. Select graph type "Trends"
 // 3. Toggle "Compare to previous"
+// Note: the runner tags rows with `compare_label` but does not set `compare: true` —
+// indexedSteps normalizes that so LineGraph dims the previous-period series.
 export const funnelResultTrendsCompare = {
     result: [
         {
@@ -331,7 +333,6 @@ export const funnelResultTrendsCompare = {
             data: [74.12, 68.67, 71.05, 72.06, 69.33, 70.83, 72.37],
             days: ['2023-02-01', '2023-02-02', '2023-02-03', '2023-02-04', '2023-02-05', '2023-02-06', '2023-02-07'],
             labels: ['1-Feb-2023', '2-Feb-2023', '3-Feb-2023', '4-Feb-2023', '5-Feb-2023', '6-Feb-2023', '7-Feb-2023'],
-            compare: true,
             compare_label: 'current',
         },
         {
@@ -347,7 +348,6 @@ export const funnelResultTrendsCompare = {
                 '30-Jan-2023',
                 '31-Jan-2023',
             ],
-            compare: true,
             compare_label: 'previous',
         },
     ],
@@ -360,6 +360,8 @@ export const funnelResultTrendsCompare = {
 // 2. Select graph type "Trends"
 // 3. Break down by country
 // 4. Toggle "Compare to previous"
+// Note: the runner tags rows with `compare_label` but does not set `compare: true` —
+// indexedSteps normalizes that so LineGraph dims the previous-period series.
 export const funnelResultTrendsCompareWithBreakdown = {
     result: [
         {
@@ -368,7 +370,6 @@ export const funnelResultTrendsCompareWithBreakdown = {
             days: ['2023-02-01', '2023-02-02', '2023-02-03', '2023-02-04', '2023-02-05', '2023-02-06', '2023-02-07'],
             labels: ['1-Feb-2023', '2-Feb-2023', '3-Feb-2023', '4-Feb-2023', '5-Feb-2023', '6-Feb-2023', '7-Feb-2023'],
             breakdown_value: 'us',
-            compare: true,
             compare_label: 'current',
         },
         {
@@ -377,7 +378,6 @@ export const funnelResultTrendsCompareWithBreakdown = {
             days: ['2023-02-01', '2023-02-02', '2023-02-03', '2023-02-04', '2023-02-05', '2023-02-06', '2023-02-07'],
             labels: ['1-Feb-2023', '2-Feb-2023', '3-Feb-2023', '4-Feb-2023', '5-Feb-2023', '6-Feb-2023', '7-Feb-2023'],
             breakdown_value: 'uk',
-            compare: true,
             compare_label: 'current',
         },
         {
@@ -394,7 +394,6 @@ export const funnelResultTrendsCompareWithBreakdown = {
                 '31-Jan-2023',
             ],
             breakdown_value: 'us',
-            compare: true,
             compare_label: 'previous',
         },
         {
@@ -411,7 +410,6 @@ export const funnelResultTrendsCompareWithBreakdown = {
                 '31-Jan-2023',
             ],
             breakdown_value: 'uk',
-            compare: true,
             compare_label: 'previous',
         },
     ],

--- a/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
+++ b/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
@@ -322,6 +322,105 @@ export const funnelResultTrends = {
 }
 
 // 1. Add step "Pageview"
+// 2. Select graph type "Trends"
+// 3. Toggle "Compare to previous"
+export const funnelResultTrendsCompare = {
+    result: [
+        {
+            count: 31,
+            data: [74.12, 68.67, 71.05, 72.06, 69.33, 70.83, 72.37],
+            days: ['2023-02-01', '2023-02-02', '2023-02-03', '2023-02-04', '2023-02-05', '2023-02-06', '2023-02-07'],
+            labels: ['1-Feb-2023', '2-Feb-2023', '3-Feb-2023', '4-Feb-2023', '5-Feb-2023', '6-Feb-2023', '7-Feb-2023'],
+            compare: true,
+            compare_label: 'current',
+        },
+        {
+            count: 18,
+            data: [55.2, 60.1, 58.9, 61.0, 56.4, 59.8, 57.3],
+            days: ['2023-01-25', '2023-01-26', '2023-01-27', '2023-01-28', '2023-01-29', '2023-01-30', '2023-01-31'],
+            labels: [
+                '25-Jan-2023',
+                '26-Jan-2023',
+                '27-Jan-2023',
+                '28-Jan-2023',
+                '29-Jan-2023',
+                '30-Jan-2023',
+                '31-Jan-2023',
+            ],
+            compare: true,
+            compare_label: 'previous',
+        },
+    ],
+    timezone: 'UTC',
+    last_refresh: '2023-03-03T18:55:57.840129Z',
+    is_cached: false,
+}
+
+// 1. Add step "Pageview"
+// 2. Select graph type "Trends"
+// 3. Break down by country
+// 4. Toggle "Compare to previous"
+export const funnelResultTrendsCompareWithBreakdown = {
+    result: [
+        {
+            count: 31,
+            data: [74.12, 68.67, 71.05, 72.06, 69.33, 70.83, 72.37],
+            days: ['2023-02-01', '2023-02-02', '2023-02-03', '2023-02-04', '2023-02-05', '2023-02-06', '2023-02-07'],
+            labels: ['1-Feb-2023', '2-Feb-2023', '3-Feb-2023', '4-Feb-2023', '5-Feb-2023', '6-Feb-2023', '7-Feb-2023'],
+            breakdown_value: 'us',
+            compare: true,
+            compare_label: 'current',
+        },
+        {
+            count: 24,
+            data: [62.5, 64.1, 60.0, 65.2, 63.4, 61.9, 66.1],
+            days: ['2023-02-01', '2023-02-02', '2023-02-03', '2023-02-04', '2023-02-05', '2023-02-06', '2023-02-07'],
+            labels: ['1-Feb-2023', '2-Feb-2023', '3-Feb-2023', '4-Feb-2023', '5-Feb-2023', '6-Feb-2023', '7-Feb-2023'],
+            breakdown_value: 'uk',
+            compare: true,
+            compare_label: 'current',
+        },
+        {
+            count: 18,
+            data: [55.2, 60.1, 58.9, 61.0, 56.4, 59.8, 57.3],
+            days: ['2023-01-25', '2023-01-26', '2023-01-27', '2023-01-28', '2023-01-29', '2023-01-30', '2023-01-31'],
+            labels: [
+                '25-Jan-2023',
+                '26-Jan-2023',
+                '27-Jan-2023',
+                '28-Jan-2023',
+                '29-Jan-2023',
+                '30-Jan-2023',
+                '31-Jan-2023',
+            ],
+            breakdown_value: 'us',
+            compare: true,
+            compare_label: 'previous',
+        },
+        {
+            count: 15,
+            data: [48.0, 51.3, 50.2, 52.7, 49.8, 53.1, 50.6],
+            days: ['2023-01-25', '2023-01-26', '2023-01-27', '2023-01-28', '2023-01-29', '2023-01-30', '2023-01-31'],
+            labels: [
+                '25-Jan-2023',
+                '26-Jan-2023',
+                '27-Jan-2023',
+                '28-Jan-2023',
+                '29-Jan-2023',
+                '30-Jan-2023',
+                '31-Jan-2023',
+            ],
+            breakdown_value: 'uk',
+            compare: true,
+            compare_label: 'previous',
+        },
+    ],
+    timezone: 'UTC',
+    last_refresh: '2023-03-03T18:55:57.840129Z',
+    is_cached: false,
+}
+
+// 1. Add step "Pageview"
 // 2. Add "Pageview" as exclusion step
 export const funnelInvalidExclusionError = {
     type: 'validation_error',

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -1352,6 +1352,10 @@ describe('funnelDataLogic', () => {
             expect(steps[1].seriesIndex).toBe(1)
             expect(steps[0].compare_label).toBe('current')
             expect(steps[1].compare_label).toBe('previous')
+            // The runner only sets `compare_label`; `indexedSteps` normalizes `compare: true`
+            // so LineGraph.processDataset dims the previous-period series.
+            expect(steps[0].compare).toBe(true)
+            expect(steps[1].compare).toBe(true)
         })
 
         it('pairs current and previous per breakdown value', async () => {

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -14,6 +14,8 @@ import {
     funnelResultTimeToConvert,
     funnelResultTimeToConvertWithoutConversions,
     funnelResultTrends,
+    funnelResultTrendsCompare,
+    funnelResultTrendsCompareWithBreakdown,
     funnelResultWithBreakdown,
     funnelResultWithMultiBreakdown,
 } from './__mocks__/funnelDataLogicMocks'
@@ -1309,6 +1311,69 @@ describe('funnelDataLogic', () => {
             }).toMatchValues({
                 incompletenessOffsetFromEnd: -3,
             })
+        })
+    })
+
+    describe('indexedSteps colorIndex pairing', () => {
+        const trendsQuery: FunnelsQuery = {
+            kind: NodeKind.FunnelsQuery,
+            series: [],
+            funnelsFilter: {
+                funnelVizType: FunnelVizType.Trends,
+            },
+        }
+
+        async function loadResult(result: unknown): Promise<void> {
+            const insight: Partial<InsightModel> = {
+                filters: { insight: InsightType.FUNNELS },
+                result: result as InsightModel['result'],
+            }
+            await expectLogic(logic, () => {
+                builtDataNodeLogic.actions.loadDataSuccess(insight)
+                logic.actions.updateQuerySource(trendsQuery)
+            }).toFinishAllListeners()
+        }
+
+        it('assigns colorIndex 0 to a single-period trends result', async () => {
+            await loadResult(funnelResultTrends.result)
+            const steps = logic.values.indexedSteps as Array<Record<string, unknown>>
+            expect(steps).toHaveLength(1)
+            expect(steps[0].colorIndex).toBe(0)
+            expect(steps[0].seriesIndex).toBe(0)
+        })
+
+        it('pairs current and previous on the same colorIndex without a breakdown', async () => {
+            await loadResult(funnelResultTrendsCompare.result)
+            const steps = logic.values.indexedSteps as Array<Record<string, unknown>>
+            expect(steps).toHaveLength(2)
+            expect(steps[0].colorIndex).toBe(0)
+            expect(steps[1].colorIndex).toBe(0)
+            expect(steps[0].seriesIndex).toBe(0)
+            expect(steps[1].seriesIndex).toBe(1)
+            expect(steps[0].compare_label).toBe('current')
+            expect(steps[1].compare_label).toBe('previous')
+        })
+
+        it('pairs current and previous per breakdown value', async () => {
+            await loadResult(funnelResultTrendsCompareWithBreakdown.result)
+            const steps = logic.values.indexedSteps as Array<Record<string, unknown>>
+            expect(steps).toHaveLength(4)
+
+            const byKey = (label: string, breakdownValue: string): Record<string, unknown> => {
+                const found = steps.find((s) => s.compare_label === label && s.breakdown_value === breakdownValue)
+                if (!found) {
+                    throw new Error(`missing row ${label}/${breakdownValue}`)
+                }
+                return found
+            }
+            const currentUs = byKey('current', 'us')
+            const previousUs = byKey('previous', 'us')
+            const currentUk = byKey('current', 'uk')
+            const previousUk = byKey('previous', 'uk')
+
+            expect(currentUs.colorIndex).toBe(previousUs.colorIndex)
+            expect(currentUk.colorIndex).toBe(previousUk.colorIndex)
+            expect(currentUs.colorIndex).not.toBe(currentUk.colorIndex)
         })
     })
 })

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -651,12 +651,22 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                         colorIndexMap.set(key, colorIndexMap.size)
                     }
                 }
-                return steps.map((step, index) => ({
-                    ...step,
-                    seriesIndex: index,
-                    colorIndex: colorIndexMap.get(getFunnelDatasetKey(step)) ?? 0,
-                    id: index,
-                }))
+                return steps.map((step, index) => {
+                    // The funnels runner tags compare rows with `compare_label` but doesn't set
+                    // `compare: true`. `LineGraph.processDataset` requires both to dim the previous
+                    // line — normalize here so the previous-period series renders at 50% alpha.
+                    const stepWithCompare = step as typeof step & {
+                        compare_label?: 'current' | 'previous'
+                        compare?: boolean
+                    }
+                    return {
+                        ...step,
+                        seriesIndex: index,
+                        colorIndex: colorIndexMap.get(getFunnelDatasetKey(step)) ?? 0,
+                        id: index,
+                        compare: stepWithCompare.compare_label != null ? true : stepWithCompare.compare,
+                    }
+                })
             },
         ],
         getFunnelsColorToken: [

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -636,8 +636,28 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         ],
         indexedSteps: [
             (s) => [s.steps],
-            (steps) =>
-                Array.isArray(steps) ? steps.map((step, index) => ({ ...step, seriesIndex: index, id: index })) : [],
+            (steps) => {
+                if (!Array.isArray(steps)) {
+                    return []
+                }
+                // Pair rows on `breakdown_value` (no `compare_label`) so current/previous of the
+                // same series share the same base color. The downstream color resolver prefers
+                // `colorIndex` over `seriesIndex` (see `getTrendResultCustomizationColorToken`),
+                // and `LineGraph.processDataset` then dims the previous-period series to 50% alpha.
+                const colorIndexMap = new Map<string, number>()
+                for (const step of steps) {
+                    const key = getFunnelDatasetKey(step)
+                    if (!colorIndexMap.has(key)) {
+                        colorIndexMap.set(key, colorIndexMap.size)
+                    }
+                }
+                return steps.map((step, index) => ({
+                    ...step,
+                    seriesIndex: index,
+                    colorIndex: colorIndexMap.get(getFunnelDatasetKey(step)) ?? 0,
+                    id: index,
+                }))
+            },
         ],
         getFunnelsColorToken: [
             (s) => [s.resultCustomizations, s.getTheme, s.breakdownFilter, s.querySource],

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -548,7 +548,7 @@ export function insightUrlForEvent(event: Pick<EventType, 'event' | 'properties'
     return query ? urls.insightNew({ query }) : undefined
 }
 
-export function getFunnelDatasetKey(dataset: FlattenedFunnelStepByBreakdown | FunnelStepWithConversionMetrics): string {
+export function getFunnelDatasetKey(dataset: { breakdown_value?: BreakdownKeyType }): string {
     const breakdown_value =
         Array.isArray(dataset.breakdown_value) && dataset.breakdown_value.length == 1
             ? dataset.breakdown_value[0]


### PR DESCRIPTION
## Problem

PR #59536 lays the backend foundation for "compare to previous" on funnel trends (line) viz, but the frontend rendering work is explicitly deferred to follow-ups. On that branch tip, enabling the toggle already produces two lines on the chart — but they pick **different palette colors** (current row → slot 0, previous row → slot 1) instead of the trends behavior, where both lines share the same base color and the previous-period line is a lighter (50%-alpha) version of it.

This PR closes that gap: the previous-period line on funnel trends now renders as a lighter shade of the current-period line, matching trends insights.

Stacked on #59536.

## Changes

Two issues had to be addressed:

**1. Pair `colorIndex` so current and previous share a base color.** Trends already does this in `trendsDataLogic.indexedResults`, and the color resolver (`getTrendResultCustomizationColorToken`) prefers `colorIndex` over `seriesIndex`. The fix:

- **`getFunnelDatasetKey`** (`frontend/src/scenes/insights/utils.tsx`): type-only signature widening to accept any `{ breakdown_value }`-shaped dataset. The body only ever reads `breakdown_value`, and all existing callers continue to type-check. This lets us reuse the helper from the funnel-trends data path.
- **`funnelDataLogic.indexedSteps`** (`frontend/src/scenes/funnels/funnelDataLogic.ts`): builds a `colorIndexMap` keyed by `getFunnelDatasetKey(step)` (i.e., `breakdown_value` only, no `compare_label`). Current and previous rows of the same breakdown (or both `undefined` in the no-breakdown case) share a key → same `colorIndex` → same base color.

**2. Normalize `compare: true` so LineGraph actually dims the previous line.** `LineGraph.processDataset` (`frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx:443`) requires `dataset.compare && dataset.compare_label === 'previous'` to apply `${themeColor}80` (50% alpha). The funnels-compare runner in #59536 only sets `compare_label`, not `compare`, so the dimming branch never fired. Normalizing this in `indexedSteps` (rather than the backend) keeps the fix scoped to this PR. The compare fixtures were also updated to drop `compare: true` so they mirror what the runner actually produces — without this, the unit tests would have green-lit the bug.

Both pieces together produce the intended visual: same base hue, previous at 50% alpha.

Sets up the follow-up for configurable colors on funnel-trends cleanly: `getFunnelDatasetKey` is the same helper `getFunnelResultCustomization` already uses for regular funnels, so a single keying scheme covers both surfaces.

## How did you test this code?

I'm an agent; I have not done manual UI testing. The automated checks I ran:

- **Unit tests:** `funnelDataLogic.test.ts` adds a new `indexedSteps colorIndex pairing` describe block with three cases:
  - single-period trends result → `colorIndex === 0`
  - no-breakdown compare → both rows `colorIndex === 0`, `seriesIndex` differs, `compare_label` preserved, **`compare` normalized to `true`**
  - breakdown compare → current+previous of `'us'` share a `colorIndex`; current+previous of `'uk'` share a different `colorIndex`; the two breakdowns get distinct slots

  Full suite: **59/59 passing** (`pnpm exec jest --testPathPattern="src/scenes/funnels/funnelDataLogic.test.ts"`).
- **Type check:** `pnpm --filter=@posthog/frontend typescript:check` — no new errors introduced by this change (baseline error count is identical with and without my diff; all errors are pre-existing in unrelated files like `products/workflows/*` and elsewhere in `funnelDataLogic.ts`).
- **Format:** `pnpm --filter=@posthog/frontend format` (oxlint + oxfmt) — clean.

**Visual review:** the `FunnelHistoricalTrendsCompare` storybook snapshot (added in #59536) will visually change — the previous-period line should be a lighter shade of the current-period line. The visual review CI run will regenerate the baseline.

**Not tested manually:** I did not run the app in a browser or interact with the live chart. A human reviewer should confirm the visual result matches the design intent before merging.

## Publish to changelog?

no

## Docs update

No docs change in this PR.

## 🤖 Agent context

Authored by PostHog Code (Claude Code).

The plan was iterated with the human author before implementation. Three key course-corrections:

1. I initially claimed funnel-trends rows had no `breakdown_value` field — the user pushed back, and inspection of `posthog/hogql_queries/insights/funnels/funnel_trends.py:373-392, 409` confirmed funnel-trends rows do set `breakdown_value` per row when a breakdown is configured. The pairing key was changed to be `breakdown_value`-based, which also gracefully handles breakdown + compare (each breakdown's current+previous pair share a `colorIndex`).
2. I initially planned to inline the pairing logic in `funnelDataLogic.indexedSteps`. The user pointed out that `getFunnelDatasetKey` already produces exactly the `{ breakdown_value }` key we need. I widened its signature (type-only) and reused it directly. This also sets up the configurable-colors follow-up: a future PR can plug into the same key scheme without adding a third keying convention.
3. After the first commit, the user reported that the lines were still the same color (no dimming). Tracing through `LineGraph.processDataset` revealed it requires `dataset.compare && dataset.compare_label === 'previous'`, while the runner in #59536 only sets `compare_label`. The fix added the `compare` normalization in `indexedSteps`. My new fixtures had `compare: true` coincidentally set, which masked the issue in the unit tests — the fixtures were updated to mirror live data so the regression is locked down.

Considered (and rejected):

- **Reusing `getTrendDatasetKey`** as-is: includes `compare_label` in the key, which would defeat the pairing (current vs previous would resolve to different slots).
- **Extracting a new `assignColorIndex` helper** and refactoring `trendsDataLogic.indexedResults` to share it: tempting, but the trends pairing uses an inline string key (`${label}_${action.order}_${breakdown_value}`) and pre-sorting on `action.order`, which doesn't map cleanly onto funnel-trends rows that lack `action.order`. A unified helper would either pollute trends with funnel-specific concerns or stay funnel-only. Left for a separate refactor if/when configurable colors land.
- **Setting `seriesIndex = 0` for all funnel-trends rows** to coerce the existing `getTrendDatasetPosition` fallback into pairing them: would break legend ordering and other consumers that rely on per-row `seriesIndex`. Setting an explicit `colorIndex` is cleaner.
- **Fixing the missing `compare: true` in the backend runner** (PR #59536): trends sets both `compare` and `compare_label` on each row, and consistency with trends would argue for the backend fix. Left in the frontend here to keep the PR scoped — the underlying inconsistency in `funnels_query_runner.py:208-214` is worth normalizing in a separate follow-up.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*