### PR TITLE
test: fix reverseProxyCheckerLogic read-only test after /query allow-list change

### DIFF
--- a/frontend/src/lib/components/ReverseProxyChecker/reverseProxyCheckerLogic.test.ts
+++ b/frontend/src/lib/components/ReverseProxyChecker/reverseProxyCheckerLogic.test.ts
@@ -3,7 +3,8 @@ import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
-import { setReadOnlyGetter } from 'lib/readOnlyGuard'
+import api from 'lib/api'
+import { ReadOnlyModeError } from 'lib/readOnlyGuard'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
@@ -117,11 +118,15 @@ describe('reverseProxyCheckerLogic', () => {
     })
 
     it('should not report read-only mode blocks to error tracking', async () => {
-        // Regression test: the read-only guard throws ReadOnlyModeError on every POST,
-        // and afterMount fires loadHasReverseProxy on every scene mount, so reporting
-        // these floods error tracking with expected failures.
-        useMockedValues(hasReverseProxyValues)
-        setReadOnlyGetter(() => true)
+        // Regression test: if loadHasReverseProxy ever encounters a ReadOnlyModeError,
+        // it must be swallowed silently — afterMount fires on every scene mount, so
+        // reporting these would flood error tracking with expected failures.
+        //
+        // We spy on api.queryHogQL directly rather than going through the read-only
+        // guard because /query is in readOnlyGuard's READ_ONLY_ALLOWED_PATTERNS
+        // (queries are reads despite being POSTs), so setReadOnlyGetter alone never
+        // triggers the error path on this endpoint.
+        const queryHogQLSpy = jest.spyOn(api, 'queryHogQL').mockRejectedValue(new ReadOnlyModeError())
 
         const captureExceptionSpy = jest.spyOn(posthog, 'captureException').mockImplementation(() => undefined)
 
@@ -139,7 +144,7 @@ describe('reverseProxyCheckerLogic', () => {
             expect(captureExceptionSpy).not.toHaveBeenCalled()
         } finally {
             captureExceptionSpy.mockRestore()
-            setReadOnlyGetter(null)
+            queryHogQLSpy.mockRestore()
         }
     })
 })

--- a/frontend/src/lib/components/ReverseProxyChecker/reverseProxyCheckerLogic.test.ts
+++ b/frontend/src/lib/components/ReverseProxyChecker/reverseProxyCheckerLogic.test.ts
@@ -118,14 +118,11 @@ describe('reverseProxyCheckerLogic', () => {
     })
 
     it('should not report read-only mode blocks to error tracking', async () => {
-        // Regression test: if loadHasReverseProxy ever encounters a ReadOnlyModeError,
-        // it must be swallowed silently — afterMount fires on every scene mount, so
-        // reporting these would flood error tracking with expected failures.
+        // Regression: ReadOnlyModeError from loadHasReverseProxy must be swallowed,
+        // otherwise every scene mount would spam error tracking via afterMount.
         //
-        // We spy on api.queryHogQL directly rather than going through the read-only
-        // guard because /query is in readOnlyGuard's READ_ONLY_ALLOWED_PATTERNS
-        // (queries are reads despite being POSTs), so setReadOnlyGetter alone never
-        // triggers the error path on this endpoint.
+        // We mock api.queryHogQL directly because /query is allow-listed in
+        // readOnlyGuard, so setReadOnlyGetter wouldn't fire here.
         const queryHogQLSpy = jest.spyOn(api, 'queryHogQL').mockRejectedValue(new ReadOnlyModeError())
 
         const captureExceptionSpy = jest.spyOn(posthog, 'captureException').mockImplementation(() => undefined)


### PR DESCRIPTION
## Summary

`frontend/src/lib/components/ReverseProxyChecker/reverseProxyCheckerLogic.test.ts` has a single failing test on master (`should not report read-only mode blocks to error tracking`, added by [#59645](https://github.com/PostHog/posthog/pull/59645)). I noticed it while wrapping up CI on an unrelated PR ([#59518](https://github.com/PostHog/posthog/pull/59518)); the failure reproduces on a clean `origin/master` worktree using a fresh `pnpm install` + the same `jest` invocation, so it's a real master-red, not a flake.

### Root cause

The test sets `setReadOnlyGetter(() => true)` and expects `loadHasReverseProxy`'s catch branch to swallow a `ReadOnlyModeError`. But that branch never runs in this test, because `readOnlyGuard.ts` already allow-lists `/query` URLs:

```ts
// frontend/src/lib/readOnlyGuard.ts (added by #59661)
const READ_ONLY_ALLOWED_PATTERNS = [
    /\/query(?:\/|$|\?)/, // /api/environments/:team_id/query, /api/environments/:team_id/query/:queryId/log, etc.
]
```

`loadHasReverseProxy` POSTs to `/api/environments/:team_id/query/:kind`, which matches that regex, so `assertNotReadOnly` short-circuits and returns without throwing. The mocked 200 response is then consumed normally and `hasReverseProxy` resolves to `true` instead of the expected `false`.

The catch branch in `loadHasReverseProxy` that handles `ReadOnlyModeError` is effectively dead code today (defensive against a future allow-list change), but the test still has value as a regression guard for the swallow behavior — it just needs a different way to reach the catch.

### Fix

Spy on `api.queryHogQL` directly and reject with `ReadOnlyModeError`. This exercises the exact same catch branch the test was written to validate, without depending on the read-only guard's URL-routing behavior:

- Drop the `setReadOnlyGetter` precondition (and its cleanup) — irrelevant to this endpoint.
- Drop the `useMockedValues(hasReverseProxyValues)` setup — not used now that the api call is fully stubbed.
- Add `jest.spyOn(api, 'queryHogQL').mockRejectedValue(new ReadOnlyModeError())`.
- Mirror the `mockRestore()` cleanup pattern from the adjacent `should swallow server errors silently…` test (line 84+).

Test-only change. No production code touched. The `READ_ONLY_ALLOWED_PATTERNS` allow-list is unchanged — the comment in `readOnlyGuard.ts` is explicit that block-listing `/query` would make the whole app unusable in read-only mode.

## Test plan

- [x] Reproduced the failure on a fresh `origin/master` worktree before the fix (1 failed, 4 passed).
- [x] After the fix: `pnpm exec jest --rootDir=frontend --config=frontend/jest.config.ts --testPathPattern='ReverseProxyChecker/reverseProxyCheckerLogic\.test' --no-coverage --maxWorkers=1` → **5 passed, 5 total**.

## Related

- [#59645](https://github.com/PostHog/posthog/pull/59645) — added the failing test and the (currently unreachable) catch branch
- [#59661](https://github.com/PostHog/posthog/pull/59661) — added `READ_ONLY_ALLOWED_PATTERNS` for `/query`, making the test's read-only path unreachable
- [#59372](https://github.com/PostHog/posthog/pull/59372) — introduced `readOnlyGuard.ts`
- [#59518](https://github.com/PostHog/posthog/pull/59518) — where the failure was noticed in CI

Made with [Cursor](https://cursor.com)
