### PR TITLE
feat(workflows): reject "all events" hog flow triggers on activation

### DIFF
--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -103,6 +103,20 @@ class HogFlowActionSerializer(serializers.Serializer):
                 trigger_is_function = True
             elif data.get("config", {}).get("type") == "event":
                 filters = data.get("config", {}).get("filters", {})
+                # An event trigger must target specific events. An "All events" entry
+                # (an event with no id) fires the workflow on the entire event stream,
+                # which can flood the workflow workers.
+                if not is_draft:
+                    for event in filters.get("events") or []:
+                        if not event.get("id"):
+                            raise serializers.ValidationError(
+                                {
+                                    "config": (
+                                        "A workflow trigger must target a specific event. "
+                                        '"All events" triggers fire on the entire event stream and are not allowed.'
+                                    )
+                                }
+                            )
                 # Move filter_test_accounts into filters for bytecode compilation
                 if data.get("config", {}).get("filter_test_accounts") is not None:
                     filters["filter_test_accounts"] = data["config"].pop("filter_test_accounts")

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -76,19 +76,40 @@ class TestHogFlowAPI(APIBaseTest):
             },
         }
 
-    def test_hog_flow_rejects_all_events_trigger_when_active(self):
-        hog_flow = {"name": "Test Flow", "status": "active", "actions": [self._all_events_trigger_action()]}
+    @parameterized.expand(
+        [
+            ("null_id_active", None, "active", 400),
+            ("empty_id_active", "", "active", 400),
+            # Drafts do not run, so the "All events" check is only enforced on activation.
+            ("null_id_draft", None, None, 201),
+        ]
+    )
+    def test_hog_flow_all_events_trigger_validation(self, _name, event_id, flow_status, expected_status):
+        trigger = self._all_events_trigger_action()
+        trigger["config"]["filters"]["events"][0]["id"] = event_id
+        hog_flow: dict = {"name": "Test Flow", "actions": [trigger]}
+        if flow_status is not None:
+            hog_flow["status"] = flow_status
 
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == expected_status, response.json()
+        if expected_status == 400:
+            assert "All events" in str(response.json())
+
+    def test_hog_flow_all_events_trigger_rejected_on_activation(self):
+        # A draft can hold an "All events" trigger; flipping it to active must re-validate and reject.
+        create = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows",
+            {"name": "Test Flow", "actions": [self._all_events_trigger_action()]},
+        )
+        assert create.status_code == 201, create.json()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{create.json()['id']}",
+            {"status": "active"},
+        )
         assert response.status_code == 400, response.json()
         assert "All events" in str(response.json())
-
-    def test_hog_flow_allows_all_events_trigger_as_draft(self):
-        # Drafts do not run, so the "All events" check is only enforced on activation.
-        hog_flow = {"name": "Test Flow", "actions": [self._all_events_trigger_action()]}
-
-        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
-        assert response.status_code == 201, response.json()
 
     def test_hog_flow_function_trigger_copied_from_action(self):
         trigger_action = {

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -63,6 +63,33 @@ class TestHogFlowAPI(APIBaseTest):
             "type": "validation_error",
         }
 
+    def _all_events_trigger_action(self):
+        return {
+            "id": "trigger_node",
+            "name": "trigger_1",
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "events": [{"id": None, "name": "All events", "type": "events", "order": 0}],
+                },
+            },
+        }
+
+    def test_hog_flow_rejects_all_events_trigger_when_active(self):
+        hog_flow = {"name": "Test Flow", "status": "active", "actions": [self._all_events_trigger_action()]}
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 400, response.json()
+        assert "All events" in str(response.json())
+
+    def test_hog_flow_allows_all_events_trigger_as_draft(self):
+        # Drafts do not run, so the "All events" check is only enforced on activation.
+        hog_flow = {"name": "Test Flow", "actions": [self._all_events_trigger_action()]}
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 201, response.json()
+
     def test_hog_flow_function_trigger_copied_from_action(self):
         trigger_action = {
             "id": "trigger_node",


### PR DESCRIPTION
## Problem

A workflow's event trigger can be configured to match "All events" — an event entry with no specific `id`. Once such a workflow is activated it fires on **every** event the team sends, turning the entire event stream into workflow invocations. A single misconfigured workflow can then generate enough load to back up the workflow job queue and starve other teams' workflows.

This is an easy footgun: alert-style templates ship expecting the user to narrow the trigger to a specific event (e.g. a failure event), and it's easy to activate one without doing so.

## Changes

Server-side validation in `HogFlowActionSerializer` (`posthog/api/hog_flow.py`): an event-type trigger that contains an "All events" entry (an event with a null, empty, or missing `id`) is now rejected with a clear error.

- Enforced **on activation**, not on drafts — consistent with the serializer's existing draft-lenient validation pattern, and drafts don't execute so they're harmless. Applies to both create and update.
- Catches `id: null`, `id: ""`, and a missing `id`.

## How did you test this code?

This PR was authored by an agent (Claude Code).

Added two automated tests in `posthog/api/test/test_hog_flow.py`:
- `test_hog_flow_rejects_all_events_trigger_when_active` — activating an all-events trigger returns 400
- `test_hog_flow_allows_all_events_trigger_as_draft` — the same trigger is allowed as a draft

I did **not** run the test suite locally — the agent environment isn't set up to run Django tests safely against an isolated test database. CI will run them.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with Claude Code.

Decisions:
- Validation lives in the serializer (the API boundary / enforcement point), in the existing event-trigger branch of `HogFlowActionSerializer.validate`.
- Enforced on activation only, not on drafts — mirrors how the rest of this serializer treats drafts leniently (`is_draft`), and a draft never triggers.
- This is backend-only. The workflow editor UI can still offer "All events" in the trigger picker; a follow-up should remove it there so users get the feedback earlier.
- Existing already-active workflows with an "All events" trigger are not auto-corrected — they will be rejected the next time they are saved while active, but a separate cleanup is needed for existing ones.