### PR TITLE
feat(hog-charts): add pie geometry and canvas primitives

### DIFF
--- a/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-canvas.ts
+++ b/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-canvas.ts
@@ -1,0 +1,150 @@
+// Stateless canvas drawing primitives for PieChart.
+//
+// Pie charts work in polar coordinates and don't share the axis-based DrawContext
+// used by line/bar/area renderers in core/canvas-renderer.ts. Keeping these
+// primitives next to the chart type avoids polluting the shared module with
+// shapes that no other chart can reuse.
+
+import * as d3 from 'd3'
+
+import type { PieLayout, ResolvedPieSlice, SliceAngle } from './pie-layout'
+import { sliceHoverOffset, sliceLabelPosition } from './pie-layout'
+
+interface DrawPieSlicesOptions {
+    /** Index of the hovered slice, or -1. */
+    hoverIndex: number
+    /** Pixels to pop a hovered slice out along its bisector. 0 disables the effect. */
+    hoverOffset: number
+    /** Radians of gap between adjacent slices. */
+    slicePadding: number
+}
+
+export function drawPieSlices(
+    ctx: CanvasRenderingContext2D,
+    layout: PieLayout,
+    slices: ResolvedPieSlice[],
+    angles: SliceAngle[],
+    options: DrawPieSlicesOptions
+): void {
+    const { hoverIndex, hoverOffset, slicePadding } = options
+    if (layout.outerRadius <= 0) {
+        return
+    }
+
+    for (const angle of angles) {
+        const slice = slices[angle.sliceIndex]
+        const isHovered = angle.sliceIndex === hoverIndex
+        const { dx, dy } = sliceHoverOffset(angle, isHovered, hoverOffset)
+
+        // Symmetric padding eats from both sides of the slice; skip when the slice
+        // is too narrow to survive the trim — drawing a negative arc paints a full circle.
+        const padHalf = slicePadding / 2
+        const start = angle.startAngle + padHalf
+        const end = angle.endAngle - padHalf
+        if (end <= start) {
+            continue
+        }
+
+        const cx = layout.cx + dx
+        const cy = layout.cy + dy
+
+        ctx.beginPath()
+        if (layout.innerRadius > 0) {
+            ctx.arc(cx, cy, layout.outerRadius, start, end)
+            ctx.arc(cx, cy, layout.innerRadius, end, start, true)
+        } else {
+            ctx.moveTo(cx, cy)
+            ctx.arc(cx, cy, layout.outerRadius, start, end)
+        }
+        ctx.closePath()
+
+        ctx.fillStyle = slice.color
+        ctx.fill()
+    }
+}
+
+interface DrawSliceLabelsOptions {
+    /** Skip the label when the slice covers less than this fraction (0–1) of the pie. */
+    minFraction: number
+    /** Text mode: numeric value (formatted) or the slice label. */
+    mode: 'value' | 'label'
+    /** Formats numeric slice values. */
+    valueFormatter: (value: number) => string
+    /** Index of the hovered slice; that slice's label is drawn at the popped-out position. */
+    hoverIndex: number
+    /** Same hover-offset used by drawPieSlices, so labels track the popped-out slice. */
+    hoverOffset: number
+}
+
+export function drawSliceLabels(
+    ctx: CanvasRenderingContext2D,
+    layout: PieLayout,
+    slices: ResolvedPieSlice[],
+    angles: SliceAngle[],
+    options: DrawSliceLabelsOptions
+): void {
+    if (layout.outerRadius <= 0) {
+        return
+    }
+    const { minFraction, mode, valueFormatter, hoverIndex, hoverOffset } = options
+
+    ctx.save()
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.font = '500 12px var(--font-sans, system-ui, -apple-system, sans-serif)'
+
+    for (const angle of angles) {
+        if (angle.fraction < minFraction) {
+            continue
+        }
+        const slice = slices[angle.sliceIndex]
+        const text = mode === 'label' ? slice.label : valueFormatter(slice.value)
+        if (!text) {
+            continue
+        }
+
+        const isHovered = angle.sliceIndex === hoverIndex
+        const { dx, dy } = sliceHoverOffset(angle, isHovered, hoverOffset)
+        const pos = sliceLabelPosition(layout, angle)
+        const x = pos.x + dx
+        const y = pos.y + dy
+
+        // Pill: filled with the slice color, white text, white border, rounded corners.
+        const metrics = ctx.measureText(text)
+        const paddingX = 8
+        const paddingY = 4
+        const w = metrics.width + paddingX * 2
+        const h = 12 + paddingY * 2
+
+        ctx.fillStyle = slice.color
+        ctx.strokeStyle = '#ffffff'
+        ctx.lineWidth = 2
+        roundedRect(ctx, x - w / 2, y - h / 2, w, h, 25)
+        ctx.fill()
+        ctx.stroke()
+
+        ctx.fillStyle = '#ffffff'
+        ctx.fillText(text, x, y)
+    }
+    ctx.restore()
+}
+
+function roundedRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, radius: number): void {
+    const r = Math.min(radius, w / 2, h / 2)
+    ctx.beginPath()
+    ctx.moveTo(x + r, y)
+    ctx.lineTo(x + w - r, y)
+    ctx.quadraticCurveTo(x + w, y, x + w, y + r)
+    ctx.lineTo(x + w, y + h - r)
+    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h)
+    ctx.lineTo(x + r, y + h)
+    ctx.quadraticCurveTo(x, y + h, x, y + h - r)
+    ctx.lineTo(x, y + r)
+    ctx.quadraticCurveTo(x, y, x + r, y)
+    ctx.closePath()
+}
+
+/** Darken the slice color a touch — same idiom BarChart uses for its hover highlight. */
+export function highlightColorFor(color: string): string {
+    return d3.color(color)?.darker(0.4).toString() ?? color
+}

