### PR TITLE
feat(funnels): scaffold hog-charts funnel line chart prerequisites

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -418,6 +418,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_HOG_CHARTS: 'product-analytics-hog-charts', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_HOG_CHARTS_BAR: 'product-analytics-hog-charts-bar', // owner: @sampennington #team-product-analytics
+    PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL: 'product-analytics-hog-charts-funnel', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineTooltip.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/FunnelLineTooltip.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useMemo } from 'react'
+
+import type { TooltipContext } from 'lib/hog-charts'
+import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
+import { getDatumTitle, type SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+
+import type { BreakdownFilter, DateRange } from '~/queries/schema/schema-general'
+import type { IntervalType } from '~/types'
+
+import { hasBreakdown } from '../../funnelUtils'
+import { FUNNEL_CONVERSION_SERIES_LABEL, type FunnelSeriesMeta } from '../shared/funnelSeriesMeta'
+
+const NOOP = (): void => {}
+
+interface FunnelLineTooltipProps {
+    context: TooltipContext<FunnelSeriesMeta>
+    timezone?: string
+    interval?: IntervalType
+    breakdownFilter?: BreakdownFilter
+    dateRange?: DateRange
+    groupTypeLabel?: string
+    onRowClick?: (datum: SeriesDatum) => void
+}
+
+export function FunnelLineTooltip({
+    context,
+    timezone,
+    interval,
+    breakdownFilter,
+    dateRange,
+    groupTypeLabel,
+    onRowClick,
+}: FunnelLineTooltipProps): React.ReactElement {
+    const seriesData = useMemo<SeriesDatum[]>(
+        () =>
+            context.seriesData.map((entry, idx) => {
+                const meta = entry.series.meta ?? ({} as FunnelSeriesMeta)
+                return {
+                    id: idx,
+                    dataIndex: context.dataIndex,
+                    datasetIndex: idx,
+                    order: meta.order ?? idx,
+                    label: entry.series.label,
+                    color: entry.color,
+                    count: entry.value,
+                    breakdown_value: meta.breakdown_value,
+                    date_label: meta.days?.[context.dataIndex],
+                }
+            }),
+        [context.seriesData, context.dataIndex]
+    )
+
+    const date = context.seriesData[0]?.series.meta?.days?.[context.dataIndex]
+
+    const renderCount = useCallback((value: number): string => `${value}%`, [])
+
+    const renderSeries = useCallback(
+        (_value: React.ReactNode, datum: SeriesDatum): React.ReactElement => {
+            if (hasBreakdown(datum.breakdown_value)) {
+                return <div className="datum-label-column">{getDatumTitle(datum, breakdownFilter)}</div>
+            }
+            return <div className="datum-label-column">{FUNNEL_CONVERSION_SERIES_LABEL}</div>
+        },
+        [breakdownFilter]
+    )
+
+    return (
+        <InsightTooltip
+            date={date}
+            timezone={timezone}
+            seriesData={seriesData}
+            breakdownFilter={breakdownFilter}
+            interval={interval}
+            dateRange={dateRange}
+            groupTypeLabel={groupTypeLabel}
+            onClose={context.onUnpin ?? NOOP}
+            renderSeries={renderSeries}
+            renderCount={renderCount}
+            onRowClick={onRowClick}
+            hideInspectActorsSection={!onRowClick}
+        />
+    )
+}

--- a/frontend/src/scenes/funnels/viz/funnel-line-chart/handleFunnelLineChartClick.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-line-chart/handleFunnelLineChartClick.tsx
@@ -1,0 +1,82 @@
+import { DateDisplay } from 'lib/components/DateDisplay'
+import { dayjs } from 'lib/dayjs'
+import { capitalizeFirstLetter } from 'lib/utils'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
+import type { OpenPersonsModalProps } from 'scenes/trends/persons-modal/PersonsModal'
+
+import type { Noun } from '~/models/groupsModel'
+import type { FormatPropertyValueForDisplayFunction } from '~/models/propertyDefinitionsModel'
+import {
+    type BreakdownFilter,
+    type FunnelsActorsQuery,
+    type FunnelsQuery,
+    NodeKind,
+    type ResolvedDateRangeResponse,
+} from '~/queries/schema/schema-general'
+import type { CohortType, IntervalType } from '~/types'
+
+import { hasBreakdown } from '../../funnelUtils'
+import type { FunnelSeriesMeta } from '../shared/funnelSeriesMeta'
+
+export interface FunnelLineChartClickDeps {
+    hasPersonsModal: boolean
+    querySource: FunnelsQuery | null | undefined
+    interval: IntervalType | null | undefined
+    timezone?: string
+    weekStartDay: number | null | undefined
+    resolvedDateRange: ResolvedDateRangeResponse | null | undefined
+    breakdownFilter: BreakdownFilter | null | undefined
+    aggregationTargetLabel: Noun
+    cohorts: CohortType[]
+    formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction | undefined
+    openPersonsModal: (props: OpenPersonsModalProps) => void
+}
+
+export function handleFunnelLineChartClick(
+    meta: FunnelSeriesMeta,
+    dataIndex: number,
+    deps: FunnelLineChartClickDeps
+): void {
+    if (!deps.hasPersonsModal || !deps.querySource) {
+        return
+    }
+
+    const day = meta.days?.[dataIndex]
+    if (day == null || day === '') {
+        return
+    }
+
+    const breakdownValue = meta.breakdown_value
+    const breakdownLabel = hasBreakdown(breakdownValue)
+        ? formatBreakdownLabel(
+              breakdownValue,
+              deps.breakdownFilter ?? null,
+              deps.cohorts,
+              deps.formatPropertyValueForDisplay
+          )
+        : null
+
+    const title = (
+        <>
+            {capitalizeFirstLetter(deps.aggregationTargetLabel.plural)} converted on{' '}
+            <DateDisplay
+                interval={deps.interval || 'day'}
+                resolvedDateRange={deps.resolvedDateRange ?? undefined}
+                timezone={deps.timezone}
+                weekStartDay={deps.weekStartDay ?? undefined}
+                date={day.toString()}
+            />
+            {breakdownLabel ? <> • {breakdownLabel}</> : null}
+        </>
+    )
+
+    const query: FunnelsActorsQuery = {
+        kind: NodeKind.FunnelsActorsQuery,
+        source: deps.querySource,
+        funnelTrendsDropOff: false,
+        includeRecordings: true,
+        funnelTrendsEntrancePeriodStart: dayjs(day).format('YYYY-MM-DD HH:mm:ss'),
+        ...(hasBreakdown(breakdownValue) ? { funnelStepBreakdown: breakdownValue } : {}),
+    }
+    deps.openPersonsModal({ title, query })
+}

--- a/frontend/src/scenes/funnels/viz/shared/funnelSeriesMeta.ts
+++ b/frontend/src/scenes/funnels/viz/shared/funnelSeriesMeta.ts
@@ -1,5 +1,7 @@
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
+export const FUNNEL_CONVERSION_SERIES_LABEL = 'Conversion'
+
 export type FunnelSeriesMeta = {
     days?: string[]
     // Narrower than BreakdownKeyType — matches SeriesDatum so the tooltip adapter needs no cast.

--- a/frontend/src/test/insight-testing/index.ts
+++ b/frontend/src/test/insight-testing/index.ts
@@ -5,12 +5,13 @@ export type { HogChart } from 'lib/hog-charts/testing'
 export { createInsightTooltipAccessor } from './tooltip-helpers'
 export type { InsightTooltipAccessor } from './tooltip-helpers'
 export {
+    buildFunnelsQuery,
     buildTrendsQuery,
     renderInsight,
     renderInsight as renderInsightPage,
     renderWithInsights,
 } from './render-insight'
-export type { RenderInsightProps, RenderWithInsightsProps } from './render-insight'
+export type { InsightQuery, RenderInsightProps, RenderWithInsightsProps } from './render-insight'
 export {
     breakdown,
     chart,

--- a/frontend/src/test/insight-testing/mocks.ts
+++ b/frontend/src/test/insight-testing/mocks.ts
@@ -7,8 +7,11 @@ import { EventDefinition, PropertyDefinition, RawAnnotationType } from '~/types'
 import {
     actionDefinitions,
     eventDefinitions as defaultEventDefs,
+    type FunnelStepData,
+    funnelTrendsSteps,
     lookupActors,
     lookupCompareSeries,
+    lookupFunnelActors,
     lookupSeries,
     personProperties,
     propertyDefinitions as defaultPropDefs,
@@ -27,12 +30,17 @@ export interface QueryBody {
     [key: string]: unknown
 }
 
+interface FunnelsQueryResponseLike {
+    results: FunnelStepData[]
+}
+
 export interface MockResponse {
     match: (query: QueryBody) => boolean
     response:
         | TrendsQueryResponse
         | ActorsQueryResponse
-        | ((query: QueryBody) => TrendsQueryResponse | ActorsQueryResponse)
+        | FunnelsQueryResponseLike
+        | ((query: QueryBody) => TrendsQueryResponse | ActorsQueryResponse | FunnelsQueryResponseLike)
 }
 
 /** Build an ActorsQueryResponse shaped like the server response, with one row
@@ -99,6 +107,35 @@ function resolveActors(query: QueryBody): Array<{ email: string }> {
     })
 }
 
+/** Funnels in trends-viz mode return a flat `FunnelStep[]` — one entry per series, or per breakdown value. */
+function buildFunnelsResponse(query: QueryBody): FunnelsQueryResponseLike {
+    const breakdownProp = query.breakdownFilter?.breakdowns?.[0]?.property ?? query.breakdownFilter?.breakdown
+    if (breakdownProp && funnelTrendsSteps.byBreakdown[breakdownProp]) {
+        return { results: funnelTrendsSteps.byBreakdown[breakdownProp] }
+    }
+    return { results: [funnelTrendsSteps.default] }
+}
+
+interface FunnelsActorsQueryShape {
+    kind?: string
+    funnelTrendsEntrancePeriodStart?: string | null
+    funnelStepBreakdown?: string | number | null
+}
+
+// PersonsModalLogic wraps the FunnelsActorsQuery in an ActorsQuery, so the funnel fields
+// sit one level deeper at body.source.*.
+function isFunnelsActorsQuery(query: QueryBody): boolean {
+    const source = (query as { source?: FunnelsActorsQueryShape }).source
+    return source?.kind === NodeKind.FunnelsActorsQuery
+}
+
+function resolveFunnelActors(query: QueryBody): Array<{ email: string }> {
+    const source = (query as { source?: FunnelsActorsQueryShape }).source ?? {}
+    // Actors are keyed by calendar date; the query sends a full 'YYYY-MM-DD HH:mm:ss' timestamp.
+    const day = source.funnelTrendsEntrancePeriodStart?.split(' ')[0] ?? null
+    return lookupFunnelActors({ day, breakdown: source.funnelStepBreakdown ?? null })
+}
+
 function resolveSeriesData(query: QueryBody): SeriesData[] {
     const breakdownProp = query.breakdownFilter?.breakdowns?.[0]?.property ?? query.breakdownFilter?.breakdown ?? null
     const isCompare = !!(query as Record<string, unknown>).compareFilter
@@ -153,6 +190,15 @@ export function setupInsightMocks({
         {
             match: (query) => query.kind === NodeKind.TrendsQuery,
             response: (query) => buildTrendsResponse(resolveSeriesData(query)),
+        },
+        {
+            match: (query) => query.kind === NodeKind.FunnelsQuery,
+            response: (query) => buildFunnelsResponse(query),
+        },
+        // Must precede the generic ActorsQuery matcher so funnel actor queries route to lookupFunnelActors.
+        {
+            match: (query) => query.kind === NodeKind.ActorsQuery && isFunnelsActorsQuery(query),
+            response: (query) => buildActorsResponse(resolveFunnelActors(query)),
         },
         {
             match: (query) => query.kind === NodeKind.ActorsQuery,

--- a/frontend/src/test/insight-testing/render-insight.tsx
+++ b/frontend/src/test/insight-testing/render-insight.tsx
@@ -5,8 +5,9 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { actionsModel } from '~/models/actionsModel'
 import { groupsModel } from '~/models/groupsModel'
-import { InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { FunnelsQuery, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
+import { FunnelVizType } from '~/types'
 
 import { initKeaTests } from '../init'
 import { resetCapturedCharts } from './chartjs-mock'
@@ -15,11 +16,28 @@ import { setupInsightMocks, type SetupMocksOptions } from './mocks'
 export const INSIGHT_TEST_KEY = 'test-harness'
 export const INSIGHT_TEST_ID = `new-AdHoc.InsightViz.${INSIGHT_TEST_KEY}`
 
+export type InsightQuery = TrendsQuery | FunnelsQuery
+
 export function buildTrendsQuery(overrides?: Partial<TrendsQuery>): TrendsQuery {
     return {
         kind: NodeKind.TrendsQuery,
         series: [{ kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' }],
         ...overrides,
+    }
+}
+
+export function buildFunnelsQuery(overrides?: Partial<FunnelsQuery>): FunnelsQuery {
+    return {
+        kind: NodeKind.FunnelsQuery,
+        series: [
+            { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
+            { kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' },
+        ],
+        ...overrides,
+        funnelsFilter: {
+            funnelVizType: FunnelVizType.Trends,
+            ...overrides?.funnelsFilter,
+        },
     }
 }
 
@@ -53,7 +71,7 @@ export function renderWithInsights(props: RenderWithInsightsProps): ReturnType<t
 }
 
 export interface RenderInsightProps {
-    query?: TrendsQuery
+    query?: InsightQuery
     showFilters?: boolean
     mocks?: SetupMocksOptions
     featureFlags?: Record<string, string | boolean>
@@ -67,7 +85,7 @@ function InsightWrapper({
     context,
     inSharedMode,
 }: {
-    query: TrendsQuery
+    query: InsightQuery
     showFilters: boolean
     context?: QueryContext<InsightVizNode>
     inSharedMode?: boolean

--- a/frontend/src/test/insight-testing/test-data.ts
+++ b/frontend/src/test/insight-testing/test-data.ts
@@ -254,3 +254,70 @@ export function lookupActors({ event, breakdown, day }: ActorsLookupQuery): Acto
     const breakdownKey = breakdown == null ? '__none__' : String(breakdown)
     return actorsByEventBreakdownDay[event]?.[breakdownKey]?.[String(day)] ?? []
 }
+
+// Funnel trends-viz response shape: `data` holds the conversion percentage over time.
+export interface FunnelStepData {
+    count: number
+    data: number[]
+    days: string[]
+    labels: string[]
+    name?: string
+    breakdown_value?: string | number
+}
+
+export const funnelTrendsSteps = {
+    default: {
+        count: 50,
+        data: [10, 25, 40, 60, 35],
+        days,
+        labels,
+        name: '$pageview → Napped',
+    } satisfies FunnelStepData,
+    byBreakdown: {
+        hedgehog: [
+            {
+                count: 30,
+                data: [20, 35, 50, 70, 45],
+                days,
+                labels,
+                name: '$pageview → Napped',
+                breakdown_value: 'Spike',
+            },
+            {
+                count: 20,
+                data: [5, 15, 30, 50, 25],
+                days,
+                labels,
+                name: '$pageview → Napped',
+                breakdown_value: 'Bramble',
+            },
+        ] satisfies FunnelStepData[],
+    } as Record<string, FunnelStepData[]>,
+}
+
+// Keyed by breakdown value (or '__none__'), then by calendar date.
+const funnelActorsByBreakdownDay: Record<string, Record<string, ActorFixture[]>> = {
+    __none__: {
+        '2024-06-12': [{ email: 'funnel-wed-a@example.com' }, { email: 'funnel-wed-b@example.com' }],
+        '2024-06-13': [{ email: 'funnel-thu-a@example.com' }],
+    },
+    Spike: {
+        '2024-06-12': [{ email: 'funnel-spike@example.com' }],
+    },
+    Bramble: {
+        '2024-06-12': [{ email: 'funnel-bramble@example.com' }],
+    },
+}
+
+export interface FunnelActorsLookupQuery {
+    day?: string | null
+    breakdown?: string | number | null
+}
+
+export function lookupFunnelActors({ day, breakdown }: FunnelActorsLookupQuery): ActorFixture[] {
+    if (!day) {
+        return []
+    }
+    const breakdownKey = breakdown == null ? '__none__' : String(breakdown)
+    return funnelActorsByBreakdownDay[breakdownKey]?.[day] ?? []
+}


### PR DESCRIPTION
## Problem

Precursor to migrating `FunnelLineGraph` to the hog-charts `TimeSeriesLineChart` (follow-up PR). Splitting out the leaf modules and shared test harness so the chart PR stays small and focused on the actual migration.

No user-visible change in this PR — it adds dormant helpers, a new feature flag constant, and test infrastructure. Behavior is unchanged until the chart PR lands and the flag flips.

## Changes

- Generalize `frontend/src/test/insight-testing/` to also accept `FunnelsQuery`: adds `buildFunnelsQuery`, broadens `RenderInsightProps`, adds a canned funnel response and actor lookups, and wires a funnel-specific mock matcher that recognizes `FunnelsActorsQuery` (ordered before the generic `ActorsQuery` matcher used by `personsModalLogic`).
- `FunnelLineTooltip` — minimal tooltip rendering "Conversion" / breakdown label plus `${value}%`, reusing `InsightTooltip` for layout.
- `handleFunnelLineChartClick` — pure click handler that produces the `FunnelsActorsQuery` shape (`funnelTrendsEntrancePeriodStart` + optional `funnelStepBreakdown`) expected by the persons modal.
- `FUNNEL_CONVERSION_SERIES_LABEL` added to `funnelSeriesMeta.ts`.
- `PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL` feature flag constant.

## How did you test this code?

I'm an agent — no manual testing. Helpers in this PR are exercised by the integration tests that land alongside `FunnelLineChart` in the follow-up. Locally:

- `oxlint` clean on the new and touched files.
- Re-ran `frontend/src/test/insight-testing` and the existing trends suites to confirm extending the shared harness didn't regress them.

## Publish to changelog?

no — no user-visible change.

## 🤖 Agent context

Authored with Claude Code (Anthropic) at the request of @sampennington. Requires human review before merge.

This PR was split out of #59541 to keep both halves under 500 lines. Approach for the split: the chart imports tooltip / click handler / meta type but those modules don't import back, so they can land as leaves with the shared test infra. The chart, its tests, stories, and scene wiring land in the follow-up stacked PR.