### PR TITLE
fix(notebooks): keep SQL editor in sync with Tiptap node attributes

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
@@ -55,7 +55,8 @@ export function useNotebookQuerySQLEditorSync<T extends { query: QuerySchema }>(
     const { queryInput, sourceQuery } = useValues(logic)
     const { initialize, runQuery, setQueryInput, setSourceQuery } = useActions(logic)
 
-    // Same two-ref approach as the Code variant — see comment there for the why.
+    // Sync Tiptap node attributes with sqlEditorLogic kea state. Two refs let us tell apart
+    // a remote attribute update (pull into kea) from a local edit (push to Tiptap).
     const lastAttrRef = useRef<DataVisualizationNode | null>(null)
     const lastLocalRef = useRef<DataVisualizationNode | null>(null)
 
@@ -153,12 +154,14 @@ export function useNotebookCodeSQLEditorSync<T extends { code: string }>({
 
         if (queryInput !== lastQueryRef.current) {
             // Editor moved — push to Tiptap and keep sourceQuery in step with the new SQL so
-            // "Run query" uses what the user is actually looking at.
+            // "Run query" uses what the user is actually looking at. Skip the push when
+            // queryInput resets to null (e.g. a re-initialize while `code` hasn't changed) —
+            // otherwise we'd write `code: null` and clear the cell on the next round-trip.
             lastQueryRef.current = queryInput
             if (queryInput !== null) {
                 setSourceQuery(buildSourceQuery(queryInput))
+                updateAttributes({ code: queryInput } as Partial<NotebookNodeAttributes<T>>)
             }
-            updateAttributes({ code: queryInput } as Partial<NotebookNodeAttributes<T>>)
             return
         }
 

--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
@@ -1,6 +1,6 @@
 import equal from 'fast-deep-equal'
 import { useActions, useValues } from 'kea'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import { SQLEditor, SQLEditorPanel } from 'scenes/data-warehouse/editor/SQLEditor'
 import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
@@ -55,26 +55,30 @@ export function useNotebookQuerySQLEditorSync<T extends { query: QuerySchema }>(
     const { queryInput, sourceQuery } = useValues(logic)
     const { initialize, runQuery, setQueryInput, setSourceQuery } = useActions(logic)
 
+    // Same two-ref approach as the Code variant — see comment there for the why.
+    const lastAttrRef = useRef<DataVisualizationNode | null>(null)
+    const lastLocalRef = useRef<DataVisualizationNode | null>(null)
+
     useEffect(() => {
         initialize()
     }, [initialize])
 
     useEffect(() => {
-        if (!editorSourceQuery || queryInput !== null) {
+        if (!editorSourceQuery) {
             return
         }
 
-        setQueryInput(editorSourceQuery.source.query)
-        setSourceQuery(editorSourceQuery)
-        runQuery(editorSourceQuery.source.query)
-    }, [editorSourceQuery, queryInput, runQuery, setQueryInput, setSourceQuery])
-
-    useEffect(() => {
-        if (!editorSourceQuery || queryInput === null) {
+        if (queryInput === null) {
+            // First mount — seed kea and run the query so results show immediately.
+            lastAttrRef.current = editorSourceQuery
+            lastLocalRef.current = editorSourceQuery
+            setQueryInput(editorSourceQuery.source.query)
+            setSourceQuery(editorSourceQuery)
+            runQuery(editorSourceQuery.source.query)
             return
         }
 
-        const nextQuery: DataVisualizationNode = {
+        const localQuery: DataVisualizationNode = {
             ...sourceQuery,
             source: {
                 ...sourceQuery.source,
@@ -83,10 +87,30 @@ export function useNotebookQuerySQLEditorSync<T extends { query: QuerySchema }>(
             display: sourceQuery.display ?? editorSourceQuery.display ?? ChartDisplayType.ActionsTable,
         }
 
-        if (!equal(nextQuery, editorSourceQuery)) {
-            updateAttributes({ query: nextQuery } as Partial<NotebookNodeAttributes<T>>)
+        if (equal(localQuery, editorSourceQuery)) {
+            lastAttrRef.current = editorSourceQuery
+            lastLocalRef.current = localQuery
+            return
         }
-    }, [editorSourceQuery, queryInput, sourceQuery, updateAttributes])
+
+        if (!equal(editorSourceQuery, lastAttrRef.current)) {
+            // Attribute moved — pull (overrides any in-flight typing: last write wins).
+            lastAttrRef.current = editorSourceQuery
+            lastLocalRef.current = editorSourceQuery
+            setQueryInput(editorSourceQuery.source.query)
+            setSourceQuery(editorSourceQuery)
+            return
+        }
+
+        if (!equal(localQuery, lastLocalRef.current)) {
+            // Editor moved — push to Tiptap.
+            lastLocalRef.current = localQuery
+            updateAttributes({ query: localQuery } as Partial<NotebookNodeAttributes<T>>)
+            return
+        }
+
+        // Tiptap hasn't propagated a push we already made — wait for the next render.
+    }, [editorSourceQuery, queryInput, sourceQuery, runQuery, setQueryInput, setSourceQuery, updateAttributes])
 
     return editorSourceQuery
 }
@@ -101,26 +125,44 @@ export function useNotebookCodeSQLEditorSync<T extends { code: string }>({
     const { queryInput, sourceQuery } = useValues(logic)
     const { initialize, setQueryInput, setSourceQuery } = useActions(logic)
 
+    // Tracks the last `code` and `queryInput` we observed in sync. A real attribute change
+    // (remote step, undo, programmatic) shows up as `code !== lastCodeRef` → pull. A real
+    // local edit shows up as `queryInput !== lastQueryRef` → push. A transient mismatch
+    // right after a push (Tiptap hasn't propagated yet) shows up as neither → wait.
+    // One ref isn't enough: after a push it would falsely classify the lag as a remote change.
+    const lastCodeRef = useRef<string | null>(null)
+    const lastQueryRef = useRef<string | null>(null)
+
     useEffect(() => {
         initialize()
     }, [initialize])
 
     useEffect(() => {
-        if (queryInput !== null) {
+        if (queryInput === code) {
+            lastCodeRef.current = code
+            lastQueryRef.current = queryInput
             return
         }
 
-        setQueryInput(code)
-        setSourceQuery(buildSourceQuery(code))
-    }, [code, queryInput, setQueryInput, setSourceQuery])
-
-    useEffect(() => {
-        if (queryInput === null || queryInput === code) {
+        if (code !== lastCodeRef.current) {
+            // Attribute moved — pull into kea (overrides any in-flight typing: last write wins).
+            lastCodeRef.current = code
+            lastQueryRef.current = code
+            setQueryInput(code)
+            setSourceQuery(buildSourceQuery(code))
             return
         }
 
-        updateAttributes({ code: queryInput } as Partial<NotebookNodeAttributes<T>>)
-    }, [code, queryInput, updateAttributes])
+        if (queryInput !== lastQueryRef.current) {
+            // Editor moved — push to Tiptap.
+            lastQueryRef.current = queryInput
+            updateAttributes({ code: queryInput } as Partial<NotebookNodeAttributes<T>>)
+            return
+        }
+
+        // Both sides match what we last observed but each other doesn't — Tiptap is still
+        // catching up to a push we already made. Do nothing; the next render will reconcile.
+    }, [code, queryInput, setQueryInput, setSourceQuery, updateAttributes])
 
     useEffect(() => {
         if (queryInput === null) {

--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
@@ -122,7 +122,7 @@ export function useNotebookCodeSQLEditorSync<T extends { code: string }>({
 }: NotebookNodeAttributeProperties<T> & { tabId: string }): void {
     const code = typeof attributes.code === 'string' ? attributes.code : ''
     const logic = sqlEditorLogic({ tabId, mode: SQLEditorMode.Embedded })
-    const { queryInput, sourceQuery } = useValues(logic)
+    const { queryInput } = useValues(logic)
     const { initialize, setQueryInput, setSourceQuery } = useActions(logic)
 
     // Tracks the last `code` and `queryInput` we observed in sync. A real attribute change
@@ -154,8 +154,12 @@ export function useNotebookCodeSQLEditorSync<T extends { code: string }>({
         }
 
         if (queryInput !== lastQueryRef.current) {
-            // Editor moved — push to Tiptap.
+            // Editor moved — push to Tiptap and keep sourceQuery in step with the new SQL so
+            // "Run query" uses what the user is actually looking at.
             lastQueryRef.current = queryInput
+            if (queryInput !== null) {
+                setSourceQuery(buildSourceQuery(queryInput))
+            }
             updateAttributes({ code: queryInput } as Partial<NotebookNodeAttributes<T>>)
             return
         }
@@ -163,25 +167,6 @@ export function useNotebookCodeSQLEditorSync<T extends { code: string }>({
         // Both sides match what we last observed but each other doesn't — Tiptap is still
         // catching up to a push we already made. Do nothing; the next render will reconcile.
     }, [code, queryInput, setQueryInput, setSourceQuery, updateAttributes])
-
-    useEffect(() => {
-        if (queryInput === null) {
-            return
-        }
-
-        const nextSourceQuery = {
-            ...sourceQuery,
-            source: {
-                ...sourceQuery.source,
-                query: queryInput,
-            },
-            display: sourceQuery.display ?? ChartDisplayType.ActionsTable,
-        }
-
-        if (!equal(nextSourceQuery, sourceQuery)) {
-            setSourceQuery(nextSourceQuery)
-        }
-    }, [queryInput, setSourceQuery, sourceQuery])
 }
 
 export function NotebookSQLEditorOutput<T extends { query: QuerySchema }>({

--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookSQLEditor.tsx
@@ -68,21 +68,11 @@ export function useNotebookQuerySQLEditorSync<T extends { query: QuerySchema }>(
             return
         }
 
-        if (queryInput === null) {
-            // First mount — seed kea and run the query so results show immediately.
-            lastAttrRef.current = editorSourceQuery
-            lastLocalRef.current = editorSourceQuery
-            setQueryInput(editorSourceQuery.source.query)
-            setSourceQuery(editorSourceQuery)
-            runQuery(editorSourceQuery.source.query)
-            return
-        }
-
         const localQuery: DataVisualizationNode = {
             ...sourceQuery,
             source: {
                 ...sourceQuery.source,
-                query: queryInput,
+                query: queryInput ?? '',
             },
             display: sourceQuery.display ?? editorSourceQuery.display ?? ChartDisplayType.ActionsTable,
         }
@@ -95,10 +85,18 @@ export function useNotebookQuerySQLEditorSync<T extends { query: QuerySchema }>(
 
         if (!equal(editorSourceQuery, lastAttrRef.current)) {
             // Attribute moved — pull (overrides any in-flight typing: last write wins).
+            // On first mount `lastAttrRef.current` is null, so we also seed kea here and
+            // kick off an initial `runQuery` so results show on load. We deliberately don't
+            // re-run on subsequent remote updates: that would fire a backend query every
+            // time another tab edits a keystroke through the collab stream.
+            const isFirstSeed = lastAttrRef.current === null
             lastAttrRef.current = editorSourceQuery
             lastLocalRef.current = editorSourceQuery
             setQueryInput(editorSourceQuery.source.query)
             setSourceQuery(editorSourceQuery)
+            if (isFirstSeed) {
+                runQuery(editorSourceQuery.source.query)
+            }
             return
         }
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Notebook SQL cells didn't sync across browser tabs (or with MCP edits, undo, or any other external attribute change). The two embedded-SQL-editor hooks seeded `sqlEditorLogic.queryInput` from the Tiptap attribute only on first mount and then ignored later changes, so remote collab steps silently arrived on the attribute but Monaco kept rendering the original SQL. The next local edit would push the stale value back, overwriting the remote change with no 409.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

<img alt="2026-05-21 16 56 08" src="https://github.com/user-attachments/assets/521add63-4163-41b1-aac6-49185f9667d6" />

## Changes

- Replace the init-once effect in `useNotebookCodeSQLEditorSync` and `useNotebookQuerySQLEditorSync` with a single effect that reconciles `attributes.code` (or `attributes.query.source.query`) with `sqlEditorLogic.queryInput` on every render.
- Use two refs to distinguish three cases: attribute moved → pull, editor moved → push, post-push lag where Tiptap hasn't propagated yet → wait. A single ref would misclassify the lag as a remote update and revert the user's typing
- Fold the previous standalone `setSourceQuery` mirror into the push/pull branches so `sourceQuery.source.query` updates atomically with the SQL string. 

## How did you test this code?

![2026-05-22 22.50.36.gif](https://app.graphite.com/user-attachments/assets/96221446-c477-4379-b404-b8cdb7a6a1dc.gif)

Manually verified cross-tab sync in two browser tabs:

- Typing in tab A → tab B reflects each keystroke as the SSE step lands.
- Typing rapidly in tab A doesn't revert in tab A (the regression case).
- Undo (Cmd-Z) in either tab restores the previous SQL.

## Publish to changelog?

no

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->