### PR TITLE
fix(ux): restore mobile nav hamburger after scene-tabs removal

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -158,7 +158,7 @@ export function PanelLayout({ className }: { className?: string }): JSX.Element 
                     clearActivePanelIdentifier()
                 }}
                 className={cn(
-                    'z-(--z-layout-panel-over-nav) md:z-(--z-layout-panel-under) fixed top-0 bottom-0 bg-fill-highlight-200 dark:bg-black/80',
+                    'z-(--z-layout-panel-over-nav) md:z-(--z-layout-panel-under) fixed top-0 bottom-0 bg-fill-highlight-200 dark:bg-black/80 transition-opacity duration-200',
                     isMobileLayout
                         ? 'left-0 w-[var(--panel-layout-mobile-offset)]'
                         : 'left-0 right-0 w-screen h-screen',
@@ -176,7 +176,7 @@ export function PanelLayout({ className }: { className?: string }): JSX.Element 
                     clearActivePanelIdentifier()
                 }}
                 className={cn(
-                    'z-(--z-layout-navbar-under) md:z-(--z-layout-navbar) fixed top-0 bottom-0 right-0 bg-fill-highlight-200 dark:bg-black/80',
+                    'z-(--z-layout-navbar-under) md:z-(--z-layout-navbar) fixed top-0 bottom-0 right-0 bg-fill-highlight-200 dark:bg-black/80 transition-opacity duration-200',
                     isMobileLayout ? 'left-(--project-navbar-width)' : 'left-0 w-screen h-screen',
                     !(isMobileLayout && isLayoutNavbarVisibleForMobile) && 'pointer-events-none opacity-0'
                 )}

--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -1,12 +1,17 @@
 import { cva } from 'cva'
 import { useActions, useMountedLogic, useValues } from 'kea'
 
+import { IconX } from '@posthog/icons'
+
+import { IconMenu } from 'lib/lemon-ui/icons'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { cn } from 'lib/utils/css-classes'
 
 import { supportTicketCounterLogic } from 'products/conversations/frontend/supportTicketCounterLogic'
 
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
 import { Nav as AiFirstNavBar } from './ai-first/Nav'
+import { PanelLayoutPanels } from './ai-first/PanelLayoutPanels'
 import { panelLayoutLogic } from './panelLayoutLogic'
 import { PROJECT_TREE_KEY } from './ProjectTree/ProjectTree'
 import { projectTreeLogic } from './ProjectTree/projectTreeLogic'
@@ -69,7 +74,11 @@ export function PanelLayout({ className }: { className?: string }): JSX.Element 
         isLayoutNavbarVisibleForDesktop,
         isLayoutNavCollapsed,
         panelWidth,
+        activePanelIdentifier,
     } = useValues(panelLayoutLogic)
+    // Panels can be surfaced from URL state (DataAndPeople, DataManagement) without flipping
+    // isLayoutPanelVisible — so for overlay visibility we key off the identifier directly.
+    const panelIsShown = isLayoutPanelVisible || activePanelIdentifier !== ''
     const { mobileLayout: isMobileLayout } = useValues(navigation3000Logic)
     const { showLayoutPanel, clearActivePanelIdentifier, showLayoutNavBar } = useActions(panelLayoutLogic)
     useMountedLogic(projectTreeLogic({ key: PROJECT_TREE_KEY }))
@@ -77,6 +86,16 @@ export function PanelLayout({ className }: { className?: string }): JSX.Element 
 
     return (
         <>
+            {isMobileLayout && (
+                <ButtonPrimitive
+                    onClick={() => showLayoutNavBar(!isLayoutNavbarVisibleForMobile)}
+                    iconOnly
+                    aria-label={isLayoutNavbarVisibleForMobile ? 'Close navigation' : 'Open navigation'}
+                    className="fixed top-1 left-1 z-760 rounded-lg bg-surface-primary border border-primary shadow-sm"
+                >
+                    {isLayoutNavbarVisibleForMobile ? <IconX /> : <IconMenu />}
+                </ButtonPrimitive>
+            )}
             <div
                 id="project-panel-layout"
                 className={cn(
@@ -102,7 +121,10 @@ export function PanelLayout({ className }: { className?: string }): JSX.Element 
                               width: 'var(--project-navbar-width)',
                               transform: isLayoutNavbarVisibleForMobile ? 'translateX(0)' : 'translateX(-100%)',
                               transition: 'transform 0.2s ease-out',
-                              zIndex: 'var(--z-layout-panel)',
+                              // Container holds the nav only on mobile (panel renders separately
+                              // below). Drop its z to the navbar layer so the dim overlay can slot
+                              // between nav (this container) and the panel.
+                              zIndex: 'var(--z-layout-navbar)',
                           } as React.CSSProperties)
                         : {}
                 }
