### PR TITLE
chore(dev-ex): re-run flox setup on cwd change (worktree forks)

### DIFF
--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
-# SessionStart hook: capture flox environment and write to CLAUDE_ENV_FILE
-# so that all subsequent Bash commands have python, node, pytest, etc. on PATH.
+# SessionStart + CwdChanged hook: capture the flox environment for the active
+# project/worktree directory and write it to CLAUDE_ENV_FILE so that all
+# subsequent Bash commands have python, node, pytest, etc. on PATH.
 #
-# CLAUDE_ENV_FILE is only available in SessionStart hooks:
-# https://code.claude.com/docs/en/hooks#sessionstart
+# CLAUDE_ENV_FILE is available in SessionStart, Setup, CwdChanged, and FileChanged
+# hooks: https://code.claude.com/docs/en/hooks
+#
+# Wiring this to CwdChanged (not just SessionStart) is what makes the flox env
+# follow you into a new worktree mid-session, e.g. after forking a conversation.
+# SessionStart only fires for startup/resume/clear/compact, never for a plain
+# working-directory change, so without CwdChanged a forked worktree would keep the
+# original directory's venv on PATH.
 
 # Skip on Claude web (no flox there) or if CLAUDE_ENV_FILE isn't set
 if [ "$CLAUDE_CODE_REMOTE" = "true" ] || [ -z "$CLAUDE_ENV_FILE" ]; then
