### PR TITLE
fix(web-analytics): include unknown regions and cities in breakdown totals

### DIFF
--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -387,10 +387,11 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
         case WebStatsBreakdown.Region:
             if (Array.isArray(value)) {
                 const [countryCode, regionCode, regionName] = value
+                const regionLabel = regionName || regionCode
                 return (
                     <>
                         {countryCodeToFlag(countryCode)} {COUNTRY_CODE_TO_LONG_NAME[countryCode] || countryCode} -{' '}
-                        {regionName || regionCode}
+                        {regionLabel ? regionLabel : <span className="text-secondary italic">(unknown region)</span>}
                     </>
                 )
             }
@@ -401,7 +402,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                 return (
                     <>
                         {countryCodeToFlag(countryCode)} {COUNTRY_CODE_TO_LONG_NAME[countryCode] || countryCode} -{' '}
-                        {cityName}
+                        {cityName ? cityName : <span className="text-secondary italic">(unknown city)</span>}
                     </>
                 )
             }
@@ -1094,12 +1095,14 @@ const getBreakdownValue = (record: unknown, breakdownBy: WebStatsBreakdown): str
             break
         case WebStatsBreakdown.Region:
             if (Array.isArray(breakdownValue)) {
-                return breakdownValue[1]
+                // Element 1 may be NULL when GeoIP can't resolve a subdivision; skip the
+                // click handler in that case since filtering by NULL has no useful behavior.
+                return breakdownValue[1] ?? undefined
             }
             break
         case WebStatsBreakdown.City:
             if (Array.isArray(breakdownValue)) {
-                return breakdownValue[1]
+                return breakdownValue[1] ?? undefined
             }
             break
         case WebStatsBreakdown.Viewport:

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -328,6 +328,10 @@ const BreakdownValueTitle: QueryContextColumnTitleComponent = (props) => {
     }
 }
 
+const UnknownBreakdownLabel = ({ label }: { label: string }): JSX.Element => (
+    <span className="text-secondary italic">({label})</span>
+)
+
 const BreakdownValueCell: QueryContextColumnComponent = (props) => {
     const { value, query } = props
     const { source } = query
@@ -383,7 +387,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                     </>
                 )
             }
-            break
+            return <UnknownBreakdownLabel label="unknown country" />
         case WebStatsBreakdown.Region:
             if (Array.isArray(value)) {
                 const [countryCode, regionCode, regionName] = value
@@ -391,7 +395,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                 return (
                     <>
                         {countryCodeToFlag(countryCode)} {COUNTRY_CODE_TO_LONG_NAME[countryCode] || countryCode} -{' '}
-                        {regionLabel ? regionLabel : <span className="text-secondary italic">(unknown region)</span>}
+                        {regionLabel ? regionLabel : <UnknownBreakdownLabel label="unknown region" />}
                     </>
                 )
             }
@@ -402,7 +406,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                 return (
                     <>
                         {countryCodeToFlag(countryCode)} {COUNTRY_CODE_TO_LONG_NAME[countryCode] || countryCode} -{' '}
-                        {cityName ? cityName : <span className="text-secondary italic">(unknown city)</span>}
+                        {cityName ? cityName : <UnknownBreakdownLabel label="unknown city" />}
                     </>
                 )
             }
@@ -411,7 +415,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
             if (typeof value === 'number') {
                 return <>{toUtcOffsetFormat(value)}</>
             }
-            break
+            return <UnknownBreakdownLabel label="unknown timezone" />
         case WebStatsBreakdown.Language:
             if (typeof value === 'string') {
                 const [languageCode, countryCode] = value.split('-')
@@ -426,23 +430,28 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                     </>
                 )
             }
-            break
+            return <UnknownBreakdownLabel label="unknown language" />
         case WebStatsBreakdown.DeviceType:
             if (typeof value === 'string') {
                 return <PropertyIcon.WithLabel property="$device_type" value={value} />
             }
-            break
+            return <UnknownBreakdownLabel label="unknown device" />
         case WebStatsBreakdown.Browser:
             if (typeof value === 'string') {
                 return <PropertyIcon.WithLabel property="$browser" value={value} />
             }
