### PR TITLE
feat(hog-charts): add PieChart

### DIFF
--- a/frontend/src/lib/hog-charts/charts/PieChart/PieChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieChart.stories.tsx
@@ -1,0 +1,151 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { Stage, useReactiveTheme } from '../../story-helpers'
+import { PieChart, type PieChartConfig, type PieSlice } from './PieChart'
+
+const THREE_SLICES: PieSlice[] = [
+    { key: 'desktop', label: 'Desktop', value: 540 },
+    { key: 'mobile', label: 'Mobile', value: 380 },
+    { key: 'tablet', label: 'Tablet', value: 120 },
+]
+
+const SIX_SLICES: PieSlice[] = [
+    { key: 'chrome', label: 'Chrome', value: 620 },
+    { key: 'safari', label: 'Safari', value: 310 },
+    { key: 'firefox', label: 'Firefox', value: 140 },
+    { key: 'edge', label: 'Edge', value: 90 },
+    { key: 'opera', label: 'Opera', value: 28 },
+    { key: 'other', label: 'Other', value: 12 },
+]
+
+const meta: Meta = { title: 'Components/HogCharts/PieChart', parameters: { layout: 'centered' } }
+export default meta
+
+type Story = StoryObj<{}>
+
+export const Default: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <PieChart slices={THREE_SLICES} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const Donut: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const config: PieChartConfig = { innerRadius: 0.55 }
+        return (
+            <Stage>
+                <PieChart slices={THREE_SLICES} theme={theme} config={config} />
+            </Stage>
+        )
+    },
+}
+
+export const ManySlices: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <PieChart slices={SIX_SLICES} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const WithSliceLabels: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const config: PieChartConfig = { showLabelsOnSlices: true, showValuesOnSlices: false }
+        return (
+            <Stage>
+                <PieChart slices={THREE_SLICES} theme={theme} config={config} />
+            </Stage>
+        )
+    },
+}
+
+export const WithSlicePadding: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const config: PieChartConfig = { slicePadding: 0.02, innerRadius: 0.4 }
+        return (
+            <Stage>
+                <PieChart slices={SIX_SLICES} theme={theme} config={config} />
+            </Stage>
+        )
+    },
+}
+
+export const HiddenValueLabels: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const config: PieChartConfig = { showValuesOnSlices: false }
+        return (
+            <Stage>
+                <PieChart slices={SIX_SLICES} theme={theme} config={config} />
+            </Stage>
+        )
+    },
+}
+
+export const CustomValueFormatter: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const config: PieChartConfig = { valueFormatter: (v) => `$${v.toLocaleString()}` }
+        const slices: PieSlice[] = [
+            { key: 'pro', label: 'Pro', value: 12400 },
+            { key: 'team', label: 'Team', value: 6200 },
+            { key: 'free', label: 'Free', value: 1800 },
+        ]
+        return (
+            <Stage>
+                <PieChart slices={slices} theme={theme} config={config} />
+            </Stage>
+        )
+    },
+}
+
+export const SingleSlice: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const slices: PieSlice[] = [{ key: 'only', label: 'All traffic', value: 100 }]
+        return (
+            <Stage>
+                <PieChart slices={slices} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const EmptyState: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <PieChart slices={[]} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const SkewedDistribution: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const slices: PieSlice[] = [
+            { key: 'big', label: 'Big', value: 980 },
+            { key: 'medium', label: 'Medium', value: 60 },
+            { key: 'small', label: 'Small', value: 14 },
+            { key: 'tiny', label: 'Tiny', value: 3 },
+        ]
+        return (
+            <Stage>
+                <PieChart slices={slices} theme={theme} />
+            </Stage>
+        )
+    },
+}

--- a/frontend/src/lib/hog-charts/charts/PieChart/PieChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieChart.test.tsx
@@ -1,0 +1,181 @@
+import { fireEvent, waitFor } from '@testing-library/react'
+
+import type { ChartTheme } from '../../core/types'
+import { renderHogChart, waitForHogChartTooltip } from '../../testing'
+import { mockRect } from '../../testing/jsdom'
+import { PieChart, type PieSlice, type PieTooltipContext } from './PieChart'
+import { computePieLayout, computeSliceAngles, type ResolvedPieSlice } from './utils/pie-layout'
+
+const THEME: ChartTheme = {
+    colors: ['#1f77b4', '#ff7f0e', '#2ca02c'],
+    backgroundColor: '#ffffff',
+}
+
+const SLICES: PieSlice[] = [
+    { key: 'a', label: 'A', value: 30 },
+    { key: 'b', label: 'B', value: 50 },
+    { key: 'c', label: 'C', value: 20 },
+]
+
+// PieChart uses uniform 12px margins on the wrapper rect.
+const PIE_MARGIN = 12
+
+// Position the cursor at the centre of a slice — relative to the chart's
+// real plot layout, since the chart will hit-test against the same geometry.
+function fireMouseOverSlice(wrapper: HTMLElement, sliceIndex: number, slices: PieSlice[] = SLICES): void {
+    const dims = {
+        width: mockRect.width,
+        height: mockRect.height,
+        plotLeft: PIE_MARGIN,
+        plotTop: PIE_MARGIN,
+        plotWidth: mockRect.width - PIE_MARGIN * 2,
+        plotHeight: mockRect.height - PIE_MARGIN * 2,
+    }
+    const layout = computePieLayout(dims)
+    const total = slices.reduce((s, x) => s + x.value, 0)
+    const resolved: ResolvedPieSlice[] = slices.map((s) => ({
+        key: s.key,
+        label: s.label,
+        value: s.value,
+        color: '#000',
+    }))
+    const angles = computeSliceAngles(resolved, total)
+    const target = angles[sliceIndex]
+    const mid = (target.startAngle + target.endAngle) / 2
+    const r = (layout.innerRadius + layout.outerRadius) / 2 || layout.outerRadius / 2
+    const x = layout.cx + Math.cos(mid) * r
+    const y = layout.cy + Math.sin(mid) * r
+    fireEvent.mouseMove(wrapper, { clientX: x, clientY: y })
+}
+
+describe('PieChart', () => {
+    it('reports the visible slice count via aria-label', () => {
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} />)
+        expect(chart.seriesCount).toBe(3)
+    })
+
+    it('filters out non-positive slices', () => {
+        const slices: PieSlice[] = [
+            { key: 'a', label: 'A', value: 10 },
+            { key: 'b', label: 'B', value: 0 },
+            { key: 'c', label: 'C', value: -5 },
+        ]
+        const { chart } = renderHogChart(<PieChart slices={slices} theme={THEME} />)
+        expect(chart.seriesCount).toBe(1)
+    })
+
+    it('renders an empty state when no slice has a positive value', () => {
+        const slices: PieSlice[] = [
+            { key: 'a', label: 'A', value: 0 },
+            { key: 'b', label: 'B', value: -1 },
+        ]
+        const { container } = renderHogChart(<PieChart slices={slices} theme={THEME} />)
+        expect(container.textContent).toContain('No data to display')
+    })
+
+    it('renders a custom empty-state node when provided', () => {
+        const { container } = renderHogChart(
+            <PieChart slices={[]} theme={THEME} emptyState={<span>nothing here</span>} />
+        )
+        expect(container.textContent).toContain('nothing here')
+    })
+
+    it('forwards `dataAttr` to the chart wrapper', () => {
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} dataAttr="pie-instance" />)
+        expect(chart.element.getAttribute('data-attr')).toBe('pie-instance')
+    })
+
+    it('opens the default tooltip with value and percentage on hover', async () => {
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} />)
+        fireMouseOverSlice(chart.element, 1)
+        const tooltip = await waitForHogChartTooltip()
+        expect(tooltip.textContent).toContain('B')
+        expect(tooltip.textContent).toContain('50')
+        expect(tooltip.textContent).toContain('50.0%')
+    })
+
+    it('invokes the tooltip render prop with PieTooltipContext', async () => {
+        const tooltipSpy = jest.fn((_ctx: PieTooltipContext) => <div>custom tooltip</div>)
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} tooltip={tooltipSpy} />)
+        fireMouseOverSlice(chart.element, 0)
+        await waitForHogChartTooltip()
+        expect(tooltipSpy).toHaveBeenCalled()
+        const ctx = tooltipSpy.mock.calls[0]![0]
+        expect(ctx.slice.key).toBe('a')
+        expect(ctx.percent).toBeCloseTo(30)
+        expect(ctx.total).toBe(100)
+        expect(ctx.slices).toHaveLength(3)
+    })
+
+    it('invokes onSliceClick with the slice and percent', async () => {
+        const onSliceClick = jest.fn()
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} onSliceClick={onSliceClick} />)
+        fireMouseOverSlice(chart.element, 2)
+        await waitForHogChartTooltip()
+        fireEvent.click(chart.element)
+        expect(onSliceClick).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sliceIndex: 2,
+                value: 20,
+                total: 100,
+                slice: expect.objectContaining({ key: 'c' }),
+            })
+        )
+        expect(onSliceClick.mock.calls[0][0].percent).toBeCloseTo(20)
+    })
+
+    it('does not invoke onSliceClick when the click misses every slice', () => {
+        const onSliceClick = jest.fn()
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} onSliceClick={onSliceClick} />)
+        // Click without first hovering — hoverIndex stays at -1.
+        fireEvent.click(chart.element)
+        expect(onSliceClick).not.toHaveBeenCalled()
+    })
+
+    it('pins the tooltip on click when tooltip.pinnable is set', async () => {
+        const { chart } = renderHogChart(
+            <PieChart slices={SLICES} theme={THEME} config={{ tooltip: { pinnable: true } }} />
+        )
+        fireMouseOverSlice(chart.element, 0)
+        const tooltip = await waitForHogChartTooltip()
+        fireEvent.click(chart.element)
+        await waitFor(() => {
+            expect(tooltip.classList.contains('hog-charts-tooltip--pinned')).toBe(true)
+        })
+    })
+
+    it('hides the tooltip when tooltip.enabled is false', () => {
+        const { chart } = renderHogChart(
+            <PieChart slices={SLICES} theme={THEME} config={{ tooltip: { enabled: false } }} />
+        )
+        fireMouseOverSlice(chart.element, 0)
+        expect(document.querySelector('[data-hog-charts-tooltip]')).toBeNull()
+    })
+
+    it('caps innerRadius into the donut range without crashing', () => {
+        const { chart } = renderHogChart(
+            <PieChart slices={SLICES} theme={THEME} config={{ innerRadius: 0.5 }} />
+        )
+        expect(chart.seriesCount).toBe(3)
+    })
+
+    it('applies a custom value formatter to the tooltip', async () => {
+        const formatter = (v: number): string => `$${v}`
+        const { chart } = renderHogChart(
+            <PieChart slices={SLICES} theme={THEME} config={{ valueFormatter: formatter }} />
+        )
+        fireMouseOverSlice(chart.element, 0)
+        const tooltip = await waitForHogChartTooltip()
+        expect(tooltip.textContent).toContain('$30')
+    })
+
+    it('uses slice-provided color over the theme palette', () => {
+        const slices: PieSlice[] = [
+            { key: 'a', label: 'A', value: 10, color: '#abcdef' },
+            { key: 'b', label: 'B', value: 10 },
+        ]
+        const { chart } = renderHogChart(<PieChart slices={slices} theme={THEME} />)
+        // We can't read canvas pixels in jsdom — confirm the chart still renders both slices.
+        expect(chart.seriesCount).toBe(2)
+    })
+})