--- a/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.test.ts
+++ b/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.test.ts
@@ -1,0 +1,154 @@
+import type { ChartDimensions } from '../../../core/types'
+import {
+    computePieLayout,
+    computeSliceAngles,
+    DEFAULT_START_ANGLE,
+    hitTestSlice,
+    type ResolvedPieSlice,
+    sliceHoverOffset,
+    sliceLabelPosition,
+} from './pie-layout'
+
+const DIMENSIONS: ChartDimensions = {
+    width: 400,
+    height: 400,
+    plotLeft: 0,
+    plotTop: 0,
+    plotWidth: 400,
+    plotHeight: 400,
+}
+
+const SLICES: ResolvedPieSlice[] = [
+    { key: 'a', label: 'A', value: 1, color: '#111' },
+    { key: 'b', label: 'B', value: 2, color: '#222' },
+    { key: 'c', label: 'C', value: 1, color: '#333' },
+]
+
+describe('computePieLayout', () => {
+    it('centres the pie within the plot area and reserves room for hover offset', () => {
+        const layout = computePieLayout(DIMENSIONS, { hoverOffset: 16 })
+        expect(layout.cx).toBe(200)
+        expect(layout.cy).toBe(200)
+        // (min(plotWidth, plotHeight) / 2) - hoverOffset = 200 - 16 = 184
+        expect(layout.outerRadius).toBe(184)
+        expect(layout.innerRadius).toBe(0)
+    })
+
+    it('honours innerRadius as a fraction of the outer radius', () => {
+        const layout = computePieLayout(DIMENSIONS, { innerRadius: 0.5, hoverOffset: 0 })
+        expect(layout.outerRadius).toBe(200)
+        expect(layout.innerRadius).toBe(100)
+    })
+
+    it('clamps innerRadius into [0, 1]', () => {
+        const big = computePieLayout(DIMENSIONS, { innerRadius: 5, hoverOffset: 0 })
+        expect(big.innerRadius).toBe(big.outerRadius)
+        const negative = computePieLayout(DIMENSIONS, { innerRadius: -1, hoverOffset: 0 })
+        expect(negative.innerRadius).toBe(0)
+    })
+
+    it('returns a zero radius rather than going negative when the plot is tiny', () => {
+        const tiny: ChartDimensions = { ...DIMENSIONS, plotWidth: 10, plotHeight: 10 }
+        const layout = computePieLayout(tiny, { hoverOffset: 16 })
+        expect(layout.outerRadius).toBe(0)
+    })
+})
+
+describe('computeSliceAngles', () => {
+    it('returns one entry per slice with cumulative angles', () => {
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        expect(angles).toHaveLength(3)
+        expect(angles[0].startAngle).toBeCloseTo(0)
+        expect(angles[0].endAngle).toBeCloseTo(Math.PI / 2) // 1/4 of full circle
+        expect(angles[1].endAngle).toBeCloseTo((3 / 4) * Math.PI * 2)
+        expect(angles[2].endAngle).toBeCloseTo(Math.PI * 2)
+    })
+
+    it('records the slice index so callers can map back to the original slice array', () => {
+        const angles = computeSliceAngles(SLICES, 4)
+        expect(angles.map((a) => a.sliceIndex)).toEqual([0, 1, 2])
+    })
+
+    it('exposes each slice as a fraction of the total', () => {
+        const angles = computeSliceAngles(SLICES, 4)
+        expect(angles[0].fraction).toBeCloseTo(0.25)
+        expect(angles[1].fraction).toBeCloseTo(0.5)
+        expect(angles[2].fraction).toBeCloseTo(0.25)
+    })
+
+    it('returns an empty array when total is zero or slices are empty', () => {
+        expect(computeSliceAngles(SLICES, 0)).toEqual([])
+        expect(computeSliceAngles([], 10)).toEqual([])
+    })
+
+    it('honours a custom start angle', () => {
+        const angles = computeSliceAngles(SLICES, 4, DEFAULT_START_ANGLE)
+        expect(angles[0].startAngle).toBeCloseTo(-Math.PI / 2)
+    })
+})
+
+describe('hitTestSlice', () => {
+    const layout = computePieLayout(DIMENSIONS, { hoverOffset: 0 })
+    const angles = computeSliceAngles(SLICES, 4, 0)
+
+    it('returns the slice index containing the cursor', () => {
+        // Cursor inside slice 0 (0 → π/2 radians; midpoint at π/4 ≈ +x,+y direction).
+        const x = layout.cx + Math.cos(Math.PI / 4) * 50
+        const y = layout.cy + Math.sin(Math.PI / 4) * 50
+        expect(hitTestSlice(x, y, layout, angles)).toBe(0)
+    })
+
+    it('returns -1 when the cursor is outside the outer radius', () => {
+        expect(hitTestSlice(layout.cx + 1000, layout.cy, layout, angles)).toBe(-1)
+    })
+
+    it('returns -1 when the cursor is inside the donut hole', () => {
+        const donutLayout = computePieLayout(DIMENSIONS, { innerRadius: 0.5, hoverOffset: 0 })
+        expect(hitTestSlice(donutLayout.cx, donutLayout.cy, donutLayout, angles)).toBe(-1)
+    })
+
+    it('returns -1 for an empty slice array', () => {
+        expect(hitTestSlice(layout.cx, layout.cy + 50, layout, [])).toBe(-1)
+    })
+
+    it('finds the correct slice for cursors at large angles (wrap around)', () => {
+        // Use a start angle of -π/2 (12 o'clock). Cursor at +x direction (3 o'clock)
+        // sits a quarter of the way round — inside slice 1.
+        const wrapAngles = computeSliceAngles(SLICES, 4, -Math.PI / 2)
+        const x = layout.cx + 50
+        const y = layout.cy
+        expect(hitTestSlice(x, y, layout, wrapAngles)).toBe(1)
+    })
+})
+
+describe('sliceLabelPosition', () => {
+    it('places the label along the bisector between inner and outer radii', () => {
+        const layout = computePieLayout(DIMENSIONS, { hoverOffset: 0 })
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        const pos = sliceLabelPosition(layout, angles[0])
+        // Midpoint angle of slice 0 (0 → π/2) is π/4. labelR = outerRadius / 2.
+        const expectedR = layout.outerRadius / 2
+        expect(pos.x).toBeCloseTo(layout.cx + Math.cos(Math.PI / 4) * expectedR)
+        expect(pos.y).toBeCloseTo(layout.cy + Math.sin(Math.PI / 4) * expectedR)
+    })
+})
+
+describe('sliceHoverOffset', () => {
+    it('returns (0, 0) when not hovered', () => {
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        expect(sliceHoverOffset(angles[0], false, 16)).toEqual({ dx: 0, dy: 0 })
+    })
+
+    it('returns (0, 0) when hover offset is disabled', () => {
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        expect(sliceHoverOffset(angles[0], true, 0)).toEqual({ dx: 0, dy: 0 })
+    })
+
+    it('offsets along the slice bisector when hovered', () => {
+        const angles = computeSliceAngles(SLICES, 4, 0)
+        const { dx, dy } = sliceHoverOffset(angles[0], true, 10)
+        // Midpoint angle π/4 — offset is (cos π/4, sin π/4) * 10
+        expect(dx).toBeCloseTo(Math.cos(Math.PI / 4) * 10)
+        expect(dy).toBeCloseTo(Math.sin(Math.PI / 4) * 10)
+    })
+})

