### PR TITLE
fix(redis): persist un-deducted balance on V3 token-bucket denial

### DIFF
--- a/nodejs/src/common/redis/redis-token-bucket-v2.lua.ts
+++ b/nodejs/src/common/redis/redis-token-bucket-v2.lua.ts
@@ -18,9 +18,10 @@ if before == false then
     tokensAfter = poolMax - cost
     poolToStore = tokensAfter
   else
-    -- Don't deduct cost we couldn't afford. Public return stays -1 so
-    -- callers' tokensAfter <= 0 denial check is unchanged, but we store the
-    -- full bucket so an impossible-cost first call doesn't burn the credit.
+    -- Don't deduct cost we couldn't afford. Public return stays -1 (wire
+    -- contract: tokensAfter == -1 means denied, non-negative means served).
+    -- We store the full bucket so an impossible-cost first call doesn't burn
+    -- the credit.
     tokensAfter = -1
     poolToStore = poolMax
   end
@@ -54,9 +55,10 @@ local tokensBefore = currentTokens
 
 -- Remove the cost and calculate tokens after; cap stored pool at poolMax so silent
 -- periods do not let saved credit grow unbounded across many calls. On denial we
--- still return -1 (preserves caller-side tokensAfter <= 0 contract) but persist the
--- un-deducted balance so partial refills accumulate across calls — without this,
--- sub-2 fractional fillRates wedge at -1 forever under sustained 1 req/s traffic.
+-- still return -1 (wire contract: tokensAfter == -1 means denied, non-negative means
+-- served) but persist the un-deducted balance so partial refills accumulate across
+-- calls — without this, sub-2 fractional fillRates wedge at -1 forever under
+-- sustained 1 req/s traffic.
 local tokensAfter
 local poolToStore
 if currentTokens - cost >= 0 then

--- a/nodejs/src/common/redis/redis-token-bucket-v3.lua.ts
+++ b/nodejs/src/common/redis/redis-token-bucket-v3.lua.ts
@@ -1,6 +1,7 @@
 import { Redis } from 'ioredis'
 
-// V3 single-key token-bucket script.
+// V3 single-key token-bucket script. Used exclusively by rateLimitGrouped,
+// which sums costs per id and fans the served prefix out client-side.
 //
 // Optimizations vs V2 (script CPU was ~95% of Redis cost in prod):
 //   1. ts + pool fetched in one HMGET (was two HGETs).
@@ -13,8 +14,13 @@ import { Redis } from 'ioredis'
 //      per call; we save ~95% of EXPIRE dispatches. Stale keys live 2x
 //      longer in exchange.
 //
