### PR TITLE
chore(ci): stop bundle-size report colliding chunk basenames across bundles

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -211,13 +211,15 @@ jobs:
             - name: Check frontend bundle size
               uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
               with:
-                  build-script: '--filter=@posthog/frontend build'
+                  build-script: '--filter=@posthog/frontend build:with-report'
                   install-script: 'pnpm --filter=@posthog/frontend... install'
                   compression: 'none'
-                  # Check all JS bundles in the dist folder
-                  pattern: 'frontend/dist/**/*.js'
-                  # Exclude source maps and chunk files (chunk hashes change every build)
-                  exclude: '{**/*.js.map,**/chunk*.js}'
+                  # dist-report/ carries the source bundle (app/exporter) and source path in the
+                  # filename, so strip-hash yields a stable identity. dist/ has cross-bundle
+                  # basename collisions that cause phantom size changes.
+                  pattern: 'frontend/dist-report/**/*.js'
+                  # Shared chunk hashes change every build, ignore those
+                  exclude: '{**/_chunks/chunk*.js}'
                   # Only show large changes
                   minimum-change-threshold: 1000
                   order-by: 'Size:desc'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -211,15 +211,13 @@ jobs:
             - name: Check frontend bundle size
               uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
               with:
-                  build-script: '--filter=@posthog/frontend build:with-report'
+                  build-script: '--filter=@posthog/frontend build'
                   install-script: 'pnpm --filter=@posthog/frontend... install'
                   compression: 'none'
-                  # dist-report/ carries the source bundle (app/exporter) and source path in the
-                  # filename, so strip-hash yields a stable identity. dist/ has cross-bundle
-                  # basename collisions that cause phantom size changes.
-                  pattern: 'frontend/dist-report/**/*.js'
-                  # Shared chunk hashes change every build, ignore those
-                  exclude: '{**/_chunks/chunk*.js}'
+                  # Check all JS bundles in the dist folder
+                  pattern: 'frontend/dist/**/*.js'
+                  # Exclude source maps and chunk files (chunk hashes change every build)
+                  exclude: '{**/*.js.map,**/chunk*.js}'
                   # Only show large changes
                   minimum-change-threshold: 1000
                   order-by: 'Size:desc'

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ playwright/__snapshots__/
 frontend/.cache/
 frontend/@posthog/apps-common/dist/
 frontend/dist/
+frontend/dist-report/
 frontend/pnpm-error.log
 frontend/public/Matter*.woff*
 frontend/tmp