@@ -15,10 +22,57 @@ if ! command -v flox &>/dev/null; then
   exit 0
 fi
 
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+# Hooks receive a JSON payload on stdin. Read it (only when stdin isn't a TTY, so
+# manual invocation doesn't block) to learn the event name and the current dir.
+HOOK_INPUT=""
+if [ ! -t 0 ]; then
+  HOOK_INPUT="$(cat)"
+fi
+_json_str() {
+  printf '%s' "$HOOK_INPUT" | tr -d '\n' | sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p"
+}
+HOOK_EVENT="$(_json_str hook_event_name)"
+HOOK_CWD="$(_json_str cwd)"
+[ -z "$HOOK_CWD" ] && HOOK_CWD="$(pwd)"
+
+# Walk up from a starting dir to the nearest ancestor (including itself) holding a
+# flox env. This is what lets the hook resolve the worktree we actually moved into.
+find_flox_dir() {
+  local dir="$1"
+  while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+    if [ -f "$dir/.flox/env/manifest.toml" ]; then
+      printf '%s' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+# Resolve which directory's flox env to activate. Prefer the flox dir at or above
+# the current cwd. On SessionStart fall back to CLAUDE_PROJECT_DIR (covers launching
+# from outside the tree); on CwdChanged do NOT fall back, so cd-ing into a non-flox
+# dir (e.g. /tmp) stays a no-op instead of re-activating the project on every cd.
+PROJECT_DIR="$(find_flox_dir "$HOOK_CWD")"
+if [ -z "$PROJECT_DIR" ] && [ "$HOOK_EVENT" != "CwdChanged" ]; then
+  PROJECT_DIR="$(find_flox_dir "${CLAUDE_PROJECT_DIR:-}")"
+fi
+[ -z "$PROJECT_DIR" ] && exit 0
+
 VENV_DIR="$PROJECT_DIR/.flox/cache/venv"
 CACHE_FILE="$PROJECT_DIR/.flox/cache/claude-env-cache"
 FLOX_MANIFEST="$PROJECT_DIR/.flox/env/manifest.toml"
+
+# On CwdChanged, skip if this dir's venv is already the active one (cheap path for
+# cd-ing between subdirs of the same worktree). The last VIRTUAL_ENV line in
+# CLAUDE_ENV_FILE reflects what subsequent Bash calls use, regardless of this hook
+# process's own environment.
+if [ "$HOOK_EVENT" = "CwdChanged" ] && [ -f "$CLAUDE_ENV_FILE" ]; then
+  LAST_VENV=$(grep '^export VIRTUAL_ENV=' "$CLAUDE_ENV_FILE" 2>/dev/null | tail -1 | sed 's/^export VIRTUAL_ENV=//; s/^"//; s/"$//')
+  if [ "$LAST_VENV" = "$VENV_DIR" ]; then
+    exit 0
+  fi
+fi
 
 # Checksum the flox manifest to auto-invalidate cache on env changes
 MANIFEST_HASH=""

--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -3,7 +3,7 @@
 # so that all subsequent Bash commands have python, node, pytest, etc. on PATH.
 #
 # CLAUDE_ENV_FILE is available in SessionStart, Setup, CwdChanged, and FileChanged hooks:
-# https://code.claude.com/docs/en/hooks
+# https://code.claude.com/docs/en/hooks#persist-environment-variables
 
 # Skip on Claude web (no flox there) or if CLAUDE_ENV_FILE isn't set
 if [ "$CLAUDE_CODE_REMOTE" = "true" ] || [ -z "$CLAUDE_ENV_FILE" ]; then

--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -1,16 +1,9 @@
 #!/bin/bash
-# SessionStart + CwdChanged hook: capture the flox environment for the active
-# project/worktree directory and write it to CLAUDE_ENV_FILE so that all
-# subsequent Bash commands have python, node, pytest, etc. on PATH.
+# SessionStart + CwdChanged hook: capture flox environment and write to CLAUDE_ENV_FILE
+# so that all subsequent Bash commands have python, node, pytest, etc. on PATH.
 #
-# CLAUDE_ENV_FILE is available in SessionStart, Setup, CwdChanged, and FileChanged
-# hooks: https://code.claude.com/docs/en/hooks
-#
-# Wiring this to CwdChanged (not just SessionStart) is what makes the flox env
-# follow you into a new worktree mid-session, e.g. after forking a conversation.
-# SessionStart only fires for startup/resume/clear/compact, never for a plain
-# working-directory change, so without CwdChanged a forked worktree would keep the
-# original directory's venv on PATH.
+# CLAUDE_ENV_FILE is available in SessionStart, Setup, CwdChanged, and FileChanged hooks:
+# https://code.claude.com/docs/en/hooks
 
 # Skip on Claude web (no flox there) or if CLAUDE_ENV_FILE isn't set
 if [ "$CLAUDE_CODE_REMOTE" = "true" ] || [ -z "$CLAUDE_ENV_FILE" ]; then
@@ -22,8 +15,7 @@ if ! command -v flox &>/dev/null; then
   exit 0
 fi
 
-# Hooks receive a JSON payload on stdin. Read it (only when stdin isn't a TTY, so
-# manual invocation doesn't block) to learn the event name and the current dir.
+# Read the hook's event and cwd from the JSON on stdin (TTY guard avoids hanging)
 HOOK_INPUT=""
 if [ ! -t 0 ]; then
   HOOK_INPUT="$(cat)"
@@ -35,8 +27,7 @@ HOOK_EVENT="$(_json_str hook_event_name)"
 HOOK_CWD="$(_json_str cwd)"
 [ -z "$HOOK_CWD" ] && HOOK_CWD="$(pwd)"
 
-# Walk up from a starting dir to the nearest ancestor (including itself) holding a
-# flox env. This is what lets the hook resolve the worktree we actually moved into.
+# Nearest ancestor (including itself) that holds a flox env
 find_flox_dir() {
   local dir="$1"
   while [ -n "$dir" ] && [ "$dir" != "/" ]; do
@@ -49,10 +40,7 @@ find_flox_dir() {
   return 1
 }
 
-# Resolve which directory's flox env to activate. Prefer the flox dir at or above
-# the current cwd. On SessionStart fall back to CLAUDE_PROJECT_DIR (covers launching
-# from outside the tree); on CwdChanged do NOT fall back, so cd-ing into a non-flox
-# dir (e.g. /tmp) stays a no-op instead of re-activating the project on every cd.
+# Use the flox dir at/above cwd; on SessionStart fall back to CLAUDE_PROJECT_DIR
 PROJECT_DIR="$(find_flox_dir "$HOOK_CWD")"
 if [ -z "$PROJECT_DIR" ] && [ "$HOOK_EVENT" != "CwdChanged" ]; then
   PROJECT_DIR="$(find_flox_dir "${CLAUDE_PROJECT_DIR:-}")"
@@ -63,10 +51,7 @@ VENV_DIR="$PROJECT_DIR/.flox/cache/venv"
 CACHE_FILE="$PROJECT_DIR/.flox/cache/claude-env-cache"
 FLOX_MANIFEST="$PROJECT_DIR/.flox/env/manifest.toml"
 
-# On CwdChanged, skip if this dir's venv is already the active one (cheap path for
-# cd-ing between subdirs of the same worktree). The last VIRTUAL_ENV line in
-# CLAUDE_ENV_FILE reflects what subsequent Bash calls use, regardless of this hook
-# process's own environment.
+# On CwdChanged, skip if this dir's venv is already active (cheap re-cd within a worktree)
 if [ "$HOOK_EVENT" = "CwdChanged" ] && [ -f "$CLAUDE_ENV_FILE" ]; then
   LAST_VENV=$(grep '^export VIRTUAL_ENV=' "$CLAUDE_ENV_FILE" 2>/dev/null | tail -1 | sed 's/^export VIRTUAL_ENV=//; s/^"//; s/"$//')
   if [ "$LAST_VENV" = "$VENV_DIR" ]; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,16 @@
                     }
                 ]
             }
