### PR TITLE
fix(max): allow new AI conversations through read-only guard

### DIFF
--- a/frontend/src/lib/readOnlyGuard.test.ts
+++ b/frontend/src/lib/readOnlyGuard.test.ts
@@ -122,7 +122,12 @@ describe('readOnlyGuard', () => {
                     '/api/environments/2/conversations/views',
                 ],
                 ['ticket saved view detail write blocked', 'PATCH', '/api/environments/2/conversations/views/abc/'],
-                ['support tickets write blocked', 'POST', '/api/projects/2/conversations/tickets/'],
+                ['support tickets write blocked (under projects)', 'POST', '/api/projects/2/conversations/tickets/'],
+                [
+                    'support tickets write blocked (under environments)',
+                    'POST',
+                    '/api/environments/2/conversations/tickets/',
+                ],
                 ['conversations-like prefix blocked', 'POST', '/api/environments/2/conversationsfoo/'],
             ] as const)('still blocks %s (%s %s) — only allowlisted paths pass', (_l, method, url) => {
                 expect(() => assertNotReadOnly(method, url)).toThrow(ReadOnlyModeError)

--- a/frontend/src/lib/readOnlyGuard.test.ts
+++ b/frontend/src/lib/readOnlyGuard.test.ts
@@ -91,6 +91,13 @@ describe('readOnlyGuard', () => {
                 ['insights timing with trailing slash', 'POST', '/api/projects/2/insights/timing/'],
                 ['metalytics (no trailing slash)', 'POST', '/api/projects/2/metalytics'],
                 ['metalytics with trailing slash', 'POST', '/api/projects/2/metalytics/'],
+                ['new AI conversation', 'POST', '/api/environments/2/conversations'],
+                ['new AI conversation with trailing slash', 'POST', '/api/environments/2/conversations/'],
+                ['AI conversation by id', 'PATCH', '/api/environments/2/conversations/abc-123/'],
+                ['AI conversation delete', 'DELETE', '/api/environments/2/conversations/abc-123/'],
+                ['AI conversation queue', 'POST', '/api/environments/2/conversations/abc-123/queue'],
+                ['AI conversation queue clear', 'POST', '/api/environments/2/conversations/abc-123/queue/clear'],
+                ['AI conversation append message', 'POST', '/api/environments/2/conversations/abc-123/append_message'],
             ] as const)('lets %s through (%s %s)', (_label, method, url) => {
                 const notifier = jest.fn()
                 setReadOnlyNotifier(notifier)
@@ -107,6 +114,10 @@ describe('readOnlyGuard', () => {
                 ['insight non-viewed sub-action blocked', 'POST', '/api/environments/2/insights/123/viewed_by'],
                 ['insight non-timing sub-action blocked', 'POST', '/api/environments/2/insights/123/timing_breakdown'],
                 ['metalytics-like prefix blocked', 'POST', '/api/projects/2/metalyticsfoo/'],
+                ['ticket saved views write blocked', 'POST', '/api/environments/2/conversations/views/'],
+                ['ticket saved view detail write blocked', 'PATCH', '/api/environments/2/conversations/views/abc/'],
+                ['support tickets write blocked', 'POST', '/api/projects/2/conversations/tickets/'],
+                ['conversations-like prefix blocked', 'POST', '/api/environments/2/conversationsfoo/'],
             ] as const)('still blocks %s (%s %s) — only allowlisted paths pass', (_l, method, url) => {
                 expect(() => assertNotReadOnly(method, url)).toThrow(ReadOnlyModeError)
             })

--- a/frontend/src/lib/readOnlyGuard.test.ts
+++ b/frontend/src/lib/readOnlyGuard.test.ts
@@ -98,6 +98,7 @@ describe('readOnlyGuard', () => {
                 ['AI conversation queue', 'POST', '/api/environments/2/conversations/abc-123/queue'],
                 ['AI conversation queue clear', 'POST', '/api/environments/2/conversations/abc-123/queue/clear'],
                 ['AI conversation append message', 'POST', '/api/environments/2/conversations/abc-123/append_message'],
+                ['AI conversation cancel', 'PATCH', '/api/environments/2/conversations/abc-123/cancel/'],
             ] as const)('lets %s through (%s %s)', (_label, method, url) => {
                 const notifier = jest.fn()
                 setReadOnlyNotifier(notifier)
@@ -115,6 +116,11 @@ describe('readOnlyGuard', () => {
                 ['insight non-timing sub-action blocked', 'POST', '/api/environments/2/insights/123/timing_breakdown'],
                 ['metalytics-like prefix blocked', 'POST', '/api/projects/2/metalyticsfoo/'],
                 ['ticket saved views write blocked', 'POST', '/api/environments/2/conversations/views/'],
+                [
+                    'ticket saved views write blocked (no trailing slash)',
+                    'POST',
+                    '/api/environments/2/conversations/views',
+                ],
                 ['ticket saved view detail write blocked', 'PATCH', '/api/environments/2/conversations/views/abc/'],
                 ['support tickets write blocked', 'POST', '/api/projects/2/conversations/tickets/'],
                 ['conversations-like prefix blocked', 'POST', '/api/environments/2/conversationsfoo/'],

--- a/frontend/src/lib/readOnlyGuard.ts
+++ b/frontend/src/lib/readOnlyGuard.ts
@@ -44,19 +44,25 @@ export function isReadOnly(): boolean {
     return getter?.() ?? false
 }
 
-// Writes that should pass through in read-only mode. Two categories:
+// Writes that should pass through in read-only mode. Three categories:
 //   1. Reads disguised as writes — /query serves HogQL / trends / funnels /
 //      retention via POST because the payload is too large for a query string.
 //      Block-listing it would make the entire app unusable.
 //   2. Passive telemetry that fires automatically on view/mount and should not
 //      raise: /file_system/log_view, /insights/viewed, /insights/timing
 //      (time-to-see-data), and /metalytics (side-panel scene view tracking).
+//   3. PostHog AI (Max) conversations — the read-only toast tells users to
+//      "Use Max or the MCP to make this change", so Max must remain usable.
+//      Excludes /conversations/views (ticket saved views, not AI). The other
+//      conversations endpoint, /projects/:team_id/conversations/tickets, is
+//      support tickets and stays blocked since it's not under /environments/.
 const READ_ONLY_ALLOWED_PATTERNS = [
     /\/query(?:\/|$|\?)/, // /api/environments/:team_id/query, /api/environments/:team_id/query/:queryId/log, etc.
     /\/file_system\/log_view(?:\/|$|\?)/, // /api/environments/:team_id/file_system/log_view
     /\/insights\/viewed(?:\/|$|\?)/, // /api/environments/:team_id/insights/viewed — passive "recently viewed" telemetry
     /\/insights\/timing(?:\/|$|\?)/, // /api/projects/:team_id/insights/timing — time-to-see-data telemetry fired after every dashboard/insight load
     /\/metalytics(?:\/|$|\?)/, // /api/projects/:team_id/metalytics — side-panel scene view tracking (only accepts metric_name=viewed)
+    /\/environments\/[^/]+\/conversations(?!\/views)(?:\/|$|\?)/, // /api/environments/:team_id/conversations[/:id[/queue|/append_message|...]] — PostHog AI (Max) conversations, but not /conversations/views (ticket saved views)
 ]
 
 function isReadDisguisedAsWrite(url: string): boolean {

--- a/frontend/src/lib/readOnlyGuard.ts
+++ b/frontend/src/lib/readOnlyGuard.ts
@@ -53,16 +53,16 @@ export function isReadOnly(): boolean {
 //      (time-to-see-data), and /metalytics (side-panel scene view tracking).
 //   3. PostHog AI (Max) conversations — the read-only toast tells users to
 //      "Use Max or the MCP to make this change", so Max must remain usable.
-//      Excludes /conversations/views (ticket saved views, not AI). The other
-//      conversations endpoint, /projects/:team_id/conversations/tickets, is
-//      support tickets and stays blocked since it's not under /environments/.
+//      Matches /conversations except the two ticket sub-features (`views` and
+//      `tickets`). Mount-path-agnostic — works under /environments/ or
+//      /projects/ — so the discriminator is the sub-feature, not the prefix.
 const READ_ONLY_ALLOWED_PATTERNS = [
     /\/query(?:\/|$|\?)/, // /api/environments/:team_id/query, /api/environments/:team_id/query/:queryId/log, etc.
     /\/file_system\/log_view(?:\/|$|\?)/, // /api/environments/:team_id/file_system/log_view
     /\/insights\/viewed(?:\/|$|\?)/, // /api/environments/:team_id/insights/viewed — passive "recently viewed" telemetry
     /\/insights\/timing(?:\/|$|\?)/, // /api/projects/:team_id/insights/timing — time-to-see-data telemetry fired after every dashboard/insight load
     /\/metalytics(?:\/|$|\?)/, // /api/projects/:team_id/metalytics — side-panel scene view tracking (only accepts metric_name=viewed)
-    /\/environments\/[^/]+\/conversations(?!\/views)(?:\/|$|\?)/, // /api/environments/:team_id/conversations[/:id[/queue|/append_message|...]] — PostHog AI (Max) conversations, but not /conversations/views (ticket saved views)
+    /\/conversations(?!\/(?:views|tickets))(?:\/|$|\?)/, // /api/.../conversations[/:id[/queue|/append_message|/cancel|...]] — PostHog AI (Max), excluding /conversations/views and /conversations/tickets
 ]
 
 function isReadDisguisedAsWrite(url: string): boolean {


### PR DESCRIPTION
## Problem

In read-only mode, the toast that fires on a blocked write tells users to "Use Max or the MCP to make this change" — but POSTs to `/api/environments/:team_id/conversations` were themselves being blocked by `assertNotReadOnly`. Starting a new PostHog AI (Max) conversation while read-only is on failed with the same toast that just instructed the user to talk to Max. The escape hatch and the trap were the same path.

## Changes

Allowlist the AI conversations URL space in `frontend/src/lib/readOnlyGuard.ts`:

```ts
/\/conversations(?!\/(?:views|tickets))(?:\/|$|\?)/
```

The negative lookahead excludes the two non-AI sub-features by name:

- `/conversations/views` — ticket saved views
- `/conversations/tickets` — support tickets

Mount-path-agnostic by design: works whether the AI conversations endpoint is mounted under `/environments/` or `/projects/`, and the `tickets` sub-feature stays blocked wherever it lives. The discriminator is the sub-feature, not the URL prefix.

Allowing the whole subtree (including `/queue`, `/queue/clear`, `/append_message`, `/cancel`, `PATCH`/`DELETE` by id) means Max remains fully usable in read-only mode — not just the create endpoint.

## How did you test this code?

I'm an agent. Added parameterized cases to `frontend/src/lib/readOnlyGuard.test.ts` and ran the suite — all 56 tests pass (`hogli test frontend/src/lib/readOnlyGuard.test.ts`):

**Allowed (8 new rows):** bare `POST /conversations`, with trailing slash, `PATCH`/`DELETE` by id, and the `queue`, `queue/clear`, `append_message`, `cancel` sub-actions.

**Still blocked (6 new rows):** `POST` and `PATCH` on `/conversations/views`, `/conversations/views` with no trailing slash (pins the lookahead's `$`-boundary), `/conversations/tickets` under both `/projects/` and `/environments/` (pins the lookahead-by-name protection), and a `conversationsfoo` look-alike to confirm the URL boundary.

No manual browser verification.

## Publish to changelog?

no

## Docs update

No docs change needed — read-only mode is internal experiment state, and the user-visible behavior change is "Max now works as the toast already claimed".

## 🤖 Agent context

- **Tool:** PostHog Code (Claude)
- **Task:** [b256bada-8bc5-4432-834c-af355addaa55](https://app.posthog.com/code/tasks/b256bada-8bc5-4432-834c-af355addaa55)
- **Decision notes:**
  - First pass anchored on `/environments/[^/]+/conversations` with a `(?!\/views)` lookahead — relied on tickets being under `/projects/` to stay blocked. QA Swarm flagged this as load-bearing-anchor / fail-open if Max ever moves mount paths.
  - After discussion, paul concluded he doesn't care whether the path is under `/projects/` or `/environments/` — the real discriminator is the sub-feature name. Rewrote to be mount-path-agnostic.
  - Considered allowing only `POST /conversations` (the create endpoint) but rejected: once a conversation exists, follow-up turns hit `PATCH` and the `queue`/`append_message`/`cancel` actions. A narrow allowlist would let users start a conversation and immediately get re-blocked on the next turn.
  - Considered an inverted regex enumerating explicit AI suffixes — rejected as premature; the original PR had already missed the `cancel` action, so an enumerated allowlist would silently break new sub-features every time the conversation API grows. The lookahead-by-name shape fails open in a way the team controls (any new `/conversations/<sub>` is presumed AI-related unless added to the exclude list).
  - Followed the existing convention in this file: one regex per allowed family, with `(?:\/|$|\?)` boundary, plus a one-line comment naming the route and why.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*