### PR TITLE
feat(property-vals): add event_name column to property_values

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -23,7 +23,7 @@
   dockerfile: ./rust/Dockerfile
   project: vznmbshh6q
 
-- image: property-values-aggregator
+- image: property-vals-rs
   dockerfile: ./rust/Dockerfile
   project: vznmbshh6q
 

--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -23,6 +23,10 @@
   dockerfile: ./rust/Dockerfile
   project: vznmbshh6q
 
+- image: property-values-aggregator
+  dockerfile: ./rust/Dockerfile
+  project: vznmbshh6q
+
 - image: cymbal
   dockerfile: ./rust/Dockerfile
   project: 8dq0xkk0ck

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -65,8 +65,8 @@ jobs:
                     - release: property-defs-rs
                       digest_key: property-defs-rs
                       values_key: image
-                    - release: property-values-aggregator
-                      digest_key: property-values-aggregator
+                    - release: property-vals-rs
+                      digest_key: property-vals-rs
                       values_key: image
                     - release: feature-flags
                       digest_key: feature-flags

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -65,6 +65,9 @@ jobs:
                     - release: property-defs-rs
                       digest_key: property-defs-rs
                       values_key: image
+                    - release: property-values-aggregator
+                      digest_key: property-values-aggregator
+                      values_key: image
                     - release: feature-flags
                       digest_key: feature-flags
                       values_key: image

--- a/posthog/clickhouse/migrations/0259_property_values_event_name_column.py
+++ b/posthog/clickhouse/migrations/0259_property_values_event_name_column.py
@@ -1,0 +1,53 @@
+from posthog import settings
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.property_values import (
+    DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL,
+    DROP_PROPERTY_VALUES_MV_SQL,
+    DROP_PROPERTY_VALUES_TABLE_SQL,
+    KAFKA_PROPERTY_VALUES_TABLE_SQL_FN,
+    PROPERTY_VALUES_MV_SQL,
+    PROPERTY_VALUES_TABLE_SQL,
+)
+
+# event_name is added to the ORDER BY, which cannot be altered in place on an
+# existing MergeTree. The storage table is fresh (no rollout yet), so we drop
+# and recreate together with the MV and Kafka engine table.
+
+if settings.CLOUD_DEPLOYMENT in ("US", "EU"):
+    _ROLES = [NodeRole.AUX]
+elif settings.CLOUD_DEPLOYMENT == "DEV":
+    _ROLES = [NodeRole.DATA]
+else:
+    _ROLES = []
+
+operations = (
+    [
+        run_sql_with_exceptions(
+            DROP_PROPERTY_VALUES_MV_SQL(),
+            node_roles=_ROLES,
+        ),
+        run_sql_with_exceptions(
+            DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL(),
+            node_roles=_ROLES,
+        ),
+        run_sql_with_exceptions(
+            DROP_PROPERTY_VALUES_TABLE_SQL(),
+            node_roles=_ROLES,
+        ),
+        run_sql_with_exceptions(
+            PROPERTY_VALUES_TABLE_SQL(),
+            node_roles=_ROLES,
+        ),
+        run_sql_with_exceptions(
+            KAFKA_PROPERTY_VALUES_TABLE_SQL_FN(),
+            node_roles=_ROLES,
+        ),
+        run_sql_with_exceptions(
+            PROPERTY_VALUES_MV_SQL(),
+            node_roles=_ROLES,
+        ),
+    ]
+    if _ROLES
+    else []
+)

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0258_hog_invocation_results_warpstream_cyclotron
+0259_property_values_event_name_column

--- a/posthog/clickhouse/property_values.py
+++ b/posthog/clickhouse/property_values.py
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
     `property_type` LowCardinality(String),
     `property_key` String,
     `property_value` String,
+    `event_name` LowCardinality(String),
     `property_count` UInt64
 ) ENGINE = {engine}
 """
@@ -30,6 +31,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
     `property_type` LowCardinality(String),
     `property_key` LowCardinality(String),
     `property_value` String,
+    `event_name` LowCardinality(String),
     `property_count` SimpleAggregateFunction(sum, UInt64),
     `last_seen` SimpleAggregateFunction(max, DateTime) DEFAULT now()
     {extra_fields}
@@ -41,7 +43,7 @@ def PROPERTY_VALUES_TABLE_SQL() -> str:
     return (
         PROPERTY_VALUES_TABLE_BASE_SQL
         + """
