### PR TITLE
chore(ws): add date partition to S3 batch folder in pipelinesV3

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/__init__.py
@@ -4,6 +4,7 @@ from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.common import (
     ensure_bucket,
     get_base_folder,
     get_data_folder,
+    get_date_partition,
     strip_s3_protocol,
 )
 from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.reader import list_parquet_files, read_parquet
@@ -16,6 +17,7 @@ __all__ = [
     "ensure_bucket",
     "get_base_folder",
     "get_data_folder",
+    "get_date_partition",
     "list_parquet_files",
     "read_parquet",
     "strip_s3_protocol",

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/common.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/common.py
@@ -27,15 +27,16 @@ def strip_s3_protocol(s3_path: str) -> str:
     return s3_path.replace("s3://", "")
 
 
-def get_date_partition() -> str:
-    """Return today's UTC date as a Hive-style partition segment (dt=YYYY-MM-DD)."""
-    return f"dt={datetime.now(UTC).strftime('%Y-%m-%d')}"
+def get_date_partition(dt: datetime) -> str:
+    """Return the given datetime's UTC date as a Hive-style partition segment (dt=YYYY-MM-DD)."""
+    return f"dt={dt.astimezone(UTC).strftime('%Y-%m-%d')}"
 
 
-def get_base_folder(team_id: int, schema_id: str, run_uuid: str, date_partition: str | None = None) -> str:
+def get_base_folder(team_id: int, schema_id: str, run_uuid: str, date_partition: str) -> str:
     """Get the base S3 folder path for a pipeline run."""
-    dt = date_partition or get_date_partition()
-    return f"s3://{settings.DATAWAREHOUSE_BUCKET}/data_pipelines_extract/{dt}/{team_id}/{schema_id}/{run_uuid}"
+    return (
+        f"s3://{settings.DATAWAREHOUSE_BUCKET}/data_pipelines_extract/{date_partition}/{team_id}/{schema_id}/{run_uuid}"
+    )
 
 
 def get_data_folder(base_folder: str) -> str:

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/common.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/common.py
@@ -1,5 +1,6 @@
 import time
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 
 from django.conf import settings
 
@@ -26,9 +27,15 @@ def strip_s3_protocol(s3_path: str) -> str:
     return s3_path.replace("s3://", "")
 
 
-def get_base_folder(team_id: int, schema_id: str, run_uuid: str) -> str:
+def get_date_partition() -> str:
+    """Return today's UTC date as a Hive-style partition segment (dt=YYYY-MM-DD)."""
+    return f"dt={datetime.now(UTC).strftime('%Y-%m-%d')}"
+
+
+def get_base_folder(team_id: int, schema_id: str, run_uuid: str, date_partition: str | None = None) -> str:
     """Get the base S3 folder path for a pipeline run."""
-    return f"s3://{settings.DATAWAREHOUSE_BUCKET}/data_pipelines_extract/{team_id}/{schema_id}/{run_uuid}"
+    dt = date_partition or get_date_partition()
+    return f"s3://{settings.DATAWAREHOUSE_BUCKET}/data_pipelines_extract/{dt}/{team_id}/{schema_id}/{run_uuid}"
 
 
 def get_data_folder(base_folder: str) -> str:

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/test_common.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/test_common.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime, timedelta, timezone
 
 from parameterized import parameterized
 
-from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.common import get_date_partition
+from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.common import get_base_folder, get_date_partition
 
 
 class TestGetDatePartition:
@@ -22,10 +22,14 @@ class TestGetDatePartition:
 
         assert get_date_partition(dt) == "dt=2026-05-23"
 
-    def test_same_partition_across_midnight_when_pinned(self) -> None:
+    def test_is_pure_function_of_input(self) -> None:
         created_at = datetime(2026, 5, 22, 23, 59, 0, tzinfo=UTC)
 
-        partition_at_start = get_date_partition(created_at)
-        partition_an_hour_later = get_date_partition(created_at)
+        assert get_date_partition(created_at) == get_date_partition(created_at) == "dt=2026-05-22"
 
-        assert partition_at_start == partition_an_hour_later == "dt=2026-05-22"
+
+class TestGetBaseFolder:
+    def test_places_partition_before_team_id(self) -> None:
+        folder = get_base_folder(team_id=42, schema_id="schema-a", run_uuid="run-b", date_partition="dt=2026-05-22")
+
+        assert folder.endswith("/data_pipelines_extract/dt=2026-05-22/42/schema-a/run-b")

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/test_common.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/test_common.py
@@ -1,0 +1,31 @@
+from datetime import UTC, datetime, timedelta, timezone
+
+from parameterized import parameterized
+
+from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.common import get_date_partition
+
+
+class TestGetDatePartition:
+    @parameterized.expand(
+        [
+            ("midday_utc", datetime(2026, 5, 22, 12, 0, 0, tzinfo=UTC), "dt=2026-05-22"),
+            ("just_before_midnight_utc", datetime(2026, 5, 22, 23, 59, 59, tzinfo=UTC), "dt=2026-05-22"),
+            ("just_after_midnight_utc", datetime(2026, 5, 23, 0, 0, 1, tzinfo=UTC), "dt=2026-05-23"),
+        ]
+    )
+    def test_formats_utc_datetime(self, _name: str, dt: datetime, expected: str) -> None:
+        assert get_date_partition(dt) == expected
+
+    def test_converts_non_utc_to_utc_date(self) -> None:
+        la = timezone(timedelta(hours=-7))
+        dt = datetime(2026, 5, 22, 19, 0, 0, tzinfo=la)
+
+        assert get_date_partition(dt) == "dt=2026-05-23"
+
+    def test_same_partition_across_midnight_when_pinned(self) -> None:
+        created_at = datetime(2026, 5, 22, 23, 59, 0, tzinfo=UTC)
+
+        partition_at_start = get_date_partition(created_at)
+        partition_an_hour_later = get_date_partition(created_at)
+
+        assert partition_at_start == partition_an_hour_later == "dt=2026-05-22"

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
@@ -19,6 +19,7 @@ from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.common import (
     ensure_bucket,
     get_base_folder,
     get_data_folder,
+    get_date_partition,
     strip_s3_protocol,
 )
 
@@ -56,7 +57,8 @@ class S3BatchWriter:
         else:
             self._run_uuid = f"generated-{str(uuid.uuid4())}"
             self._logger.warning("S3BatchWriter: No run_uuid provided, using generated UUID", run_uuid=self._run_uuid)
-        self._base_folder = get_base_folder(self._job.team_id, self._schema_id, self._run_uuid)
+        self._date_partition = get_date_partition()
+        self._base_folder = get_base_folder(self._job.team_id, self._schema_id, self._run_uuid, self._date_partition)
         self._data_folder = get_data_folder(self._base_folder)
         self._schema = None
         self._s3 = get_s3_client()

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
@@ -57,7 +57,7 @@ class S3BatchWriter:
         else:
             self._run_uuid = f"generated-{str(uuid.uuid4())}"
             self._logger.warning("S3BatchWriter: No run_uuid provided, using generated UUID", run_uuid=self._run_uuid)
-        self._date_partition = get_date_partition()
+        self._date_partition = get_date_partition(self._job.created_at)
         self._base_folder = get_base_folder(self._job.team_id, self._schema_id, self._run_uuid, self._date_partition)
         self._data_folder = get_data_folder(self._base_folder)
         self._schema = None


### PR DESCRIPTION
## Problem

We need to leave the batches in S3 for a bit to make sure all consumers can work with them, so we need an easy way to delete old batches. 

## Changes

Add date partition to batches

## How did you test this code?

Local run
Test pass

## Publish to changelog?

NO

## Docs update

NO
