### PR TITLE
fix(experiments): allow query POSTs through read-only guard

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6734,7 +6734,7 @@ const api = {
     ): Promise<T> {
         url = prepareUrl(url)
         ensureProjectIdNotInvalid(url)
-        assertNotReadOnly(method)
+        assertNotReadOnly(method, url)
         const isFormData = data instanceof FormData
 
         const response = await handleFetch(url, method, async () => {
@@ -6770,7 +6770,7 @@ const api = {
     async createResponse(url: string, data?: any, options?: ApiMethodOptions): Promise<Response> {
         url = prepareUrl(url)
         ensureProjectIdNotInvalid(url)
-        assertNotReadOnly('POST')
+        assertNotReadOnly('POST', url)
         const isFormData = data instanceof FormData
 
         return await handleFetch(url, 'POST', () =>
@@ -6791,7 +6791,7 @@ const api = {
     async delete(url: string): Promise<any> {
         url = prepareUrl(url)
         ensureProjectIdNotInvalid(url)
-        assertNotReadOnly('DELETE')
+        assertNotReadOnly('DELETE', url)
         return await handleFetch(url, 'DELETE', () =>
             fetch(url, {
                 method: 'DELETE',

--- a/frontend/src/lib/readOnlyGuard.test.ts
+++ b/frontend/src/lib/readOnlyGuard.test.ts
@@ -1,0 +1,143 @@
+import {
+    assertNotReadOnly,
+    isReadOnly,
+    ReadOnlyModeError,
+    setReadOnlyGetter,
+    setReadOnlyNotifier,
+} from 'lib/readOnlyGuard'
+
+describe('readOnlyGuard', () => {
+    afterEach(() => {
+        // Tear down module-level state so each test starts from a clean slate.
+        setReadOnlyGetter(null)
+        setReadOnlyNotifier(null)
+    })
+
+    describe('isReadOnly()', () => {
+        it('returns false when no getter is registered', () => {
+            expect(isReadOnly()).toBe(false)
+        })
+
+        it.each([
+            ['getter returns true', true, true],
+            ['getter returns false', false, false],
+        ])('reflects the registered getter when %s', (_label, getterReturn, expected) => {
+            setReadOnlyGetter(() => getterReturn)
+            expect(isReadOnly()).toBe(expected)
+        })
+    })
+
+    describe('assertNotReadOnly()', () => {
+        describe('when not in read-only mode', () => {
+            it.each([
+                ['POST', '/api/environments/2/dashboards/'],
+                ['PATCH', '/api/environments/2/dashboards/1/'],
+                ['PUT', '/api/environments/2/dashboards/1/'],
+                ['DELETE', '/api/environments/2/dashboards/1/'],
+                ['POST', '/api/environments/2/query/'],
+            ] as const)('lets %s %s through silently', (method, url) => {
+                setReadOnlyGetter(() => false)
+                const notifier = jest.fn()
+                setReadOnlyNotifier(notifier)
+
+                expect(() => assertNotReadOnly(method, url)).not.toThrow()
+                expect(notifier).not.toHaveBeenCalled()
+            })
+        })
+
+        describe('when in read-only mode', () => {
+            beforeEach(() => {
+                setReadOnlyGetter(() => true)
+            })
+
+            it.each([
+                ['POST', '/api/environments/2/dashboards/'],
+                ['PATCH', '/api/environments/2/dashboards/1/'],
+                ['PUT', '/api/environments/2/dashboards/1/'],
+                ['DELETE', '/api/environments/2/dashboards/1/'],
+            ] as const)('blocks %s %s with a ReadOnlyModeError', (method, url) => {
+                expect(() => assertNotReadOnly(method, url)).toThrow(ReadOnlyModeError)
+            })
+
+            it('calls the notifier with the blocked method', () => {
+                const notifier = jest.fn()
+                setReadOnlyNotifier(notifier)
+                expect(() => assertNotReadOnly('POST', '/api/environments/2/dashboards/')).toThrow(ReadOnlyModeError)
+                expect(notifier).toHaveBeenCalledTimes(1)
+                expect(notifier).toHaveBeenCalledWith('POST')
+            })
+
+            it('does not throw when no notifier is registered', () => {
+                // Notifier is optional — guard should still block but stay quiet.
+                expect(() => assertNotReadOnly('POST', '/api/environments/2/dashboards/')).toThrow(ReadOnlyModeError)
+            })
+
+            // Reads-disguised-as-writes (e.g. HogQL/trends/funnels via POST to /query/)
+            // must pass through even in read-only mode — otherwise the app becomes
+            // unusable.
+            it.each([
+                ['plain query', 'POST', '/api/environments/2/query/'],
+                ['query with id', 'POST', '/api/environments/2/query/abc-123/'],
+                ['query upgrade', 'POST', '/api/environments/2/query/upgrade'],
+                ['query log', 'POST', '/api/environments/2/query/abc-123/log'],
+                ['query with trailing query string', 'POST', '/api/environments/2/query/?refresh=true'],
+                ['delete on query path', 'DELETE', '/api/environments/2/query/abc-123/'],
+            ] as const)('lets %s through (%s %s)', (_label, method, url) => {
+                const notifier = jest.fn()
+                setReadOnlyNotifier(notifier)
+                expect(() => assertNotReadOnly(method, url)).not.toThrow()
+                expect(notifier).not.toHaveBeenCalled()
+            })
+
+            it.each([
+                ['endpoint that just contains the word query in a name', 'POST', '/api/environments/2/queryless/'],
+                ['similar prefix without slash', 'POST', '/api/environments/2/queryteam/'],
+            ] as const)('still blocks %s (%s %s) — only paths with /query/ segment are allowed', (_l, method, url) => {
+                expect(() => assertNotReadOnly(method, url)).toThrow(ReadOnlyModeError)
+            })
+        })
+    })
+
+    describe('ReadOnlyModeError', () => {
+        it('has a sensible default detail message so caller error-fallback patterns produce truthful toasts', () => {
+            const err = new ReadOnlyModeError()
+            expect(err.detail).toBe('Read-only mode is on — change blocked. Use Max or the MCP to make this change.')
+            expect(err.name).toBe('ReadOnlyModeError')
+        })
+
+        it('accepts a custom message', () => {
+            const err = new ReadOnlyModeError('custom message')
+            expect(err.message).toBe('custom message')
+        })
+    })
+
+    describe('setReadOnlyGetter', () => {
+        let warnSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+        })
+
+        afterEach(() => {
+            warnSpy.mockRestore()
+        })
+
+        it('warns when overwriting an existing getter (double-mount detection)', () => {
+            setReadOnlyGetter(() => true)
+            setReadOnlyGetter(() => false)
+            expect(warnSpy).toHaveBeenCalledTimes(1)
+            expect(warnSpy.mock.calls[0][0]).toContain('setReadOnlyGetter')
+        })
+
+        it('does not warn when clearing the getter', () => {
+            setReadOnlyGetter(() => true)
+            setReadOnlyGetter(null)
+            expect(warnSpy).not.toHaveBeenCalled()
+        })
+
+        it('does not warn on first registration', () => {
+            setReadOnlyGetter(() => true)
+            expect(warnSpy).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/frontend/src/lib/readOnlyGuard.ts
+++ b/frontend/src/lib/readOnlyGuard.ts
@@ -44,8 +44,23 @@ export function isReadOnly(): boolean {
     return getter?.() ?? false
 }
 
-export function assertNotReadOnly(method: 'PATCH' | 'PUT' | 'POST' | 'DELETE'): void {
+// URLs that look like writes but are actually reads. The query endpoint is the
+// obvious one — it serves HogQL / trends / funnels / retention via POST because
+// the payload is too large for a query string. Block-listing these would make
+// the entire app unusable in read-only mode.
+const READ_ONLY_ALLOWED_PATTERNS = [
+    /\/query(?:\/|$|\?)/, // /api/environments/:team_id/query, /api/environments/:team_id/query/:queryId/log, etc.
+]
+
+function isReadDisguisedAsWrite(url: string): boolean {
+    return READ_ONLY_ALLOWED_PATTERNS.some((pattern) => pattern.test(url))
+}
+
+export function assertNotReadOnly(method: 'PATCH' | 'PUT' | 'POST' | 'DELETE', url: string): void {
     if (!isReadOnly()) {
+        return
+    }
+    if (isReadDisguisedAsWrite(url)) {
         return
     }
     notifier?.(method)


### PR DESCRIPTION
## Problem

When `READ_ONLY_MODE` is on, the read-only guard short-circuits **every** PATCH/PUT/POST/DELETE through `lib/api.ts`. That includes the `/api/environments/:team_id/query/` endpoint, which serves HogQL, trends, funnels, retention, and just about every other read operation — they're POSTs because the payload is too large for a query string.

Result: with the flag on, the app barely renders anything (every insight, every query-backed widget errors out).

## Changes

`frontend/src/lib/readOnlyGuard.ts`:

- Adds a small `READ_ONLY_ALLOWED_PATTERNS` allowlist of URL regexes that look like writes but are actually reads.
- `assertNotReadOnly` now takes the URL and returns early when it matches the allowlist.
- Today: the query endpoint (`/query/` segment). Future read-disguised-as-write paths can be added to the same list.

`frontend/src/lib/api.ts`: the three call sites pass `url` through to the guard.

## How did you test this code?

I'm an agent — no manual run since storybook isn't started locally right now. Reasoning verified by inspecting the loader path in `lib/api.ts` (`query`/`queryStatus`/`queryUpgrade`/`queryLog` all hit a URL containing `/query/`).

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Follow-up to #59372 — the read-only experiment widget. Paul noticed every query insight broke with the flag on; this surfaces the allowlist that lets reads through.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*