### PR TITLE
fix(notebooks): treat client-ahead conflicts as stale instead of empty-step loops

### DIFF
--- a/products/notebooks/backend/collab.py
+++ b/products/notebooks/backend/collab.py
@@ -139,6 +139,11 @@ def submit_steps(
 
 
 def _fetch_missed_steps(stream_key: str, *, last_seen_version: int, current_stream_version: int) -> SubmitResult:
+    # Client is somehow ahead of the stream — no missed range we could send.
+    # The only safe response is "reload the notebook".
+    if current_stream_version < last_seen_version:
+        return SubmitResult(status="stale", version=current_stream_version)
+
     client = redis_module.get_client()
     raw = client.xrange(stream_key, min=f"({last_seen_version}-0", max=f"{current_stream_version}-0")
 

--- a/products/notebooks/backend/test/test_collab.py
+++ b/products/notebooks/backend/test/test_collab.py
@@ -170,6 +170,31 @@ class TestNotebookCollab(BaseTest):
         assert result.status == "accepted"
         assert result.version == 947
 
+    def test_non_empty_stream_with_client_ahead_returns_stale(self):
+        # Stream's latest version is below the client's baseline — there is no missed range to
+        # rebase against. Verify we return `stale` so the client opens the conflict modal
+        # instead of looping on conflict-with-empty-steps.
+        submit_steps(
+            self.team.pk,
+            "nb_client_ahead_nonempty",
+            "client1",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            0,
+            last_saved_version=0,
+        )
+
+        result = submit_steps(
+            self.team.pk,
+            "nb_client_ahead_nonempty",
+            "client_stale",
+            [{"stepType": "replace", "from": 1, "to": 1}],
+            last_seen_version=5,
+            last_saved_version=5,
+        )
+        assert result.status == "stale"
+        assert result.version == 1
+        assert result.steps_since is None
+
     def test_stream_maxlen_constant_is_sane(self):
         # Sanity: MAXLEN must comfortably hold an hour of edits. Adjust deliberately if changed.
         assert STREAM_MAX_LENGTH >= 1000


### PR DESCRIPTION
## Problem

When the Redis stream's latest version is below the client's `last_seen_version`, the server reports a 409 conflict but `_fetch_missed_steps` asks Redis for an inverted XRANGE — gets nothing back — and the trim-detection guard (`len(missed) < gap_size`) silently passes because `gap_size` is negative. So we return 409 with an empty `steps` array. The client has nothing to rebase, retries with the same baseline, gets the same 409 — infinite loop.

![CleanShot 2026-05-20 at 17.00.11 (1).gif](https://app.graphite.com/user-attachments/assets/6b5e154e-2e9d-4f96-b0b6-d103453f0126.gif)



This can happen whenever the Redis stream falls behind Postgres: Redis was evicted/flushed and re-seeded from a lower baseline by a subsequent save, or the legacy `PATCH /notebooks/:id` endpoint advanced `notebook.version` without writing to Redis.

## Changes

- Short-circuit `_fetch_missed_steps` to return `stale` (HTTP 410) when `current_stream_version < last_seen_version`. The client's 410 handler opens the conflict modal and reloads instead of retrying the same doomed save.

## How did you test this code?

```
pytest products/notebooks/backend/test/test_collab.py
```

## Publish to changelog?

no