### PR TITLE
fix(cdp): re-assert hog_invocation_results data table in migration 0258

### DIFF
--- a/posthog/clickhouse/migrations/0258_hog_invocation_results_warpstream_cyclotron.py
+++ b/posthog/clickhouse/migrations/0258_hog_invocation_results_warpstream_cyclotron.py
@@ -1,18 +1,32 @@
 from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.hog_invocation_results.sql import (
+    DISTRIBUTED_HOG_INVOCATION_RESULTS_TABLE_SQL,
     DROP_HOG_INVOCATION_RESULTS_MV_SQL,
     DROP_KAFKA_HOG_INVOCATION_RESULTS_TABLE_SQL,
+    HOG_INVOCATION_RESULTS_DATA_TABLE_SQL,
     HOG_INVOCATION_RESULTS_MV_SQL,
     KAFKA_HOG_INVOCATION_RESULTS_TABLE_SQL,
 )
 
 # Repoint the hog_invocation_results Kafka engine table from the warpstream-shared
-# named collection to warpstream-cyclotron. The CDP producer writes lifecycle
+# named collection to warpstream-cyclotron — the CDP producer writes lifecycle
 # rows to the cyclotron Warpstream cluster, so ClickHouse must consume from the
-# same cluster. The Kafka engine table and MV are non-replicated, so a plain
-# drop + recreate is safe (no SYNC needed); the data table is untouched.
+# same cluster.
+#
+# The Kafka engine table + MV are non-replicated, so they're dropped and
+# recreated outright (no SYNC needed). The data table and distributed read
+# alias are re-asserted with CREATE ... IF NOT EXISTS first: 0254 creates them,
+# but a cluster that lost its AUX local tables (e.g. a rebuilt dev AUX cluster)
+# still has 0254 recorded as applied — leaving the MV recreate below to fail
+# with "table does not exist". IF NOT EXISTS makes the re-assert a no-op
+# wherever the tables are already present.
 operations = [
+    # Ensure the local data table the MV targets exists.
+    run_sql_with_exceptions(
+        HOG_INVOCATION_RESULTS_DATA_TABLE_SQL(),
+        node_roles=[NodeRole.AUX],
+    ),
     # Drop the MV first — it reads from the Kafka engine table.
     run_sql_with_exceptions(
         DROP_HOG_INVOCATION_RESULTS_MV_SQL(),
@@ -31,5 +45,10 @@ operations = [
     run_sql_with_exceptions(
         HOG_INVOCATION_RESULTS_MV_SQL(),
         node_roles=[NodeRole.AUX],
+    ),
+    # Ensure the distributed read alias exists (HogQL queries resolve through it).
+    run_sql_with_exceptions(
+        DISTRIBUTED_HOG_INVOCATION_RESULTS_TABLE_SQL(),
+        node_roles=[NodeRole.AUX, NodeRole.DATA],
     ),
 ]


### PR DESCRIPTION
## Problem

Migration `0258_hog_invocation_results_warpstream_cyclotron` (merged in #59360) repoints the `hog_invocation_results` Kafka engine table to the warpstream-cyclotron named collection by dropping + recreating the Kafka table and its materialized view.

The MV recreate targets the local data table `hog_invocation_results_data`, created by `0254`. On a cluster that lost its AUX local tables — e.g. a rebuilt dev AUX cluster — `0254` is still recorded as applied, but the table is gone, so `0258` fails:

```
DB::Exception: Table posthog.hog_invocation_results_data does not exist
```

`0258` never records as applied there, so it can't self-heal and blocks every later migration. A new migration can't fix this — it would never run, because `0258` fails first.

## Changes

`0258` now re-asserts the data table and the distributed read alias with `CREATE ... IF NOT EXISTS` before recreating the MV:

- A no-op wherever the tables already exist (prod, healthy clusters) — `IF NOT EXISTS`.
- On a cluster missing the AUX family, it rebuilds the data table + distributed alias so the MV recreate succeeds and `0258` completes.

`0258` is safe to edit: it has not successfully applied anywhere it's failing, and the additions are purely idempotent. Where `0258` already applied cleanly, it won't re-run and the edit is moot.

## How did you test this code?

Agent-authored (Claude Code). Automated only: `ruff` + `ty check` pass (pre-commit). The data table / distributed SQL are unchanged (same `*_SQL` builders as `0254`), so `test_schema` snapshots are unaffected. I did not run the migration against a live cluster.

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Diagnosed from a dev `migrate_clickhouse` failure: `0258`'s `CREATE MATERIALIZED VIEW ... TO hog_invocation_results_data` raised "table does not exist" on the AUX hosts. Editing `0258` (rather than adding `0259`) is required because a failing `0258` blocks all later migrations from running.