@@ -110,27 +132,52 @@ export function PanelLayout({ className }: { className?: string }): JSX.Element 
                 <AiFirstNavBar />
             </div>
 
-            {/* Panel overlay - always rendered for exit animation */}
+            {/* Mobile-only positioning anchor for panel content. Decoupled from #project-panel-layout
+                so the panel gets its own stacking context at --z-layout-panel. The wrapper is
+                left:0 width:0 — PanelLayoutPanel's inner nav uses absolute left:var(--panel-layout-mobile-offset)
+                which resolves against this wrapper's 0-width left edge → lands at viewport 40px.
+                pointer-events:none so the empty wrapper area doesn't intercept clicks on the dim
+                or right overlays — panel content re-enables pointer-events via its own cva. */}
+            {isMobileLayout && (
+                <div
+                    className="fixed top-0 left-0 h-screen z-[var(--z-layout-panel)] pointer-events-none"
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ width: 0 }}
+                >
+                    <div className="relative h-full">
+                        <PanelLayoutPanels />
+                    </div>
+                </div>
+            )}
+
+            {/* Panel dim overlay — click closes the panel. On mobile hugs the visible nav strip
+                (the 40px the panel doesn't cover); on desktop covers the full viewport. */}
             <div
                 onClick={() => {
                     showLayoutPanel(false)
                     clearActivePanelIdentifier()
                 }}
                 className={cn(
-                    'z-[var(--z-layout-panel-under)] fixed inset-0 w-screen h-screen bg-fill-highlight-200 dark:bg-black/80 overlay-fade',
-                    !isLayoutPanelVisible && 'pointer-events-none opacity-0'
+                    'z-(--z-layout-panel-over-nav) md:z-(--z-layout-panel-under) fixed top-0 bottom-0 bg-fill-highlight-200 dark:bg-black/80',
+                    isMobileLayout
+                        ? 'left-0 w-[var(--panel-layout-mobile-offset)]'
+                        : 'left-0 right-0 w-screen h-screen',
+                    !panelIsShown && 'pointer-events-none opacity-0'
                 )}
-                aria-hidden={!isLayoutPanelVisible}
+                aria-hidden={!panelIsShown}
             />
 
-            {/* Mobile overlay for new app-layout - outside transformed container so it fades instead of slides */}
+            {/* Mobile navbar overlay — sits right of the nav (and panel when open) so a tap
+                "right of panel" closes everything. */}
             <div
                 onClick={() => {
                     showLayoutNavBar(false)
+                    showLayoutPanel(false)
                     clearActivePanelIdentifier()
                 }}
                 className={cn(
-                    'z-[var(--z-layout-navbar-under)] fixed inset-0 w-screen h-screen bg-fill-highlight-200 dark:bg-black/80 overlay-fade',
+                    'z-(--z-layout-navbar-under) md:z-(--z-layout-navbar) fixed top-0 bottom-0 right-0 bg-fill-highlight-200 dark:bg-black/80',
+                    isMobileLayout ? 'left-(--project-navbar-width)' : 'left-0 w-screen h-screen',
                     !(isMobileLayout && isLayoutNavbarVisibleForMobile) && 'pointer-events-none opacity-0'
                 )}
                 aria-hidden={!(isMobileLayout && isLayoutNavbarVisibleForMobile)}