--- a/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.ts
+++ b/frontend/src/lib/hog-charts/charts/PieChart/utils/pie-layout.ts
@@ -1,0 +1,144 @@
+import type { ChartDimensions } from '../../../core/types'
+
+/** Start at 12 o'clock and sweep clockwise — matches the SQL pie convention. */
+export const DEFAULT_START_ANGLE = -Math.PI / 2
+
+export interface ResolvedPieSlice {
+    key: string
+    label: string
+    value: number
+    color: string
+}
+
+export interface PieLayout {
+    /** Centre of the pie in canvas pixels. */
+    cx: number
+    /** Centre of the pie in canvas pixels. */
+    cy: number
+    /** Outer radius in pixels. */
+    outerRadius: number
+    /** Inner (donut hole) radius in pixels. 0 for a full pie. */
+    innerRadius: number
+}
+
+export interface SliceAngle {
+    /** Index into the *filtered* (positive-value) slice array. */
+    sliceIndex: number
+    /** Start angle in radians. */
+    startAngle: number
+    /** End angle in radians. */
+    endAngle: number
+    /** Fraction of the total (0–1). */
+    fraction: number
+}
+
+interface PieLayoutOptions {
+    /** Donut hole, 0–1 fraction of outer radius. Defaults to 0. */
+    innerRadius?: number
+    /** Extra space reserved for hover-offset / value labels. Defaults to 16. */
+    hoverOffset?: number
+}
+
+/** Compute the pie centre and radius from the available chart dimensions.
+ *  Reserves `hoverOffset` pixels of breathing room so a popped-out slice
+ *  doesn't get clipped by the canvas edge. */
+export function computePieLayout(dimensions: ChartDimensions, options: PieLayoutOptions = {}): PieLayout {
+    const { innerRadius = 0, hoverOffset = 16 } = options
+    const cx = dimensions.plotLeft + dimensions.plotWidth / 2
+    const cy = dimensions.plotTop + dimensions.plotHeight / 2
+    const available = Math.min(dimensions.plotWidth, dimensions.plotHeight) / 2
+    const outerRadius = Math.max(0, available - Math.max(0, hoverOffset))
+    const clampedInner = Math.max(0, Math.min(1, innerRadius))
+    return { cx, cy, outerRadius, innerRadius: outerRadius * clampedInner }
+}
+
+/** Compute the angular span of each slice. Filters happen at the caller —
+ *  this function trusts the slices it receives. */
+export function computeSliceAngles(
+    slices: ResolvedPieSlice[],
+    total: number,
+    startAngle: number = DEFAULT_START_ANGLE
+): SliceAngle[] {
+    if (total <= 0 || slices.length === 0) {
+        return []
+    }
+    const out: SliceAngle[] = []
+    let cursor = startAngle
+    for (let i = 0; i < slices.length; i++) {
+        const fraction = slices[i].value / total
+        const sweep = fraction * Math.PI * 2
+        out.push({ sliceIndex: i, startAngle: cursor, endAngle: cursor + sweep, fraction })
+        cursor += sweep
+    }
+    return out
+}
+
+/** Returns the index of the slice under the cursor, or -1.
+ *  Cursor position is in canvas pixels (relative to the wrapper). */
+export function hitTestSlice(cursorX: number, cursorY: number, layout: PieLayout, sliceAngles: SliceAngle[]): number {
+    if (sliceAngles.length === 0 || layout.outerRadius <= 0) {
+        return -1
+    }
+    const dx = cursorX - layout.cx
+    const dy = cursorY - layout.cy
+    const distance = Math.hypot(dx, dy)
+    if (distance > layout.outerRadius || distance < layout.innerRadius) {
+        return -1
+    }
+    // atan2 returns (-π, π]; normalise into [0, 2π) for comparisons.
+    const rawAngle = Math.atan2(dy, dx)
+    for (const slice of sliceAngles) {
+        if (isAngleInRange(rawAngle, slice.startAngle, slice.endAngle)) {
+            return slice.sliceIndex
+        }
+    }
+    return -1
+}
+
+/** Inclusive on `start`, exclusive on `end`. Handles arbitrary positive/negative
+ *  start/end angles by normalising into [0, 2π). */
+function isAngleInRange(angle: number, start: number, end: number): boolean {
+    const twoPi = Math.PI * 2
+    const a = ((angle % twoPi) + twoPi) % twoPi
+    const s = ((start % twoPi) + twoPi) % twoPi
+    let sweep = end - start
+    if (sweep <= 0) {
+        return false
+    }
+    if (sweep >= twoPi) {
+        return true
+    }
+    let delta = a - s
+    if (delta < 0) {
+        delta += twoPi
+    }
+    return delta < sweep
+}
+
+/** Returns the (x, y) position where a slice's label should be drawn —
+ *  on the bisector of the slice at the midpoint between inner and outer radii.
+ *  Callers that need to nudge the label for a hovered slice add the offset from
+ *  `sliceHoverOffset` to the returned `{x, y}` instead of passing it here. */
+export function sliceLabelPosition(layout: PieLayout, angle: SliceAngle): { x: number; y: number; midAngle: number } {
+    const midAngle = (angle.startAngle + angle.endAngle) / 2
+    const labelR = (layout.innerRadius + layout.outerRadius) / 2
+    return {
+        x: layout.cx + Math.cos(midAngle) * labelR,
+        y: layout.cy + Math.sin(midAngle) * labelR,
+        midAngle,
+    }
+}
+
+/** Returns the offset vector (dx, dy) for a hovered slice — used to "pop out"
+ *  the slice along its bisector. Returns (0, 0) for non-hovered slices. */
+export function sliceHoverOffset(
+    angle: SliceAngle,
+    isHovered: boolean,
+    hoverOffsetPx: number
+): { dx: number; dy: number } {
+    if (!isHovered || hoverOffsetPx <= 0) {
+        return { dx: 0, dy: 0 }
+    }
+    const mid = (angle.startAngle + angle.endAngle) / 2
+    return { dx: Math.cos(mid) * hoverOffsetPx, dy: Math.sin(mid) * hoverOffsetPx }
+}


