### PR TITLE
feat(ui): persist tab UI state across browser restarts (#59648)

### DIFF
--- a/frontend/src/lib/logic/tabUiStateLogic.test.ts
+++ b/frontend/src/lib/logic/tabUiStateLogic.test.ts
@@ -3,6 +3,7 @@ import {
     TAB_UI_STATE_STORAGE_KEY,
     TAB_UI_STATE_STORAGE_VERSION,
     TAB_UI_STATE_TTL_MS,
+    clearPersistedTabUiState,
     readPersistedState,
     tabUiStateLogic,
 } from 'lib/logic/tabUiStateLogic'
@@ -276,27 +277,28 @@ describe('tabUiStateLogic', () => {
             })
         })
 
-        it('readPersistedState ignores payloads with wrong version', () => {
-            window.localStorage.setItem(
-                TAB_UI_STATE_STORAGE_KEY,
-                JSON.stringify({
-                    version: TAB_UI_STATE_STORAGE_VERSION + 1,
-                    updatedAt: Date.now(),
-                    state: { chatDraftsByTab: { [TAB_A]: 'stale' } },
-                })
-            )
-            expect(readPersistedState().chatDraftsByTab).toEqual({})
-        })
-
-        it('readPersistedState ignores payloads older than the TTL', () => {
-            window.localStorage.setItem(
-                TAB_UI_STATE_STORAGE_KEY,
-                JSON.stringify({
-                    version: TAB_UI_STATE_STORAGE_VERSION,
-                    updatedAt: Date.now() - TAB_UI_STATE_TTL_MS - 1,
-                    state: { chatDraftsByTab: { [TAB_A]: 'expired' } },
-                })
-            )
+        it.each([
+            [
+                'wrong version',
+                () =>
+                    JSON.stringify({
+                        version: TAB_UI_STATE_STORAGE_VERSION + 1,
+                        updatedAt: Date.now(),
+                        state: { chatDraftsByTab: { [TAB_A]: 'stale' } },
+                    }),
+            ],
+            [
+                'older than TTL',
+                () =>
+                    JSON.stringify({
+                        version: TAB_UI_STATE_STORAGE_VERSION,
+                        updatedAt: Date.now() - TAB_UI_STATE_TTL_MS - 1,
+                        state: { chatDraftsByTab: { [TAB_A]: 'expired' } },
+                    }),
+            ],
+            ['corrupt JSON', () => 'not-json{'],
+        ])('readPersistedState returns empty for payload with %s', (_label, makePayload) => {
+            window.localStorage.setItem(TAB_UI_STATE_STORAGE_KEY, makePayload())
             expect(readPersistedState().chatDraftsByTab).toEqual({})
         })
 
@@ -318,13 +320,7 @@ describe('tabUiStateLogic', () => {
             expect(restored.expandedRowsByTabAndVizKey[TAB_A][VIZ_KEY]).toEqual([1, 2])
         })
 
-        it('readPersistedState recovers from corrupt JSON', () => {
-            window.localStorage.setItem(TAB_UI_STATE_STORAGE_KEY, 'not-json{')
-            expect(readPersistedState().chatDraftsByTab).toEqual({})
-        })
-
         it('does not crash when localStorage.setItem throws (quota guard)', () => {
-            const original = window.localStorage.setItem.bind(window.localStorage)
             const spy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
                 throw new Error('QuotaExceededError')
             })
@@ -335,8 +331,21 @@ describe('tabUiStateLogic', () => {
             } finally {
                 spy.mockRestore()
                 warn.mockRestore()
-                window.localStorage.setItem = original
             }
+        })
+
+        it('clearPersistedTabUiState removes the storage key', () => {
+            window.localStorage.setItem(
+                TAB_UI_STATE_STORAGE_KEY,
+                JSON.stringify({
+                    version: TAB_UI_STATE_STORAGE_VERSION,
+                    updatedAt: Date.now(),
+                    state: { chatDraftsByTab: { [TAB_A]: 'secret' } },
+                })
+            )
+            clearPersistedTabUiState()
+            expect(window.localStorage.getItem(TAB_UI_STATE_STORAGE_KEY)).toBeNull()
+            expect(readPersistedState().chatDraftsByTab).toEqual({})
         })
     })
 })

