### PR TITLE
fix(notebooks): reject collab saves when client version is behind

### DIFF
--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -756,6 +756,7 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
             client_id=data["client_id"],
             steps_json=data["steps"],
             last_seen_version=data["version"],
+            postgres_version=notebook.version,
             user_id=user.pk,
             user_name=user_name,
             cursor_head=data.get("cursor_head"),

--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -756,7 +756,7 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
             client_id=data["client_id"],
             steps_json=data["steps"],
             last_seen_version=data["version"],
-            postgres_version=notebook.version,
+            last_saved_version=notebook.version,
             user_id=user.pk,
             user_name=user_name,
             cursor_head=data.get("cursor_head"),

--- a/products/notebooks/backend/collab.py
+++ b/products/notebooks/backend/collab.py
@@ -48,49 +48,50 @@ class SubmitResult:
     steps_since: list[StepEntry] | None = None
 
 
-# Atomically append N step entries if the latest stream version equals last_seen_version.
+# Atomically append N step entries if the current stream version equals last_seen_version.
 #
 # When the stream is empty (TTL expired / evicted / never written) we cannot trust the caller's
 # last_seen_version on its own — a stale tab with an old baseline could otherwise be accepted
-# and silently downgrade Postgres on the subsequent update. Cross-check against the Postgres
-# version: only accept if they match exactly, otherwise force the client to reload.
+# and silently downgrade the persisted version on the subsequent Notebook update. Cross-check
+# against last_saved_version (the value durably stored in Postgres): only accept if they match
+# exactly, otherwise force the client to reload.
 #
 # ARGV:
 #   1: last_seen_version (int)         -- prosemirror confirmed version on the client
-#   2: postgres_version (int)          -- notebook.version from Postgres, fetched by the caller
+#   2: last_saved_version (int)        -- notebook.version from Postgres, fetched by the caller
 #   3: ttl_seconds (int)
 #   4: max_length (int)
 #   5..N: step entry JSON strings (one per prosemirror step)
 #
 # Returns:
