### PR TITLE
feat: add per-channel and TCP retransmit metrics to personhog-router

### DIFF
--- a/rust/personhog-common/src/lib.rs
+++ b/rust/personhog-common/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod grpc;
 mod pool_monitor;
+mod tcp_monitor;
 
 pub use pool_monitor::{spawn_pool_monitor, MonitoredPool};
+pub use tcp_monitor::spawn_tcp_monitor;

--- a/rust/personhog-common/src/tcp_monitor.rs
+++ b/rust/personhog-common/src/tcp_monitor.rs
@@ -1,0 +1,83 @@
+use std::time::Duration;
+
+const TCP_RETRANSMIT_SEGMENTS: &str = "tcp_retransmit_segments";
+const TCP_SEGMENTS_OUT: &str = "tcp_segments_out";
+
+#[cfg(target_os = "linux")]
+pub fn spawn_tcp_monitor(interval: Duration) {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            if let Err(e) = report_tcp_stats() {
+                tracing::warn!("tcp monitor stopped: {e}");
+                return;
+            }
+        }
+    });
+}
+
+#[cfg(target_os = "linux")]
+fn report_tcp_stats() -> Result<(), String> {
+    let contents =
+        std::fs::read_to_string("/proc/net/snmp").map_err(|e| format!("read /proc/net/snmp: {e}"))?;
+
+    let mut lines = contents.lines();
+    let (headers, values) = loop {
+        match lines.next() {
+            Some(line) if line.starts_with("Tcp:") => {
+                let header_line = line;
+                let value_line = lines
+                    .next()
+                    .ok_or("missing Tcp values line in /proc/net/snmp")?;
+                break (header_line, value_line);
+            }
+            Some(_) => continue,
+            None => return Err("no Tcp: line found in /proc/net/snmp".to_string()),
+        }
+    };
+
+    let header_fields: Vec<&str> = headers.split_whitespace().collect();
+    let value_fields: Vec<&str> = values.split_whitespace().collect();
+
+    if header_fields.len() != value_fields.len() {
+        return Err("Tcp header/value field count mismatch".to_string());
+    }
+
+    for (h, v) in header_fields.iter().zip(value_fields.iter()) {
+        match *h {
+            "RetransSegs" => {
+                if let Ok(val) = v.parse::<f64>() {
+                    metrics::gauge!(TCP_RETRANSMIT_SEGMENTS).set(val);
+                }
+            }
+            "OutSegs" => {
+                if let Ok(val) = v.parse::<f64>() {
+                    metrics::gauge!(TCP_SEGMENTS_OUT).set(val);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn spawn_tcp_monitor(_interval: Duration) {
+    tracing::info!("tcp monitor: /proc/net/snmp not available on this platform, skipping");
+}
+
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_tcp_stats_parses_successfully() {
+        // On Linux CI, /proc/net/snmp should be readable
+        let result = report_tcp_stats();
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    }
+}

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -119,6 +119,9 @@ impl ReplicaBackend {
             "created replica backend channels"
         );
 
+        metrics::gauge!("personhog_router_replica_channels_configured")
+            .set(num_channels as f64);
+
         Self {
             clients,
             raw_channels,
@@ -127,15 +130,20 @@ impl ReplicaBackend {
         }
     }
 
-    fn next_client(&self) -> PersonHogReplicaClient<Channel> {
+    fn next_client_indexed(&self) -> (PersonHogReplicaClient<Channel>, usize) {
         let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % self.clients.len();
-        self.clients[idx].clone()
+        (self.clients[idx].clone(), idx)
     }
 
     /// Get the next raw channel for byte-level proxying.
     pub fn next_raw_channel(&self) -> Channel {
         let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % self.raw_channels.len();
         self.raw_channels[idx].clone()
+    }
+
+    pub fn next_raw_channel_indexed(&self) -> (Channel, usize) {
+        let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % self.raw_channels.len();
+        (self.raw_channels[idx].clone(), idx)
     }
 
     pub fn retry_config(&self) -> &RetryConfig {
@@ -149,15 +157,30 @@ impl ReplicaBackend {
 macro_rules! retry_call {
     ($self:expr, $method:ident, $request:expr) => {{
         with_retry(&$self.retry_config, stringify!($method), || {
-            let mut client = $self.next_client();
+            let (mut client, channel_idx) = $self.next_client_indexed();
             let req = $request.clone();
             let client_name = current_client_name();
+            let method_name = stringify!($method);
             async move {
                 let mut request = Request::new(req);
                 if let Ok(val) = client_name.parse() {
                     request.metadata_mut().insert("x-client-name", val);
                 }
-                client.$method(request).await.map(|r| r.into_inner())
+                let start = std::time::Instant::now();
+                let result = client.$method(request).await.map(|r| r.into_inner());
+                let ch_label = channel_idx.to_string();
+                metrics::counter!(
+                    "personhog_router_channel_requests_total",
+                    "channel" => ch_label.clone(),
+                )
+                .increment(1);
+                metrics::histogram!(
+                    "personhog_router_channel_duration_ms",
+                    "channel" => ch_label,
+                    "method" => method_name,
+                )
+                .record(start.elapsed().as_secs_f64() * 1000.0);
+                result
             }
         })
         .await
@@ -443,7 +466,8 @@ mod tests {
         let backend = make_backend(4);
         for round in 0..3u64 {
             for ch in 0..4u64 {
-                backend.next_client();
+                let (_, idx) = backend.next_client_indexed();
+                assert_eq!(idx, (round * 4 + ch) as usize % 4);
                 let expected = round * 4 + ch + 1;
                 assert_eq!(backend.next_idx.load(Ordering::Relaxed), expected as usize);
             }
@@ -454,12 +478,12 @@ mod tests {
     async fn next_client_wraps_around() {
         let backend = make_backend(3);
         for _ in 0..3 {
-            backend.next_client();
+            backend.next_client_indexed();
         }
-        // 4th call uses counter=3, so index = 3 % 3 = 0 (wraps back to first channel)
         let idx_before = backend.next_idx.load(Ordering::Relaxed);
-        backend.next_client();
+        let (_, idx) = backend.next_client_indexed();
         assert_eq!(idx_before % backend.clients.len(), 0);
+        assert_eq!(idx, 0);
     }
 
     #[tokio::test]

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -117,6 +117,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .install_recorder()
             .expect("Failed to install metrics recorder");
 
+        personhog_common::spawn_tcp_monitor(Duration::from_secs(10));
+
         let health_router = Router::new()
             .route(
                 "/_readiness",

--- a/rust/personhog-router/src/proxy.rs
+++ b/rust/personhog-router/src/proxy.rs
@@ -222,7 +222,7 @@ impl RawProxyInner {
         let mut delay_ms = self.retry_config.initial_backoff_ms;
 
         for attempt in 0..=self.retry_config.max_retries {
-            let channel = self.replica.next_raw_channel();
+            let (channel, channel_idx) = self.replica.next_raw_channel_indexed();
 
             let body = BoxBody::new(Full::new(body_bytes.clone()).map_err(|never| match never {}));
 
@@ -235,9 +235,37 @@ impl RawProxyInner {
             *req.version_mut() = parts.version;
             *req.headers_mut() = parts.headers.clone();
 
+            let start = std::time::Instant::now();
             match channel.oneshot(req).await {
-                Ok(response) => return response,
+                Ok(response) => {
+                    let ch_label = channel_idx.to_string();
+                    counter!(
+                        "personhog_router_channel_requests_total",
+                        "channel" => ch_label.clone(),
+                    )
+                    .increment(1);
+                    histogram!(
+                        "personhog_router_channel_duration_ms",
+                        "channel" => ch_label,
+                        "method" => method.to_string(),
+                    )
+                    .record(start.elapsed().as_secs_f64() * 1000.0);
+                    return response;
+                }
                 Err(e) => {
+                    let ch_label = channel_idx.to_string();
+                    counter!(
+                        "personhog_router_channel_requests_total",
+                        "channel" => ch_label.clone(),
+                    )
+                    .increment(1);
+                    histogram!(
+                        "personhog_router_channel_duration_ms",
+                        "channel" => ch_label,
+                        "method" => method.to_string(),
+                    )
+                    .record(start.elapsed().as_secs_f64() * 1000.0);
+
                     let is_last = attempt >= self.retry_config.max_retries;
                     if is_last {
                         return grpc_error_response(


### PR DESCRIPTION
## Problem

Can't tell where some bad p99 latency is coming from for certain personhog methods. Current observability tells me its coming from the router->replica connection. We need more metrics to understand what the driving cause might be.

## Changes

three new metrics:
- personhog_router_channel_requests_total{channel} — per-channel request counter to verify round-robin fairness
- personhog_router_channel_duration_ms{channel, method} — per-channel latency histogram to identify degraded connections
- tcp_retransmit_segments / tcp_segments_out — kernel TCP counters from /proc/net/snmp to compute retransmit ratio

## How did you test this code?

current tests run
