### PR TITLE
test(web-analytics): skip flaky test_session_just_after_window_start_attributed_correctly

### DIFF
--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
@@ -438,6 +438,10 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
 
     # --- Group C: forward-only pad + compare readiness ---------------------
 
+    @unittest.skip(
+        "Flaky on CI since #59075 — same root cause as test_lazy_result_matches_raw_result. "
+        "Lazy path returns empty rows despite READY job. Root cause under investigation."
+    )
     @freeze_time("2024-01-15T12:00:00Z")
     def test_session_just_after_window_start_attributed_correctly(self):
         # Forward-only pad regression: a session starting near the leading edge


### PR DESCRIPTION
## Problem

`test_session_just_after_window_start_attributed_correctly` in `products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py` is flaky on CI — same root cause as `test_lazy_result_matches_raw_result` and the pacific-timezone variant skipped in #59614. Lazy path returns empty rows (0 / None) despite a READY precompute job. Suspected read-after-write visibility on the Distributed table, tracked in #59075.

The test was missed in #59614 and is now blocking unrelated PRs from passing CI (e.g. #58162).

## Changes

Add `@unittest.skip(...)` above the existing `@freeze_time` decorator, matching the reason-string style of the two siblings already skipped in this file. No production code changes.

## 🤖 Agent context

Follow-up to #59614. Root-cause tracker: #59075. Unblocks CI on #58162.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*