### PR TITLE
fix(settings): keep re-authentication inline in settings

### DIFF
--- a/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
@@ -161,14 +161,22 @@ export function TimeSensitiveAuthenticationArea({ children }: { children: JSX.El
     useOnMountEffect(checkReauthentication)
 
     return timeSensitiveAuthenticationRequired ? (
-        <div className="flex-1 bg-primary border border-primary rounded flex flex-col items-center p-6 text-center w-full">
-            <h2>Re-authentication required</h2>
+        <div className="w-full">
+            <div className="max-w-3xl rounded border border-primary bg-primary p-8">
+                <div className="flex flex-col items-start gap-4 text-left">
+                    <div>
+                        <h2 className="text-2xl font-semibold m-0 mb-4">Re-authentication required</h2>
+                        <p className="m-0 text-base text-secondary">
+                            This settings area contains sensitive information, so we need you to re-authenticate before
+                            continuing.
+                        </p>
+                    </div>
 
-            <p>This area requires that you re-authenticate.</p>
-
-            <LemonButton type="primary" onClick={() => setDismissedReauthentication(false)}>
-                Re-authenticate
-            </LemonButton>
+                    <LemonButton type="primary" onClick={() => setDismissedReauthentication(false)}>
+                        Re-authenticate
+                    </LemonButton>
+                </div>
+            </div>
         </div>
     ) : (
         children

--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -366,17 +366,19 @@ export function Settings({
                 </div>
             )}
 
-            <AuthenticationAreaComponent>
-                <div
-                    className={clsx(
-                        'flex-1 w-full min-w-0 space-y-2 self-start pb-32',
-                        isFullScene && !hideSections && !isCompact && 'pl-[calc(var(--settings-nav-width)+2rem)]'
-                    )}
-                >
-                    {headerSlot}
-                    <SettingsRenderer {...props} handleLocally={handleLocally} />
-                </div>
-            </AuthenticationAreaComponent>
+            <div
+                className={clsx(
+                    'flex-1 w-full min-w-0 self-start pb-32',
+                    isFullScene && !hideSections && !isCompact && 'pl-[calc(var(--settings-nav-width)+2rem)]'
+                )}
+            >
+                <AuthenticationAreaComponent>
+                    <div className="space-y-2">
+                        {headerSlot}
+                        <SettingsRenderer {...props} handleLocally={handleLocally} />
+                    </div>
+                </AuthenticationAreaComponent>
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The re-authentication prompt in settings rendered as a small centered card that broke out of the settings layout. When a sensitive settings area required re-auth, the prompt looked disconnected from the surrounding settings UI.

<img width="960" height="349" alt="image" src="https://github.com/user-attachments/assets/7b95a327-f84a-4ed0-9627-7256a251a09a" />


## Changes

- `TimeSensitiveAuthentication.tsx`: re-auth prompt now renders left-aligned in a contained card (`max-w-3xl`, padded), with a clearer message explaining why re-authentication is needed.
- `Settings.tsx`: moved `AuthenticationAreaComponent` inside the settings content wrapper so the re-auth prompt inherits the same width and padding as the rest of settings, keeping it inline instead of full-bleed.

<img width="872" height="350" alt="image" src="https://github.com/user-attachments/assets/7ffb815b-2c3c-44bd-8919-3fc436ea5527" />


## How did you test this code?

Yes

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored via PostHog Code (Task-Id `923f027a-a905-44bd-909b-7d79045b6330`), PR opened with Claude Code. The change keeps the re-authentication UI within the settings content column rather than rendering it as a standalone centered card.