### PR TITLE
chore(ci): switch bundle-size report to dist-report tree

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -211,13 +211,15 @@ jobs:
             - name: Check frontend bundle size
               uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
               with:
-                  build-script: '--filter=@posthog/frontend build'
+                  build-script: '--filter=@posthog/frontend build:with-report'
                   install-script: 'pnpm --filter=@posthog/frontend... install'
                   compression: 'none'
-                  # Check all JS bundles in the dist folder
-                  pattern: 'frontend/dist/**/*.js'
-                  # Exclude source maps and chunk files (chunk hashes change every build)
-                  exclude: '{**/*.js.map,**/chunk*.js}'
+                  # dist-report/ carries the source bundle (posthog-app, exporter, …) and source
+                  # path in the filename, so strip-hash yields a deterministic identity. dist/ has
+                  # cross-bundle basename collisions that cause phantom size changes.
+                  pattern: 'frontend/dist-report/**/*.js'
+                  # Shared chunk hashes change every build, ignore those
+                  exclude: '{**/_chunks/chunk*.js}'
                   # Only show large changes
                   minimum-change-threshold: 1000
                   order-by: 'Size:desc'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -211,13 +211,15 @@ jobs:
             - name: Check frontend bundle size
               uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
               with:
-                  build-script: '--filter=@posthog/frontend build'
+                  build-script: '--filter=@posthog/frontend build:with-report'
                   install-script: 'pnpm --filter=@posthog/frontend... install'
                   compression: 'none'
-                  # Check all JS bundles in the dist folder
-                  pattern: 'frontend/dist/**/*.js'
-                  # Exclude source maps and chunk files (chunk hashes change every build)
-                  exclude: '{**/*.js.map,**/chunk*.js}'
+                  # dist-report/ carries the source bundle (app/exporter) and source path in the
+                  # filename, so strip-hash yields a stable identity. dist/ has cross-bundle
+                  # basename collisions that cause phantom size changes.
+                  pattern: 'frontend/dist-report/**/*.js'
+                  # Shared chunk hashes change every build, ignore those
+                  exclude: '{**/_chunks/chunk*.js}'
                   # Only show large changes
                   minimum-change-threshold: 1000
                   order-by: 'Size:desc'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -211,15 +211,13 @@ jobs:
             - name: Check frontend bundle size
               uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
               with:
-                  build-script: '--filter=@posthog/frontend build:with-report'
+                  build-script: '--filter=@posthog/frontend build'
                   install-script: 'pnpm --filter=@posthog/frontend... install'
                   compression: 'none'
-                  # dist-report/ carries the source bundle (app/exporter) and source path in the
-                  # filename, so strip-hash yields a stable identity. dist/ has cross-bundle
-                  # basename collisions that cause phantom size changes.
-                  pattern: 'frontend/dist-report/**/*.js'
-                  # Shared chunk hashes change every build, ignore those
-                  exclude: '{**/_chunks/chunk*.js}'
+                  # Check all JS bundles in the dist folder
+                  pattern: 'frontend/dist/**/*.js'
+                  # Exclude source maps and chunk files (chunk hashes change every build)
+                  exclude: '{**/*.js.map,**/chunk*.js}'
                   # Only show large changes
                   minimum-change-threshold: 1000
                   order-by: 'Size:desc'

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ playwright/__snapshots__/
 frontend/.cache/
 frontend/@posthog/apps-common/dist/
 frontend/dist/
+frontend/dist-report/
 frontend/pnpm-error.log
 frontend/public/Matter*.woff*
 frontend/tmp

