### PR TITLE
fix(llma): fall back to plain text when XML parsing fails in trace viewer

### DIFF
--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -358,7 +358,7 @@ export function Settings({
                     className={clsx(
                         'border rounded w-[var(--settings-nav-width)] flex flex-col',
                         isFullScene
-                            ? 'sticky top-[calc(var(--scene-layout-header-height)+var(--scene-padding))] self-start max-h-[calc(100dvh-var(--scene-layout-header-height)-var(--scene-padding))]'
+                            ? 'fixed top-[calc(var(--scene-layout-header-height)+var(--scene-padding))] bottom-[var(--scene-padding)]'
                             : 'sticky top-[var(--scene-layout-header-height)] self-start max-h-[calc(100dvh-var(--scene-layout-header-height)-var(--scene-padding))]'
                     )}
                 >

--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -358,7 +358,7 @@ export function Settings({
                     className={clsx(
                         'border rounded w-[var(--settings-nav-width)] flex flex-col',
                         isFullScene
-                            ? 'fixed top-[calc(var(--scene-layout-header-height)+var(--scene-padding))] bottom-[var(--scene-padding)]'
+                            ? 'sticky top-[calc(var(--scene-layout-header-height)+var(--scene-padding))] self-start max-h-[calc(100dvh-var(--scene-layout-header-height)-var(--scene-padding))]'
                             : 'sticky top-[var(--scene-layout-header-height)] self-start max-h-[calc(100dvh-var(--scene-layout-header-height)-var(--scene-padding))]'
                     )}
                 >

--- a/products/llm_analytics/frontend/ConversationDisplay/XMLViewer.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/XMLViewer.tsx
@@ -18,7 +18,9 @@ export function XMLViewer({ children: xmlContent, collapsed = 3 }: XMLViewerProp
     const parsedXML = parseXML(xmlContent)
 
     if (!parsedXML) {
-        return <span className="font-mono whitespace-pre-wrap text-danger">Invalid XML content</span>
+        // Content looks like XML but isn't valid (e.g. markdown with embedded HTML tags).
+        // Render as plain text instead of surfacing a confusing parse error to the user.
+        return <span className="font-mono whitespace-pre-wrap">{xmlContent}</span>
     }
 
     return (


### PR DESCRIPTION
## Changes

When a tool response contains content that *looks* like XML (e.g. markdown with HTML tags like `<img>`, `<div>`, `<a href="...">`) but is not valid XML, `XMLViewer` calls `DOMParser` which fails on the parse. The component then renders a red **"Invalid XML content"** message in the trace viewer — hiding the actual tool response content from the user.

**Before:** tool response with HTML-embedded markdown → "Invalid XML content" (red error, content hidden)
**After:** falls back to plain `whitespace-pre-wrap` text, same as when XML highlighting is toggled off

## Root cause

`looksLikeXml()` correctly identifies content containing `</` or `/>` as a candidate. Any README or file-reading tool response containing HTML in markdown passes this check, which routes to the `XMLViewer`. `DOMParser` requires strict XML validity, so unescaped `&`, mismatched tags, or HTML void elements cause it to return a parse error node.

## Fix

One-line change in `XMLViewer.tsx`: when `parseXML` returns `null`, render the raw string as plain pre-wrapped text instead of a confusing error message.

## Related

Fixes #46759