### PR TITLE
feat(web-analytics): add lazy precompute rollout metrics

### DIFF
--- a/products/web_analytics/backend/hogql_queries/test/test_web_analytics_metrics.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_analytics_metrics.py
@@ -12,6 +12,12 @@ from products.web_analytics.backend.hogql_queries.metrics import (
     WEB_ANALYTICS_QUERY_DURATION,
     WEB_ANALYTICS_QUERY_ERRORS,
 )
+from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute import (
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK,
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_REJECTED,
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS,
+    can_use_lazy_precompute,
+)
 from products.web_analytics.backend.hogql_queries.web_analytics_query_runner import WebAnalyticsQueryRunner
 
 
@@ -77,6 +83,9 @@ class TestWebAnalyticsMetrics(TestCase):
         WEB_ANALYTICS_QUERY_COUNTER._metrics.clear()
         WEB_ANALYTICS_QUERY_DURATION._metrics.clear()
         WEB_ANALYTICS_QUERY_ERRORS._metrics.clear()
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_REJECTED._metrics.clear()
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK._metrics.clear()
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS._metrics.clear()
 
     @parameterized.expand(
         [
@@ -290,6 +299,85 @@ class TestWebAnalyticsMetrics(TestCase):
             )
             == 1.0
         )
+
+    @parameterized.expand(
+        [
+            ("web_overview", "web_overview"),
+            ("web_stats", "web_stats"),
+        ]
+    )
+    def test_lazy_precompute_gate_rejection_increments_counter(self, _name, family):
+        runner = MagicMock()
+        runner.team = MagicMock(pk=42, uuid="00000000-0000-0000-0000-000000000000", organization_id=7, id=42)
+        runner.query = MagicMock(useWebAnalyticsPrecompute=True)
+
+        with patch(
+            "products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            assert can_use_lazy_precompute(runner, log_prefix=family) is False
+
+        assert (
+            _get_counter_value(
+                WEB_ANALYTICS_LAZY_PRECOMPUTE_REJECTED,
+                {"family": family, "reason": "OrgFeatureFlagDisabled"},
+            )
+            == 1.0
+        )
+
+    def test_lazy_precompute_per_query_opt_in_not_set_rejection(self):
+        runner = MagicMock()
+        runner.team = MagicMock(pk=42, uuid="00000000-0000-0000-0000-000000000000", organization_id=7, id=42)
+        runner.query = MagicMock(useWebAnalyticsPrecompute=False)
+
+        with patch(
+            "products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute.posthoganalytics.feature_enabled",
+            return_value=True,
+        ):
+            assert can_use_lazy_precompute(runner, log_prefix="web_overview") is False
+
+        assert (
+            _get_counter_value(
+                WEB_ANALYTICS_LAZY_PRECOMPUTE_REJECTED,
+                {"family": "web_overview", "reason": "PerQueryOptInNotSet"},
+            )
+            == 1.0
+        )
+
+    @parameterized.expand(
+        [
+            ("empty_range",),
+            ("no_job_ids",),
+            ("current_not_ready",),
+            ("previous_not_ready",),
+        ]
+    )
+    def test_lazy_precompute_fallback_counter_label_space(self, reason):
+        # Verifies the metric accepts each `reason` value the lazy modules emit.
+        # Integration coverage of the actual call sites lives in the per-runner
+        # lazy precompute tests; this test is a fast guard against label drift.
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family="web_overview", reason=reason).inc()
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family="web_stats", reason=reason).inc()
+
+        assert (
+            _get_counter_value(
+                WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK,
+                {"family": "web_overview", "reason": reason},
+            )
+            == 1.0
+        )
+        assert (
+            _get_counter_value(
+                WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK,
+                {"family": "web_stats", "reason": reason},
+            )
+            == 1.0
+        )
+
+    @parameterized.expand([("web_overview",), ("web_stats",)])
+    def test_lazy_precompute_success_counter_label_space(self, family):
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS.labels(family=family).inc()
+        assert _get_counter_value(WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS, {"family": family}) == 1.0
 
     @patch(
         "products.web_analytics.backend.hogql_queries.web_analytics_query_runner.get_query_tag_value", return_value=None

--- a/products/web_analytics/backend/hogql_queries/test/test_web_analytics_metrics.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_analytics_metrics.py
@@ -325,7 +325,13 @@ class TestWebAnalyticsMetrics(TestCase):
             == 1.0
         )
 