--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -509,7 +509,7 @@ export async function buildOrWatch(config) {
 
             if (writeMetaFile) {
                 await fs.writeFile(
-                    `${config.name.toLowerCase().replace(' ', '-')}-esbuild-meta.json`,
+                    `${config.name.toLowerCase().replace(/ /g, '-')}-esbuild-meta.json`,
                     JSON.stringify(buildResult.metafile)
                 )
             }

--- a/frontend/bin/build-bundle-report.mjs
+++ b/frontend/bin/build-bundle-report.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import fse from 'fs-extra'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const frontendDir = path.resolve(__dirname, '..')
+const reportDir = path.join(frontendDir, 'dist-report')
+
+const builds = [
+    { name: 'app', metaFile: 'posthog-app-esbuild-meta.json' },
+    { name: 'exporter', metaFile: 'exporter-esbuild-meta.json' },
+]
+
+function sanitizeSourcePath(p) {
+    return p
+        .split(path.sep)
+        .map((s) => (s === '..' ? '_parent' : s))
+        .join(path.sep)
+}
+
+fse.removeSync(reportDir)
+fse.mkdirSync(reportDir, { recursive: true })
+
+let totalCopied = 0
+for (const build of builds) {
+    const metaPath = path.join(frontendDir, build.metaFile)
+    if (!fse.existsSync(metaPath)) {
+        console.warn(`Bundle report: metafile not found for ${build.name} at ${metaPath}, skipping`)
+        continue
+    }
+    const meta = JSON.parse(fse.readFileSync(metaPath, 'utf-8'))
+
+    for (const [outPath, outInfo] of Object.entries(meta.outputs)) {
+        if (!outPath.endsWith('.js')) {
+            continue
+        }
+        const src = path.resolve(frontendDir, outPath)
+        if (!fse.existsSync(src)) {
+            continue
+        }
+
+        const baseFile = path.basename(outPath)
+        const subPath = outInfo.entryPoint
+            ? path.join(sanitizeSourcePath(path.dirname(outInfo.entryPoint)), baseFile)
+            : path.join('_chunks', baseFile)
+
+        const dest = path.join(reportDir, build.name, subPath)
+        fse.mkdirSync(path.dirname(dest), { recursive: true })
+        fse.copyFileSync(src, dest)
+        totalCopied++
+    }
+}
+
+console.info(`Bundle report: wrote ${totalCopied} files to ${reportDir}`)

--- a/frontend/bin/build-bundle-report.mjs
+++ b/frontend/bin/build-bundle-report.mjs
@@ -7,11 +7,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const frontendDir = path.resolve(__dirname, '..')
 const reportDir = path.join(frontendDir, 'dist-report')
 
-const builds = [
-    { name: 'app', metaFile: 'posthog-app-esbuild-meta.json' },
-    { name: 'exporter', metaFile: 'exporter-esbuild-meta.json' },
-]
+const META_SUFFIX = '-esbuild-meta.json'
 
+// entryPoint can be `../products/...` for workspace imports — flatten `..` so the
+// destination stays under the per-bundle subdir of dist-report/.
+// The CI bundle-size action's `**/_chunks/chunk*.js` exclude (in
+// .github/workflows/ci-frontend.yml) depends on the `_chunks` literal below;
+// keep them in sync if either changes.
 function sanitizeSourcePath(p) {
     return p
         .split(path.sep)
@@ -19,37 +21,72 @@ function sanitizeSourcePath(p) {
         .join(path.sep)
 }
 
+function discoverMetafiles() {
+    return fse
+        .readdirSync(frontendDir)
+        .filter((name) => name.endsWith(META_SUFFIX))
+        .map((name) => ({
+            name: name.slice(0, -META_SUFFIX.length),
+            metaPath: path.join(frontendDir, name),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+}
+
 fse.removeSync(reportDir)
 fse.mkdirSync(reportDir, { recursive: true })
 
-let totalCopied = 0
-for (const build of builds) {
-    const metaPath = path.join(frontendDir, build.metaFile)
-    if (!fse.existsSync(metaPath)) {
-        console.warn(`Bundle report: metafile not found for ${build.name} at ${metaPath}, skipping`)
-        continue
-    }
-    const meta = JSON.parse(fse.readFileSync(metaPath, 'utf-8'))
+const metafiles = discoverMetafiles()
+if (metafiles.length === 0) {
+    console.error(
+        `Bundle report: no ${META_SUFFIX} files found in ${frontendDir}. ` +
+            `Each production esbuild config must have writeMetaFile enabled — see frontend/build.mjs. ` +
+            `Did the esbuild step run?`
+    )
+    process.exit(1)
+}
 
+let totalCopied = 0
+for (const { name, metaPath } of metafiles) {
+    let meta
+    try {
+        meta = JSON.parse(fse.readFileSync(metaPath, 'utf-8'))
+    } catch (err) {
+        console.error(`Bundle report: failed to parse ${metaPath}: ${err.message}`)
+        process.exit(1)
+    }
+
+    let copiedForBundle = 0
     for (const [outPath, outInfo] of Object.entries(meta.outputs)) {
         if (!outPath.endsWith('.js')) {
             continue
         }
         const src = path.resolve(frontendDir, outPath)
         if (!fse.existsSync(src)) {
+            console.warn(`Bundle report: ${name} metafile lists ${outPath} but file is missing on disk; skipping`)
             continue
         }
 
         const baseFile = path.basename(outPath)
-        const subPath = outInfo.entryPoint
-            ? path.join(sanitizeSourcePath(path.dirname(outInfo.entryPoint)), baseFile)
-            : path.join('_chunks', baseFile)
+        const subPath =
+            outInfo.entryPoint && outInfo.entryPoint !== '.'
+                ? path.join(sanitizeSourcePath(path.dirname(outInfo.entryPoint)), baseFile)
+                : path.join('_chunks', baseFile)
 
-        const dest = path.join(reportDir, build.name, subPath)
+        const dest = path.join(reportDir, name, subPath)
         fse.mkdirSync(path.dirname(dest), { recursive: true })
         fse.copyFileSync(src, dest)
+        copiedForBundle++
         totalCopied++
+    }
+
+    if (copiedForBundle === 0) {
+        console.error(`Bundle report: bundle "${name}" contributed zero .js outputs; metafile may be stale`)
+        process.exit(1)
     }
 }
 
-console.info(`Bundle report: wrote ${totalCopied} files to ${reportDir}`)
+console.info(
+    `Bundle report: wrote ${totalCopied} files from ${metafiles.length} bundle(s) (${metafiles
+        .map((m) => m.name)
+        .join(', ')}) to ${reportDir}`
+)

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -47,6 +47,7 @@ await buildInParallel(
             splitting: true,
             format: 'esm',
             outdir: path.resolve(__dirname, 'dist'),
+            writeMetaFile: !isDev,
             ...common,
         },
         {
@@ -86,6 +87,7 @@ await buildInParallel(
             splitting: true,
             format: 'esm',
             outdir: path.resolve(__dirname, 'dist'),
+            writeMetaFile: !isDev,
             ...common,
         },
         {

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -36,6 +36,7 @@ await import('./build-products.mjs')
 const common = {
     absWorkingDir: __dirname,
     bundle: true,
+    writeMetaFile: !isDev,
 }
 
 await buildInParallel(
@@ -47,7 +48,6 @@ await buildInParallel(
             splitting: true,
             format: 'esm',
             outdir: path.resolve(__dirname, 'dist'),
-            writeMetaFile: !isDev,
             ...common,
         },
         {
@@ -87,7 +87,6 @@ await buildInParallel(
             splitting: true,
             format: 'esm',
             outdir: path.resolve(__dirname, 'dist'),
-            writeMetaFile: !isDev,
             ...common,
         },
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
         "copy-scripts": "mkdir -p dist/ && ./bin/copy-posthog-js",
         "clean": "rm -rf dist && mkdir dist",
         "build": "pnpm copy-scripts && pnpm build:esbuild",
+        "build:with-report": "pnpm build && node ./bin/build-bundle-report.mjs",
         "build:esbuild": "DEBUG=0 node ./build.mjs",
         "build:products": "DEBUG=0 node build-products.mjs",
         "build:tailwind": "pnpm --filter=@posthog/tailwind build",


### PR DESCRIPTION
> Stacked on #59626. Will only build cleanly once that PR has merged to master.

## Problem

Companion to #59626. That PR shipped the infrastructure (`frontend/bin/build-bundle-report.mjs`, the `build:with-report` pnpm script, `writeMetaFile: !isDev` hoisted into shared `common`) but deliberately did not touch `.github/workflows/ci-frontend.yml` — the `compressed-size-action` runs the build-script on both PR HEAD and the base branch, and master didn't have the new pnpm script yet, so doing both in one PR failed the base build with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`.

Once #59626 lands, master will have `build:with-report` available and this PR can switch the action over to the collision-free `dist-report/` tree.

## Changes

One-file change to `.github/workflows/ci-frontend.yml`:

- `build-script: '--filter=@posthog/frontend build'` → `'--filter=@posthog/frontend build:with-report'`
- `pattern: 'frontend/dist/**/*.js'` → `'frontend/dist-report/**/*.js'`
- `exclude: '{**/*.js.map,**/chunk*.js}'` → `'{**/_chunks/chunk*.js}'`
- Updated the inline comment to reflect the new layout.

`strip-hash` regex unchanged: only the trailing `-HASH.js` gets stripped, and the disambiguating bundle/source-path prefix survives.

## How did you test this code?

Agent-authored, no manual UI testing.

The base-branch build will only work once #59626 is on master, so CI on this PR will be red against the current master until then. After #59626 merges, this PR's CI should turn green automatically (or after a rebase).

The infrastructure side was tested in #59626 — local `pnpm --filter=@posthog/frontend build:with-report` produces 1030 files across 8 bundles with zero stripped-name collisions.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code, an agent. Pure CI configuration change — the work to make this possible is in the parent PR #59626.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
