### PR TITLE
fix(data-warehouse): reject credentials smuggled into the custom manifest

### DIFF
--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -1,8 +1,8 @@
 import json
 from typing import Any, Literal, Optional, cast
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -28,6 +28,39 @@ from products.data_warehouse.backend.types import ExternalDataSourceType, Increm
 # Credential keys that must NOT appear inline in the manifest — they belong in
 # the dedicated secret `auth_*` config fields so the API layer can redact them.
 INLINE_SECRET_KEYS = ("token", "api_key", "password")
+
+# Header names and URL-parameter names that carry credentials. `manifest_json`
+# is a non-secret config field that round-trips to the client un-redacted, so a
+# secret embedded in a header or URL there would leak — credentials belong in
+# the dedicated secret `auth_*` fields instead.
+_CREDENTIAL_HEADER_NAMES = frozenset({"authorization", "proxy-authorization", "cookie"})
+_CREDENTIAL_NAME_SUBSTRINGS = (
+    "token",
+    "secret",
+    "password",
+    "apikey",
+    "api-key",
+    "api_key",
+    "access-key",
+    "access_key",
+)
+
+
+def _name_looks_like_credential(name: str) -> bool:
+    lowered = name.strip().lower()
+    return lowered in _CREDENTIAL_HEADER_NAMES or any(hint in lowered for hint in _CREDENTIAL_NAME_SUBSTRINGS)
+
+
+def _assert_url_carries_no_credentials(url: str, field: str) -> None:
+    """Reject a URL that embeds a credential in userinfo or a query parameter."""
+    parsed = urlparse(url)
+    if parsed.username or parsed.password:
+        raise ValueError(f"{field} must not embed credentials in the URL — use the dedicated auth fields")
+    for param, _value in parse_qsl(parsed.query):
+        if _name_looks_like_credential(param):
+            raise ValueError(
+                f"{field} must not embed a credential ({param!r}) in the query string — use the dedicated auth fields"
+            )
 
 
 class ManifestValidationError(ValueError):
@@ -63,6 +96,28 @@ class _ManifestAuth(BaseModel):
 class _ManifestClient(BaseModel):
     base_url: str = Field(min_length=1)
     auth: _ManifestAuth | None = None
+    # `headers` is modelled (rather than passed through as an extra) only so a
+    # credential smuggled into a header name can be rejected; the raw value
+    # still reaches the REST engine untouched.
+    headers: dict[str, str] | None = None
+
+    @field_validator("base_url")
+    @classmethod
+    def _base_url_carries_no_credentials(cls, value: str) -> str:
+        _assert_url_carries_no_credentials(value, "client.base_url")
+        return value
+
+    @field_validator("headers")
+    @classmethod
+    def _reject_credential_headers(cls, headers: dict[str, str] | None) -> dict[str, str] | None:
+        if headers:
+            offending = sorted(name for name in headers if _name_looks_like_credential(name))
+            if offending:
+                raise ValueError(
+                    f"client.headers must not carry credentials ({', '.join(offending)}) — "
+                    "use the dedicated auth fields"
+                )
+        return headers
 
 
 class _ManifestEndpoint(BaseModel):
@@ -72,6 +127,13 @@ class _ManifestEndpoint(BaseModel):
     # PUT/PATCH/DELETE are excluded so a misconfigured manifest can't mutate or
     # delete upstream data.
     method: Literal["GET", "POST", "get", "post"] | None = None
+
+    @field_validator("path")
+    @classmethod
+    def _path_carries_no_credentials(cls, value: str) -> str:
+        if value.startswith(("http://", "https://")):
+            _assert_url_carries_no_credentials(value, "endpoint.path")
+        return value
 
 
 class _ManifestResource(BaseModel):

--- a/posthog/temporal/data_imports/sources/custom/test_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_source.py
@@ -325,6 +325,50 @@ class TestCustomSourceValidateCredentials(SimpleTestCase):
         assert mock_session.call_args.kwargs["team_id"] == 999
 
 
