### PR TITLE
fix(web-analytics): scope WebStatsTableTile dataNode key per tile

### DIFF
--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -891,11 +891,13 @@ export const WebStatsTableTile = ({
     control,
     attachTo,
     headerSlot,
+    uniqueKey,
 }: QueryWithInsightProps<DataTableNode> & {
     breakdownBy: WebStatsBreakdown
     control?: JSX.Element
     tileId: TileId
     headerSlot?: React.ReactNode
+    uniqueKey: string
 }): JSX.Element => {
     const { togglePropertyFilter } = useActions(webAnalyticsLogic)
     const { productTab } = useValues(webAnalyticsLogic)
@@ -1056,7 +1058,7 @@ export const WebStatsTableTile = ({
         query,
         insightProps,
         context,
-        uniqueKey: 'WebAnalytics.WebStatsTableTile',
+        uniqueKey,
     })
 
     return (
@@ -1067,13 +1069,7 @@ export const WebStatsTableTile = ({
                 dataNodeLogicProps={dataNodeLogicProps}
                 skeleton={<TableTileSkeleton numericColumns={numericColumns} />}
             >
-                <Query
-                    uniqueKey="WebAnalytics.WebStatsTableTile"
-                    attachTo={attachTo}
-                    query={query}
-                    readOnly={true}
-                    context={context}
-                />
+                <Query uniqueKey={uniqueKey} attachTo={attachTo} query={query} readOnly={true} context={context} />
             </WebAnalyticsTileSkeletonGate>
         </div>
     )
@@ -1420,6 +1416,7 @@ export const WebQuery = ({
                 control={control}
                 tileId={tileId}
                 headerSlot={headerSlot}
+                uniqueKey={uniqueKey}
             />
         )
     }


### PR DESCRIPTION
## Problem

Web analytics tiles were rendering identical data across stats-table tiles (Paths, Channels, Browsers, Devices, Geography…). Channels and Browsers, for example, showed path values instead of channel types or browser names. Backend queries were correct; the frontend was reading the wrong dataNode response.

## Changes

`WebStatsTableTile` hardcoded `uniqueKey="WebAnalytics.WebStatsTableTile"` for both `<Query>` and `buildDataTableTileDataNodeLogicProps`. `dataTableLogic` is keyed by `vizKey`, so every stats-table tile collapsed into one singleton. The first tile to mount established its `dataNodeLogic` connection in `connect()`, and every other tile read the same response — hence Paths data bleeding into Channels/Browsers/etc.

The fix threads the per-tile `uniqueKey` already passed to `WebQuery` (e.g. `WebAnalytics.\${tileId}.\${tab.id}`) down into `WebStatsTableTile`, so each tile gets its own `dataTableLogic` instance bound to its own `dataNodeLogic`.

## How did you test this code?

Agent-authored. Did not exercise the UI manually. Ran:

- `hogli test frontend/src/scenes/web-analytics/tiles/skeletons/skeletons.test.tsx` — 10/10 pass.

Manual verification of the fix in the dashboard is still recommended before merge.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Investigation path: started from the screenshot showing identical row sets across Paths/Channels/Browsers. Ruled out a backend regression after the user confirmed the response JSON for the Viewport tile was correct. Traced the frontend rendering path through `WebQuery` → `WebStatsTableTile` → `<Query>` → `DataTable` → `dataTableLogic` and noticed `dataTableLogic`'s `key((props) => props.vizKey)` combined with the hardcoded uniqueKey collapsed all tiles into a singleton.
- The hardcoded string predates this regression, but PR #58869 (skeleton gate) made the collision more reliable by pre-mounting `dataNodeLogic` before the inner `<Query>` could establish its own; with the dashboard simplifications in PR #59105 the symptom became consistent.
- Considered also widening `dataNodeLogic` collision protection but the per-tile `uniqueKey` already propagates from the dashboard, so the minimal fix is to use it.