### PR TITLE
feat(ingestion): null created_at for historical group types

### DIFF
--- a/nodejs/src/ingestion/event-processing/groups.test.ts
+++ b/nodejs/src/ingestion/event-processing/groups.test.ts
@@ -54,31 +54,38 @@ describe('addGroupProperties', () => {
         expect(mgr.fetchGroupTypeIndex).not.toHaveBeenCalled()
     })
 
-    it('resolves group types via fetchGroupTypeIndex and sets $group_N', async () => {
-        const mgr = mockGroupTypeManager({ organization: 0, project: 1, foobar: null })
+    it.each([
+        { desc: 'default historicalMigration is false', historicalMigration: undefined, expectedFlag: false },
+        { desc: 'historicalMigration=true is forwarded', historicalMigration: true, expectedFlag: true },
+        { desc: 'historicalMigration=false is forwarded', historicalMigration: false, expectedFlag: false },
+    ])(
+        'resolves group types via fetchGroupTypeIndex and sets $group_N: $desc',
+        async ({ historicalMigration, expectedFlag }) => {
+            const mgr = mockGroupTypeManager({ organization: 0, project: 1, foobar: null })
 
-        const properties = {
-            foo: 'bar',
-            $groups: {
-                organization: 'PostHog',
-                project: 'web',
-                foobar: 'afsafa',
-            },
+            const properties = {
+                foo: 'bar',
+                $groups: {
+                    organization: 'PostHog',
+                    project: 'web',
+                    foobar: 'afsafa',
+                },
+            }
+
+            expect(await addGroupProperties(2, 2 as ProjectId, properties, mgr as any, historicalMigration)).toEqual({
+                foo: 'bar',
+                $groups: {
+                    organization: 'PostHog',
+                    project: 'web',
+                    foobar: 'afsafa',
+                },
+                $group_0: 'PostHog',
+                $group_1: 'web',
+            })
+
+            expect(mgr.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 2, 'organization', expectedFlag)
+            expect(mgr.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 2, 'project', expectedFlag)
+            expect(mgr.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 2, 'foobar', expectedFlag)
         }
-
-        expect(await addGroupProperties(2, 2 as ProjectId, properties, mgr as any)).toEqual({
-            foo: 'bar',
-            $groups: {
-                organization: 'PostHog',
-                project: 'web',
-                foobar: 'afsafa',
-            },
-            $group_0: 'PostHog',
-            $group_1: 'web',
-        })
-
-        expect(mgr.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 2, 'organization')
-        expect(mgr.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 2, 'project')
-        expect(mgr.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 2, 'foobar')
-    })
+    )
 })