+class TestManifestRejectsSmuggledCredentials(SimpleTestCase):
+    """A credential must not be embeddable in the non-secret manifest_json."""
+
+    def test_rejects_credential_bearing_header(self):
+        manifest = _minimal_manifest()
+        manifest["client"]["headers"] = {"Authorization": "Bearer leaked"}
+        with self.assertRaises(ManifestValidationError) as ctx:
+            validate_manifest(manifest)
+        assert "headers" in str(ctx.exception)
+
+    def test_rejects_credential_query_param_in_base_url(self):
+        manifest = _minimal_manifest(base_url="https://api.example.com?api_key=leaked")
+        with self.assertRaises(ManifestValidationError) as ctx:
+            validate_manifest(manifest)
+        assert "base_url" in str(ctx.exception)
+
+    def test_rejects_credentials_in_base_url_userinfo(self):
+        manifest = _minimal_manifest(base_url="https://user:leaked@api.example.com")
+        with self.assertRaises(ManifestValidationError) as ctx:
+            validate_manifest(manifest)
+        assert "base_url" in str(ctx.exception)
+
+    def test_rejects_credential_query_param_in_absolute_resource_path(self):
+        manifest = _minimal_manifest()
+        manifest["resources"][0]["endpoint"]["path"] = "https://api.example.com/users?access_token=leaked"
+        with self.assertRaises(ManifestValidationError) as ctx:
+            validate_manifest(manifest)
+        assert "path" in str(ctx.exception)
+
+    def test_rejects_unknown_auth_field(self):
+        # An unrecognized auth key (here `header` instead of `name`) must fail
+        # validation, not crash the REST engine's create_auth at sync time.
+        manifest = _minimal_manifest()
+        manifest["client"]["auth"] = {"type": "api_key", "header": "X-Key"}
+        with self.assertRaises(ManifestValidationError) as ctx:
+            validate_manifest(manifest)
+        assert "header" in str(ctx.exception)
+
+    def test_accepts_non_credential_headers(self):
+        manifest = _minimal_manifest()
+        manifest["client"]["headers"] = {"Accept": "application/json", "User-Agent": "posthog"}
+        validate_manifest(manifest)
+
+
 class TestCustomSourceSourceForPipeline(SimpleTestCase):
     def test_invalid_manifest_raises_non_retryable(self):
         # A permanent config error must fail fast, not burn the Temporal retry budget.


### PR DESCRIPTION
## Problem

The Custom source stores its manifest in `manifest_json`, a non-secret config
field. Credentials are meant to live in the dedicated secret `auth_*` fields,
which the API layer redacts from responses. But `manifest_json` round-trips to
the client un-redacted — so a credential a user embeds inside it (in a header
value, in `base_url` userinfo, or in a query parameter) is returned in API
responses to every team member with data warehouse read access, where the same
secret placed in `auth_*` would have been redacted.

## Changes

Reject, at manifest-validation time, credentials embedded in the non-secret
manifest:

- `base_url` and absolute endpoint paths must not carry userinfo
  (`user:pass@host`) or credential-looking query parameters.
- `client.headers` must not use credential-bearing header names
  (Authorization, Cookie, X-Api-Key, …).

Credential detection is a conservative name/substring heuristic — it funnels
secrets into the redactable `auth_*` fields rather than being an airtight
boundary.

This is the top PR of a 3-PR split of the original `custom-source-ssrf-guard`
branch; it carries only the manifest credential guard.

## How did you test this code?

I'm an agent (Claude Code) and did not perform manual testing. Automated tests,
run locally: `posthog/temporal/data_imports/sources/custom/test_source.py` —
54 tests passing, including a new `TestManifestRejectsSmuggledCredentials` class
covering credential-bearing headers, `base_url` userinfo and query parameters,
and absolute-path query parameters.

## Publish to changelog?

no — internal hardening of the data warehouse Custom source.

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with Claude Code (Opus). Stacked on `custom-source-ssrf-guard` (#59525).

Top PR of a 3-PR split of the original oversized `custom-source-ssrf-guard`
branch. The credential exposure addressed here is low-severity — same-tenant,
and the user has to mis-place the secret themselves — so this is defence in
depth that funnels secrets into the fields that get redacted, not a fix for an
active exploit.

Note: `test_rejects_unknown_auth_field` in this PR's test class exercises the
`extra="forbid"` behaviour on `_ManifestAuth`, which is introduced in #59612 —
the test lands here because it shares the credential-hardening test class, and
passes once the full stack is applied.

Agent-authored; requires human review before merge.
