### PR TITLE
feat(mcp-analytics): register the daily clustering schedule behind a feature flag (PR7/9)

### DIFF
--- a/posthog/temporal/mcp_analytics/intent_clustering/schedule.py
+++ b/posthog/temporal/mcp_analytics/intent_clustering/schedule.py
@@ -44,18 +44,25 @@ FEATURE_FLAG_KEY = "mcp-analytics-clustering-schedule"
 FEATURE_FLAG_DISTINCT_ID = "internal_mcpa_clustering_schedule"
 
 
-def _schedule_enabled() -> bool:
-    """Return True only when the feature flag is explicitly ON.
+def _schedule_enabled() -> tuple[bool, bool]:
+    """Return ``(enabled, check_succeeded)``.
 
-    Any FF error (network, missing key, malformed payload) defaults to OFF —
-    the schedule registration is the riskier side, so fail-closed is right.
+    Three logical states the caller must distinguish:
+
+    * ``(True, True)``  — FF explicitly ON. Register / update the schedule.
+    * ``(False, True)`` — FF explicitly OFF. Delete any existing schedule
+      (kill switch).
+    * ``(False, False)`` — FF check raised. **Preserve current state.** Do
+      not register a new schedule (fail-closed on registration) and do not
+      delete an existing one (a transient PostHog API outage shouldn't tear
+      down a properly-enabled production schedule).
     """
     try:
         enabled = posthoganalytics.feature_enabled(FEATURE_FLAG_KEY, FEATURE_FLAG_DISTINCT_ID)
-        return bool(enabled)
+        return bool(enabled), True
     except Exception:
         logger.warning("mcpa.intent_clustering.schedule.feature_flag_check_failed_defaulting_off", exc_info=True)
-        return False
+        return False, False
 
 
 async def create_intent_clustering_coordinator_schedule(client: Client) -> None:
@@ -64,12 +71,24 @@ async def create_intent_clustering_coordinator_schedule(client: Client) -> None:
     When the feature flag is OFF, any existing schedule is deleted so flipping
     the flag off cleanly disables the daily path. The schedule is created
     with ``trigger_immediately=False`` to avoid stampeding a worker on first
-    deploy.
+    deploy. If the FF check itself fails (transient PostHog API outage),
+    the current schedule state is preserved — we don't tear down a valid
+    production schedule on a blip.
     """
     # posthoganalytics.feature_enabled() is sync and can block on a network call,
     # so offload to a thread to keep the asyncio loop responsive — matches the
     # llm_analytics/team_discovery.py pattern.