--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -29,7 +29,7 @@ interface PanelLayoutPanelProps {
 }
 
 const panelLayoutPanelVariants = cva({
-    base: 'w-full flex flex-col max-h-screen min-h-screen absolute border-r border-primary transition-[width] duration-100 prefers-reduced-motion:transition-none',
+    base: 'pointer-events-auto w-full flex flex-col max-h-screen min-h-screen absolute border-r border-primary transition-[width] duration-100 prefers-reduced-motion:transition-none',
     variants: {
         isLayoutNavCollapsed: {
             true: '',

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -11,7 +11,6 @@ import { RenderKeybind } from 'lib/components/AppShortcuts/AppShortcutMenu'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
 import { commandLogic } from 'lib/components/Command/commandLogic'
-import { NotificationsPanel } from 'lib/components/NotificationsMenu/NotificationsPanel'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Collapsible } from 'lib/ui/Collapsible/Collapsible'
@@ -24,7 +23,7 @@ import { NavExperimentTab, PanelLayoutNavIdentifier, panelLayoutLogic } from '~/
 
 import { navigation3000Logic } from '../../navigation-3000/navigationLogic'
 import { NavBarFooter } from '../NavBarFooter'
-import { PROJECT_TREE_KEY, ProjectTree } from '../ProjectTree/ProjectTree'
+import { PanelLayoutPanels } from './PanelLayoutPanels'
 import { NavTabBrowse } from './tabs/NavTabBrowse'
 const NavTabChat = lazy(() => import('./tabs/NavTabChat').then((m) => ({ default: m.NavTabChat })))
 
@@ -304,45 +303,12 @@ export function Nav(): JSX.Element {
                 )}
             </nav>
 
-            {activePanelIdentifier === 'DataAndPeople' && (
-                <ProjectTree root="data-and-people://" searchPlaceholder="Search data" />
-            )}
-            {activePanelIdentifier === 'Project' && (
-                <ProjectTree
-                    root="project://"
-                    logicKey={PROJECT_TREE_KEY}
-                    searchPlaceholder="Search files"
-                    showRecents
-                />
-            )}
-            {activePanelIdentifier === 'Products' && <ProjectTree root="products://" searchPlaceholder="Search apps" />}
-            {activePanelIdentifier === 'Shortcuts' && (
-                <ProjectTree root="shortcuts://" searchPlaceholder="Search starred items" />
-            )}
-            {activePanelIdentifier === 'Notifications' && <NotificationsPanel />}
-            {activePanelIdentifier === 'Chat' && (
-                <div className="flex flex-col h-full min-h-screen max-h-screen bg-surface-tertiary border-r overflow-hidden w-[var(--project-panel-width)]">
-                    <Suspense
-                        fallback={
-                            <div className="flex flex-col gap-px px-1 pt-2">
-                                {Array.from({ length: 15 }).map((_, index) => (
-                                    <WrappingLoadingSkeleton fullWidth key={index}>
-                                        <ButtonPrimitive aria-hidden inert menuItem />
-                                    </WrappingLoadingSkeleton>
-                                ))}
-                            </div>
-                        }
-                    >
-                        <NavTabChat
-                            inPanel
-                            onItemClick={() => {
-                                clearActivePanelIdentifier()
-                                showLayoutPanel(false)
-                            }}
-                        />
-                    </Suspense>
-                </div>
-            )}
+            {/* Desktop renders panel content inline next to the nav (PanelLayoutPanel's
+                ResizableElement positions it via left:100% of this flex parent). On mobile we
+                lift the panel out to PanelLayout.tsx so it can have its own stacking context
+                independent of #project-panel-layout — this lets the dim overlay slot between
+                the nav and the panel. */}
+            {!isMobileLayout && <PanelLayoutPanels />}
         </div>
     )
 }