+        ],
+        "CwdChanged": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/setup-flox.sh"
+                    }
+                ]
+            }
         ]
     },
     "enabledPlugins": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ When automating a convention, try these in order — only fall back to the next 
 3. **Skills** (`.agents/skills/`) — scaffold with `hogli init:skill`
 4. **AGENTS.md / CLAUDE.md instructions** — when automated enforcement isn't suitable
 
-Claude Code hooks are reserved for environment bootstrapping (`SessionStart` only) — do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks as they add latency and are fragile. Changes to `.claude/hooks/` trigger a lint-staged warning; changes to `.claude/settings.json` are blocked outright.
+Claude Code hooks are reserved for environment bootstrapping (`SessionStart` and `CwdChanged`) — do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks as they add latency and are fragile. The sole `CwdChanged` hook is `setup-flox.sh`, which makes the flox env follow you into a new worktree mid-session (for example after forking a conversation); its handler short-circuits immediately when the target directory has no flox env, so it stays cheap on every `cd`. Changes to `.claude/hooks/` trigger a lint-staged warning; changes to `.claude/settings.json` are blocked outright.
 
 ### Mandatory skill invocation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ When automating a convention, try these in order — only fall back to the next 
 3. **Skills** (`.agents/skills/`) — scaffold with `hogli init:skill`
 4. **AGENTS.md / CLAUDE.md instructions** — when automated enforcement isn't suitable
 
-Claude Code hooks are reserved for environment bootstrapping (`SessionStart` and `CwdChanged`) — do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks as they add latency and are fragile. The sole `CwdChanged` hook is `setup-flox.sh`, which makes the flox env follow you into a new worktree mid-session (for example after forking a conversation); its handler short-circuits immediately when the target directory has no flox env, so it stays cheap on every `cd`. Changes to `.claude/hooks/` trigger a lint-staged warning; changes to `.claude/settings.json` are blocked outright.
+Claude Code hooks are reserved for environment bootstrapping (`SessionStart` and `CwdChanged`) — do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks as they add latency and are fragile. Changes to `.claude/hooks/` trigger a lint-staged warning; changes to `.claude/settings.json` are blocked outright.
 
 ### Mandatory skill invocation
 


### PR DESCRIPTION
## Problem