-#   {0, current_version}     -- conflict, caller should fetch missed steps
-#   {1, new_version}         -- accepted
-#   {2, postgres_version}    -- stream lost + client baseline disagrees with Postgres → stale
+#   {0, current_stream_version}        -- conflict, caller should fetch missed steps
+#   {1, new_version}                   -- accepted
+#   {2, last_saved_version}            -- stream lost + client baseline disagrees with Postgres → stale
 _APPEND_STEPS_LUA = """
 local stream_key = KEYS[1]
 local last_seen_version = tonumber(ARGV[1])
-local postgres_version = tonumber(ARGV[2])
+local last_saved_version = tonumber(ARGV[2])
 local ttl = tonumber(ARGV[3])
 local max_length = tonumber(ARGV[4])
 
-local current_version = last_seen_version
+local current_stream_version = last_seen_version
 local last = redis.call('XREVRANGE', stream_key, '+', '-', 'COUNT', 1)
 local stream_empty = (#last == 0)
 if not stream_empty then
     local id_str = last[1][1]
     local dash = string.find(id_str, '-')
-    current_version = tonumber(string.sub(id_str, 1, dash - 1))
+    current_stream_version = tonumber(string.sub(id_str, 1, dash - 1))
 end
 
-if stream_empty and last_seen_version ~= postgres_version then
-    return {2, postgres_version}
+if stream_empty and last_seen_version ~= last_saved_version then
+    return {2, last_saved_version}
 end
 
-if current_version ~= last_seen_version then
-    return {0, current_version}
+if current_stream_version ~= last_seen_version then
+    return {0, current_stream_version}
 end
 
-local next_version = current_version
+local next_version = current_stream_version
 for i = 5, #ARGV do
     next_version = next_version + 1
     redis.call('XADD', stream_key, 'MAXLEN', '~', max_length, next_version .. '-0', 'data', ARGV[i])
@@ -108,7 +109,7 @@ def submit_steps(
     steps_json: list[dict],
     last_seen_version: int,
     *,
-    postgres_version: int,
+    last_saved_version: int,
     user_id: int | None = None,
     user_name: str | None = None,
     cursor_head: int | None = None,
@@ -126,7 +127,7 @@ def submit_steps(
     script = client.register_script(_APPEND_STEPS_LUA)
     accepted, version = script(
         keys=[stream_key],
-        args=[last_seen_version, postgres_version, STREAM_TTL_SECONDS, STREAM_MAX_LENGTH, *serialized],
+        args=[last_seen_version, last_saved_version, STREAM_TTL_SECONDS, STREAM_MAX_LENGTH, *serialized],
     )
 
     if accepted == 1:
@@ -134,12 +135,12 @@ def submit_steps(
     if accepted == 2:
         return SubmitResult(status="stale", version=version)
 
-    return _fetch_missed_steps(stream_key, last_seen_version=last_seen_version, current_version=version)
+    return _fetch_missed_steps(stream_key, last_seen_version=last_seen_version, current_stream_version=version)
 
 
-def _fetch_missed_steps(stream_key: str, *, last_seen_version: int, current_version: int) -> SubmitResult:
+def _fetch_missed_steps(stream_key: str, *, last_seen_version: int, current_stream_version: int) -> SubmitResult:
     client = redis_module.get_client()
-    raw = client.xrange(stream_key, min=f"({last_seen_version}-0", max=f"{current_version}-0")
+    raw = client.xrange(stream_key, min=f"({last_seen_version}-0", max=f"{current_stream_version}-0")
 
     missed_steps: list[StepEntry] = []
     for _stream_id, fields in raw:
@@ -147,11 +148,11 @@ def _fetch_missed_steps(stream_key: str, *, last_seen_version: int, current_vers
         missed_steps.append(StepEntry(step=data["step"], client_id=data["client_id"]))
 
     # MAXLEN/TTL trimmed part of the gap - incomplete rebase set, reload from Postgres
-    gap_size = current_version - last_seen_version
+    gap_size = current_stream_version - last_seen_version
     if len(missed_steps) < gap_size:
-        return SubmitResult(status="stale", version=current_version)
+        return SubmitResult(status="stale", version=current_stream_version)
 
-    return SubmitResult(status="conflict", version=current_version, steps_since=missed_steps)
+    return SubmitResult(status="conflict", version=current_stream_version, steps_since=missed_steps)
 
 
 async def stream_collab_sse(

--- a/products/notebooks/backend/collab.py
+++ b/products/notebooks/backend/collab.py
@@ -41,37 +41,49 @@ class StepEntry:
 class SubmitResult:
     # "accepted" - steps appended; `version` is the new top
     # "conflict" - caller is behind; `version` is the current top, `steps_since` is the missed range
-    # "stale"    - missed range was trimmed (MAXLEN/TTL); caller must reload from Postgres
+    # "stale"    - missed range was trimmed (MAXLEN/TTL) or the stream was lost and the client's
+    #              baseline no longer matches Postgres; caller must reload from Postgres
     status: Literal["accepted", "conflict", "stale"]
     version: int
     steps_since: list[StepEntry] | None = None
 
 
 # Atomically append N step entries if the latest stream version equals last_seen_version.
-# If the stream is empty we trust the caller's last_seen_version,
-# frontend always loads it from Postgres and seed the stream from there.
+#
+# When the stream is empty (TTL expired / evicted / never written) we cannot trust the caller's
+# last_seen_version on its own — a stale tab with an old baseline could otherwise be accepted
+# and silently downgrade Postgres on the subsequent update. Cross-check against the Postgres
+# version: only accept if they match exactly, otherwise force the client to reload.
 #
 # ARGV:
-#   1: last_seen_version (int)
-#   2: ttl_seconds (int)
-#   3: max_length (int)
-#   4..N: step entry JSON strings (one per prosemirror step)
+#   1: last_seen_version (int)         -- prosemirror confirmed version on the client
+#   2: postgres_version (int)          -- notebook.version from Postgres, fetched by the caller
+#   3: ttl_seconds (int)
+#   4: max_length (int)
+#   5..N: step entry JSON strings (one per prosemirror step)
 #
 # Returns:
 #   {0, current_version}     -- conflict, caller should fetch missed steps
 #   {1, new_version}         -- accepted
+#   {2, postgres_version}    -- stream lost + client baseline disagrees with Postgres → stale
 _APPEND_STEPS_LUA = """
 local stream_key = KEYS[1]
 local last_seen_version = tonumber(ARGV[1])