--- a/frontend/src/layout/panel-layout/ai-first/PanelLayoutPanels.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/PanelLayoutPanels.tsx
@@ -1,0 +1,64 @@
+import { useActions, useValues } from 'kea'
+import { lazy, Suspense } from 'react'
+
+import { NotificationsPanel } from 'lib/components/NotificationsMenu/NotificationsPanel'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
+
+import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
+
+import { PROJECT_TREE_KEY, ProjectTree } from '../ProjectTree/ProjectTree'
+
+const NavTabChat = lazy(() => import('./tabs/NavTabChat').then((m) => ({ default: m.NavTabChat })))
+
+// Renders the currently-active panel (Project tree, Notifications, Chat, etc.). Extracted so the
+// same active-panel JSX can be mounted at different positions in the DOM/stacking tree depending
+// on layout mode — inside the nav container on desktop, as a fixed sibling on mobile.
+export function PanelLayoutPanels(): JSX.Element | null {
+    const { activePanelIdentifier } = useValues(panelLayoutLogic)
+    const { clearActivePanelIdentifier, showLayoutPanel } = useActions(panelLayoutLogic)
+
+    if (activePanelIdentifier === 'DataAndPeople') {
+        return <ProjectTree root="data-and-people://" searchPlaceholder="Search data" />
+    }
+    if (activePanelIdentifier === 'Project') {
+        return (
+            <ProjectTree root="project://" logicKey={PROJECT_TREE_KEY} searchPlaceholder="Search files" showRecents />
+        )
+    }
+    if (activePanelIdentifier === 'Products') {
+        return <ProjectTree root="products://" searchPlaceholder="Search apps" />
+    }
+    if (activePanelIdentifier === 'Shortcuts') {
+        return <ProjectTree root="shortcuts://" searchPlaceholder="Search starred items" />
+    }
+    if (activePanelIdentifier === 'Notifications') {
+        return <NotificationsPanel />
+    }
+    if (activePanelIdentifier === 'Chat') {
+        return (
+            <div className="pointer-events-auto flex flex-col h-full min-h-screen max-h-screen bg-surface-tertiary border-r overflow-hidden w-[var(--project-panel-width)]">
+                <Suspense
+                    fallback={
+                        <div className="flex flex-col gap-px px-1 pt-2">
+                            {Array.from({ length: 15 }).map((_, index) => (
+                                <WrappingLoadingSkeleton fullWidth key={index}>
+                                    <ButtonPrimitive aria-hidden inert menuItem />
+                                </WrappingLoadingSkeleton>
+                            ))}
+                        </div>
+                    }
+                >
+                    <NavTabChat
+                        inPanel
+                        onItemClick={() => {
+                            clearActivePanelIdentifier()
+                            showLayoutPanel(false)
+                        }}
+                    />
+                </Suspense>
+            </div>
+        )
+    }
+    return null
+}

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -1,5 +1,5 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
-import { router } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 
 import { LemonTreeRef } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
@@ -258,6 +258,15 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
         ],
         pathname: [(s) => [s.location], (location): string => location.pathname],
     }),
