### PR TITLE
fix(mcp): cache initialize params

### DIFF
--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -66,8 +66,13 @@ export class RequestStateResolver {
 
         const { features, tools, version: clientVersion, organizationId, projectId, readOnly, mode } = props
 
-        if (organizationId) {await reqCtx.cache.set('orgId', organizationId)}
-        if (projectId) {await reqCtx.cache.set('projectId', projectId)}
+        await reqCtx.cache.setMany({
+            ...(organizationId ? { orgId: organizationId } : {}),
+            ...(projectId ? { projectId } : {}),
+            ...(props.mcpClientName ? { mcpClientName: props.mcpClientName } : {}),
+            ...(props.mcpClientVersion ? { mcpClientVersion: props.mcpClientVersion } : {}),
+            ...(props.mcpProtocolVersion ? { mcpProtocolVersion: props.mcpProtocolVersion } : {}),
+        })
 
         let cachedProjectId = projectId || (await reqCtx.cache.get('projectId'))
         if (!cachedProjectId) {
@@ -94,9 +99,11 @@ export class RequestStateResolver {
             : undefined
 
         const oauthClientName = (await reqCtx.cache.get('clientName')) || undefined
+        const mcpClientName = props.mcpClientName || (await reqCtx.cache.get('mcpClientName')) || undefined
+        const mcpClientVersion = props.mcpClientVersion || (await reqCtx.cache.get('mcpClientVersion')) || undefined
         const clientProfile = new MCPClientProfile({
-            clientName: props.mcpClientName,
-            clientVersion: props.mcpClientVersion,
+            clientName: mcpClientName,
+            clientVersion: mcpClientVersion,
             consumer: props.mcpConsumer,
             oauthClientName,
         })

--- a/services/mcp/src/lib/cache/ScopedCache.ts
+++ b/services/mcp/src/lib/cache/ScopedCache.ts
@@ -5,4 +5,15 @@ export abstract class ScopedCache<T extends Record<string, any>> {
     abstract set<K extends keyof T>(key: K, value: T[K]): Promise<void>
     abstract delete<K extends keyof T>(key: K): Promise<void>
     abstract clear(): Promise<void>
+
+    async setMany(entries: Partial<{ [K in keyof T]: T[K] }>): Promise<void> {
+        const promises: Promise<void>[] = []
+        for (const key of Object.keys(entries) as (keyof T)[]) {
+            const value = entries[key]
+            if (value !== undefined) {
+                promises.push(this.set(key, value as T[typeof key]))
+            }
+        }
+        await Promise.all(promises)
+    }
 }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -97,6 +97,9 @@ export class MCP extends McpAgent<Env> {
         region: undefined,
         apiKey: undefined,
         clientName: undefined,
+        mcpClientName: undefined,
+        mcpClientVersion: undefined,
+        mcpProtocolVersion: undefined,
     }
 
     _cache: DurableObjectCache<State> | undefined

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -26,6 +26,9 @@ export type State = {
     region: CloudRegion | undefined
     apiKey: ApiRedactedPersonalApiKey | undefined
     clientName: string | undefined
+    mcpClientName: string | undefined
+    mcpClientVersion: string | undefined
+    mcpProtocolVersion: string | undefined
 } & Record<PrefixedString<'session'>, SessionState> &
     Record<PrefixedString<'groupTypes'>, GroupType[] | undefined> &
     Record<PrefixedString<'groupTypesFetchedAt'>, number | undefined> &

--- a/services/mcp/tests/hono/redis-cache.test.ts
+++ b/services/mcp/tests/hono/redis-cache.test.ts
@@ -99,6 +99,29 @@ describe('RedisCache', () => {
         })
     })
 
+    describe('setMany', () => {
+        it('should set multiple keys in parallel', async () => {
+            await cache.setMany({ region: 'us', projectId: '123' })
+
+            expect(await cache.get('region')).toBe('us')
+            expect(await cache.get('projectId')).toBe('123')
+            expect(mockRedis.set).toHaveBeenCalledTimes(2)
+        })
+
+        it('should skip undefined values', async () => {
+            await cache.setMany({ region: 'eu', projectId: undefined })
+
+            expect(await cache.get('region')).toBe('eu')
+            expect(await cache.get('projectId')).toBeUndefined()
+            expect(mockRedis.set).toHaveBeenCalledTimes(1)
+        })
+
+        it('should handle empty entries', async () => {
+            await cache.setMany({})
+            expect(mockRedis.set).not.toHaveBeenCalled()
+        })
+    })
+
     describe('clear', () => {
         it('should only clear keys for the scoped user', async () => {
             mockRedis._store.set('mcp:user:test-user-hash:region', '"us"')

--- a/services/mcp/tests/hono/redis-cache.test.ts
+++ b/services/mcp/tests/hono/redis-cache.test.ts
@@ -7,6 +7,9 @@ type TestState = {
     projectId: string | undefined
     distinctId: string | undefined
     orgId: string | undefined
+    mcpClientName: string | undefined
+    mcpClientVersion: string | undefined
+    mcpProtocolVersion: string | undefined
 }
 
 interface MockRedis extends RedisLike {
@@ -100,7 +103,7 @@ describe('RedisCache', () => {
     })
 
     describe('setMany', () => {
-        it('should set multiple keys in parallel', async () => {
+        it('should set multiple keys in a single call', async () => {
             await cache.setMany({ region: 'us', projectId: '123' })
 
             expect(await cache.get('region')).toBe('us')
@@ -119,6 +122,27 @@ describe('RedisCache', () => {
         it('should handle empty entries', async () => {
             await cache.setMany({})
             expect(mockRedis.set).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('client info caching across requests', () => {
+        it('seeds client info on initialize and reads it back on subsequent requests', async () => {
+            await cache.setMany({
+                mcpClientName: 'claude-code',
+                mcpClientVersion: '1.2.3',
+                mcpProtocolVersion: '2025-03-26',
+            })
+
+            expect(await cache.get('mcpClientName')).toBe('claude-code')
+            expect(await cache.get('mcpClientVersion')).toBe('1.2.3')
+            expect(await cache.get('mcpProtocolVersion')).toBe('2025-03-26')
+        })
+
+        it('does not overwrite cached client info when subsequent request has no client info', async () => {
+            await cache.setMany({ mcpClientName: 'claude-code' })
+            await cache.setMany({})
+
+            expect(await cache.get('mcpClientName')).toBe('claude-code')
         })
     })
 


### PR DESCRIPTION
these are passed in the initialize call, lets cache them correctly so flags evaluate properly