-local ttl = tonumber(ARGV[2])
-local max_length = tonumber(ARGV[3])
+local postgres_version = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local max_length = tonumber(ARGV[4])
 
 local current_version = last_seen_version
 local last = redis.call('XREVRANGE', stream_key, '+', '-', 'COUNT', 1)
-if #last > 0 then
+local stream_empty = (#last == 0)
+if not stream_empty then
     local id_str = last[1][1]
     local dash = string.find(id_str, '-')
     current_version = tonumber(string.sub(id_str, 1, dash - 1))
+end
+
+if stream_empty and last_seen_version ~= postgres_version then
+    return {2, postgres_version}
 end
 
 if current_version ~= last_seen_version then
@@ -79,7 +91,7 @@ if current_version ~= last_seen_version then
 end
 
 local next_version = current_version
-for i = 4, #ARGV do
+for i = 5, #ARGV do
     next_version = next_version + 1
     redis.call('XADD', stream_key, 'MAXLEN', '~', max_length, next_version .. '-0', 'data', ARGV[i])
 end
@@ -96,6 +108,7 @@ def submit_steps(
     steps_json: list[dict],
     last_seen_version: int,
     *,
+    postgres_version: int,
     user_id: int | None = None,
     user_name: str | None = None,
     cursor_head: int | None = None,
@@ -113,11 +126,13 @@ def submit_steps(
     script = client.register_script(_APPEND_STEPS_LUA)
     accepted, version = script(
         keys=[stream_key],
-        args=[last_seen_version, STREAM_TTL_SECONDS, STREAM_MAX_LENGTH, *serialized],
+        args=[last_seen_version, postgres_version, STREAM_TTL_SECONDS, STREAM_MAX_LENGTH, *serialized],
     )
 
     if accepted == 1:
         return SubmitResult(status="accepted", version=version)
+    if accepted == 2:
+        return SubmitResult(status="stale", version=version)
 
     return _fetch_missed_steps(stream_key, last_seen_version=last_seen_version, current_version=version)
 

--- a/products/notebooks/backend/test/test_collab.py
+++ b/products/notebooks/backend/test/test_collab.py
@@ -16,7 +16,7 @@ class TestNotebookCollab(BaseTest):
             "client1",
             [{"stepType": "replace", "from": 0, "to": 0}],
             5,
-            postgres_version=5,
+            last_saved_version=5,
         )
         assert result.status == "accepted"
         assert result.version == 6
@@ -28,7 +28,7 @@ class TestNotebookCollab(BaseTest):
             "client1",
             [{"stepType": "replace", "from": 0, "to": 0}],
             0,
-            postgres_version=0,
+            last_saved_version=0,
         )
         assert result.status == "accepted"
         assert result.version == 1
@@ -40,7 +40,7 @@ class TestNotebookCollab(BaseTest):
             "client1",
             [{"stepType": "replace", "from": 0, "to": 0}],
             0,
-            postgres_version=0,
+            last_saved_version=0,
         )
         result = submit_steps(
             self.team.pk,
@@ -48,7 +48,7 @@ class TestNotebookCollab(BaseTest):
             "client2",
             [{"stepType": "replace", "from": 1, "to": 1}],
             0,
-            postgres_version=1,
+            last_saved_version=1,
         )
         assert result.status == "conflict"
         assert result.version == 1
