### PR TITLE
fix(personhog): route batch queries to batch pool

### DIFF
--- a/rust/personhog-replica/src/storage/postgres/group.rs
+++ b/rust/personhog-replica/src/storage/postgres/group.rs
@@ -119,7 +119,7 @@ impl GroupStorage for PostgresStorage {
         }
 
         let client = current_client_name();
-        let pool_label = PostgresStorage::pool_label(consistency);
+        let pool_label = PostgresStorage::bulk_pool_label(consistency);
         let labels = [
             ("operation".to_string(), "get_groups_batch".to_string()),
             ("pool".to_string(), pool_label.to_string()),
@@ -127,7 +127,7 @@ impl GroupStorage for PostgresStorage {
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
-        let pool = self.pool_for_consistency(consistency);
+        let pool = self.bulk_pool_for_consistency(consistency);
         let mut conn = PostgresStorage::acquire_timed(pool, pool_label).await?;
 
         let team_ids: Vec<i32> = keys.iter().map(|k| k.team_id as i32).collect();
@@ -237,7 +237,7 @@ impl GroupStorage for PostgresStorage {
         }
 
         let client = current_client_name();
-        let pool_label = PostgresStorage::pool_label(consistency);
+        let pool_label = PostgresStorage::bulk_pool_label(consistency);
         let labels = [
             (
                 "operation".to_string(),
@@ -248,7 +248,7 @@ impl GroupStorage for PostgresStorage {
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
-        let pool = self.pool_for_consistency(consistency);
+        let pool = self.bulk_pool_for_consistency(consistency);
         let mut conn = PostgresStorage::acquire_timed(pool, pool_label).await?;
 
         let team_ids_i32: Vec<i32> = team_ids.iter().map(|&id| id as i32).collect();
@@ -345,7 +345,7 @@ impl GroupStorage for PostgresStorage {
         }
 
         let client = current_client_name();
-        let pool_label = PostgresStorage::pool_label(consistency);
+        let pool_label = PostgresStorage::bulk_pool_label(consistency);
         let labels = [
             (
                 "operation".to_string(),
@@ -356,7 +356,7 @@ impl GroupStorage for PostgresStorage {
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
-        let pool = self.pool_for_consistency(consistency);
+        let pool = self.bulk_pool_for_consistency(consistency);
         let mut conn = PostgresStorage::acquire_timed(pool, pool_label).await?;
 
         let rows = sqlx::query_as!(
@@ -445,7 +445,7 @@ impl GroupStorage for PostgresStorage {
         consistency: ConsistencyLevel,
     ) -> StorageResult<(Vec<Group>, bool)> {
         let client = current_client_name();
-        let pool_label = PostgresStorage::pool_label(consistency);
+        let pool_label = PostgresStorage::bulk_pool_label(consistency);
         let labels = [
             ("operation".to_string(), "list_groups".to_string()),
             ("pool".to_string(), pool_label.to_string()),
@@ -453,7 +453,7 @@ impl GroupStorage for PostgresStorage {
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
-        let pool = self.pool_for_consistency(consistency);
+        let pool = self.bulk_pool_for_consistency(consistency);
         let mut conn = PostgresStorage::acquire_timed(pool, pool_label).await?;
 
         let fetch_limit = (limit as i64) + 1;


### PR DESCRIPTION
## Problem

Personhog replica has two pg connection pools for different query characterisctics. We need to route the batch queries through the batch pool properly

## Changes

move multiple batch queries to the bulk pg pool

## How did you test this code?

Just routing queries to different pools, not much to test
