### PR TITLE
feat(funnels): migrate FunnelHistogram to hog-charts BarChart

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1868,6 +1868,10 @@ snapshots:
         hash: v1.k794b7964.85a7028e6729988dedf767a52640b16c94aa48baf0ab9c89b1085c38d4e8cc8e.wDERvaZQvyEVwZsoj2q7nTwZSDswGOq-6dnRNcvuRpw
     insights-funnelcorrelationtable--default--light:
         hash: v1.k794b7964.a5ccf40b74b63001bb7383ff53cb81b8f4f4a07308e0b6a2ad590ff821efc3ee.wCJ8wpYAyHJfnQB7k7qNZZKqiPtIq2sppx3qVS4IGQQ
+    insights-funnelhistogramchart--default--dark:
+        hash: v1.k794b7964.e0eeac72672d73139955c1822f77a0f4b7c3120ab66b4803b7bdfee62aeaeb52.tdaIqudDsCaiQ8QSe1x2RNTG0QwLiCmTEfhk6_5WEu0
+    insights-funnelhistogramchart--default--light:
+        hash: v1.k794b7964.64f2986bdea7e5f61e7b7900a52c683c8223df30f550701fb08028c8b203c807.tdD0sW9MOaReK_5QRGviTL5QDK2jG126L3hQj5pd2Cw
     insights-funnellinechart--default--dark:
         hash: v1.k794b7964.88b532c89fa992eac628ca0a779b0889d74e00e650284960e1d935f5e7e8704c.9XjpRbnpuvI56K35oITlbW-Z4_d8VXboPy03ork9yaY
     insights-funnellinechart--default--light:

--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -14,6 +14,7 @@ import { FunnelBarVertical } from './FunnelBarVertical/FunnelBarVertical'
 import { funnelDataLogic } from './funnelDataLogic'
 import { FunnelFlowGraph } from './FunnelFlowGraph/FunnelFlowGraph'
 import { FunnelHistogram } from './FunnelHistogram'
