### PR TITLE
fix(ci): add --only flag to wait-for-docker helpers

### DIFF
--- a/bin/ci-wait-for-docker
+++ b/bin/ci-wait-for-docker
@@ -26,9 +26,12 @@ usage() {
     cat <<'EOF'
 Usage:
   bin/ci-wait-for-docker launch [--down|--down-all-profiles] [--background] [services...]
-  bin/ci-wait-for-docker wait [services...]
+  bin/ci-wait-for-docker wait [--only] [services...]
 
 `wait` is the default command when omitted.
+With no args, `wait` blocks on the core stack (db redis7 kafka clickhouse).
+Extra services are appended to the core list. Pass `--only` to wait ONLY for
+the listed services (skipping core) — for jobs that launched a subset.
 EOF
 }
 
@@ -259,8 +262,31 @@ run_launch() {
 }
 
 run_wait() {
-    local core_services=(db redis7 kafka clickhouse)
-    local wait_services=("${core_services[@]}" "$@")
+    # Default: wait for core (db redis7 kafka clickhouse) plus any extras passed
+    # as args — matches `bin/wait-for-docker`'s semantics so the two helpers stay
+    # consistent. Pass `--only` as the first arg to wait ONLY for the listed
+    # services (skipping core) — for CI jobs that intentionally launch a subset
+    # of the stack and shouldn't block on services they never started.
+    local default_services=(db redis7 kafka clickhouse)
+    local only_listed=0
+    local forward_args=()
+    if [ "${1:-}" = "--only" ]; then
+        only_listed=1
+        shift
+        if [ "$#" -eq 0 ]; then
+            echo "ci-wait-for-docker wait: --only requires at least one service argument" >&2
+            return 2
+        fi
+        forward_args=(--only "$@")
+    else
+        forward_args=("$@")
+    fi
+    local wait_services
+    if [ "$only_listed" -eq 1 ]; then
+        wait_services=("$@")
+    else
+        wait_services=("${default_services[@]}" "$@")
+    fi
     local initial_timeout="${WAIT_FOR_DOCKER_TIMEOUT:-300}"
     local current_timeout="$initial_timeout"
     local attempt=0
@@ -279,7 +305,7 @@ run_wait() {
             echo "Proceeding with readiness checks even though the background docker compose launch is still running."
         fi
 
-        if WAIT_FOR_DOCKER_TIMEOUT="$current_timeout" "${SCRIPT_DIR}/wait-for-docker" "$@"; then
+        if WAIT_FOR_DOCKER_TIMEOUT="$current_timeout" "${SCRIPT_DIR}/wait-for-docker" "${forward_args[@]}"; then
             return 0
         fi
 

--- a/bin/wait-for-docker
+++ b/bin/wait-for-docker
@@ -5,8 +5,10 @@ set -euo pipefail
 # Read-only: does not start, stop, or recreate any containers.
 # Used by phrocs processes to block until infrastructure is ready.
 #
-# Always checks core services (db, redis7, kafka, clickhouse).
-# Pass extra service names as arguments, e.g.: bin/wait-for-docker temporal
+# Usage:
+#   bin/wait-for-docker                     # wait for core (db redis7 kafka clickhouse)
+#   bin/wait-for-docker temporal            # wait for core + temporal
+#   bin/wait-for-docker --only db redis7    # wait only for db and redis7 (skip core)
 
 # In a sandbox container, infra is managed by docker compose externally
 # and is guaranteed healthy via depends_on health checks.
@@ -20,8 +22,22 @@ REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 DEFAULT_COMPOSE_FILE="${REPO_ROOT}/docker-compose.dev.yml"
 TIMEOUT="${WAIT_FOR_DOCKER_TIMEOUT:-300}"
 
-SERVICES=(db redis7 kafka clickhouse)
-SERVICES+=("$@")
+only_listed=0
+if [ "${1:-}" = "--only" ]; then
+    only_listed=1
+    shift
+fi
+
+if [ "$only_listed" -eq 1 ]; then
+    if [ "$#" -eq 0 ]; then
+        echo "wait-for-docker: --only requires at least one service argument" >&2
+        exit 2
+    fi
+    SERVICES=("$@")
+else
+    SERVICES=(db redis7 kafka clickhouse)
+    SERVICES+=("$@")
+fi
 
 unique_services=()
 for svc in "${SERVICES[@]}"; do


### PR DESCRIPTION
## Problem

`bin/ci-wait-for-docker wait <services>` and `bin/wait-for-docker <services>` unconditionally append the hardcoded core list `(db redis7 kafka clickhouse)` to the wait set. Callers that intentionally launch a subset of the stack hit the 300s `WAIT_FOR_DOCKER_TIMEOUT` on services they never started, then fall into the retry-recovery branch which brings them up anyway.

Observed in PR #58015's `Validate OpenAPI types` job (run 26251889955): `Wait for Docker services` ran 5m 16s for `wait db`, recovering by running `compose up -d redis7 kafka clickhouse` after the timeout.

## Changes

- `bin/wait-for-docker`: new `--only` flag waits only for the services passed after it.
- `bin/ci-wait-for-docker wait`: same flag, forwarded to the inner script.
- Default behavior unchanged: extras are still appended to core. Existing callers like `bin/wait-for-docker temporal`, `ci-wait-for-docker wait temporal` (ci-mcp.yml), and `wait capture temporal` (ci-e2e-playwright.yml) keep the implicit core-readiness check.
- `--only` with no service args exits 2 — no silent no-op trap.

## How did you test this code?

- `bash -n` on both scripts
- Smoke-tested the four argument paths (no args, positional, `--only` subset, `--only` empty) against an inline replica of the parsing logic — confirmed `SERVICES` list matches intent in each case

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Found while reviewing PR #58015 (split-check-migrations-openapi). That PR added partial-launch CI jobs but couldn't deliver its full latency win because the wait helper was forcing kafka into readiness checks regardless. First-pass fix changed the default semantics; code review flagged that this would regress existing callers in `ci-mcp.yml` and `ci-e2e-playwright.yml` that rely on the implicit core-readiness check. Redesigned as an opt-in `--only` flag — zero behavior change for any existing caller. PR #58015 (and any future partial-launch caller) opts in explicitly at the call site.