--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -509,7 +509,7 @@ export async function buildOrWatch(config) {
 
             if (writeMetaFile) {
                 await fs.writeFile(
-                    `${config.name.toLowerCase().replace(' ', '-')}-esbuild-meta.json`,
+                    `${config.name.toLowerCase().replace(/ /g, '-')}-esbuild-meta.json`,
                     JSON.stringify(buildResult.metafile)
                 )
             }

--- a/frontend/bin/build-bundle-report.mjs
+++ b/frontend/bin/build-bundle-report.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import fse from 'fs-extra'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const frontendDir = path.resolve(__dirname, '..')
+const reportDir = path.join(frontendDir, 'dist-report')
+
+const builds = [
+    { name: 'app', metaFile: 'posthog-app-esbuild-meta.json' },
+    { name: 'exporter', metaFile: 'exporter-esbuild-meta.json' },
+]
+
+function sanitizeSourcePath(p) {
+    return p
+        .split(path.sep)
+        .map((s) => (s === '..' ? '_parent' : s))
+        .join(path.sep)
+}
+
+fse.removeSync(reportDir)
+fse.mkdirSync(reportDir, { recursive: true })
+
+let totalCopied = 0
+for (const build of builds) {
+    const metaPath = path.join(frontendDir, build.metaFile)
+    if (!fse.existsSync(metaPath)) {
+        console.warn(`Bundle report: metafile not found for ${build.name} at ${metaPath}, skipping`)
+        continue
+    }
+    const meta = JSON.parse(fse.readFileSync(metaPath, 'utf-8'))
+
+    for (const [outPath, outInfo] of Object.entries(meta.outputs)) {
+        if (!outPath.endsWith('.js')) {
+            continue
+        }
+        const src = path.resolve(frontendDir, outPath)
+        if (!fse.existsSync(src)) {
+            continue
+        }
+
+        const baseFile = path.basename(outPath)
+        const subPath = outInfo.entryPoint
+            ? path.join(sanitizeSourcePath(path.dirname(outInfo.entryPoint)), baseFile)
+            : path.join('_chunks', baseFile)
+
+        const dest = path.join(reportDir, build.name, subPath)
+        fse.mkdirSync(path.dirname(dest), { recursive: true })
+        fse.copyFileSync(src, dest)
+        totalCopied++
+    }
+}
+
+console.info(`Bundle report: wrote ${totalCopied} files to ${reportDir}`)

--- a/frontend/bin/build-bundle-report.mjs
+++ b/frontend/bin/build-bundle-report.mjs
@@ -7,11 +7,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const frontendDir = path.resolve(__dirname, '..')
 const reportDir = path.join(frontendDir, 'dist-report')
 
-const builds = [
-    { name: 'app', metaFile: 'posthog-app-esbuild-meta.json' },
-    { name: 'exporter', metaFile: 'exporter-esbuild-meta.json' },
-]
+const META_SUFFIX = '-esbuild-meta.json'
 
+// entryPoint can be `../products/...` for workspace imports — flatten `..` so the
+// destination stays under the per-bundle subdir of dist-report/.
+// The CI bundle-size action's `**/_chunks/chunk*.js` exclude (in
+// .github/workflows/ci-frontend.yml) depends on the `_chunks` literal below;
+// keep them in sync if either changes.
 function sanitizeSourcePath(p) {
     return p
         .split(path.sep)
@@ -19,37 +21,72 @@ function sanitizeSourcePath(p) {
         .join(path.sep)
 }
 
+function discoverMetafiles() {
+    return fse
+        .readdirSync(frontendDir)
+        .filter((name) => name.endsWith(META_SUFFIX))
+        .map((name) => ({
+            name: name.slice(0, -META_SUFFIX.length),
+            metaPath: path.join(frontendDir, name),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+}
+
 fse.removeSync(reportDir)
 fse.mkdirSync(reportDir, { recursive: true })
 
-let totalCopied = 0
-for (const build of builds) {
-    const metaPath = path.join(frontendDir, build.metaFile)
-    if (!fse.existsSync(metaPath)) {
-        console.warn(`Bundle report: metafile not found for ${build.name} at ${metaPath}, skipping`)
-        continue
-    }
-    const meta = JSON.parse(fse.readFileSync(metaPath, 'utf-8'))
+const metafiles = discoverMetafiles()
+if (metafiles.length === 0) {
+    console.error(
+        `Bundle report: no ${META_SUFFIX} files found in ${frontendDir}. ` +
+            `Each production esbuild config must have writeMetaFile enabled — see frontend/build.mjs. ` +
+            `Did the esbuild step run?`
+    )
+    process.exit(1)
+}
 
+let totalCopied = 0
+for (const { name, metaPath } of metafiles) {
+    let meta
+    try {
+        meta = JSON.parse(fse.readFileSync(metaPath, 'utf-8'))
+    } catch (err) {
+        console.error(`Bundle report: failed to parse ${metaPath}: ${err.message}`)
+        process.exit(1)
+    }
+
+    let copiedForBundle = 0
     for (const [outPath, outInfo] of Object.entries(meta.outputs)) {
         if (!outPath.endsWith('.js')) {
             continue
         }
         const src = path.resolve(frontendDir, outPath)
         if (!fse.existsSync(src)) {
+            console.warn(`Bundle report: ${name} metafile lists ${outPath} but file is missing on disk; skipping`)
             continue
         }
 
         const baseFile = path.basename(outPath)
-        const subPath = outInfo.entryPoint
-            ? path.join(sanitizeSourcePath(path.dirname(outInfo.entryPoint)), baseFile)
-            : path.join('_chunks', baseFile)
+        const subPath =
+            outInfo.entryPoint && outInfo.entryPoint !== '.'
+                ? path.join(sanitizeSourcePath(path.dirname(outInfo.entryPoint)), baseFile)
+                : path.join('_chunks', baseFile)
 
-        const dest = path.join(reportDir, build.name, subPath)
+        const dest = path.join(reportDir, name, subPath)
         fse.mkdirSync(path.dirname(dest), { recursive: true })
         fse.copyFileSync(src, dest)
+        copiedForBundle++
         totalCopied++
+    }
+
+    if (copiedForBundle === 0) {
+        console.error(`Bundle report: bundle "${name}" contributed zero .js outputs; metafile may be stale`)
+        process.exit(1)
     }
 }
 
-console.info(`Bundle report: wrote ${totalCopied} files to ${reportDir}`)
+console.info(
+    `Bundle report: wrote ${totalCopied} files from ${metafiles.length} bundle(s) (${metafiles
+        .map((m) => m.name)
+        .join(', ')}) to ${reportDir}`
+)

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -47,6 +47,7 @@ await buildInParallel(
             splitting: true,
             format: 'esm',
             outdir: path.resolve(__dirname, 'dist'),
+            writeMetaFile: !isDev,
             ...common,
         },
         {
@@ -86,6 +87,7 @@ await buildInParallel(
             splitting: true,
             format: 'esm',
             outdir: path.resolve(__dirname, 'dist'),
+            writeMetaFile: !isDev,
             ...common,
         },
         {

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -36,6 +36,7 @@ await import('./build-products.mjs')
 const common = {
     absWorkingDir: __dirname,
     bundle: true,
+    writeMetaFile: !isDev,
 }
 
 await buildInParallel(
@@ -47,7 +48,6 @@ await buildInParallel(
             splitting: true,
             format: 'esm',
             outdir: path.resolve(__dirname, 'dist'),
-            writeMetaFile: !isDev,
             ...common,
         },
         {
@@ -87,7 +87,6 @@ await buildInParallel(
             splitting: true,
             format: 'esm',
             outdir: path.resolve(__dirname, 'dist'),
-            writeMetaFile: !isDev,
             ...common,
         },
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
         "copy-scripts": "mkdir -p dist/ && ./bin/copy-posthog-js",
         "clean": "rm -rf dist && mkdir dist",
         "build": "pnpm copy-scripts && pnpm build:esbuild",
+        "build:with-report": "pnpm build && node ./bin/build-bundle-report.mjs",
         "build:esbuild": "DEBUG=0 node ./build.mjs",
         "build:products": "DEBUG=0 node build-products.mjs",
         "build:tailwind": "pnpm --filter=@posthog/tailwind build",


### PR DESCRIPTION
## Problem

The frontend bundle-size CI report (`preactjs/compressed-size-action`) shows several scene chunks (e.g. `CalendarHeatMap`, `EndpointsScene`, `SupportTicketScene`, `DataWarehouseScene`) as changing on most PRs even when their source hasn't been touched. The bundler itself is deterministic — I verified by running `pnpm --filter=@posthog/frontend build` twice from a clean tree and got byte-identical outputs across every chunk in `frontend/dist/`.

The real cause is **chunk-basename collisions in `dist/`**: multiple physical files share one stripped logical name.

- Two esbuild invocations in `frontend/build.mjs` (`PostHog App` and `Exporter`) both use `splitting: true` and the same `outdir: dist`. Each lazy-imports the same scene files, and esbuild names dynamic-import chunks after the source's basename (`commonConfig.chunkNames: '[name]-[hash]'`). So both builds emit their own `CalendarHeatMap-HASH.js` referencing their own shared chunks.
- A few scene source files exist in two locations with the same basename, e.g. `frontend/src/scenes/data-warehouse/DataWarehouseScene.tsx` and `products/data_warehouse/DataWarehouseScene.tsx`.

The size action's `strip-hash: "-[A-Za-z0-9]{8}\.js$"` collapses all of these to one logical name. The action then picks one physical file per stripped name; which one it picks depends on the alphabetical order of the hashes. When unrelated source changes shuffle shared-chunk hashes, the alphabetical winner flips and the action reports a phantom diff — e.g. the originally screenshotted `CalendarHeatMap -3.97 kB (-43.9%)` is exactly `9037 − 5070 = 3967` bytes, the size delta between the App and Exporter chunks of the same source file.

## Changes

Build infrastructure only. Runtime `dist/` layout, Django/CDN paths, and `index.html` references are untouched. **This PR ships the infrastructure but does not yet switch the workflow over** — see *Follow-up* below.

- `common/esbuilder/utils.mjs` — fix `.replace(' ', '-')` to `.replace(/ /g, '-')` so multi-word build names (e.g. `'Monaco Editor Worker'`) produce clean metafile filenames.
- `frontend/build.mjs` — hoist `writeMetaFile: !isDev` into the shared `common` config so every prod build (PostHog App, Exporter, Decompression Worker, Monaco Editor/JSON/TypeScript Workers, Render Query, Toolbar) emits a metafile.
- `frontend/bin/build-bundle-report.mjs` — new post-build script. Discovers metafiles via `*-esbuild-meta.json` glob (no hard-coded list), reads each metafile, and copies every emitted `.js` into a parallel `frontend/dist-report/<bundle>/<source-path>/<original-filename>` tree where collisions are structurally impossible. Outputs without `entryPoint` go under `_chunks/`. `..` segments in source paths become `_parent` so the tree stays inside the per-bundle subdir. Fails loud (`exit 1`) on missing metafiles, malformed JSON, or any bundle contributing zero outputs.
- `frontend/package.json` — new `build:with-report` script: `pnpm build && node ./bin/build-bundle-report.mjs`.
- `.gitignore` — ignore `frontend/dist-report/`.

After the change, a stripped path like `posthog-app/src/scenes/insights/views/CalendarHeatMap/CalendarHeatMap.js` is distinct from `exporter/src/scenes/insights/views/CalendarHeatMap/CalendarHeatMap.js`, and the three `DataWarehouseScene` chunks each land at distinct disambiguated paths.

## Follow-up

A follow-up PR will switch `.github/workflows/ci-frontend.yml`'s `compressed-size-action` step from `build` / `frontend/dist/**/*.js` to `build:with-report` / `frontend/dist-report/**/*.js`. That couldn't be done here because the action checks out the base branch and runs the build-script there too — master doesn't have `build:with-report` yet, so doing both in one PR fails the base build with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`. Once this PR lands, the workflow switch is a clean one-file change.

## How did you test this code?

Agent-authored, no manual UI testing.

Automated verification done locally:

- Ran `pnpm --filter=@posthog/frontend build` twice from a clean tree and confirmed byte-identical hashes/sizes for the previously "flapping" scene chunks. Bundling is deterministic.
- Ran `pnpm --filter=@posthog/frontend build:with-report` and verified:
    - `dist/` is unchanged vs the previous build (2650 files, hashless entrypoints `index.js`/`index.css`/`exporter.js` still emitted by `createHashlessEntrypoints`).
    - `dist-report/` contains 1030 `.js` files across **8 bundles** (posthog-app, exporter, decompression-worker, monaco-editor-worker, monaco-json-worker, monaco-typescript-worker, render-query, toolbar) and **zero stripped-name collisions** (down from many in `dist/`).
    - All previously colliding scenes (`CalendarHeatMap`, `EndpointsScene`, `SupportTicketScene`, `DataWarehouseScene`) are disambiguated under `posthog-app/` vs `exporter/` subdirs.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code, an agent.

- Tools used: Read, Edit, Write, Bash, Grep, Glob, Graphite MCP for git/PR ops, qa-swarm review skill (paul-reviewer + xp-reviewer + qa-team specialists; security-audit skipped — PostHog MCP not available in this session).
- Iteration history:
    1. First commit shipped the workflow switch in one go. CI base-branch build then failed because master didn't have the new `build:with-report` script.
    2. Second commit responded to convergent feedback from qa-swarm (paul + xp) and external bots (greptile-apps, chatgpt-codex-connector): replaced the hard-coded `builds` array with a glob, added fail-loud behaviour on missing/malformed/empty metafiles, hoisted `writeMetaFile: !isDev` into shared `common` so all 8 prod bundles get coverage (was 2), and fixed the upstream `replace(' ', '-')` multi-space bug.
    3. Third commit (this one) reverts the workflow change so the infrastructure can land on master first; a follow-up PR will switch the workflow.
- Approach considered and rejected: per-build `chunkNames: 'app/[name]-[hash]'` / `'exporter/[name]-[hash]'` in `build.mjs`. Effective, but it changes runtime `/static/...` paths and would knock on through Django staticfiles, CDN cache keys, and any hardcoded references. Rejected in favour of a CI-only parallel report tree that leaves runtime untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
