### PR TITLE
chore(max-ai): instrument conversations api with otel spans

### DIFF
--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -469,9 +469,18 @@ class AgentToolsExecutable(BaseAgentLoopExecutable):
         )
 
         try:
-            result = await tool.ainvoke(
-                ToolCall(type="tool_call", name=tool_call.name, args=tool_call.args, id=tool_call.id), config=config
-            )
+            with _tracer.start_as_current_span(
+                "posthog_ai.tool.invoke",
+                attributes={
+                    "posthog_ai.tool_name": tool_call.name,
+                    "posthog_ai.tool_call_id": tool_call.id,
+                    "posthog_ai.team_id": self._team.id,
+                },
+            ):
+                result = await tool.ainvoke(
+                    ToolCall(type="tool_call", name=tool_call.name, args=tool_call.args, id=tool_call.id),
+                    config=config,
+                )
             if not isinstance(result, LangchainToolMessage):
                 raise ValueError(
                     f"Tool '{tool_call.name}' returned {type(result).__name__}, expected LangchainToolMessage"

--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -469,14 +469,15 @@ class AgentToolsExecutable(BaseAgentLoopExecutable):
         )
 
         try:
-            with _tracer.start_as_current_span(
-                "posthog_ai.tool.invoke",
-                attributes={
-                    "posthog_ai.tool_name": tool_call.name,
-                    "posthog_ai.tool_call_id": tool_call.id,
-                    "posthog_ai.team_id": self._team.id,
-                },
-            ):
+            # tool_call.id is typed as str|None in some LangChain shapes; OTel rejects None
+            # attribute values with a warning, so include the id only when present.
+            tool_span_attributes: dict[str, str | int] = {
+                "posthog_ai.tool_name": tool_call.name,
+                "posthog_ai.team_id": self._team.id,
+            }
+            if tool_call.id is not None:
+                tool_span_attributes["posthog_ai.tool_call_id"] = tool_call.id
+            with _tracer.start_as_current_span("posthog_ai.tool.invoke", attributes=tool_span_attributes):
                 result = await tool.ainvoke(
                     ToolCall(type="tool_call", name=tool_call.name, args=tool_call.args, id=tool_call.id),
                     config=config,

--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -482,10 +482,12 @@ class AgentToolsExecutable(BaseAgentLoopExecutable):
                     ToolCall(type="tool_call", name=tool_call.name, args=tool_call.args, id=tool_call.id),
                     config=config,
                 )
-            if not isinstance(result, LangchainToolMessage):
-                raise ValueError(
-                    f"Tool '{tool_call.name}' returned {type(result).__name__}, expected LangchainToolMessage"
-                )
+                # Keep the type-mismatch raise inside the span so OTel records the exception
+                # on the tool.invoke span rather than on its (unrelated) parent.
+                if not isinstance(result, LangchainToolMessage):
+                    raise ValueError(
+                        f"Tool '{tool_call.name}' returned {type(result).__name__}, expected LangchainToolMessage"
+                    )
 
             # Track successful tool execution
             user_distinct_id = self._get_user_distinct_id(config)

--- a/ee/hogai/core/executor.py
+++ b/ee/hogai/core/executor.py
@@ -171,6 +171,7 @@ class AgentExecutor:
                             "Existing workflow still running, using existing handle",
                             workflow_id=self._workflow_id,
                         )
+                        span.set_attribute("posthog_ai.start_workflow.attempts", attempt + 1)
                         return existing_handle
                     except Exception:
                         # Workflow completed (possibly with error), retry starting a new one

--- a/ee/hogai/core/executor.py
+++ b/ee/hogai/core/executor.py
@@ -8,6 +8,7 @@ from django.conf import settings
 
 import structlog
 import posthoganalytics
+from opentelemetry import trace
 from prometheus_client import Histogram
 from temporalio.client import WorkflowExecutionStatus, WorkflowHandle
 from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
@@ -35,6 +36,7 @@ from ee.hogai.utils.types import AssistantOutput
 from ee.models.assistant import Conversation
 
 logger = structlog.get_logger(__name__)