-    def test_lazy_precompute_per_query_opt_in_not_set_rejection(self):
+    @parameterized.expand(
+        [
+            ("web_overview", "web_overview"),
+            ("web_stats", "web_stats"),
+        ]
+    )
+    def test_lazy_precompute_per_query_opt_in_not_set_rejection(self, _name, family):
         runner = MagicMock()
         runner.team = MagicMock(pk=42, uuid="00000000-0000-0000-0000-000000000000", organization_id=7, id=42)
         runner.query = MagicMock(useWebAnalyticsPrecompute=False)
@@ -334,12 +340,12 @@ class TestWebAnalyticsMetrics(TestCase):
             "products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute.posthoganalytics.feature_enabled",
             return_value=True,
         ):
-            assert can_use_lazy_precompute(runner, log_prefix="web_overview") is False
+            assert can_use_lazy_precompute(runner, log_prefix=family) is False
 
         assert (
             _get_counter_value(
                 WEB_ANALYTICS_LAZY_PRECOMPUTE_REJECTED,
-                {"family": "web_overview", "reason": "PerQueryOptInNotSet"},
+                {"family": family, "reason": "PerQueryOptInNotSet"},
             )
             == 1.0
         )

--- a/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
@@ -14,6 +14,7 @@ from typing import Optional, Protocol, Union
 
 import structlog
 import posthoganalytics
+from prometheus_client import Counter
 
 from posthog.schema import EventPropertyFilter, PropertyOperator, WebOverviewQuery, WebStatsTableQuery
 
@@ -24,6 +25,33 @@ from posthog.hogql.transforms.preaggregated_table_transformation import is_integ
 from posthog.models.team import Team
 
 logger = structlog.get_logger(__name__)
+
+
+# Counts requests refused by `can_use_lazy_precompute`. `family` is the
+# `log_prefix` (`web_overview` / `web_stats`); `reason` is the
+# `LazyPrecomputeIneligible` subclass name. Together with `_fallback_total`
+# and `_success_total`, callers can compute lazy adoption per family.
+WEB_ANALYTICS_LAZY_PRECOMPUTE_REJECTED = Counter(
+    "web_analytics_lazy_precompute_rejected_total",
+    "Requests refused by the lazy precompute gate, by family and rejection reason.",
+    ["family", "reason"],
+)
+
+# Counts requests that passed the gate but couldn't be served from precompute
+# (window empty, no jobs created, current/previous period not yet READY). The
+# caller falls back to the raw / v2 path on each of these.
+WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK = Counter(
+    "web_analytics_lazy_precompute_fallback_total",
+    "Lazy precompute fall-throughs after the gate accepted, by family and reason.",
+    ["family", "reason"],
+)
+
+# Counts requests where the lazy path successfully returned a precomputed row.
+WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS = Counter(
+    "web_analytics_lazy_precompute_success_total",
+    "Requests served from the lazy precompute path, by family.",
+    ["family"],
+)
 
 # Bucketing the precompute hourly keeps reads correct for any whole-hour-offset
 # timezone — boundaries line up exactly when the team-local window is converted
