### PR TITLE
chore(readme): add yolo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo


### PR DESCRIPTION
## Problem

Adds a small marker line to the bottom of the repo README per request.

## Changes

- Appended `yolo` to the end of `README.md`.

## How did you test this code?

I'm an agent. No automated tests were run for this README-only text change.

## Publish to changelog?

do not publish to changelog

## Docs update

skip-inkeep-docs

## 🤖 Agent context

PostHog Code task. The user asked to "add yolo to posthog/posthog readme and create a draft pr". Implemented as a single text append at the bottom of `README.md`. Signed commit was created via the GitHub GraphQL `createCommitOnBranch` mutation as a workaround because the `mcp__posthog-local__git_signed_commit` tool was not loaded into this Claude Code session despite being referenced in the harness system prompt — worth flagging for the harness team.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*