### PR TITLE
fix(cdp): re-add cyclotron jobs-processed and batch-utilization metrics

### DIFF
--- a/nodejs/src/cdp/cdp-e2e.test.ts
+++ b/nodejs/src/cdp/cdp-e2e.test.ts
@@ -111,7 +111,7 @@ describe('CDP Consumer loop', () => {
                 ...HOG_FILTERS_EXAMPLES.no_filters,
             })
 
-            const kafkaQueue = new CyclotronJobQueueKafka(hub.KAFKA_CLIENT_RACK, hub)
+            const kafkaQueue = new CyclotronJobQueueKafka(hub.KAFKA_CLIENT_RACK, hub, hub.CONSUMER_BATCH_SIZE)
             const postgresV2Queue = new CyclotronJobQueuePostgresV2(hub.CONSUMER_BATCH_SIZE, hub)
 
             eventsConsumer = new CdpEventsConsumer(hub, createCdpConsumerDeps(hub, kafkaProducer), {

--- a/nodejs/src/cdp/rerun/rerun-e2e.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-e2e.test.ts
@@ -190,7 +190,7 @@ describe('CDP hog invocation rerun e2e', () => {
             ...HOG_FILTERS_EXAMPLES.no_filters,
         })
 
-        kafkaQueue = new CyclotronJobQueueKafka(hub.KAFKA_CLIENT_RACK, hub)
+        kafkaQueue = new CyclotronJobQueueKafka(hub.KAFKA_CLIENT_RACK, hub, hub.CONSUMER_BATCH_SIZE)
         postgresV2Queue = new CyclotronJobQueuePostgresV2(hub.CONSUMER_BATCH_SIZE, hub)
 
         eventsConsumer = new CdpEventsConsumer(hub, createCdpConsumerDeps(hub, kafkaProducer), {

--- a/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
@@ -14,7 +14,7 @@ import { logger } from '../../../utils/logger'
 import { CdpConfig } from '../../config'
 import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueueKind } from '../../types'
 import { JobQueue } from './job-queue.interface'
-import { cdpJobSizeCompressedKb, cdpJobSizeKb, createInvocationSanitizer } from './shared'
+import { cdpJobSizeCompressedKb, cdpJobSizeKb, createInvocationSanitizer, observeConsumedBatch } from './shared'
 
 export class CyclotronJobQueueKafka implements JobQueue {
     private kafkaConsumer?: KafkaConsumerInterface
@@ -28,7 +28,8 @@ export class CyclotronJobQueueKafka implements JobQueue {
         private config: Pick<
             CdpConfig,
             'CDP_CYCLOTRON_COMPRESS_KAFKA_DATA' | 'CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS'
-        >
+        >,
+        private consumerBatchSize: number
     ) {
         this.sanitizer = createInvocationSanitizer(config)
     }
@@ -163,6 +164,12 @@ export class CyclotronJobQueueKafka implements JobQueue {
 
     private async consumeKafkaBatch(messages: Message[]): Promise<{ backgroundTask: Promise<any> }> {
         if (messages.length === 0) {
+            observeConsumedBatch({
+                queue: this.queue!,
+                source: 'kafka',
+                batchSize: 0,
+                maxBatchSize: this.consumerBatchSize,
+            })
             return await this.consumeBatch!([])
         }
 
@@ -183,6 +190,13 @@ export class CyclotronJobQueueKafka implements JobQueue {
             invocation.queueSource = 'kafka' // NOTE: We always set this here, as we know it came from kafka
             invocations.push(invocation)
         }
+
+        observeConsumedBatch({
+            queue: this.queue!,
+            source: 'kafka',
+            batchSize: invocations.length,
+            maxBatchSize: this.consumerBatchSize,
+        })
 
         return await this.consumeBatch!(invocations)
     }

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
@@ -10,7 +10,7 @@ import { CdpConfig } from '../../config'
 import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueueKind } from '../../types'
 import { CyclotronV2DequeuedJob, CyclotronV2JobInit, CyclotronV2Manager, CyclotronV2Worker } from '../cyclotron-v2'
 import { JobQueue } from './job-queue.interface'
-import { cdpJobSizeCompressedKb, cdpJobSizeKb, createInvocationSanitizer } from './shared'
+import { cdpJobSizeCompressedKb, cdpJobSizeKb, createInvocationSanitizer, observeConsumedBatch } from './shared'
 
 const pendingJobsGauge = new Gauge({
     name: 'cdp_cyclotron_v2_pending_jobs',
@@ -90,6 +90,13 @@ export class CyclotronJobQueuePostgresV2 implements JobQueue {
             }
 
             pendingJobsGauge.set(this.pendingJobs.size)
+
+            observeConsumedBatch({
+                queue,
+                source: 'postgres-v2',
+                batchSize: invocations.length,
+                maxBatchSize: this.consumerBatchSize,
+            })
 
             await consumeBatch(invocations)
 

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -23,7 +23,7 @@ import { captureException } from '../../../utils/posthog'
 import { CdpConfig } from '../../config'
 import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueueKind } from '../../types'
 import { JobQueue } from './job-queue.interface'
-import { createInvocationSanitizer } from './shared'
+import { createInvocationSanitizer, observeConsumedBatch } from './shared'
 
 /**
  * Legacy postgres v1 queue via @posthog/cyclotron.
@@ -33,6 +33,7 @@ import { createInvocationSanitizer } from './shared'
 export class CyclotronJobQueuePostgres implements JobQueue {
     private cyclotronWorker?: CyclotronWorker
     private cyclotronManager?: CyclotronManager
+    private queue?: CyclotronJobQueueKind
     private consumeBatch?: (invocations: CyclotronJobInvocation[]) => Promise<{ backgroundTask: Promise<any> }>
     private sanitizer: ReturnType<typeof createInvocationSanitizer>
 
@@ -82,6 +83,7 @@ export class CyclotronJobQueuePostgres implements JobQueue {
         queue: CyclotronJobQueueKind,
         consumeBatch: (invocations: CyclotronJobInvocation[]) => Promise<{ backgroundTask: Promise<any> }>
     ) {
+        this.queue = queue
         this.consumeBatch = consumeBatch
 
         if (!this.config.CYCLOTRON_DATABASE_URL) {
@@ -241,6 +243,13 @@ export class CyclotronJobQueuePostgres implements JobQueue {
             const invocation = cyclotronJobToInvocation(job)
             invocations.push(invocation)
         }
+
+        observeConsumedBatch({
+            queue: this.queue!,
+            source: 'postgres',
+            batchSize: invocations.length,
+            maxBatchSize: this.consumerBatchSize,
+        })
 
         await this.consumeBatch!(invocations)
         // TODO: Ensure that all jobs eventually get acked!!!

--- a/nodejs/src/cdp/services/job-queue/shared.ts
+++ b/nodejs/src/cdp/services/job-queue/shared.ts
@@ -1,9 +1,14 @@
-import { Histogram } from 'prom-client'
+import { Counter, Gauge, Histogram } from 'prom-client'
 
 import { buildIntegerMatcher } from '../../../config/config'
 import { ValueMatcher } from '../../../types'
 import { CdpConfig } from '../../config'
-import { CyclotronJobInvocation, CyclotronJobInvocationResult } from '../../types'
+import {
+    CyclotronJobInvocation,
+    CyclotronJobInvocationResult,
+    CyclotronJobQueueKind,
+    CyclotronJobQueueSource,
+} from '../../types'
 
 export const cdpJobSizeKb = new Histogram({
     name: 'cdp_cyclotron_job_size_kb',
@@ -18,6 +23,34 @@ export const cdpJobSizeCompressedKb = new Histogram({
     buckets: [0, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, Infinity],
     labelNames: ['queue_kind'],
 })
+
+const cdpCyclotronBatchUtilization = new Gauge({
+    name: 'cdp_cyclotron_batch_utilization',
+    help: 'Indicates how big batches are we are processing compared to the max batch size. Useful as a scaling metric',
+    labelNames: ['queue', 'source'],
+})
+
+const cdpCyclotronJobsProcessed = new Counter({
+    name: 'cdp_cyclotron_jobs_processed',
+    help: 'The number of jobs we are managing to process',
+    labelNames: ['queue', 'source'],
+})
+
+/**
+ * Records throughput and batch utilization for a consumed batch.
+ * `cdp_cyclotron_batch_utilization` is consumed by KEDA to autoscale the cyclotron workers, so this
+ * must be called on every batch — including empty ones — so idle workers report zero and can scale down.
+ */
+export function observeConsumedBatch(params: {
+    queue: CyclotronJobQueueKind
+    source: CyclotronJobQueueSource
+    batchSize: number
+    maxBatchSize: number
+}): void {
+    const { queue, source, batchSize, maxBatchSize } = params
+    cdpCyclotronBatchUtilization.labels({ queue, source }).set(maxBatchSize > 0 ? batchSize / maxBatchSize : 0)
+    cdpCyclotronJobsProcessed.inc({ queue, source }, batchSize)
+}
 
 /**
  * Strip transient data from invocation state before persisting.

--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -110,7 +110,7 @@ describe.each(['postgres-v2' as const, 'postgres' as const])('Workflows E2E (%s)
 
         const deps = createCdpConsumerDeps(hub, kafkaProducer)
 
-        const kafkaQueue = new CyclotronJobQueueKafka(hub.KAFKA_CLIENT_RACK, hub)
+        const kafkaQueue = new CyclotronJobQueueKafka(hub.KAFKA_CLIENT_RACK, hub, hub.CONSUMER_BATCH_SIZE)
 
         // Build the hogflow queue for the current mode
         let hogflowQueue: JobQueue

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -141,7 +141,11 @@ export class PluginServer implements NodeServer {
         }
 
         // Create shared job queue backends — each consumer gets the one(s) it needs
-        const kafkaQueue = new CyclotronJobQueueKafka(this.config.KAFKA_CLIENT_RACK, this.config)
+        const kafkaQueue = new CyclotronJobQueueKafka(
+            this.config.KAFKA_CLIENT_RACK,
+            this.config,
+            this.config.CONSUMER_BATCH_SIZE
+        )
         const postgresV2Queue = new CyclotronJobQueuePostgresV2(this.config.CONSUMER_BATCH_SIZE, this.config)
 
         if (capabilities.cdpProcessedEvents) {


### PR DESCRIPTION
## Problem

The router-elimination refactor (#58997) deleted `job-queue.ts`, which also defined two Prometheus metrics that were not re-created anywhere:

- **`cdp_cyclotron_batch_utilization`** — consumed by KEDA `prometheusTriggers` to autoscale the cyclotron workers. With it gone, the workers lost their responsive scaling signal and fell back to a high CPU-only target. Because cyclotron workers are DB-I/O-bound (not CPU-bound), they effectively stopped scaling up and stayed near `minPods`, leading to a v2 queue backlog and stalled-job thrash under load.
- **`cdp_cyclotron_jobs_processed`** — backed the "Hogflow jobs processed by source" dashboard panel, which went blank.

## Changes

Re-adds both metrics in `shared.ts` with **identical** name, help text, and labels (`queue`, `source`) as the deleted definitions, so the existing Grafana dashboards and the charts KEDA trigger queries resolve again with no charts change.

- New `observeConsumedBatch()` helper in `shared.ts` sets `cdp_cyclotron_batch_utilization` and increments `cdp_cyclotron_jobs_processed`. It is called on every consumed batch — including empty ones — so idle workers report `0` utilization and KEDA can scale them down.
- All three queue backends emit it per consumed batch, matching the old router's coverage:
  - `CyclotronJobQueueKafka` → `source: 'kafka'`
  - `CyclotronJobQueuePostgresV2` → `source: 'postgres-v2'`
  - `CyclotronJobQueuePostgres` (legacy v1) → `source: 'postgres'` — kept because v1 is still being drained.
- `CyclotronJobQueueKafka` now takes `consumerBatchSize` as a constructor argument (it is not a `CdpConfig` key); the 4 call sites are updated. The Kafka hot path (`consumeKafkaBatch`) is otherwise untouched — the empty-batch early return is preserved.

## How did you test this code?

I'm an agent (Claude Code). I ran `pnpm typescript:check` on the `nodejs` project — passes clean. TypeScript enforces that all `CyclotronJobQueueKafka` constructor call sites match the new signature. I did not run the test suite locally; CI covers it.

The emitted metrics were compared line-by-line against the deleted `job-queue.ts` definitions — identical metric name, type, help text, label names, label values, and the `batchSize / maxBatchSize` ratio. The only deltas are a divide-by-zero guard (`maxBatchSize > 0`) and that emission is a pure synchronous side-effect that cannot affect job processing.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- **Tool:** Claude Code (Opus 4.7)
- Root cause traced from a prod-us issue: `CdpCyclotronV2PendingJobsHigh` + `CdpCyclotronV2StalledJobsHigh` alerts, with the hogflow worker unable to autoscale.
- Decision: emit from each backend rather than reintroducing a shared router, to fit the post-#58997 injected-backend architecture. Metric names/labels kept byte-identical so no charts/KEDA change is required.
- The legacy v1 backend emits with `source: 'postgres'` — retained intentionally because the v1 queue is still being drained and its utilization/throughput should remain observable until the drain completes.