### PR TITLE
fix(workflows): search in batch invocations no longer collapses group

### DIFF
--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
@@ -38,8 +38,9 @@ export type LogsViewerLogicProps = {
     groupByInstanceId?: boolean
     searchGroups?: string[]
     defaultFilters?: Partial<LogEntryParams>
-    /** When false, filter state is not synced to URL params. Use when LogsViewer is embedded inside
-     * another component (e.g. a collapsible panel) to prevent URL changes from resetting parent state. */
+    /** When false, disables two-way URL sync: filter/grouping state is neither written to URL params
+     * nor initialized from them. Use when LogsViewer is embedded inside another component (e.g. a
+     * collapsible panel) to prevent URL changes from resetting parent state. */
     syncToUrl?: boolean
 }
 
@@ -577,6 +578,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         // Disposables handle cleanup automatically
     }),
     actionToUrl(({ values, props }) => {
+        const shouldSyncToUrl = props.syncToUrl !== false
         const syncProperties = (
             properties: Record<string, any>
         ): [string, Record<string, any>, Record<string, any>] => {
@@ -590,8 +592,8 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         }
 
         return {
-            setFilters: ({ filters }) => (props.syncToUrl === false ? undefined : syncProperties(filters)),
-            setIsGrouped: () => (props.syncToUrl === false ? undefined : syncProperties({ grouped: values.isGrouped })),
+            setFilters: ({ filters }) => (shouldSyncToUrl ? syncProperties(filters) : undefined),
+            setIsGrouped: () => (shouldSyncToUrl ? syncProperties({ grouped: values.isGrouped }) : undefined),
         }
     }),
     urlToAction(({ actions, values, props }) => ({

--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
@@ -38,6 +38,9 @@ export type LogsViewerLogicProps = {
     groupByInstanceId?: boolean
     searchGroups?: string[]
     defaultFilters?: Partial<LogEntryParams>
+    /** When false, filter state is not synced to URL params. Use when LogsViewer is embedded inside
+     * another component (e.g. a collapsible panel) to prevent URL changes from resetting parent state. */
+    syncToUrl?: boolean
 }
 
 export type LogsViewerFilters = {
@@ -573,7 +576,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
     beforeUnmount(() => {
         // Disposables handle cleanup automatically
     }),
-    actionToUrl(({ values }) => {
+    actionToUrl(({ values, props }) => {
         const syncProperties = (
             properties: Record<string, any>
         ): [string, Record<string, any>, Record<string, any>] => {
@@ -587,12 +590,15 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         }
 
         return {
-            setFilters: ({ filters }) => syncProperties(filters),
-            setIsGrouped: () => syncProperties({ grouped: values.isGrouped }),
+            setFilters: ({ filters }) => (props.syncToUrl === false ? undefined : syncProperties(filters)),
+            setIsGrouped: () => (props.syncToUrl === false ? undefined : syncProperties({ grouped: values.isGrouped })),
         }
     }),
-    urlToAction(({ actions, values }) => {
-        const reactToTabChange = (_: any, search: Record<string, any>): void => {
+    urlToAction(({ actions, values, props }) => ({
+        '*': (_: any, search: Record<string, any>): void => {
+            if (props.syncToUrl === false) {
+                return
+            }
             Object.keys(search).forEach((key) => {
                 if (key in values.filters && search[key] !== values.filters[key as keyof LogsViewerFilters]) {
                     actions.setFilters({ [key]: search[key] })
@@ -602,10 +608,6 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             if (typeof search.grouped === 'boolean' && search.grouped !== values.isGrouped) {
                 actions.setIsGrouped(search.grouped)
             }
-        }
-
-        return {
-            '*': reactToTabChange,
-        }
-    }),
+        },
+    })),
 ])

--- a/products/workflows/frontend/Workflows/WorkflowLogs.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowLogs.tsx
@@ -80,6 +80,7 @@ function BatchRunInfo({ job }: { job: HogFlowBatchJob }): JSX.Element {
                 groupByInstanceId
                 instanceLabel="workflow job"
                 renderMessage={(m) => renderWorkflowLogMessage(workflow, m)}
+                syncToUrl={false}
             />
         </div>
     )


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Closes #59403 

Users on the batch workflow Invocations tab who expanded a job group and typed in the log search box would see the group collapse immediately after the first keystroke, making search completely unusable.

**Root cause:** `logsViewerLogic` syncs its filter state (search, levels, date range) to URL search params via `actionToUrl`/`urlToAction`. When embedded inside a `LemonCollapse` panel, typing triggered a URL push. The
`urlToAction` handler compared the `levels` array by reference — not by value — so it was always seen as changed, creating a dispatch loop. Each iteration pushed a new URL, causing `WorkflowScene` (which subscribes to `router.searchParams`) to re-render. The cascade of rapid re-renders reset `LemonCollapse`'s internal `useState` that tracks the open panel, collapsing it.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Added a `syncToUrl` prop to `LogsViewerLogicProps` (defaults to `true`, preserving existing behaviour everywhere else). When `false`, the `actionToUrl` and `urlToAction` hooks short-circuit — filter state still drives queries but never touches the URL.

Passed `syncToUrl={false}` to the `LogsViewer` inside `BatchRunInfo` in
`WorkflowLogs.tsx`, cutting the chain at its root.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

Manually reproduced the issue before the fix:

https://github.com/user-attachments/assets/791af4a5-e853-4366-9aef-05e1547a9ab1

After the fix, the group stays open as you type:

https://github.com/user-attachments/assets/2e57696e-6287-49c6-86c4-d3fc3e3665c7


## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
No

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
No docs changes needed.
