### PR TITLE
feat(capture): update rate limiter event-response classification

### DIFF
--- a/rust/capture/src/v1/analytics/constants.rs
+++ b/rust/capture/src/v1/analytics/constants.rs
@@ -10,7 +10,7 @@ pub const ACCEPT_JSON: HeaderValue = HeaderValue::from_static("application/json"
 /// Accepted compression encodings advertised in Accept-Encoding response header.
 pub const ACCEPT_ENCODING_ALL: HeaderValue = HeaderValue::from_static("gzip, deflate, br, zstd");
 
-/// Retry-After value (seconds) sent on retryable error responses (429, 408, 5xx).
+/// Retry-After value (seconds) sent on retryable error responses (408, 5xx).
 /// SDKs are expected to layer their own jittered exponential backoff on top of this floor.
 pub const DEFAULT_RETRY_AFTER_SECS: HeaderValue = HeaderValue::from_static("1");
 

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -31,7 +31,8 @@ fn empty_raw_object() -> Box<RawValue> {
 }
 
 /// Per-event outcome in the batch response.
-/// Maps to HTTP semantics: Ok (2xx), Drop (4xx), Limited (429), Retry (5xx).
+/// Ok: captured successfully. Drop: rejected (billing/validation). Limited: accepted
+/// with person processing disabled (do not resubmit). Retry: not persisted, safe to resubmit.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EventResult {
@@ -56,10 +57,7 @@ pub struct Batch {
 pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cookieless_mode: Option<bool>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        alias = "disable_skew_adjustment"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_skew_correction: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_tour_id: Option<String>,

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -59,7 +59,7 @@ pub async fn apply_quota_limits(
                 has_product_tour_id: ev.has_property("product_tour_id"),
             };
             if predicate(info) {
-                ev.result = EventResult::Limited;
+                ev.result = EventResult::Drop;
                 ev.destination = Destination::Drop;
                 ev.details = Some(match resource {
                     QuotaResource::Exceptions => "exceptions_over_quota",
@@ -320,10 +320,10 @@ mod tests {
         names
     }
 
-    fn limited_event_names(events: &[WrappedEvent]) -> Vec<&str> {
+    fn quota_dropped_event_names(events: &[WrappedEvent]) -> Vec<&str> {
         let mut names: Vec<&str> = events
             .iter()
-            .filter(|e| e.result == EventResult::Limited)
+            .filter(|e| e.result == EventResult::Drop && e.destination == Destination::Drop)
             .map(|e| e.event.event.as_str())
             .collect();
         names.sort();
@@ -359,7 +359,7 @@ mod tests {
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
         assert_eq!(ok_event_names(&events).len(), 4);
-        assert!(limited_event_names(&events).is_empty());
+        assert!(quota_dropped_event_names(&events).is_empty());
     }
 
     // -----------------------------------------------------------------------
@@ -381,7 +381,7 @@ mod tests {
 
         // Global limit short-circuits without mutating events
         assert_eq!(ok_event_names(&events).len(), 4);
-        assert!(limited_event_names(&events).is_empty());
+        assert!(quota_dropped_event_names(&events).is_empty());
     }
 
     #[tokio::test]
@@ -444,10 +444,10 @@ mod tests {
         ok.sort();
         assert_eq!(ok, vec!["$pageview", "survey sent"]);
         assert_eq!(
-            limited_event_names(&events),
+            quota_dropped_event_names(&events),
             vec!["$exception", "$exception"]
         );
-        for ev in events.iter().filter(|e| e.result == EventResult::Limited) {
+        for ev in events.iter().filter(|e| e.result == EventResult::Drop) {
             assert_eq!(ev.details, Some("exceptions_over_quota"));
         }
     }
@@ -462,7 +462,7 @@ mod tests {
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_err());
-        assert_eq!(limited_event_names(&events).len(), 2);
+        assert_eq!(quota_dropped_event_names(&events).len(), 2);
     }
 
     // -----------------------------------------------------------------------
@@ -486,8 +486,8 @@ mod tests {
         let mut ok = ok_event_names(&events);
         ok.sort();
         assert_eq!(ok, vec!["$exception", "$pageview"]);
-        assert_eq!(limited_event_names(&events).len(), 3);
-        for ev in events.iter().filter(|e| e.result == EventResult::Limited) {
+        assert_eq!(quota_dropped_event_names(&events).len(), 3);
+        for ev in events.iter().filter(|e| e.result == EventResult::Drop) {
             assert_eq!(ev.details, Some("survey_responses_over_quota"));
         }
     }
@@ -502,12 +502,12 @@ mod tests {
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
 
-        // Product tour survey → Ok, regular survey → Limited
+        // Product tour survey → Ok, regular survey → Drop (quota exceeded)
         assert_eq!(
             events.iter().find(|e| e.uuid == tour_uuid).unwrap().result,
             EventResult::Ok
         );
-        assert_eq!(limited_event_names(&events).len(), 1);
+        assert_eq!(quota_dropped_event_names(&events).len(), 1);
     }
 
     // -----------------------------------------------------------------------
@@ -528,8 +528,8 @@ mod tests {
         assert!(result.is_ok());
 
         assert_eq!(ok_event_names(&events), vec!["$pageview"]);
-        assert_eq!(limited_event_names(&events).len(), 3);
-        for ev in events.iter().filter(|e| e.result == EventResult::Limited) {
+        assert_eq!(quota_dropped_event_names(&events).len(), 3);
+        for ev in events.iter().filter(|e| e.result == EventResult::Drop) {
             assert_eq!(ev.details, Some("llm_events_over_quota"));
         }
     }
@@ -549,7 +549,7 @@ mod tests {
         let mut ok = ok_event_names(&events);
         ok.sort();
         assert_eq!(ok, vec!["$ainotcounted", "ai_generation"]);
-        assert_eq!(limited_event_names(&events), vec!["$ai_generation"]);
+        assert_eq!(quota_dropped_event_names(&events), vec!["$ai_generation"]);
     }
 
     // -----------------------------------------------------------------------
@@ -579,7 +579,7 @@ mod tests {
         assert!(result.is_ok());
 
         assert_eq!(ok_event_names(&events), vec!["$pageview"]);
-        assert_eq!(limited_event_names(&events).len(), 3);
+        assert_eq!(quota_dropped_event_names(&events).len(), 3);
         assert_eq!(
             find_unique_by_name(&events, "$exception").details,
             Some("exceptions_over_quota")
@@ -657,7 +657,7 @@ mod tests {
         pv_ev.destination = Destination::Drop;
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
-        // $exception → Limited, $pageview → already Drop → all non-Ok → error
+        // $exception → Drop (quota), $pageview → already Drop → all non-Ok → error
         assert!(result.is_err());
     }
 


### PR DESCRIPTION

## Problem
Now that `EventResult::Limited` means "don't resend but know your person processing was disabled" to the v1 SDKs, we need to explicitly set `EventResult::Drop` on quota limited events that should not be resubmitted
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Update quota-check event classification and related tests
* Misc. small tweaks for parity with decided behavior (stale comments, 429s eliminated, etc.)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
Claude was read in on a strictly need-to-know basis
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
