### PR TITLE
chore(ci): trigger openapi check on MCP schema source changes

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -207,8 +207,13 @@ jobs:
                         - 'frontend/bin/generate-openapi-types.mjs'
                         - 'frontend/src/lib/api-orval-mutator.ts'
                         - 'services/mcp/scripts/**/*'
+                        # MCP tool config sources - feed generate-tools.ts
                         - 'services/mcp/definitions/**/*.yaml'
+                        - 'services/mcp/definitions/prompts/**/*.md'
                         - 'products/*/mcp/**/*.yaml'
+                        - 'products/*/mcp/prompts/**/*.md'
+                        - 'services/mcp/schema/tool-definitions.json'
+                        - 'services/mcp/schema/tool-definitions-v2.json'
                         - 'services/mcp/src/tools/generated/**/*'
                         - 'services/mcp/schema/generated-tool-definitions.json'
                         - 'services/mcp/schema/tool-definitions-all.json'


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

A recent MCP PR went green on CI then broke `check-migrations` on master, because it touched MCP schema sources that weren't covered by the paths-filter that gates the OpenAPI types check on PRs.

The `openapi_types` filter in `ci-backend.yml` watched the *generated* tool definitions and the YAML configs, but not the handwritten v1/v2 schema JSONs or the markdown prompt files referenced from YAML via `description_file` — all of which feed `generate-tools.ts`. On master pushes the filter is bypassed (`if: github.event_name != 'push'`), which is why master caught the stale `tool-definitions-all.json` and the PR didn't.

## Changes

Add the missing source inputs to the `openapi_types` filter:

- `services/mcp/schema/tool-definitions.json` (handwritten v1 source)
- `services/mcp/schema/tool-definitions-v2.json` (handwritten v2 source)
- `services/mcp/definitions/prompts/**/*.md`
- `products/*/mcp/prompts/**/*.md`

## How did you test this code?

I'm an agent. No manual testing beyond running `hogli build:openapi` locally against a clean checkout of `origin/master` to confirm there's no leftover drift before this lands. The change itself is a YAML path-filter edit; CI on this PR exercises the new filter — touching one of the newly listed paths in a follow-up should now trigger `check-migrations`.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude Code at @webjunkie's request after Marcel flagged the gap in Slack.

Investigation:
- Traced the offending commit to confirm it modified `services/mcp/schema/tool-definitions.json` and a couple `services/mcp/src/` TS files — none matched the existing `backend` or `openapi_types` filters.
- Read `services/mcp/scripts/generate-tools.ts` to enumerate every input that flows into the generated outputs (`OPENAPI_PATH`, `SCHEMA_JSON_PATH`, the v1/v2 schema JSONs, YAML configs, and `description_file` markdown paths). `OPENAPI_PATH` is gitignored and `SCHEMA_JSON_PATH` is already covered by the `backend` filter (which also gates `check-migrations`); the rest were either already present or are the four entries added here.
- Kept the additions narrow rather than broadening to `products/*/mcp/**` because that directory also contains MCP UI app TSX which doesn't affect generated tool definitions.