+    urlToAction(({ actions, values }) => ({
+        '*': () => {
+            if (values.mobileLayout && (values.isLayoutNavbarVisibleForMobile || values.isLayoutPanelVisible)) {
+                actions.showLayoutNavBar(false)
+                actions.showLayoutPanel(false)
+                actions.clearActivePanelIdentifier()
+            }
+        },
+    })),
     afterMount(({ actions, cache, values }) => {
         // Watch for window resize
         if (typeof window !== 'undefined') {

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -260,7 +260,11 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
     }),
     urlToAction(({ actions, values }) => ({
         '*': () => {
-            if (values.mobileLayout && (values.isLayoutNavbarVisibleForMobile || values.isLayoutPanelVisible)) {
+            // URL-surfaced panels (DataAndPeople, DataManagement) set activePanelIdentifier
+            // without flipping isLayoutPanelVisible, so check the identifier too — otherwise
+            // navigating away from one leaves the panel and its dim mounted.
+            const panelIsShown = values.isLayoutPanelVisible || values.activePanelIdentifier !== ''
+            if (values.mobileLayout && (values.isLayoutNavbarVisibleForMobile || panelIsShown)) {
                 actions.showLayoutNavBar(false)
                 actions.showLayoutPanel(false)
                 actions.clearActivePanelIdentifier()

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -668,8 +668,8 @@
     --z-scene-layout-content-panel: 770;
     --z-scene-layout-content-panel-under: 769;
     --z-layout-panel: 761;
-    --z-layout-panel-over-nav: 761; // mobile dim sitting above the nav, below the panel
     --z-layout-panel-under: 760;
+    --z-layout-panel-over-nav: 759; // mobile dim sitting above the nav (756), below the panel (761)
     --z-layout-navbar-over: 757;
     --z-layout-navbar: 756;
     --z-layout-navbar-under: 755;

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -667,8 +667,9 @@
     --z-notifications-popover: 800; // below the TZ aware popover but over the main-nav
     --z-scene-layout-content-panel: 770;
     --z-scene-layout-content-panel-under: 769;
-    --z-layout-panel: 760;
-    --z-layout-panel-under: 759;
+    --z-layout-panel: 761;
+    --z-layout-panel-over-nav: 761; // mobile dim sitting above the nav, below the panel
+    --z-layout-panel-under: 760;
     --z-layout-navbar-over: 757;
     --z-layout-navbar: 756;
     --z-layout-navbar-under: 755;
@@ -1991,22 +1992,6 @@
     /* stylelint-disable-next-line order/order */
     .animate-fade-in {
         animation: fade-in 0.4s ease-out forwards;
-    }
-
-    /* Overlay fade in/out transitions */
-    .overlay-fade {
-        opacity: 1;
-        transition: opacity 0.2s ease-out;
-
-        /* Exit animation - opacity controlled by utility class */
-        &.opacity-0 {
-            opacity: 0;
-        }
-
-        /* Entry animation - fade in from 0 */
-        @starting-style {
-            opacity: 0;
-        }
     }
 
     /* stylelint-disable-next-line keyframes-name-pattern */


### PR DESCRIPTION
## Problem

#59764 removed the in-app scene tabs, which also took away the mobile-only hamburger button that lived inside `SceneTabs.tsx`. Without it, mobile users had no way to open the nav, and panels surfaced from the URL had no way to be dismissed.

Desktop (no changes, showing it works as intended)
<img width="2066" height="1264" alt="2026-05-24 16 31 58" src="https://github.com/user-attachments/assets/b50b3ad3-f603-4bbf-95a5-fba9036c4ece" />


Mobile fixed up
<img width="1148" height="1264" alt="2026-05-24 16 33 19" src="https://github.com/user-attachments/assets/6791b317-8490-4d2d-a27c-ff0f986783be" />

## Changes

- **Hamburger button** (`PanelLayout.tsx`): fixed top-left `ButtonPrimitive` rendered only on mobile. Toggles `showLayoutNavBar`. Icon swaps `IconMenu` ↔ `IconX`.
- **URL-change auto-close** (`panelLayoutLogic.tsx`): added `urlToAction` so navigating to a new URL on mobile while the nav or a panel is open closes both, plus clears `activePanelIdentifier`. Prevents the overlays from persisting after a nav click.
- **Restructured the mobile stacking** so a dim overlay can slot between the nav and the panel content:
  - `#project-panel-layout` now holds only the nav on mobile and drops its `z-index` to `--z-layout-navbar`.
  - Panel rendering extracted into a new shared `PanelLayoutPanels` component. Desktop still mounts it inside `Nav.tsx` (flex sibling of `<nav>`, positioned via `left:100%` like before). Mobile mounts it as a fixed `left:0 width:0` positioning anchor in `PanelLayout.tsx`, so `PanelLayoutPanel`'s `absolute left:var(--panel-layout-mobile-offset)` lands at viewport 40px just as it did before. The anchor is `pointer-events:none` so it doesn't intercept overlay clicks; `PanelLayoutPanel`'s inner nav gets `pointer-events-auto` so the panel itself stays interactive.
  - Added `--z-layout-panel-over-nav` between the nav and panel layers; the left dim overlay uses it (mobile) or falls back to `--z-layout-panel-under` on desktop (via `md:` variant).
- **Split-zone overlay clicks**: on mobile the left dim overlay hugs the 40px visible nav strip and closes the panel only. The right overlay (right of the panel) closes everything (nav + panel + identifier).
- **Visibility signal**: the dim overlay keys off `isLayoutPanelVisible || activePanelIdentifier !== ''`, so URL-surfaced panels (`DataAndPeople`, `DataManagement`) also get the dim.

## How did you test this code?
Locally. 

## Publish to changelog?

No

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Iterative session — the structure went through three attempts:
1. First pass put the mobile dim overlay alongside the existing right overlay and tried to slot it between nav and panel by z-index alone. That failed because `#project-panel-layout` (fixed + transformed) created a stacking context that nav and panel both lived inside, so no outside z value could sit between them.
2. Second pass moved the dim overlay *inside* the layout container's stacking context. Worked but coupled the overlay to Nav.tsx.
3. Final pass (option 3 from the proposed alternatives): lifted the panel rendering out of the nav container into its own fixed wrapper with its own stacking context, dropped the nav container to `--z-layout-navbar`, and slotted the dim overlay between via `--z-layout-panel-over-nav`. This is what shipped.

The 0-width / pointer-events:none anchor pattern was chosen to preserve `PanelLayoutPanel`'s existing `absolute left:var(--panel-layout-mobile-offset)` math without modifying the component's positioning cva — avoids cross-cutting changes to every panel call site.