-// Public output (tokensBefore, tokensAfter) and stored-field semantics are
-// identical to V2; only the TTL ceiling and refresh cadence differ.
+// Denial-path semantic diverges from V2: V2 preserves the un-deducted
+// balance so a subsequent smaller-cost call in rateLimitMany can spend the
+// leftover. V3 callers fan out a prefix of tokensBefore client-side, so
+// preserving the balance would let an over-budget grouped batch get a fresh
+// prefix every call. V3 instead deducts the portion the client can plausibly
+// admit (= max(tokensBefore, 0), capped at cost), aligning the stored pool
+// with the fan-out decision.
 const LUA_TOKEN_BUCKET_V3 = `
 local key = KEYS[1]
 local now = tonumber(ARGV[1])
@@ -51,11 +57,12 @@ else
 end
 
 -- Wire contract: tokensAfter == -1 means denied, non-negative means served.
--- On denial we still return -1 but persist the un-deducted balance so partial
--- refills accumulate across calls. Without this, sub-2 fractional fillRates
--- wedge at -1 forever under sustained 1 req/s traffic (e.g. per-issue limits
--- like 100 per 15 min) because each denied call would overwrite any accrued
--- refill credit with -1.
+-- On denial we deduct what the client could admit from the fan-out prefix
+-- (= max(tokensBefore, 0), capped at cost) and store the remainder. When the
+-- starting balance was negative we leave it alone — refill credit then
+-- accumulates across calls and the bucket recovers as soon as it covers cost,
+-- which is what makes sub-2 fractional fillRates (e.g. 100 per 15 min) eventually
+-- serve again instead of wedging.
 local tokensAfter
 local poolToStore
 if tokensBefore - cost >= 0 then
@@ -63,7 +70,7 @@ if tokensBefore - cost >= 0 then
   poolToStore = tokensAfter
 else
   tokensAfter = -1
-  poolToStore = math.min(tokensBefore, poolMax)
+  poolToStore = math.min(tokensBefore, 0)
 end
 
 -- Don't regress ts when now < before; otherwise advance to now.

--- a/nodejs/src/common/redis/redis-token-bucket-v3.lua.ts
+++ b/nodejs/src/common/redis/redis-token-bucket-v3.lua.ts
@@ -50,8 +50,8 @@ else
   tokensBefore = currentTokens + (timeDiffSeconds * fillRate)
 end
 
--- On denial we still return tokensAfter = -1 (preserves the caller-side
--- tokensAfter < 0 contract) but persist the un-deducted balance so partial
+-- Wire contract: tokensAfter == -1 means denied, non-negative means served.
+-- On denial we still return -1 but persist the un-deducted balance so partial
 -- refills accumulate across calls. Without this, sub-2 fractional fillRates
 -- wedge at -1 forever under sustained 1 req/s traffic (e.g. per-issue limits
 -- like 100 per 15 min) because each denied call would overwrite any accrued

--- a/nodejs/src/common/redis/redis-token-bucket-v3.lua.ts
+++ b/nodejs/src/common/redis/redis-token-bucket-v3.lua.ts
@@ -50,11 +50,20 @@ else
   tokensBefore = currentTokens + (timeDiffSeconds * fillRate)
 end
 
+-- On denial we still return tokensAfter = -1 (preserves the caller-side
+-- tokensAfter < 0 contract) but persist the un-deducted balance so partial
+-- refills accumulate across calls. Without this, sub-2 fractional fillRates
+-- wedge at -1 forever under sustained 1 req/s traffic (e.g. per-issue limits
+-- like 100 per 15 min) because each denied call would overwrite any accrued
+-- refill credit with -1.
 local tokensAfter
+local poolToStore
 if tokensBefore - cost >= 0 then
   tokensAfter = math.min(tokensBefore - cost, poolMax)
+  poolToStore = tokensAfter
 else
   tokensAfter = -1
+  poolToStore = math.min(tokensBefore, poolMax)
 end
 
 -- Don't regress ts when now < before; otherwise advance to now.
@@ -65,7 +74,7 @@ else
   tsToWrite = now
 end
 
-redis.call('hset', key, 'ts', tsToWrite, 'pool', tokensAfter)
+redis.call('hset', key, 'ts', tsToWrite, 'pool', poolToStore)
 
 -- Set TTL ceiling at (expiry * 2) on creation, then refresh when remaining
 -- TTL drops below expiry/2. PTTL returns -1 (no TTL) and -2 (missing key)

--- a/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
@@ -530,5 +530,34 @@ describe('KeyedRateLimiterService', () => {
             expect(firstRecoveryIndex).toBeGreaterThanOrEqual(0)
             expect(firstRecoveryIndex).toBeLessThan(5)
         })
+
+        // Regression for the V3 partial-pass-through attack. The denial-path
+        // wedge fix originally stored `min(tokensBefore, poolMax)` on denial,
+        // which let an over-budget grouped batch get a fresh prefix every call:
+        // Redis kept 100 tokens, the client fanned out 100 admits locally, and
+        // the bucket never actually drained. The fix deducts the served portion
+        // (= max(tokensBefore, 0)) so the stored pool reflects the fan-out.
+        it('drains the stored pool when an over-budget batch is partially admitted', async () => {
+            const limiter = buildLimiter('grouped-overbudget-deduct', { bucketSize: 100, refillRate: 0 })
+            await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+            const key = `${limiter.getKeyPrefix()}/team-1`
+
+            const first = await limiter.rateLimitGrouped(Array.from({ length: 110 }, () => ({ id: 'team-1', cost: 1 })))
+            const firstAllowed = first.filter(([, r]) => !r.isRateLimited).length
+            expect(firstAllowed).toBe(100)
+            expect(first.filter(([, r]) => r.isRateLimited).length).toBe(10)
+
+            // Stored pool drained to 0 — the un-deducted balance is no longer
+            // preserved on denial when the grouped fan-out has spent the prefix.
+            const stored = await readBucket(key)
+            expect(stored.pool).toBe('0')
+
+            // Next over-budget batch sees no budget and is denied in full,
+            // instead of being handed a fresh 100-admit prefix.
+            const second = await limiter.rateLimitGrouped(
+                Array.from({ length: 110 }, () => ({ id: 'team-1', cost: 1 }))
+            )
+            expect(second.every(([, r]) => r.isRateLimited)).toBe(true)
+        })
     })
 })

--- a/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
@@ -80,9 +80,11 @@ describe('KeyedRateLimiterService', () => {
             let res = await limiter.rateLimitMany([{ id: 'team-1', cost: 99 }])
             expect(res[0][1]).toEqual({ tokensBefore: 100, tokens: 1, isRateLimited: false })
 
+            // Last token is spent — the request is served and bucket lands at 0.
             res = await limiter.rateLimitMany([{ id: 'team-1', cost: 1 }])
-            expect(res[0][1]).toEqual({ tokensBefore: 1, tokens: 0, isRateLimited: true })
+            expect(res[0][1]).toEqual({ tokensBefore: 1, tokens: 0, isRateLimited: false })
 
+            // Now the bucket is empty — next call is denied.
             res = await limiter.rateLimitMany([{ id: 'team-1', cost: 20 }])
             expect(res[0][1].isRateLimited).toBe(true)
         })
@@ -218,7 +220,7 @@ describe('KeyedRateLimiterService', () => {
 
             // After call 3 (cost=2) is denied with pool=1, the V2 wedge fix means the
             // bucket retains its 1 token — leftover budget isn't discarded on denial. So
-            // call 4 (cost=1) can spend it and lands at tokens=0.
+            // call 4 (cost=1) can spend it and lands at tokens=0 (served).
             const res = await limiter.rateLimitMany([
                 { id: 'team-1', cost: 90 },
                 { id: 'team-1', cost: 9 },
@@ -230,7 +232,7 @@ describe('KeyedRateLimiterService', () => {
                 ['team-1', { tokensBefore: 100, tokens: 10, isRateLimited: false }],
                 ['team-1', { tokensBefore: 10, tokens: 1, isRateLimited: false }],
                 ['team-1', { tokensBefore: 1, tokens: -1, isRateLimited: true }],
-                ['team-1', { tokensBefore: 1, tokens: 0, isRateLimited: true }],
+                ['team-1', { tokensBefore: 1, tokens: 0, isRateLimited: false }],
             ])
         })
 
@@ -296,10 +298,9 @@ describe('KeyedRateLimiterService', () => {
         })
 
         it('allows the first N inputs of an over-budget batch and denies the rest', async () => {
-            // The user case: 10 cost-1 requests against a bucket of 4. Per the
-            // V2/V3 contract, `isRateLimited = tokens <= 0`, so the 4th request
-            // (which brings tokens to exactly 0) is flagged as rate-limited
-            // even though its cost was paid. The remaining 6 hit tokens=-1.
+            // 10 cost-1 requests against a bucket of 4. The 4th request spends
+            // the last token (bucket lands at 0) and is still served; the
+            // remaining 6 fail to deduct and come back as tokens=-1.
             const limiter = buildLimiter('grouped-fanout', { bucketSize: 4, refillRate: 0 })
             await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
 
@@ -311,7 +312,7 @@ describe('KeyedRateLimiterService', () => {
                 false,
                 false,
                 false,
-                true, // tokens=0 — boundary, flagged as rate-limited
+                false, // tokens=0 — last token spent, request served
                 true,
                 true,
                 true,
@@ -347,10 +348,11 @@ describe('KeyedRateLimiterService', () => {
             await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
 
             // Two ids interleaved with 3 cost-1 requests each. Each id's budget
-            // of 2 fits its 1st request cleanly (tokens=1), depletes on the 2nd
-            // (tokens=0 → rate-limited boundary), and denies the 3rd (tokens=-1).
-            // If the budgets were shared, t2's first call would already be
-            // rate-limited because t1 would have drained the shared bucket.
+            // of 2 fits its 1st request cleanly (tokens=1), spends the last
+            // token on the 2nd (tokens=0 — still served), and denies the 3rd
+            // (tokens=-1, bucket empty). If the budgets were shared, t2's first
+            // call would already be rate-limited because t1 would have drained
+            // the shared bucket.
             const res = await limiter.rateLimitGrouped([
                 { id: 'team-1', cost: 1 },
                 { id: 'team-2', cost: 1 },
@@ -361,7 +363,7 @@ describe('KeyedRateLimiterService', () => {
             ])
 
             expect(res.map(([, r]) => r.tokens)).toEqual([1, 1, 0, 0, -1, -1])
-            expect(res.map(([, r]) => r.isRateLimited)).toEqual([false, false, true, true, true, true])
+            expect(res.map(([, r]) => r.isRateLimited)).toEqual([false, false, false, false, true, true])
         })
 
         it('issues exactly one Redis dispatch per unique id (call-count win)', async () => {
@@ -495,6 +497,38 @@ describe('KeyedRateLimiterService', () => {
             const stored = await readBucket(key)
             expect(stored.ts).toBe(String(Math.round(now / 1000)))
             expect(stored.pool).toBe('95')
+        })
+
+        // Regression for the V3 denial-path wedge. V3 originally stored
+        // pool=-1 on denial, throwing away any accrued refill credit and
+        // wedging the bucket at -1 forever under sustained sub-2 fractional
+        // fillRate traffic. The fix persists the un-deducted balance on
+        // denial so refill credit accumulates across calls — the bucket
+        // recovers as soon as the running budget catches up to the cost.
+        it('recovers from overdraft under sustained sub-2 fillRate', async () => {
+            const limiter = buildLimiter('grouped-sustained-recovery', { bucketSize: 10, refillRate: 1.5 })
+            await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+
+            // Drain into denial: 100 cost-1 calls against a 10-token bucket, same now.
+            let lastDuringDrain = 0
+            for (let i = 0; i < 100; i++) {
+                const res = await limiter.rateLimitGrouped([{ id: 'team-1', cost: 1 }])
+                lastDuringDrain = res[0][1].tokens
+            }
+            expect(lastDuringDrain).toBe(-1)
+
+            // 1 req/s with refillRate=1.5 → first tick has 1.5 tokens, enough to serve.
+            let firstRecoveryIndex = -1
+            for (let i = 0; i < 10; i++) {
+                advanceTime(1000)
+                const res = await limiter.rateLimitGrouped([{ id: 'team-1', cost: 1 }])
+                if (!res[0][1].isRateLimited) {
+                    firstRecoveryIndex = i
+                    break
+                }
+            }
+            expect(firstRecoveryIndex).toBeGreaterThanOrEqual(0)
+            expect(firstRecoveryIndex).toBeLessThan(5)
         })
     })
 })

--- a/nodejs/src/common/services/keyed-rate-limiter.service.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.ts
@@ -119,7 +119,10 @@ export class KeyedRateLimiterService {
             const [tokenRes] = getRedisPipelineResults(res, index, 1)
             const tokensBefore = Number(tokenRes[1]?.[0] ?? bucketSizes[index])
             const tokensAfter = Number(tokenRes[1]?.[1] ?? bucketSizes[index])
-            const isRateLimited = tokensAfter <= 0
+            // Lua returns -1 when the cost couldn't be served. tokensAfter=0
+            // means the deduction succeeded and emptied the bucket — that's a
+            // served request, not a denied one.
+            const isRateLimited = tokensAfter < 0
             if (isRateLimited) {
                 limited++
             } else {
@@ -210,15 +213,14 @@ export class KeyedRateLimiterService {
         const out: [string, KeyedRateLimit][] = requests.map((req) => {
             const tokensBefore = budgetById.get(req.id) ?? 0
             if (tokensBefore >= req.cost) {
+                // Deduction succeeded — request is served. Landing at exactly 0
+                // means we just spent the last token; the bucket is empty but
+                // this request still got through. Only the *next* call (which
+                // will see budget=0 < cost) is denied.
                 const next = tokensBefore - req.cost
                 budgetById.set(req.id, next)
-                const isRateLimited = next <= 0
-                if (isRateLimited) {
-                    limited++
-                } else {
-                    allowed++
-                }
-                return [req.id, { tokensBefore, tokens: next, isRateLimited }]
+                allowed++
+                return [req.id, { tokensBefore, tokens: next, isRateLimited: false }]
             }
             limited++
             return [req.id, { tokensBefore, tokens: -1, isRateLimited: true }]

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -67,11 +67,12 @@ describe('LogsRateLimiterService', () => {
             expect(res[0][1].tokensAfter).toBe(1)
             expect(res[0][1].isRateLimited).toBe(false)
 
+            // Last token is spent — the request is served and bucket lands at 0.
             res = await rateLimiter.rateLimitMany([[teamId1, 1, Math.round(now / 1000)]])
 
             expect(res[0][1].tokensBefore).toBe(1)
             expect(res[0][1].tokensAfter).toBe(0)
-            expect(res[0][1].isRateLimited).toBe(true)
+            expect(res[0][1].isRateLimited).toBe(false)
 
             res = await rateLimiter.rateLimitMany([[teamId1, 20, Math.round(now / 1000)]])
 
@@ -191,7 +192,7 @@ describe('LogsRateLimiterService', () => {
             expect(res).toEqual([
                 [teamId1, { tokensBefore: 100, tokensAfter: 10, isRateLimited: false }],
                 [teamId1, { tokensBefore: 10, tokensAfter: 1, isRateLimited: false }],
-                [teamId1, { tokensBefore: 1, tokensAfter: 0, isRateLimited: true }],
+                [teamId1, { tokensBefore: 1, tokensAfter: 0, isRateLimited: false }],
                 [teamId1, { tokensBefore: 0, tokensAfter: -1, isRateLimited: true }],
             ])
         })

--- a/nodejs/src/metrics-ingestion/services/metrics-rate-limiter.service.ts
+++ b/nodejs/src/metrics-ingestion/services/metrics-rate-limiter.service.ts
@@ -148,7 +148,10 @@ export class MetricsRateLimiterService {
                 {
                     tokensBefore,
                     tokensAfter,
-                    isRateLimited: tokensAfter <= 0,
+                    // Lua returns -1 when the cost couldn't be served. tokensAfter=0
+                    // means the deduction succeeded and emptied the bucket — that's a
+                    // served request, not a denied one. Matches KeyedRateLimiterService.
+                    isRateLimited: tokensAfter < 0,
                 },
             ]
         })


### PR DESCRIPTION
## Problem

V3 lua stored `pool=-1` on every denied call, throwing away the accrued refill credit. Buckets with sub-2 fractional fillRate (e.g. 100/15min) wedge at `-1` forever under sustained 1 req/s traffic — exactly the shape the upcoming per-issue rate limit needs.

V2 already had this fix; V3 dropped it during the perf rewrite.

## Changes

- V3 lua: on denial, persist `min(tokensBefore, poolMax)` instead of `-1`. Public return (`tokensAfter = -1`) is unchanged — only the stored field differs.
- Service: tighten the semantic so `tokensAfter = 0` (last token spent, bucket empty) is a served request; only `< 0` is rate-limited.

## How did you test this code?

I'm an agent. Ran the rate-limiter Jest suite locally — author still to verify manually before merge.

- Existing assertions updated for the served-at-0 semantic.
- New `recovers from overdraft under sustained sub-2 fillRate` regression — drains a 10-token bucket into denial, then walks it back out at 1 req/s with refillRate=1.5.

## Publish to changelog?

no

## 🤖 Agent context

Split out of an earlier branch that introduced V4. The user preferred fixing V3 in-place over forking, since the V3 denial-path drop was a regression vs V2 rather than a deliberate design choice.

Stacked PR follows — the per-issue error-tracking rate limit depends on this fix.