### PR TITLE
fix(read-only): allow insights/timing telemetry in read-only mode

### DIFF
--- a/frontend/src/lib/readOnlyGuard.test.ts
+++ b/frontend/src/lib/readOnlyGuard.test.ts
@@ -82,6 +82,9 @@ describe('readOnlyGuard', () => {
                 ['query log', 'POST', '/api/environments/2/query/abc-123/log'],
                 ['query with trailing query string', 'POST', '/api/environments/2/query/?refresh=true'],
                 ['delete on query path', 'DELETE', '/api/environments/2/query/abc-123/'],
+                ['insights timing telemetry', 'POST', '/api/projects/2/insights/timing'],
+                ['insights timing with trailing slash', 'POST', '/api/projects/2/insights/timing/'],
+                ['insights timing with query string', 'POST', '/api/projects/2/insights/timing?foo=bar'],
             ] as const)('lets %s through (%s %s)', (_label, method, url) => {
                 const notifier = jest.fn()
                 setReadOnlyNotifier(notifier)
@@ -92,7 +95,9 @@ describe('readOnlyGuard', () => {
             it.each([
                 ['endpoint that just contains the word query in a name', 'POST', '/api/environments/2/queryless/'],
                 ['similar prefix without slash', 'POST', '/api/environments/2/queryteam/'],
-            ] as const)('still blocks %s (%s %s) — only paths with /query/ segment are allowed', (_l, method, url) => {
+                ['insights endpoint that is not timing', 'POST', '/api/projects/2/insights/'],
+                ['insights timing prefix match without slash', 'POST', '/api/projects/2/insights/timings/'],
+            ] as const)('still blocks %s (%s %s) — only exact allow-list paths pass through', (_l, method, url) => {
                 expect(() => assertNotReadOnly(method, url)).toThrow(ReadOnlyModeError)
             })
         })

--- a/frontend/src/lib/readOnlyGuard.ts
+++ b/frontend/src/lib/readOnlyGuard.ts
@@ -50,6 +50,7 @@ export function isReadOnly(): boolean {
 // the entire app unusable in read-only mode.
 const READ_ONLY_ALLOWED_PATTERNS = [
     /\/query(?:\/|$|\?)/, // /api/environments/:team_id/query, /api/environments/:team_id/query/:queryId/log, etc.
+    /\/insights\/timing(?:\/|$|\?)/,
 ]
 
 function isReadDisguisedAsWrite(url: string): boolean {


### PR DESCRIPTION
## Problem

Self read-only mode shipped in #59372 and added `assertNotReadOnly('POST')` inside `api.createResponse`. That guard is too broad — `captureTimeToSeeData` POSTs fire-and-forget telemetry to `api/projects/{id}/insights/timing`, so every filter dropdown interaction by a self-read-only user now throws `ReadOnlyModeError`. The catch block correctly swallows the failure for the user, but also calls `posthog.captureException(e)`, which surfaces the noise as an error tracking issue.

## Changes

Add `/insights/timing` to `READ_ONLY_ALLOWED_PATTERNS` in `frontend/src/lib/readOnlyGuard.ts`. Same rationale as `/query`: the URL looks like a write but the request is not user-driven, and we want this telemetry to keep flowing for read-only users.

## How did you test this code?

I'm an agent; I have not exercised the UI manually. I extended the existing parameterized tests in `frontend/src/lib/readOnlyGuard.test.ts` to cover three allow-through cases (with/without trailing slash, with query string) and two adjacent-but-different paths that must still be blocked (`/insights/`, `/insights/timings/`). The full `readOnlyGuard` suite passes (32/32) under `pnpm exec jest`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code on behalf of @pauldambra. The robot proposed short-circuiting `captureTimeToSeeData` inside `internalMetrics.ts` (or swallowing `ReadOnlyModeError` in the catch block); we chose the allow-list route instead because the user wants this metrics data to keep flowing even in read-only mode, and the existing `/query` pattern already establishes the "looks like a write, isn't" exception. Tests follow the same parameterized shape already in the file.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*