### PR TITLE
chore(flags): add finding-deleted-feature-flags skill

### DIFF
--- a/products/feature_flags/skills/finding-deleted-feature-flags/SKILL.md
+++ b/products/feature_flags/skills/finding-deleted-feature-flags/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: finding-deleted-feature-flags
+description: 'Find feature flags that were soft-deleted in the active project within a recent time window. Use when the user asks "what flags were deleted in the last N days", "show me recently deleted feature flags", "who deleted flag X", "audit recent flag deletions", or anything similar. Handles the non-obvious gotcha that system.feature_flags exposes the deleted boolean but does not expose a deletion timestamp — the actual deleted-at time lives in the per-flag activity log and must be cross-referenced.'
+---
+
+# Finding recently deleted feature flags
+
+This skill produces a list of feature flags that were soft-deleted in the active project within a user-specified time window, along with who deleted each one and when.
+
+## When to use this skill
+
+- The user asks "what flags got deleted last week / in the last N days?"
+- The user wants an audit of recent flag deletions (who, when, what was removed)
+- The user wants to find when a specific flag was deleted, or by whom
+- Any "recently deleted feature flags" framing
+
+Don't use this for **active** stale-flag cleanup — that's `cleaning-up-stale-feature-flags`. This skill is for flags that have already been removed.
+
+## The gotcha that makes this non-trivial
+
+`system.feature_flags` exposes `deleted` as a boolean but does **not** expose `deleted_at`, `updated_at`, or `last_modified_at`. There's no way to filter soft-deleted flags by deletion time in a single SQL query — trying to use those columns will return `Unable to resolve field`.
+
+The actual deletion timestamp lives in the per-flag activity log, reachable only via `posthog:feature-flags-activity-retrieve` (one call per flag id). There is no bulk activity endpoint.
+
+So the workflow is two-stage: SQL to enumerate candidates, then parallel activity-log lookups to find each deletion event.
+
+## Workflow
+
+### 1. Clarify the window if ambiguous
+
+"Last week" is ambiguous — it can mean rolling 7 days from now, or the previous calendar week (Mon–Sun). If the user wasn't explicit, ask, or surface both interpretations in the final report.
+
+Always compute the cutoff in UTC and keep the user's local interpretation in your head separately.
+
+### 2. Enumerate soft-deleted flags via SQL
+
+Query `system.feature_flags` for `deleted = true` in the active project, ordered by `created_at DESC`:
+
+```sql
+SELECT id, key, created_at
+FROM system.feature_flags
+WHERE team_id = <team_id> AND deleted = true
+ORDER BY created_at DESC
+LIMIT 100
+```
+
+Order by `created_at DESC` because deletions empirically cluster near creation — most flags get deleted within a few days of being created — so walking the most-recently-created candidates first finds recent deletions fastest. **But** this is a heuristic, not a guarantee: an older flag deleted recently won't be at the top of this list. Be explicit about that limitation when you report.
+
+`team_id` defaults to the active project, but include it explicitly for clarity.
+
+### 3. Fan out activity-log lookups in parallel
+
+For each candidate id, call `posthog:feature-flags-activity-retrieve` with `limit: 5, page: 1`. **Issue all calls in one message so they run concurrently** — sequential calls are dramatically slower.
+
+```text
+call feature-flags-activity-retrieve {"id": <flag_id>, "limit": 5, "page": 1}
+```
+
+Reasonable batch sizes:
+
+- "last 7 days" → top 20–25 candidates
+- "last 30 days" → top 50
+- "last 90 days" → walk the full ~100
+
+If you sample fewer than the full set, say so in the report and offer to walk the rest as a follow-up.
+
+### 4. Extract the deletion event from each response
+
+In each response, find the entry where `activity == "deleted"`. That entry's `created_at` is the actual deletion time, and `user.email` / `user.first_name` identify the deleter.
+
+The deletion event's `detail.changes` array typically contains:
+
+- `{field: "deleted", before: false, after: true}` — the actual delete
+- `{field: "key", before: "<original>", after: "<original>:deleted:<id>"}` — Django renames the key on delete to free up the unique constraint
+- `{field: "name", ...}` — the name sometimes gets reset
+
+For most flags there's exactly one delete event. If a flag has been deleted-and-restored multiple times, take the most recent `activity: deleted` event within the window.
+
+### 5. Filter and report
+
+Filter the collected deletion events to those whose `created_at` falls inside the requested window. Present as a table:
+
+| Flag ID | Key | Deleted at (UTC) | Deleted by |
+
+State your methodology in the report (how many candidates you walked vs. how many soft-deleted flags exist total), so the user knows what was and wasn't checked.
+
+## Watch-outs
+
+- **Borderline cases**: if a deletion is within ~1 hour of the window cutoff, surface it as borderline rather than silently dropping it.
+- **Don't trust `created_at` as a proxy for deletion time**: a flag created in 2024 can still have been deleted last week. The activity log is the only authority.
+- **Renamed keys are normal**: a flag with key `foo:deleted:12345` was the flag originally keyed `foo`. The original key/name appears in the delete event's `detail.changes` array — surface that to the user, not the renamed form.
+- **Walking all candidates is possible but slow**: ~100 parallel activity-log calls is doable. Offer it as a follow-up rather than the default for short windows.
+
+## Example interaction
+
+User: "what flags got deleted in the last week?"
+
+1. Clarify if needed, or note both interpretations: "rolling 7 days ending now (UTC), in the active project"
+2. Run the SQL enumeration to get up to 100 soft-deleted candidates ordered by `created_at DESC`
+3. Fan out activity-log lookups in parallel across the top ~25 candidates
+4. Extract `activity: deleted` entries; filter to those whose `created_at >= now - 7 days`
+5. Report:
+
+   ```text
+   Found 2 feature flags deleted in the last 7 days (rolling, ending 2026-05-22 19:04 UTC):
+
+   | Flag ID | Key                                       | Deleted at (UTC)     | Deleted by  |
+   |---------|-------------------------------------------|----------------------|-------------|
+   | 687432  | high_frequency_alerts                     | 2026-05-22 17:23     | Matt P.     |
+   | 676665  | tasks-sendblue-prewarmed-sandbox-pool     | 2026-05-15 13:45     | Alessandro  |
+
+   Methodology: walked the activity log for the 25 most-recently-created soft-deleted
+   flags. Team 2 has ~100 soft-deleted flags total; the remaining ~75 were created
+   before mid-March 2026 and were not checked. Want me to walk the rest?
+   ```
+
+## Related tools
+
+- `posthog:execute-sql`: Used in step 2 to enumerate soft-deleted candidates against `system.feature_flags`
+- `posthog:feature-flags-activity-retrieve`: Used in step 3 to find the actual deletion event for each candidate
+- `posthog:feature-flag-get-definition`: Useful if the user then wants to inspect what the deleted flag looked like


