### PR TITLE
fix(signals): ensure report failed status idempotency

### DIFF
--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -488,19 +488,28 @@ async def mark_report_failed_activity(input: MarkReportFailedInput) -> None:
     try:
 
         @transaction.atomic
-        def do_update() -> int:
+        def do_update() -> tuple[int, bool]:
             report = SignalReport.objects.select_for_update().get(id=input.report_id, team_id=input.team_id)
+            if report.status == SignalReport.Status.FAILED:
+                return report.run_count, True
             updated_fields = report.transition_to(SignalReport.Status.FAILED, error=input.error)
             report.save(update_fields=updated_fields)
-            return report.run_count
+            return report.run_count, False
 
-        run_count = await database_sync_to_async(do_update, thread_sensitive=False)()
+        run_count, was_already_failed = await database_sync_to_async(do_update, thread_sensitive=False)()
     except Exception as e:
         logger.exception(
             f"Failed to mark report {input.report_id} as failed: {e}",
             report_id=input.report_id,
         )
         raise
+
+    if was_already_failed:
+        logger.info(
+            f"Report {input.report_id} already in failed status, skipping duplicate transition",
+            report_id=input.report_id,
+        )
+        return
 
     team = await Team.objects.select_related("organization").aget(pk=input.team_id)
     _capture_report_event(

--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -383,19 +383,28 @@ async def mark_report_in_progress_activity(input: MarkReportInProgressInput) -> 
     try:
 
         @transaction.atomic
-        def do_update() -> int:
+        def do_update() -> tuple[int, bool]:
             report = SignalReport.objects.select_for_update().get(id=input.report_id, team_id=input.team_id)
+            if report.status == SignalReport.Status.IN_PROGRESS:
+                return report.run_count, True
             updated_fields = report.transition_to(SignalReport.Status.IN_PROGRESS, signals_at_run_increment=3)
             report.save(update_fields=updated_fields)
-            return report.run_count
+            return report.run_count, False
 
-        run_count = await database_sync_to_async(do_update, thread_sensitive=False)()
+        run_count, was_already_in_progress = await database_sync_to_async(do_update, thread_sensitive=False)()
     except Exception as e:
         logger.exception(
             f"Failed to mark report {input.report_id} as in_progress: {e}",
             report_id=input.report_id,
         )
         raise
+
+    if was_already_in_progress:
+        logger.info(
+            f"Report {input.report_id} already in in_progress status, skipping duplicate transition",
+            report_id=input.report_id,
+        )
+        return
 
     team = await Team.objects.select_related("organization").aget(pk=input.team_id)
     _capture_report_event(
@@ -431,8 +440,13 @@ async def mark_report_ready_activity(input: MarkReportReadyInput) -> bool:
     try:
 
         @transaction.atomic
-        def do_update() -> tuple[bool, int]:
+        def do_update() -> tuple[bool, int, bool]:
             report = SignalReport.objects.select_for_update().get(id=input.report_id, team_id=input.team_id)
+            if report.status == SignalReport.Status.READY:
+                return False, report.run_count, True
+            if report.status == SignalReport.Status.CANDIDATE:
+                # Previous attempt took the re-promotion branch; preserve has_new_signals=True.
+                return True, report.run_count, True
             updated_fields = report.transition_to(SignalReport.Status.READY, title=input.title, summary=input.summary)
             report.save(update_fields=updated_fields)
             has_new_signals = report.signal_count > input.processed_signal_count
@@ -441,15 +455,23 @@ async def mark_report_ready_activity(input: MarkReportReadyInput) -> bool:
                 # re-promote it back to candidate and loop to also process new signals
                 candidate_fields = report.transition_to(SignalReport.Status.CANDIDATE)
                 report.save(update_fields=candidate_fields)
-            return has_new_signals, report.run_count
+            return has_new_signals, report.run_count, False
 
-        has_new_signals, run_count = await database_sync_to_async(do_update, thread_sensitive=False)()
+        has_new_signals, run_count, was_already_done = await database_sync_to_async(do_update, thread_sensitive=False)()
     except Exception as e:
         logger.exception(
             f"Failed to mark report {input.report_id} as ready: {e}",
             report_id=input.report_id,
         )
         raise
+
+    if was_already_done:
+        logger.info(
+            f"Report {input.report_id} already past ready transition, skipping duplicate",
+            report_id=input.report_id,
+            has_new_signals=has_new_signals,
+        )
+        return has_new_signals
 
     team = await Team.objects.select_related("organization").aget(pk=input.team_id)
     _capture_report_event(
@@ -548,21 +570,30 @@ async def mark_report_pending_input_activity(input: MarkReportPendingInput) -> N
     try:
 
         @transaction.atomic
-        def do_update() -> int:
+        def do_update() -> tuple[int, bool]:
             report = SignalReport.objects.select_for_update().get(id=input.report_id, team_id=input.team_id)
+            if report.status == SignalReport.Status.PENDING_INPUT:
+                return report.run_count, True
             updated_fields = report.transition_to(
                 SignalReport.Status.PENDING_INPUT, title=input.title, summary=input.summary, error=input.reason
             )
             report.save(update_fields=updated_fields)
-            return report.run_count
+            return report.run_count, False
 
-        run_count = await database_sync_to_async(do_update, thread_sensitive=False)()
+        run_count, was_already_pending_input = await database_sync_to_async(do_update, thread_sensitive=False)()
     except Exception as e:
         logger.exception(
             f"Failed to mark report {input.report_id} as pending_input: {e}",
             report_id=input.report_id,
         )
         raise
+
+    if was_already_pending_input:
+        logger.info(
+            f"Report {input.report_id} already in pending_input status, skipping duplicate transition",
+            report_id=input.report_id,
+        )
+        return
 
     team = await Team.objects.select_related("organization").aget(pk=input.team_id)
     _capture_report_event(
@@ -598,19 +629,28 @@ async def reset_report_to_potential_activity(input: ResetReportToPotentialInput)
     try:
 
         @transaction.atomic
-        def do_update() -> int:
+        def do_update() -> tuple[int, bool]:
             report = SignalReport.objects.select_for_update().get(id=input.report_id, team_id=input.team_id)
+            if report.status == SignalReport.Status.POTENTIAL:
+                return report.run_count, True
             updated_fields = report.transition_to(SignalReport.Status.POTENTIAL, reset_weight=True, error=input.reason)
             report.save(update_fields=updated_fields)
-            return report.run_count
+            return report.run_count, False
 
-        run_count = await database_sync_to_async(do_update, thread_sensitive=False)()
+        run_count, was_already_potential = await database_sync_to_async(do_update, thread_sensitive=False)()
     except Exception as e:
         logger.exception(
             f"Failed to reset report {input.report_id} to potential: {e}",
             report_id=input.report_id,
         )
         raise
+
+    if was_already_potential:
+        logger.info(
+            f"Report {input.report_id} already in potential status, skipping duplicate transition",
+            report_id=input.report_id,
+        )
+        return
 
     team = await Team.objects.select_related("organization").aget(pk=input.team_id)
     _capture_report_event(

--- a/products/signals/backend/test/test_report_telemetry.py
+++ b/products/signals/backend/test/test_report_telemetry.py
@@ -116,3 +116,33 @@ async def test_failed_fires_completed_with_failure_reason(ateam):
     assert kwargs["properties"]["failure_reason"] == "safety_judge_rejected"
     assert kwargs["properties"]["signal_count"] == 3
     assert kwargs["properties"]["source_products"] == ["zendesk"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_failed_is_idempotent_when_already_failed(ateam):
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.FAILED,
+        signal_count=3,
+        total_weight=2.0,
+        error="Original failure",
+    )
+    report_id = str(report.id)
+
+    with patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture") as capture:
+        await mark_report_failed_activity(
+            MarkReportFailedInput(
+                team_id=ateam.id,
+                report_id=report_id,
+                error="Retry-attempt error message",
+                failure_reason="agentic_activity_error",
+                signal_count=3,
+                source_products=["zendesk"],
+            )
+        )
+
+    capture.assert_not_called()
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report_id)
+    assert refreshed.status == SignalReport.Status.FAILED
+    assert refreshed.error == "Original failure"

--- a/products/signals/backend/test/test_report_telemetry.py
+++ b/products/signals/backend/test/test_report_telemetry.py
@@ -13,10 +13,14 @@ from products.signals.backend.models import SignalReport
 from products.signals.backend.temporal.summary import (
     MarkReportFailedInput,
     MarkReportInProgressInput,
+    MarkReportPendingInput,
     MarkReportReadyInput,
+    ResetReportToPotentialInput,
     mark_report_failed_activity,
     mark_report_in_progress_activity,
+    mark_report_pending_input_activity,
     mark_report_ready_activity,
+    reset_report_to_potential_activity,
 )
 
 PIPELINE_MODULE_PATH = "products.signals.backend.temporal.summary"
@@ -146,3 +150,139 @@ async def test_failed_is_idempotent_when_already_failed(ateam):
     refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report_id)
     assert refreshed.status == SignalReport.Status.FAILED
     assert refreshed.error == "Original failure"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_in_progress_is_idempotent_when_already_in_progress(ateam):
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.IN_PROGRESS,
+        signal_count=2,
+        total_weight=1.0,
+        run_count=4,
+        signals_at_run=5,
+    )
+    report_id = str(report.id)
+
+    with patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture") as capture:
+        await mark_report_in_progress_activity(
+            MarkReportInProgressInput(
+                team_id=ateam.id,
+                report_id=report_id,
+                signal_count=2,
+                source_products=["zendesk"],
+            )
+        )
+
+    capture.assert_not_called()
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report_id)
+    assert refreshed.status == SignalReport.Status.IN_PROGRESS
+    # Run count and signals_at_run must not be advanced again on retry.
+    assert refreshed.run_count == 4
+    assert refreshed.signals_at_run == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "preexisting_status,expected_has_new_signals",
+    [
+        (SignalReport.Status.READY, False),
+        (SignalReport.Status.CANDIDATE, True),
+    ],
+)
+async def test_ready_is_idempotent_after_partial_commit(ateam, preexisting_status, expected_has_new_signals):
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=preexisting_status,
+        signal_count=3,
+        total_weight=2.0,
+        title="existing title",
+        summary="existing summary",
+    )
+    report_id = str(report.id)
+
+    with patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture") as capture:
+        has_new_signals = await mark_report_ready_activity(
+            MarkReportReadyInput(
+                team_id=ateam.id,
+                report_id=report_id,
+                title="retry title",
+                summary="retry summary",
+                processed_signal_count=3,
+                source_products=["zendesk"],
+            )
+        )
+
+    assert has_new_signals is expected_has_new_signals
+    capture.assert_not_called()
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report_id)
+    assert refreshed.status == preexisting_status
+    assert refreshed.title == "existing title"
+    assert refreshed.summary == "existing summary"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_pending_input_is_idempotent_when_already_pending_input(ateam):
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.PENDING_INPUT,
+        signal_count=3,
+        total_weight=2.0,
+        title="existing title",
+        summary="existing summary",
+        error="Original reason",
+    )
+    report_id = str(report.id)
+
+    with patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture") as capture:
+        await mark_report_pending_input_activity(
+            MarkReportPendingInput(
+                team_id=ateam.id,
+                report_id=report_id,
+                title="retry title",
+                summary="retry summary",
+                reason="Retry reason",
+                signal_count=3,
+                source_products=["zendesk"],
+            )
+        )
+
+    capture.assert_not_called()
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report_id)
+    assert refreshed.status == SignalReport.Status.PENDING_INPUT
+    assert refreshed.title == "existing title"
+    assert refreshed.summary == "existing summary"
+    assert refreshed.error == "Original reason"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_reset_to_potential_is_idempotent_when_already_potential(ateam):
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.POTENTIAL,
+        signal_count=3,
+        total_weight=0.0,
+        error="Original reset reason",
+    )
+    report_id = str(report.id)
+
+    with patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture") as capture:
+        await reset_report_to_potential_activity(
+            ResetReportToPotentialInput(
+                team_id=ateam.id,
+                report_id=report_id,
+                reason="Retry reason",
+                signal_count=3,
+                source_products=["zendesk"],
+            )
+        )
+
+    capture.assert_not_called()
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report_id)
+    assert refreshed.status == SignalReport.Status.POTENTIAL
+    assert refreshed.error == "Original reset reason"
+    assert refreshed.total_weight == 0.0


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

- The "set report to failed" check wasn't idempotent

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- Now it is

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->