### PR TITLE
fix(proxy): return actionable error when reverse proxy diagnose fails

### DIFF
--- a/posthog/api/proxy_record.py
+++ b/posthog/api/proxy_record.py
@@ -306,7 +306,20 @@ class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
             )
 
-        report = diagnose_proxy_record(record)
+        try:
+            report = diagnose_proxy_record(record)
+        except Exception as e:
+            capture_exception(e, {"proxy_record_id": str(record.id), "domain": record.domain})
+            return Response(
+                {
+                    "detail": (
+                        "Couldn't run diagnostics for this proxy. Please try again in a few minutes; "
+                        "if this keeps happening, contact PostHog support."
+                    )
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
         serializer = DiagnosticReportSerializer(report)
         return Response(serializer.data)
 

--- a/posthog/api/proxy_record_diagnostics.py
+++ b/posthog/api/proxy_record_diagnostics.py
@@ -295,6 +295,26 @@ def _check_cloudflare(record: ProxyRecord) -> tuple[CheckResult, Optional[Custom
             ),
             None,
         )
+    except Exception as e:
+        # Catches ValueError from misconfigured CLOUDFLARE_API_TOKEN/ZONE_ID,
+        # ValueError/KeyError from response shape changes in _parse_hostname,
+        # and any other unexpected library exception. "warned" (not "failed") so
+        # the rest of the report still runs — downstream checks already _skip
+        # when hostname_info is None.
+        capture_exception(e, {"proxy_record_id": str(record.id), "domain": record.domain})
+        return (
+            CheckResult(
+                id="cloudflare",
+                name="Cloudflare custom hostname",
+                status="warned",
+                detail=(
+                    "We couldn't query our certificate provider for this proxy's status. "
+                    "Other checks below may still be informative. Try again in a few minutes; "
+                    "if it keeps happening, contact support."
+                ),
+            ),
+            None,
+        )
 
     if info is None:
         return (

--- a/posthog/api/test/test_proxy_record.py
+++ b/posthog/api/test/test_proxy_record.py
@@ -502,3 +502,33 @@ class TestProxyRecordAPI(APIBaseTest):
 
         # Sanity: diagnose function only called once despite two requests.
         assert mock_diagnose.call_count == 1
+
+    @patch("posthog.api.proxy_record.diagnose_proxy_record")
+    def test_diagnose_returns_structured_error_on_unexpected_exception(self, mock_diagnose):
+        from django.core.cache import cache
+
+        cache.clear()
+        mock_diagnose.side_effect = RuntimeError("something broke")
+        record = ProxyRecord.objects.create(
+            organization=self.organization,
+            created_by=self.user,
+            domain="failed-diagnose.example.com",
+            target_cname="abc123.proxy.posthog.com",
+            status=ProxyRecord.Status.ERRORING,
+        )
+
+        with patch("posthog.api.proxy_record.capture_exception") as cap_mock:
+            response = self.client.post(
+                f"/api/organizations/{self.organization.id}/proxy_records/{record.id}/diagnose/",
+            )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        body = response.json()
+        # Regression-pin: must not be DRF's default 500 message.
+        assert body["detail"] != "A server error occurred."
+        assert "try again" in body["detail"].lower()
+        assert "support" in body["detail"].lower()
+        cap_mock.assert_called_once()
+        _exc, props = cap_mock.call_args[0]
+        assert props["proxy_record_id"] == str(record.id)
+        assert props["domain"] == record.domain

--- a/posthog/api/test/test_proxy_record_diagnostics.py
+++ b/posthog/api/test/test_proxy_record_diagnostics.py
@@ -127,12 +127,20 @@ class TestCheckCloudflare(TestCase):
         self.assertEqual(result.status, "failed")
         self.assertIn("certificate provider", result.detail.lower())
 
+    @parameterized.expand(
+        [
+            # ValueError from cloudflare._get_headers() when CLOUDFLARE_API_TOKEN is unset,
+            # or from cloudflare._parse_hostname() when Cloudflare returns an unknown enum
+            # status value.
+            ("value_error", ValueError("CLOUDFLARE_API_TOKEN must be configured")),
+            # KeyError from cloudflare._parse_hostname() if the response is missing a
+            # previously-guaranteed field like `id`, `hostname`, or `status`.
+            ("key_error", KeyError("status")),
+        ]
+    )
     @patch("posthog.api.proxy_record_diagnostics.get_custom_hostname_by_domain")
-    def test_warn_when_value_error_escapes(self, get_mock):
-        # ValueError comes from cloudflare._get_headers() when CLOUDFLARE_API_TOKEN is
-        # unset, or from cloudflare._parse_hostname() when Cloudflare returns an
-        # unknown enum status value.
-        get_mock.side_effect = ValueError("CLOUDFLARE_API_TOKEN must be configured")
+    def test_warn_when_unexpected_exception_escapes(self, _name, exc, get_mock):
+        get_mock.side_effect = exc
         with patch("posthog.api.proxy_record_diagnostics.capture_exception") as cap_mock:
             result, info = diagnostics._check_cloudflare(_record())
         self.assertEqual(result.status, "warned")
@@ -142,16 +150,6 @@ class TestCheckCloudflare(TestCase):
         _exc, props = cap_mock.call_args[0]
         self.assertIn("proxy_record_id", props)
         self.assertIn("domain", props)
-
-    @patch("posthog.api.proxy_record_diagnostics.get_custom_hostname_by_domain")
-    def test_warn_when_key_error_escapes(self, get_mock):
-        # KeyError comes from cloudflare._parse_hostname() if the response is missing
-        # a previously-guaranteed field like `id`, `hostname`, or `status`.
-        get_mock.side_effect = KeyError("status")
-        with patch("posthog.api.proxy_record_diagnostics.capture_exception"):
-            result, info = diagnostics._check_cloudflare(_record())
-        self.assertEqual(result.status, "warned")
-        self.assertIsNone(info)
 
 
 class TestCheckCaa(TestCase):

--- a/posthog/api/test/test_proxy_record_diagnostics.py
+++ b/posthog/api/test/test_proxy_record_diagnostics.py
@@ -127,6 +127,32 @@ class TestCheckCloudflare(TestCase):
         self.assertEqual(result.status, "failed")
         self.assertIn("certificate provider", result.detail.lower())
 
+    @patch("posthog.api.proxy_record_diagnostics.get_custom_hostname_by_domain")
+    def test_warn_when_value_error_escapes(self, get_mock):
+        # ValueError comes from cloudflare._get_headers() when CLOUDFLARE_API_TOKEN is
+        # unset, or from cloudflare._parse_hostname() when Cloudflare returns an
+        # unknown enum status value.
+        get_mock.side_effect = ValueError("CLOUDFLARE_API_TOKEN must be configured")
+        with patch("posthog.api.proxy_record_diagnostics.capture_exception") as cap_mock:
+            result, info = diagnostics._check_cloudflare(_record())
+        self.assertEqual(result.status, "warned")
+        self.assertIsNone(info)
+        self.assertIsNone(result.remediation)
+        cap_mock.assert_called_once()
+        _exc, props = cap_mock.call_args[0]
+        self.assertIn("proxy_record_id", props)
+        self.assertIn("domain", props)
+
+    @patch("posthog.api.proxy_record_diagnostics.get_custom_hostname_by_domain")
+    def test_warn_when_key_error_escapes(self, get_mock):
+        # KeyError comes from cloudflare._parse_hostname() if the response is missing
+        # a previously-guaranteed field like `id`, `hostname`, or `status`.
+        get_mock.side_effect = KeyError("status")
+        with patch("posthog.api.proxy_record_diagnostics.capture_exception"):
+            result, info = diagnostics._check_cloudflare(_record())
+        self.assertEqual(result.status, "warned")
+        self.assertIsNone(info)
+
 
 class TestCheckCaa(TestCase):
     @patch("posthog.api.proxy_record_diagnostics.dns.resolver.Resolver")


### PR DESCRIPTION
## Problem

When a user clicks **Diagnose** on a managed reverse proxy that is unhealthy, they currently get the toast *"Diagnose failed: A server error occurred."* — the generic DRF 500 string. That leaves them unable to debug why their proxy is broken, which (since the proxy fronts event capture) is exactly when they most need actionable feedback.

Two failure paths can reach that generic 500 today:

- `_check_cloudflare` in `posthog/api/proxy_record_diagnostics.py` only catches `CloudflareAPIError`. A `ValueError` from `_get_headers()` (unset/blank `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID`) or from `_parse_hostname()` (unrecognized Cloudflare enum status), or a `KeyError` from a malformed response, escapes the check entirely.
- The `diagnose` viewset action calls `diagnose_proxy_record(record)` with no `try`/`except`, so any unhandled exception in any of the six checks turns into DRF's generic 500.

## Changes

- **`posthog/api/proxy_record_diagnostics.py`** — `_check_cloudflare` gets a second `except Exception` branch after the existing `CloudflareAPIError` block. It calls `capture_exception` with `proxy_record_id` and `domain`, and returns a `warned` `CheckResult` with `None` for `hostname_info` so the downstream CAA / HTTP / live-event / cert checks gracefully skip rather than crashing the whole report.
- **`posthog/api/proxy_record.py`** — `diagnose` wraps `diagnose_proxy_record(record)` in `try`/`except`. On exception it captures with the same context and returns HTTP 500 with `{"detail": "Couldn't run diagnostics for this proxy. Please try again in a few minutes; if this keeps happening, contact PostHog support."}`. The frontend already surfaces `detail` straight into the toast, so no frontend change is needed.
- **Tests** — three new tests:
  - `TestCheckCloudflare.test_warn_when_value_error_escapes`
  - `TestCheckCloudflare.test_warn_when_key_error_escapes`
  - `TestProxyRecordAPI.test_diagnose_returns_structured_error_on_unexpected_exception` — regression-pins the response body against DRF's default `"A server error occurred."` and asserts `capture_exception` was invoked with the right context.

## How did you test this code?

I am an agent (Claude) and did not run the test suite or boot the app in this environment (no Python/Django/`hogli` available in the sandbox). What I did:

- Static syntax check (`python3 -c "import ast; ast.parse(...)"`) on all four files.
- Read the existing `TestCheckCloudflare` and `TestProxyRecordAPI` tests and modelled the new tests on the patterns already in those files (`@patch("posthog.api.proxy_record_diagnostics.capture_exception")`, `cache.clear()` to avoid cooldown cross-talk, `mock.call_args[0]` unpack for positional kwargs).
- Verified the imports needed by the patches (`capture_exception`, `status`) are already present at the top of `posthog/api/proxy_record.py`.

Locally a reviewer can run:

```
hogli test posthog/api/test/test_proxy_record.py posthog/api/test/test_proxy_record_diagnostics.py
```

Manual repro for Layer 1 (Cloudflare resilience): blank `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID` in local env, click **Diagnose** — report should render with `cloudflare` showing `warned`, other checks still informative, instead of a 500 toast.

## Publish to changelog?

no

## Docs update

No user-facing docs need updating — this is a server-side reliability fix with no API or UI contract change. The toast template (`Diagnose failed: <detail>`) is unchanged; only what fills the `<detail>` improves.

## 🤖 Agent context

- Tool: Claude Code (this session). The agent investigated the customer's "Diagnose failed: A server error occurred." report by tracing the toast from `proxyLogic.ts:267-278` back through `ApiError` (`frontend/src/lib/api.ts`) to the DRF default 500 from `posthog/api/proxy_record.py:309`, then identified `_check_cloudflare` as the most likely escape path because it's the only check whose `try/except` was narrower than its peers (the other five checks already handle broad exception classes locally).
- Decisions:
  - Returned `warned` (not `failed`) from `_check_cloudflare` on the unexpected-exception path. Rationale: we don't actually know the proxy is broken; we only know our introspection of it failed. `warned` keeps `_build_summary` from forcing the report into `fail` and preserves whatever signal the other five checks produced.
  - Did NOT refactor the other five checks behind a `_safe_check` wrapper. They already catch their known exception types locally, and a broader refactor would muddy the surface a reviewer needs to look at for this hotfix. The viewset-level `try/except` covers the residual blast radius.
  - Did NOT change the frontend toast template. The existing `Diagnose failed: ${message}` template flows the new detail through without modification; rewording it is a separate cleanup.
  - Did NOT add an OpenAPI error-response shape via `OpenApiResponse(response=ErrorSerializer)`. The four actions on this viewset (`create`, `retry`, `destroy`, `diagnose`) all have the same gap; tightening one in isolation would be inconsistent. Worth a follow-up across the file.
- Reviewer attention: the most subtle line is the `warned` status choice in `_check_cloudflare` — please confirm you want that vs `failed`, since the customer's perception ("diagnostics failed") may differ from the semantic ("we don't know").