### PR DESCRIPTION
## Problem

When someone asks an agent \"what feature flags got deleted in the last week?\", the agent can't one-shot the answer. `system.feature_flags` exposes the soft-delete `deleted` boolean but **no deletion timestamp** (`deleted_at` / `updated_at` / `last_modified_at` are all unresolvable). So a single SQL query can't filter by deletion time — the actual deleted-at lives only in the per-flag activity log, reached via `feature-flags-activity-retrieve` (one call per flag, no bulk endpoint).

Without a skill, the agent has to rediscover this schema gap every time and then improvise the cross-reference, which is slow and inconsistent.

## Changes

Adds `products/feature_flags/skills/finding-deleted-feature-flags/SKILL.md` documenting the two-stage workflow:

1. SQL against `system.feature_flags` to enumerate soft-deleted candidates ordered by `created_at DESC`.
2. Parallel `feature-flags-activity-retrieve` fan-out across the top N candidates; extract `activity: deleted` events; filter to the requested window.

Includes the relevant gotchas: deletions cluster near creation in practice (so top-N is a good heuristic), the `:deleted:<id>` key-rename pattern on soft-delete, \"last week\" ambiguity (rolling 7 days vs. calendar week), and when to walk the full set vs. sampling.

## How did you test this code?

- Agent-authored. Ran `hogli lint:skills` — passes (42 skills).
- Workflow itself was validated end-to-end against project 2 in the session that motivated this skill (found two deletions in the last 7 days: `high_frequency_alerts` and `tasks-sendblue-prewarmed-sandbox-pool`). The skill encodes that workflow.
- No manual UI testing performed.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- The skill came out of an actual session running this exact workflow against team 2. The cross-reference between `system.feature_flags` and the per-flag activity log was the non-obvious step worth capturing — I'd hit the missing-timestamp gotcha and then had to improvise the parallel fan-out. The skill is the codified version of that one-off.
- Decision: kept it as a single SKILL.md (no `references/` split) — the job-to-be-done is narrow enough that progressive disclosure isn't needed.
- Decision: placed under `products/feature_flags/skills/` alongside `cleaning-up-stale-feature-flags`, since this is the audit-trail counterpart to that cleanup skill.