### PR TITLE
fix(llma): route personal_spend through events table to dodge ai_events shim

### DIFF
--- a/products/llm_analytics/backend/api/personal_spend.py
+++ b/products/llm_analytics/backend/api/personal_spend.py
@@ -34,6 +34,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.models import Team, User
 from posthog.permissions import APIScopePermission
 from posthog.rate_limit import PersonalSpendBurstThrottle, PersonalSpendDailyThrottle, PersonalSpendSustainedThrottle
@@ -286,10 +287,11 @@ class PersonalSpendAnalysisResponseSerializer(serializers.Serializer):
 
 
 def _email_filter(email: str) -> ast.Expr:
-    # `person.properties.email` resolves via distinct_id → pdi → person, so it catches every
-    # event the user identified with (including historical distinct_ids merged into the same
-    # person). This is the same shape the LLM Analytics "Users" tab uses against the `events`
-    # table — see `products/llm_analytics/frontend/tabs/llmAnalyticsUsersLogic.ts`.
+    # With person-on-events, the event row carries `person_id` directly; HogQL then joins to
+    # `person` to read `properties.email`. The join is bounded to one person per event (not a
+    # full pdi walk), and on the main cluster the printer transparently uses the materialized
+    # `pmat_email` column when registered. Same shape the LLM Analytics "Users" tab uses
+    # against `events` -- see `products/llm_analytics/frontend/tabs/llmAnalyticsUsersLogic.ts`.
     return ast.CompareOperation(
         op=ast.CompareOperationOp.Eq,
         left=ast.Field(chain=["person", "properties", "email"]),
@@ -580,13 +582,18 @@ class PersonalSpendViewSet(viewsets.ViewSet):
     callers cannot pivot to other users' data. Authorization model is "any
     authenticated PostHog user may read their own spend" via `user:read` (the
     same scope that covers `/api/users/@me/`). Queries the shared `events`
-    table directly — same pattern as the LLM Analytics "Users" tab and every
-    other person-property filter on AI events. The HogQL printer transparently
-    uses the materialized `pmat_email` column on the main cluster's `person`
-    table when it's registered, so there's no perf penalty vs the ai_events
-    satellite path; the WHERE clause hits the events table's sort key
-    (`team_id`, `event`, `timestamp`) before the person join fires. The
-    endpoint is also cached for 5 minutes per user. Optionally filter tool /
+    table directly -- same pattern as the LLM Analytics "Users" tab and every
+    other person-property filter on AI events. We don't route through
+    `execute_with_ai_events_fallback` because the satellite `ai_events`
+    cluster's Distributed `person` shim doesn't declare materialized columns
+    like `pmat_email`, and the helper's fallback only catches empty results,
+    not the unresolved-identifier exception that would fire there. The
+    `events`-table WHERE clauses lead with the sort-key columns (`team_id`,
+    `event`, `timestamp`) so the scan narrows before the person join fires,
+    and the HogQL printer uses `pmat_email` on the main cluster's `person`
+    when registered -- so this path should be comparable to what the
+    satellite would have served. The endpoint is cached for 5 minutes per
+    user (see `CACHE_TIMEOUT_SECONDS`). Optionally filter tool /
     model / trace breakdowns to a single
     `ai_product` via the `product` query param; `by_product` always returns
     the full cross-product breakdown. The endpoint is only registered on US
@@ -665,22 +672,26 @@ class PersonalSpendViewSet(viewsets.ViewSet):
             logger.exception("personal_spend.team_missing", team_id=team_id)
             raise exceptions.NotFound("Internal analytics team is not provisioned on this deployment.")
 