-    if not await asyncio.to_thread(_schedule_enabled):
+    enabled, check_succeeded = await asyncio.to_thread(_schedule_enabled)
+
+    if not enabled:
+        if not check_succeeded:
+            # FF check raised. Don't touch the existing schedule (if any) —
+            # transient PostHog outages must not silently disable production.
+            logger.info(
+                "mcpa.intent_clustering.schedule.feature_flag_check_failed_preserving_state",
+                schedule_id=COORDINATOR_SCHEDULE_ID,
+            )
+            return
         if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
             logger.info(
                 "mcpa.intent_clustering.schedule.disabled_removing_existing", schedule_id=COORDINATOR_SCHEDULE_ID

--- a/posthog/temporal/mcp_analytics/intent_clustering/schedule.py
+++ b/posthog/temporal/mcp_analytics/intent_clustering/schedule.py
@@ -8,6 +8,7 @@ flag off after a deploy also removes the schedule on next init, so we can
 disable the daily path without rolling back code.
 """
 
+import asyncio
 from datetime import timedelta
 
 from django.conf import settings
@@ -65,7 +66,10 @@ async def create_intent_clustering_coordinator_schedule(client: Client) -> None:
     with ``trigger_immediately=False`` to avoid stampeding a worker on first
     deploy.
     """
-    if not _schedule_enabled():
+    # posthoganalytics.feature_enabled() is sync and can block on a network call,
+    # so offload to a thread to keep the asyncio loop responsive — matches the
+    # llm_analytics/team_discovery.py pattern.
+    if not await asyncio.to_thread(_schedule_enabled):
         if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
             logger.info(
                 "mcpa.intent_clustering.schedule.disabled_removing_existing", schedule_id=COORDINATOR_SCHEDULE_ID

--- a/posthog/temporal/mcp_analytics/intent_clustering/schedule.py
+++ b/posthog/temporal/mcp_analytics/intent_clustering/schedule.py
@@ -1,0 +1,108 @@
+"""Daily schedule for the MCP analytics intent clustering coordinator.
+
+Gated behind the ``mcp-analytics-clustering-schedule`` PostHog feature flag.
+This is a kill switch: the schedule isn't registered when the flag is off,
+which keeps the daily fan-out from kicking before the dedicated
+``mcp-analytics-task-queue`` worker exists in production. Flipping the
+flag off after a deploy also removes the schedule on next init, so we can
+disable the daily path without rolling back code.
+"""
+
+from datetime import timedelta
+
+from django.conf import settings
+
+import structlog
+import posthoganalytics
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
+
+from posthog.temporal.common.schedule import a_create_schedule, a_delete_schedule, a_schedule_exists, a_update_schedule
+from posthog.temporal.mcp_analytics.intent_clustering.constants import (
+    COORDINATOR_EXECUTION_TIMEOUT,
+    COORDINATOR_SCHEDULE_ID,
+    COORDINATOR_WORKFLOW_NAME,
+    DEFAULT_LOOKBACK_DAYS,
+    DEFAULT_TOP_N_INTENTS,
+)
+from posthog.temporal.mcp_analytics.intent_clustering.coordinator import IntentClusteringCoordinatorInputs
+
+logger = structlog.get_logger(__name__)
+
+FEATURE_FLAG_KEY = "mcp-analytics-clustering-schedule"
+# Stable distinct_id for the schedule registration check — the decision is
+# deployment-scoped, not user-scoped. Matches the LLMA team_discovery
+# convention (``internal_llma_team_discovery``).
+FEATURE_FLAG_DISTINCT_ID = "internal_mcpa_clustering_schedule"
+
+
+def _schedule_enabled() -> bool:
+    """Return True only when the feature flag is explicitly ON.
+
+    Any FF error (network, missing key, malformed payload) defaults to OFF —
+    the schedule registration is the riskier side, so fail-closed is right.
+    """
+    try:
+        enabled = posthoganalytics.feature_enabled(FEATURE_FLAG_KEY, FEATURE_FLAG_DISTINCT_ID)
+        return bool(enabled)
+    except Exception:
+        logger.warning("mcpa.intent_clustering.schedule.feature_flag_check_failed_defaulting_off", exc_info=True)
+        return False
+
+
+async def create_intent_clustering_coordinator_schedule(client: Client) -> None:
+    """Register (or update) the daily intent clustering coordinator schedule.
+
+    When the feature flag is OFF, any existing schedule is deleted so flipping
+    the flag off cleanly disables the daily path. The schedule is created
+    with ``trigger_immediately=False`` to avoid stampeding a worker on first
+    deploy.
+    """
+    if not _schedule_enabled():
+        if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
+            logger.info(
+                "mcpa.intent_clustering.schedule.disabled_removing_existing", schedule_id=COORDINATOR_SCHEDULE_ID
+            )
+            await a_delete_schedule(client, COORDINATOR_SCHEDULE_ID)
+        else:
+            logger.info("mcpa.intent_clustering.schedule.disabled_no_action", schedule_id=COORDINATOR_SCHEDULE_ID)
+        return
+
+    coordinator_schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            COORDINATOR_WORKFLOW_NAME,
+            IntentClusteringCoordinatorInputs(
+                lookback_days=DEFAULT_LOOKBACK_DAYS,
+                top_n=DEFAULT_TOP_N_INTENTS,
+            ),
+            id=COORDINATOR_SCHEDULE_ID,
+            task_queue=settings.MCPA_TASK_QUEUE,
+            execution_timeout=COORDINATOR_EXECUTION_TIMEOUT,
+        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+    )
+
+    if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
+        logger.info("mcpa.intent_clustering.schedule.updating", schedule_id=COORDINATOR_SCHEDULE_ID)
+        await a_update_schedule(client, COORDINATOR_SCHEDULE_ID, coordinator_schedule)
+    else:
+        logger.info("mcpa.intent_clustering.schedule.creating", schedule_id=COORDINATOR_SCHEDULE_ID)
+        await a_create_schedule(
+            client,
+            COORDINATOR_SCHEDULE_ID,
+            coordinator_schedule,
+            trigger_immediately=False,
+        )
+
+
+async def delete_intent_clustering_coordinator_schedule(client: Client) -> None:
+    """Explicit-delete helper. Used by tests; not wired into init_schedules."""
+    await a_delete_schedule(client, COORDINATOR_SCHEDULE_ID)

--- a/posthog/temporal/mcp_analytics/intent_clustering/tests/test_schedule.py
+++ b/posthog/temporal/mcp_analytics/intent_clustering/tests/test_schedule.py
@@ -42,72 +42,65 @@ def mock_client():
 
 class TestCreateIntentClusteringCoordinatorSchedule:
     @pytest.mark.asyncio
-    async def test_flag_off_no_existing_schedule_is_noop(self, mock_client, schedule_helpers) -> None:
-        schedule_helpers["exists"].return_value = False
-        with patch(
-            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
-            return_value=False,
-        ):
+    @pytest.mark.parametrize(
+        "case_id, flag_enabled, exists_returns, expected_create, expected_update, expected_delete",
+        [
+            # Flag OFF + no schedule → no-op.
+            ("flag_off_no_existing", False, False, False, False, False),
+            # Flag OFF + existing schedule → delete (kill-switch).
+            ("flag_off_existing", False, True, False, False, True),
+            # Flag ON + no schedule → create (with trigger_immediately=False).
+            ("flag_on_no_existing", True, False, True, False, False),
+            # Flag ON + existing schedule → update.
+            ("flag_on_existing", True, True, False, True, False),
+            # FF check raises → defaults to disabled, no schedule exists → no-op.
+            # Sentinel value None means "raise from the FF SDK".
+            ("flag_check_raises", None, False, False, False, False),
+        ],
+    )
+    async def test_create_intent_clustering_coordinator_schedule(
+        self,
+        mock_client,
+        schedule_helpers,
+        case_id: str,
+        flag_enabled: bool | None,
+        exists_returns: bool,
+        expected_create: bool,
+        expected_update: bool,
+        expected_delete: bool,
+    ) -> None:
+        schedule_helpers["exists"].return_value = exists_returns
+        # None sentinel = SDK raises. Otherwise return_value=flag_enabled.
+        if flag_enabled is None:
+            feature_enabled_patch = patch(
+                "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
+                side_effect=RuntimeError("PostHog FF API down"),
+            )
+        else:
+            feature_enabled_patch = patch(
+                "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
+                return_value=flag_enabled,
+            )
+
+        with feature_enabled_patch:
             await create_intent_clustering_coordinator_schedule(mock_client)
 
-        schedule_helpers["create"].assert_not_called()
-        schedule_helpers["update"].assert_not_called()
-        schedule_helpers["delete"].assert_not_called()
+        if expected_create:
+            schedule_helpers["create"].assert_awaited_once()
+            # trigger_immediately=False so first-deploy doesn't dogpile the worker.
+            assert schedule_helpers["create"].call_args.kwargs.get("trigger_immediately") is False
+        else:
+            schedule_helpers["create"].assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_flag_off_existing_schedule_is_deleted(self, mock_client, schedule_helpers) -> None:
-        schedule_helpers["exists"].return_value = True
-        with patch(
-            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
-            return_value=False,
-        ):
-            await create_intent_clustering_coordinator_schedule(mock_client)
+        if expected_update:
+            schedule_helpers["update"].assert_awaited_once()
+        else:
+            schedule_helpers["update"].assert_not_called()
 
-        schedule_helpers["delete"].assert_awaited_once_with(mock_client, COORDINATOR_SCHEDULE_ID)
-        schedule_helpers["create"].assert_not_called()
-        schedule_helpers["update"].assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_flag_on_no_existing_schedule_creates(self, mock_client, schedule_helpers) -> None:
-        schedule_helpers["exists"].return_value = False
-        with patch(
-            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
-            return_value=True,
-        ):
-            await create_intent_clustering_coordinator_schedule(mock_client)
-
-        schedule_helpers["create"].assert_awaited_once()
-        # Assert trigger_immediately=False so first-deploy doesn't dogpile the worker.
-        call_kwargs = schedule_helpers["create"].call_args.kwargs
-        assert call_kwargs.get("trigger_immediately") is False
-        schedule_helpers["update"].assert_not_called()
-        schedule_helpers["delete"].assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_flag_on_existing_schedule_updates(self, mock_client, schedule_helpers) -> None:
-        schedule_helpers["exists"].return_value = True
-        with patch(
-            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
-            return_value=True,
-        ):
-            await create_intent_clustering_coordinator_schedule(mock_client)
-
-        schedule_helpers["update"].assert_awaited_once()
-        schedule_helpers["create"].assert_not_called()
-        schedule_helpers["delete"].assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_flag_check_exception_defaults_to_disabled(self, mock_client, schedule_helpers) -> None:
-        # Network failure / SDK bug must not crash schedule init for other modules.
-        schedule_helpers["exists"].return_value = False
-        with patch(
-            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
-            side_effect=RuntimeError("PostHog FF API down"),
-        ):
-            await create_intent_clustering_coordinator_schedule(mock_client)
-
-        schedule_helpers["create"].assert_not_called()
-        schedule_helpers["update"].assert_not_called()
+        if expected_delete:
+            schedule_helpers["delete"].assert_awaited_once_with(mock_client, COORDINATOR_SCHEDULE_ID)
+        else:
+            schedule_helpers["delete"].assert_not_called()
 
 
 class TestFeatureFlagKeyIsStable:

--- a/posthog/temporal/mcp_analytics/intent_clustering/tests/test_schedule.py
+++ b/posthog/temporal/mcp_analytics/intent_clustering/tests/test_schedule.py
@@ -53,9 +53,15 @@ class TestCreateIntentClusteringCoordinatorSchedule:
             ("flag_on_no_existing", True, False, True, False, False),
             # Flag ON + existing schedule → update.
             ("flag_on_existing", True, True, False, True, False),
-            # FF check raises → defaults to disabled, no schedule exists → no-op.
+            # FF check raises + no schedule exists → no-op. We don't register
+            # on an uncertain FF state.
             # Sentinel value None means "raise from the FF SDK".
-            ("flag_check_raises", None, False, False, False, False),
+            ("flag_check_raises_no_existing", None, False, False, False, False),
+            # FF check raises + schedule EXISTS → preserve state (no delete!).
+            # A transient PostHog API outage must not silently disable a
+            # properly-enabled production schedule. This is the regression
+            # test for the graphite-app P1 bug.
+            ("flag_check_raises_preserves_existing", None, True, False, False, False),
         ],
     )
     async def test_create_intent_clustering_coordinator_schedule(

--- a/posthog/temporal/mcp_analytics/intent_clustering/tests/test_schedule.py
+++ b/posthog/temporal/mcp_analytics/intent_clustering/tests/test_schedule.py
@@ -1,0 +1,118 @@
+"""Tests for the intent clustering coordinator schedule.
+
+The schedule is gated on the ``mcp-analytics-clustering-schedule`` feature
+flag. These tests mock the FF and the Temporal client helpers; they don't
+exercise an actual Temporal server.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from posthog.temporal.mcp_analytics.intent_clustering.constants import COORDINATOR_SCHEDULE_ID
+from posthog.temporal.mcp_analytics.intent_clustering.schedule import (
+    FEATURE_FLAG_KEY,
+    create_intent_clustering_coordinator_schedule,
+)
+
+
+@pytest.fixture
+def schedule_helpers():
+    """Patch the four schedule helpers; yield the mocks for assertions."""
+    with (
+        patch(
+            "posthog.temporal.mcp_analytics.intent_clustering.schedule.a_create_schedule", new_callable=AsyncMock
+        ) as create,
+        patch(
+            "posthog.temporal.mcp_analytics.intent_clustering.schedule.a_update_schedule", new_callable=AsyncMock
+        ) as update,
+        patch(
+            "posthog.temporal.mcp_analytics.intent_clustering.schedule.a_delete_schedule", new_callable=AsyncMock
+        ) as delete,
+        patch(
+            "posthog.temporal.mcp_analytics.intent_clustering.schedule.a_schedule_exists", new_callable=AsyncMock
+        ) as exists,
+    ):
+        yield {"create": create, "update": update, "delete": delete, "exists": exists}
+
+
+@pytest.fixture
+def mock_client():
+    return object()
+
+
+class TestCreateIntentClusteringCoordinatorSchedule:
+    @pytest.mark.asyncio
+    async def test_flag_off_no_existing_schedule_is_noop(self, mock_client, schedule_helpers) -> None:
+        schedule_helpers["exists"].return_value = False
+        with patch(
+            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            await create_intent_clustering_coordinator_schedule(mock_client)
+
+        schedule_helpers["create"].assert_not_called()
+        schedule_helpers["update"].assert_not_called()
+        schedule_helpers["delete"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_existing_schedule_is_deleted(self, mock_client, schedule_helpers) -> None:
+        schedule_helpers["exists"].return_value = True
+        with patch(
+            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            await create_intent_clustering_coordinator_schedule(mock_client)
+
+        schedule_helpers["delete"].assert_awaited_once_with(mock_client, COORDINATOR_SCHEDULE_ID)
+        schedule_helpers["create"].assert_not_called()
+        schedule_helpers["update"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_on_no_existing_schedule_creates(self, mock_client, schedule_helpers) -> None:
+        schedule_helpers["exists"].return_value = False
+        with patch(
+            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
+            return_value=True,
+        ):
+            await create_intent_clustering_coordinator_schedule(mock_client)
+
+        schedule_helpers["create"].assert_awaited_once()
+        # Assert trigger_immediately=False so first-deploy doesn't dogpile the worker.
+        call_kwargs = schedule_helpers["create"].call_args.kwargs
+        assert call_kwargs.get("trigger_immediately") is False
+        schedule_helpers["update"].assert_not_called()
+        schedule_helpers["delete"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_on_existing_schedule_updates(self, mock_client, schedule_helpers) -> None:
+        schedule_helpers["exists"].return_value = True
+        with patch(
+            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
+            return_value=True,
+        ):
+            await create_intent_clustering_coordinator_schedule(mock_client)
+
+        schedule_helpers["update"].assert_awaited_once()
+        schedule_helpers["create"].assert_not_called()
+        schedule_helpers["delete"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_check_exception_defaults_to_disabled(self, mock_client, schedule_helpers) -> None:
+        # Network failure / SDK bug must not crash schedule init for other modules.
+        schedule_helpers["exists"].return_value = False
+        with patch(
+            "posthog.temporal.mcp_analytics.intent_clustering.schedule.posthoganalytics.feature_enabled",
+            side_effect=RuntimeError("PostHog FF API down"),
+        ):
+            await create_intent_clustering_coordinator_schedule(mock_client)
+
+        schedule_helpers["create"].assert_not_called()
+        schedule_helpers["update"].assert_not_called()
+
+
+class TestFeatureFlagKeyIsStable:
+    def test_flag_key_matches_documented_value(self) -> None:
+        # The feature flag must be created in PostHog with this exact key.
+        # Changing the key here without coordinating with the FF setup will
+        # silently leave the schedule off forever.
+        assert FEATURE_FLAG_KEY == "mcp-analytics-clustering-schedule"

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -57,6 +57,7 @@ from posthog.temporal.experiments.schedule import (
 from posthog.temporal.health_checks.schedule import create_health_check_schedules
 from posthog.temporal.ingestion_acceptance_test.schedule import create_ingestion_acceptance_test_schedule
 from posthog.temporal.logs_alerting.schedule import create_logs_alert_check_schedule
+from posthog.temporal.mcp_analytics.intent_clustering.schedule import create_intent_clustering_coordinator_schedule
 from posthog.temporal.messaging.schedule import create_all_realtime_cohort_calculation_schedules
 from posthog.temporal.product_analytics.upgrade_queries_workflow import UpgradeQueriesWorkflowInputs
 from posthog.temporal.quota_limiting.run_quota_limiting import RunQuotaLimitingInputs
@@ -591,6 +592,7 @@ schedules = [
     create_batch_generation_summarization_schedule,
     create_trace_clustering_coordinator_schedule,
     create_generation_clustering_coordinator_schedule,
+    create_intent_clustering_coordinator_schedule,
     create_eval_reports_schedule,
     create_count_trigger_schedule,
     create_evaluation_sampler_schedule,


### PR DESCRIPTION
The schedule is gated on PostHog feature flag
mcp-analytics-clustering-schedule using distinct_id
internal_mcpa_clustering_schedule. When the flag is OFF (the default), the
schedule isn't registered — and if a schedule already exists, it's deleted
on next init. That lets us cleanly kill the daily fan-out without
shipping a code change once the worker for mcp-analytics-task-queue is
deployed.

trigger_immediately=False on first creation so deploys don't dogpile the
worker. Failures reading the feature flag default to OFF (fail-closed)
so a PostHog API outage can't accidentally enable the schedule.

Generated-By: PostHog Code
Task-Id: 973975fd-03b4-460b-b81e-3ee5c636e086

---
## Part of stack — MCP analytics intent clustering (7/9)

Production-readying the MCP analytics intent clustering pipeline. Stack chain:
1. window corpus → 2. drop fallback → 3. embedding cache → 4. temporal scaffold → 5. daily workflow → 6. coordinator → 7. schedule → 8. metrics → 9. retire celery

This is PR **7 of 9**. Base: `posthog-code/mcpa-clustering-6-coordinator`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

---
> Part of the 9-PR clustering stack — see #59684 for the full plan.
