### PR TITLE
refactor(taxonomic-filter): extract eventMetadataTaxonomicGroupsLogic

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/eventMetadataTaxonomicGroupsLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/eventMetadataTaxonomicGroupsLogic.ts
@@ -1,0 +1,51 @@
+import { connect, kea, key, path, props, selectors } from 'kea'
+
+import {
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterLogicProps,
+} from 'lib/components/TaxonomicFilter/types'
+import { getEventMetadataDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
+
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { getCoreFilterDefinition } from '~/taxonomy/helpers'
+import { PropertyDefinition } from '~/types'
+
+import type { eventMetadataTaxonomicGroupsLogicType } from './eventMetadataTaxonomicGroupsLogicType'
+
+export const eventMetadataTaxonomicGroupsLogic = kea<eventMetadataTaxonomicGroupsLogicType>([
+    props({} as TaxonomicFilterLogicProps),
+    key((props) => `${props.taxonomicFilterLogicKey}`),
+    path((key) => ['lib', 'components', 'TaxonomicFilter', 'eventMetadataTaxonomicGroupsLogic', key]),
+
+    connect(() => ({
+        values: [propertyDefinitionsModel, ['eventMetadataPropertyDefinitions']],
+    })),
+
+    selectors({
+        eventMetadataTaxonomicGroups: [
+            (s) => [s.eventMetadataPropertyDefinitions],
+            (eventMetadataPropertyDefinitions): TaxonomicFilterGroup[] => [
+                {
+                    name: 'Event metadata',
+                    searchPlaceholder: 'event metadata',
+                    type: TaxonomicFilterGroupType.EventMetadata,
+                    options: eventMetadataPropertyDefinitions,
+                    getIcon: (option: PropertyDefinition) => getEventMetadataDefinitionIcon(option),
+                    getName: (option: PropertyDefinition) => {
+                        const coreDefinition = getCoreFilterDefinition(
+                            option.id,
+                            TaxonomicFilterGroupType.EventMetadata
+                        )
+                        return coreDefinition ? coreDefinition.label : option.name
+                    },
+                    getValue: (option: PropertyDefinition) => option.id,
+                    valuesEndpoint: (key) => {
+                        return `api/event/values/?key=${encodeURIComponent(key)}&is_column=true`
+                    },
+                    getPopoverHeader: () => 'Event metadata',
+                },
+            ],
+        ],
+    }),
+])

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -56,7 +56,6 @@ import { isDefinitionStale } from 'lib/utils/definitions'
 import { getPrimaryPropertyForEvent } from 'lib/utils/primaryEventProperty'
 import {
     getEventDefinitionIcon,
-    getEventMetadataDefinitionIcon,
     getPropertyDefinitionIcon,
     getRevenueAnalyticsDefinitionIcon,
 } from 'scenes/data-management/events/DefinitionHeader'
@@ -75,7 +74,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { actionsModel } from '~/models/actionsModel'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { primaryEventPropertiesModel } from '~/models/primaryEventPropertiesModel'
-import { propertyDefinitionsModel, updatePropertyDefinitions } from '~/models/propertyDefinitionsModel'
+import { updatePropertyDefinitions } from '~/models/propertyDefinitionsModel'
 import { DatabaseSchemaField, DatabaseSchemaTable } from '~/queries/schema/schema-general'
 import { getCoreFilterDefinition, getFilterLabel } from '~/taxonomy/helpers'
 import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
@@ -102,6 +101,7 @@ import { HogFlowTaxonomicFilters } from 'products/workflows/frontend/Workflows/h
 
 import { PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE } from '../PropertyFilters/utils'
 import { cohortTaxonomicGroupsLogic } from './cohortTaxonomicGroupsLogic'
+import { eventMetadataTaxonomicGroupsLogic } from './eventMetadataTaxonomicGroupsLogic'
 import { groupAnalyticsTaxonomicGroupsLogic } from './groupAnalyticsTaxonomicGroupsLogic'
 import { hogQLExpressionTaxonomicGroupsLogic } from './hogQLExpressionTaxonomicGroupsLogic'
 import type { taxonomicFilterLogicType } from './taxonomicFilterLogicType'
@@ -321,8 +321,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             ['dataWarehouseTables'],
             joinsLogic,
             ['columnsJoinedToPersons'],
-            propertyDefinitionsModel,
-            ['eventMetadataPropertyDefinitions'],
             featureFlagLogic,
             ['featureFlags'],
             primaryEventPropertiesModel,
@@ -333,6 +331,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             ['cohortTaxonomicGroups'],
             hogQLExpressionTaxonomicGroupsLogic,
             ['hogQLExpressionTaxonomicGroups'],
+            eventMetadataTaxonomicGroupsLogic,
+            ['eventMetadataTaxonomicGroups'],
         ],
         actions: [primaryEventPropertiesModel, ['ensureLoadedForEvents']],
     })),
@@ -551,7 +551,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 s.hogQLExpressionTaxonomicGroups,
                 s.suggestedFiltersLabel,
                 s.propertyFilters,
-                s.eventMetadataPropertyDefinitions,
+                s.eventMetadataTaxonomicGroups,
                 s.maxContextOptions,
                 s.cohortTaxonomicGroups,
                 s.endpointFilters,
@@ -571,7 +571,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 hogQLExpressionTaxonomicGroups: TaxonomicFilterGroup[],
                 suggestedFiltersLabel: string | undefined,
                 propertyFilters,
-                eventMetadataPropertyDefinitions: PropertyDefinition[],
+                eventMetadataTaxonomicGroups: TaxonomicFilterGroup[],
                 maxContextOptions: MaxContextTaxonomicFilterOption[],
                 cohortTaxonomicGroups: TaxonomicFilterGroup[],
                 endpointFilters: Record<string, any> | undefined,
@@ -782,25 +782,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getIcon: getPropertyDefinitionIcon,
                         getPopoverHeader: () => 'Internal event properties',
                     },
-                    {
-                        name: 'Event metadata',
-                        searchPlaceholder: 'event metadata',
-                        type: TaxonomicFilterGroupType.EventMetadata,
-                        options: eventMetadataPropertyDefinitions,
-                        getIcon: (option: PropertyDefinition) => getEventMetadataDefinitionIcon(option),
-                        getName: (option: PropertyDefinition) => {
-                            const coreDefinition = getCoreFilterDefinition(
-                                option.id,
-                                TaxonomicFilterGroupType.EventMetadata
-                            )
-                            return coreDefinition ? coreDefinition.label : option.name
-                        },
-                        getValue: (option: PropertyDefinition) => option.id,
-                        valuesEndpoint: (key) => {
-                            return `api/event/values/?key=${encodeURIComponent(key)}&is_column=true`
-                        },
-                        getPopoverHeader: () => 'Event metadata',
-                    },
+                    ...eventMetadataTaxonomicGroups,
                     {
                         name: 'Feature flags',
                         searchPlaceholder: 'feature flags',


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