-            break
+            return <UnknownBreakdownLabel label="unknown browser" />
         case WebStatsBreakdown.OS:
             if (typeof value === 'string') {
                 return <PropertyIcon.WithLabel property="$os" value={value} />
             }
-            break
+            return <UnknownBreakdownLabel label="unknown OS" />
         case WebStatsBreakdown.InitialReferringDomain:
+            // NULL referrer is canonically "Direct" in PostHog (matches the channel-type
+            // bucketing in sessions_v2). Keep that wording to stay consistent across tiles.
+            if (value == null) {
+                return <UnknownBreakdownLabel label="direct" />
+            }
             if (featureFlags[FEATURE_FLAGS.SHOW_REFERRER_FAVICON]) {
                 if (typeof value === 'string') {
                     return (
@@ -465,6 +474,16 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                 return <>{value.replace(BREAKDOWN_REFERRER_PREFIX, '')}</>
             }
             break
+        case WebStatsBreakdown.InitialUTMSource:
+            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM source" />
+        case WebStatsBreakdown.InitialUTMMedium:
+            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM medium" />
+        case WebStatsBreakdown.InitialUTMCampaign:
+            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM campaign" />
+        case WebStatsBreakdown.InitialUTMTerm:
+            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM term" />
+        case WebStatsBreakdown.InitialUTMContent:
+            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM content" />
     }
 
     if (typeof value === 'string') {

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -328,9 +328,9 @@ const BreakdownValueTitle: QueryContextColumnTitleComponent = (props) => {
     }
 }
 
-const UnknownBreakdownLabel = ({ label }: { label: string }): JSX.Element => (
-    <span className="text-secondary italic">({label})</span>
-)
+const NotSetBreakdownLabel = (): JSX.Element => <span className="text-secondary italic">(not set)</span>
+
+const DirectBreakdownLabel = (): JSX.Element => <span className="text-secondary italic">(direct)</span>
 
 const BreakdownValueCell: QueryContextColumnComponent = (props) => {
     const { value, query } = props
@@ -387,7 +387,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                     </>
                 )
             }
-            return <UnknownBreakdownLabel label="unknown country" />
+            return <NotSetBreakdownLabel />
         case WebStatsBreakdown.Region:
             if (Array.isArray(value)) {
                 const [countryCode, regionCode, regionName] = value
@@ -395,7 +395,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                 return (
                     <>
                         {countryCodeToFlag(countryCode)} {COUNTRY_CODE_TO_LONG_NAME[countryCode] || countryCode} -{' '}
-                        {regionLabel ? regionLabel : <UnknownBreakdownLabel label="unknown region" />}
+                        {regionLabel ? regionLabel : <NotSetBreakdownLabel />}
                     </>
                 )
             }
@@ -406,7 +406,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                 return (
                     <>
                         {countryCodeToFlag(countryCode)} {COUNTRY_CODE_TO_LONG_NAME[countryCode] || countryCode} -{' '}
-                        {cityName ? cityName : <UnknownBreakdownLabel label="unknown city" />}
+                        {cityName ? cityName : <NotSetBreakdownLabel />}
                     </>
                 )
             }
@@ -415,7 +415,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
             if (typeof value === 'number') {
                 return <>{toUtcOffsetFormat(value)}</>
             }
-            return <UnknownBreakdownLabel label="unknown timezone" />
+            return <NotSetBreakdownLabel />
         case WebStatsBreakdown.Language:
             if (typeof value === 'string') {
                 const [languageCode, countryCode] = value.split('-')
@@ -430,27 +430,27 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                     </>
                 )
             }
-            return <UnknownBreakdownLabel label="unknown language" />
+            return <NotSetBreakdownLabel />
         case WebStatsBreakdown.DeviceType:
             if (typeof value === 'string') {
                 return <PropertyIcon.WithLabel property="$device_type" value={value} />
             }
-            return <UnknownBreakdownLabel label="unknown device" />
+            return <NotSetBreakdownLabel />
         case WebStatsBreakdown.Browser:
             if (typeof value === 'string') {
                 return <PropertyIcon.WithLabel property="$browser" value={value} />
             }
