### PR TITLE
fix(data-warehouse): mark postgres cdc as beta in source setup

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
@@ -447,7 +447,7 @@ function CDCConfigSection(): JSX.Element {
                                 <div>
                                     <div className="flex items-center gap-2 mb-1">
                                         <h4 className="mb-0 text-base font-semibold">Change data capture (CDC)</h4>
-                                        <LemonTag type="success">Recommended</LemonTag>
+                                        <LemonTag type="completion">Beta</LemonTag>
                                     </div>
                                     <p className="text-sm text-secondary mb-2">
                                         Real-time sync via PostgreSQL logical replication. Captures inserts, updates,

--- a/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
@@ -447,7 +447,7 @@ function CDCConfigSection(): JSX.Element {
                                 <div>
                                     <div className="flex items-center gap-2 mb-1">
                                         <h4 className="mb-0 text-base font-semibold">Change data capture (CDC)</h4>
-                                        <LemonTag type="completion">Beta</LemonTag>
+                                        <LemonTag type="completion">Alpha</LemonTag>
                                     </div>
                                     <p className="text-sm text-secondary mb-2">
                                         Real-time sync via PostgreSQL logical replication. Captures inserts, updates,


### PR DESCRIPTION
## Problem

The Postgres CDC option in the source setup page currently shows a "Recommended" badge, but Change data capture is still in Beta. The badge sets expectations that don't match the feature's maturity.

## Changes

- Replace the `Recommended` `LemonTag` next to the **Change data capture (CDC)** heading with a `Beta` tag in `products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx`.

## How did you test this code?

I'm an agent. No manual UI testing performed — only the local format/lint hooks that run on commit. The change is a single tag label/type swap in `CDCConfigSection`; please verify visually in the Postgres source setup page.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Tool: PostHog Code (Claude).
- Searched for the source string "Change data capture" and the adjacent `Recommended` tag, both of which lived only in `SourceForm.tsx` inside `CDCConfigSection`.
- Considered also hiding the entire tag, but the user asked for a Beta badge, so swapped `type="success"` / "Recommended" for `type="completion"` / "Beta" to match the convention already used for other Beta features (e.g. `HogFunctionStatusTag`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*