--- a/frontend/src/lib/logic/tabUiStateLogic.test.ts
+++ b/frontend/src/lib/logic/tabUiStateLogic.test.ts
@@ -1,5 +1,11 @@
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { tabUiStateLogic } from 'lib/logic/tabUiStateLogic'
+import {
+    TAB_UI_STATE_STORAGE_KEY,
+    TAB_UI_STATE_STORAGE_VERSION,
+    TAB_UI_STATE_TTL_MS,
+    readPersistedState,
+    tabUiStateLogic,
+} from 'lib/logic/tabUiStateLogic'
 
 import { dataTableLogic } from '~/queries/nodes/DataTable/dataTableLogic'
 import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
@@ -19,6 +25,7 @@ const dataTableQuery: DataTableNode = setLatestVersionsOnQuery({
 
 describe('tabUiStateLogic', () => {
     beforeEach(() => {
+        window.localStorage.clear()
         initKeaTests()
         featureFlagLogic.mount()
         tabUiStateLogic.mount()
@@ -227,6 +234,109 @@ describe('tabUiStateLogic', () => {
 
             expect(tabUiStateLogic.values.chatDraftFor(TAB_A)).toBe('')
             expect(tabUiStateLogic.values.chatDraftFor(TAB_B)).toBe('two')
+        })
+    })
+
+    describe('localStorage persistence', () => {
+        function readEnvelope(): { version: number; updatedAt: number; state: Record<string, any> } | null {
+            const raw = window.localStorage.getItem(TAB_UI_STATE_STORAGE_KEY)
+            return raw ? JSON.parse(raw) : null
+        }
+
+        it('writes a versioned, timestamped envelope on each mutating action', () => {
+            const before = Date.now()
+            tabUiStateLogic.actions.setChatDraftForTab(TAB_A, 'rozepsano')
+            const after = Date.now()
+
+            const env = readEnvelope()
+            expect(env).not.toBeNull()
+            expect(env!.version).toBe(TAB_UI_STATE_STORAGE_VERSION)
+            expect(env!.updatedAt).toBeGreaterThanOrEqual(before)
+            expect(env!.updatedAt).toBeLessThanOrEqual(after)
+            expect(env!.state.chatDraftsByTab[TAB_A]).toBe('rozepsano')
+        })
+
+        it('refreshes updatedAt on every write', async () => {
+            tabUiStateLogic.actions.setChatDraftForTab(TAB_A, 'one')
+            const first = readEnvelope()!.updatedAt
+
+            await new Promise((r) => setTimeout(r, 5))
+            tabUiStateLogic.actions.setChatDraftForTab(TAB_A, 'two')
+            const second = readEnvelope()!.updatedAt
+
+            expect(second).toBeGreaterThan(first)
+        })
+
+        it('readPersistedState returns empty for missing payload', () => {
+            window.localStorage.clear()
+            expect(readPersistedState()).toEqual({
+                expandedRowsByTabAndVizKey: {},
+                savedQueriesByTabAndScene: {},
+                chatDraftsByTab: {},
+            })
+        })
+
+        it('readPersistedState ignores payloads with wrong version', () => {
+            window.localStorage.setItem(
+                TAB_UI_STATE_STORAGE_KEY,
+                JSON.stringify({
+                    version: TAB_UI_STATE_STORAGE_VERSION + 1,
+                    updatedAt: Date.now(),
+                    state: { chatDraftsByTab: { [TAB_A]: 'stale' } },
+                })
+            )
+            expect(readPersistedState().chatDraftsByTab).toEqual({})
+        })
+
+        it('readPersistedState ignores payloads older than the TTL', () => {
+            window.localStorage.setItem(
+                TAB_UI_STATE_STORAGE_KEY,
+                JSON.stringify({
+                    version: TAB_UI_STATE_STORAGE_VERSION,
+                    updatedAt: Date.now() - TAB_UI_STATE_TTL_MS - 1,
+                    state: { chatDraftsByTab: { [TAB_A]: 'expired' } },
+                })
+            )
+            expect(readPersistedState().chatDraftsByTab).toEqual({})
+        })
+
+        it('readPersistedState accepts fresh payloads within the TTL', () => {
+            window.localStorage.setItem(
+                TAB_UI_STATE_STORAGE_KEY,
+                JSON.stringify({
+                    version: TAB_UI_STATE_STORAGE_VERSION,
+                    updatedAt: Date.now() - 1000,
+                    state: {
+                        expandedRowsByTabAndVizKey: { [TAB_A]: { [VIZ_KEY]: [1, 2] } },
+                        savedQueriesByTabAndScene: {},
+                        chatDraftsByTab: { [TAB_A]: 'fresh' },
+                    },
+                })
+            )
+            const restored = readPersistedState()
+            expect(restored.chatDraftsByTab[TAB_A]).toBe('fresh')
+            expect(restored.expandedRowsByTabAndVizKey[TAB_A][VIZ_KEY]).toEqual([1, 2])
+        })
+
+        it('readPersistedState recovers from corrupt JSON', () => {
+            window.localStorage.setItem(TAB_UI_STATE_STORAGE_KEY, 'not-json{')
+            expect(readPersistedState().chatDraftsByTab).toEqual({})
+        })
+
+        it('does not crash when localStorage.setItem throws (quota guard)', () => {
+            const original = window.localStorage.setItem.bind(window.localStorage)
+            const spy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+                throw new Error('QuotaExceededError')
+            })
+            const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+            try {
+                expect(() => tabUiStateLogic.actions.setChatDraftForTab(TAB_A, 'x')).not.toThrow()
+                expect(tabUiStateLogic.values.chatDraftFor(TAB_A)).toBe('x')
+            } finally {
+                spy.mockRestore()
+                warn.mockRestore()
+                window.localStorage.setItem = original
+            }
         })
     })
 })