+import { FunnelHistogramChart } from './viz/funnel-histogram/FunnelHistogramChart'
 import { FunnelLineChart } from './viz/funnel-line-chart/FunnelLineChart'
 
 export function Funnel(props: ChartParams): JSX.Element {
@@ -26,7 +27,7 @@ export function Funnel(props: ChartParams): JSX.Element {
     if (funnelVizType == FunnelVizType.Trends) {
         viz = hogChartsFunnelEnabled ? <FunnelLineChart {...props} /> : <FunnelLineGraph {...props} />
     } else if (funnelVizType == FunnelVizType.TimeToConvert) {
-        viz = <FunnelHistogram />
+        viz = hogChartsFunnelEnabled ? <FunnelHistogramChart /> : <FunnelHistogram />
     } else if (funnelVizType === FunnelVizType.Flow) {
         viz = <FunnelFlowGraph />
     } else if ((layout || FunnelLayout.vertical) === FunnelLayout.vertical) {

--- a/frontend/src/scenes/funnels/viz/funnel-histogram/FunnelHistogramChart.stories.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-histogram/FunnelHistogramChart.stories.tsx
@@ -1,0 +1,68 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { BindLogic } from 'kea'
+import { useState } from 'react'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { getCachedResults } from '~/queries/nodes/InsightViz/utils'
+import { InsightLogicProps, InsightShortId } from '~/types'
+
+import { FunnelHistogramChart } from './FunnelHistogramChart'
+
+type Story = StoryObj<{}>
+
+const meta: Meta = {
+    title: 'Insights/FunnelHistogramChart',
+    component: FunnelHistogramChart,
+    parameters: {
+        layout: 'centered',
+        mockDate: '2022-03-12',
+        testOptions: { snapshotBrowsers: ['chromium'] },
+    },
+}
+export default meta
+
+let uniqueNode = 0
+
+function Stage({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ height: 360, width: 720, display: 'flex', flexDirection: 'column' }}>{children}</div>
+    )
+}
+
+function renderFunnelHistogramChart(insightFixture: any): JSX.Element {
+    const [dashboardItemId] = useState(() => `FunnelHistogramChartStory.${uniqueNode++}` as InsightShortId)
+    const source = insightFixture.query.source
+    const cachedInsight = { ...insightFixture, short_id: dashboardItemId }
+
+    const insightProps: InsightLogicProps = { dashboardItemId, doNotLoad: true, cachedInsight }
+    const dataNodeLogicProps: DataNodeLogicProps = {
+        query: source,
+        key: insightVizDataNodeKey(insightProps),
+        cachedResults: getCachedResults(cachedInsight, source),
+        doNotLoad: true,
+    }
+
+    return (
+        <BindLogic logic={insightLogic} props={insightProps}>
+            <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+                <Stage>
+                    <FunnelHistogramChart />
+                </Stage>
+            </BindLogic>
+        </BindLogic>
+    )
+}
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const funnelTimeToConvertInsight = (): any =>
+    require('../../../../mocks/fixtures/api/projects/team_id/insights/funnelTimeToConvert.json')
+
+export const Default: Story = {
+    render: () => renderFunnelHistogramChart(funnelTimeToConvertInsight()),
+}
+/* eslint-enable @typescript-eslint/no-var-requires */

--- a/frontend/src/scenes/funnels/viz/funnel-histogram/FunnelHistogramChart.tsx
+++ b/frontend/src/scenes/funnels/viz/funnel-histogram/FunnelHistogramChart.tsx
@@ -1,0 +1,62 @@
+import { useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useMemo, type ErrorInfo } from 'react'
+
+import { buildTheme } from 'lib/charts/utils/theme'
+import { BarChart, ValueLabels } from 'lib/hog-charts'
+import type { BarChartConfig } from 'lib/hog-charts'
+import { humanFriendlyNumber } from 'lib/utils'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+
+import { funnelDataLogic } from '../../funnelDataLogic'
+import { buildFunnelHistogramData } from './funnelHistogramTransforms'
+
+const CHART_CONFIG: BarChartConfig = {
+    showGrid: true,
+    barCornerRadius: 4,
+    yTickFormatter: (value) => humanFriendlyNumber(value),
+    tooltip: { placement: 'top' },
+}
+
+const handleChartError = (error: Error, info: ErrorInfo): void => {
+    posthog.captureException(error, {
+        feature: 'funnels-histogram-chart',
+        componentStack: info.componentStack ?? undefined,
+    })
+}
+
+export function FunnelHistogramChart(): JSX.Element | null {
+    const { isDarkModeOn } = useValues(themeLogic)
+    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const { insightProps } = useValues(insightLogic)
+    const { histogramGraphData } = useValues(funnelDataLogic(insightProps))
+    const { theme: dataColorTheme } = useValues(insightVizDataLogic(insightProps))
+
+    const histogramData = useMemo(
+        () => buildFunnelHistogramData(histogramGraphData ?? [], { color: dataColorTheme?.['preset-1'] }),
+        [histogramGraphData, dataColorTheme]
+    )
+
+    if (!histogramGraphData || histogramGraphData.length === 0) {
+        return null
+    }
+
+    return (
+        <BarChart
+            series={histogramData.series}
+            labels={histogramData.labels}
+            theme={theme}
+            config={CHART_CONFIG}
+            className="FunnelHistogramChart"
+            dataAttr="funnel-histogram"
+            onError={handleChartError}
+        >
+            <ValueLabels
+                valueFormatter={(_value, _seriesIndex, dataIndex) => histogramData.barLabels[dataIndex] ?? ''}
+            />
+        </BarChart>
+    )
+}

--- a/frontend/src/scenes/funnels/viz/funnel-histogram/funnelHistogramTransforms.test.ts
+++ b/frontend/src/scenes/funnels/viz/funnel-histogram/funnelHistogramTransforms.test.ts
@@ -1,0 +1,56 @@
+import type { HistogramGraphDatum } from '~/types'
+
+import {
+    buildFunnelHistogramData,
+    FUNNEL_HISTOGRAM_SERIES_KEY,
+    FUNNEL_HISTOGRAM_SERIES_LABEL,
+} from './funnelHistogramTransforms'
+
+const bins: HistogramGraphDatum[] = [
+    { id: 0, bin0: 0, bin1: 60, count: 12, label: '60%' },
+    { id: 60, bin0: 60, bin1: 120, count: 6, label: '30%' },
+    { id: 120, bin0: 120, bin1: 180, count: 2, label: '10%' },
+]
+
+describe('buildFunnelHistogramData', () => {
+    it('maps the bins onto a single conversion bar series', () => {
+        const { series } = buildFunnelHistogramData(bins)
+
+        expect(series).toHaveLength(1)
+        expect(series[0].key).toBe(FUNNEL_HISTOGRAM_SERIES_KEY)
+        expect(series[0].label).toBe(FUNNEL_HISTOGRAM_SERIES_LABEL)
+        expect(series[0].data).toEqual([12, 6, 2])
+    })
+
+    it('labels each bar with the humanized lower bound of its bin', () => {
+        const { labels } = buildFunnelHistogramData(bins)
+
+        expect(labels).toEqual(['0s', '1m', '2m'])
+    })
+
+    it('carries the per-bin percentage labels', () => {
+        const { barLabels } = buildFunnelHistogramData(bins)
+
+        expect(barLabels).toEqual(['60%', '30%', '10%'])
+    })
+
+    it('applies the provided series color', () => {
+        const { series } = buildFunnelHistogramData(bins, { color: '#1d4aff' })
+
+        expect(series[0].color).toBe('#1d4aff')
+    })
+
+    it('leaves the color unset when none is provided', () => {
+        const { series } = buildFunnelHistogramData(bins)
+
+        expect(series[0].color).toBeUndefined()
+    })
+
+    it('handles an empty bin list', () => {
+        const { series, labels, barLabels } = buildFunnelHistogramData([])
+
+        expect(labels).toEqual([])
+        expect(barLabels).toEqual([])
+        expect(series[0].data).toEqual([])
+    })
+})

--- a/frontend/src/scenes/funnels/viz/funnel-histogram/funnelHistogramTransforms.ts
+++ b/frontend/src/scenes/funnels/viz/funnel-histogram/funnelHistogramTransforms.ts
@@ -1,0 +1,35 @@
+import type { Series } from 'lib/hog-charts'
+import { humanFriendlyDuration } from 'lib/utils'
+
+import type { HistogramGraphDatum } from '~/types'
+
+export const FUNNEL_HISTOGRAM_SERIES_KEY = 'funnel-histogram-conversions'
+export const FUNNEL_HISTOGRAM_SERIES_LABEL = 'Conversions'
+
+export interface FunnelHistogramData {
+    /** Single bar series; `data[i]` is the conversion count for bin `i`. */
+    series: Series[]
+    /** Category labels — the lower bound of each duration bin, one per bar. */
+    labels: string[]
+    /** Per-bar percentage label (share of total conversions), indexed to match `labels`. */
+    barLabels: string[]
+}
+
+/** Maps the funnel time-to-convert bins onto a categorical hog-charts bar series. */
+export function buildFunnelHistogramData(
+    histogramGraphData: HistogramGraphDatum[],
+    options?: { color?: string }
+): FunnelHistogramData {
+    return {
+        labels: histogramGraphData.map((datum) => humanFriendlyDuration(datum.bin0, { maxUnits: 2 })),
+        barLabels: histogramGraphData.map((datum) => datum.label),
+        series: [
+            {
+                key: FUNNEL_HISTOGRAM_SERIES_KEY,
+                label: FUNNEL_HISTOGRAM_SERIES_LABEL,
+                data: histogramGraphData.map((datum) => datum.count),
+                color: options?.color,
+            },
+        ],
+    }
+}


### PR DESCRIPTION
## Problem

The funnel time-to-convert histogram still renders through the legacy d3 `Histogram` component. Trends and the funnel line chart already moved to the canvas-based hog-charts library (gated behind `PRODUCT_ANALYTICS_HOG_CHARTS` / `PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL`); the histogram is the remaining funnel viz on the old renderer.

This is the bar/histogram follow-up to #59667 (funnel line chart). No visible change until the flag flips — `Funnel.tsx` falls back to the legacy `FunnelHistogram` while `PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL` is off (default).

## Changes

- New `frontend/src/scenes/funnels/viz/funnel-histogram/`:
  - `funnelHistogramTransforms.ts` — pure transform mapping the time-to-convert `bins` onto a categorical hog-charts bar series (one bar per bin, `bin0` humanized as the x label, conversion `count` as the value, per-bin percentage carried as `barLabels`).
  - `FunnelHistogramChart.tsx` — renders a hog-charts `BarChart` with a `ValueLabels` overlay drawing the percentage on each bar. Series color comes from the insight data theme (`preset-1`), the same source the legacy `Histogram` used.
  - `funnelHistogramTransforms.test.ts` — unit tests for the transform.
  - `FunnelHistogramChart.stories.tsx` — Storybook snapshot story (baseline generated on first CI run).
- `Funnel.tsx` wires the flag: renders `FunnelHistogramChart` when `PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL` is on, falls back to `FunnelHistogram` when off — matching the existing line chart wiring.

## How did you test this code?

I'm an agent — no manual click-through. Locally:

- `funnelHistogramTransforms.test.ts` passes (`hogli test`).
- Per-file `tsc` clean on the new and changed files.
- `oxlint` clean on the new files.

Canvas output can't be asserted in jsdom, so the Storybook story is the visual-regression surface. No integration test: the shared `insight-testing` harness's funnel mock only produces trends-viz `FunnelStep[]`, not time-to-convert `bins` — extending it is out of scope here, so coverage is the transform unit tests plus the Storybook snapshot.

## Publish to changelog?

no — flag-gated, not user-visible until rollout.

## 🤖 Agent context

Authored with Claude Code (Anthropic) at the request of @sampennington. Requires human review before merge.

Approach decisions:

- **Followed the #59667 line chart structure.** Separate pure-transform module + thin component + story, gated behind the same `PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL` flag, so the histogram migration is consistent with the line chart one and revertable without code changes.
- **`BarChart` (categorical) over `TimeSeriesBarChart`.** The histogram x-axis is duration bins, not dates — each bin maps to a category label, so the categorical bar chart is the right primitive.
- **`ValueLabels` overlay for the percentage.** The legacy histogram always draws the per-bin percentage on each bar; the `ValueLabels` overlay reproduces that, formatting by `dataIndex` from the precomputed `barLabels`.
- **Scope limited to the time-to-convert histogram.** The funnel step bars (`FunnelBarVertical`/`FunnelBarHorizontal`) are highly custom interactive components, not chart-library candidates, and were intentionally left out.