-        summary = _fetch_summary(team, email, from_dt, to_dt, product)
-        by_tool = _fetch_by_tool(team, email, from_dt, to_dt, product, limit)
-        scoped = summary["scoped_cost_usd"] or 0.0
-        # `cost_usd` in by_tool can exceed scoped_cost_usd because multi-tool generations
-        # contribute to every tool. `share_of_scoped` is independent per row, so agents can
-        # present headline percentages directly without reconciling sums.
-        for row in by_tool["items"]:
-            row["share_of_scoped"] = (row["cost_usd"] / scoped) if scoped > 0 else 0.0
+        # Tag the underlying ClickHouse reads with the LLM_ANALYTICS product so they show up
+        # in the existing per-product Prometheus + cost-attribution dashboards alongside the
+        # rest of AI observability traffic. Wraps every call into `_fetch_*` -> HogQL.
+        with tags_context(product=Product.LLM_ANALYTICS):
+            summary = _fetch_summary(team, email, from_dt, to_dt, product)
+            by_tool = _fetch_by_tool(team, email, from_dt, to_dt, product, limit)
+            scoped = summary["scoped_cost_usd"] or 0.0
+            # `cost_usd` in by_tool can exceed scoped_cost_usd because multi-tool generations
+            # contribute to every tool. `share_of_scoped` is independent per row, so agents can
+            # present headline percentages directly without reconciling sums.
+            for row in by_tool["items"]:
+                row["share_of_scoped"] = (row["cost_usd"] / scoped) if scoped > 0 else 0.0
 
-        payload = {
-            "summary": summary,
-            "by_product": _fetch_by_product(team, email, from_dt, to_dt, limit),
-            "by_tool": by_tool,
-            "by_model": _fetch_by_model(team, email, from_dt, to_dt, product, limit),
-            "top_traces": _fetch_top_traces(team, email, from_dt, to_dt, product, limit),
-        }
+            payload = {
+                "summary": summary,
+                "by_product": _fetch_by_product(team, email, from_dt, to_dt, limit),
+                "by_tool": by_tool,
+                "by_model": _fetch_by_model(team, email, from_dt, to_dt, product, limit),
+                "top_traces": _fetch_top_traces(team, email, from_dt, to_dt, product, limit),
+            }
 
         response_data = PersonalSpendAnalysisResponseSerializer(payload).data
         cache.set(cache_key, response_data, timeout=CACHE_TIMEOUT_SECONDS)

--- a/products/llm_analytics/backend/api/personal_spend.py
+++ b/products/llm_analytics/backend/api/personal_spend.py
@@ -31,9 +31,9 @@ from rest_framework.response import Response
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
 
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
-from posthog.hogql_queries.ai.ai_table_resolver import execute_with_ai_events_fallback
 from posthog.models import Team, User
 from posthog.permissions import APIScopePermission
 from posthog.rate_limit import PersonalSpendBurstThrottle, PersonalSpendDailyThrottle, PersonalSpendSustainedThrottle
@@ -286,10 +286,10 @@ class PersonalSpendAnalysisResponseSerializer(serializers.Serializer):
 
 
 def _email_filter(email: str) -> ast.Expr:
