### PR TITLE
fix: Recover stuck CANDIDATE groups and avoid similar cases in the future

### DIFF
--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -716,17 +716,22 @@ async def assign_and_emit_signal_activity(input: AssignAndEmitSignalInput) -> As
             #   signals_at_run defaults to 0 so fresh reports always pass) and weight threshold is met.
             # - READY and RESOLVED reports are re-promoted on every new signal so the pipeline
             #   reruns with latest evidence (resolved: issue recurred post-merge fix).
+            # - CANDIDATE re-promotes on every new signal to self-heal from failed spawn attempts. Concurrent runs blocked by Temporal.
             if (
                 report.status == SignalReport.Status.READY
                 or report.status == SignalReport.Status.RESOLVED
+                or report.status == SignalReport.Status.CANDIDATE
                 or (
                     report.status == SignalReport.Status.POTENTIAL
                     and report.total_weight >= WEIGHT_THRESHOLD
                     and report.signal_count >= report.signals_at_run
                 )
             ):
-                updated_fields = report.transition_to(SignalReport.Status.CANDIDATE)
-                report.save(update_fields=updated_fields)
+                # If candidate got here - it usually means CH issue down the way
+                # (e.g. CH wait raised before start_child_workflow)
+                if report.status != SignalReport.Status.CANDIDATE:
+                    updated_fields = report.transition_to(SignalReport.Status.CANDIDATE)
+                    report.save(update_fields=updated_fields)
                 promoted = True
 
             report_id = str(report.id)
@@ -1191,27 +1196,31 @@ async def _process_signal_batch(
             retry_policy=RetryPolicy(maximum_attempts=2),
         )
 
-    # Spawn summary workflows after CH wait so they can find the signals.
-    for report_input, run_count in promoted_reports.values():
+    # Spawn summary workflows after CH wait. Stable ID + ALLOW_DUPLICATE: Temporal rejects concurrent
+    # starts with the same ID (caught below); re-spawning is allowed only if the previous run has closed.
+    for report_input, _run_count in promoted_reports.values():
         try:
-            base_id = SignalReportSummaryWorkflow.workflow_id_for(report_input.team_id, report_input.report_id)
-            # Include run_count in the workflow ID to allow re-generating READY reports when enough new signals arrive,
-            # as without it ALLOW_DUPLICATE_FAILED_ONLY will prevent the re-report from starting
-            workflow_id = base_id if run_count == 0 else f"{base_id}:run-{run_count + 1}"
-            # Concurrent report generation of the same report can't happen: promotion only fires for
-            # READY/RESOLVED (every new qualifying signal) or POTENTIAL past weight/snooze gates—never while
-            # CANDIDATE/IN_PROGRESS/PENDING_INPUT/etc.
+            workflow_id = SignalReportSummaryWorkflow.workflow_id_for(report_input.team_id, report_input.report_id)
             await workflow.start_child_workflow(
                 SignalReportSummaryWorkflow.run,
                 report_input,
                 id=workflow_id,
                 task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
                 parent_close_policy=ParentClosePolicy.ABANDON,
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
                 execution_timeout=timedelta(hours=1),
             )
         except temporalio.exceptions.WorkflowAlreadyStartedError:
+            # Expected when CANDIDATE re-promotion fires against an in-flight workflow; no-op.
             pass
+        except Exception:
+            # Log and continue: raising here would reprocess the whole batch and double-count
+            # signals. The report stays CANDIDATE and re-promotes on the next matching signal.
+            logger.exception(
+                "Failed to start summary workflow for promoted report; will retry on next signal",
+                team_id=report_input.team_id,
+                report_id=report_input.report_id,
+            )
 
     return dropped, type_examples_result
 

