### PR TITLE
fix(llma): extract pydantic-ai tool calls from output parts

### DIFF
--- a/nodejs/src/ingestion/ai/process-ai-event.test.ts
+++ b/nodejs/src/ingestion/ai/process-ai-event.test.ts
@@ -244,6 +244,64 @@ describe('processAiEvent()', () => {
         })
     })
 
+    describe('OTel ingestion', () => {
+        it('extracts Pydantic AI tool calls from output message parts', () => {
+            event.properties = {
+                $ai_ingestion_source: 'otel',
+                'logfire.json_schema': '{}',
+                'gen_ai.response.model': 'testing_model',
+                'gen_ai.provider.name': 'openai',
+                'gen_ai.usage.input_tokens': 100,
+                'gen_ai.usage.output_tokens': 50,
+                'gen_ai.output.messages': JSON.stringify([
+                    {
+                        role: 'assistant',
+                        parts: [
+                            { type: 'text', content: 'Let me check.' },
+                            {
+                                type: 'tool_call',
+                                id: 'call_weather',
+                                name: 'get_weather',
+                                arguments: '{"city":"NYC"}',
+                            },
+                            {
+                                type: 'tool_call',
+                                id: 'call_docs',
+                                name: 'search_docs',
+                                arguments: '{"query":"weather"}',
+                            },
+                        ],
+                    },
+                ]),
+            }
+
+            const result = processAiEvent(event)
+
+            expect(result.properties!.$ai_output_choices).toEqual([
+                {
+                    role: 'assistant',
+                    parts: [
+                        { type: 'text', content: 'Let me check.' },
+                        {
+                            type: 'tool_call',
+                            id: 'call_weather',
+                            name: 'get_weather',
+                            arguments: '{"city":"NYC"}',
+                        },
+                        {
+                            type: 'tool_call',
+                            id: 'call_docs',
+                            name: 'search_docs',
+                            arguments: '{"query":"weather"}',
+                        },
+                    ],
+                },
+            ])
+            expect(result.properties!.$ai_tools_called).toBe('get_weather,search_docs')
+            expect(result.properties!.$ai_tool_call_count).toBe(2)
+        })
+    })
+
     describe('model matching', () => {
         it('matches exact model names', () => {
             const result = processAiEvent(event)

--- a/nodejs/src/ingestion/ai/tools/extract-tool-calls.test.ts
+++ b/nodejs/src/ingestion/ai/tools/extract-tool-calls.test.ts
@@ -170,6 +170,93 @@ describe('extractToolCallNames', () => {
         })
     })
 
+    describe('Pydantic AI OTel format (parts with type=tool_call)', () => {
+        it.each([
+            [
+                'single tool_call part',
+                [
+                    {
+                        role: 'assistant',
+                        parts: [
+                            {
+                                type: 'tool_call',
+                                id: 'call_abc',
+                                name: 'get_weather',
+                                arguments: '{"city":"NYC"}',
+                            },
+                        ],
+                    },
+                ],
+                ['get_weather'],
+            ],
+            [
+                'multiple tool_call parts',
+                [
+                    {
+                        role: 'assistant',
+                        parts: [
+                            { type: 'tool_call', id: 'call_1', name: 'get_weather', arguments: '{}' },
+                            { type: 'tool_call', id: 'call_2', name: 'search_docs', arguments: '{}' },
+                        ],
+                    },
+                ],
+                ['get_weather', 'search_docs'],
+            ],
+            [
+                'mixed text and tool_call parts',
+                [
+                    {
+                        role: 'assistant',
+                        parts: [
+                            { type: 'text', content: 'Let me check.' },
+                            {
+                                type: 'tool_call',
+                                id: 'call_1',
+                                name: 'get_weather',
+                                arguments: '{"city":"NYC"}',
+                            },
+                        ],
+                    },
+                ],
+                ['get_weather'],
+            ],
+            [
+                'tool_call parts inside message wrapper',
+                [
+                    {
+                        message: {
+                            parts: [
+                                {
+                                    type: 'tool_call',
+                                    id: 'call_abc',
+                                    name: 'get_weather',
+                                    arguments: '{}',
+                                },
+                            ],
+                        },
+                    },
+                ],
+                ['get_weather'],
+            ],
+            [
+                'ignores malformed tool_call parts without string names',
+                [
+                    {
+                        role: 'assistant',
+                        parts: [
+                            { type: 'tool_call', id: 'call_1', arguments: '{}' },
+                            { type: 'tool_call', id: 'call_2', name: 123, arguments: '{}' },
+                            { type: 'tool_call', id: 'call_3', name: 'search_docs', arguments: '{}' },
+                        ],
+                    },
+                ],
+                ['search_docs'],
+            ],
+        ])('%s', (_description, input, expected) => {
+            expect(extractToolCallNames(input)).toEqual(expected)
+        })
+    })
+
     describe('OpenAI Responses API (flat function_call items)', () => {
         it.each([
             [
@@ -589,6 +676,36 @@ describe('processAiToolCallExtraction', () => {
 
         expect(result.properties!['$ai_tools_called']).toBe('get_weather')
         expect(result.properties!['$ai_tool_call_count']).toBe(1)
+    })
+
+    it('extracts Pydantic AI OTel tool_call parts from stringified JSON', () => {
+        const event = createEvent('$ai_generation', {
+            $ai_output_choices: JSON.stringify([
+                {
+                    role: 'assistant',
+                    parts: [
+                        { type: 'text', content: 'Let me check.' },
+                        {
+                            type: 'tool_call',
+                            id: 'call_abc',
+                            name: 'get_weather',
+                            arguments: '{"city":"NYC"}',
+                        },
+                        {
+                            type: 'tool_call',
+                            id: 'call_def',
+                            name: 'search_docs',
+                            arguments: '{"q":"weather"}',
+                        },
+                    ],
+                },
+            ]),
+        })
+
+        const result = processAiToolCallExtraction(event)
+
+        expect(result.properties!['$ai_tools_called']).toBe('get_weather,search_docs')
+        expect(result.properties!['$ai_tool_call_count']).toBe(2)
     })
 
     it('extracts normalized format with content.type=function', () => {

--- a/nodejs/src/ingestion/ai/tools/extract-tool-calls.test.ts
+++ b/nodejs/src/ingestion/ai/tools/extract-tool-calls.test.ts
@@ -678,10 +678,9 @@ describe('processAiToolCallExtraction', () => {
         expect(result.properties!['$ai_tool_call_count']).toBe(1)
     })
 
-    it.each([
-        [
-            'Pydantic AI OTel tool_call parts from stringified JSON',
-            JSON.stringify([
+    it('extracts Pydantic AI OTel tool_call parts from stringified JSON', () => {
+        const event = createEvent('$ai_generation', {
+            $ai_output_choices: JSON.stringify([
                 {
                     role: 'assistant',
                     parts: [
@@ -701,18 +700,12 @@ describe('processAiToolCallExtraction', () => {
                     ],
                 },
             ]),
-            'get_weather,search_docs',
-            2,
-        ],
-    ])('%s', (_description, outputChoices, expectedToolsCalled, expectedCount) => {
-        const event = createEvent('$ai_generation', {
-            $ai_output_choices: outputChoices,
         })
 
         const result = processAiToolCallExtraction(event)
 
-        expect(result.properties!['$ai_tools_called']).toBe(expectedToolsCalled)
-        expect(result.properties!['$ai_tool_call_count']).toBe(expectedCount)
+        expect(result.properties!['$ai_tools_called']).toBe('get_weather,search_docs')
+        expect(result.properties!['$ai_tool_call_count']).toBe(2)
     })
 
     it('extracts normalized format with content.type=function', () => {

--- a/nodejs/src/ingestion/ai/tools/extract-tool-calls.test.ts
+++ b/nodejs/src/ingestion/ai/tools/extract-tool-calls.test.ts
@@ -678,9 +678,10 @@ describe('processAiToolCallExtraction', () => {
         expect(result.properties!['$ai_tool_call_count']).toBe(1)
     })
 
-    it('extracts Pydantic AI OTel tool_call parts from stringified JSON', () => {
-        const event = createEvent('$ai_generation', {
-            $ai_output_choices: JSON.stringify([
+    it.each([
+        [
+            'Pydantic AI OTel tool_call parts from stringified JSON',
+            JSON.stringify([
                 {
                     role: 'assistant',
                     parts: [
@@ -700,12 +701,18 @@ describe('processAiToolCallExtraction', () => {
                     ],
                 },
             ]),
+            'get_weather,search_docs',
+            2,
+        ],
+    ])('%s', (_description, outputChoices, expectedToolsCalled, expectedCount) => {
+        const event = createEvent('$ai_generation', {
+            $ai_output_choices: outputChoices,
         })
 
         const result = processAiToolCallExtraction(event)
 
-        expect(result.properties!['$ai_tools_called']).toBe('get_weather,search_docs')
-        expect(result.properties!['$ai_tool_call_count']).toBe(2)
+        expect(result.properties!['$ai_tools_called']).toBe(expectedToolsCalled)
+        expect(result.properties!['$ai_tool_call_count']).toBe(expectedCount)
     })
 
     it('extracts normalized format with content.type=function', () => {

--- a/nodejs/src/ingestion/ai/tools/extract-tool-calls.ts
+++ b/nodejs/src/ingestion/ai/tools/extract-tool-calls.ts
@@ -7,6 +7,7 @@
  * - OpenAI Responses API: flat `[].type="function_call"` with `name` at top level
  * - Normalized SDK: `[].content[].type="function"` with `function.name`
  * - Vercel AI SDK / OTel: `[].content[].type="tool-call"` with `function.name`
+ * - Pydantic AI OTel: `[].parts[].type="tool_call"` with `name`
  * - Anthropic: `[].message.content[].type="tool_use"` with `name`
  * - Python repr (OpenAI Agents SDK): `ResponseFunctionToolCall(name='...')`
  */
@@ -27,10 +28,12 @@ interface OutputItem {
     name?: string
     role?: string
     content?: ToolCallItem[]
+    parts?: ToolCallItem[]
     tool_calls?: ToolCallItem[]
     message?: {
         tool_calls?: ToolCallItem[]
         content?: ToolCallItem[]
+        parts?: ToolCallItem[]
     }
 }
 
@@ -67,26 +70,30 @@ function extractFromToolCalls(toolCalls: unknown[], names: string[], cap: number
     }
 }
 
-function extractFromContentBlocks(content: unknown[], names: string[], cap: number): void {
-    for (const block of content) {
+function extractFromMessageParts(parts: unknown[], names: string[], cap: number): void {
+    for (const part of parts) {
         if (names.length >= cap) {
             return
         }
-        if (typeof block !== 'object' || block === null) {
+        if (typeof part !== 'object' || part === null) {
             continue
         }
-        const cb = block as ToolCallItem
+        const messagePart = part as ToolCallItem
+        // Pydantic AI OTel: {type: "tool_call", name: "..."}
+        if (messagePart.type === 'tool_call' && messagePart.name && typeof messagePart.name === 'string') {
+            pushSanitized(names, messagePart.name)
+        }
         // Anthropic: {type: "tool_use", name: "..."}
-        if (cb.type === 'tool_use' && cb.name && typeof cb.name === 'string') {
-            pushSanitized(names, cb.name)
+        else if (messagePart.type === 'tool_use' && messagePart.name && typeof messagePart.name === 'string') {
+            pushSanitized(names, messagePart.name)
         }
         // Normalized OpenAI / Vercel AI SDK / OTel: {type: "function"|"tool-call", function: {name: "..."}}
         else if (
-            (cb.type === 'function' || cb.type === 'tool-call') &&
-            cb.function?.name &&
-            typeof cb.function.name === 'string'
+            (messagePart.type === 'function' || messagePart.type === 'tool-call') &&
+            messagePart.function?.name &&
+            typeof messagePart.function.name === 'string'
         ) {
-            pushSanitized(names, cb.function.name)
+            pushSanitized(names, messagePart.function.name)
         }
     }
 }
@@ -158,7 +165,10 @@ export function extractToolCallNames(outputChoices: unknown, rawString?: string)
                 extractFromToolCalls(c.message.tool_calls, names, MAX_TOOLS_PER_EVENT)
             }
             if ('content' in c.message && Array.isArray(c.message.content)) {
-                extractFromContentBlocks(c.message.content, names, MAX_TOOLS_PER_EVENT)
+                extractFromMessageParts(c.message.content, names, MAX_TOOLS_PER_EVENT)
+            }
+            if ('parts' in c.message && Array.isArray(c.message.parts)) {
+                extractFromMessageParts(c.message.parts, names, MAX_TOOLS_PER_EVENT)
             }
         } else {
             // Unwrapped: {tool_calls: [...], role: "assistant"} (no message wrapper)
@@ -168,7 +178,12 @@ export function extractToolCallNames(outputChoices: unknown, rawString?: string)
 
             // Normalized: {content: [...], role: "assistant"} (no message wrapper)
             if ('content' in c && Array.isArray(c.content)) {
-                extractFromContentBlocks(c.content, names, MAX_TOOLS_PER_EVENT)
+                extractFromMessageParts(c.content, names, MAX_TOOLS_PER_EVENT)
+            }
+
+            // Pydantic AI OTel: {parts: [{type: "tool_call", name: "..."}], role: "assistant"}
+            if ('parts' in c && Array.isArray(c.parts)) {
+                extractFromMessageParts(c.parts, names, MAX_TOOLS_PER_EVENT)
             }
         }
     }


### PR DESCRIPTION
## Problem

Pydantic AI's current OpenTelemetry instrumentation stores generation output in `gen_ai.output.messages`, which PostHog maps to `$ai_output_choices`. Tool calls in that output are represented as message `parts` with `type: "tool_call"` and a top-level `name`.

PostHog already extracts tool calls from several provider shapes, but not this Pydantic AI message-parts shape, so affected `$ai_generation` events do not get `$ai_tools_called` or `$ai_tool_call_count` populated.

Pydantic AI instrumentation docs: https://pydantic.dev/docs/ai/api/models/instrumented/

## Changes

- Teach AI tool-call extraction to read `parts[]` arrays on output choices and message wrappers.
- Extract `part.name` when `part.type === "tool_call"`.
- Reuse existing sanitization, ordering, duplicate preservation, and per-event cap behavior.
- Add tests for direct extraction, malformed parts, stringified JSON, and the full OTel ingestion path.

## How did you test this code?

I tested this locally in Docker.

```bash
pnpm --filter=@posthog/nodejs format:check
pnpm --filter=@posthog/nodejs lint
pnpm --filter=@posthog/nodejs build
```

All passed.

```bash
pnpm exec jest --runInBand --forceExit \
  src/ingestion/ai/tools/extract-tool-calls.test.ts \
  src/ingestion/ai/otel/attribute-mapping.test.ts \
  src/ingestion/ai/process-ai-event.test.ts
```

Result: 3 suites passed, 288 tests passed.

```bash
git diff --check
```

Passed.

## Publish to changelog?

Do not publish to changelog.

## Docs update

No docs update. This is a backend ingestion compatibility fix for an already documented tools normalization field.

## 🤖 Agent context

I used Codex to help me with this PR.

Codex helped inspect the existing tool-call extractor patterns, implement the narrow Pydantic AI `parts[].type === "tool_call"` extraction path, and add focused tests.

The implementation stays local to the existing extractor and reuses the current sanitizer, ordering, duplicate preservation, and count behavior. The added tests cover wrapped and unwrapped output shapes, malformed parts, mixed text/tool parts, stringified JSON, and the full OTel ingestion path.