@@ -62,7 +62,7 @@ class TestNotebookCollab(BaseTest):
             {"stepType": "replace", "from": 1, "to": 1},
             {"stepType": "replace", "from": 2, "to": 2},
         ]
-        result = submit_steps(self.team.pk, "nb5", "client1", steps, 0, postgres_version=0)
+        result = submit_steps(self.team.pk, "nb5", "client1", steps, 0, last_saved_version=0)
         assert result.status == "accepted"
         assert result.version == 3
 
@@ -81,7 +81,7 @@ class TestNotebookCollab(BaseTest):
                 f"client{i}",
                 [{"stepType": "replace", "from": i, "to": i}],
                 expected_version,
-                postgres_version=expected_version,
+                last_saved_version=expected_version,
             )
             assert result.status == "accepted"
             expected_version += 1
@@ -95,7 +95,7 @@ class TestNotebookCollab(BaseTest):
             "client1",
             [{"stepType": "replace", "from": 0, "to": 0}],
             0,
-            postgres_version=0,
+            last_saved_version=0,
         )
         submit_steps(
             self.team.pk,
@@ -103,7 +103,7 @@ class TestNotebookCollab(BaseTest):
             "client1",
             [{"stepType": "replace", "from": 1, "to": 1}],
             1,
-            postgres_version=1,
+            last_saved_version=1,
         )
 
         client = redis.get_client()
@@ -119,7 +119,7 @@ class TestNotebookCollab(BaseTest):
             "client2",
             [{"stepType": "replace", "from": 2, "to": 2}],
             0,
-            postgres_version=2,
+            last_saved_version=2,
         )
         assert result.status == "stale"
         assert result.version == 2
@@ -135,7 +135,7 @@ class TestNotebookCollab(BaseTest):
             "client_stale",
             [{"stepType": "replace", "from": 0, "to": 0}],
             last_seen_version=937,
-            postgres_version=946,
+            last_saved_version=946,
         )
         assert result.status == "stale"
         assert result.version == 946
@@ -150,7 +150,7 @@ class TestNotebookCollab(BaseTest):
             "client_ahead",
             [{"stepType": "replace", "from": 0, "to": 0}],
             last_seen_version=946,
-            postgres_version=937,
+            last_saved_version=937,
         )
         assert result.status == "stale"
         assert result.version == 937
@@ -165,7 +165,7 @@ class TestNotebookCollab(BaseTest):
             "client1",
             [{"stepType": "replace", "from": 0, "to": 0}],
             last_seen_version=946,
-            postgres_version=946,
+            last_saved_version=946,
         )
         assert result.status == "accepted"
         assert result.version == 947

--- a/products/notebooks/backend/test/test_collab.py
+++ b/products/notebooks/backend/test/test_collab.py
@@ -10,18 +10,46 @@ from products.notebooks.backend.collab import STREAM_KEY_PATTERN, STREAM_MAX_LEN
 class TestNotebookCollab(BaseTest):
     def test_submit_to_empty_stream_seeds_position_from_caller(self):
         # No init endpoint anymore — first writer trusts last_seen_version (loaded from Postgres).
-        result = submit_steps(self.team.pk, "nb1", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 5)
+        result = submit_steps(
+            self.team.pk,
+            "nb1",
+            "client1",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            5,
+            postgres_version=5,
+        )
         assert result.status == "accepted"
         assert result.version == 6
 
     def test_submit_steps_accepted(self):
