### PR TITLE
chore(gateway): tag limits by product

### DIFF
--- a/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
+++ b/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
@@ -99,7 +99,7 @@ COST_BY_TEAM_USD = TopKCounter(
 RATE_LIMIT_EXCEEDED = Counter(
     "llm_gateway_rate_limit_exceeded_total",
     "Rate limit exceeded events",
-    labelnames=["scope"],
+    labelnames=["scope", "product"],
 )
 
 PRODUCT_COST_WINDOW_USD = Gauge(

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/middleware.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/middleware.py
@@ -7,9 +7,9 @@ from llm_gateway.rate_limiting.redis_limiter import RateLimiter
 logger = structlog.get_logger(__name__)
 
 
-async def check_rate_limit(user: AuthenticatedUser, limiter: RateLimiter) -> bool:
+async def check_rate_limit(user: AuthenticatedUser, limiter: RateLimiter, product: str = "unknown") -> bool:
     allowed, scope = await limiter.check(user.user_id)
     if not allowed and scope:
-        RATE_LIMIT_EXCEEDED.labels(scope=scope).inc()
-        logger.warning("rate_limit_exceeded", user_id=user.user_id, scope=scope)
+        RATE_LIMIT_EXCEEDED.labels(scope=scope, product=product).inc()
+        logger.warning("rate_limit_exceeded", user_id=user.user_id, scope=scope, product=product)
     return allowed

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/runner.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/runner.py
@@ -26,7 +26,7 @@ class ThrottleRunner:
         for throttle, result in zip(self._throttles, results, strict=True):
             if not result.allowed:
                 scope = result.scope or throttle.scope
-                RATE_LIMIT_EXCEEDED.labels(scope=scope).inc()
+                RATE_LIMIT_EXCEEDED.labels(scope=scope, product=context.product).inc()
                 logger.warning(
                     "throttle_denied",
                     user_id=context.user.user_id,

--- a/services/llm-gateway/tests/test_metrics.py
+++ b/services/llm-gateway/tests/test_metrics.py
@@ -31,7 +31,7 @@ class TestMetricsConfiguration:
             pytest.param(REQUEST_LATENCY, {"endpoint", "provider", "streaming", "product"}, id="request_latency"),
             pytest.param(TOKENS_INPUT, {"provider", "model", "product"}, id="tokens_input"),
             pytest.param(TOKENS_OUTPUT, {"provider", "model", "product"}, id="tokens_output"),
-            pytest.param(RATE_LIMIT_EXCEEDED, {"scope"}, id="rate_limit_exceeded"),
+            pytest.param(RATE_LIMIT_EXCEEDED, {"scope", "product"}, id="rate_limit_exceeded"),
             pytest.param(PROVIDER_ERRORS, {"provider", "error_type", "product"}, id="provider_errors"),
             pytest.param(ACTIVE_STREAMS, {"provider", "model", "product"}, id="active_streams"),
             pytest.param(CONCURRENT_REQUESTS, {"provider", "model", "product"}, id="concurrent_requests"),
@@ -82,9 +82,9 @@ class TestMetricsExport:
 
 class TestMetricsRecording:
     def test_rate_limit_exceeded_increments_without_user_id(self) -> None:
-        initial_value = RATE_LIMIT_EXCEEDED.labels(scope="burst")._value.get()
-        RATE_LIMIT_EXCEEDED.labels(scope="burst").inc()
-        assert RATE_LIMIT_EXCEEDED.labels(scope="burst")._value.get() == initial_value + 1
+        initial_value = RATE_LIMIT_EXCEEDED.labels(scope="burst", product="llm_gateway")._value.get()
+        RATE_LIMIT_EXCEEDED.labels(scope="burst", product="llm_gateway").inc()
+        assert RATE_LIMIT_EXCEEDED.labels(scope="burst", product="llm_gateway")._value.get() == initial_value + 1
 
     def test_provider_errors_tracks_error_types(self) -> None:
         initial_value = PROVIDER_ERRORS.labels(


### PR DESCRIPTION
we’re not tagging this, so it’s hard to know which product is rate limited