### PR TITLE
chore(readme): add yolo to title

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   </a>
 </p>
 
-## PostHog is an all-in-one, open source platform for building successful products
+## PostHog yolo is an all-in-one, open source platform for building successful products
 
 [PostHog](https://posthog.com/) provides every tool you need to build a successful product including:
 


### PR DESCRIPTION
## Problem

Lighthearted README tweak requested by the task author.

## Changes

- Add "yolo" to the top-level README title.

## How did you test this code?

I'm an agent. No automated tests were run — this is a one-line README copy change with no code paths affected.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) at the user's request.
- The user asked to add "yolo" to the PostHog README title; the only matching title is the H2 on line 22 of `README.md`.
- Commit created via the GitHub GraphQL `createCommitOnBranch` mutation directly because the in-session signed-commit MCP tool was anchored to `/tmp/workspace` rather than the cloned repo path — the mutation produces the same server-signed Verified commit.