### PR TITLE
chore(mcp): reuse master schema cache to skip full migrations

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -266,7 +266,10 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  fetch-depth: 1
+                  # Deep clone so we can compute the merge-base with the PR base ref
+                  # for the schema cache key (matches ci-backend.yml's turbo-discover).
+                  fetch-depth: 1000
+                  filter: blob:none
 
             - name: Clean up data directories with container permissions
               run: |
@@ -402,6 +405,44 @@ jobs:
                   COMPOSE_PROFILES: temporal
               run: bin/ci-wait-for-docker wait temporal
 
+            - name: Compute schema cache key from merge-base
+              id: schema-key
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: |
+                  git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF" || true
+                  # HEAD is the synthetic merge commit on PR; HEAD^2 is the PR branch tip.
+                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                  if [ -n "$MERGE_BASE" ]; then
+                      echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
+                  else
+                      echo "key=" >> $GITHUB_OUTPUT
+                      echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
+                  fi
+
+            - name: Restore schema cache from master
+              if: ${{ github.event_name == 'pull_request' && steps.schema-key.outputs.key != '' }}
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: schema.sql.gz
+                  key: ${{ steps.schema-key.outputs.key }}
+
+            - name: Prime posthog DB from cached schema
+              # No-op on cache miss; the migrations step below falls back to a full migrate.
+              # Mirrors the pytest --reuse-db pattern in ci-backend.yml.
+              if: ${{ github.event_name == 'pull_request' }}
+              env:
+                  TARGET_DB: posthog
+              run: |
+                  if [ ! -f schema.sql.gz ]; then
+                      echo "::notice::Schema cache miss — full Django migrations will run"
+                      exit 0
+                  fi
+                  mkdir -p .postgres-backups
+                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
+                  ./bin/hogli db:restore-test-db
+
             - name: Run migrations
               run: |
                   # Create persons database and run sqlx migrations first
@@ -409,7 +450,9 @@ jobs:
                     sqlx database create
                   DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons" \
                     sqlx migrate run --source rust/persons_migrations/
-                  # Then run Django migrations
+                  # Then run Django migrations. When the schema cache primed the DB above,
+                  # this only applies migrations added by the PR (the django_migrations
+                  # table from the dump tells Django which ones are already applied).
                   python manage.py migrate --noinput
                   python manage.py migrate_clickhouse
 

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -405,14 +405,21 @@ jobs:
                   COMPOSE_PROFILES: temporal
               run: bin/ci-wait-for-docker wait temporal
 
+            - name: Fetch current PR base for merge-base
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
             - name: Compute schema cache key from merge-base
               id: schema-key
               if: github.event_name == 'pull_request'
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
               run: |
-                  git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF" || true
-                  # HEAD is the synthetic merge commit on PR; HEAD^2 is the PR branch tip.
+                  # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                  # The fetch-depth:1000 checkout + base-ref fetch above ensure the
+                  # full ancestry needed to find the divergence point is available.
                   MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
                   if [ -n "$MERGE_BASE" ]; then
                       echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
@@ -428,15 +435,16 @@ jobs:
                   path: schema.sql.gz
                   key: ${{ steps.schema-key.outputs.key }}
 
-            - name: Prime posthog DB from cached schema
-              # No-op on cache miss; the migrations step below falls back to a full migrate.
-              # Mirrors the pytest --reuse-db pattern in ci-backend.yml.
+            - name: Prime posthog from cached schema
+              # No-op on cache miss; manage.py migrate below falls back to a full migrate.
+              # MCP integration tests hit the live posthog DB, not test_posthog — that's
+              # the only deviation from ci-backend.yml's equivalent step.
               if: ${{ github.event_name == 'pull_request' }}
               env:
                   TARGET_DB: posthog
               run: |
                   if [ ! -f schema.sql.gz ]; then
-                      echo "::notice::Schema cache miss — full Django migrations will run"
+                      echo "::notice::Schema cache miss — manage.py migrate will run from scratch"
                       exit 0
                   fi
                   mkdir -p .postgres-backups


### PR DESCRIPTION
## Problem

MCP integration tests were running `python manage.py migrate` from scratch on every PR run, which dominated the setup time of the `Integration Tests` job. Backend pytest jobs in `ci-backend.yml` already solved this — they restore a pre-built `schema.sql.gz` produced by the master-only `check-migrations` job and pass `--reuse-db` to pytest so Django only applies the delta added by the PR. The MCP workflow wasn't plugged into that cache, so it paid the full migration cost.

## Changes

Mirror the backend cache flow in the MCP `integration-tests` job:

| Step | Backend (`ci-backend.yml`) | MCP (this PR) |
|---|---|---|
| Compute key | `turbo-discover` outputs `posthog-schema-master-<merge-base-sha>` | Inline step in `integration-tests` |
| Restore cache | `actions/cache/restore` on `schema.sql.gz` | Same |
| Prime DB | `./bin/hogli db:restore-test-db` (default `TARGET_DB=test_posthog`) | Same, with `TARGET_DB=posthog` |
| Apply delta | pytest `--reuse-db` | `manage.py migrate --noinput` (idempotent — only applies migrations new to the PR) |

The producer (`check-migrations` job on master push in `ci-backend.yml`) already writes the cache; no master-side changes are needed.

Other notes:
- The checkout for `integration-tests` is bumped from `fetch-depth: 1` to `fetch-depth: 1000` with `filter: blob:none` so `git merge-base HEAD^2 origin/<base>` resolves.
- Steps are gated on `github.event_name == 'pull_request'`. Master push still runs migrations end-to-end (validates the full chain and seeds the next cache entry).
- Persons DB (`sqlx migrate`) and `migrate_clickhouse` are unaffected — only the Postgres `posthog` DB is covered by the cache, same scope as backend tests.
- Cache miss is a no-op: the prime step exits 0 if `schema.sql.gz` wasn't restored, and `manage.py migrate` does a full migrate as today.

## How did you test this code?

I'm an agent. I have not run this in CI. Reviewed the diff against the equivalent backend job (`ci-backend.yml` lines 442-459, 988-1017, 261-299) and against `hogli`'s `db:restore-test-db` implementation in `tools/hogli-commands/hogli_commands/db_schema.py` (`TARGET_DB` env var is honored at line 563). The real validation will be the first PR run on CI — expect "Schema cache miss — full Django migrations will run" until a master push lands and seeds the cache for the merge-base SHA.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Tools: Claude Code (Opus 4.7) via PostHog Code session.
- Decision: kept the merge-base key computation inline in `integration-tests` rather than threading it as an output from the `changes` job. Backend uses a dedicated `turbo-discover` job because that job already needs the deep clone for Turbo affectedness; MCP's `changes` job uses a shallow clone for path-filter only, so adding a second consumer of that depth wasn't worth the plumbing.
- Decision: `TARGET_DB=posthog` rather than `test_posthog` because MCP integration tests connect to the live `posthog` DB (the same one docker compose creates). The hogli helper exposes this via env var, so no code change in hogli was needed.
- Left `manage.py migrate` as the unconditional follow-up rather than gating it on cache hit/miss, since it's idempotent — on cache hit it's a near-no-op (reads `django_migrations`, finds nothing pending or only PR migrations); on miss it's the existing full migrate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*