### PR DESCRIPTION
## Problem

The `PieChart` component (#59765) is being split into smaller reviewable units. This PR introduces the pure geometry + canvas drawing primitives that the upcoming component PRs will consume — no React, no integration into a chart yet.

## Changes

- `utils/pie-layout.ts`: slice angle computation, donut layout, hit-testing, label position, hover offset vector. Default start angle is `-π/2` (12 o'clock) to match the SQL pie convention.
- `utils/pie-layout.test.ts`: 18 unit tests covering layout, angle computation, hit-testing edge cases (donut hole, outside outer radius, start angle, slice boundaries), label positions, and hover offsets.
- `utils/pie-canvas.ts`: `drawPieSlices`, `drawSliceLabels`, `highlightColorFor` — canvas-side rendering primitives the upcoming component will call from its draw effect.

Stacked on #59768 for sequencing; this PR doesn't actually depend on those harness changes — once #59768 lands, this rebases cleanly onto master.

## How did you test this code?

I'm an agent; only automated checks were run.

- `pnpm jest src/lib/hog-charts/` → 904/904 passing (18 new tests in `pie-layout.test.ts`).
- `pnpm exec tsc --noEmit` → no errors in `frontend/src/lib/hog-charts/**`.
- `oxfmt --check` → clean.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update — internal library, no public surface (utilities not exported yet).

## 🤖 Agent context

Agent-authored split of the original PieChart PR (#59765). Tooling: Claude Code via PostHog Code harness.

Approach notes:
- Considered shipping `pie-layout` and `pie-canvas` separately. Rejected — `pie-canvas` calls `sliceHoverOffset` / `sliceLabelPosition` from `pie-layout`, and the layout tests already cover both files' helpers in concert. Keeping them as a single "pie primitives" unit is the cleanest reviewable shape.
- `drawSliceLabels` accepts `hoverIndex` / `hoverOffset` so the upcoming interactive PieChart can pop hovered slice labels along their bisector. The upcoming non-interactive PieChart pass `hoverIndex: -1, hoverOffset: 0` and gets unanimated labels.