The flox dev environment is set up by a `SessionStart` hook (`.claude/hooks/setup-flox.sh`) that captures flox's `PATH` / `VIRTUAL_ENV` into `CLAUDE_ENV_FILE`. `SessionStart` only fires for `startup`, `resume`, `clear`, and `compact`, so it never re-runs on a mid-session working-directory change. When you fork a Claude Code conversation into a new worktree, the cwd moves but the flox env does not follow: the original worktree's venv stays on `PATH`, so `python` / `pytest` / `node` resolve to the wrong venv (or one that doesn't exist yet in the new worktree).

## Changes

- **Wire `setup-flox.sh` to the `CwdChanged` hook** (`.claude/settings.json`). `CLAUDE_ENV_FILE` is available in `CwdChanged` per the [hooks docs](https://code.claude.com/docs/en/hooks#persist-environment-variables), so the env can be recaptured when the directory changes.
- **Resolve the target directory from the hook's `cwd`** instead of `CLAUDE_PROJECT_DIR` (which stays pinned to the original project root, even in a `CwdChanged` hook). The script now reads the hook's JSON payload and walks up from the cwd to the nearest `.flox/env/manifest.toml`. This is correct for both `SessionStart` and `CwdChanged`.
- **Keep the `CwdChanged` path cheap.** It short-circuits when the new directory has no flox env (e.g. `cd /tmp`) and when that directory's venv is already active, so it does not add latency on every `cd`. `SessionStart` keeps its previous fallback to `CLAUDE_PROJECT_DIR`.
- **Update the hook policy in `AGENTS.md`** from "`SessionStart` only" to allow `CwdChanged` for this env-follow case.

## How did you test this code?

I'm an agent and did **not** exercise a live `CwdChanged` event inside Claude Code (it can't be triggered from a tool call). The `CwdChanged` behavior should be confirmed by actually forking a conversation after this merges. Automated checks I ran:

- A hermetic shell test with two fake worktrees and pre-seeded caches (so no real `flox activate` runs):

  | case | expected | result |
  | --- | --- | --- |
  | old script, `CwdChanged` cwd=wtB, project=wtA | picks wtA (ignores cwd, reproduces bug) | pass |
  | new script, same inputs | follows cwd into wtB | pass |
  | new script, `CwdChanged` into non-flox dir | no-op | pass |
  | new script, `SessionStart`, cwd has no flox | falls back to `CLAUDE_PROJECT_DIR` | pass |
  | new script, `CwdChanged`, venv already active | no-op (idempotent) | pass |

- `bash -n` syntax check on the rewritten script.
- A real-worktree `SessionStart` invocation confirming it resolves this worktree's venv via the fast cache path.

## Publish to changelog?

no

## Docs update

Not product-facing (developer tooling plus `AGENTS.md`). Add the `skip-inkeep-docs` label.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7), tools used: file edits, Bash, and a web fetch of the official Claude Code hooks docs.

Investigation: the script's old comment claimed `CLAUDE_ENV_FILE` was "SessionStart only"; the current docs confirm it is also available in `Setup`, `CwdChanged`, and `FileChanged`. Root cause of "flox doesn't follow a fork" is that `SessionStart` has no source value for a mid-session cwd change, and there was no `CwdChanged` hook wired.

Decisions:
- Walk up from the hook's `cwd` rather than trusting `CLAUDE_PROJECT_DIR`. Verified that simply wiring the old script to `CwdChanged` would have re-set-up the original directory, not the new worktree.
- No `CLAUDE_PROJECT_DIR` fallback on `CwdChanged`, plus an already-active guard, because `CwdChanged` has no matcher and fires on every `cd`; the guards keep it from adding latency or re-running `flox activate` on unrelated directories.
- `.claude/settings.json` is hard-blocked by a lint-staged guard intended to stop accidental personal-permission commits. This deliberate shared-hook edit was committed with `--no-verify` with the human author's explicit approval.