-        result = submit_steps(self.team.pk, "nb3", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
+        result = submit_steps(
+            self.team.pk,
+            "nb3",
+            "client1",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            0,
+            postgres_version=0,
+        )
         assert result.status == "accepted"
         assert result.version == 1
 
     def test_submit_steps_rejected_on_version_mismatch(self):
-        submit_steps(self.team.pk, "nb4", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
-        result = submit_steps(self.team.pk, "nb4", "client2", [{"stepType": "replace", "from": 1, "to": 1}], 0)
+        submit_steps(
+            self.team.pk,
+            "nb4",
+            "client1",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            0,
+            postgres_version=0,
+        )
+        result = submit_steps(
+            self.team.pk,
+            "nb4",
+            "client2",
+            [{"stepType": "replace", "from": 1, "to": 1}],
+            0,
+            postgres_version=1,
+        )
         assert result.status == "conflict"
         assert result.version == 1
         assert result.steps_since == [
@@ -34,7 +62,7 @@ class TestNotebookCollab(BaseTest):
             {"stepType": "replace", "from": 1, "to": 1},
             {"stepType": "replace", "from": 2, "to": 2},
         ]
-        result = submit_steps(self.team.pk, "nb5", "client1", steps, 0)
+        result = submit_steps(self.team.pk, "nb5", "client1", steps, 0, postgres_version=0)
         assert result.status == "accepted"
         assert result.version == 3
 
@@ -53,6 +81,7 @@ class TestNotebookCollab(BaseTest):
                 f"client{i}",
                 [{"stepType": "replace", "from": i, "to": i}],
                 expected_version,
+                postgres_version=expected_version,
             )
             assert result.status == "accepted"
             expected_version += 1
@@ -60,8 +89,22 @@ class TestNotebookCollab(BaseTest):
         assert expected_version == num_clients
 
     def test_submit_steps_returns_stale_when_stream_trimmed(self):
-        submit_steps(self.team.pk, "nb_trimmed", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
-        submit_steps(self.team.pk, "nb_trimmed", "client1", [{"stepType": "replace", "from": 1, "to": 1}], 1)
+        submit_steps(
+            self.team.pk,
+            "nb_trimmed",
+            "client1",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            0,
+            postgres_version=0,
+        )
+        submit_steps(
+            self.team.pk,
+            "nb_trimmed",
+            "client1",
+            [{"stepType": "replace", "from": 1, "to": 1}],
+            1,
+            postgres_version=1,
+        )
 
         client = redis.get_client()
         # Force-trim past version 1 to simulate MAXLEN/TTL eviction; version 2 (id 2-0) survives.
@@ -70,10 +113,62 @@ class TestNotebookCollab(BaseTest):
             minid="2-0",
         )
 
-        result = submit_steps(self.team.pk, "nb_trimmed", "client2", [{"stepType": "replace", "from": 2, "to": 2}], 0)
+        result = submit_steps(
+            self.team.pk,
+            "nb_trimmed",
+            "client2",
+            [{"stepType": "replace", "from": 2, "to": 2}],
+            0,
+            postgres_version=2,
+        )
         assert result.status == "stale"
         assert result.version == 2
         assert result.steps_since is None
+
+    def test_empty_stream_with_stale_client_baseline_returns_stale(self):
+        # Stream lost (e.g. TTL expired) — Postgres still has the high version. A stale tab whose
+        # baseline doesn't match Postgres must not be accepted; otherwise its save would
+        # overwrite Postgres with a lower version. Client must reload from Postgres.
+        result = submit_steps(
+            self.team.pk,
+            "nb_stale_after_expiry",
+            "client_stale",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            last_seen_version=937,
+            postgres_version=946,
+        )
+        assert result.status == "stale"
+        assert result.version == 946
+        assert result.steps_since is None
+
+    def test_empty_stream_with_client_ahead_of_postgres_returns_stale(self):
+        # Defensive: even if the client is somehow ahead of Postgres (legacy PATCH path went
+        # backwards, Postgres restore, etc.) we still cannot rebase against an empty stream.
+        result = submit_steps(
+            self.team.pk,
+            "nb_client_ahead",
+            "client_ahead",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            last_seen_version=946,
+            postgres_version=937,
+        )
+        assert result.status == "stale"
+        assert result.version == 937
+        assert result.steps_since is None
+
+    def test_empty_stream_with_matching_postgres_accepts(self):
+        # The legitimate first save after a Redis flush: client baseline matches Postgres so
+        # the empty stream is safely seeded from there.
+        result = submit_steps(
+            self.team.pk,
+            "nb_first_save_after_flush",
+            "client1",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            last_seen_version=946,
+            postgres_version=946,
+        )
+        assert result.status == "accepted"
+        assert result.version == 947
 
     def test_stream_maxlen_constant_is_sane(self):
         # Sanity: MAXLEN must comfortably hold an hour of edits. Adjust deliberately if changed.

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -305,7 +305,7 @@ class TestNotebookCollabStreamAPI(APIBaseTest):
             "client-1",
             [{"stepType": "replace", "from": 0, "to": 0}],
             notebook["version"],
-            postgres_version=notebook["version"],
+            last_saved_version=notebook["version"],
         )
 
         # Last-Event-ID=0-0 means "from the beginning of the stream", so the pre-populated
