### PR TITLE
feat(data-warehouse): enforce the SSRF guard

### DIFF
--- a/posthog/settings/data_warehouse.py
+++ b/posthog/settings/data_warehouse.py
@@ -19,11 +19,10 @@ USE_LOCAL_SETUP = TEST or (DEBUG and len(os.getenv("OBJECT_STORAGE_ENDPOINT", "h
 
 PYARROW_DEBUG_LOGGING = get_from_env("PYARROW_DEBUG_LOGGING", False, type_cast=str_to_bool)
 
-# While False, the data-import SSRF guard runs in monitor mode: it evaluates
-# every outbound host and logs would-be blocks (`data_imports.http.blocked`,
-# `enforced=false`) but does not fail the request. Flipped to True to enforce —
-# staged so the guard can be observed in Grafana before it starts failing syncs.
-DATA_IMPORTS_SSRF_GUARD_ENFORCED: bool = False
+# The data-import SSRF guard blocks requests to internal/private hosts. Set
+# this to False to drop back to monitor mode — evaluate every host and log
+# `data_imports.http.blocked` but don't fail the request.
+DATA_IMPORTS_SSRF_GUARD_ENFORCED: bool = True
 
 GOOGLE_ADS_SERVICE_ACCOUNT_CLIENT_EMAIL: str | None = os.getenv("GOOGLE_ADS_SERVICE_ACCOUNT_CLIENT_EMAIL")
 GOOGLE_ADS_SERVICE_ACCOUNT_PRIVATE_KEY: str | None = os.getenv("GOOGLE_ADS_SERVICE_ACCOUNT_PRIVATE_KEY")


### PR DESCRIPTION
## Problem

The data-import SSRF guard (#59525) ships in monitor mode — it evaluates every
outbound host and logs would-be blocks (`data_imports.http.blocked`,
`enforced=false`) but does not fail any request. That makes #59525 safe to
merge, but it does not protect anything until enforcement is turned on.

## Changes

Flip `DATA_IMPORTS_SSRF_GUARD_ENFORCED` to `True`: a data-warehouse request to
an internal/private host is now blocked (raises `BlockedHostError`), not just
logged.

This is a deliberate one-line switch (a plain boolean flip), kept as its own PR
so enabling enforcement is a separate, explicit decision from shipping the
guard. Merge it once the monitor-mode data from #59525 confirms no legitimate
source is caught. Reverting this PR drops straight back to monitor mode without
touching the guard itself.

## How did you test this code?

I'm an agent (Claude Code) and did not perform manual testing. The guard's
behaviour under enforcement is covered by the automated tests in #59525 (the
`ssrf_enforced` fixture pins `DATA_IMPORTS_SSRF_GUARD_ENFORCED=True`); those
tests pass with this PR's flipped default in place.

## Publish to changelog?

no — internal hardening rollout step.

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with Claude Code (Opus). Top of the stack, on `custom-source-ssrf-guard`
(#59525).

This PR exists only to make "turn the SSRF guard on" a separate, deliberate,
trivially-revertible step from "ship the SSRF guard" (#59525). The guard
itself, monitor mode, and the `DATA_IMPORTS_SSRF_GUARD_ENFORCED` setting all
live in #59525.

Agent-authored; requires human review before merge.