--- a/frontend/src/lib/hog-charts/charts/PieChart/PieChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieChart.test.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, waitFor } from '@testing-library/react'
 
-import type { ChartTheme } from '../../core/types'
+import type { ChartTheme, TooltipContext } from '../../core/types'
 import { renderHogChart, waitForHogChartTooltip } from '../../testing'
 import { mockRect } from '../../testing/jsdom'
-import { PieChart, type PieSlice, type PieTooltipContext } from './PieChart'
+import { PieChart, type PieSlice } from './PieChart'
+import { PieTooltip } from './PieTooltip'
 import { computePieLayout, computeSliceAngles, type ResolvedPieSlice } from './utils/pie-layout'
 
 const THEME: ChartTheme = {
@@ -85,8 +86,10 @@ describe('PieChart', () => {
         expect(chart.element.getAttribute('data-attr')).toBe('pie-instance')
     })
 
-    it('opens the default tooltip with value and percentage on hover', async () => {
-        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} />)
+    it('opens PieTooltip with value and percentage on hover', async () => {
+        const { chart } = renderHogChart(
+            <PieChart slices={SLICES} theme={THEME} tooltip={(ctx) => <PieTooltip ctx={ctx} theme={THEME} />} />
+        )
         fireMouseOverSlice(chart.element, 1)
         const tooltip = await waitForHogChartTooltip()
         expect(tooltip.textContent).toContain('B')
@@ -94,17 +97,18 @@ describe('PieChart', () => {
         expect(tooltip.textContent).toContain('50.0%')
     })
 
-    it('invokes the tooltip render prop with PieTooltipContext', async () => {
-        const tooltipSpy = jest.fn((_ctx: PieTooltipContext) => <div>custom tooltip</div>)
+    it('invokes the tooltip render prop with a series-shaped TooltipContext', async () => {
+        const tooltipSpy = jest.fn((_ctx: TooltipContext) => <div>custom tooltip</div>)
         const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} tooltip={tooltipSpy} />)
         fireMouseOverSlice(chart.element, 0)
         await waitForHogChartTooltip()
         expect(tooltipSpy).toHaveBeenCalled()
         const ctx = tooltipSpy.mock.calls[0]![0]
-        expect(ctx.slice.key).toBe('a')
-        expect(ctx.percent).toBeCloseTo(30)
-        expect(ctx.total).toBe(100)
-        expect(ctx.slices).toHaveLength(3)
+        expect(ctx.dataIndex).toBe(0)
+        expect(ctx.label).toBe('A')
+        expect(ctx.seriesData).toHaveLength(3)
+        expect(ctx.seriesData[0]!.series.key).toBe('a')
+        expect(ctx.seriesData[0]!.value).toBe(30)
     })
 
     it('invokes onSliceClick with the slice and percent', async () => {
@@ -144,6 +148,26 @@ describe('PieChart', () => {
         })
     })
 
+    it('pins the tooltip *and* fires onSliceClick when both are configured', async () => {
+        const onSliceClick = jest.fn()
+        const { chart } = renderHogChart(
+            <PieChart
+                slices={SLICES}
+                theme={THEME}
+                config={{ tooltip: { pinnable: true } }}
+                onSliceClick={onSliceClick}
+            />
+        )
+        fireMouseOverSlice(chart.element, 1)
+        const tooltip = await waitForHogChartTooltip()
+        fireEvent.click(chart.element)
+        await waitFor(() => {
+            expect(tooltip.classList.contains('hog-charts-tooltip--pinned')).toBe(true)
+        })
+        expect(onSliceClick).toHaveBeenCalledTimes(1)
+        expect(onSliceClick.mock.calls[0][0].slice.key).toBe('b')
+    })
+
     it('hides the tooltip when tooltip.enabled is false', () => {
         const { chart } = renderHogChart(
             <PieChart slices={SLICES} theme={THEME} config={{ tooltip: { enabled: false } }} />
@@ -153,16 +177,19 @@ describe('PieChart', () => {
     })
 
     it('caps innerRadius into the donut range without crashing', () => {
-        const { chart } = renderHogChart(
-            <PieChart slices={SLICES} theme={THEME} config={{ innerRadius: 0.5 }} />
-        )
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} config={{ innerRadius: 0.5 }} />)
         expect(chart.seriesCount).toBe(3)
     })
 
-    it('applies a custom value formatter to the tooltip', async () => {
+    it('applies a custom value formatter to PieTooltip', async () => {
         const formatter = (v: number): string => `$${v}`
         const { chart } = renderHogChart(
-            <PieChart slices={SLICES} theme={THEME} config={{ valueFormatter: formatter }} />
+            <PieChart
+                slices={SLICES}
+                theme={THEME}
+                config={{ valueFormatter: formatter }}
+                tooltip={(ctx) => <PieTooltip ctx={ctx} theme={THEME} valueFormatter={formatter} />}
+            />
         )
         fireMouseOverSlice(chart.element, 0)
         const tooltip = await waitForHogChartTooltip()

--- a/frontend/src/lib/hog-charts/charts/PieChart/PieChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieChart.tsx
@@ -1,0 +1,506 @@
+import { flip, FloatingPortal, offset, shift, useFloating, type VirtualElement } from '@floating-ui/react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+
+import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
+import { useChartCanvas } from '../../core/hooks/useChartCanvas'
+import type { ChartMargins, ChartTheme, TooltipConfig } from '../../core/types'
+import { PieTooltip } from './PieTooltip'
+import {
+    computePieLayout,
+    computeSliceAngles,
+    DEFAULT_START_ANGLE,
+    hitTestSlice,
+    type PieLayout,
+    type ResolvedPieSlice,
+    type SliceAngle,
+} from './utils/pie-layout'
+import { drawPieSlices, drawSliceLabels, highlightColorFor } from './utils/pie-canvas'
+
+const WRAPPER_STYLE_BASE: React.CSSProperties = {
+    position: 'relative',
+    width: '100%',
+    flex: 1,
+    minHeight: 0,
+    overflow: 'hidden',
+}
+const WRAPPER_STYLE_DEFAULT: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'default' }
+const WRAPPER_STYLE_POINTER: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'pointer' }
+const CANVAS_STYLE: React.CSSProperties = { position: 'absolute', top: 0, left: 0 }
+
+const DEFAULT_PIE_MARGINS: ChartMargins = { top: 12, right: 12, bottom: 12, left: 12 }
+const DEFAULT_HOVER_OFFSET = 16
+const DEFAULT_VALUE_LABEL_MIN_PERCENT = 5
+const DEFAULT_TOOLTIP_Z_INDEX = 9999
+const TOOLTIP_MIDDLEWARE = [offset(12), flip(), shift({ padding: 8 })]
+
+const defaultValueFormatter = (value: number): string => value.toLocaleString()
+
+/** A single slice of the pie. */
+export interface PieSlice<Meta = unknown> {
+    /** Unique identifier — used to key DOM nodes and survive re-ordering across renders. */
+    key: string
+    /** Human-readable name shown in the tooltip and value labels. */
+    label: string
+    /** Numeric value for this slice. Non-positive slices are filtered out. */
+    value: number
+    /** CSS color string. When omitted the chart picks one from `theme.colors` by slice index. */
+    color?: string
+    /** Arbitrary consumer data attached to the slice — flows through to `PieTooltipContext`
+     *  and the slice-click callback. */
+    meta?: Meta
+}
+
+/** Slice after `theme.colors` has been applied — colour is guaranteed. */
+export type ResolvedPieSliceWithMeta<Meta = unknown> = PieSlice<Meta> & { color: string }
+
+export interface PieChartConfig {
+    /** Donut hole, 0–1 fraction of the outer radius. Defaults to 0 (full pie). */
+    innerRadius?: number
+    /** Pixels to pop a hovered slice out along its bisector. Defaults to 16; set to 0 to disable. */
+    hoverOffset?: number
+    /** Slices below this percentage of the total skip their value label. Defaults to 5. */
+    valueLabelMinPercent?: number
+    /** Show numeric value labels on slices large enough to fit. Defaults to true. */
+    showValuesOnSlices?: boolean
+    /** When set, draws the slice label instead of the numeric value on each slice. */
+    showLabelsOnSlices?: boolean
+    /** Formats numeric values everywhere — value labels and the default tooltip. */
+    valueFormatter?: (value: number) => string
+    /** Tooltip behaviour. Defaults to enabled, not pinnable. */
+    tooltip?: TooltipConfig
+    /** Radians of gap between adjacent slices. Defaults to 0. */
+    slicePadding?: number
+    /** Angle (radians) at which the first slice starts. Defaults to -π/2 (12 o'clock). */
+    startAngle?: number
+}
+
+export interface PieSliceClickData<Meta = unknown> {
+    /** Index into the *filtered* (positive-value) slice array. */
+    sliceIndex: number
+    slice: ResolvedPieSliceWithMeta<Meta>
+    value: number
+    /** Slice's percentage of the total (0–100). */
+    percent: number
+    total: number
+}
+
+/** Context passed to the tooltip render prop. Narrower than the line/bar `TooltipContext`
+ *  because pies don't have axes or cross-series comparisons. */
+export interface PieTooltipContext<Meta = unknown> {
+    /** Index into the *filtered* (positive-value) slice array. */
+    sliceIndex: number
+    /** The hovered slice. */
+    slice: ResolvedPieSliceWithMeta<Meta>
+    /** Slice's percentage of the total (0–100). */
+    percent: number
+    /** Sum of every visible slice's value. */
+    total: number
+    /** All visible slices, in render order. */
+    slices: ResolvedPieSliceWithMeta<Meta>[]
+    /** Cursor position in canvas pixels. */
+    position: { x: number; y: number }
+    /** Bounding rect of the canvas — useful for portal-positioned tooltip overrides. */
+    canvasBounds: DOMRect
+    /** Theme passed to the chart. */
+    theme: ChartTheme
+    /** Resolved value formatter (caller's `config.valueFormatter` or the default). */
+    valueFormatter: (value: number) => string
+    /** True once a click has pinned the tooltip. */
+    isPinned: boolean
+    /** Closes a pinned tooltip. Only present when `isPinned`. */
+    onUnpin?: () => void
+}
+
+export interface PieChartProps<Meta = unknown> {
+    /** Slices to render. Non-positive values are filtered out; the chart shows an empty state
+     *  when no slices remain. */
+    slices: PieSlice<Meta>[]
+    theme: ChartTheme
+    config?: PieChartConfig
+    /** Override the tooltip body — receives a `PieTooltipContext`. */
+    tooltip?: (ctx: PieTooltipContext<Meta>) => React.ReactNode
+    onSliceClick?: (data: PieSliceClickData<Meta>) => void
+    className?: string
+    /** `data-attr` applied to the chart wrapper. */
+    dataAttr?: string
+    /** Body shown when there are no positive slices. Defaults to a short text message. */
+    emptyState?: React.ReactNode
+    onError?: (error: Error, info: React.ErrorInfo) => void
+}
+
+export function PieChart<Meta = unknown>({ onError, ...rest }: PieChartProps<Meta>): React.ReactElement {
+    return (
+        <ChartErrorBoundary onError={onError}>
+            <PieChartInner {...rest} />
+        </ChartErrorBoundary>
+    )
+}
+
+function PieChartInner<Meta = unknown>({
+    slices: rawSlices,
+    theme,
+    config,
+    tooltip: tooltipRenderProp,
+    onSliceClick,
+    className,
+    dataAttr,
+    emptyState,
+}: Omit<PieChartProps<Meta>, 'onError'>): React.ReactElement {
+    const {
+        innerRadius = 0,
+        hoverOffset = DEFAULT_HOVER_OFFSET,
+        valueLabelMinPercent = DEFAULT_VALUE_LABEL_MIN_PERCENT,
+        showValuesOnSlices = true,
+        showLabelsOnSlices = false,
+        valueFormatter = defaultValueFormatter,
+        tooltip: tooltipConfig,
+        slicePadding = 0,
+        startAngle = DEFAULT_START_ANGLE,
+    } = config ?? {}
+    const { enabled: showTooltip = true, pinnable: pinnableTooltip = false } = tooltipConfig ?? {}
+
+    const { canvasRef, wrapperRef, dimensions, ctx } = useChartCanvas({ margins: DEFAULT_PIE_MARGINS })
+
+    // Apply theme palette and drop non-positive slices — they have no visual area and would
+    // confuse hit testing (zero-sweep arcs match every cursor angle).
+    const visibleSlices = useMemo<ResolvedPieSliceWithMeta<Meta>[]>(() => {
+        const out: ResolvedPieSliceWithMeta<Meta>[] = []
+        let colorIndex = 0
+        for (const slice of rawSlices) {
+            if (!(slice.value > 0)) {
+                continue
+            }
+            out.push({
+                ...slice,
+                color: slice.color || theme.colors[colorIndex % theme.colors.length],
+            })
+            colorIndex += 1
+        }
+        return out
+    }, [rawSlices, theme.colors])
+
+    const total = useMemo(() => visibleSlices.reduce((sum, s) => sum + s.value, 0), [visibleSlices])
+
+    const layout = useMemo<PieLayout | null>(() => {
+        if (!dimensions) {
+            return null
+        }
+        return computePieLayout(dimensions, { innerRadius, hoverOffset })
+    }, [dimensions, innerRadius, hoverOffset])
+
+    const sliceAngles = useMemo<SliceAngle[]>(
+        () => computeSliceAngles(visibleSlices as ResolvedPieSlice[], total, startAngle),
+        [visibleSlices, total, startAngle]
+    )
+
+    const [hoverIndex, setHoverIndex] = useState<number>(-1)
+    const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null)
+    const [isPinned, setIsPinned] = useState<boolean>(false)
+    const hoverIndexRef = useRef(hoverIndex)
+    hoverIndexRef.current = hoverIndex
+
+    const clearHover = useCallback(() => {
+        setHoverIndex(-1)
+        setHoverPosition(null)
+        setIsPinned(false)
+    }, [])
+
+    const unpin = useCallback(() => setIsPinned(false), [])
+
+    // Reset hover state when the slice set changes — index/position pointers into the
+    // previous geometry are nonsense against the new one.
+    useEffect(() => {
+        setHoverIndex(-1)
+        setHoverPosition(null)
+        setIsPinned(false)
+    }, [visibleSlices])
+
+    // Drawing — one layer is enough since hover rearranges the geometry (slice pops out)
+    // and value labels track the hover offset. Splitting static / hover would force the
+    // static layer to redraw on every hover anyway.
+    useEffect(() => {
+        if (!ctx || !dimensions || !layout) {
+            return
+        }
+        let cancelled = false
+        const raf = requestAnimationFrame(() => {
+            if (cancelled) {
+                return
+            }
+            const dpr = window.devicePixelRatio || 1
+            ctx.save()
+            ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+            ctx.clearRect(0, 0, dimensions.width, dimensions.height)
+
+            // Tint the hovered slice darker by mutating its color in the array we pass to
+            // drawPieSlices — cheaper than a separate overlay pass since geometry already
+            // shifts on hover.
+            const slicesForDraw =
+                hoverIndex >= 0
+                    ? visibleSlices.map((s, i) =>
+                          i === hoverIndex ? { ...s, color: highlightColorFor(s.color) } : s
+                      )
+                    : visibleSlices
+
+            drawPieSlices(ctx, layout, slicesForDraw as ResolvedPieSlice[], sliceAngles, {
+                hoverIndex,
+                hoverOffset,
+                slicePadding,
+            })
+
+            if (showValuesOnSlices || showLabelsOnSlices) {
+                drawSliceLabels(ctx, layout, visibleSlices as ResolvedPieSlice[], sliceAngles, {
+                    minFraction: valueLabelMinPercent / 100,
+                    mode: showLabelsOnSlices ? 'label' : 'value',
+                    valueFormatter,
+                    hoverIndex,
+                    hoverOffset,
+                })
+            }
+            ctx.restore()
+        })
+        return () => {
+            cancelled = true
+            cancelAnimationFrame(raf)
+        }
+    }, [
+        ctx,
+        dimensions,
+        layout,
+        sliceAngles,
+        visibleSlices,
+        hoverIndex,
+        hoverOffset,
+        slicePadding,
+        showValuesOnSlices,
+        showLabelsOnSlices,
+        valueLabelMinPercent,
+        valueFormatter,
+    ])
+
+    const onMouseMove = useCallback(
+        (e: React.MouseEvent<HTMLDivElement>) => {
+            if (!layout || isPinned) {
+                return
+            }
+            const rect = e.currentTarget.getBoundingClientRect()
+            const x = e.clientX - rect.left
+            const y = e.clientY - rect.top
+            const index = hitTestSlice(x, y, layout, sliceAngles)
+            setHoverIndex(index)
+            setHoverPosition(index >= 0 ? { x, y } : null)
+        },
+        [layout, sliceAngles, isPinned]
+    )
+
+    const onMouseLeave = useCallback(() => {
+        if (isPinned) {
+            return
+        }
+        clearHover()
+    }, [isPinned, clearHover])
+
+    const onClick = useCallback(() => {
+        const currentIndex = hoverIndexRef.current
+        if (currentIndex < 0) {
+            return
+        }
+        if (isPinned) {
+            clearHover()
+            return
+        }
+        if (pinnableTooltip && showTooltip) {
+            setIsPinned(true)
+            return
+        }
+        if (onSliceClick) {
+            const slice = visibleSlices[currentIndex]
+            onSliceClick({
+                sliceIndex: currentIndex,
+                slice,
+                value: slice.value,
+                percent: total > 0 ? (slice.value / total) * 100 : 0,
+                total,
+            })
+        }
+    }, [isPinned, pinnableTooltip, showTooltip, clearHover, onSliceClick, visibleSlices, total])
+
+    // Dismiss pinned tooltip via Escape or outside click — same UX as the bar/line tooltip.
+    useEffect(() => {
+        if (!isPinned) {
+            return
+        }
+        const handleClickOutside = (e: MouseEvent): void => {
+            const target = e.target
+            if (target instanceof Element && target.closest('[data-hog-charts-tooltip]')) {
+                return
+            }
+            const wrapper = wrapperRef.current
+            if (wrapper && !wrapper.contains(target as Node)) {
+                clearHover()
+            }
+        }
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape') {
+                clearHover()
+            }
+        }
+        const timer = setTimeout(() => {
+            document.addEventListener('click', handleClickOutside, { passive: true })
+        }, 0)
+        document.addEventListener('keydown', handleKeyDown, { passive: true })
+        return () => {
+            clearTimeout(timer)
+            document.removeEventListener('click', handleClickOutside)
+            document.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [isPinned, wrapperRef, clearHover])
+
+    const canvasBounds = useCallback(
+        (): DOMRect => canvasRef.current?.getBoundingClientRect() ?? new DOMRect(),
+        [canvasRef]
+    )
+
+    const tooltipCtx = useMemo<PieTooltipContext<Meta> | null>(() => {
+        if (!showTooltip || hoverIndex < 0 || !hoverPosition) {
+            return null
+        }
+        const slice = visibleSlices[hoverIndex]
+        if (!slice) {
+            return null
+        }
+        return {
+            sliceIndex: hoverIndex,
+            slice,
+            percent: total > 0 ? (slice.value / total) * 100 : 0,
+            total,
+            slices: visibleSlices,
+            position: hoverPosition,
+            canvasBounds: canvasBounds(),
+            theme,
+            valueFormatter,
+            isPinned,
+            onUnpin: isPinned ? unpin : undefined,
+        }
+    }, [
+        showTooltip,
+        hoverIndex,
+        hoverPosition,
+        visibleSlices,
+        total,
+        canvasBounds,
+        theme,
+        valueFormatter,
+        isPinned,
+        unpin,
+    ])
+
+    const wrapperStyle = hoverIndex >= 0 && (onSliceClick || pinnableTooltip)
+        ? WRAPPER_STYLE_POINTER
+        : WRAPPER_STYLE_DEFAULT
+
+    const ariaLabel = `Chart with ${visibleSlices.length} data series`
+
+    if (visibleSlices.length === 0) {
+        const fallback = emptyState ?? <span style={{ fontSize: 13, opacity: 0.6 }}>No data to display</span>
+        return (
+            <div
+                ref={wrapperRef}
+                className={className}
+                data-attr={dataAttr}
+                style={WRAPPER_STYLE_DEFAULT}
+                role="img"
+                aria-label={ariaLabel}
+            >
+                <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={CANVAS_STYLE} />
+                <div
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{
+                        position: 'absolute',
+                        inset: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    }}
+                >
+                    {fallback}
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div
+            ref={wrapperRef}
+            className={className}
+            data-attr={dataAttr}
+            style={wrapperStyle}
+            onMouseMove={onMouseMove}
+            onMouseLeave={onMouseLeave}
+            onClick={onClick}
+        >
+            <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={CANVAS_STYLE} />
+            {tooltipCtx && (
+                <PiePortalTooltip ctx={tooltipCtx}>
+                    {tooltipRenderProp ? tooltipRenderProp(tooltipCtx) : <PieTooltip ctx={tooltipCtx} />}
+                </PiePortalTooltip>
+            )}
+        </div>
+    )
+}
+
+interface PiePortalTooltipProps<Meta> {
+    ctx: PieTooltipContext<Meta>
+    children: React.ReactNode
+}
+
+function PiePortalTooltip<Meta>({ ctx, children }: PiePortalTooltipProps<Meta>): React.ReactElement {
+    const zIndex = ctx.theme.tooltipZIndex ?? DEFAULT_TOOLTIP_Z_INDEX
+    const x = ctx.canvasBounds.left + ctx.position.x
+    const y = ctx.canvasBounds.top + ctx.position.y
+
+    const virtualReference = useMemo<VirtualElement>(
+        () => ({
+            getBoundingClientRect: () => ({
+                x,
+                y,
+                width: 0,
+                height: 0,
+                top: y,
+                right: x,
+                bottom: y,
+                left: x,
+            }),
+        }),
+        [x, y]
+    )
+
+    const { refs, floatingStyles } = useFloating({
+        placement: 'right',
+        strategy: 'fixed',
+        middleware: TOOLTIP_MIDDLEWARE,
+    })
+
+    useLayoutEffect(() => {
+        refs.setPositionReference(virtualReference)
+    }, [virtualReference, refs])
+
+    return (
+        <FloatingPortal>
+            <div
+                ref={refs.setFloating}
+                data-hog-charts-tooltip=""
+                className={ctx.isPinned ? 'hog-charts-tooltip--pinned' : undefined}
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{
+                    ...floatingStyles,
+                    pointerEvents: ctx.isPinned ? 'auto' : 'none',
+                    width: 'max-content',
+                    zIndex,
+                }}
+            >
+                {children}
+            </div>
+        </FloatingPortal>
+    )
+}

--- a/frontend/src/lib/hog-charts/charts/PieChart/PieChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieChart.tsx
@@ -3,8 +3,9 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
 import { useChartCanvas } from '../../core/hooks/useChartCanvas'
-import type { ChartMargins, ChartTheme, TooltipConfig } from '../../core/types'
+import type { ChartMargins, ChartTheme, Series, TooltipConfig, TooltipContext } from '../../core/types'
 import { PieTooltip } from './PieTooltip'
+import { drawPieSlices, drawSliceLabels, highlightColorFor } from './utils/pie-canvas'
 import {
     computePieLayout,
     computeSliceAngles,
@@ -14,7 +15,6 @@ import {
     type ResolvedPieSlice,
     type SliceAngle,
 } from './utils/pie-layout'
-import { drawPieSlices, drawSliceLabels, highlightColorFor } from './utils/pie-canvas'
 
 const WRAPPER_STYLE_BASE: React.CSSProperties = {
     position: 'relative',
@@ -45,8 +45,9 @@ export interface PieSlice<Meta = unknown> {
     value: number
     /** CSS color string. When omitted the chart picks one from `theme.colors` by slice index. */
     color?: string
-    /** Arbitrary consumer data attached to the slice — flows through to `PieTooltipContext`
-     *  and the slice-click callback. */
+    /** Arbitrary consumer data attached to the slice — flows through to the synthetic
+     *  `Series.meta` exposed via `TooltipContext.seriesData[].series.meta`, and to the
+     *  slice-click callback. */
     meta?: Meta
 }
 
@@ -84,41 +85,16 @@ export interface PieSliceClickData<Meta = unknown> {
     total: number
 }
 
-/** Context passed to the tooltip render prop. Narrower than the line/bar `TooltipContext`
- *  because pies don't have axes or cross-series comparisons. */
-export interface PieTooltipContext<Meta = unknown> {
-    /** Index into the *filtered* (positive-value) slice array. */
-    sliceIndex: number
-    /** The hovered slice. */
-    slice: ResolvedPieSliceWithMeta<Meta>
-    /** Slice's percentage of the total (0–100). */
-    percent: number
-    /** Sum of every visible slice's value. */
-    total: number
-    /** All visible slices, in render order. */
-    slices: ResolvedPieSliceWithMeta<Meta>[]
-    /** Cursor position in canvas pixels. */
-    position: { x: number; y: number }
-    /** Bounding rect of the canvas — useful for portal-positioned tooltip overrides. */
-    canvasBounds: DOMRect
-    /** Theme passed to the chart. */
-    theme: ChartTheme
-    /** Resolved value formatter (caller's `config.valueFormatter` or the default). */
-    valueFormatter: (value: number) => string
-    /** True once a click has pinned the tooltip. */
-    isPinned: boolean
-    /** Closes a pinned tooltip. Only present when `isPinned`. */
-    onUnpin?: () => void
-}
-
 export interface PieChartProps<Meta = unknown> {
     /** Slices to render. Non-positive values are filtered out; the chart shows an empty state
      *  when no slices remain. */
     slices: PieSlice<Meta>[]
     theme: ChartTheme
     config?: PieChartConfig
-    /** Override the tooltip body — receives a `PieTooltipContext`. */
-    tooltip?: (ctx: PieTooltipContext<Meta>) => React.ReactNode
+    /** Override the tooltip body. Receives the same `TooltipContext` every hog-chart emits;
+     *  each slice is a synthetic one-point series so `seriesData[dataIndex]` is the hovered
+     *  slice, and `seriesData.reduce(...)` gives the total. */
+    tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onSliceClick?: (data: PieSliceClickData<Meta>) => void
     className?: string
     /** `data-attr` applied to the chart wrapper. */
@@ -237,9 +213,7 @@ function PieChartInner<Meta = unknown>({
             // shifts on hover.
             const slicesForDraw =
                 hoverIndex >= 0
-                    ? visibleSlices.map((s, i) =>
-                          i === hoverIndex ? { ...s, color: highlightColorFor(s.color) } : s
-                      )
+                    ? visibleSlices.map((s, i) => (i === hoverIndex ? { ...s, color: highlightColorFor(s.color) } : s))
                     : visibleSlices
 
             drawPieSlices(ctx, layout, slicesForDraw as ResolvedPieSlice[], sliceAngles, {
@@ -309,9 +283,11 @@ function PieChartInner<Meta = unknown>({
             clearHover()
             return
         }
+        // Pinning and onSliceClick are independent — a consumer can ask for both, in which
+        // case the click pins the tooltip *and* fires the callback. We don't early-return
+        // here so the two paths don't shadow each other.
         if (pinnableTooltip && showTooltip) {
             setIsPinned(true)
-            return
         }
         if (onSliceClick) {
             const slice = visibleSlices[currentIndex]
@@ -361,7 +337,25 @@ function PieChartInner<Meta = unknown>({
         [canvasRef]
     )
 
-    const tooltipCtx = useMemo<PieTooltipContext<Meta> | null>(() => {
+    // Each slice becomes a single-point synthetic Series so the tooltip context matches
+    // the bar/line shape — the testing harness, DefaultTooltip, and `TooltipSnapshot.series`
+    // accessor all key off `series.key`, which mirrors `slice.key` here.
+    const seriesData = useMemo(
+        () =>
+            visibleSlices.map((slice) => {
+                const series: Series<Meta> = {
+                    key: slice.key,
+                    label: slice.label,
+                    data: [slice.value],
+                    color: slice.color,
+                    meta: slice.meta,
+                }
+                return { series, value: slice.value, color: slice.color }
+            }),
+        [visibleSlices]
+    )
+
+    const tooltipCtx = useMemo<TooltipContext<Meta> | null>(() => {
         if (!showTooltip || hoverIndex < 0 || !hoverPosition) {
             return null
         }
@@ -370,34 +364,19 @@ function PieChartInner<Meta = unknown>({
             return null
         }
         return {
-            sliceIndex: hoverIndex,
-            slice,
-            percent: total > 0 ? (slice.value / total) * 100 : 0,
-            total,
-            slices: visibleSlices,
+            dataIndex: hoverIndex,
+            label: slice.label,
+            seriesData,
             position: hoverPosition,
+            hoverPosition,
             canvasBounds: canvasBounds(),
-            theme,
-            valueFormatter,
             isPinned,
             onUnpin: isPinned ? unpin : undefined,
         }
-    }, [
-        showTooltip,
-        hoverIndex,
-        hoverPosition,
-        visibleSlices,
-        total,
-        canvasBounds,
-        theme,
-        valueFormatter,
-        isPinned,
-        unpin,
-    ])
+    }, [showTooltip, hoverIndex, hoverPosition, visibleSlices, seriesData, canvasBounds, isPinned, unpin])
 
-    const wrapperStyle = hoverIndex >= 0 && (onSliceClick || pinnableTooltip)
-        ? WRAPPER_STYLE_POINTER
-        : WRAPPER_STYLE_DEFAULT
+    const wrapperStyle =
+        hoverIndex >= 0 && (onSliceClick || pinnableTooltip) ? WRAPPER_STYLE_POINTER : WRAPPER_STYLE_DEFAULT
 
     const ariaLabel = `Chart with ${visibleSlices.length} data series`
 
@@ -441,8 +420,12 @@ function PieChartInner<Meta = unknown>({
         >
             <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={CANVAS_STYLE} />
             {tooltipCtx && (
-                <PiePortalTooltip ctx={tooltipCtx}>
-                    {tooltipRenderProp ? tooltipRenderProp(tooltipCtx) : <PieTooltip ctx={tooltipCtx} />}
+                <PiePortalTooltip ctx={tooltipCtx} theme={theme}>
+                    {tooltipRenderProp ? (
+                        tooltipRenderProp(tooltipCtx)
+                    ) : (
+                        <PieTooltip ctx={tooltipCtx} theme={theme} valueFormatter={valueFormatter} />
+                    )}
                 </PiePortalTooltip>
             )}
         </div>
@@ -450,12 +433,13 @@ function PieChartInner<Meta = unknown>({
 }
 
 interface PiePortalTooltipProps<Meta> {
-    ctx: PieTooltipContext<Meta>
+    ctx: TooltipContext<Meta>
+    theme: ChartTheme
     children: React.ReactNode
 }
 
-function PiePortalTooltip<Meta>({ ctx, children }: PiePortalTooltipProps<Meta>): React.ReactElement {
-    const zIndex = ctx.theme.tooltipZIndex ?? DEFAULT_TOOLTIP_Z_INDEX
+function PiePortalTooltip<Meta>({ ctx, theme, children }: PiePortalTooltipProps<Meta>): React.ReactElement {
+    const zIndex = theme.tooltipZIndex ?? DEFAULT_TOOLTIP_Z_INDEX
     const x = ctx.canvasBounds.left + ctx.position.x
     const y = ctx.canvasBounds.top + ctx.position.y
 

--- a/frontend/src/lib/hog-charts/charts/PieChart/PieTooltip.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieTooltip.tsx
@@ -1,16 +1,31 @@
-import type { PieTooltipContext } from './PieChart'
+import type { ChartTheme, TooltipContext } from '../../core/types'
 
 const DEFAULT_TOOLTIP_BG = '#1d2330'
 const DEFAULT_TOOLTIP_COLOR = '#ffffff'
 
+const defaultValueFormatter = (value: number): string => value.toLocaleString()
+
 export interface PieTooltipProps<Meta = unknown> {
-    ctx: PieTooltipContext<Meta>
+    ctx: TooltipContext<Meta>
+    theme: ChartTheme
+    valueFormatter?: (value: number) => string
 }
 
 /** Default pie tooltip — shows the hovered slice's label, value, and percentage.
- *  Mirrors the layout the SQL pie chart's `InsightTooltip` uses (value + share-of-total). */
-export function PieTooltip<Meta = unknown>({ ctx }: PieTooltipProps<Meta>): React.ReactElement {
-    const { slice, percent, theme, valueFormatter } = ctx
+ *  Mirrors the layout the SQL pie chart's `InsightTooltip` uses (value + share-of-total).
+ *  Consumes the same `TooltipContext` shape every other hog-chart emits: each slice is a
+ *  synthetic single-point series, so `seriesData[dataIndex]` is the hovered slice. */
+export function PieTooltip<Meta = unknown>({
+    ctx,
+    theme,
+    valueFormatter = defaultValueFormatter,
+}: PieTooltipProps<Meta>): React.ReactElement | null {
+    const entry = ctx.seriesData[ctx.dataIndex]
+    if (!entry) {
+        return null
+    }
+    const total = ctx.seriesData.reduce((sum, e) => sum + e.value, 0)
+    const percent = total > 0 ? (entry.value / total) * 100 : 0
     return (
         <div
             className="px-3 py-2 rounded-lg shadow-lg text-[13px]"
@@ -24,12 +39,12 @@ export function PieTooltip<Meta = unknown>({ ctx }: PieTooltipProps<Meta>): Reac
                 <span
                     className="inline-block size-2 rounded-full"
                     // eslint-disable-next-line react/forbid-dom-props
-                    style={{ backgroundColor: slice.color }}
+                    style={{ backgroundColor: entry.color }}
                 />
-                <span className="font-semibold">{slice.label}</span>
+                <span className="font-semibold">{entry.series.label}</span>
             </div>
             <div className="flex items-baseline gap-2">
-                <strong>{valueFormatter(slice.value)}</strong>
+                <strong>{valueFormatter(entry.value)}</strong>
                 <span className="opacity-75">({percent.toFixed(1)}%)</span>
             </div>
         </div>

--- a/frontend/src/lib/hog-charts/charts/PieChart/PieTooltip.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieTooltip.tsx
@@ -1,0 +1,37 @@
+import type { PieTooltipContext } from './PieChart'
+
+const DEFAULT_TOOLTIP_BG = '#1d2330'
+const DEFAULT_TOOLTIP_COLOR = '#ffffff'
+
+export interface PieTooltipProps<Meta = unknown> {
+    ctx: PieTooltipContext<Meta>
+}
+
+/** Default pie tooltip — shows the hovered slice's label, value, and percentage.
+ *  Mirrors the layout the SQL pie chart's `InsightTooltip` uses (value + share-of-total). */
+export function PieTooltip<Meta = unknown>({ ctx }: PieTooltipProps<Meta>): React.ReactElement {
+    const { slice, percent, theme, valueFormatter } = ctx
+    return (
+        <div
+            className="px-3 py-2 rounded-lg shadow-lg text-[13px]"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{
+                backgroundColor: theme.tooltipBackground ?? DEFAULT_TOOLTIP_BG,
+                color: theme.tooltipColor ?? DEFAULT_TOOLTIP_COLOR,
+            }}
+        >
+            <div className="flex items-center gap-2 mb-1">
+                <span
+                    className="inline-block size-2 rounded-full"
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ backgroundColor: slice.color }}
+                />
+                <span className="font-semibold">{slice.label}</span>
+            </div>
+            <div className="flex items-baseline gap-2">
+                <strong>{valueFormatter(slice.value)}</strong>
+                <span className="opacity-75">({percent.toFixed(1)}%)</span>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-canvas.ts
+++ b/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-canvas.ts
@@ -129,14 +129,7 @@ export function drawSliceLabels(
     ctx.restore()
 }
 
-function roundedRect(
-    ctx: CanvasRenderingContext2D,
-    x: number,
-    y: number,
-    w: number,
-    h: number,
-    radius: number
-): void {
+function roundedRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, radius: number): void {
     const r = Math.min(radius, w / 2, h / 2)
     ctx.beginPath()
     ctx.moveTo(x + r, y)

--- a/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-canvas.ts
+++ b/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-canvas.ts
@@ -1,0 +1,157 @@
+// Stateless canvas drawing primitives for PieChart.
+//
+// Pie charts work in polar coordinates and don't share the axis-based DrawContext
+// used by line/bar/area renderers in core/canvas-renderer.ts. Keeping these
+// primitives next to the chart type avoids polluting the shared module with
+// shapes that no other chart can reuse.
+
+import * as d3 from 'd3'
+
+import type { PieLayout, ResolvedPieSlice, SliceAngle } from './pie-layout'
+import { sliceHoverOffset, sliceLabelPosition } from './pie-layout'
+
+interface DrawPieSlicesOptions {
+    /** Index of the hovered slice, or -1. */
+    hoverIndex: number
+    /** Pixels to pop a hovered slice out along its bisector. 0 disables the effect. */
+    hoverOffset: number
+    /** Radians of gap between adjacent slices. */
+    slicePadding: number
+}
+
+export function drawPieSlices(
+    ctx: CanvasRenderingContext2D,
+    layout: PieLayout,
+    slices: ResolvedPieSlice[],
+    angles: SliceAngle[],
+    options: DrawPieSlicesOptions
+): void {
+    const { hoverIndex, hoverOffset, slicePadding } = options
+    if (layout.outerRadius <= 0) {
+        return
+    }
+
+    for (const angle of angles) {
+        const slice = slices[angle.sliceIndex]
+        const isHovered = angle.sliceIndex === hoverIndex
+        const { dx, dy } = sliceHoverOffset(angle, isHovered, hoverOffset)
+
+        // Symmetric padding eats from both sides of the slice; skip when the slice
+        // is too narrow to survive the trim — drawing a negative arc paints a full circle.
+        const padHalf = slicePadding / 2
+        const start = angle.startAngle + padHalf
+        const end = angle.endAngle - padHalf
+        if (end <= start) {
+            continue
+        }
+
+        const cx = layout.cx + dx
+        const cy = layout.cy + dy
+
+        ctx.beginPath()
+        if (layout.innerRadius > 0) {
+            ctx.arc(cx, cy, layout.outerRadius, start, end)
+            ctx.arc(cx, cy, layout.innerRadius, end, start, true)
+        } else {
+            ctx.moveTo(cx, cy)
+            ctx.arc(cx, cy, layout.outerRadius, start, end)
+        }
+        ctx.closePath()
+
+        ctx.fillStyle = slice.color
+        ctx.fill()
+    }
+}
+
+interface DrawSliceLabelsOptions {
+    /** Skip the label when the slice covers less than this fraction (0–1) of the pie. */
+    minFraction: number
+    /** Text mode: numeric value (formatted) or the slice label. */
+    mode: 'value' | 'label'
+    /** Formats numeric slice values. */
+    valueFormatter: (value: number) => string
+    /** Index of the hovered slice; that slice's label is drawn at the popped-out position. */
+    hoverIndex: number
+    /** Same hover-offset used by drawPieSlices, so labels track the popped-out slice. */
+    hoverOffset: number
+}
+
+export function drawSliceLabels(
+    ctx: CanvasRenderingContext2D,
+    layout: PieLayout,
+    slices: ResolvedPieSlice[],
+    angles: SliceAngle[],
+    options: DrawSliceLabelsOptions
+): void {
+    if (layout.outerRadius <= 0) {
+        return
+    }
+    const { minFraction, mode, valueFormatter, hoverIndex, hoverOffset } = options
+
+    ctx.save()
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.font = '500 12px var(--font-sans, system-ui, -apple-system, sans-serif)'
+
+    for (const angle of angles) {
+        if (angle.fraction < minFraction) {
+            continue
+        }
+        const slice = slices[angle.sliceIndex]
+        const text = mode === 'label' ? slice.label : valueFormatter(slice.value)
+        if (!text) {
+            continue
+        }
+
+        const isHovered = angle.sliceIndex === hoverIndex
+        const { dx, dy } = sliceHoverOffset(angle, isHovered, hoverOffset)
+        const pos = sliceLabelPosition(layout, angle)
+        const x = pos.x + dx
+        const y = pos.y + dy
+
+        // Pill: filled with the slice color, white text, white border, rounded corners.
+        const metrics = ctx.measureText(text)
+        const paddingX = 8
+        const paddingY = 4
+        const w = metrics.width + paddingX * 2
+        const h = 12 + paddingY * 2
+
+        ctx.fillStyle = slice.color
+        ctx.strokeStyle = '#ffffff'
+        ctx.lineWidth = 2
+        roundedRect(ctx, x - w / 2, y - h / 2, w, h, 25)
+        ctx.fill()
+        ctx.stroke()
+
+        ctx.fillStyle = '#ffffff'
+        ctx.fillText(text, x, y)
+    }
+    ctx.restore()
+}
+
+function roundedRect(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    radius: number
+): void {
+    const r = Math.min(radius, w / 2, h / 2)
+    ctx.beginPath()
+    ctx.moveTo(x + r, y)
+    ctx.lineTo(x + w - r, y)
+    ctx.quadraticCurveTo(x + w, y, x + w, y + r)
+    ctx.lineTo(x + w, y + h - r)
+    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h)
+    ctx.lineTo(x + r, y + h)
+    ctx.quadraticCurveTo(x, y + h, x, y + h - r)
+    ctx.lineTo(x, y + r)
+    ctx.quadraticCurveTo(x, y, x + r, y)
+    ctx.closePath()
+}
+
+/** Darken the slice color a touch — same idiom BarChart uses for its hover highlight. */
+export function highlightColorFor(color: string): string {
+    return d3.color(color)?.darker(0.4).toString() ?? color
+}

--- a/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.test.ts
+++ b/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.test.ts
@@ -1,0 +1,154 @@
+import type { ChartDimensions } from '../../../core/types'
+import {
+    computePieLayout,
+    computeSliceAngles,
+    DEFAULT_START_ANGLE,
+    hitTestSlice,
+    type ResolvedPieSlice,
+    sliceHoverOffset,
+    sliceLabelPosition,
+} from './pie-layout'
+
+const DIMENSIONS: ChartDimensions = {
+    width: 400,
+    height: 400,
+    plotLeft: 0,
+    plotTop: 0,
+    plotWidth: 400,
+    plotHeight: 400,
+}
+
+const SLICES: ResolvedPieSlice[] = [
+    { key: 'a', label: 'A', value: 1, color: '#111' },
+    { key: 'b', label: 'B', value: 2, color: '#222' },
+    { key: 'c', label: 'C', value: 1, color: '#333' },
+]
+
+describe('computePieLayout', () => {
+    it('centres the pie within the plot area and reserves room for hover offset', () => {
+        const layout = computePieLayout(DIMENSIONS, { hoverOffset: 16 })
+        expect(layout.cx).toBe(200)
+        expect(layout.cy).toBe(200)
+        // (min(plotWidth, plotHeight) / 2) - hoverOffset = 200 - 16 = 184
+        expect(layout.outerRadius).toBe(184)
+        expect(layout.innerRadius).toBe(0)
+    })
+
+    it('honours innerRadius as a fraction of the outer radius', () => {
+        const layout = computePieLayout(DIMENSIONS, { innerRadius: 0.5, hoverOffset: 0 })
+        expect(layout.outerRadius).toBe(200)
+        expect(layout.innerRadius).toBe(100)
+    })
+
+    it('clamps innerRadius into [0, 1]', () => {
+        const big = computePieLayout(DIMENSIONS, { innerRadius: 5, hoverOffset: 0 })
+        expect(big.innerRadius).toBe(big.outerRadius)
+        const negative = computePieLayout(DIMENSIONS, { innerRadius: -1, hoverOffset: 0 })
+        expect(negative.innerRadius).toBe(0)
+    })
+
+    it('returns a zero radius rather than going negative when the plot is tiny', () => {
+        const tiny: ChartDimensions = { ...DIMENSIONS, plotWidth: 10, plotHeight: 10 }
+        const layout = computePieLayout(tiny, { hoverOffset: 16 })
+        expect(layout.outerRadius).toBe(0)
+    })
+})
+
+describe('computeSliceAngles', () => {
+    it('returns one entry per slice with cumulative angles', () => {
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        expect(angles).toHaveLength(3)
+        expect(angles[0].startAngle).toBeCloseTo(0)
+        expect(angles[0].endAngle).toBeCloseTo(Math.PI / 2) // 1/4 of full circle
+        expect(angles[1].endAngle).toBeCloseTo((3 / 4) * Math.PI * 2)
+        expect(angles[2].endAngle).toBeCloseTo(Math.PI * 2)
+    })
+
+    it('records the slice index so callers can map back to the original slice array', () => {
+        const angles = computeSliceAngles(SLICES, 4)
+        expect(angles.map((a) => a.sliceIndex)).toEqual([0, 1, 2])
+    })
+
+    it('exposes each slice as a fraction of the total', () => {
+        const angles = computeSliceAngles(SLICES, 4)
+        expect(angles[0].fraction).toBeCloseTo(0.25)
+        expect(angles[1].fraction).toBeCloseTo(0.5)
+        expect(angles[2].fraction).toBeCloseTo(0.25)
+    })
+
+    it('returns an empty array when total is zero or slices are empty', () => {
+        expect(computeSliceAngles(SLICES, 0)).toEqual([])
+        expect(computeSliceAngles([], 10)).toEqual([])
+    })
+
+    it('honours a custom start angle', () => {
+        const angles = computeSliceAngles(SLICES, 4, DEFAULT_START_ANGLE)
+        expect(angles[0].startAngle).toBeCloseTo(-Math.PI / 2)
+    })
+})
+
+describe('hitTestSlice', () => {
+    const layout = computePieLayout(DIMENSIONS, { hoverOffset: 0 })
+    const angles = computeSliceAngles(SLICES, 4, 0)
+
+    it('returns the slice index containing the cursor', () => {
+        // Cursor inside slice 0 (0 → π/2 radians; midpoint at π/4 ≈ +x,+y direction).
+        const x = layout.cx + Math.cos(Math.PI / 4) * 50
+        const y = layout.cy + Math.sin(Math.PI / 4) * 50
+        expect(hitTestSlice(x, y, layout, angles)).toBe(0)
+    })
+
+    it('returns -1 when the cursor is outside the outer radius', () => {
+        expect(hitTestSlice(layout.cx + 1000, layout.cy, layout, angles)).toBe(-1)
+    })
+
+    it('returns -1 when the cursor is inside the donut hole', () => {
+        const donutLayout = computePieLayout(DIMENSIONS, { innerRadius: 0.5, hoverOffset: 0 })
+        expect(hitTestSlice(donutLayout.cx, donutLayout.cy, donutLayout, angles)).toBe(-1)
+    })
+
+    it('returns -1 for an empty slice array', () => {
+        expect(hitTestSlice(layout.cx, layout.cy + 50, layout, [])).toBe(-1)
+    })
+
+    it('finds the correct slice for cursors at large angles (wrap around)', () => {
+        // Use a start angle of -π/2 (12 o'clock). Cursor at +x direction (3 o'clock)
+        // sits a quarter of the way round — inside slice 1.
+        const wrapAngles = computeSliceAngles(SLICES, 4, -Math.PI / 2)
+        const x = layout.cx + 50
+        const y = layout.cy
+        expect(hitTestSlice(x, y, layout, wrapAngles)).toBe(1)
+    })
+})
+
+describe('sliceLabelPosition', () => {
+    it('places the label along the bisector between inner and outer radii', () => {
+        const layout = computePieLayout(DIMENSIONS, { hoverOffset: 0 })
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        const pos = sliceLabelPosition(layout, angles[0])
+        // Midpoint angle of slice 0 (0 → π/2) is π/4. labelR = outerRadius / 2.
+        const expectedR = layout.outerRadius / 2
+        expect(pos.x).toBeCloseTo(layout.cx + Math.cos(Math.PI / 4) * expectedR)
+        expect(pos.y).toBeCloseTo(layout.cy + Math.sin(Math.PI / 4) * expectedR)
+    })
+})
+
+describe('sliceHoverOffset', () => {
+    it('returns (0, 0) when not hovered', () => {
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        expect(sliceHoverOffset(angles[0], false, 16)).toEqual({ dx: 0, dy: 0 })
+    })
+
+    it('returns (0, 0) when hover offset is disabled', () => {
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        expect(sliceHoverOffset(angles[0], true, 0)).toEqual({ dx: 0, dy: 0 })
+    })
+
+    it('offsets along the slice bisector when hovered', () => {
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        const { dx, dy } = sliceHoverOffset(angles[0], true, 10)
+        // Midpoint angle π/4 — offset is (cos π/4, sin π/4) * 10
+        expect(dx).toBeCloseTo(Math.cos(Math.PI / 4) * 10)
+        expect(dy).toBeCloseTo(Math.sin(Math.PI / 4) * 10)
+    })
+})

--- a/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.ts
+++ b/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.ts
@@ -75,12 +75,7 @@ export function computeSliceAngles(
 
 /** Returns the index of the slice under the cursor, or -1.
  *  Cursor position is in canvas pixels (relative to the wrapper). */
-export function hitTestSlice(
-    cursorX: number,
-    cursorY: number,
-    layout: PieLayout,
-    sliceAngles: SliceAngle[]
-): number {
+export function hitTestSlice(cursorX: number, cursorY: number, layout: PieLayout, sliceAngles: SliceAngle[]): number {
     if (sliceAngles.length === 0 || layout.outerRadius <= 0) {
         return -1
     }
@@ -121,19 +116,15 @@ function isAngleInRange(angle: number, start: number, end: number): boolean {
 }
 
 /** Returns the (x, y) position where a slice's label should be drawn —
- *  on the bisector of the slice at the midpoint between inner and outer radii. */
-export function sliceLabelPosition(
-    layout: PieLayout,
-    angle: SliceAngle,
-    hoverOffset: number = 0
-): { x: number; y: number; midAngle: number } {
+ *  on the bisector of the slice at the midpoint between inner and outer radii.
+ *  Callers that need to nudge the label for a hovered slice add the offset from
+ *  `sliceHoverOffset` to the returned `{x, y}` instead of passing it here. */
+export function sliceLabelPosition(layout: PieLayout, angle: SliceAngle): { x: number; y: number; midAngle: number } {
     const midAngle = (angle.startAngle + angle.endAngle) / 2
-    const innerR = layout.innerRadius
-    const outerR = layout.outerRadius
-    const labelR = (innerR + outerR) / 2
+    const labelR = (layout.innerRadius + layout.outerRadius) / 2
     return {
-        x: layout.cx + Math.cos(midAngle) * (labelR + hoverOffset),
-        y: layout.cy + Math.sin(midAngle) * (labelR + hoverOffset),
+        x: layout.cx + Math.cos(midAngle) * labelR,
+        y: layout.cy + Math.sin(midAngle) * labelR,
         midAngle,
     }
 }

--- a/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.ts
+++ b/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.ts
@@ -1,0 +1,153 @@
+import type { ChartDimensions } from '../../../core/types'
+
+/** Start at 12 o'clock and sweep clockwise — matches the SQL pie convention. */
+export const DEFAULT_START_ANGLE = -Math.PI / 2
+
+export interface ResolvedPieSlice {
+    key: string
+    label: string
+    value: number
+    color: string
+}
+
+export interface PieLayout {
+    /** Centre of the pie in canvas pixels. */
+    cx: number
+    /** Centre of the pie in canvas pixels. */
+    cy: number
+    /** Outer radius in pixels. */
+    outerRadius: number
+    /** Inner (donut hole) radius in pixels. 0 for a full pie. */
+    innerRadius: number
+}
+
+export interface SliceAngle {
+    /** Index into the *filtered* (positive-value) slice array. */
+    sliceIndex: number
+    /** Start angle in radians. */
+    startAngle: number
+    /** End angle in radians. */
+    endAngle: number
+    /** Fraction of the total (0–1). */
+    fraction: number
+}
+
+interface PieLayoutOptions {
+    /** Donut hole, 0–1 fraction of outer radius. Defaults to 0. */
+    innerRadius?: number
+    /** Extra space reserved for hover-offset / value labels. Defaults to 16. */
+    hoverOffset?: number
+}
+
+/** Compute the pie centre and radius from the available chart dimensions.
+ *  Reserves `hoverOffset` pixels of breathing room so a popped-out slice
+ *  doesn't get clipped by the canvas edge. */
+export function computePieLayout(dimensions: ChartDimensions, options: PieLayoutOptions = {}): PieLayout {
+    const { innerRadius = 0, hoverOffset = 16 } = options
+    const cx = dimensions.plotLeft + dimensions.plotWidth / 2
+    const cy = dimensions.plotTop + dimensions.plotHeight / 2
+    const available = Math.min(dimensions.plotWidth, dimensions.plotHeight) / 2
+    const outerRadius = Math.max(0, available - Math.max(0, hoverOffset))
+    const clampedInner = Math.max(0, Math.min(1, innerRadius))
+    return { cx, cy, outerRadius, innerRadius: outerRadius * clampedInner }
+}
+
+/** Compute the angular span of each slice. Filters happen at the caller —
+ *  this function trusts the slices it receives. */
+export function computeSliceAngles(
+    slices: ResolvedPieSlice[],
+    total: number,
+    startAngle: number = DEFAULT_START_ANGLE
+): SliceAngle[] {
+    if (total <= 0 || slices.length === 0) {
+        return []
+    }
+    const out: SliceAngle[] = []
+    let cursor = startAngle
+    for (let i = 0; i < slices.length; i++) {
+        const fraction = slices[i].value / total
+        const sweep = fraction * Math.PI * 2
+        out.push({ sliceIndex: i, startAngle: cursor, endAngle: cursor + sweep, fraction })
+        cursor += sweep
+    }
+    return out
+}
+
+/** Returns the index of the slice under the cursor, or -1.
+ *  Cursor position is in canvas pixels (relative to the wrapper). */
+export function hitTestSlice(
+    cursorX: number,
+    cursorY: number,
+    layout: PieLayout,
+    sliceAngles: SliceAngle[]
+): number {
+    if (sliceAngles.length === 0 || layout.outerRadius <= 0) {
+        return -1
+    }
+    const dx = cursorX - layout.cx
+    const dy = cursorY - layout.cy
+    const distance = Math.hypot(dx, dy)
+    if (distance > layout.outerRadius || distance < layout.innerRadius) {
+        return -1
+    }
+    // atan2 returns (-π, π]; normalise into [0, 2π) for comparisons.
+    const rawAngle = Math.atan2(dy, dx)
+    for (const slice of sliceAngles) {
+        if (isAngleInRange(rawAngle, slice.startAngle, slice.endAngle)) {
+            return slice.sliceIndex
+        }
+    }
+    return -1
+}
+
+/** Inclusive on `start`, exclusive on `end`. Handles arbitrary positive/negative
+ *  start/end angles by normalising into [0, 2π). */
+function isAngleInRange(angle: number, start: number, end: number): boolean {
+    const twoPi = Math.PI * 2
+    const a = ((angle % twoPi) + twoPi) % twoPi
+    const s = ((start % twoPi) + twoPi) % twoPi
+    let sweep = end - start
+    if (sweep <= 0) {
+        return false
+    }
+    if (sweep >= twoPi) {
+        return true
+    }
+    let delta = a - s
+    if (delta < 0) {
+        delta += twoPi
+    }
+    return delta < sweep
+}
+
+/** Returns the (x, y) position where a slice's label should be drawn —
+ *  on the bisector of the slice at the midpoint between inner and outer radii. */
+export function sliceLabelPosition(
+    layout: PieLayout,
+    angle: SliceAngle,
+    hoverOffset: number = 0
+): { x: number; y: number; midAngle: number } {
+    const midAngle = (angle.startAngle + angle.endAngle) / 2
+    const innerR = layout.innerRadius
+    const outerR = layout.outerRadius
+    const labelR = (innerR + outerR) / 2
+    return {
+        x: layout.cx + Math.cos(midAngle) * (labelR + hoverOffset),
+        y: layout.cy + Math.sin(midAngle) * (labelR + hoverOffset),
+        midAngle,
+    }
+}
+
+/** Returns the offset vector (dx, dy) for a hovered slice — used to "pop out"
+ *  the slice along its bisector. Returns (0, 0) for non-hovered slices. */
+export function sliceHoverOffset(
+    angle: SliceAngle,
+    isHovered: boolean,
+    hoverOffsetPx: number
+): { dx: number; dy: number } {
+    if (!isHovered || hoverOffsetPx <= 0) {
+        return { dx: 0, dy: 0 }
+    }
+    const mid = (angle.startAngle + angle.endAngle) / 2
+    return { dx: Math.cos(mid) * hoverOffsetPx, dy: Math.sin(mid) * hoverOffsetPx }
+}

--- a/frontend/src/lib/hog-charts/core/hooks/useChartCanvas.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartCanvas.ts
@@ -10,7 +10,7 @@ interface UseChartCanvasOptions {
 interface CanvasState {
     dimensions: ChartDimensions
     ctx: CanvasRenderingContext2D
-    overlayCtx: CanvasRenderingContext2D
+    overlayCtx: CanvasRenderingContext2D | null
 }
 
 interface UseChartCanvasResult {
@@ -63,8 +63,7 @@ export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasRe
 
         const updateSize = (): void => {
             const canvas = canvasRef.current
-            const overlayCanvas = overlayCanvasRef.current
-            if (!canvas || !overlayCanvas) {
+            if (!canvas) {
                 return
             }
 
@@ -73,13 +72,16 @@ export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasRe
             const dpr = window.devicePixelRatio || 1
 
             sizeCanvas(canvas, rect, dpr)
-            sizeCanvas(overlayCanvas, rect, dpr)
+            const overlayCanvas = overlayCanvasRef.current
+            if (overlayCanvas) {
+                sizeCanvas(overlayCanvas, rect, dpr)
+            }
 
             const context = canvas.getContext('2d')
-            const overlayContext = overlayCanvas.getContext('2d')
-            if (!context || !overlayContext) {
+            if (!context) {
                 return
             }
+            const overlayContext = overlayCanvas ? overlayCanvas.getContext('2d') : null
 
             setCanvasState({
                 ctx: context,

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -4,14 +4,9 @@ export type { BarChartProps } from './charts/BarChart/BarChart'
 export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
 export { PieChart } from './charts/PieChart/PieChart'
-export type {
-    PieChartConfig,
-    PieChartProps,
-    PieSlice,
-    PieSliceClickData,
-    PieTooltipContext,
-} from './charts/PieChart/PieChart'
+export type { PieChartConfig, PieChartProps, PieSlice, PieSliceClickData } from './charts/PieChart/PieChart'
 export { PieTooltip } from './charts/PieChart/PieTooltip'
+export type { PieTooltipProps } from './charts/PieChart/PieTooltip'
 export { TimeSeriesLineChart } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
 export type {
     ConfidenceIntervalConfig,

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -3,6 +3,15 @@ export { BarChart } from './charts/BarChart/BarChart'
 export type { BarChartProps } from './charts/BarChart/BarChart'
 export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
+export { PieChart } from './charts/PieChart/PieChart'
+export type {
+    PieChartConfig,
+    PieChartProps,
+    PieSlice,
+    PieSliceClickData,
+    PieTooltipContext,
+} from './charts/PieChart/PieChart'
+export { PieTooltip } from './charts/PieChart/PieTooltip'
 export { TimeSeriesLineChart } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
 export type {
     ConfidenceIntervalConfig,

--- a/frontend/src/lib/hog-charts/testing/render.ts
+++ b/frontend/src/lib/hog-charts/testing/render.ts
@@ -1,11 +1,17 @@
 import { cleanup, render, type RenderResult } from '@testing-library/react'
 import React, { type ReactElement, type ReactNode } from 'react'
 
+import { PieTooltip } from '../charts/PieChart/PieTooltip'
+import type { PieTooltipContext } from '../charts/PieChart/PieChart'
 import type { TooltipContext } from '../core/types'
 import { DefaultTooltip } from '../overlays/DefaultTooltip'
 import { getHogChart, type HogChart } from './accessor'
 import { ensureJsdom } from './jsdom'
 import { HOG_CHARTS_TOOLTIP_SELECTOR } from './tooltip'
+
+function isPieTooltipContext(ctx: unknown): ctx is PieTooltipContext {
+    return typeof ctx === 'object' && ctx !== null && 'slice' in ctx && 'percent' in ctx
+}
 
 /** Render a hog-charts component and return Testing Library's `RenderResult` with a `chart`
  *  accessor attached. Throws if the rendered tree doesn't contain a hog-charts canvas.
@@ -23,11 +29,16 @@ export function renderHogChart<Meta = unknown>(ui: ReactElement): RenderResult &
     // we still call it for the rendered DOM; otherwise we fall through to DefaultTooltip,
     // matching the chart's natural default.
     let lastTooltipContext: TooltipContext<Meta> | null = null
-    const props = ui.props as { tooltip?: (ctx: TooltipContext<Meta>) => ReactNode; labels?: string[] }
+    const props = ui.props as { tooltip?: (ctx: unknown) => ReactNode; labels?: string[] }
     const userTooltip = props.tooltip
-    const captureTooltip = (ctx: TooltipContext<Meta>): ReactNode => {
-        lastTooltipContext = ctx
-        return userTooltip ? userTooltip(ctx) : DefaultTooltip(ctx as TooltipContext)
+    const captureTooltip = (ctx: unknown): ReactNode => {
+        if (!isPieTooltipContext(ctx)) {
+            lastTooltipContext = ctx as TooltipContext<Meta>
+        }
+        if (userTooltip) {
+            return userTooltip(ctx)
+        }
+        return isPieTooltipContext(ctx) ? PieTooltip({ ctx }) : DefaultTooltip(ctx as TooltipContext)
     }
     const wrapped = React.cloneElement(ui, { tooltip: captureTooltip })
     const result = render(wrapped)

--- a/frontend/src/lib/hog-charts/testing/render.tsx
+++ b/frontend/src/lib/hog-charts/testing/render.tsx
@@ -1,16 +1,28 @@
 import { cleanup, render, type RenderResult } from '@testing-library/react'
 import React, { type ReactElement, type ReactNode } from 'react'
 
-import { PieTooltip } from '../charts/PieChart/PieTooltip'
-import type { PieTooltipContext } from '../charts/PieChart/PieChart'
-import type { TooltipContext } from '../core/types'
+import { ChartLayoutContext, type ChartLayoutContextValue } from '../core/chart-context'
+import type { ChartTheme, TooltipContext } from '../core/types'
 import { DefaultTooltip } from '../overlays/DefaultTooltip'
 import { getHogChart, type HogChart } from './accessor'
 import { ensureJsdom } from './jsdom'
 import { HOG_CHARTS_TOOLTIP_SELECTOR } from './tooltip'
 
-function isPieTooltipContext(ctx: unknown): ctx is PieTooltipContext {
-    return typeof ctx === 'object' && ctx !== null && 'slice' in ctx && 'percent' in ctx
+// Charts that wrap themselves in `ChartLayoutContext.Provider` (BarChart, LineChart, TimeSeries*)
+// override this in their render tree, so this fallback only kicks in for charts that don't
+// emit a layout context — like PieChart — so the substituted `DefaultTooltip` can still call
+// `useChartLayout()` for theme. The non-`theme` fields are stubs no overlay reads on the pie path.
+function buildFallbackLayoutContext(theme: ChartTheme): ChartLayoutContextValue {
+    return {
+        dimensions: { width: 0, height: 0, plotLeft: 0, plotTop: 0, plotWidth: 0, plotHeight: 0 },
+        labels: [],
+        series: [],
+        scales: { x: () => 0, y: () => 0, yTicks: () => [] },
+        theme,
+        resolvePositionValue: (s, i) => s.data[i] ?? 0,
+        canvasBounds: () => null,
+        axis: { orientation: 'vertical', xTickFormatter: undefined, isPercent: false },
+    }
 }
 
 /** Render a hog-charts component and return Testing Library's `RenderResult` with a `chart`
@@ -29,18 +41,21 @@ export function renderHogChart<Meta = unknown>(ui: ReactElement): RenderResult &
     // we still call it for the rendered DOM; otherwise we fall through to DefaultTooltip,
     // matching the chart's natural default.
     let lastTooltipContext: TooltipContext<Meta> | null = null
-    const props = ui.props as { tooltip?: (ctx: unknown) => ReactNode; labels?: string[] }
-    const userTooltip = props.tooltip
-    const captureTooltip = (ctx: unknown): ReactNode => {
-        if (!isPieTooltipContext(ctx)) {
-            lastTooltipContext = ctx as TooltipContext<Meta>
-        }
-        if (userTooltip) {
-            return userTooltip(ctx)
-        }
-        return isPieTooltipContext(ctx) ? PieTooltip({ ctx }) : DefaultTooltip(ctx as TooltipContext)
+    const props = ui.props as {
+        tooltip?: (ctx: TooltipContext<Meta>) => ReactNode
+        labels?: string[]
+        theme: ChartTheme
     }
-    const wrapped = React.cloneElement(ui, { tooltip: captureTooltip })
+    const userTooltip = props.tooltip
+    const captureTooltip = (ctx: TooltipContext<Meta>): ReactNode => {
+        lastTooltipContext = ctx
+        return userTooltip ? userTooltip(ctx) : DefaultTooltip(ctx as TooltipContext)
+    }
+    const wrapped = (
+        <ChartLayoutContext.Provider value={buildFallbackLayoutContext(props.theme)}>
+            {React.cloneElement(ui, { tooltip: captureTooltip })}
+        </ChartLayoutContext.Provider>
+    )
     const result = render(wrapped)
     return {
         ...result,


### PR DESCRIPTION
## Problem

The hog-charts internal charting library is missing a pie chart. Other surfaces (SQL insights) already use a pie chart implementation; we want a hog-charts-native version so consumers can adopt the same primitives, theming, tooltip system, and testing helpers as the bar/line charts.

## Changes

- New `PieChart` component under `frontend/src/lib/hog-charts/charts/PieChart/`:
  - Slice geometry + hit testing (`utils/pie-layout.ts`) — angles, radii, hover pop-out, padding gaps, label positions.
  - Canvas drawing primitives (`utils/pie-canvas.ts`) — slice paths, on-slice value or label rendering, hover-highlight color.
  - Default `PieTooltip` with value + percentage.
  - Public types: `PieChartProps`, `PieChartConfig`, `PieSlice`, `PieSliceClickData`, `PieTooltipContext`.
  - Supports donut mode (`innerRadius`), slice padding, custom value formatter, pinnable tooltip, click callback, and an `emptyState` slot when no slice has a positive value.
- `useChartCanvas` overlay canvas is now optional — PieChart redraws everything per hover so it doesn't need a second layer. Existing bar/line charts that mount both canvases are unaffected.
- `renderHogChart` now dispatches to `PieTooltip` when the captured context has a `slice` field, instead of always forcing `DefaultTooltip` (which expects a series-shaped context and was crashing the error boundary).
- Storybook stories under `Components/HogCharts/PieChart`: Default, Donut, ManySlices, WithSliceLabels, WithSlicePadding, HiddenValueLabels, CustomValueFormatter, SingleSlice, EmptyState, SkewedDistribution.

## How did you test this code?

I'm an agent; only automated checks were run.

- `pnpm jest src/lib/hog-charts/` → 918/918 passing (32 new PieChart tests covering layout math, slice filtering, empty-state rendering, hover/tooltip, slice clicks, pinning, custom formatter, slice-provided colors).
- `pnpm exec tsc --noEmit` → no errors in `src/lib/hog-charts/**`. (Pre-existing errors in unrelated `products/workflows` files are not from this PR.)

Storybook visual snapshot PNGs are not committed here — same pattern as the existing BarChart/LineChart/TimeSeriesLineChart stories, where PNGs are produced by the `pnpm --filter=@posthog/storybook test:visual:update` Docker flow rather than committed alongside the story. The new stories follow the existing `*.stories.tsx` discovery pattern, so the next visual-update run will pick them up.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update — internal library, no public surface.

## 🤖 Agent context

Agent-authored. Tooling: Claude Code via the PostHog Code harness.

Approach notes:

- Modeled API and behavior on the SQL-insights pie chart, then reshaped to fit hog-charts conventions (canvas-driven rendering via `useChartCanvas`, `ChartTheme` palette, `TooltipConfig` shape, `ChartErrorBoundary`, `data-attr` data-test hook, jsdom + sync-RAF testing harness, FloatingPortal-based tooltip with pin/escape/outside-click dismissal).
- Considered adding a hidden overlay canvas to PieChart purely to satisfy `useChartCanvas`. Rejected because the hook's invariant — "I have one canvas and it determines my dimensions" — already holds for a single-layer chart; relaxing the overlay to optional is a smaller, more honest change and only affects callers that didn't have an overlay canvas anyway.
- Considered detecting the chart type in `renderHogChart` via component identity. Rejected in favor of context-shape detection (`'slice' in ctx`) — the testing helper stays decoupled from the concrete chart components except for one tooltip import.