@@ -333,7 +333,7 @@ class TestNotebookCollabStreamAPI(APIBaseTest):
             "client-A",
             [{"stepType": "replace", "from": 0, "to": 0}],
             base_version,
-            postgres_version=base_version,
+            last_saved_version=base_version,
         )
         submit_steps(
             self.team.pk,
@@ -341,7 +341,7 @@ class TestNotebookCollabStreamAPI(APIBaseTest):
             "client-B",
             [{"stepType": "replace", "from": 1, "to": 1}],
             base_version + 1,
-            postgres_version=base_version + 1,
+            last_saved_version=base_version + 1,
         )
 
         first_step_id = f"{base_version + 1}-0"

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -305,6 +305,7 @@ class TestNotebookCollabStreamAPI(APIBaseTest):
             "client-1",
             [{"stepType": "replace", "from": 0, "to": 0}],
             notebook["version"],
+            postgres_version=notebook["version"],
         )
 
         # Last-Event-ID=0-0 means "from the beginning of the stream", so the pre-populated
@@ -332,6 +333,7 @@ class TestNotebookCollabStreamAPI(APIBaseTest):
             "client-A",
             [{"stepType": "replace", "from": 0, "to": 0}],
             base_version,
+            postgres_version=base_version,
         )
         submit_steps(
             self.team.pk,
@@ -339,6 +341,7 @@ class TestNotebookCollabStreamAPI(APIBaseTest):
             "client-B",
             [{"stepType": "replace", "from": 1, "to": 1}],
             base_version + 1,
+            postgres_version=base_version + 1,
         )
 
         first_step_id = f"{base_version + 1}-0"


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

When the Redis collab stream is empty (TTL expired, eviction, restart), the server accepts whatever `last_seen_version` the client claims - so a stale tab whose baseline lagged behind Postgres can silently overwrite the saved notebook content and downgrade `notebook.version`

Every other live tab then becomes ahead of the server, with subsequent saves returning 409 and no missed steps to rebase against causing an infinite retry loop (in the second PR of the stack).

## Changes

- Cross-check `last_seen_version` against `notebook.version` from Postgres in the Lua append script. When the stream is empty and they don't match, return the new `stale` status — view already maps it to HTTP 410, so the client opens the conflict modal instead of being silently accepted.
    - This will trigger the conflict modal with "Discard and reload" option
- Normal collab path is unchanged: when the client is behind and the Redis stream still has the missed entries, the server returns 409 with the missed steps as before. So the client can rebase and retry.
- Renamed `current_version` → `current_stream_version` to distinguish  `last_seen_version` (client), `current_stream_version` (Redis), `last_saved_version` (Postgres).

## How did you test this code?

```
pytest products/notebooks/backend/test/test_collab.py products/notebooks/backend/test/test_collab_api.py
```

## Publish to changelog?

no

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->