@@ -169,10 +197,12 @@ def can_use_lazy_precompute(
         if extra_check is not None:
             extra_check(runner)
     except LazyPrecomputeIneligible as exc:
+        reason = type(exc).__name__
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_REJECTED.labels(family=log_prefix, reason=reason).inc()
         logger.info(
             f"{log_prefix}_lazy_precompute_rejected",
             team_id=runner.team.pk,
-            reason=type(exc).__name__,
+            reason=reason,
             detail=str(exc) or None,
         )
         return False

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -21,6 +21,8 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
 from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute import (
     LAZY_TTL_SECONDS,
     SESSION_FORWARD_PAD_MINUTES,
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK,
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS,
     can_use_lazy_precompute as _can_use_lazy_precompute_shared,
     ceil_utc_day,
     check_common_eligible,
@@ -29,6 +31,8 @@ from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute 
     test_account_filter_expr,
     user_filter_expr,
 )
+
+_FAMILY = "web_overview"
 
 if TYPE_CHECKING:
     from products.web_analytics.backend.hogql_queries.web_overview import WebOverviewQueryRunner
@@ -231,6 +235,7 @@ def execute_lazy_precomputed_read(
         time_range_end = ceil_utc_day(current_end_utc)
 
         if time_range_start >= time_range_end:
+            WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="empty_range").inc()
             logger.info(
                 "web_overview_lazy_precompute_empty_range",
                 team_id=team_id,
@@ -263,9 +268,11 @@ def execute_lazy_precomputed_read(
         )
 
         if not result.job_ids:
+            WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="no_job_ids").inc()
             return None
 
         if not result.ready:
+            WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="current_not_ready").inc()
             logger.info(
                 "web_overview_lazy_precompute_current_not_ready",
                 team_id=team_id,
@@ -300,6 +307,7 @@ def execute_lazy_precomputed_read(
                     ensure_duration_ms += int((time.perf_counter() - prev_ensure_started) * 1000)
 
                     if not prev_result.ready:
+                        WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="previous_not_ready").inc()
                         logger.info(
                             "web_overview_lazy_precompute_previous_not_ready",
                             team_id=team_id,
@@ -321,6 +329,7 @@ def execute_lazy_precomputed_read(
         read_duration_ms = int((time.perf_counter() - read_started) * 1000)
         total_duration_ms = int((time.perf_counter() - overall_started) * 1000)
 
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS.labels(family=_FAMILY).inc()
         logger.info(
             "web_overview_lazy_precompute_completed",
             team_id=team_id,

--- a/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
@@ -23,6 +23,8 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
 from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute import (
     LAZY_TTL_SECONDS,
     SESSION_FORWARD_PAD_MINUTES,
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK,
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS,
     LazyPrecomputeIneligible,
     LazyPrecomputeRunner,
     can_use_lazy_precompute as _can_use_lazy_precompute_shared,
@@ -32,6 +34,8 @@ from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute 
     test_account_filter_expr,
     user_filter_expr,
 )
+
+_FAMILY = "web_stats"
 
 if TYPE_CHECKING:
     from products.web_analytics.backend.hogql_queries.stats_table import WebStatsTableQueryRunner
@@ -368,6 +372,7 @@ def execute_lazy_precomputed_read(
         time_range_end = ceil_utc_day(current_end_utc)
 
         if time_range_start >= time_range_end:
+            WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="empty_range").inc()
             logger.info(
                 "web_stats_lazy_precompute_empty_range",
                 team_id=team_id,
@@ -392,6 +397,7 @@ def execute_lazy_precomputed_read(
         )
 
         if not result.job_ids:
+            WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="no_job_ids").inc()
             logger.info(
                 "web_stats_lazy_precompute_no_job_ids",
                 team_id=team_id,
@@ -400,6 +406,7 @@ def execute_lazy_precomputed_read(
             return None
 
         if not result.ready:
+            WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="current_not_ready").inc()
             logger.info(
                 "web_stats_lazy_precompute_current_not_ready",
                 team_id=team_id,
@@ -438,6 +445,7 @@ def execute_lazy_precomputed_read(
                     )
 
                     if not prev_result.ready:
+                        WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="previous_not_ready").inc()
                         logger.info(
                             "web_stats_lazy_precompute_previous_not_ready",
                             team_id=team_id,
@@ -456,6 +464,7 @@ def execute_lazy_precomputed_read(
             previous_end_utc=previous_end_utc,
         )
 
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS.labels(family=_FAMILY).inc()
         logger.info(
             "web_stats_lazy_precompute_completed",
             team_id=team_id,


### PR DESCRIPTION
## Problem

The lazy precompute path (PR #59075) currently has one Prometheus metric: `web_overview_lazy_precompute_failed_total` (and the stats equivalent). Everything else about lazy adoption — gate rejections, eligible-but-cache-miss fall-throughs, successful serves — is logged but not counted.

That makes it impossible to answer rollout-health questions like "why isn't team X seeing lazy?" or "what % of eligible requests are still falling back to the raw path?" from Grafana without log diving. The Web Analytics — Query Performance and Preaggregation module — queue health dashboards already have placeholder space for these signals.

## Changes

Three new Prometheus counters in `web_analytics_lazy_precompute.py` (the shared module), each labelled by `family` (`web_overview` / `web_stats`):

- `web_analytics_lazy_precompute_rejected_total{family, reason}` — fires once per gate rejection; `reason` is the `LazyPrecomputeIneligible` subclass name (`OrgFeatureFlagDisabled`, `PerQueryOptInNotSet`, `NonIntegerTimezone`, `TooManyFilters`, …).
- `web_analytics_lazy_precompute_fallback_total{family, reason}` — fires when the gate accepted but the cache couldn't serve. `reason` is one of `empty_range` / `no_job_ids` / `current_not_ready` / `previous_not_ready`.
- `web_analytics_lazy_precompute_success_total{family}` — fires when a precomputed row is actually returned.

Wired into both `web_overview_lazy_precompute.py` and `web_stats_lazy_precompute.py` next to the existing structured log lines, so every existing log event has a matching counter.

Together with the existing `_failed_total` counter, callers can compute the lazy serving rate per family directly from Prometheus:

\`success / (success + fallback + rejected + failed)\`

## How did you test this code?

I'm an agent. Tests run locally:

- \`hogli test products/web_analytics/backend/hogql_queries/test/test_web_analytics_metrics.py\` — 44 passed (9 new cases covering rejection counter via the real gate function, per-query opt-in rejection, and fallback/success label-space guards).
- \`hogli test products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py\` — 66 passed, 2 skipped (no regressions in the existing lazy precompute integration tests).
- \`ruff format\` + \`ruff check --fix\` clean.

No production traffic exercised.

## Publish to changelog?

no

## Docs update

No.

## 🤖 Agent context

- Tooling: Claude Code with the Grafana MCP for dashboard work and the Explore subagent for the source audit.
- Decision trail:
  - I started by considering a single \`compute_path\` label on the existing counters and a per-CH-operation emission scheme; both were rejected after feedback that we should ship dashboards first and instrument from data. Reverted both attempts and built two Grafana dashboards instead (\`Web Analytics — Query Performance\` and \`Preaggregation module — queue health\`).
  - Those dashboards exposed concrete gaps: gate rejections were invisible, the four "lazy didn't serve" branches were each a silent fallback, and there was no Prometheus-native success counter to compute serving rate.
  - Considered Loki-only solutions (the structured logs already carry every signal). Decided counters are worth it because they remove dashboard reliance on log aggregation, and the cardinality is tiny (\`family × reason\` ≤ ~30 series total).
  - Considered adding ensure/read duration histograms but skipped them — \`system.query_log\` already covers \`web_overview_lazy_insert\` durations and Loki's \`insert_duration_ms\` covers the cross-table case at low cost.
- Other observability gaps the audit surfaced but this PR intentionally skips: cache warmer failure counter, sampling-enabled label on the main metric, notable changes preagg fallback metric, empty-row-result detection. Each is a small follow-up.
- Branch is stacked on \`feat/web-stats-lazy-precompute\` because the shared module \`web_analytics_lazy_precompute.py\` lives there; rebase onto master once the parent merges.