### PR TITLE
chore(ai): add Microsoft to third-party LLM provider list and add BAA webhook tests

### DIFF
--- a/frontend/src/scenes/max/components/AILiabilityNotice.tsx
+++ b/frontend/src/scenes/max/components/AILiabilityNotice.tsx
@@ -19,8 +19,8 @@ export function AILiabilityNotice(): JSX.Element | null {
     return (
         <div className="flex flex-col mb-2 max-w-160 w-full px-3">
             <LemonBanner type="ai" onClose={dismissLiabilityNotice}>
-                PostHog AI uses third-party LLM providers (OpenAI, Anthropic, and Alphabet). Your data will not be used
-                for training third-party models.
+                PostHog AI uses third-party LLM providers (Alphabet, Anthropic, Microsoft, and OpenAI). Your data will
+                not be used for training third-party models.
                 {isAdminOrOwner && (
                     <>
                         {' '}

--- a/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
+++ b/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
@@ -4,7 +4,7 @@ import { dayjs } from 'lib/dayjs'
 import { Link } from 'lib/lemon-ui/Link'
 
 export function getExternalAIProvidersTooltipTitle(): string {
-    return `As of ${dayjs().format('MMMM YYYY')}: Anthropic, OpenAI, and Alphabet`
+    return `As of ${dayjs().format('MMMM YYYY')}: Alphabet, Anthropic, Microsoft, and OpenAI`
 }
 
 export function AIHipaaDisclaimer(): JSX.Element {

--- a/posthog/templates/email/baa_signed_ai_disabled.html
+++ b/posthog/templates/email/baa_signed_ai_disabled.html
@@ -5,9 +5,9 @@
     Thanks for signing the Business Associate Agreement ("BAA") with PostHog.
 </p>
 <p>
-    Heads up: the BAA does not cover the third-party AI services PostHog uses (currently Anthropic, OpenAI, and
-    Alphabet). To keep your organization's data out of those AI subprocessors by default, we've automatically turned
-    off AI features that use them for <strong>{{ organization_name }}</strong>.
+    Heads up: the BAA does not cover the third-party AI services PostHog uses (currently Alphabet, Anthropic,
+    Microsoft, and OpenAI). To keep your organization's data out of those AI subprocessors by default, we've
+    automatically turned off AI features that use them for <strong>{{ organization_name }}</strong>.
 </p>
 <p>
     If your team still wants to use these AI features for workflows that do <em>not</em> involve Protected Health

--- a/products/legal_documents/backend/tests/test_api.py
+++ b/products/legal_documents/backend/tests/test_api.py
@@ -568,6 +568,99 @@ class TestLegalDocumentPandaDocWebhook(APIBaseTest):
         write_spy.assert_not_called()
         event_spy.assert_not_called()
 
+    def _swap_to_baa_document(self) -> None:
+        """The default fixture is a DPA. For BAA-side-effect tests, retarget it."""
+        self.document.document_type = "BAA"
+        self.document.save(update_fields=["document_type"])
+
+    @contextmanager
+    def _fake_pdf_pipeline(self):
+        @contextmanager
+        def fake_stream_cm(*, document_id):  # noqa: ARG001
+            yield object()
+
+        with (
+            patch(
+                "products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.stream_document",
+                side_effect=fake_stream_cm,
+            ),
+            patch("products.legal_documents.backend.logic.object_storage.write_stream"),
+        ):
+            yield
+
+    def test_signed_baa_opts_organization_out_of_ai_data_processing(self) -> None:
+        self._swap_to_baa_document()
+        # New orgs default to True now — explicitly set so this isn't accidentally testing the default.
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save(update_fields=["is_ai_data_processing_approved"])
+
+        body = json.dumps(self._completed_payload(template_id=self.BAA_TEMPLATE_ID)).encode("utf-8")
+        with self._override(), self._fake_pdf_pipeline():
+            response = self._post_raw(body, self._sign(body))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.organization.refresh_from_db()
+        self.assertFalse(self.organization.is_ai_data_processing_approved)
+
+    def test_signed_dpa_does_not_change_ai_flag(self) -> None:
+        # Default fixture is a DPA, so don't swap.
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save(update_fields=["is_ai_data_processing_approved"])
+
+        body = json.dumps(self._completed_payload()).encode("utf-8")
+        with self._override(), self._fake_pdf_pipeline():
+            response = self._post_raw(body, self._sign(body))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.organization.refresh_from_db()
+        self.assertTrue(self.organization.is_ai_data_processing_approved)
+
+    def test_signed_baa_emails_org_owners(self) -> None:
+        self._swap_to_baa_document()
+        # Promote the test user to OWNER so the email path has a recipient.
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.OWNER
+        membership.save(update_fields=["level"])
+
+        body = json.dumps(self._completed_payload(template_id=self.BAA_TEMPLATE_ID)).encode("utf-8")
+        with (
+            self._override(),
+            self._fake_pdf_pipeline(),
+            patch("products.legal_documents.backend.logic.is_email_available", return_value=True),
+            patch("products.legal_documents.backend.logic.EmailMessage") as email_cls,
+        ):
+            response = self._post_raw(body, self._sign(body))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        email_cls.assert_called_once()
+        kwargs = email_cls.call_args.kwargs
+        self.assertEqual(kwargs["template_name"], "baa_signed_ai_disabled")
+        self.assertTrue(kwargs["use_http"])
+        self.assertEqual(kwargs["template_context"]["organization_name"], self.organization.name)
+        self.assertIn("organization-ai-consent", kwargs["template_context"]["ai_settings_url"])
+        instance = email_cls.return_value
+        instance.add_user_recipient.assert_called_once_with(self.user)
+        instance.send.assert_called_once_with(send_async=True)
+
+    def test_signed_baa_skips_email_when_no_owner(self) -> None:
+        self._swap_to_baa_document()
+        # Default APIBaseTest membership is MEMBER, not OWNER — so no recipients.
+
+        body = json.dumps(self._completed_payload(template_id=self.BAA_TEMPLATE_ID)).encode("utf-8")
+        with (
+            self._override(),
+            self._fake_pdf_pipeline(),
+            patch("products.legal_documents.backend.logic.is_email_available", return_value=True),
+            patch("products.legal_documents.backend.logic.EmailMessage") as email_cls,
+        ):
+            response = self._post_raw(body, self._sign(body))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        email_cls.assert_not_called()
+        self.organization.refresh_from_db()
+        # Opt-out still happens even when there are no owners to notify.
+        self.assertFalse(self.organization.is_ai_data_processing_approved)
+
 
 @override_settings(CLOUD_DEPLOYMENT=None, DEBUG=False)
 class TestLegalDocumentsSelfHostedGate(APIBaseTest):


### PR DESCRIPTION
Adds Microsoft to the list of third-party LLM providers referenced across the AI liability notice, AI consent tooltip, and BAA-signed email template, updating the provider list to be alphabetically ordered (Alphabet, Anthropic, Microsoft, and OpenAI).

Also adds test coverage for the BAA webhook side effects, verifying that:
- Signing a BAA opts the organization out of AI data processing
- Signing a DPA does not affect the AI data processing flag
- Signing a BAA sends a notification email to organization owners
- Signing a BAA still opts the organization out even when there are no owners to notify