### PR TITLE
refactor(taxonomic-filter): extract eventPropertiesTaxonomicGroupsLogic

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/eventPropertiesTaxonomicGroupsLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/eventPropertiesTaxonomicGroupsLogic.ts
@@ -1,0 +1,116 @@
+import { connect, kea, key, path, props, selectors } from 'kea'
+import { combineUrl } from 'kea-router'
+
+import { buildEventTypeFilterShortcuts } from 'lib/components/TaxonomicFilter/eventTypeShortcuts'
+import {
+    TRAFFIC_TYPE_VIRTUAL_PROPERTIES,
+    propertyTaxonomicGroupProps,
+} from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
+import {
+    ExcludedProperties,
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterLogicProps,
+} from 'lib/components/TaxonomicFilter/types'
+import { withKeywordShortcuts } from 'lib/components/TaxonomicFilter/withKeywordShortcuts'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { isString, pluralize } from 'lib/utils'
+import { getPropertyDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
+import { getProductEventPropertyFilterOptions } from 'scenes/hog-functions/filters/HogFunctionFiltersInternal'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { PropertyDefinition } from '~/types'
+
+import type { eventPropertiesTaxonomicGroupsLogicType } from './eventPropertiesTaxonomicGroupsLogicType'
+
+export const eventPropertiesTaxonomicGroupsLogic = kea<eventPropertiesTaxonomicGroupsLogicType>([
+    props({} as TaxonomicFilterLogicProps),
+    key((props) => `${props.taxonomicFilterLogicKey}`),
+    path((key) => ['lib', 'components', 'TaxonomicFilter', 'eventPropertiesTaxonomicGroupsLogic', key]),
+
+    connect(() => ({
+        values: [projectLogic, ['currentProjectId'], featureFlagLogic, ['featureFlags']],
+    })),
+
+    selectors({
+        eventNames: [() => [(_, props) => props.eventNames], (eventNames) => eventNames ?? []],
+        excludedProperties: [
+            () => [(_, props) => props.excludedProperties],
+            (excludedProperties) => (excludedProperties ?? {}) as ExcludedProperties,
+        ],
+        propertyAllowList: [
+            () => [(_, props) => props.propertyAllowList],
+            (propertyAllowList) => propertyAllowList as TaxonomicFilterLogicProps['propertyAllowList'],
+        ],
+        eventPropertiesTaxonomicGroups: [
+            (s) => [s.currentProjectId, s.featureFlags, s.eventNames, s.excludedProperties, s.propertyAllowList],
+            (projectId, featureFlags, eventNames, excludedProperties, propertyAllowList): TaxonomicFilterGroup[] => [
+                {
+                    name: 'Event properties',
+                    searchPlaceholder: 'event properties',
+                    type: TaxonomicFilterGroupType.EventProperties,
+                    endpoint: combineUrl(`api/projects/${projectId}/property_definitions`, {
+                        is_feature_flag: false,
+                        ...(eventNames.length > 0 ? { event_names: eventNames } : {}),
+                        properties: propertyAllowList?.[TaxonomicFilterGroupType.EventProperties]
+                            ? propertyAllowList[TaxonomicFilterGroupType.EventProperties].join(',')
+                            : undefined,
+                        exclude_hidden: true,
+                        exclude_restricted: true,
+                    }).url,
+                    scopedEndpoint:
+                        eventNames.length > 0
+                            ? combineUrl(`api/projects/${projectId}/property_definitions`, {
+                                  event_names: eventNames,
+                                  is_feature_flag: false,
+                                  filter_by_event_names: true,
+                                  properties: propertyAllowList?.[TaxonomicFilterGroupType.EventProperties]
+                                      ? propertyAllowList[TaxonomicFilterGroupType.EventProperties].join(',')
+                                      : undefined,
+                                  exclude_hidden: true,
+                                  exclude_restricted: true,
+                              }).url
+                            : undefined,
+                    expandLabel: ({ count, expandedCount }: { count: number; expandedCount: number }) =>
+                        `Show ${pluralize(expandedCount - count, 'property', 'properties')} that ${pluralize(
+                            expandedCount - count,
+                            'has',
+                            'have',
+                            false
+                        )}n't been seen with ${pluralize(eventNames.length, 'this event', 'these events', false)}`,
+                    excludedProperties: [
+                        ...(excludedProperties?.[TaxonomicFilterGroupType.EventProperties]?.filter(isString) ?? []),
+                        ...(!featureFlags[FEATURE_FLAGS.TRAFFIC_TYPE_VIRTUAL_PROPERTIES]
+                            ? TRAFFIC_TYPE_VIRTUAL_PROPERTIES
+                            : []),
+                    ],
+                    propertyAllowList: propertyAllowList?.[TaxonomicFilterGroupType.EventProperties]?.filter(isString),
+                    ...withKeywordShortcuts<PropertyDefinition>(
+                        {
+                            getName: (propertyDefinition) => propertyDefinition.name,
+                            getValue: (propertyDefinition) => propertyDefinition.name,
+                            ...propertyTaxonomicGroupProps(),
+                        },
+                        {
+                            popoverHeader: 'Event type shortcut',
+                            buildShortcuts: buildEventTypeFilterShortcuts,
+                        }
+                    ),
+                },
+                {
+                    name: 'Internal event properties',
+                    searchPlaceholder: 'internal event properties',
+                    type: TaxonomicFilterGroupType.InternalEventProperties,
+                    options: getProductEventPropertyFilterOptions('activity-log').map((value) => ({
+                        name: value,
+                        value,
+                        group: TaxonomicFilterGroupType.EventProperties,
+                    })),
+                    getIcon: getPropertyDefinitionIcon,
+                    getPopoverHeader: () => 'Internal event properties',
+                },
+            ],
+        ],
+    }),
+])

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -16,8 +16,6 @@ import {
 import { combineUrl } from 'kea-router'
 import posthog from 'posthog-js'
 
-import { IconCursor } from '@posthog/icons'
-
 import { infiniteListLogic } from 'lib/components/TaxonomicFilter/infiniteListLogic'
 import { infiniteListLogicType } from 'lib/components/TaxonomicFilter/infiniteListLogicType'
 import {
@@ -30,7 +28,6 @@ import {
     DataWarehousePopoverField,
     ExcludedProperties,
     ListStorage,
-    QuickFilterItem,
     SelectedProperties,
     SimpleOption,
     SkeletonItem,
@@ -43,10 +40,7 @@ import {
 } from 'lib/components/TaxonomicFilter/types'
 import { isString, objectsEqual, pluralize } from 'lib/utils'
 import { isDefinitionStale } from 'lib/utils/definitions'
-import {
-    getEventDefinitionIcon,
-    getPropertyDefinitionIcon,
-} from 'scenes/data-management/events/DefinitionHeader'
+import { getEventDefinitionIcon, getPropertyDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
 import { getProductEventPropertyFilterOptions } from 'scenes/hog-functions/filters/HogFunctionFiltersInternal'
 import { projectLogic } from 'scenes/projectLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -54,13 +48,11 @@ import { teamLogic } from 'scenes/teamLogic'
 import { actionsModel } from '~/models/actionsModel'
 import { primaryEventPropertiesModel } from '~/models/primaryEventPropertiesModel'
 import { updatePropertyDefinitions } from '~/models/propertyDefinitionsModel'
-import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
 import {
     ActionType,
     CoreFilterDefinition,
     EventDefinition,
-    EventDefinitionType,
     PersonProperty,
     PersonType,
     PropertyDefinition,
@@ -228,50 +220,6 @@ export const propertyTaxonomicGroupProps = (
     },
     getIcon: getPropertyDefinitionIcon,
 })
-
-function keywordShortcutValue(item: QuickFilterItem): string {
-    // Synthetic identity string used only as a React/selection key. Never parsed by consumers.
-    return JSON.stringify({
-        q: item.propertyKey,
-        v: item.filterValue,
-        e: item.eventName ?? null,
-    })
-}
-
-type BaseGroupFns<T> = {
-    getName: (instance: T) => string
-    getValue: (instance: T) => TaxonomicFilterValue
-    getIcon?: (instance: T) => JSX.Element
-    getPopoverHeader: (instance: T) => string
-}
-
-/** Extend a group's presentation methods so they also handle `QuickFilterItem`s (keyword
- *  shortcuts), and attach a `keywordShortcuts` builder. `popoverHeader` lets each group label
- *  its own shortcut kind (e.g. "Autocapture shortcut" for series, "Event type shortcut" for
- *  property filters). */
-function withKeywordShortcuts<T>(
-    base: BaseGroupFns<T>,
-    {
-        popoverHeader,
-        buildShortcuts,
-    }: {
-        popoverHeader: string
-        buildShortcuts: (searchQuery: string) => QuickFilterItem[]
-    }
-): Pick<TaxonomicFilterGroup, 'getName' | 'getValue' | 'getIcon' | 'getPopoverHeader' | 'keywordShortcuts'> {
-    const baseGetIcon = base.getIcon
-    return {
-        getName: (item: T | QuickFilterItem) => (isQuickFilterItem(item) ? item.name : base.getName(item)),
-        getValue: (item: T | QuickFilterItem) =>
-            isQuickFilterItem(item) ? keywordShortcutValue(item) : base.getValue(item),
-        getIcon: baseGetIcon
-            ? (item: T | QuickFilterItem) => (isQuickFilterItem(item) ? <IconCursor /> : baseGetIcon(item))
-            : undefined,
-        getPopoverHeader: (item: T | QuickFilterItem) =>
-            isQuickFilterItem(item) ? popoverHeader : base.getPopoverHeader(item),
-        keywordShortcuts: buildShortcuts,
-    }
-}
 
 export const defaultDataWarehousePopoverFields: DataWarehousePopoverField[] = [
     {

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -18,7 +18,6 @@ import posthog from 'posthog-js'
 
 import { IconCursor } from '@posthog/icons'
 
-import { buildEventTypeFilterShortcuts } from 'lib/components/TaxonomicFilter/eventTypeShortcuts'
 import { infiniteListLogic } from 'lib/components/TaxonomicFilter/infiniteListLogic'
 import { infiniteListLogicType } from 'lib/components/TaxonomicFilter/infiniteListLogicType'
 import {
@@ -42,8 +41,6 @@ import {
     TaxonomicFilterValue,
     isQuickFilterItem,
 } from 'lib/components/TaxonomicFilter/types'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isString, objectsEqual, pluralize } from 'lib/utils'
 import { isDefinitionStale } from 'lib/utils/definitions'
 import {
@@ -79,6 +76,7 @@ import { customEventsTaxonomicGroupsLogic } from './customEventsTaxonomicGroupsL
 import { dataWarehouseTaxonomicGroupsLogic } from './dataWarehouseTaxonomicGroupsLogic'
 import { errorTrackingTaxonomicGroupsLogic } from './errorTrackingTaxonomicGroupsLogic'
 import { eventMetadataTaxonomicGroupsLogic } from './eventMetadataTaxonomicGroupsLogic'
+import { eventPropertiesTaxonomicGroupsLogic } from './eventPropertiesTaxonomicGroupsLogic'
 import { eventsTaxonomicGroupsLogic } from './eventsTaxonomicGroupsLogic'
 import { groupAnalyticsTaxonomicGroupsLogic } from './groupAnalyticsTaxonomicGroupsLogic'
 import { hogQLExpressionTaxonomicGroupsLogic } from './hogQLExpressionTaxonomicGroupsLogic'
@@ -122,7 +120,7 @@ const SHORTCUT_TO_PROPERTY_FILTER_GROUP_TYPES = new Set<TaxonomicFilterGroupType
 export const DEFAULT_SLOTS_PER_GROUP = 5
 export const MAX_TOP_MATCHES_PER_GROUP = 10
 
-const TRAFFIC_TYPE_VIRTUAL_PROPERTIES = [
+export const TRAFFIC_TYPE_VIRTUAL_PROPERTIES = [
     '$virt_is_bot',
     '$virt_traffic_type',
     '$virt_traffic_category',
@@ -302,8 +300,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             ['currentTeamId', 'currentTeam'],
             projectLogic,
             ['currentProjectId'],
-            featureFlagLogic,
-            ['featureFlags'],
             groupAnalyticsTaxonomicGroupsLogic,
             ['groupAnalyticsTaxonomicGroups', 'groupAnalyticsTaxonomicGroupNames'],
             cohortTaxonomicGroupsLogic,
@@ -336,6 +332,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             ['eventsTaxonomicGroups'],
             customEventsTaxonomicGroupsLogic,
             ['customEventsTaxonomicGroups'],
+            eventPropertiesTaxonomicGroupsLogic,
+            ['eventPropertiesTaxonomicGroups'],
         ],
         actions: [primaryEventPropertiesModel, ['ensureLoadedForEvents']],
     })),
@@ -537,7 +535,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 s.maxAIContextTaxonomicGroups,
                 s.cohortTaxonomicGroups,
                 s.apmTaxonomicGroups,
-                s.featureFlags,
+                s.eventPropertiesTaxonomicGroups,
                 s.replayTaxonomicGroups,
                 s.posthogResourcesTaxonomicGroups,
                 s.errorTrackingTaxonomicGroups,
@@ -559,7 +557,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 maxAIContextTaxonomicGroups: TaxonomicFilterGroup[],
                 cohortTaxonomicGroups: TaxonomicFilterGroup[],
                 apmTaxonomicGroups: TaxonomicFilterGroup[],
-                featureFlags: Record<string, boolean | string | undefined>,
+                eventPropertiesTaxonomicGroups: TaxonomicFilterGroup[],
                 replayTaxonomicGroups: TaxonomicFilterGroup[],
                 posthogResourcesTaxonomicGroups: TaxonomicFilterGroup[],
                 errorTrackingTaxonomicGroups: TaxonomicFilterGroup[],
@@ -630,71 +628,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         ...propertyTaxonomicGroupProps(CORE_FILTER_DEFINITIONS_BY_GROUP.metadata),
                     },
-                    {
-                        name: 'Event properties',
-                        searchPlaceholder: 'event properties',
-                        type: TaxonomicFilterGroupType.EventProperties,
-                        endpoint: combineUrl(`api/projects/${projectId}/property_definitions`, {
-                            is_feature_flag: false,
-                            ...(eventNames.length > 0 ? { event_names: eventNames } : {}),
-                            properties: propertyAllowList?.[TaxonomicFilterGroupType.EventProperties]
-                                ? propertyAllowList[TaxonomicFilterGroupType.EventProperties].join(',')
-                                : undefined,
-                            exclude_hidden: true,
-                            exclude_restricted: true,
-                        }).url,
-                        scopedEndpoint:
-                            eventNames.length > 0
-                                ? combineUrl(`api/projects/${projectId}/property_definitions`, {
-                                      event_names: eventNames,
-                                      is_feature_flag: false,
-                                      filter_by_event_names: true,
-                                      properties: propertyAllowList?.[TaxonomicFilterGroupType.EventProperties]
-                                          ? propertyAllowList[TaxonomicFilterGroupType.EventProperties].join(',')
-                                          : undefined,
-                                      exclude_hidden: true,
-                                      exclude_restricted: true,
-                                  }).url
-                                : undefined,
-                        expandLabel: ({ count, expandedCount }: { count: number; expandedCount: number }) =>
-                            `Show ${pluralize(expandedCount - count, 'property', 'properties')} that ${pluralize(
-                                expandedCount - count,
-                                'has',
-                                'have',
-                                false
-                            )}n't been seen with ${pluralize(eventNames.length, 'this event', 'these events', false)}`,
-                        excludedProperties: [
-                            ...(excludedProperties?.[TaxonomicFilterGroupType.EventProperties]?.filter(isString) ?? []),
-                            ...(!featureFlags[FEATURE_FLAGS.TRAFFIC_TYPE_VIRTUAL_PROPERTIES]
-                                ? TRAFFIC_TYPE_VIRTUAL_PROPERTIES
-                                : []),
-                        ],
-                        propertyAllowList:
-                            propertyAllowList?.[TaxonomicFilterGroupType.EventProperties]?.filter(isString),
-                        ...withKeywordShortcuts<PropertyDefinition>(
-                            {
-                                getName: (propertyDefinition) => propertyDefinition.name,
-                                getValue: (propertyDefinition) => propertyDefinition.name,
-                                ...propertyTaxonomicGroupProps(),
-                            },
-                            {
-                                popoverHeader: 'Event type shortcut',
-                                buildShortcuts: buildEventTypeFilterShortcuts,
-                            }
-                        ),
-                    },
-                    {
-                        name: 'Internal event properties',
-                        searchPlaceholder: 'internal event properties',
-                        type: TaxonomicFilterGroupType.InternalEventProperties,
-                        options: getProductEventPropertyFilterOptions('activity-log').map((value) => ({
-                            name: value,
-                            value,
-                            group: TaxonomicFilterGroupType.EventProperties,
-                        })),
-                        getIcon: getPropertyDefinitionIcon,
-                        getPopoverHeader: () => 'Internal event properties',
-                    },
+                    ...eventPropertiesTaxonomicGroups,
                     ...eventMetadataTaxonomicGroups,
                     {
                         name: 'Feature flags',


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