-ORDER BY (team_id, property_type, property_key, property_value)
+ORDER BY (team_id, property_type, property_key, property_value, event_name)
 TTL last_seen + INTERVAL 30 DAY DELETE
 SETTINGS
     index_granularity = 8192,
@@ -74,6 +76,10 @@ def DROP_PROPERTY_VALUES_MV_SQL() -> str:
     return f"DROP TABLE IF EXISTS {MV_NAME}"
 
 
+def DROP_PROPERTY_VALUES_TABLE_SQL() -> str:
+    return f"DROP TABLE IF EXISTS {TABLE_NAME} SYNC"
+
+
 def PROPERTY_VALUES_MV_SQL() -> str:
     return """
 CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name}
@@ -83,6 +89,7 @@ AS SELECT
     property_type,
     property_key,
     property_value,
+    event_name,
     property_count,
     coalesce(_timestamp, now()) as last_seen
 FROM {database}.{kafka_table}

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -575,6 +575,7 @@
       `property_type` LowCardinality(String),
       `property_key` String,
       `property_value` String,
+      `event_name` LowCardinality(String),
       `property_count` UInt64
   ) ENGINE = Kafka(warpstream_ingestion, kafka_topic_list = 'clickhouse_property_values_test', kafka_group_name = 'clickhouse_property_values', kafka_format = 'JSONEachRow')
   
@@ -2402,6 +2403,7 @@
       `property_type` LowCardinality(String),
       `property_key` String,
       `property_value` String,
+      `event_name` LowCardinality(String),
       `property_count` UInt64
   ) ENGINE = Kafka(warpstream_ingestion, kafka_topic_list = 'clickhouse_property_values_test', kafka_group_name = 'clickhouse_property_values', kafka_format = 'JSONEachRow')
   
@@ -3674,13 +3676,14 @@
       `property_type` LowCardinality(String),
       `property_key` LowCardinality(String),
       `property_value` String,
+      `event_name` LowCardinality(String),
       `property_count` SimpleAggregateFunction(sum, UInt64),
       `last_seen` SimpleAggregateFunction(max, DateTime) DEFAULT now()
       ,
       INDEX idx_property_value property_value TYPE text(tokenizer = ngrams(3), preprocessor = lower(property_value)) GRANULARITY 1
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.property_values', '{replica}-{shard}')
   
-  ORDER BY (team_id, property_type, property_key, property_value)
+  ORDER BY (team_id, property_type, property_key, property_value, event_name)
   TTL last_seen + INTERVAL 30 DAY DELETE
   SETTINGS
       index_granularity = 8192,
@@ -3697,6 +3700,7 @@
       `property_type` LowCardinality(String),
       `property_key` LowCardinality(String),
       `property_value` String,
+      `event_name` LowCardinality(String),
       `property_count` SimpleAggregateFunction(sum, UInt64),
       `last_seen` SimpleAggregateFunction(max, DateTime) DEFAULT now()
       
@@ -3714,6 +3718,7 @@
       property_type,
       property_key,
       property_value,
+      event_name,
       property_count,
       coalesce(_timestamp, now()) as last_seen
   FROM posthog_test.kafka_property_values
@@ -8114,13 +8119,14 @@
       `property_type` LowCardinality(String),
       `property_key` LowCardinality(String),
       `property_value` String,
+      `event_name` LowCardinality(String),
       `property_count` SimpleAggregateFunction(sum, UInt64),
       `last_seen` SimpleAggregateFunction(max, DateTime) DEFAULT now()
       ,
       INDEX idx_property_value property_value TYPE text(tokenizer = ngrams(3), preprocessor = lower(property_value)) GRANULARITY 1
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.property_values', '{replica}-{shard}')
   
-  ORDER BY (team_id, property_type, property_key, property_value)
+  ORDER BY (team_id, property_type, property_key, property_value, event_name)
   TTL last_seen + INTERVAL 30 DAY DELETE
   SETTINGS
       index_granularity = 8192,

--- a/rust/property-vals-rs/src/aggregator.rs
+++ b/rust/property-vals-rs/src/aggregator.rs
@@ -48,6 +48,7 @@ mod tests {
             property_type: PropertyType::Event,
             property_key: key.to_string(),
             property_value: value.to_string(),
+            event_name: "$pageview".to_string(),
         }
     }
 
@@ -65,8 +66,9 @@ mod tests {
             property_type in arb_property_type(),
             property_key in "[a-c]{1,3}",
             property_value in "[x-z]{1,3}",
+            event_name in prop_oneof!["[a-c]{1,3}", Just("$pageview".to_string())],
         ) -> TupleKey {
-            TupleKey { team_id, property_type, property_key, property_value }
+            TupleKey { team_id, property_type, property_key, property_value, event_name }
         }
     }
 

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -5,14 +5,28 @@ use crate::types::{Event, GroupIdentify, PropertyType, TupleKey};
 pub const MAX_PROPERTY_KEY_LEN: usize = 400;
 pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
 
+pub const GROUP_IDENTIFY_EVENT_NAME: &str = "$groupidentify";
+
 pub fn fan_out(event: &Event) -> Vec<TupleKey> {
     let mut out = Vec::new();
 
     if let Some(raw) = &event.properties {
-        emit_from_blob(event.team_id, PropertyType::Event, raw, &mut out);
+        emit_from_blob(
+            event.team_id,
+            PropertyType::Event,
+            &event.event,
+            raw,
+            &mut out,
+        );
     }
     if let Some(raw) = &event.person_properties {
-        emit_from_blob(event.team_id, PropertyType::Person, raw, &mut out);
+        emit_from_blob(
+            event.team_id,
+            PropertyType::Person,
+            &event.event,
+            raw,
+            &mut out,
+        );
     }
 
     out
@@ -24,6 +38,7 @@ pub fn fan_out_group(event: &GroupIdentify) -> Vec<TupleKey> {
         emit_from_blob(
             event.team_id,
             PropertyType::Group(event.group_type_index),
+            GROUP_IDENTIFY_EVENT_NAME,
             raw,
             &mut out,
         );
@@ -31,7 +46,13 @@ pub fn fan_out_group(event: &GroupIdentify) -> Vec<TupleKey> {
     out
 }
 
-fn emit_from_blob(team_id: i64, property_type: PropertyType, raw: &str, out: &mut Vec<TupleKey>) {
+fn emit_from_blob(
+    team_id: i64,
+    property_type: PropertyType,
+    event_name: &str,
+    raw: &str,
+    out: &mut Vec<TupleKey>,
+) {
     let parsed: Value = match serde_json::from_str(raw) {
         Ok(v) => v,
         Err(_) => return,
@@ -61,6 +82,7 @@ fn emit_from_blob(team_id: i64, property_type: PropertyType, raw: &str, out: &mu
             property_type,
             property_key: key.clone(),
             property_value,
+            event_name: event_name.to_string(),
         });
     }
 }
@@ -81,6 +103,7 @@ mod tests {
     fn event(properties: &str) -> Event {
         Event {
             team_id: 2,
+            event: "$pageview".to_string(),
             properties: Some(properties.to_string()),
             person_properties: None,
         }
@@ -116,13 +139,23 @@ mod tests {
         }
     }
 
+    fn arb_event_name() -> impl Strategy<Value = String> {
+        prop_oneof![
+            Just("$pageview".to_string()),
+            Just("$autocapture".to_string()),
+            Just("$identify".to_string()),
+            "[a-z_]{1,20}",
+        ]
+    }
+
     prop_compose! {
         fn arb_event()(
             team_id: i64,
+            event in arb_event_name(),
             properties in prop::option::of(arb_blob()),
             person_properties in prop::option::of(arb_blob()),
         ) -> Event {
-            Event { team_id, properties, person_properties }
+            Event { team_id, event, properties, person_properties }
         }
     }
 
@@ -202,6 +235,7 @@ mod tests {
     fn person_properties_emit_person_type() {
         let ev = Event {
             team_id: 2,
+            event: "$identify".to_string(),
             properties: None,
             person_properties: Some(r#"{"email":"foo@bar.com"}"#.to_string()),
         };
@@ -210,6 +244,20 @@ mod tests {
         assert_eq!(tuples[0].property_type, PropertyType::Person);
         assert_eq!(tuples[0].property_key, "email");
         assert_eq!(tuples[0].property_value, "foo@bar.com");
+        assert_eq!(tuples[0].event_name, "$identify");
+    }
+
+    #[test]
+    fn event_property_carries_event_name() {
+        let tuples = fan_out(&event(r#"{"$browser":"Chrome"}"#));
+        assert_eq!(tuples[0].event_name, "$pageview");
+    }
+
+    #[test]
+    fn group_identify_emits_groupidentify_event_name() {
+        let tuples = fan_out_group(&group_identify(0, r#"{"plan":"enterprise"}"#));
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].event_name, GROUP_IDENTIFY_EVENT_NAME);
     }
 
     #[test]

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -18,6 +18,7 @@ struct Outgoing<'a> {
     property_type: PropertyType,
     property_key: &'a str,
     property_value: &'a str,
+    event_name: &'a str,
     property_count: u64,
 }
 
@@ -80,6 +81,7 @@ impl Producer for AggregatedProducer {
                 property_type: tuple.property_type,
                 property_key: &tuple.property_key,
                 property_value: &tuple.property_value,
+                event_name: &tuple.event_name,
                 property_count: *count,
             })
             .collect();

--- a/rust/property-vals-rs/src/types.rs
+++ b/rust/property-vals-rs/src/types.rs
@@ -9,6 +9,8 @@ pub struct Event {
     pub team_id: i64,
 
     #[serde(default)]
+    pub event: String,
+    #[serde(default)]
     pub properties: Option<String>,
     #[serde(default)]
     pub person_properties: Option<String>,
@@ -40,6 +42,7 @@ pub struct TupleKey {
     pub property_type: PropertyType,
     pub property_key: String,
     pub property_value: String,
+    pub event_name: String,
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -209,6 +209,7 @@ mod tests {
             property_type: PropertyType::Event,
             property_key: key.to_string(),
             property_value: value.to_string(),
+            event_name: "$pageview".to_string(),
         }
     }
 
@@ -321,8 +322,9 @@ mod tests {
             property_type in arb_property_type(),
             property_key in "[a-c]{1,2}",
             property_value in "[x-z]{1,2}",
+            event_name in prop_oneof!["[a-c]{1,2}", Just("$pageview".to_string())],
         ) -> TupleKey {
-            TupleKey { team_id, property_type, property_key, property_value }
+            TupleKey { team_id, property_type, property_key, property_value, event_name }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds `event_name` to the `property_values` table's merge key and threads it through the property-vals-rs service.

The value-search UX needs to scope by event: "give me all values of `email` seen on `$identify` events." Without `event_name` in the merge key, queries had to scan all values for a property and filter. With it, the ORDER BY prefix `(team_id, property_type, property_key, event_name)` is a precise index lookup. Targeted searches across one event (or a small `IN` set) are fast; users can iterate over a few candidate events without paying a scan tax per query.

## Changes

- ClickHouse: migration `0259_property_values_event_name_column` drops + recreates the storage table, Kafka engine table, and MV with `event_name` as the fifth ORDER BY column. The storage table can't be `ALTER`-ed to add a new ORDER BY column in place; it's fresh (no rollout yet) so dropping is safe.
- Rust service: `TupleKey` gains an `event_name: String` field. `fan_out` threads `event.event` through for both event and person properties. `fan_out_group` uses the constant `"$groupidentify"` since group properties always originate from that event in the events stream.
- `Outgoing` JSON gains `event_name` so the Kafka engine populates the new column.
- Tests: existing example tests updated for the new `TupleKey` shape. Proptest generators in `aggregator.rs`, `worker.rs`, and `fan_out.rs` cover the new field. Two new example tests assert event_name propagates correctly (event property and group identify).

## Storage cost

Row count multiplies by the fanout of distinct event_names per `(team, type, key, value)`. For typical teams ~3–5x. Hot properties seen on many events get a deeper multiplier. `event_name` is `LowCardinality(String)` so the per-row overhead is dictionary-encoded. The trade buys precise index lookups for event-scoped queries, which is the dominant access pattern for autocomplete.

## Deploy order

Migration first, then service. Until 0259 applies, the storage table doesn't have an `event_name` column, so the old MV body would mismatch. With `ROLLOUT_PERCENTAGE=0` the service isn't actively producing in prod, so the window during which old + new schemas coexist is risk-free, but the migration should still be applied first as standard hygiene.

## 🤖 Agent context

Stacked on top of #59194 (CI image). Builds toward the property-values autocomplete UX. The `event_name = "$groupidentify"` convention for group properties is intentional: a user filtering `event = $groupidentify` will surface group properties, which matches the events-stream reality (group identification is an event with that name carrying `group_properties`).
