### PR TITLE
chore(ci): improve ClickHouse migration comment cleanup logic

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1098,12 +1098,14 @@ jobs:
               # GITHUB_TOKEN is read-only for fork PRs, so only comment on same-repo PRs.
               if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  HAS_CHANGES: ${{ steps.render_ch_sql.outputs.has_changes }}
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
                       const fs = require('fs');
                       const marker = '<!-- ch-migration-sql -->';
-                      const hasChanges = '${{ steps.render_ch_sql.outputs.has_changes }}' === 'true';
+                      const hasChanges = process.env.HAS_CHANGES === 'true';
                       const { data: comments } = await github.rest.issues.listComments({
                           owner: context.repo.owner,
                           repo: context.repo.repo,

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1034,19 +1034,21 @@ jobs:
               # environment and reuse the output both for the Actions log groups and the PR comment
               # (environment -> node type(s) -> SQL). Environments that render identically are
               # grouped together; if all environments match, the environment level is collapsed.
+              id: render_ch_sql
               if: github.event_name == 'pull_request'
               run: |
                   CHANGED=$(git diff --name-only --diff-filter=AM origin/master..HEAD | grep '^posthog/clickhouse/migrations/[0-9]' | grep -v __pycache__ || true)
+                  if [ -z "$CHANGED" ]; then
+                      echo "No ClickHouse migrations changed."
+                      echo "has_changes=false" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+                  echo "has_changes=true" >> "$GITHUB_OUTPUT"
                   {
                       echo '<!-- ch-migration-sql -->'
                       echo '## ClickHouse migration SQL per cloud environment'
                       echo ''
                   } > ch_migration_sql_comment.md
-                  if [ -z "$CHANGED" ]; then
-                      echo "No ClickHouse migrations changed."
-                      echo '_No ClickHouse migrations changed in this PR._' >> ch_migration_sql_comment.md
-                      exit 0
-                  fi
                   mkdir -p ch_sql_env
                   DEPLOYMENTS=('' US EU DEV)
                   LABELS=(unset US EU DEV)
@@ -1101,18 +1103,31 @@ jobs:
                   script: |
                       const fs = require('fs');
                       const marker = '<!-- ch-migration-sql -->';
-                      let body = fs.readFileSync('ch_migration_sql_comment.md', 'utf8');
-                      const LIMIT = 65000; // GitHub caps comment bodies at 65536 chars
-                      if (body.length > LIMIT) {
-                          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-                          body = body.slice(0, LIMIT - 400) + `\n\n_…truncated. See the full SQL in the [workflow logs](${runUrl})._`;
-                      }
+                      const hasChanges = '${{ steps.render_ch_sql.outputs.has_changes }}' === 'true';
                       const { data: comments } = await github.rest.issues.listComments({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           issue_number: context.issue.number,
                       });
                       const existing = comments.find((c) => c.body.includes(marker));
+                      if (!hasChanges) {
+                          // No migrations changed — clean up a stale sticky comment if one exists
+                          // (e.g. migrations were added then removed in a later push), otherwise no-op.
+                          if (existing) {
+                              await github.rest.issues.deleteComment({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  comment_id: existing.id,
+                              });
+                          }
+                          return;
+                      }
+                      let body = fs.readFileSync('ch_migration_sql_comment.md', 'utf8');
+                      const LIMIT = 65000; // GitHub caps comment bodies at 65536 chars
+                      if (body.length > LIMIT) {
+                          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                          body = body.slice(0, LIMIT - 400) + `\n\n_…truncated. See the full SQL in the [workflow logs](${runUrl})._`;
+                      }
                       if (existing) {
                           await github.rest.issues.updateComment({
                               owner: context.repo.owner,


### PR DESCRIPTION
## Problem

The ClickHouse migration SQL comment rendering workflow has two issues:

1. When no migrations are changed, the comment file is created with a header but the "no changes" message is added after the early exit, making the logic harder to follow
2. When migrations are removed in a later push (leaving no migrations), the stale comment from a previous push remains on the PR instead of being cleaned up

## Changes

- Added an `id: render_ch_sql` output to the migration detection step to expose whether changes were found
- Moved the "no changes" check earlier in the script, before creating the comment file
- Updated the comment posting logic to:
  - Check the `has_changes` output from the render step
  - Delete any existing stale comment if no migrations are present
  - Only read and post the comment file if migrations were actually changed
- This ensures the PR comment is kept in sync with the current state of migrations

## How did you test this code?

The changes are to CI workflow logic. Verification would require:
- Pushing a branch with ClickHouse migrations to confirm the comment is created
- Pushing a follow-up commit that removes those migrations to confirm the comment is deleted
- Existing CI tests will validate the workflow syntax

## Publish to changelog?

no

https://claude.ai/code/session_01YEQJrXqTM8oX9A4ss5hYdM