+_tracer = trace.get_tracer(__name__)
 
 STREAM_DJANGO_EVENT_LOOP_LATENCY_HISTOGRAM = Histogram(
     "posthog_ai_stream_django_event_loop_latency_seconds",
@@ -85,25 +87,35 @@ class AgentExecutor:
     async def start_workflow(
         self, workflow: type[AgentBaseWorkflow], inputs: Any
     ) -> AsyncGenerator[AssistantOutput, Any]:
-        try:
-            # Delete the stream to ensure we start fresh
-            # since there might be a stale stream from a previous conversation gone wrong
-            await self._redis_stream.delete_stream()
+        with _tracer.start_as_current_span(
+            "posthog_ai.executor.start_workflow",
+            attributes={
+                "posthog_ai.conversation_id": str(self._conversation.id),
+                "posthog_ai.workflow_id": self._workflow_id,
+                "posthog_ai.workflow_class": workflow.__name__,
+            },
+        ):
+            try:
+                # Delete the stream to ensure we start fresh
+                # since there might be a stale stream from a previous conversation gone wrong
+                with _tracer.start_as_current_span("posthog_ai.executor.delete_stale_stream"):
+                    await self._redis_stream.delete_stream()
 
-            client = await async_connect()
+                with _tracer.start_as_current_span("posthog_ai.executor.temporal_connect"):
+                    client = await async_connect()
 
-            handle = await self._start_workflow_with_retry(client, workflow, inputs)
+                handle = await self._start_workflow_with_retry(client, workflow, inputs)
 
-            # Wait for the workflow to start running before streaming
-            is_workflow_running = await self._wait_for_workflow_to_start(handle)
-            if not is_workflow_running:
-                raise Exception(f"Workflow failed to start within timeout: {self._workflow_id}")
+                # Wait for the workflow to start running before streaming
+                is_workflow_running = await self._wait_for_workflow_to_start(handle)
+                if not is_workflow_running:
+                    raise Exception(f"Workflow failed to start within timeout: {self._workflow_id}")
 
-        except Exception as e:
-            posthoganalytics.capture_exception(e, properties={"tag": "max_ai"})
-            logger.exception("Error starting workflow", error=e)
-            yield self._failure_message()
-            return
+            except Exception as e:
+                posthoganalytics.capture_exception(e, properties={"tag": "max_ai"})
+                logger.exception("Error starting workflow", error=e)
+                yield self._failure_message()
+                return
 
         async for chunk in self.stream_conversation():
             yield chunk
@@ -117,16 +129,23 @@ class AgentExecutor:
         where starting a new workflow with the same ID fails even with USE_EXISTING policy.
         This method handles that by waiting for the existing workflow to complete and retrying.
         """
+        span = trace.get_current_span()
         for attempt in range(max_retries):
             try:
-                return await client.start_workflow(
-                    workflow.run,
-                    inputs,
-                    id=self._workflow_id,
-                    task_queue=settings.MAX_AI_TASK_QUEUE,
-                    id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
-                    id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-                )
+                with _tracer.start_as_current_span(
+                    "posthog_ai.executor.temporal_start_workflow",
+                    attributes={"posthog_ai.attempt": attempt},
+                ):
+                    handle = await client.start_workflow(
+                        workflow.run,
+                        inputs,
+                        id=self._workflow_id,
+                        task_queue=settings.MAX_AI_TASK_QUEUE,
+                        id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+                        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                    )
+                span.set_attribute("posthog_ai.start_workflow.attempts", attempt + 1)
+                return handle
             except WorkflowAlreadyStartedError:
                 if attempt < max_retries - 1:
                     # Get handle to existing workflow and wait for it to complete
@@ -168,18 +187,25 @@ class AgentExecutor:
         max_attempts = 10 * 60  # 60 seconds total with 0.1s sleep
         attempts = 0
 
-        while attempts < max_attempts:
-            description = await handle.describe()
-            if description.status is None:
-                attempts += 1
-                await asyncio.sleep(0.1)
-            elif description.status == WorkflowExecutionStatus.RUNNING:
-                # Temporal only has one Open execution status, see: https://docs.temporal.io/workflow-execution
-                return True
-            else:
-                return False
+        with _tracer.start_as_current_span("posthog_ai.executor.wait_for_workflow_start") as span:
+            while attempts < max_attempts:
+                description = await handle.describe()
+                if description.status is None:
+                    attempts += 1
+                    await asyncio.sleep(0.1)
+                elif description.status == WorkflowExecutionStatus.RUNNING:
+                    # Temporal only has one Open execution status, see: https://docs.temporal.io/workflow-execution
+                    span.set_attribute("posthog_ai.poll_attempts", attempts)
+                    span.set_attribute("posthog_ai.outcome", "running")
+                    return True
+                else:
+                    span.set_attribute("posthog_ai.poll_attempts", attempts)
+                    span.set_attribute("posthog_ai.outcome", "not_running")
+                    return False
 
-        return False
+            span.set_attribute("posthog_ai.poll_attempts", attempts)
+            span.set_attribute("posthog_ai.outcome", "timeout")
+            return False
 
     async def stream_conversation(self) -> AsyncGenerator[AssistantOutput, Any]:
         """Stream conversation updates from Redis stream.
@@ -187,29 +213,37 @@ class AgentExecutor:
         Returns:
             AssistantOutput generator
         """
-        try:
-            # Wait for stream to be created
-            is_stream_available = await self._redis_stream.wait_for_stream()
-            if not is_stream_available:
-                raise StreamError("Stream for this conversation not available - Temporal workflow might have failed")
-            last_chunk_time = time.time()
-            async for chunk in self._redis_stream.read_stream():
-                message = await self._redis_stream_to_assistant_output(chunk)
-
-                temporal_to_code_latency = last_chunk_time - chunk.timestamp
-                if temporal_to_code_latency > 0:
-                    STREAM_DJANGO_EVENT_LOOP_LATENCY_HISTOGRAM.observe(temporal_to_code_latency)
+        chunk_count = 0
+        with _tracer.start_as_current_span(
+            "posthog_ai.executor.stream_conversation",
+            attributes={"posthog_ai.conversation_id": str(self._conversation.id)},
+        ) as span:
+            try:
+                # Wait for stream to be created
+                is_stream_available = await self._redis_stream.wait_for_stream()
+                if not is_stream_available:
+                    raise StreamError(
+                        "Stream for this conversation not available - Temporal workflow might have failed"
+                    )
                 last_chunk_time = time.time()
+                async for chunk in self._redis_stream.read_stream():
+                    message = await self._redis_stream_to_assistant_output(chunk)
 
-                if message:
-                    yield message
-        except Exception as e:
-            posthoganalytics.capture_exception(e, properties={"tag": "max_ai"})
-            logger.exception("Error streaming conversation", error=e)
-            yield self._failure_message()
+                    temporal_to_code_latency = last_chunk_time - chunk.timestamp
+                    if temporal_to_code_latency > 0:
+                        STREAM_DJANGO_EVENT_LOOP_LATENCY_HISTOGRAM.observe(temporal_to_code_latency)
+                    last_chunk_time = time.time()
+                    chunk_count += 1
 
-        finally:
-            await self._redis_stream.delete_stream()
+                    if message:
+                        yield message
+            except Exception as e:
+                posthoganalytics.capture_exception(e, properties={"tag": "max_ai"})
+                logger.exception("Error streaming conversation", error=e)
+                yield self._failure_message()
+            finally:
+                span.set_attribute("posthog_ai.stream_conversation.chunks", chunk_count)
+                await self._redis_stream.delete_stream()
 
     async def _redis_stream_to_assistant_output(self, message: StreamEvent) -> AssistantOutput | None:
         """Convert Redis stream event to Assistant output.
@@ -223,8 +257,12 @@ class AgentExecutor:
         if isinstance(message.event, MessageEvent):
             return (AssistantEventType.MESSAGE, message.event.payload)
         elif isinstance(message.event, ConversationEvent):
-            # nosemgrep: idor-lookup-without-team (ID from internal Redis stream, caller validates user+team ownership)
-            conversation = await Conversation.objects.select_related("user").aget(id=message.event.payload)
+            with _tracer.start_as_current_span(
+                "posthog_ai.executor.conversation_aget",
+                attributes={"posthog_ai.conversation_id": str(message.event.payload)},
+            ):
+                # nosemgrep: idor-lookup-without-team (ID from internal Redis stream, caller validates user+team ownership)
+                conversation = await Conversation.objects.select_related("user").aget(id=message.event.payload)
             return (AssistantEventType.CONVERSATION, conversation)
         elif isinstance(message.event, UpdateEvent):
             return (AssistantEventType.UPDATE, message.event.payload)

--- a/ee/hogai/core/executor.py
+++ b/ee/hogai/core/executor.py
@@ -87,6 +87,10 @@ class AgentExecutor:
     async def start_workflow(
         self, workflow: type[AgentBaseWorkflow], inputs: Any
     ) -> AsyncGenerator[AssistantOutput, Any]:
+        # Capture the failure outcome inside the span and yield outside it — yielding from
+        # an async generator while a span is "current" leaks that span into the consumer
+        # task's contextvars. See stream_conversation for the longer note.
+        failed = False
         with _tracer.start_as_current_span(
             "posthog_ai.executor.start_workflow",
             attributes={
@@ -114,8 +118,11 @@ class AgentExecutor:
             except Exception as e:
                 posthoganalytics.capture_exception(e, properties={"tag": "max_ai"})
                 logger.exception("Error starting workflow", error=e)
-                yield self._failure_message()
-                return
+                failed = True
+
+        if failed:
+            yield self._failure_message()
+            return
 
         async for chunk in self.stream_conversation():
             yield chunk
@@ -214,36 +221,54 @@ class AgentExecutor:
             AssistantOutput generator
         """
         chunk_count = 0
-        with _tracer.start_as_current_span(
+        # Use start_span + use_span (without making the span "current" across yields).
+        # `start_as_current_span` inside an async generator attaches the span to the running
+        # task's contextvars; when the generator yields, the consumer task resumes with that
+        # context still set, leaking this span as the consumer's "current span". We scope
+        # the current-span context only around the non-yielding bookkeeping so child spans
+        # still parent correctly, while yields run outside the attached context.
+        # See https://github.com/open-telemetry/opentelemetry-python/issues/2606.
+        span = _tracer.start_span(
             "posthog_ai.executor.stream_conversation",
             attributes={"posthog_ai.conversation_id": str(self._conversation.id)},
-        ) as span:
+        )
+        try:
             try:
-                # Wait for stream to be created
-                is_stream_available = await self._redis_stream.wait_for_stream()
-                if not is_stream_available:
-                    raise StreamError(
-                        "Stream for this conversation not available - Temporal workflow might have failed"
-                    )
-                last_chunk_time = time.time()
-                async for chunk in self._redis_stream.read_stream():
-                    message = await self._redis_stream_to_assistant_output(chunk)
-
-                    temporal_to_code_latency = last_chunk_time - chunk.timestamp
-                    if temporal_to_code_latency > 0:
-                        STREAM_DJANGO_EVENT_LOOP_LATENCY_HISTOGRAM.observe(temporal_to_code_latency)
+                with trace.use_span(span, end_on_exit=False):
+                    # Wait for stream to be created
+                    is_stream_available = await self._redis_stream.wait_for_stream()
+                    if not is_stream_available:
+                        raise StreamError(
+                            "Stream for this conversation not available - Temporal workflow might have failed"
+                        )
                     last_chunk_time = time.time()
-                    chunk_count += 1
+                read_iter = self._redis_stream.read_stream().__aiter__()
+                while True:
+                    with trace.use_span(span, end_on_exit=False):
+                        try:
+                            chunk = await read_iter.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        message = await self._redis_stream_to_assistant_output(chunk)
+
+                        temporal_to_code_latency = last_chunk_time - chunk.timestamp
+                        if temporal_to_code_latency > 0:
+                            STREAM_DJANGO_EVENT_LOOP_LATENCY_HISTOGRAM.observe(temporal_to_code_latency)
+                        last_chunk_time = time.time()
+                        chunk_count += 1
 
                     if message:
                         yield message
             except Exception as e:
-                posthoganalytics.capture_exception(e, properties={"tag": "max_ai"})
-                logger.exception("Error streaming conversation", error=e)
+                with trace.use_span(span, end_on_exit=False):
+                    posthoganalytics.capture_exception(e, properties={"tag": "max_ai"})
+                    logger.exception("Error streaming conversation", error=e)
                 yield self._failure_message()
-            finally:
+        finally:
+            with trace.use_span(span, end_on_exit=False):
                 span.set_attribute("posthog_ai.stream_conversation.chunks", chunk_count)
                 await self._redis_stream.delete_stream()
+            span.end()
 
     async def _redis_stream_to_assistant_output(self, message: StreamEvent) -> AssistantOutput | None:
         """Convert Redis stream event to Assistant output.

--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -16,6 +16,7 @@ from langchain_core.runnables.config import RunnableConfig
 from langgraph.errors import GraphInterrupt, GraphRecursionError
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import Command, StreamMode
+from opentelemetry import trace
 from posthoganalytics.ai.langchain.callbacks import CallbackHandler
 
 from posthog.schema import (
@@ -69,6 +70,7 @@ from ee.hogai.utils.types.composed import AssistantMaxGraphState, AssistantMaxPa
 from ee.models import Conversation
 
 logger = structlog.get_logger(__name__)
+_tracer = trace.get_tracer(__name__)
 
 
 class SubagentCallbackHandler(CallbackHandler):
@@ -623,12 +625,16 @@ class BaseAgentRunner(ABC):
     ):
         if not self._user:
             return
-        await database_sync_to_async(report_user_action)(
-            self._user,
-            event_name,
-            properties,
-            send_feature_flags=True,
-        )
+        with _tracer.start_as_current_span(
+            "posthog_ai.runner.report_conversation_state",
+            attributes={"posthog_ai.event_name": event_name},
+        ):
+            await database_sync_to_async(report_user_action)(
+                self._user,
+                event_name,
+                properties,
+                send_feature_flags=True,
+            )
 
     @asynccontextmanager
     async def _lock_conversation(self):
@@ -640,12 +646,14 @@ class BaseAgentRunner(ABC):
             return
 
         try:
-            self._conversation.status = Conversation.Status.IN_PROGRESS
-            await self._conversation.asave(update_fields=["status"])
+            with _tracer.start_as_current_span("posthog_ai.runner.lock_conversation"):
+                self._conversation.status = Conversation.Status.IN_PROGRESS
+                await self._conversation.asave(update_fields=["status"])
             yield
         finally:
-            self._conversation.status = Conversation.Status.IDLE
-            await self._conversation.asave(update_fields=["status", "updated_at"])
+            with _tracer.start_as_current_span("posthog_ai.runner.unlock_conversation"):
+                self._conversation.status = Conversation.Status.IDLE
+                await self._conversation.asave(update_fields=["status", "updated_at"])
 
     def _capture_exception(self, e: Exception):
         posthoganalytics.capture_exception(

--- a/ee/hogai/stream/redis_stream.py
+++ b/ee/hogai/stream/redis_stream.py
@@ -9,6 +9,7 @@ from django.conf import settings
 
 import structlog
 import redis.exceptions as redis_exceptions
+from opentelemetry import trace
 from prometheus_client import Histogram
 from pydantic import BaseModel, Field
 
@@ -27,6 +28,7 @@ from ee.hogai.utils.types.base import ApprovalPayload, AssistantStreamedMessageU
 from ee.models.assistant import Conversation
 
 logger = structlog.get_logger(__name__)
+_tracer = trace.get_tracer(__name__)
 
 REDIS_TO_CLIENT_LATENCY_HISTOGRAM = Histogram(
     "posthog_ai_redis_to_client_latency_seconds",
@@ -236,33 +238,43 @@ class ConversationRedisStream:
         timeout = 60.0  # 60 seconds timeout
         start_time = asyncio.get_event_loop().time()
         last_iteration_time = None
+        attempts = 0
 
-        while True:
-            current_time = time.time()
-            if last_iteration_time is not None:
-                iteration_duration = current_time - last_iteration_time
-                REDIS_STREAM_INIT_ITERATION_LATENCY_HISTOGRAM.observe(iteration_duration)
-            last_iteration_time = current_time
+        with _tracer.start_as_current_span(
+            "posthog_ai.redis_stream.wait_for_stream",
+            attributes={"posthog_ai.stream_key": self._stream_key},
+        ) as span:
+            while True:
+                current_time = time.time()
+                if last_iteration_time is not None:
+                    iteration_duration = current_time - last_iteration_time
+                    REDIS_STREAM_INIT_ITERATION_LATENCY_HISTOGRAM.observe(iteration_duration)
+                last_iteration_time = current_time
+                attempts += 1
 
-            elapsed_time = asyncio.get_event_loop().time() - start_time
-            if elapsed_time >= timeout:
+                elapsed_time = asyncio.get_event_loop().time() - start_time
+                if elapsed_time >= timeout:
+                    logger.debug(
+                        f"Stream creation timeout after {elapsed_time:.2f}s",
+                        stream_key=self._stream_key,
+                    )
+                    span.set_attribute("posthog_ai.poll_attempts", attempts)
+                    span.set_attribute("posthog_ai.outcome", "timeout")
+                    return False
+
+                if await self._redis_client.exists(self._stream_key):
+                    span.set_attribute("posthog_ai.poll_attempts", attempts)
+                    span.set_attribute("posthog_ai.outcome", "ready")
+                    return True
+
                 logger.debug(
-                    f"Stream creation timeout after {elapsed_time:.2f}s",
+                    f"Stream not found, retrying in {delay}s (elapsed: {elapsed_time:.2f}s)",
                     stream_key=self._stream_key,
                 )
-                return False
+                await asyncio.sleep(delay)
 
-            if await self._redis_client.exists(self._stream_key):
-                return True
-
-            logger.debug(
-                f"Stream not found, retrying in {delay}s (elapsed: {elapsed_time:.2f}s)",
-                stream_key=self._stream_key,
-            )
-            await asyncio.sleep(delay)
-
-            # Linear backoff
-            delay = min(delay + delay_increment, max_delay)
+                # Linear backoff
+                delay = min(delay + delay_increment, max_delay)
 
     async def read_stream(
         self,

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -531,7 +531,13 @@ class Command(BaseCommand):
 
         tag_queries(kind="temporal")
 
-        enable_otel = settings.TEMPORAL_OTEL_PLUGIN_ENABLED is True and settings.OTEL_SERVICE_NAME is not None
+        # Max AI traces span the Django request and the Temporal activity that runs the agent loop.
+        # Without the OTel plugin on the worker, every span emitted from an activity is a root span
+        # and the conversation trace splits across disconnected pieces. Force-enable for that queue
+        # so investigations don't depend on an operator flipping TEMPORAL_OTEL_PLUGIN_ENABLED.
+        enable_otel = (
+            settings.TEMPORAL_OTEL_PLUGIN_ENABLED is True or task_queue == settings.MAX_AI_TASK_QUEUE
+        ) and settings.OTEL_SERVICE_NAME is not None
         if enable_otel is True:
             # Mypy doesn't understand we have already checked settings.OTEL_SERVICE_NAME
             initialize_otel(settings.OTEL_SERVICE_NAME, settings.TEMPORAL_OTEL_LIBRARIES_TO_INSTRUMENT)  # type: ignore

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -305,6 +305,7 @@ async def create_worker(
             # Worker will flush heartbeats every
             # min(heartbeat_timeout * 0.8, max_heartbeat_throttle_interval).
             max_heartbeat_throttle_interval=dt.timedelta(seconds=5),
+            plugins=plugins,
         )
     else:
         worker = Worker(


### PR DESCRIPTION
conversations seem slow to me, particularly in hands-free mode
but our traces don't help see where time is being spent

## Problem

PostHog LLM traces only carry `$ai_generation` events emitted by the llm-gateway's LiteLLM callback (`services/llm-gateway/src/llm_gateway/callbacks/posthog.py`). They instrument the model call and nothing else, so when a conversations API request is slow it's impossible to tell whether the wall-clock time is LLM time or surrounding work (Temporal workflow startup, Redis stream init, per-chunk DB reads, tool execution).

A breakdown of the last 7 days of multi-turn `posthog_ai` traces (n=105,346) shows the gap clearly:

| Percentile | LLM time | Trace span | Gap (non-LLM) | % non-LLM |
|---|---|---|---|---|
| p50 | 27.3s | 31.0s | 3.0s | ~10% |
| p95 | 140s | 197s | 57s | ~29% |
| p99 | 281s | 449s | 215s | ~48% |

At p50 the LLM dominates; the tail is increasingly orchestration / tools / I/O. The `session_replay` agent mode is the outlier — 78% of p95 wall time is non-LLM. Today none of that shows up in our LLM traces.

## Changes

OTel spans added to every non-LLM hop in the conversations API path:

- `ee/hogai/core/executor.py` — `start_workflow`, `temporal_connect`, `temporal_start_workflow`, `wait_for_workflow_start` (with `poll_attempts`/`outcome`), `stream_conversation` (with `chunks` count), and `conversation_aget` for the per-chunk Postgres read on the SSE hot path.
- `ee/hogai/stream/redis_stream.py` — `wait_for_stream` polling loop (with `poll_attempts`/`outcome`).
- `ee/hogai/core/runner.py` — `lock_conversation` / `unlock_conversation` and `report_conversation_state`.
- `ee/hogai/core/agent_modes/executables.py` — `tool.invoke` with `tool_name`, `tool_call_id`, `team_id` attributes. This is the most important addition — tool execution is currently invisible in traces.

Plus two cross-process plumbing changes so a conversations request produces a single connected trace, not two disjoint ones:

- `posthog/management/commands/start_temporal_worker.py` — auto-enables `OpenTelemetryPlugin` on the Max AI Temporal worker when `OTEL_SERVICE_NAME` is set, without requiring the global `TEMPORAL_OTEL_PLUGIN_ENABLED` flip. Other queues stay opt-in.
- `posthog/temporal/common/worker.py` — fixes a latent bug where the resource-tuner branch of `create_worker` silently dropped the `plugins` kwarg, so the plugin would never apply on memory-tuned workers.

## How did you test this code?

I'm an agent. Verification done:

- `python3 -m py_compile` on every changed file (passes).
- `ruff check` and `ruff format --check` (clean).
- Inspected test files under `ee/hogai/**/test/` and `posthog/temporal/common/` — none assert on span names or attributes, so these additions are non-breaking by inspection.

Not tested manually — no local agent stack in this environment. Once shipped, validate via:

- `OTEL_SERVICE_NAME` set on the Max AI worker deployment (should already be the case).
- `OTEL_TRACES_SAMPLER_ARG` set non-zero. It currently defaults to `0` (see `posthog/otel_instrumentation.py:70`); without that, nothing exports.
- A Max AI conversation. The new spans should appear under the Django request span, with the Temporal-side spans (`tool.invoke`, `lock_conversation`, etc.) nested via the propagated trace context.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude (Claude Code, model `claude-opus-4-7`). Session started with the user asking whether the conversations API is "all LLM time" or has non-LLM headroom worth optimizing.

Investigation notes that informed the choices:

- The LiteLLM callback in llm-gateway is the only place `$ai_generation` is emitted, and it intentionally only wraps the model call. There is no `$ai_trace` parent and no `$ai_span` children for tools / DB / orchestration.
- Auto-instrumentation already covers Postgres (`PsycopgInstrumentor`), Redis (`RedisInstrumentor`), and Django requests (`DjangoInstrumentor`) — the manual spans here only fill the gaps (workflow start polling, tool execution, stream lifecycle).
- Chose OTel over emitting more `$ai_span` events because the existing auto-instrumentation already lives on OTel, and trace context propagation between the Django request and the Temporal activity is already wired (`temporalio.contrib.opentelemetry.TracingInterceptor` on the client side, `OpenTelemetryPlugin` on the worker side).
- Force-on for the Max AI task queue rather than changing the global default — keeps blast radius small.
- Fixed the dropped `plugins` kwarg in `create_worker` while in the area; it's a latent bug that would silently neutralise the plugin on memory-tuned workers and was easy to miss.
- Did NOT change `OTEL_TRACES_SAMPLER_ARG`. That's an ops concern and changing it from code feels wrong.

Two caveats called out in the description and worth a second look from a human reviewer:

1. The Django auto-span typically closes when the view returns, not when the SSE stream finishes. Temporal-side spans still flow via the propagated context, but the Django parent's duration may look shorter than the actual conversation. Worth eyeballing once telemetry's live.
2. Sampling must be non-zero in prod or all of this exports nothing.

Tools used: Claude Code, PostHog MCP (`execute-sql` for the latency breakdown query, `read-data-schema` for property discovery, `llma-skill-get` to fetch the pr-shepherd skill).