-    # With person-on-events mode `person.properties.email` is a denormalized column on
-    # the events row, so this is a single column read rather than a join — it also catches
-    # every event the user identified with, including historical distinct_ids merged into
-    # the same person.
+    # `person.properties.email` resolves via distinct_id → pdi → person, so it catches every
+    # event the user identified with (including historical distinct_ids merged into the same
+    # person). This is the same shape the LLM Analytics "Users" tab uses against the `events`
+    # table — see `products/llm_analytics/frontend/tabs/llmAnalyticsUsersLogic.ts`.
     return ast.CompareOperation(
         op=ast.CompareOperationOp.Eq,
         left=ast.Field(chain=["person", "properties", "email"]),
@@ -354,11 +354,11 @@ def _fetch_summary(
             round(sumIf(toFloat(properties.$ai_total_cost_usd), {product_filter}), 6) AS scoped_cost_usd,
             count() AS event_count,
             round(sum(toFloat(properties.$ai_total_cost_usd)), 6) AS total_cost_usd
-        FROM posthog.ai_events
+        FROM events
         WHERE {event_in} AND {email_filter} AND {timestamp_filter}
         """
     )
-    result = execute_with_ai_events_fallback(
+    result = execute_hogql_query(
         query=query,
         placeholders={
             "product_filter": _product_filter(product),
@@ -390,14 +390,14 @@ def _fetch_by_product(
             properties.ai_product AS product,
             count() AS event_count,
             round(sum(toFloat(properties.$ai_total_cost_usd)), 6) AS cost_usd
-        FROM posthog.ai_events
+        FROM events
         WHERE {event_in} AND {email_filter} AND {timestamp_filter}
         GROUP BY product
         ORDER BY cost_usd DESC
         LIMIT {limit}
         """
     )
-    result = execute_with_ai_events_fallback(
+    result = execute_hogql_query(
         query=query,
         placeholders={
             "event_in": _event_in(["$ai_generation", "$ai_embedding"]),
@@ -438,7 +438,7 @@ def _fetch_by_tool(
             count() AS generation_count,
             round(sum(toFloat(properties.$ai_total_cost_usd)), 6) AS cost_usd,
             round(avg(toFloat(properties.$ai_input_tokens)), 0) AS avg_input_tokens
-        FROM posthog.ai_events
+        FROM events
         WHERE equals(event, '$ai_generation')
             AND {product_filter}
             AND {email_filter}
@@ -448,7 +448,7 @@ def _fetch_by_tool(
         LIMIT {limit}
         """
     )
-    result = execute_with_ai_events_fallback(
+    result = execute_hogql_query(
         query=query,
         placeholders={
             "product_filter": _product_filter(product),
@@ -487,7 +487,7 @@ def _fetch_by_model(
             round(sum(toFloat(properties.$ai_total_cost_usd)), 6) AS cost_usd,
             sum(toFloat(properties.$ai_input_tokens)) AS input_tokens,
             sum(toFloat(properties.$ai_output_tokens)) AS output_tokens
-        FROM posthog.ai_events
+        FROM events
         WHERE {event_in}
             AND {product_filter}
             AND {email_filter}
@@ -497,7 +497,7 @@ def _fetch_by_model(
         LIMIT {limit}
         """
     )
-    result = execute_with_ai_events_fallback(
+    result = execute_hogql_query(
         query=query,
         placeholders={
             "event_in": _event_in(["$ai_generation", "$ai_embedding"]),
@@ -537,7 +537,7 @@ def _fetch_top_traces(
             count() AS generation_count,
             round(sum(toFloat(properties.$ai_total_cost_usd)), 6) AS cost_usd,
             min(timestamp) AS started_at
-        FROM posthog.ai_events
+        FROM events
         WHERE equals(event, '$ai_generation')
             AND {product_filter}
             AND {email_filter}
@@ -547,7 +547,7 @@ def _fetch_top_traces(
         LIMIT {limit}
         """
     )
-    result = execute_with_ai_events_fallback(
+    result = execute_hogql_query(
         query=query,
         placeholders={
             "product_filter": _product_filter(product),
@@ -579,10 +579,15 @@ class PersonalSpendViewSet(viewsets.ViewSet):
     authenticated user's email (read off the events row via person-on-events) —
     callers cannot pivot to other users' data. Authorization model is "any
     authenticated PostHog user may read their own spend" via `user:read` (the
-    same scope that covers `/api/users/@me/`). Routes through
-    `execute_with_ai_events_fallback` so reads hit the
-    dedicated `ai_events` table when enabled, with the shared `events` table as
-    a fallback. Optionally filter tool / model / trace breakdowns to a single
+    same scope that covers `/api/users/@me/`). Queries the shared `events`
+    table directly — same pattern as the LLM Analytics "Users" tab and every
+    other person-property filter on AI events. The HogQL printer transparently
+    uses the materialized `pmat_email` column on the main cluster's `person`
+    table when it's registered, so there's no perf penalty vs the ai_events
+    satellite path; the WHERE clause hits the events table's sort key
+    (`team_id`, `event`, `timestamp`) before the person join fires. The
+    endpoint is also cached for 5 minutes per user. Optionally filter tool /
+    model / trace breakdowns to a single
     `ai_product` via the `product` query param; `by_product` always returns
     the full cross-product breakdown. The endpoint is only registered on US
     Cloud + dev/test envs; hobby / self-hosted deploys never see this URL;

--- a/products/llm_analytics/backend/api/test/__snapshots__/test_personal_spend.ambr
+++ b/products/llm_analytics/backend/api/test/__snapshots__/test_personal_spend.ambr
@@ -143,7 +143,7 @@
                                                     GROUP BY person.id
                                                     HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
   WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_generation', '$ai_embedding')), ifNull(equals(events__person.properties___email, 'user1@posthog.com'), 0), and(greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(events.timestamp, toDateTime64('today', 6, 'UTC'))))
-  GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_model'), ''), 'null'), '^"|"$', '')
+  GROUP BY model
   ORDER BY cost_usd DESC
   LIMIT 51 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -183,7 +183,7 @@
                                                     GROUP BY person.id
                                                     HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$ai_generation'), ifNull(equals(events__person.properties___email, 'user1@posthog.com'), 0), and(greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(events.timestamp, toDateTime64('today', 6, 'UTC'))))
-  GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')
+  GROUP BY trace_id
   ORDER BY cost_usd DESC
   LIMIT 51 SETTINGS readonly=2,
                     max_execution_time=60,

--- a/products/llm_analytics/backend/api/test/test_personal_spend.py
+++ b/products/llm_analytics/backend/api/test/test_personal_spend.py
@@ -310,7 +310,7 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
         assert response.json()["summary"]["total_cost_usd"] == 1.0
 
     def test_date_window_passes_through_to_query_layer(self) -> None:
-        with patch("products.llm_analytics.backend.api.personal_spend.execute_with_ai_events_fallback") as mock_exec:
+        with patch("products.llm_analytics.backend.api.personal_spend.execute_hogql_query") as mock_exec:
             mock_exec.return_value.results = []
             response = self.client.get(f"{ENDPOINT}?date_from=-7d")
 
@@ -319,7 +319,7 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
         assert mock_exec.call_count == 5
 
     def test_second_call_serves_from_cache(self) -> None:
-        with patch("products.llm_analytics.backend.api.personal_spend.execute_with_ai_events_fallback") as mock_exec:
+        with patch("products.llm_analytics.backend.api.personal_spend.execute_hogql_query") as mock_exec:
             mock_exec.return_value.results = []
             self.client.get(ENDPOINT)
             first = mock_exec.call_count
@@ -327,7 +327,7 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
             assert mock_exec.call_count == first
 
     def test_refresh_bypasses_cache(self) -> None:
-        with patch("products.llm_analytics.backend.api.personal_spend.execute_with_ai_events_fallback") as mock_exec:
+        with patch("products.llm_analytics.backend.api.personal_spend.execute_hogql_query") as mock_exec:
             mock_exec.return_value.results = []
             self.client.get(ENDPOINT)
             first = mock_exec.call_count
@@ -335,7 +335,7 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
             assert mock_exec.call_count == first * 2
 
     def test_cache_key_includes_date_from(self) -> None:
-        with patch("products.llm_analytics.backend.api.personal_spend.execute_with_ai_events_fallback") as mock_exec:
+        with patch("products.llm_analytics.backend.api.personal_spend.execute_hogql_query") as mock_exec:
             mock_exec.return_value.results = []
             self.client.get(f"{ENDPOINT}?date_from=-7d")
             first = mock_exec.call_count
@@ -343,7 +343,7 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
             assert mock_exec.call_count == first * 2
 
     def test_cache_key_includes_product(self) -> None:
-        with patch("products.llm_analytics.backend.api.personal_spend.execute_with_ai_events_fallback") as mock_exec:
+        with patch("products.llm_analytics.backend.api.personal_spend.execute_hogql_query") as mock_exec:
             mock_exec.return_value.results = []
             self.client.get(ENDPOINT)
             first = mock_exec.call_count
@@ -351,7 +351,7 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
             assert mock_exec.call_count == first * 2
 
     def test_cache_key_includes_limit(self) -> None:
-        with patch("products.llm_analytics.backend.api.personal_spend.execute_with_ai_events_fallback") as mock_exec:
+        with patch("products.llm_analytics.backend.api.personal_spend.execute_hogql_query") as mock_exec:
             mock_exec.return_value.results = []
             self.client.get(f"{ENDPOINT}?limit=10")
             first = mock_exec.call_count


### PR DESCRIPTION
## Problem

`/api/llm_analytics/@me/spend/` was 500'ing in production with:

```
DB::Exception: Identifier '__table5.pmat_email' cannot be resolved
```

The endpoint queries `ai_events` (the satellite ClickHouse cluster optimized for AI observability) joined to `person.properties.email`. The HogQL printer rewrites `person.properties.email` → `<person_table>.pmat_email` whenever the materialized column is registered on `person`. On the main cluster that's fine — the column exists. On the satellite cluster the `person` table is a Distributed shim back to the main cluster, and the shim's `extra_fields=""` declaration doesn't include any materialized columns. The column reference must parse locally before being forwarded — and the parse fails.

This is the first endpoint in the codebase to filter `ai_events` by `person.properties.<materialized_column>`. No other code path hits this shape, which is why the shim never declared `pmat_email`.

## Changes

Swap `FROM posthog.ai_events` for `FROM events` in all five `personal_spend` queries, and call `execute_hogql_query` directly. Drop the `execute_with_ai_events_fallback` indirection.

This is the same pattern every other person-property filter on AI events already uses — see [`products/llm_analytics/frontend/tabs/llmAnalyticsUsersLogic.ts`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/frontend/tabs/llmAnalyticsUsersLogic.ts) which queries `FROM events WHERE event = '$ai_generation' AND {filters}` for the LLM Analytics "Users" tab.

**No perf regression:** on the main cluster the HogQL printer transparently rewrites to `pmat_email` when registered, so this path benefits from the materialized column the same way `ai_events` would have. WHERE clauses align with the events sort key — `team_id`, `event`, `timestamp` lead the predicate before the person join fires (see snapshot in `test_personal_spend.ambr`). The endpoint stays cached for 5 minutes per user.

Companion PR #59534 (a ClickHouse migration to declare `pmat_email` on the satellite `person` shim) is no longer needed for this 500 — it can land later as part of the broader satellite-cluster materialize-column rollout the team-llma owns.

## How did you test this code?

Agent-authored — I'm an AI agent and did not perform manual testing. Automated tests run locally:

- `hogli test products/llm_analytics/backend/api/test/test_personal_spend.py` — all 40 tests pass, including the `@snapshot_clickhouse_queries`-decorated `test_empty_result_when_no_events` which captures all five generated SQL queries (summary, by_product, by_tool, by_model, top_traces) and confirms the WHERE shape leads with `events.team_id`, `events.event`, and `events.timestamp` before the person join.

The endpoint should be verified manually in production after merge by hitting `/api/llm_analytics/@me/spend/?date_from=-30d&product=posthog_code` with a `*` PAT (the original repro).

## Publish to changelog?

no

## 🤖 Agent context

Tool: Claude Code (PostHog Code harness).

Path the investigation took:

1. Initial diagnosis via the PostHog error-tracking MCP — found the 500 was a ClickHouse `Identifier '__table5.pmat_email' cannot be resolved` error, not an auth issue.
2. First attempt was to land #59534 — a ClickHouse migration adding the `pmat_email` shim column on the AI_EVENTS satellite cluster. Tests passed but the change had broader implications for the team-llma satellite-cluster story.
3. Second attempt added a `force_events_table=True` kwarg to the shared `execute_with_ai_events_fallback` helper. Rejected by the human reviewer on the grounds that the existing LLM Analytics UI already queries persons by email without any of this machinery — there must be a simpler pattern to follow.
4. Final approach (this PR) matches that pattern: query `events` directly, call `execute_hogql_query` directly, drop the indirection. Verified that the materialized-column rewrite still applies on the main cluster (no perf loss), and that the WHERE shape aligns with the events sort key.

Companion PR #59534 should be closed or held for the team-llma satellite-cluster work — it isn't needed to fix the 500.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*