### PR TITLE
chore(mcp-analytics): drop summariser fallback from intent corpus (PR2/9)

### DIFF
--- a/posthog/temporal/mcp_analytics/summarize_session_intents/activities.py
+++ b/posthog/temporal/mcp_analytics/summarize_session_intents/activities.py
@@ -25,6 +25,12 @@ _PRIORITY_TEAM_ID = 2
 # monopolising the global LLM budget by emitting many unique session ids.
 _PER_TEAM_CAP = 10
 
+# Placeholder written when an MCP session has no recordable tool-call intents.
+# Exported so downstream consumers (e.g. intent clustering) can filter it out
+# of their corpus — clustering an "empty" placeholder produces a meaningless
+# pseudo-cluster in real data.
+NO_INTENT_RECORDED_FALLBACK = "No agent intent was recorded for this session."
+
 SYSTEM_PROMPT = (
     "You summarise what an AI agent was trying to accomplish during a single MCP session. "
     "You are given the per-tool-call intents the agent recorded, in chronological order. "
@@ -146,7 +152,7 @@ async def _summarise_one(
     async with semaphore:
         intents = await _fetch_tool_call_intents(team_id, session_id)
         if not intents:
-            await _save_intent(team_id, session_id, "No agent intent was recorded for this session.")
+            await _save_intent(team_id, session_id, NO_INTENT_RECORDED_FALLBACK)
             return "no_intents"
 
         summary = await asyncio.to_thread(_summarize_intents_sync, intents)

--- a/products/mcp_analytics/backend/intent_clustering.py
+++ b/products/mcp_analytics/backend/intent_clustering.py
@@ -33,6 +33,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.api.embedding_worker import EmbeddingResponse, async_generate_embedding
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.team.team import Team
+from posthog.temporal.mcp_analytics.summarize_session_intents.activities import NO_INTENT_RECORDED_FALLBACK
 
 from products.mcp_analytics.backend.models import MCPSession
 
@@ -135,10 +136,13 @@ def fetch_intent_corpus(
         return [], {}
 
     # Map session_id -> intent_text (last write wins per session).
+    # Skip the summariser's "no intents recorded" placeholder — clustering
+    # it produces a meaningless pseudo-cluster of sessions with nothing in
+    # common except that their tool calls had no $mcp_intent property.
     intent_by_session: dict[str, str] = {}
     for session_id, intent_text in session_rows:
         text = (intent_text or "").strip()
-        if not session_id or not text:
+        if not session_id or not text or text == NO_INTENT_RECORDED_FALLBACK:
             continue
         intent_by_session[session_id] = text
 

--- a/products/mcp_analytics/backend/tests/test_intent_clustering.py
+++ b/products/mcp_analytics/backend/tests/test_intent_clustering.py
@@ -329,14 +329,13 @@ class TestFetchIntentCorpus(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixi
 
         assert [r.intent_text for r in records] == expected_intents
 
-    @pytest.mark.parametrize(
-        "placeholder_text",
+    @parameterized.expand(
         [
-            NO_INTENT_RECORDED_FALLBACK,
-            f"  {NO_INTENT_RECORDED_FALLBACK}  ",
-        ],
+            ("raw", NO_INTENT_RECORDED_FALLBACK),
+            ("padded_whitespace", f"  {NO_INTENT_RECORDED_FALLBACK}  "),
+        ]
     )
-    def test_summariser_fallback_intent_is_excluded(self, placeholder_text: str) -> None:
+    def test_summariser_fallback_intent_is_excluded(self, _name: str, placeholder_text: str) -> None:
         # Session whose intent column holds the summariser's "nothing here"
         # placeholder — must be excluded so it doesn't form its own cluster.
         # Whitespace variants must also be excluded after .strip().

--- a/products/mcp_analytics/backend/tests/test_intent_clustering.py
+++ b/products/mcp_analytics/backend/tests/test_intent_clustering.py
@@ -15,6 +15,8 @@ from posthog.test.base import BaseTest, ClickhouseTestMixin, _create_event, flus
 import numpy as np
 from parameterized import parameterized
 
+from posthog.temporal.mcp_analytics.summarize_session_intents.activities import NO_INTENT_RECORDED_FALLBACK
+
 from products.mcp_analytics.backend.intent_clustering import (
     DEFAULT_DISTANCE_THRESHOLD,
     IntentRecord,
@@ -326,3 +328,22 @@ class TestFetchIntentCorpus(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixi
         records, _ = fetch_intent_corpus(self.team, lookback_days=lookback_days)
 
         assert [r.intent_text for r in records] == expected_intents
+
+    @pytest.mark.parametrize(
+        "placeholder_text",
+        [
+            NO_INTENT_RECORDED_FALLBACK,
+            f"  {NO_INTENT_RECORDED_FALLBACK}  ",
+        ],
+    )
+    def test_summariser_fallback_intent_is_excluded(self, placeholder_text: str) -> None:
+        # Session whose intent column holds the summariser's "nothing here"
+        # placeholder — must be excluded so it doesn't form its own cluster.
+        # Whitespace variants must also be excluded after .strip().
+        self._seed_session("placeholder", placeholder_text)
+        self._seed_session("real", "look up feature flag rollout")
+
+        records, intent_by_session = fetch_intent_corpus(self.team)
+
+        assert [r.intent_text for r in records] == ["look up feature flag rollout"]
+        assert intent_by_session == {"real": "look up feature flag rollout"}


### PR DESCRIPTION
The summariser writes "No agent intent was recorded for this session."
when a session has no recordable tool-call intents. That string then
clusters together as a meaningless pseudo-cluster of sessions whose
only commonality is that nothing was logged.

Promote the literal to NO_INTENT_RECORDED_FALLBACK in the summariser
activity and skip rows matching it in fetch_intent_corpus.

Generated-By: PostHog Code
Task-Id: 973975fd-03b4-460b-b81e-3ee5c636e086

---
## Part of stack — MCP analytics intent clustering (2/9)

Production-readying the MCP analytics intent clustering pipeline. Stack chain:
1. window corpus → 2. drop fallback → 3. embedding cache → 4. temporal scaffold → 5. daily workflow → 6. coordinator → 7. schedule → 8. metrics → 9. retire celery

This is PR **2 of 9**. Base: `posthog-code/mcpa-clustering-1-window-corpus`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

---
> Part of the 9-PR clustering stack — see #59684 for the full plan.