--- a/nodejs/src/ingestion/event-processing/groups.ts
+++ b/nodejs/src/ingestion/event-processing/groups.ts
@@ -25,7 +25,8 @@ export async function addGroupProperties(
     teamId: TeamId,
     projectId: ProjectId,
     properties: Properties,
-    groupTypeManager: GroupTypeManager
+    groupTypeManager: GroupTypeManager,
+    historicalMigration: boolean = false
 ): Promise<Properties> {
     const groups = properties.$groups
     if (typeof groups !== 'object' || groups === null || Array.isArray(groups)) {
@@ -33,7 +34,12 @@ export async function addGroupProperties(
     }
     const resolvedTypes: GroupTypeToColumnIndex = {}
     for (const [groupType] of Object.entries(groups)) {
-        const columnIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, projectId, groupType)
+        const columnIndex = await groupTypeManager.fetchGroupTypeIndex(
+            teamId,
+            projectId,
+            groupType,
+            historicalMigration
+        )
         if (columnIndex !== null) {
             resolvedTypes[groupType] = columnIndex
         }

--- a/nodejs/src/ingestion/event-processing/process-groups-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-groups-step.test.ts
@@ -24,6 +24,7 @@ type TestInput = {
     preparedEvent: PreIngestionEvent
     team: Team
     processPerson: boolean
+    historicalMigration: boolean
 }
 
 describe('createProcessGroupsStep', () => {
@@ -43,6 +44,7 @@ describe('createProcessGroupsStep', () => {
         preparedEvent: createTestPreIngestionEvent(),
         team: createTestTeam(),
         processPerson: true,
+        historicalMigration: false,
         ...overrides,
     })
 
@@ -198,6 +200,46 @@ describe('createProcessGroupsStep', () => {
         const result = await step(createInput())
 
         expect(result.type).toBe(PipelineResultType.OK)
+    })
+
+    it.each([
+        { desc: 'historicalMigration=true is forwarded to fetchGroupTypeIndex', historicalMigration: true },
+        { desc: 'historicalMigration=false is forwarded to fetchGroupTypeIndex', historicalMigration: false },
+    ])('$desc', async ({ historicalMigration }) => {
+        mockGroupTypeManager.fetchGroupTypeIndex.mockResolvedValue(0)
+
+        const step = createStep()
+        const result = await step(
+            createInput({
+                historicalMigration,
+                preparedEvent: createTestPreIngestionEvent({
+                    event: '$groupidentify',
+                    properties: {
+                        $group_type: 'organization',
+                        $group_key: 'org::5',
+                        $group_set: { foo: 'bar' },
+                    },
+                }),
+            })
+        )
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        // Called once from updateGroupsAndFirstEvent + once from upsertGroup — both should forward the flag.
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenCalledTimes(2)
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenNthCalledWith(
+            1,
+            1,
+            1,
+            'organization',
+            historicalMigration
+        )
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenNthCalledWith(
+            2,
+            1,
+            1,
+            'organization',
+            historicalMigration
+        )
     })
 
     it('skips updateGroupsAndFirstEvent for $$plugin_metrics events', async () => {

--- a/nodejs/src/ingestion/event-processing/process-groups-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-groups-step.test.ts
@@ -242,6 +242,28 @@ describe('createProcessGroupsStep', () => {
         )
     })
 
+    it.each([
+        { desc: 'historicalMigration=true is forwarded via addGroupProperties', historicalMigration: true },
+        { desc: 'historicalMigration=false is forwarded via addGroupProperties', historicalMigration: false },
+    ])('non-$groupidentify event with $groups: $desc', async ({ historicalMigration }) => {
+        mockGroupTypeManager.fetchGroupTypeIndex.mockResolvedValue(0)
+
+        const step = createStep()
+        const result = await step(
+            createInput({
+                historicalMigration,
+                preparedEvent: createTestPreIngestionEvent({
+                    event: '$pageview',
+                    properties: { $groups: { org: 'posthog' } },
+                }),
+            })
+        )
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenCalledTimes(1)
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenCalledWith(1, 1, 'org', historicalMigration)
+    })
+
     it('skips updateGroupsAndFirstEvent for $$plugin_metrics events', async () => {
         const step = createStep()
         await step(

--- a/nodejs/src/ingestion/event-processing/process-groups-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-groups-step.ts
@@ -51,7 +51,8 @@ export function createProcessGroupsStep<TInput extends ProcessGroupsStepInput>(
                 team.id,
                 team.project_id,
                 preparedEvent.properties,
-                groupTypeManager
+                groupTypeManager,
+                historicalMigration
             )
 
             if (preparedEvent.event === '$groupidentify') {

--- a/nodejs/src/ingestion/event-processing/process-groups-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-groups-step.ts
@@ -19,6 +19,7 @@ export interface ProcessGroupsStepInput {
     preparedEvent: PreIngestionEvent
     team: Team
     processPerson: boolean
+    historicalMigration: boolean
 }
 
 export type ProcessGroupsStepResult<TInput> = TInput
@@ -30,11 +31,11 @@ export function createProcessGroupsStep<TInput extends ProcessGroupsStepInput>(
     options: Pick<EventPipelineRunnerOptions, 'SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP'>
 ): ProcessingStep<TInput, ProcessGroupsStepResult<TInput>> {
     return async function processGroupsStep(input: TInput) {
-        const { preparedEvent, team, processPerson } = input
+        const { preparedEvent, team, processPerson, historicalMigration } = input
 
         if (!options.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP) {
             try {
-                await updateGroupsAndFirstEvent(teamManager, groupTypeManager, team, preparedEvent)
+                await updateGroupsAndFirstEvent(teamManager, groupTypeManager, team, preparedEvent, historicalMigration)
             } catch (err) {
                 captureException(err, { tags: { team_id: team.id } })
                 logger.warn('⚠️', 'Failed to update groups and first event for event ', {
@@ -60,7 +61,8 @@ export function createProcessGroupsStep<TInput extends ProcessGroupsStepInput>(
                     team.id,
                     team.project_id,
                     preparedEvent.properties,
-                    DateTime.fromISO(preparedEvent.timestamp)
+                    DateTime.fromISO(preparedEvent.timestamp),
+                    historicalMigration
                 )
             }
         }
@@ -73,7 +75,8 @@ async function updateGroupsAndFirstEvent(
     teamManager: TeamManager,
     groupTypeManager: GroupTypeManager,
     team: Team,
-    preparedEvent: PreIngestionEvent
+    preparedEvent: PreIngestionEvent,
+    historicalMigration: boolean
 ): Promise<void> {
     if (EVENTS_WITHOUT_EVENT_DEFINITION.includes(preparedEvent.event)) {
         return
@@ -84,7 +87,9 @@ async function updateGroupsAndFirstEvent(
     if (preparedEvent.event === '$groupidentify') {
         const { $group_type: groupType, $group_set: groupPropertiesToSet } = preparedEvent.properties
         if (groupType != null && groupPropertiesToSet != null) {
-            promises.push(groupTypeManager.fetchGroupTypeIndex(team.id, team.project_id, groupType))
+            promises.push(
+                groupTypeManager.fetchGroupTypeIndex(team.id, team.project_id, groupType, historicalMigration)
+            )
         }
     }
 
@@ -97,14 +102,15 @@ async function upsertGroup(
     teamId: TeamId,
     projectId: ProjectId,
     properties: Properties,
-    timestamp: DateTime
+    timestamp: DateTime,
+    historicalMigration: boolean
 ): Promise<void> {
     if (!properties['$group_type'] || !properties['$group_key']) {
         return
     }
 
     const { $group_type: groupType, $group_key: groupKey, $group_set: groupPropertiesToSet } = properties
-    const groupTypeIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, projectId, groupType)
+    const groupTypeIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, projectId, groupType, historicalMigration)
     if (groupTypeIndex !== null) {
         await groupStore.upsertGroup(
             teamId,

--- a/nodejs/src/ingestion/personhog/personhog-group-repository.test.ts
+++ b/nodejs/src/ingestion/personhog/personhog-group-repository.test.ts
@@ -587,14 +587,24 @@ describe('PersonHogGroupRepository', () => {
             )
         })
 
-        it('insertGroupType', async () => {
+        it.each([
+            { desc: 'insertGroupType without historicalMigration', historicalMigration: undefined },
+            { desc: 'insertGroupType forwards historicalMigration=true', historicalMigration: true },
+            { desc: 'insertGroupType forwards historicalMigration=false', historicalMigration: false },
+        ])('$desc', async ({ historicalMigration }) => {
             mockPostgres.insertGroupType.mockResolvedValue([0 as GroupTypeIndex, true])
             const repo = createRepo(100)
 
-            const result = await repo.insertGroupType(TEAM_ID, PROJECT_ID, 'organization', 0)
+            const result = await repo.insertGroupType(TEAM_ID, PROJECT_ID, 'organization', 0, historicalMigration)
 
             expect(result).toEqual([0, true])
-            expect(mockPostgres.insertGroupType).toHaveBeenCalledWith(TEAM_ID, PROJECT_ID, 'organization', 0)
+            expect(mockPostgres.insertGroupType).toHaveBeenCalledWith(
+                TEAM_ID,
+                PROJECT_ID,
+                'organization',
+                0,
+                historicalMigration
+            )
         })
 
         it('inTransaction', async () => {

--- a/nodejs/src/ingestion/personhog/personhog-group-repository.ts
+++ b/nodejs/src/ingestion/personhog/personhog-group-repository.ts
@@ -203,9 +203,10 @@ export class PersonHogGroupRepository implements GroupRepository {
         teamId: TeamId,
         projectId: ProjectId,
         groupType: string,
-        index: number
+        index: number,
+        historicalMigration?: boolean
     ): Promise<[GroupTypeIndex | null, boolean]> {
-        return this.postgres.insertGroupType(teamId, projectId, groupType, index)
+        return this.postgres.insertGroupType(teamId, projectId, groupType, index, historicalMigration)
     }
 
     inTransaction<T>(description: string, transaction: (tx: GroupRepositoryTransaction) => Promise<T>): Promise<T> {

--- a/nodejs/src/worker/ingestion/group-type-manager.test.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.test.ts
@@ -200,6 +200,32 @@ describe('GroupTypeManager()', () => {
             })
         })
 
+        it.each([
+            { desc: 'historicalMigration=true inserts NULL created_at', historicalMigration: true },
+            { desc: 'historicalMigration=false inserts a non-null created_at', historicalMigration: false },
+            {
+                desc: 'historicalMigration default (undefined) inserts a non-null created_at',
+                historicalMigration: undefined,
+            },
+        ])('$desc', async ({ historicalMigration }) => {
+            expect(
+                await groupTypeManager.fetchGroupTypeIndex(2, 2 as ProjectId, 'historical_group', historicalMigration)
+            ).toEqual(0)
+
+            const result = await hub.postgres.query<{ created_at: Date | null }>(
+                PostgresUse.PERSONS_WRITE,
+                "SELECT created_at FROM posthog_grouptypemapping WHERE project_id = 2 AND group_type = 'historical_group'",
+                undefined,
+                'selectGroupTypeCreatedAt'
+            )
+            expect(result.rows).toHaveLength(1)
+            if (historicalMigration === true) {
+                expect(result.rows[0].created_at).toBeNull()
+            } else {
+                expect(result.rows[0].created_at).not.toBeNull()
+            }
+        })
+
         it('uses next available index after a group type is deleted', async () => {
             await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'A', 0)
             await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'B', 1)

--- a/nodejs/src/worker/ingestion/group-type-manager.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.ts
@@ -55,7 +55,8 @@ export class GroupTypeManager {
     public async fetchGroupTypeIndex(
         teamId: TeamId,
         projectId: ProjectId,
-        groupType: string
+        groupType: string,
+        historicalMigration: boolean = false
     ): Promise<GroupTypeIndex | null> {
         const groupTypes = await this.fetchGroupTypes(projectId)
         if (groupType in groupTypes) {
@@ -76,7 +77,8 @@ export class GroupTypeManager {
             teamId,
             projectId,
             groupType,
-            nextAvailableIndex
+            nextAvailableIndex,
+            historicalMigration
         )
         if (groupTypeIndex !== null) {
             this.loader.markForRefresh(projectId.toString())

--- a/nodejs/src/worker/ingestion/groups/repositories/group-repository-transaction.interface.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/group-repository-transaction.interface.ts
@@ -67,6 +67,7 @@ export interface GroupRepositoryTransaction {
         teamId: TeamId,
         projectId: ProjectId,
         groupType: string,
-        index: number
+        index: number,
+        historicalMigration?: boolean
     ): Promise<[GroupTypeIndex | null, boolean]>
 }

--- a/nodejs/src/worker/ingestion/groups/repositories/group-repository.interface.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/group-repository.interface.ts
@@ -79,7 +79,8 @@ export interface GroupRepository {
         teamId: TeamId,
         projectId: ProjectId,
         groupType: string,
-        index: number
+        index: number,
+        historicalMigration?: boolean
     ): Promise<[GroupTypeIndex | null, boolean]>
 
     // Transaction Methods

--- a/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
@@ -104,8 +104,9 @@ export class PostgresGroupRepositoryTransaction implements GroupRepositoryTransa
         teamId: TeamId,
         projectId: ProjectId,
         groupType: string,
-        index: number
+        index: number,
+        historicalMigration?: boolean
     ): Promise<[GroupTypeIndex | null, boolean]> {
-        return await this.repository.insertGroupType(teamId, projectId, groupType, index, this.tx)
+        return await this.repository.insertGroupType(teamId, projectId, groupType, index, historicalMigration, this.tx)
     }
 }

--- a/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository.integration.test.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository.integration.test.ts
@@ -1476,7 +1476,7 @@ describe('PostgresGroupRepository Integration', () => {
             await insertTestTeam(teamId)
 
             const result = await repository.inRawTransaction('test insertGroupType raw transaction', async (tx) => {
-                return await repository.insertGroupType(teamId, teamId as ProjectId, 'company', 0, tx)
+                return await repository.insertGroupType(teamId, teamId as ProjectId, 'company', 0, false, tx)
             })
 
             expect(result).toEqual([0, true])
@@ -1515,6 +1515,42 @@ describe('PostgresGroupRepository Integration', () => {
             )
 
             expect(rows).toHaveLength(0)
+        })
+
+        it.each([
+            { desc: 'historicalMigration=true sets created_at to NULL', historicalMigration: true, expectNull: true },
+            { desc: 'historicalMigration=false sets created_at to now', historicalMigration: false, expectNull: false },
+            {
+                desc: 'historicalMigration default (undefined) sets created_at to now',
+                historicalMigration: undefined,
+                expectNull: false,
+            },
+        ])('$desc', async ({ historicalMigration, expectNull }) => {
+            await insertTestTeam(teamId)
+
+            const [groupTypeIndex, isInsert] = await repository.insertGroupType(
+                teamId,
+                teamId as ProjectId,
+                'historical_company',
+                0,
+                historicalMigration
+            )
+
+            expect(groupTypeIndex).toBe(0)
+            expect(isInsert).toBe(true)
+
+            const { rows } = await postgres.query<{ created_at: Date | null }>(
+                PostgresUse.PERSONS_READ,
+                'SELECT created_at FROM posthog_grouptypemapping WHERE team_id = $1 AND project_id = $2 AND group_type = $3',
+                [teamId, teamId, 'historical_company'],
+                'test-fetch-group-type-created-at'
+            )
+            expect(rows).toHaveLength(1)
+            if (expectNull) {
+                expect(rows[0].created_at).toBeNull()
+            } else {
+                expect(rows[0].created_at).not.toBeNull()
+            }
         })
 
         it('should handle special characters in group type names', async () => {

--- a/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
@@ -324,6 +324,7 @@ export class PostgresGroupRepository
         projectId: ProjectId,
         groupType: string,
         index: number,
+        historicalMigration: boolean = false,
         tx?: TransactionClient
     ): Promise<[GroupTypeIndex | null, boolean]> {
         if (index < 0 || index >= MAX_GROUP_TYPES_PER_TEAM) {
@@ -343,12 +344,12 @@ export class PostgresGroupRepository
             UNION
             SELECT group_type_index, 0 AS is_insert FROM posthog_grouptypemapping WHERE project_id = $2 AND group_type = $3;
             `,
-            [teamId, projectId, groupType, index, new Date()],
+            [teamId, projectId, groupType, index, historicalMigration ? null : new Date()],
             'insertGroupType'
         )
 
         if (insertGroupTypeResult.rows.length == 0) {
-            return await this.insertGroupType(teamId, projectId, groupType, index + 1, tx)
+            return await this.insertGroupType(teamId, projectId, groupType, index + 1, historicalMigration, tx)
         }
 
         const { group_type_index, is_insert } = insertGroupTypeResult.rows[0]

--- a/nodejs/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
@@ -86,6 +86,7 @@ export interface RawPostgresGroupRepository {
         projectId: ProjectId,
         groupType: string,
         index: number,
+        historicalMigration?: boolean,
         tx?: TransactionClient
     ): Promise<[GroupTypeIndex | null, boolean]>
 


### PR DESCRIPTION
## Problem

Fixes https://github.com/posthog/posthog/issues/39989

Customers performing historical data backfills (events sent with the `historical_migration` Kafka header) expect those events to look like they were captured at the original timestamps – the whole point of the backfill is to preserve historical truth. Today this breaks down at one specific seam: when a backfill event introduces a brand-new group type (via `$groupidentify`, or via `$groups` on any event), the resulting `posthog_grouptypemapping` row gets `created_at = <now>` – the wall-clock time at which the worker happened to process that backfill event.

That's misleading in two ways:
1. It misrepresents when the team actually started using that group type. Anyone looking at the GroupTypeMapping list (admin UI, downstream queries, "when did we start tracking organizations?" analyses) sees today's date instead of the truth, which is that we don't know.
2. It's inconsistent with the column's design. `GroupTypeMapping.created_at` is nullable with no `auto_now_add`, and there's already a `create_group_type_mapping_without_created_at` test helper explicitly demonstrating that `NULL` is the intended way to express "we don't know when this was created" for backfilled data. The ingestion path just doesn't honor that today.

This PR closes the gap: when ingestion creates a new GroupTypeMapping as a side effect of a `historical_migration` event, the row's `created_at` is `NULL` instead of "now", matching the semantics the model already supports.

When PostHog ingests events with the `historical_migration` Kafka header (backfills of old data, validated to be at least 48 hours old), any new `posthog_grouptypemapping` row created as a side effect of those events gets stamped with `created_at = <current wall-clock time>`. That's misleading: the group type wasn't created _now_, we just learned about it from a historical event.

The `GroupTypeMapping.created_at` column is already nullable (`null=True, blank=True`, no `auto_now_add` — see `posthog/models/group_type_mapping.py`), and there is already a test helper (`create_group_type_mapping_without_created_at`) that intentionally creates rows with `created_at = NULL`. This change makes the ingestion pipeline produce that same NULL state on the historical-migration path.

## Changes

Plumb the existing `historicalMigration` boolean (already extracted from the Kafka header in `prepare-event-step.ts`) down through `processGroupsStep` → `GroupTypeManager.fetchGroupTypeIndex` → `GroupRepository.insertGroupType` → the SQL insert. When the flag is true, the new row's `created_at` is `NULL` instead of `new Date()`.

Both code paths that can insert a brand-new `posthog_grouptypemapping` are covered:
- `$groupidentify` events – via `updateGroupsAndFirstEvent` and `upsertGroup`
- any event with a previously-unseen group type in its `$groups` property – via `addGroupProperties`

For already-existing mappings (the `ON CONFLICT DO NOTHING` / fallthrough `SELECT` path), nothing changes — we do not retroactively null out `created_at`.

Out of scope: backfilling existing rows, the Python ORM `save()` override (admin/API only, not ingestion), Rust ingestion paths (they don't create `GroupTypeMapping` rows).

## How did you test this code?

I'm an agent. I did not perform manual end-to-end ingestion testing. Automated checks I ran:

- `pnpm typescript:check` and `pnpm lint` over the touched files – clean.
- New parameterized unit tests in `process-groups-step.test.ts` and `groups.test.ts` covering both call sites (`$groupidentify` and any event with `$groups`) and asserting the flag is forwarded.
- New parameterized integration tests in `group-type-manager.test.ts` and `postgres-group-repository.integration.test.ts` that assert `created_at IS NULL` when `historicalMigration=true` and a non-null timestamp when `false` / omitted.
- Existing wrapper tests (`personhog-group-repository.test.ts`, `postgres-group-repository.integration.test.ts` transaction case) updated for the new optional positional param.
- Re-ran the pre-existing parity suite (`personhog-postgres-parity.test.ts`) to confirm no regressions: 25/25 pass.

## Publish to changelog?

do not publish to changelog

## Docs update

n/a

## 🤖 Agent context

Authored by Claude (PostHog Code) end-to-end – planning, implementation, and tests. Decisions made along the way:

- Source of truth: the `historical_migration` Kafka header (already parsed by `prepare-event-step.ts` and validated by `validate-historical-migration.ts` for the 48-hour age rule), not an event property. There is no existing path that reads `event.properties.historical_migration`, and the header is already trusted across the rest of the pipeline.
- Scope decision: the original task only mentioned `$groupidentify`, but `addGroupProperties` also calls `fetchGroupTypeIndex` for any event with `$groups` and can therefore also create a new mapping. The flag is wired through that path too so semantics are consistent ("we learned about this group type from historical data, so don't fabricate a `created_at`"). This was confirmed with the human before extending scope.
- Param placement: added `historicalMigration?: boolean` between the existing `index: number` and the optional `tx?: TransactionClient` in repository signatures. One positional-arg call site (`postgres-group-repository.integration.test.ts` raw-transaction test) had to be updated to pass `false, tx` instead of just `tx`. Considered putting `historicalMigration` after `tx?` for backward compatibility but rejected since `tx` is the infrastructure-level optional that should stay last.
