### PR TITLE
feat(hog-charts): add PieChart interactivity

### DIFF
--- a/frontend/src/lib/hog-charts/charts/PieChart/PieChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieChart.test.tsx
@@ -1,6 +1,11 @@
-import type { ChartTheme } from '../../core/types'
-import { renderHogChart } from '../../testing'
+import { fireEvent, waitFor } from '@testing-library/react'
+
+import type { ChartTheme, TooltipContext } from '../../core/types'
+import { renderHogChart, waitForHogChartTooltip } from '../../testing'
+import { mockRect } from '../../testing/jsdom'
 import { PieChart, type PieSlice } from './PieChart'
+import { PieTooltip } from './PieTooltip'
+import { computePieLayout, computeSliceAngles, type ResolvedPieSlice } from './utils/pie-layout'
 
 const THEME: ChartTheme = {
     colors: ['#1f77b4', '#ff7f0e', '#2ca02c'],
@@ -12,6 +17,37 @@ const SLICES: PieSlice[] = [
     { key: 'b', label: 'B', value: 50 },
     { key: 'c', label: 'C', value: 20 },
 ]
+
+// PieChart uses uniform 12px margins on the wrapper rect.
+const PIE_MARGIN = 12
+
+// Position the cursor at the centre of a slice — relative to the chart's
+// real plot layout, since the chart will hit-test against the same geometry.
+function fireMouseOverSlice(wrapper: HTMLElement, sliceIndex: number, slices: PieSlice[] = SLICES): void {
+    const dims = {
+        width: mockRect.width,
+        height: mockRect.height,
+        plotLeft: PIE_MARGIN,
+        plotTop: PIE_MARGIN,
+        plotWidth: mockRect.width - PIE_MARGIN * 2,
+        plotHeight: mockRect.height - PIE_MARGIN * 2,
+    }
+    const layout = computePieLayout(dims)
+    const total = slices.reduce((s, x) => s + x.value, 0)
+    const resolved: ResolvedPieSlice[] = slices.map((s) => ({
+        key: s.key,
+        label: s.label,
+        value: s.value,
+        color: '#000',
+    }))
+    const angles = computeSliceAngles(resolved, total)
+    const target = angles[sliceIndex]
+    const mid = (target.startAngle + target.endAngle) / 2
+    const r = (layout.innerRadius + layout.outerRadius) / 2 || layout.outerRadius / 2
+    const x = layout.cx + Math.cos(mid) * r
+    const y = layout.cy + Math.sin(mid) * r
+    fireEvent.mouseMove(wrapper, { clientX: x, clientY: y })
+}
 
 describe('PieChart', () => {
     it('reports the visible slice count via aria-label', () => {
@@ -50,9 +86,114 @@ describe('PieChart', () => {
         expect(chart.element.getAttribute('data-attr')).toBe('pie-instance')
     })
 
+    it('opens PieTooltip with value and percentage on hover', async () => {
+        const { chart } = renderHogChart(
+            <PieChart slices={SLICES} theme={THEME} tooltip={(ctx) => <PieTooltip ctx={ctx} theme={THEME} />} />
+        )
+        fireMouseOverSlice(chart.element, 1)
+        const tooltip = await waitForHogChartTooltip()
+        expect(tooltip.textContent).toContain('B')
+        expect(tooltip.textContent).toContain('50')
+        expect(tooltip.textContent).toContain('50.0%')
+    })
+
+    it('invokes the tooltip render prop with a series-shaped TooltipContext', async () => {
+        const tooltipSpy = jest.fn((_ctx: TooltipContext) => <div>custom tooltip</div>)
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} tooltip={tooltipSpy} />)
+        fireMouseOverSlice(chart.element, 0)
+        await waitForHogChartTooltip()
+        expect(tooltipSpy).toHaveBeenCalled()
+        const ctx = tooltipSpy.mock.calls[0]![0]
+        expect(ctx.dataIndex).toBe(0)
+        expect(ctx.label).toBe('A')
+        expect(ctx.seriesData).toHaveLength(3)
+        expect(ctx.seriesData[0]!.series.key).toBe('a')
+        expect(ctx.seriesData[0]!.value).toBe(30)
+    })
+
+    it('invokes onSliceClick with the slice and percent', async () => {
+        const onSliceClick = jest.fn()
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} onSliceClick={onSliceClick} />)
+        fireMouseOverSlice(chart.element, 2)
+        await waitForHogChartTooltip()
+        fireEvent.click(chart.element)
+        expect(onSliceClick).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sliceIndex: 2,
+                value: 20,
+                total: 100,
+                slice: expect.objectContaining({ key: 'c' }),
+            })
+        )
+        expect(onSliceClick.mock.calls[0][0].percent).toBeCloseTo(20)
+    })
+
+    it('does not invoke onSliceClick when the click misses every slice', () => {
+        const onSliceClick = jest.fn()
+        const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} onSliceClick={onSliceClick} />)
+        // Click without first hovering — hoverIndex stays at -1.
+        fireEvent.click(chart.element)
+        expect(onSliceClick).not.toHaveBeenCalled()
+    })
+
+    it('pins the tooltip on click when tooltip.pinnable is set', async () => {
+        const { chart } = renderHogChart(
+            <PieChart slices={SLICES} theme={THEME} config={{ tooltip: { pinnable: true } }} />
+        )
+        fireMouseOverSlice(chart.element, 0)
+        const tooltip = await waitForHogChartTooltip()
+        fireEvent.click(chart.element)
+        await waitFor(() => {
+            expect(tooltip.classList.contains('hog-charts-tooltip--pinned')).toBe(true)
+        })
+    })
+
+    it('pins the tooltip *and* fires onSliceClick when both are configured', async () => {
+        const onSliceClick = jest.fn()
+        const { chart } = renderHogChart(
+            <PieChart
+                slices={SLICES}
+                theme={THEME}
+                config={{ tooltip: { pinnable: true } }}
+                onSliceClick={onSliceClick}
+            />
+        )
+        fireMouseOverSlice(chart.element, 1)
+        const tooltip = await waitForHogChartTooltip()
+        fireEvent.click(chart.element)
+        await waitFor(() => {
+            expect(tooltip.classList.contains('hog-charts-tooltip--pinned')).toBe(true)
+        })
+        expect(onSliceClick).toHaveBeenCalledTimes(1)
+        expect(onSliceClick.mock.calls[0][0].slice.key).toBe('b')
+    })
+
+    it('hides the tooltip when tooltip.enabled is false', () => {
+        const { chart } = renderHogChart(
+            <PieChart slices={SLICES} theme={THEME} config={{ tooltip: { enabled: false } }} />
+        )
+        fireMouseOverSlice(chart.element, 0)
+        expect(document.querySelector('[data-hog-charts-tooltip]')).toBeNull()
+    })
+
     it('caps innerRadius into the donut range without crashing', () => {
         const { chart } = renderHogChart(<PieChart slices={SLICES} theme={THEME} config={{ innerRadius: 0.5 }} />)
         expect(chart.seriesCount).toBe(3)
+    })
+
+    it('applies a custom value formatter to PieTooltip', async () => {
+        const formatter = (v: number): string => `$${v}`
+        const { chart } = renderHogChart(
+            <PieChart
+                slices={SLICES}
+                theme={THEME}
+                config={{ valueFormatter: formatter }}
+                tooltip={(ctx) => <PieTooltip ctx={ctx} theme={THEME} valueFormatter={formatter} />}
+            />
+        )
+        fireMouseOverSlice(chart.element, 0)
+        const tooltip = await waitForHogChartTooltip()
+        expect(tooltip.textContent).toContain('$30')
     })
 
     it('uses slice-provided color over the theme palette', () => {

--- a/frontend/src/lib/hog-charts/charts/PieChart/PieChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieChart.tsx
@@ -1,26 +1,37 @@
-import React, { useEffect, useMemo } from 'react'
+import { flip, FloatingPortal, offset, shift, useFloating, type VirtualElement } from '@floating-ui/react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
 import { useChartCanvas } from '../../core/hooks/useChartCanvas'
-import type { ChartMargins, ChartTheme } from '../../core/types'
-import { drawPieSlices, drawSliceLabels } from './utils/pie-canvas'
-import { computePieLayout, computeSliceAngles, DEFAULT_START_ANGLE, type ResolvedPieSlice } from './utils/pie-layout'
+import type { ChartMargins, ChartTheme, Series, TooltipConfig, TooltipContext } from '../../core/types'
+import { PieTooltip } from './PieTooltip'
+import { drawPieSlices, drawSliceLabels, highlightColorFor } from './utils/pie-canvas'
+import {
+    computePieLayout,
+    computeSliceAngles,
+    DEFAULT_START_ANGLE,
+    hitTestSlice,
+    type PieLayout,
+    type ResolvedPieSlice,
+    type SliceAngle,
+} from './utils/pie-layout'
 
-const WRAPPER_STYLE: React.CSSProperties = {
+const WRAPPER_STYLE_BASE: React.CSSProperties = {
     position: 'relative',
     width: '100%',
     flex: 1,
     minHeight: 0,
     overflow: 'hidden',
-    cursor: 'default',
 }
+const WRAPPER_STYLE_DEFAULT: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'default' }
+const WRAPPER_STYLE_POINTER: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'pointer' }
 const CANVAS_STYLE: React.CSSProperties = { position: 'absolute', top: 0, left: 0 }
 
 const DEFAULT_PIE_MARGINS: ChartMargins = { top: 12, right: 12, bottom: 12, left: 12 }
-// Reserved breathing room from the canvas edge so on-slice value labels don't get clipped.
-// Exposed as `hoverOffset` to `computePieLayout`; here it's a fixed visual margin.
-const EDGE_PADDING_PX = 16
+const DEFAULT_HOVER_OFFSET = 16
 const DEFAULT_VALUE_LABEL_MIN_PERCENT = 5
+const DEFAULT_TOOLTIP_Z_INDEX = 9999
+const TOOLTIP_MIDDLEWARE = [offset(12), flip(), shift({ padding: 8 })]
 
 const defaultValueFormatter = (value: number): string => value.toLocaleString()
 
@@ -28,13 +39,15 @@ const defaultValueFormatter = (value: number): string => value.toLocaleString()
 export interface PieSlice<Meta = unknown> {
     /** Unique identifier — used to key DOM nodes and survive re-ordering across renders. */
     key: string
-    /** Human-readable name shown in value labels. */
+    /** Human-readable name shown in the tooltip and value labels. */
     label: string
     /** Numeric value for this slice. Non-positive slices are filtered out. */
     value: number
     /** CSS color string. When omitted the chart picks one from `theme.colors` by slice index. */
     color?: string
-    /** Arbitrary consumer data attached to the slice. */
+    /** Arbitrary consumer data attached to the slice — flows through to the synthetic
+     *  `Series.meta` exposed via `TooltipContext.seriesData[].series.meta`, and to the
+     *  slice-click callback. */
     meta?: Meta
 }
 
@@ -44,18 +57,32 @@ export type ResolvedPieSliceWithMeta<Meta = unknown> = PieSlice<Meta> & { color:
 export interface PieChartConfig {
     /** Donut hole, 0–1 fraction of the outer radius. Defaults to 0 (full pie). */
     innerRadius?: number
+    /** Pixels to pop a hovered slice out along its bisector. Defaults to 16; set to 0 to disable. */
+    hoverOffset?: number
     /** Slices below this percentage of the total skip their value label. Defaults to 5. */
     valueLabelMinPercent?: number
     /** Show numeric value labels on slices large enough to fit. Defaults to true. */
     showValuesOnSlices?: boolean
     /** When set, draws the slice label instead of the numeric value on each slice. */
     showLabelsOnSlices?: boolean
-    /** Formats numeric values on slice labels. */
+    /** Formats numeric values everywhere — value labels and the default tooltip. */
     valueFormatter?: (value: number) => string
+    /** Tooltip behaviour. Defaults to enabled, not pinnable. */
+    tooltip?: TooltipConfig
     /** Radians of gap between adjacent slices. Defaults to 0. */
     slicePadding?: number
     /** Angle (radians) at which the first slice starts. Defaults to -π/2 (12 o'clock). */
     startAngle?: number
+}
+
+export interface PieSliceClickData<Meta = unknown> {
+    /** Index into the *filtered* (positive-value) slice array. */
+    sliceIndex: number
+    slice: ResolvedPieSliceWithMeta<Meta>
+    value: number
+    /** Slice's percentage of the total (0–100). */
+    percent: number
+    total: number
 }
 
 export interface PieChartProps<Meta = unknown> {
@@ -64,6 +91,11 @@ export interface PieChartProps<Meta = unknown> {
     slices: PieSlice<Meta>[]
     theme: ChartTheme
     config?: PieChartConfig
+    /** Override the tooltip body. Receives the same `TooltipContext` every hog-chart emits;
+     *  each slice is a synthetic one-point series so `seriesData[dataIndex]` is the hovered
+     *  slice, and `seriesData.reduce(...)` gives the total. */
+    tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
+    onSliceClick?: (data: PieSliceClickData<Meta>) => void
     className?: string
     /** `data-attr` applied to the chart wrapper. */
     dataAttr?: string
@@ -84,24 +116,29 @@ function PieChartInner<Meta = unknown>({
     slices: rawSlices,
     theme,
     config,
+    tooltip: tooltipRenderProp,
+    onSliceClick,
     className,
     dataAttr,
     emptyState,
 }: Omit<PieChartProps<Meta>, 'onError'>): React.ReactElement {
     const {
         innerRadius = 0,
+        hoverOffset = DEFAULT_HOVER_OFFSET,
         valueLabelMinPercent = DEFAULT_VALUE_LABEL_MIN_PERCENT,
         showValuesOnSlices = true,
         showLabelsOnSlices = false,
         valueFormatter = defaultValueFormatter,
+        tooltip: tooltipConfig,
         slicePadding = 0,
         startAngle = DEFAULT_START_ANGLE,
     } = config ?? {}
+    const { enabled: showTooltip = true, pinnable: pinnableTooltip = false } = tooltipConfig ?? {}
 
     const { canvasRef, wrapperRef, dimensions, ctx } = useChartCanvas({ margins: DEFAULT_PIE_MARGINS })
 
     // Apply theme palette and drop non-positive slices — they have no visual area and would
-    // confuse rendering (zero-sweep arcs draw to nothing but still count as series).
+    // confuse hit testing (zero-sweep arcs match every cursor angle).
     const visibleSlices = useMemo<ResolvedPieSliceWithMeta<Meta>[]>(() => {
         const out: ResolvedPieSliceWithMeta<Meta>[] = []
         let colorIndex = 0
@@ -120,18 +157,43 @@ function PieChartInner<Meta = unknown>({
 
     const total = useMemo(() => visibleSlices.reduce((sum, s) => sum + s.value, 0), [visibleSlices])
 
-    const layout = useMemo(() => {
+    const layout = useMemo<PieLayout | null>(() => {
         if (!dimensions) {
             return null
         }
-        return computePieLayout(dimensions, { innerRadius, hoverOffset: EDGE_PADDING_PX })
-    }, [dimensions, innerRadius])
+        return computePieLayout(dimensions, { innerRadius, hoverOffset })
+    }, [dimensions, innerRadius, hoverOffset])
 
-    const sliceAngles = useMemo(
+    const sliceAngles = useMemo<SliceAngle[]>(
         () => computeSliceAngles(visibleSlices as ResolvedPieSlice[], total, startAngle),
         [visibleSlices, total, startAngle]
     )
 
+    const [hoverIndex, setHoverIndex] = useState<number>(-1)
+    const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null)
+    const [isPinned, setIsPinned] = useState<boolean>(false)
+    const hoverIndexRef = useRef(hoverIndex)
+    hoverIndexRef.current = hoverIndex
+
+    const clearHover = useCallback(() => {
+        setHoverIndex(-1)
+        setHoverPosition(null)
+        setIsPinned(false)
+    }, [])
+
+    const unpin = useCallback(() => setIsPinned(false), [])
+
+    // Reset hover state when the slice set changes — index/position pointers into the
+    // previous geometry are nonsense against the new one.
+    useEffect(() => {
+        setHoverIndex(-1)
+        setHoverPosition(null)
+        setIsPinned(false)
+    }, [visibleSlices])
+
+    // Drawing — one layer is enough since hover rearranges the geometry (slice pops out)
+    // and value labels track the hover offset. Splitting static / hover would force the
+    // static layer to redraw on every hover anyway.
     useEffect(() => {
         if (!ctx || !dimensions || !layout) {
             return
@@ -146,9 +208,17 @@ function PieChartInner<Meta = unknown>({
             ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
             ctx.clearRect(0, 0, dimensions.width, dimensions.height)
 
-            drawPieSlices(ctx, layout, visibleSlices as ResolvedPieSlice[], sliceAngles, {
-                hoverIndex: -1,
-                hoverOffset: 0,
+            // Tint the hovered slice darker by mutating its color in the array we pass to
+            // drawPieSlices — cheaper than a separate overlay pass since geometry already
+            // shifts on hover.
+            const slicesForDraw =
+                hoverIndex >= 0
+                    ? visibleSlices.map((s, i) => (i === hoverIndex ? { ...s, color: highlightColorFor(s.color) } : s))
+                    : visibleSlices
+
+            drawPieSlices(ctx, layout, slicesForDraw as ResolvedPieSlice[], sliceAngles, {
+                hoverIndex,
+                hoverOffset,
                 slicePadding,
             })
 
@@ -157,8 +227,8 @@ function PieChartInner<Meta = unknown>({
                     minFraction: valueLabelMinPercent / 100,
                     mode: showLabelsOnSlices ? 'label' : 'value',
                     valueFormatter,
-                    hoverIndex: -1,
-                    hoverOffset: 0,
+                    hoverIndex,
+                    hoverOffset,
                 })
             }
             ctx.restore()
@@ -173,12 +243,140 @@ function PieChartInner<Meta = unknown>({
         layout,
         sliceAngles,
         visibleSlices,
+        hoverIndex,
+        hoverOffset,
         slicePadding,
         showValuesOnSlices,
         showLabelsOnSlices,
         valueLabelMinPercent,
         valueFormatter,
     ])
+
+    const onMouseMove = useCallback(
+        (e: React.MouseEvent<HTMLDivElement>) => {
+            if (!layout || isPinned) {
+                return
+            }
+            const rect = e.currentTarget.getBoundingClientRect()
+            const x = e.clientX - rect.left
+            const y = e.clientY - rect.top
+            const index = hitTestSlice(x, y, layout, sliceAngles)
+            setHoverIndex(index)
+            setHoverPosition(index >= 0 ? { x, y } : null)
+        },
+        [layout, sliceAngles, isPinned]
+    )
+
+    const onMouseLeave = useCallback(() => {
+        if (isPinned) {
+            return
+        }
+        clearHover()
+    }, [isPinned, clearHover])
+
+    const onClick = useCallback(() => {
+        const currentIndex = hoverIndexRef.current
+        if (currentIndex < 0) {
+            return
+        }
+        if (isPinned) {
+            clearHover()
+            return
+        }
+        // Pinning and onSliceClick are independent — a consumer can ask for both, in which
+        // case the click pins the tooltip *and* fires the callback. We don't early-return
+        // here so the two paths don't shadow each other.
+        if (pinnableTooltip && showTooltip) {
+            setIsPinned(true)
+        }
+        if (onSliceClick) {
+            const slice = visibleSlices[currentIndex]
+            onSliceClick({
+                sliceIndex: currentIndex,
+                slice,
+                value: slice.value,
+                percent: total > 0 ? (slice.value / total) * 100 : 0,
+                total,
+            })
+        }
+    }, [isPinned, pinnableTooltip, showTooltip, clearHover, onSliceClick, visibleSlices, total])
+
+    // Dismiss pinned tooltip via Escape or outside click — same UX as the bar/line tooltip.
+    useEffect(() => {
+        if (!isPinned) {
+            return
+        }
+        const handleClickOutside = (e: MouseEvent): void => {
+            const target = e.target
+            if (target instanceof Element && target.closest('[data-hog-charts-tooltip]')) {
+                return
+            }
+            const wrapper = wrapperRef.current
+            if (wrapper && !wrapper.contains(target as Node)) {
+                clearHover()
+            }
+        }
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape') {
+                clearHover()
+            }
+        }
+        const timer = setTimeout(() => {
+            document.addEventListener('click', handleClickOutside, { passive: true })
+        }, 0)
+        document.addEventListener('keydown', handleKeyDown, { passive: true })
+        return () => {
+            clearTimeout(timer)
+            document.removeEventListener('click', handleClickOutside)
+            document.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [isPinned, wrapperRef, clearHover])
+
+    const canvasBounds = useCallback(
+        (): DOMRect => canvasRef.current?.getBoundingClientRect() ?? new DOMRect(),
+        [canvasRef]
+    )
+
+    // Each slice becomes a single-point synthetic Series so the tooltip context matches
+    // the bar/line shape — the testing harness, DefaultTooltip, and `TooltipSnapshot.series`
+    // accessor all key off `series.key`, which mirrors `slice.key` here.
+    const seriesData = useMemo(
+        () =>
+            visibleSlices.map((slice) => {
+                const series: Series<Meta> = {
+                    key: slice.key,
+                    label: slice.label,
+                    data: [slice.value],
+                    color: slice.color,
+                    meta: slice.meta,
+                }
+                return { series, value: slice.value, color: slice.color }
+            }),
+        [visibleSlices]
+    )
+
+    const tooltipCtx = useMemo<TooltipContext<Meta> | null>(() => {
+        if (!showTooltip || hoverIndex < 0 || !hoverPosition) {
+            return null
+        }
+        const slice = visibleSlices[hoverIndex]
+        if (!slice) {
+            return null
+        }
+        return {
+            dataIndex: hoverIndex,
+            label: slice.label,
+            seriesData,
+            position: hoverPosition,
+            hoverPosition,
+            canvasBounds: canvasBounds(),
+            isPinned,
+            onUnpin: isPinned ? unpin : undefined,
+        }
+    }, [showTooltip, hoverIndex, hoverPosition, visibleSlices, seriesData, canvasBounds, isPinned, unpin])
+
+    const wrapperStyle =
+        hoverIndex >= 0 && (onSliceClick || pinnableTooltip) ? WRAPPER_STYLE_POINTER : WRAPPER_STYLE_DEFAULT
 
     const ariaLabel = `Chart with ${visibleSlices.length} data series`
 
@@ -189,7 +387,7 @@ function PieChartInner<Meta = unknown>({
                 ref={wrapperRef}
                 className={className}
                 data-attr={dataAttr}
-                style={WRAPPER_STYLE}
+                style={WRAPPER_STYLE_DEFAULT}
                 role="img"
                 aria-label={ariaLabel}
             >
@@ -211,8 +409,82 @@ function PieChartInner<Meta = unknown>({
     }
 
     return (
-        <div ref={wrapperRef} className={className} data-attr={dataAttr} style={WRAPPER_STYLE}>
+        <div
+            ref={wrapperRef}
+            className={className}
+            data-attr={dataAttr}
+            style={wrapperStyle}
+            onMouseMove={onMouseMove}
+            onMouseLeave={onMouseLeave}
+            onClick={onClick}
+        >
             <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={CANVAS_STYLE} />
+            {tooltipCtx && (
+                <PiePortalTooltip ctx={tooltipCtx} theme={theme}>
+                    {tooltipRenderProp ? (
+                        tooltipRenderProp(tooltipCtx)
+                    ) : (
+                        <PieTooltip ctx={tooltipCtx} theme={theme} valueFormatter={valueFormatter} />
+                    )}
+                </PiePortalTooltip>
+            )}
         </div>
+    )
+}
+
+interface PiePortalTooltipProps<Meta> {
+    ctx: TooltipContext<Meta>
+    theme: ChartTheme
+    children: React.ReactNode
+}
+
+function PiePortalTooltip<Meta>({ ctx, theme, children }: PiePortalTooltipProps<Meta>): React.ReactElement {
+    const zIndex = theme.tooltipZIndex ?? DEFAULT_TOOLTIP_Z_INDEX
+    const x = ctx.canvasBounds.left + ctx.position.x
+    const y = ctx.canvasBounds.top + ctx.position.y
+
+    const virtualReference = useMemo<VirtualElement>(
+        () => ({
+            getBoundingClientRect: () => ({
+                x,
+                y,
+                width: 0,
+                height: 0,
+                top: y,
+                right: x,
+                bottom: y,
+                left: x,
+            }),
+        }),
+        [x, y]
+    )
+
+    const { refs, floatingStyles } = useFloating({
+        placement: 'right',
+        strategy: 'fixed',
+        middleware: TOOLTIP_MIDDLEWARE,
+    })
+
+    useLayoutEffect(() => {
+        refs.setPositionReference(virtualReference)
+    }, [virtualReference, refs])
+
+    return (
+        <FloatingPortal>
+            <div
+                ref={refs.setFloating}
+                data-hog-charts-tooltip=""
+                className={ctx.isPinned ? 'hog-charts-tooltip--pinned' : undefined}
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{
+                    ...floatingStyles,
+                    pointerEvents: ctx.isPinned ? 'auto' : 'none',
+                    width: 'max-content',
+                    zIndex,
+                }}
+            >
+                {children}
+            </div>
+        </FloatingPortal>
     )
 }

--- a/frontend/src/lib/hog-charts/charts/PieChart/PieTooltip.tsx
+++ b/frontend/src/lib/hog-charts/charts/PieChart/PieTooltip.tsx
@@ -1,0 +1,52 @@
+import type { ChartTheme, TooltipContext } from '../../core/types'
+
+const DEFAULT_TOOLTIP_BG = '#1d2330'
+const DEFAULT_TOOLTIP_COLOR = '#ffffff'
+
+const defaultValueFormatter = (value: number): string => value.toLocaleString()
+
+export interface PieTooltipProps<Meta = unknown> {
+    ctx: TooltipContext<Meta>
+    theme: ChartTheme
+    valueFormatter?: (value: number) => string
+}
+
+/** Default pie tooltip — shows the hovered slice's label, value, and percentage.
+ *  Mirrors the layout the SQL pie chart's `InsightTooltip` uses (value + share-of-total).
+ *  Consumes the same `TooltipContext` shape every other hog-chart emits: each slice is a
+ *  synthetic single-point series, so `seriesData[dataIndex]` is the hovered slice. */
+export function PieTooltip<Meta = unknown>({
+    ctx,
+    theme,
+    valueFormatter = defaultValueFormatter,
+}: PieTooltipProps<Meta>): React.ReactElement | null {
+    const entry = ctx.seriesData[ctx.dataIndex]
+    if (!entry) {
+        return null
+    }
+    const total = ctx.seriesData.reduce((sum, e) => sum + e.value, 0)
+    const percent = total > 0 ? (entry.value / total) * 100 : 0
+    return (
+        <div
+            className="px-3 py-2 rounded-lg shadow-lg text-[13px]"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{
+                backgroundColor: theme.tooltipBackground ?? DEFAULT_TOOLTIP_BG,
+                color: theme.tooltipColor ?? DEFAULT_TOOLTIP_COLOR,
+            }}
+        >
+            <div className="flex items-center gap-2 mb-1">
+                <span
+                    className="inline-block size-2 rounded-full"
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ backgroundColor: entry.color }}
+                />
+                <span className="font-semibold">{entry.series.label}</span>
+            </div>
+            <div className="flex items-baseline gap-2">
+                <strong>{valueFormatter(entry.value)}</strong>
+                <span className="opacity-75">({percent.toFixed(1)}%)</span>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -4,7 +4,9 @@ export type { BarChartProps } from './charts/BarChart/BarChart'
 export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
 export { PieChart } from './charts/PieChart/PieChart'
-export type { PieChartConfig, PieChartProps, PieSlice } from './charts/PieChart/PieChart'
+export type { PieChartConfig, PieChartProps, PieSlice, PieSliceClickData } from './charts/PieChart/PieChart'
+export { PieTooltip } from './charts/PieChart/PieTooltip'
+export type { PieTooltipProps } from './charts/PieChart/PieTooltip'
 export { TimeSeriesLineChart } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
 export type {
     ConfidenceIntervalConfig,


### PR DESCRIPTION
## Problem

Continuing the split of #59765. This PR layers hover, tooltip, click and pinning on top of the non-interactive PieChart from #59772.

## Changes

- Hover state, slice pop-out (`config.hoverOffset`, default 16px), and value labels that track the pop-out.
- `tooltip` render prop on `PieChartProps`. Each slice is exposed as a synthetic one-point `Series`, so the context matches the shape every other hog-chart emits — `seriesData[dataIndex]` is the hovered slice; `seriesData.reduce(...)` gives the total. Lets the same `DefaultTooltip` / overlay tooling work for pie too.
- `PieTooltip` (and `PieTooltipProps`) — default body showing the hovered slice's value and percentage. Theme + `valueFormatter` are props so the component works outside the bar/line `ChartLayoutContext`.
- `config.tooltip` (`TooltipConfig`) — disable the tooltip or make it pinnable on click.
- `onSliceClick` callback and `PieSliceClickData` type. Click pins **and** fires `onSliceClick` when both are configured — they represent independent intents.
- Escape / outside-click dismissal for the pinned tooltip, mirroring bar/line UX.
- 12 component tests covering hover, the render-prop context shape, click callback, pinning, click+pin together, the `tooltip.enabled: false` path, and value-formatter wiring.

Stacked on #59772 (non-interactive PieChart) → #59771 (utilities) → #59768 (test harness).

## How did you test this code?

I'm an agent; only automated checks were run.

- `pnpm jest src/lib/hog-charts/` → 919/919 passing (33 PieChart tests across PR 3a + 3b).
- `pnpm exec tsc --noEmit` → no errors in `frontend/src/lib/hog-charts/**`.
- `oxfmt --check` → clean.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update — internal library, no public surface beyond hog-charts consumers.

## 🤖 Agent context

Agent-authored. Tooling: Claude Code via PostHog Code harness.

Approach notes:
- Considered keeping a pie-specific `PieTooltipContext` shape (with `slice`, `percent`, `total`, `slices`). Rejected after review feedback — synthesizing each slice as a one-point `Series` lets the rest of the testing harness, `DefaultTooltip`, and the `TooltipSnapshot.series` accessor work for pie too with no special cases.
- `PieTooltip` takes `theme` and `valueFormatter` as props rather than reading them from `ChartLayoutContext`. PieChart doesn't emit a layout context (no axes / scales), so the bar/line `useChartLayout()` shape doesn't fit — passing them in keeps the tooltip standalone.
- Click handler fires the callback *and* pins when both are configured (an earlier draft early-returned after pinning; greptile flagged it on the parent PR and a regression test now guards this).