--- a/frontend/src/lib/logic/tabUiStateLogic.ts
+++ b/frontend/src/lib/logic/tabUiStateLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, path, reducers, selectors } from 'kea'
+import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 
 import type { Node } from '~/queries/schema/schema-general'
 
@@ -6,9 +6,109 @@ import type { tabUiStateLogicType } from './tabUiStateLogicType'
 
 const NO_TAB = '__no_tab__'
 
+export const TAB_UI_STATE_STORAGE_KEY = 'ph_tab_ui_state'
+// Bump when PersistedShape changes in a backwards-incompatible way (renamed/removed
+// key, changed value type). Old payloads are discarded on read — no migration needed.
+export const TAB_UI_STATE_STORAGE_VERSION = 1
+export const TAB_UI_STATE_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
 export type ExpandedRowsByTabAndVizKey = Record<string, Record<string, number[]>>
 export type SavedQueriesByTabAndScene = Record<string, Record<string, Node>>
 export type ChatDraftsByTab = Record<string, string>
+
+// 🚨 Changing this shape (rename/remove key, change a value type) requires
+// bumping TAB_UI_STATE_STORAGE_VERSION so stale payloads in user browsers
+// are discarded on read instead of crashing consumers.
+type PersistedShape = {
+    expandedRowsByTabAndVizKey: ExpandedRowsByTabAndVizKey
+    savedQueriesByTabAndScene: SavedQueriesByTabAndScene
+    chatDraftsByTab: ChatDraftsByTab
+}
+
+type PersistedEnvelope = {
+    version: number
+    updatedAt: number
+    state: PersistedShape
+}
+
+const EMPTY_PERSISTED: PersistedShape = {
+    expandedRowsByTabAndVizKey: {},
+    savedQueriesByTabAndScene: {},
+    chatDraftsByTab: {},
+}
+
+function getStorage(): Storage | null {
+    try {
+        if (typeof window === 'undefined') {
+            return null
+        }
+        return window.localStorage
+    } catch {
+        return null
+    }
+}
+
+export function readPersistedState(): PersistedShape {
+    const storage = getStorage()
+    if (!storage) {
+        return EMPTY_PERSISTED
+    }
+    let raw: string | null
+    try {
+        raw = storage.getItem(TAB_UI_STATE_STORAGE_KEY)
+    } catch {
+        return EMPTY_PERSISTED
+    }
+    if (!raw) {
+        return EMPTY_PERSISTED
+    }
+    let parsed: PersistedEnvelope
+    try {
+        parsed = JSON.parse(raw) as PersistedEnvelope
+    } catch {
+        return EMPTY_PERSISTED
+    }
+    if (
+        !parsed ||
+        typeof parsed !== 'object' ||
+        parsed.version !== TAB_UI_STATE_STORAGE_VERSION ||
+        typeof parsed.updatedAt !== 'number' ||
+        Date.now() - parsed.updatedAt > TAB_UI_STATE_TTL_MS ||
+        !parsed.state ||
+        typeof parsed.state !== 'object'
+    ) {
+        return EMPTY_PERSISTED
+    }
+    return {
+        expandedRowsByTabAndVizKey: parsed.state.expandedRowsByTabAndVizKey ?? {},
+        savedQueriesByTabAndScene: parsed.state.savedQueriesByTabAndScene ?? {},
+        chatDraftsByTab: parsed.state.chatDraftsByTab ?? {},
+    }
+}
+
+let writeWarned = false
+
+function writePersistedState(state: PersistedShape): void {
+    const storage = getStorage()
+    if (!storage) {
+        return
+    }
+    const envelope: PersistedEnvelope = {
+        version: TAB_UI_STATE_STORAGE_VERSION,
+        updatedAt: Date.now(),
+        state,
+    }
+    try {
+        storage.setItem(TAB_UI_STATE_STORAGE_KEY, JSON.stringify(envelope))
+    } catch (error) {
+        if (!writeWarned) {
+            writeWarned = true
+            console.warn('[tabUiStateLogic] failed to persist tab UI state', error)
+        }
+    }
+}
+
+const INITIAL_PERSISTED = readPersistedState()
 
 export const tabUiStateLogic = kea<tabUiStateLogicType>([
     path(['lib', 'logic', 'tabUiStateLogic']),
@@ -31,7 +131,7 @@ export const tabUiStateLogic = kea<tabUiStateLogicType>([
     }),
     reducers({
         expandedRowsByTabAndVizKey: [
-            {} as ExpandedRowsByTabAndVizKey,
+            INITIAL_PERSISTED.expandedRowsByTabAndVizKey as ExpandedRowsByTabAndVizKey,
             {
                 toggleExpandedRow: (state, { tabId, vizKey, rowIndex }) => {
                     const tabState = state[tabId] ?? {}
@@ -52,7 +152,7 @@ export const tabUiStateLogic = kea<tabUiStateLogicType>([
             },
         ],
         savedQueriesByTabAndScene: [
-            {} as SavedQueriesByTabAndScene,
+            INITIAL_PERSISTED.savedQueriesByTabAndScene as SavedQueriesByTabAndScene,
             {
                 setSavedQueryForTab: (state, { tabId, sceneKey, query }) => {
                     if (query === null) {
@@ -86,7 +186,7 @@ export const tabUiStateLogic = kea<tabUiStateLogicType>([
             },
         ],
         chatDraftsByTab: [
-            {} as ChatDraftsByTab,
+            INITIAL_PERSISTED.chatDraftsByTab as ChatDraftsByTab,
             {
                 setChatDraftForTab: (state, { tabId, draft }) => {
                     if (draft === '') {
@@ -109,6 +209,21 @@ export const tabUiStateLogic = kea<tabUiStateLogicType>([
                 },
             },
         ],
+    }),
+    listeners(({ values }) => {
+        const persist = (): void => {
+            writePersistedState({
+                expandedRowsByTabAndVizKey: values.expandedRowsByTabAndVizKey,
+                savedQueriesByTabAndScene: values.savedQueriesByTabAndScene,
+                chatDraftsByTab: values.chatDraftsByTab,
+            })
+        }
+        return {
+            toggleExpandedRow: persist,
+            clearTabUiState: persist,
+            setSavedQueryForTab: persist,
+            setChatDraftForTab: persist,
+        }
     }),
     selectors({
         expandedRowsFor: [

--- a/frontend/src/lib/logic/tabUiStateLogic.ts
+++ b/frontend/src/lib/logic/tabUiStateLogic.ts
@@ -86,6 +86,18 @@ export function readPersistedState(): PersistedShape {
     }
 }
 
+export function clearPersistedTabUiState(): void {
+    const storage = getStorage()
+    if (!storage) {
+        return
+    }
+    try {
+        storage.removeItem(TAB_UI_STATE_STORAGE_KEY)
+    } catch {
+        // ignore — best-effort cleanup
+    }
+}
+
 let writeWarned = false
 
 function writePersistedState(state: PersistedShape): void {

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -8,6 +8,7 @@ import api, { getCookie } from 'lib/api'
 import { DashboardCompatibleScenes } from 'lib/components/SceneDashboardChoice/sceneDashboardChoiceModalLogic'
 // eslint-disable-next-line import/no-cycle
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { clearPersistedTabUiState } from 'lib/logic/tabUiStateLogic'
 import { getAppContext } from 'lib/utils/getAppContext'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
@@ -261,6 +262,7 @@ export const userLogic = kea<userLogicType>([
             }
             cache.loggingOut = true
             posthog.reset()
+            clearPersistedTabUiState()
 
             const form = document.createElement('form')
             form.method = 'POST'


### PR DESCRIPTION
  Closes #59648
  Follow-up to #58224.

  ## Problem

  `tabUiStateLogic` (from #58224) holds Max chat drafts, expanded DataTable rows, and the per-tab saved query fallback in memory only. Hard refresh or browser restart wipes it. The previous PR fixed tab-switch loss; this PR covers refresh and restart.

  Scope note: filters in Events/Sessions already survive refresh via `tabAwareActionToUrl` in `eventsSceneLogic.tsx` and `sessionsSceneLogic.tsx`. This PR doesn't touch that. What it adds persistence for: chat drafts, expanded rows, and the `savedQueriesByTabAndScene` fallback used when navigation arrives without `?q`.

  ## Changes

  - Single localStorage key `ph_tab_ui_state` holding `{ version, updatedAt, state }`. One blob, not per-tab keys.
  - 30-day TTL. `updatedAt` is rewritten on every state change, so an active user never expires.
  - Lazy expire on read: if `now - updatedAt > TTL`, version mismatches, or JSON is corrupt, `readPersistedState()` returns empty and the next write overwrites.
  - Schema versioning via `TAB_UI_STATE_STORAGE_VERSION`. Bump when `PersistedShape` changes incompatibly; stale payloads are discarded on read. Comment placed on both the constant and the type as a reminder.
  - Writes wrapped in try/catch. On `QuotaExceededError`: skip, `console.warn` once per session, don't crash the UI.
  - Synchronous hydration in kea reducer `defaults` so the first render sees the restored state; no rehydrate flicker.
  - SSR / private-mode safe: `getStorage()` returns `null` if `window` is undefined or `localStorage` access throws.
  - Persistence is triggered by a kea `listeners` block on each mutating action (`toggleExpandedRow`, `clearTabUiState`, `setSavedQueryForTab`, `setChatDraftForTab`), which writes the full blob.

  ## How did you test this code?

  Manual against a local dev stack (see screen recording below):

https://github.com/user-attachments/assets/03875275-2681-423b-a8c7-31d0f48d5db9

  8 new unit tests cover envelope shape, `updatedAt` refresh, version mismatch, TTL expiry, fresh hydration, corrupt-JSON recovery, and quota guard. All jests passed.

  ## Open for feedback

  Two trade-offs worth checking out:

  - **Per-user namespacing (`ph_tab_ui_state__${userId}`): skipped.** This means on a shared workstation, the next user logging in sees the previous user's tab state, including any half-written Max chat draft, which could contain sensitive context (eg. customer names...). I skipped it because resolving `userId` before the first read defeats synchronous hydration, and shared workstations aren't a typical PostHog use case. But this is an explicit trade-off rather than a non-issue, if the team thinks it's the wrong call, I'm happy to add namespacing and accept the hydration cost.
  - **Cross-tab live sync: skipped.** Two browser tabs share the key, last write wins on reload. Live sync via the `storage` event would need merge rules and wasn't in the original spec, feels like overkill.

  ## Publish to changelog?

  do not publish to changelog

  ## Docs update

  skip-inkeep-docs

  ## 🤖 Agent context

  Used Claude Code while implementing this:

  - Located `tabUiStateLogic` and its consumers (`dataTableLogic`, `eventsSceneLogic`, `sessionsSceneLogic`, `maxLogic`, `aiFirstHomepageLogic`) to scope the change.
  - Scaffolded `readPersistedState` / `writePersistedState`, the envelope shape, version + TTL constants, the `listeners` wiring, and the 8 persistence unit tests.
  - Considered and rejected: runtime schema validation via zod (overkill for a 3-field shallow state, manual `TAB_UI_STATE_STORAGE_VERSION` bump is the cheaper trade-off, with a reminder comment).

  Note on types: same as #58224 – `tabUiStateLogicType.ts` is unchanged because `listeners` don't affect the generated signature. Re-running `pnpm kea-typegen` on a clean Node 24 setup should produce identical output.