-            return <UnknownBreakdownLabel label="unknown browser" />
+            return <NotSetBreakdownLabel />
         case WebStatsBreakdown.OS:
             if (typeof value === 'string') {
                 return <PropertyIcon.WithLabel property="$os" value={value} />
             }
-            return <UnknownBreakdownLabel label="unknown OS" />
+            return <NotSetBreakdownLabel />
         case WebStatsBreakdown.InitialReferringDomain:
             // NULL referrer is canonically "Direct" in PostHog (matches the channel-type
             // bucketing in sessions_v2). Keep that wording to stay consistent across tiles.
             if (value == null) {
-                return <UnknownBreakdownLabel label="direct" />
+                return <DirectBreakdownLabel />
             }
             if (featureFlags[FEATURE_FLAGS.SHOW_REFERRER_FAVICON]) {
                 if (typeof value === 'string') {
@@ -475,15 +475,11 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
             }
             break
         case WebStatsBreakdown.InitialUTMSource:
-            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM source" />
         case WebStatsBreakdown.InitialUTMMedium:
-            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM medium" />
         case WebStatsBreakdown.InitialUTMCampaign:
-            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM campaign" />
         case WebStatsBreakdown.InitialUTMTerm:
-            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM term" />
         case WebStatsBreakdown.InitialUTMContent:
-            return typeof value === 'string' ? <>{value}</> : <UnknownBreakdownLabel label="no UTM content" />
+            return typeof value === 'string' ? <>{value}</> : <NotSetBreakdownLabel />
     }
 
     if (typeof value === 'string') {

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -55,7 +55,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -128,7 +127,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -201,7 +199,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -274,7 +271,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -347,7 +343,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -420,7 +415,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -493,7 +487,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -566,7 +559,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -639,7 +631,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -712,7 +703,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -785,7 +775,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -858,7 +847,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -931,7 +919,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -1004,7 +991,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -1077,7 +1063,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC

--- a/products/web_analytics/backend/hogql_queries/stats_table.py
+++ b/products/web_analytics/backend/hogql_queries/stats_table.py
@@ -598,10 +598,9 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
     def outer_where_breakdown(self) -> ast.Expr | None:
         match self.query.breakdownBy:
             case WebStatsBreakdown.REGION | WebStatsBreakdown.CITY:
-                # Filter only on the country code (element 1) — the region/city (element 2)
-                # may be NULL when GeoIP can't resolve the subdivision/city. Dropping those rows
-                # made the region/city totals diverge from the country totals; instead, keep them
-                # and let the frontend render the NULL element as "(unknown region/city)".
+                # Country (element 1) must be present; region/city (element 2) may be NULL when
+                # GeoIP can't resolve the subdivision/city — those rows surface in the UI as
+                # "(unknown region/city)" so totals stay consistent with the parent Country view.
                 return parse_expr("tupleElement(`context.columns.breakdown_value`, 1) IS NOT NULL")
             case WebStatsBreakdown.VIEWPORT:
                 return parse_expr(
@@ -609,13 +608,24 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
                     "tupleElement(`context.columns.breakdown_value`, 1) != 0 AND tupleElement(`context.columns.breakdown_value`, 2) != 0"
                 )
             case (
-                WebStatsBreakdown.INITIAL_UTM_SOURCE
+                # Breakdowns where missing data is real and worth surfacing as "(unknown ...)"
+                # rather than silently dropped — keeps totals consistent with the overview tile
+                # and parent breakdowns. Path-like breakdowns (PAGE/INITIAL_PAGE/EXIT_*/...) still
+                # drop NULLs via the default branch since a pageview without a path is junk.
+                WebStatsBreakdown.COUNTRY
+                | WebStatsBreakdown.BROWSER
+                | WebStatsBreakdown.OS
+                | WebStatsBreakdown.DEVICE_TYPE
+                | WebStatsBreakdown.LANGUAGE
+                | WebStatsBreakdown.TIMEZONE
+                | WebStatsBreakdown.INITIAL_REFERRING_DOMAIN
+                | WebStatsBreakdown.INITIAL_UTM_SOURCE
                 | WebStatsBreakdown.INITIAL_UTM_CAMPAIGN
                 | WebStatsBreakdown.INITIAL_UTM_MEDIUM
                 | WebStatsBreakdown.INITIAL_UTM_TERM
                 | WebStatsBreakdown.INITIAL_UTM_CONTENT
             ):
-                return None  # actually show null values
+                return None
             case WebStatsBreakdown.INITIAL_CHANNEL_TYPE:
                 return parse_expr(
                     "`context.columns.breakdown_value` IS NOT NULL AND `context.columns.breakdown_value` != ''"

--- a/products/web_analytics/backend/hogql_queries/stats_table.py
+++ b/products/web_analytics/backend/hogql_queries/stats_table.py
@@ -598,7 +598,11 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
     def outer_where_breakdown(self) -> ast.Expr | None:
         match self.query.breakdownBy:
             case WebStatsBreakdown.REGION | WebStatsBreakdown.CITY:
-                return parse_expr("tupleElement(`context.columns.breakdown_value`, 2) IS NOT NULL")
+                # Filter only on the country code (element 1) — the region/city (element 2)
+                # may be NULL when GeoIP can't resolve the subdivision/city. Dropping those rows
+                # made the region/city totals diverge from the country totals; instead, keep them
+                # and let the frontend render the NULL element as "(unknown region/city)".
+                return parse_expr("tupleElement(`context.columns.breakdown_value`, 1) IS NOT NULL")
             case WebStatsBreakdown.VIEWPORT:
                 return parse_expr(
                     "tupleElement(`context.columns.breakdown_value`, 1) IS NOT NULL AND tupleElement(`context.columns.breakdown_value`, 2) IS NOT NULL AND "

--- a/products/web_analytics/backend/hogql_queries/stats_table.py
+++ b/products/web_analytics/backend/hogql_queries/stats_table.py
@@ -600,7 +600,7 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
             case WebStatsBreakdown.REGION | WebStatsBreakdown.CITY:
                 # Country (element 1) must be present; region/city (element 2) may be NULL when
                 # GeoIP can't resolve the subdivision/city — those rows surface in the UI as
-                # "(unknown region/city)" so totals stay consistent with the parent Country view.
+                # "(not set)" so totals stay consistent with the parent Country view.
                 return parse_expr("tupleElement(`context.columns.breakdown_value`, 1) IS NOT NULL")
             case WebStatsBreakdown.VIEWPORT:
                 return parse_expr(
@@ -608,7 +608,7 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
                     "tupleElement(`context.columns.breakdown_value`, 1) != 0 AND tupleElement(`context.columns.breakdown_value`, 2) != 0"
                 )
             case (
-                # Breakdowns where missing data is real and worth surfacing as "(unknown ...)"
+                # Breakdowns where missing data is real and worth surfacing as "(not set)"
                 # rather than silently dropped — keeps totals consistent with the overview tile
                 # and parent breakdowns. Path-like breakdowns (PAGE/INITIAL_PAGE/EXIT_*/...) still
                 # drop NULLs via the default branch since a pageview without a path is junk.

--- a/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_sample_web_analytics_queries.hogql.ambr
+++ b/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_sample_web_analytics_queries.hogql.ambr
@@ -449,7 +449,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(`context.columns.breakdown_value`, NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -501,7 +500,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(`context.columns.breakdown_value`, NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -527,7 +525,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(`context.columns.breakdown_value`, NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -685,7 +682,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(`context.columns.breakdown_value`, NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -863,7 +859,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(`context.columns.breakdown_value`, NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -889,7 +884,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(`context.columns.breakdown_value`, NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -1019,7 +1013,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(`context.columns.breakdown_value`, NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -1352,7 +1345,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(`context.columns.breakdown_value`, NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC

--- a/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_sample_web_analytics_queries.hogql.ambr
+++ b/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_sample_web_analytics_queries.hogql.ambr
@@ -475,7 +475,7 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(tupleElement(`context.columns.breakdown_value`, 2), NULL)
+  HAVING notEquals(tupleElement(`context.columns.breakdown_value`, 1), NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -967,7 +967,7 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING notEquals(tupleElement(`context.columns.breakdown_value`, 2), NULL)
+  HAVING notEquals(tupleElement(`context.columns.breakdown_value`, 1), NULL)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC

--- a/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_web_stats_pre_aggregated.ambr
+++ b/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_web_stats_pre_aggregated.ambr
@@ -55,7 +55,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -128,7 +127,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -201,7 +199,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC

--- a/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_web_stats_table.ambr
+++ b/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_web_stats_table.ambr
@@ -2661,7 +2661,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -4691,7 +4690,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -4752,7 +4750,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -4813,7 +4810,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
@@ -4874,7 +4870,6 @@
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_table.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_table.py
@@ -1360,7 +1360,7 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest, FloatAwareT
 
             # Invalid timezone offsets collapse to a single NULL row instead of being dropped,
             # so totals stay consistent with the overview tile (the frontend renders this as
-            # "(unknown timezone)").
+            # "(not set)").
             assert len(results) == 1
             assert results[0][0] is None
             assert results[0][1][0] == idx + 1  # visitors == number of distinct persons seen so far

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_table.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_table.py
@@ -1358,7 +1358,13 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest, FloatAwareT
                 breakdown_by=WebStatsBreakdown.TIMEZONE,
             ).results
 
-            assert results == []
+            # Invalid timezone offsets collapse to a single NULL row instead of being dropped,
+            # so totals stay consistent with the overview tile (the frontend renders this as
+            # "(unknown timezone)").
+            assert len(results) == 1
+            assert results[0][0] is None
+            assert results[0][1][0] == idx + 1  # visitors == number of distinct persons seen so far
+            assert results[0][2][0] == sum(range(idx + 2))  # views == cumulative pageview count
 
     def test_conversion_goal_no_conversions(self):
         s1 = str(uuid7("2023-12-01"))


### PR DESCRIPTION
## Problem

When a user drills from the Countries breakdown into Regions (or Cities), the totals collapse compared to the parent country row. Reported by a customer: ~36.9K US visitors in the Countries view, but the Regions view (with the US filter applied automatically) only accounted for ~14K — ~22K visitors silently dropped.

The cause is GeoIP: country resolution is reliable, but subdivision/city resolution often is not (VPNs, server IPs, mobile data). The web-analytics query was hard-filtering rows where the subdivision/city was NULL, so they disappeared entirely from the Regions/Cities tabs.

## Changes

- **Backend (`stats_table.py`)**: for `REGION` and `CITY` breakdowns, drop the `tupleElement(breakdown_value, 2) IS NOT NULL` predicate. Filter only on the country code (element 1) so rows with a known country but unknown region/city are still aggregated. Behaviour now matches how UTM breakdowns already handle NULLs.
- **Frontend (`WebAnalyticsTile.tsx`)**: render NULL region/city tuple elements as a clearly distinct `(unknown region)` / `(unknown city)` label (italic, muted) instead of an empty trailing dash. Click-to-filter is suppressed on unknown rows since filtering by NULL has no useful semantics.

## How did you test this code?

Agent-authored.

- `hogli test products/web_analytics/backend/hogql_queries/test/test_web_stats_table.py` — 63 passed, 129 snapshots green.

Manual verification of the Regions/Cities tabs against a country with known-incomplete GeoIP coverage (e.g. US) is still recommended before merge.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7), triggered from a Pylon ticket.
- Investigation: traced the totals discrepancy from the customer's screenshots down to `outer_where_breakdown` in `stats_table.py:600`, which was filtering on element 2 of the breakdown tuple for `REGION`/`CITY`. UTM breakdowns (line 607-614) already keep NULLs intentionally — applied the same treatment here, scoped to country presence so rows without any geo data don't sneak in.
- Left the pre-aggregated path alone: `_default_breakdown_query` already does not filter on `breakdown_value IS NOT NULL`, but the pre-agg returns scalar `region_code` / `city_name` rather than the (country, region, name) tuple the regular path returns. That shape divergence is a separate cleanup; this PR matches the customer report which was running on the non-pre-aggregated path.