### PR TITLE
fix(settings): use sticky positioning for nav to prevent invite banner overlap

### DIFF
--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -358,7 +358,7 @@ export function Settings({
                     className={clsx(
                         'border rounded w-[var(--settings-nav-width)] flex flex-col',
                         isFullScene
-                            ? 'fixed top-[calc(var(--scene-layout-header-height)+var(--scene-padding))] bottom-[var(--scene-padding)]'
+                            ? 'sticky top-[calc(var(--scene-layout-header-height)+var(--scene-padding))] self-start max-h-[calc(100dvh-var(--scene-layout-header-height)-var(--scene-padding))]'
                             : 'sticky top-[var(--scene-layout-header-height)] self-start max-h-[calc(100dvh-var(--scene-layout-header-height)-var(--scene-padding))]'
                     )}
                 >


### PR DESCRIPTION
## Problem

The settings page nav uses `fixed` positioning, which takes it out of document flow. When an invite banner is rendered above the settings content (in normal document flow), the nav overlaps it and the banner is hidden behind the nav panel.

## Fix

Change `fixed` to `sticky` with `self-start` and `max-h-[calc(100dvh-...)]` on the `isFullScene` branch. This matches the pattern already used for the non-full-scene case on the same element — sticky keeps the nav within document flow so it stacks correctly with banners, while still following scroll.

## Visual

Before: `fixed top-[...] bottom-[...]` (out of flow, overlaps banners)
After: `sticky top-[...] self-start max-h-[...]` (in flow, respects banners)

Fixes #59203