--- a/products/signals/backend/test/test_assign_and_emit_signal.py
+++ b/products/signals/backend/test/test_assign_and_emit_signal.py
@@ -1,0 +1,404 @@
+import uuid
+import random
+from datetime import timedelta
+
+import pytest
+from unittest.mock import patch
+
+from django.utils import timezone
+
+import pytest_asyncio
+from asgiref.sync import sync_to_async
+
+from posthog.models import Organization, Team
+from posthog.sync import database_sync_to_async
+
+from products.signals.backend.models import SignalReport
+from products.signals.backend.temporal.grouping import (
+    WEIGHT_THRESHOLD,
+    AssignAndEmitSignalInput,
+    assign_and_emit_signal_activity,
+)
+from products.signals.backend.temporal.types import (
+    ExistingReportMatch,
+    MatchedMetadata,
+    NewReportMatch,
+    NoMatchMetadata,
+)
+
+GROUPING_MODULE_PATH = "products.signals.backend.temporal.grouping"
+
+
+@pytest_asyncio.fixture
+async def aorganization():
+    organization = await sync_to_async(Organization.objects.create)(
+        name=f"SignalsAssignOrg-{random.randint(1, 99999)}",
+    )
+    yield organization
+    await sync_to_async(organization.delete)()
+
+
+@pytest_asyncio.fixture
+async def ateam(aorganization):
+    team = await sync_to_async(Team.objects.create)(
+        organization=aorganization,
+        name=f"SignalsAssignTeam-{random.randint(1, 99999)}",
+    )
+    yield team
+    await sync_to_async(team.delete)()
+
+
+@pytest.fixture(autouse=True)
+def patch_side_effects():
+    """Mock only the external side effects (Kafka, analytics, ClickHouse). The Postgres state
+    machine is the SUT and is exercised against a real DB."""
+    with (
+        patch(f"{GROUPING_MODULE_PATH}.emit_embedding_request") as emit_mock,
+        patch(f"{GROUPING_MODULE_PATH}.posthoganalytics.capture") as capture_mock,
+        patch(f"{GROUPING_MODULE_PATH}.soft_delete_report_signals") as soft_delete_mock,
+    ):
+        yield {"emit": emit_mock, "capture": capture_mock, "soft_delete": soft_delete_mock}
+
+
+def _existing_match(report_id: str) -> ExistingReportMatch:
+    return ExistingReportMatch(
+        report_id=report_id,
+        match_metadata=MatchedMetadata(
+            parent_signal_id=str(uuid.uuid4()),
+            match_query="test query",
+            reason="similar content",
+        ),
+    )
+
+
+def _new_match(title: str = "Test title", summary: str = "Test summary") -> NewReportMatch:
+    return NewReportMatch(
+        title=title,
+        summary=summary,
+        match_metadata=NoMatchMetadata(reason="no matching candidates"),
+    )
+
+
+def _build_input(
+    team_id: int,
+    match_result: ExistingReportMatch | NewReportMatch,
+    weight: float = 0.5,
+) -> AssignAndEmitSignalInput:
+    return AssignAndEmitSignalInput(
+        team_id=team_id,
+        signal_id=str(uuid.uuid4()),
+        description="A test signal description",
+        weight=weight,
+        source_product="conversations",
+        source_type="ticket",
+        source_id=f"src-{uuid.uuid4()}",
+        extra={},
+        embedding=[0.0] * 1536,
+        match_result=match_result,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: new POTENTIAL report from NewReportMatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_new_match_creates_potential_report_below_threshold(ateam):
+    """A first signal below weight threshold creates a POTENTIAL report, not promoted yet."""
+    input_ = _build_input(ateam.id, _new_match(), weight=WEIGHT_THRESHOLD * 0.5)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.promoted is False
+    report = await database_sync_to_async(SignalReport.objects.get)(id=result.report_id)
+    assert report.status == SignalReport.Status.POTENTIAL
+    assert report.total_weight == pytest.approx(WEIGHT_THRESHOLD * 0.5)
+    assert report.signal_count == 1
+    assert report.promoted_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_new_match_creates_and_immediately_promotes_when_above_threshold(ateam):
+    """A first signal at/above threshold creates a POTENTIAL report and promotes it in one shot."""
+    input_ = _build_input(ateam.id, _new_match(), weight=WEIGHT_THRESHOLD)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.promoted is True
+    report = await database_sync_to_async(SignalReport.objects.get)(id=result.report_id)
+    assert report.status == SignalReport.Status.CANDIDATE
+    assert report.promoted_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Happy path: existing POTENTIAL crossing thresholds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_potential_promotes_when_weight_crosses_threshold(ateam):
+    """An existing POTENTIAL report below threshold gets pushed over by the new signal's weight."""
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.POTENTIAL,
+        total_weight=WEIGHT_THRESHOLD * 0.6,
+        signal_count=1,
+    )
+    input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=WEIGHT_THRESHOLD * 0.6)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.promoted is True
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.status == SignalReport.Status.CANDIDATE
+    assert refreshed.total_weight == pytest.approx(WEIGHT_THRESHOLD * 1.2)
+    assert refreshed.signal_count == 2
+    assert refreshed.promoted_at is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_potential_does_not_promote_below_weight_threshold(ateam):
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.POTENTIAL,
+        total_weight=WEIGHT_THRESHOLD * 0.2,
+        signal_count=1,
+    )
+    input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=WEIGHT_THRESHOLD * 0.2)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.promoted is False
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.status == SignalReport.Status.POTENTIAL
+    assert refreshed.promoted_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_potential_does_not_promote_when_signals_at_run_gate_holds(ateam):
+    """Snooze gate: even at weight threshold, a POTENTIAL with signals_at_run > signal_count stays put."""
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.POTENTIAL,
+        total_weight=WEIGHT_THRESHOLD,
+        signal_count=2,
+        signals_at_run=10,  # need 10 signals before re-promoting
+    )
+    input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=0.5)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.promoted is False
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.status == SignalReport.Status.POTENTIAL
+    assert refreshed.signal_count == 3
+
+
+# ---------------------------------------------------------------------------
+# THE NEW BEHAVIOR — CANDIDATE re-promotion as self-healing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_candidate_returns_promoted_true_without_changing_status(ateam):
+    """A new signal arriving at an already-CANDIDATE report must:
+    - return promoted=True so the caller spawns a recovery workflow
+    - leave status at CANDIDATE
+    - increment weight + signal_count atomically
+    """
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.CANDIDATE,
+        total_weight=2.0,
+        signal_count=3,
+    )
+    input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=0.5)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.promoted is True
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.status == SignalReport.Status.CANDIDATE
+    assert refreshed.total_weight == pytest.approx(2.5)
+    assert refreshed.signal_count == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_candidate_repromotion_preserves_original_promoted_at(ateam):
+    """promoted_at must not be reset on re-promotion of an already-CANDIDATE report — the
+    original timestamp is more useful (it reflects when the report first became actionable)."""
+    original_promoted_at = timezone.now() - timedelta(hours=2)
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.CANDIDATE,
+        total_weight=1.5,
+        signal_count=2,
+        promoted_at=original_promoted_at,
+    )
+    input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=0.5)
+
+    await assign_and_emit_signal_activity(input_)
+
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.promoted_at == original_promoted_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_repeated_signals_to_candidate_never_raise_invalid_transition(ateam):
+    """The havoc test: ten signals in a row at the same CANDIDATE report must not raise
+    InvalidStatusTransition (which transition_to would, since CANDIDATE -> CANDIDATE has no
+    case in the match). All counter increments must persist."""
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.CANDIDATE,
+        total_weight=1.0,
+        signal_count=1,
+    )
+
+    for _ in range(10):
+        input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=0.1)
+        result = await assign_and_emit_signal_activity(input_)
+        assert result.promoted is True
+
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.status == SignalReport.Status.CANDIDATE
+    assert refreshed.total_weight == pytest.approx(2.0)
+    assert refreshed.signal_count == 11
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_candidate_repromotion_does_not_advance_run_count(ateam):
+    """run_count is incremented by mark_report_in_progress_activity (CANDIDATE -> IN_PROGRESS),
+    NOT by the assign-and-emit gate. Re-promoting an already-CANDIDATE report must not touch it."""
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.CANDIDATE,
+        total_weight=1.5,
+        signal_count=2,
+        run_count=3,
+    )
+    input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=0.5)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.run_count == 3
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.run_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Existing re-promotion behaviors — preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "starting_status",
+    [SignalReport.Status.READY, SignalReport.Status.RESOLVED],
+)
+async def test_ready_and_resolved_repromote_to_candidate_on_any_signal(ateam, starting_status):
+    """READY and RESOLVED re-promote on every signal regardless of weight thresholds."""
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=starting_status,
+        total_weight=1.5,
+        signal_count=2,
+        title="original title",
+        summary="original summary",
+    )
+    input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=0.1)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.promoted is True
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.status == SignalReport.Status.CANDIDATE
+    assert refreshed.promoted_at is not None
+    # title/summary must be preserved through the transition
+    assert refreshed.title == "original title"
+    assert refreshed.summary == "original summary"
+
+
+# ---------------------------------------------------------------------------
+# States that should NOT promote
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "starting_status",
+    [
+        SignalReport.Status.IN_PROGRESS,
+        SignalReport.Status.PENDING_INPUT,
+        SignalReport.Status.FAILED,
+        SignalReport.Status.SUPPRESSED,
+    ],
+)
+async def test_non_promoting_states_increment_counters_but_do_not_promote(ateam, starting_status):
+    """For IN_PROGRESS / PENDING_INPUT / FAILED / SUPPRESSED:
+    - weight + signal_count still update
+    - status is unchanged
+    - promoted=False so no workflow spawn attempt
+    """
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=starting_status,
+        total_weight=1.0,
+        signal_count=2,
+    )
+    input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=0.5)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.promoted is False
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.status == starting_status
+    assert refreshed.total_weight == pytest.approx(1.5)
+    assert refreshed.signal_count == 3
+
+
+# ---------------------------------------------------------------------------
+# DELETED report short-circuit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_deleted_report_skips_counter_updates_and_marks_signal_deleted(ateam, patch_side_effects):
+    """When a signal matches a DELETED report:
+    - counters are NOT incremented
+    - status remains DELETED
+    - the signal is still emitted to ClickHouse but marked deleted=True in metadata
+    - soft_delete_report_signals is invoked to clean up stale rows
+    """
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=ateam,
+        status=SignalReport.Status.DELETED,
+        total_weight=2.0,
+        signal_count=3,
+    )
+    input_ = _build_input(ateam.id, _existing_match(str(report.id)), weight=0.5)
+
+    result = await assign_and_emit_signal_activity(input_)
+
+    assert result.promoted is False
+    refreshed = await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+    assert refreshed.status == SignalReport.Status.DELETED
+    assert refreshed.total_weight == 2.0
+    assert refreshed.signal_count == 3
+
+    patch_side_effects["soft_delete"].assert_called_once()
+    emit_kwargs = patch_side_effects["emit"].call_args.kwargs
+    assert emit_kwargs["metadata"]["deleted"] is True


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

- A ClickHouse hiccup caused multiple `SignalReport`s to get stuck in `CANDIDATE` forever, with no workflow running to advance them. It could happen again.
- wait_for_signal_in_clickhouse_activity` raised between the Postgres commit of `transition_to(CANDIDATE)` and the `start_child_workflow` call, so the report never happened.
- No recovery path: only re-promoted `READY` / `RESOLVED` / threshold-met `POTENTIAL` — never `CANDIDATE` — so subsequent signals arriving at a stuck report incremented its counters but never re-attempted to spawn the report.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Added `CANDIDATE` to the re-promotion conditions. Self-heals stuck reports on the next matching signal.
- Dropped the `:run-N` suffix; spawns always use `base_id`, and switched from `ALLOW_DUPLICATE_FAILED_ONLY` to `ALLOW_DUPLICATE`. Concurrent runs are still blocked at the Temporal protocol level (`WorkflowExecutionAlreadyStarted`), independent of the reuse policy.
- Added a generic `except Exception` around `start_child_workflow` so one bad spawn doesn't strand the rest of the batch. The report retries on its next matching signal via the CANDIDATE re-promotion path.


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
