### PR TITLE
chore(mcp): extend timeout for mcp shutdowns

### DIFF
--- a/services/mcp/src/hono/shutdown.ts
+++ b/services/mcp/src/hono/shutdown.ts
@@ -4,8 +4,8 @@ import type Redis from 'ioredis'
 import type { Lifecycle } from './app'
 import { shuttingDown as shuttingDownMetric } from './metrics'
 
-const SHUTDOWN_GRACE_MS = parseInt(process.env.SHUTDOWN_GRACE_MS || '30000', 10)
-const SHUTDOWN_PRESTOP_DELAY_MS = parseInt(process.env.SHUTDOWN_PRESTOP_DELAY_MS || '5000', 10)
+const SHUTDOWN_GRACE_MS = parseInt(process.env.SHUTDOWN_GRACE_MS || '300000', 10)
+const SHUTDOWN_PRESTOP_DELAY_MS = parseInt(process.env.SHUTDOWN_PRESTOP_DELAY_MS || '0', 10)
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 


### PR DESCRIPTION
we want to give in-flight queries up to 5 mins before we kill them on a new deployment