### PR TITLE
feat(hogql): default to rust-py parser, emit shadow comparison events

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -20989,7 +20989,7 @@
                     "type": "boolean"
                 },
                 "parserMode": {
-                    "description": "HogQL parser backend; absent → `cpp_only`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip.",
+                    "description": "HogQL parser backend; absent → `rust_py_with_cpp_shadow`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip.",
                     "enum": [
                         "cpp_only",
                         "cpp_with_rust_shadow",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -451,7 +451,7 @@ export interface HogQLQueryModifiers {
     /** If these are provided, the query will fail if these skip indexes are not used */
     forceClickhouseDataSkippingIndexes?: string[]
     inlineCohortCalculation?: 'off' | 'auto' | 'always'
-    /** HogQL parser backend; absent → `cpp_only`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
+    /** HogQL parser backend; absent → `rust_py_with_cpp_shadow`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
     parserMode?:
         | 'cpp_only'
         | 'cpp_with_rust_shadow'

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -1,5 +1,6 @@
 import sys
 import copy
+import time
 import random
 import threading
 from collections.abc import Callable
@@ -9,6 +10,7 @@ from typing import Any, Literal, cast
 
 from django.conf import settings
 
+import posthoganalytics
 from antlr4 import CommonTokenStream, InputStream, ParserRuleContext, ParseTreeVisitor
 from antlr4.error.ErrorListener import ErrorListener
 from cachetools import LRUCache
@@ -39,6 +41,7 @@ from posthog.hogql.timings import HogQLTimings
 from posthog.hogql.visitor import clear_locations
 
 from posthog.exceptions_capture import capture_exception
+from posthog.utils import get_machine_id
 
 logger = getLogger(__name__)
 
@@ -231,19 +234,26 @@ def _resolve_parser_mode(
 ) -> tuple[HogQLParserBackend, HogQLParserBackend | None]:
     """Resolve a `parserMode` modifier to `(primary, shadow)` backends.
 
-    In TEST: an absent modifier defaults to `CPP_WITH_RUST_SHADOW` so the
-    test suite exercises both backends on every parse and raises on AST
-    divergence (see `_run_shadow_comparison`). Honour an explicit
-    `backend=` override (test factories / parity scripts) untouched.
+    In prod an absent modifier (no team override) defaults to
+    `RUST_PY_WITH_CPP_SHADOW`: `rust-py` is the primary whose result is
+    returned, `cpp-json` runs as a `_SHADOW_SAMPLE_RATE` shadow to catch
+    divergence (see `_run_shadow_comparison`). Resolved here at the call site,
+    never written back onto the modifier, so the query hash is unaffected.
 
-    In prod: an absent modifier is treated as `cpp_only` — resolved here at
-    the call site, never written back onto the modifier, so the query
-    hash is unaffected. The explicitly-passed `backend` is honoured
-    (default `cpp-json`).
+    In TEST an absent modifier stays `CPP_WITH_RUST_SHADOW`: `cpp-json` remains
+    the primary the suite's AST snapshots were recorded against (rust-py and
+    cpp produce structurally identical ASTs but differ in node spans), while
+    `rust-json` runs as a 100% shadow so any structural divergence still fails
+    loud. `rust-py`'s own structural parity is covered by `test_parser_rust_py`.
+
+    An explicitly-passed non-default `backend` (test factories / parity
+    scripts) is honoured untouched, with no shadow.
     """
     if parser_mode is None:
-        if settings.TEST and backend == DEFAULT_BACKEND:
-            return _PARSER_MODE_BACKENDS[ParserMode.CPP_WITH_RUST_SHADOW]
+        if backend == DEFAULT_BACKEND:
+            if settings.TEST:
+                return _PARSER_MODE_BACKENDS[ParserMode.CPP_WITH_RUST_SHADOW]
+            return _PARSER_MODE_BACKENDS[ParserMode.RUST_PY_WITH_CPP_SHADOW]
         return backend, None
     return _PARSER_MODE_BACKENDS[parser_mode]
 
@@ -260,6 +270,65 @@ _SHADOW_BACKEND_FAILURES = Counter(
     "Captured but never propagated — primary backend's result is always returned.",
     labelnames=["rule", "shadow"],
 )
+
+_SHADOW_COMPARISON_EVENT = "hogql_parser_shadow_comparison"
+# Constant per process; the parser has no user/team to attribute these to, so we
+# key on the instance like other PostHog instance-telemetry events.
+_MACHINE_ID = get_machine_id()
+
+
+def _capture_shadow_event(
+    rule: ParseRule,
+    primary_backend: HogQLParserBackend,
+    shadow_backend: HogQLParserBackend,
+    matched: bool,
+    statement: str,
+    shadow_ms: float,
+    start: int | None,
+) -> None:
+    """Emit a product-analytics event for one sampled shadow parse.
+
+    Fired on every sampled shadow run, matched or not, so the mismatch rate is
+    computable as a fraction of the total. The raw `query` is attached only on a
+    mismatch, so divergent queries can be looked up without logging every parse.
+
+    The primary is re-parsed here purely to time it head-to-head with the shadow
+    on this statement: the returned node already came back (possibly from cache),
+    so its own parse time isn't observable at this point.
+
+    Fire-and-forget on the global (batched, non-blocking) client; never raises
+    into the parser. The global client can drop events in short-lived Celery
+    workers, which is acceptable for sampled telemetry.
+    """
+    try:
+        primary_started = time.perf_counter()
+        _invoke_parser(primary_backend, rule, statement, start)
+        primary_ms: float | None = (time.perf_counter() - primary_started) * 1000.0
+    except Exception:
+        # The primary already parsed successfully once; a flake on the timing
+        # re-parse must not cost us the event.
+        primary_ms = None
+
+    properties: dict[str, Any] = {
+        "rule": str(rule),
+        "primary_backend": primary_backend,
+        "shadow_backend": shadow_backend,
+        "matched": matched,
+        "primary_parse_ms": primary_ms,
+        "shadow_parse_ms": shadow_ms,
+        "statement_length": len(statement),
+    }
+    if not matched:
+        properties["query"] = statement
+
+    try:
+        posthoganalytics.capture(
+            distinct_id=_MACHINE_ID,
+            event=_SHADOW_COMPARISON_EVENT,
+            properties=properties,
+        )
+    except Exception:
+        logger.exception("failed to capture %s event", _SHADOW_COMPARISON_EVENT)
 
 
 def _run_shadow_comparison(
@@ -289,6 +358,7 @@ def _run_shadow_comparison(
     if random.random() >= _shadow_sample_rate():
         return
     test_mode = settings.TEST
+    shadow_started = time.perf_counter()
     try:
         shadow_node = _invoke_parser(shadow_backend, rule, statement, start)
     except BaseHogQLError as err:
@@ -321,7 +391,14 @@ def _run_shadow_comparison(
             },
         )
         return
-    if clear_locations(primary_node) == clear_locations(shadow_node):
+    shadow_ms = (time.perf_counter() - shadow_started) * 1000.0
+    matched = clear_locations(primary_node) == clear_locations(shadow_node)
+    if not test_mode:
+        # Telemetry only — skipped in TEST, where analytics is disabled and the
+        # 100%-shadow path would otherwise pay for the timing re-parse on every
+        # query in the suite.
+        _capture_shadow_event(rule, primary_backend, shadow_backend, matched, statement, shadow_ms, start)
+    if matched:
         return
     mismatch = HogQLParserShadowMismatch(f"{rule} parser AST mismatch: {primary_backend} vs {shadow_backend}")
     if test_mode:

--- a/posthog/hogql/test/test_parser_mode.py
+++ b/posthog/hogql/test/test_parser_mode.py
@@ -12,9 +12,10 @@ from posthog.hogql.parser import HogQLParserShadowMismatch, _resolve_parser_mode
 class TestParserMode(BaseTest):
     @parameterized.expand(
         [
-            # An absent modifier in TEST defaults to CPP_WITH_RUST_SHADOW so
-            # every test-suite parse exercises both backends and raises on
-            # divergence (see `_run_shadow_comparison`).
+            # An absent modifier in TEST stays CPP_WITH_RUST_SHADOW so the suite
+            # parses on the cpp primary its AST snapshots were recorded against,
+            # with rust-json as a 100% shadow. The prod default (rust-py primary)
+            # is asserted separately below.
             (None, ("cpp-json", "rust-json")),
             (ParserMode.CPP_ONLY, ("cpp-json", None)),
             (ParserMode.RUST_ONLY, ("rust-json", None)),
@@ -28,17 +29,17 @@ class TestParserMode(BaseTest):
         self.assertEqual(_resolve_parser_mode(mode, "cpp-json"), expected)
 
     def test_resolve_parser_mode_honours_explicit_backend_when_absent(self):
-        # With no modifier the `backend=` override still wins — this is the
-        # path the test/diagnostic harness relies on. Even in TEST, an
-        # explicit non-default backend disables the auto-shadow.
+        # With no modifier an explicit non-default `backend=` override still
+        # wins (the path the test/diagnostic harness relies on) and gets no
+        # shadow.
         self.assertEqual(_resolve_parser_mode(None, "rust-json"), ("rust-json", None))
 
-    def test_resolve_parser_mode_prod_absent_modifier_no_shadow(self):
-        # The TEST-only auto-shadow is gated on `settings.TEST`; with that
-        # flag off (i.e. production) an absent modifier means "no shadow".
+    def test_resolve_parser_mode_prod_absent_modifier_defaults_to_rust_py_shadow(self):
+        # The default applies in production too (not just TEST): an absent
+        # modifier means rust-py primary with a cpp-json shadow.
         with patch("posthog.hogql.parser.settings") as mock_settings:
             mock_settings.TEST = False
-            self.assertEqual(_resolve_parser_mode(None, "cpp-json"), ("cpp-json", None))
+            self.assertEqual(_resolve_parser_mode(None, "cpp-json"), ("rust-py", "cpp-json"))
 
     def test_shadow_silent_when_backends_agree(self):
         # A `*_shadow` mode parses with the shadow backend on every sampled
@@ -141,3 +142,91 @@ class TestParserMode(BaseTest):
         self.assertIsInstance(node, ast.SelectQuery)
         captured.assert_called_once()
         self.assertIsInstance(captured.call_args.args[0], ImportError)
+
+    def test_shadow_emits_analytics_event_with_timings_on_match_in_prod(self):
+        # In production every sampled shadow run emits an analytics event
+        # carrying each backend's parse time, so the mismatch rate is a
+        # fraction of a known total. A matching run carries no raw query.
+        with (
+            patch("posthog.hogql.parser._SHADOW_SAMPLE_RATE", 1.0),
+            patch("posthog.hogql.parser.settings") as mock_settings,
+            patch("posthog.hogql.parser.posthoganalytics") as mock_ph,
+        ):
+            mock_settings.TEST = False
+            node = parse_select(
+                "select a, b from events where a > 1",
+                parser_mode=ParserMode.RUST_PY_WITH_CPP_SHADOW,
+            )
+        self.assertIsInstance(node, ast.SelectQuery)
+        mock_ph.capture.assert_called_once()
+        kwargs = mock_ph.capture.call_args.kwargs
+        self.assertEqual(kwargs["event"], "hogql_parser_shadow_comparison")
+        props = kwargs["properties"]
+        self.assertTrue(props["matched"])
+        self.assertEqual(props["primary_backend"], "rust-py")
+        self.assertEqual(props["shadow_backend"], "cpp-json")
+        self.assertIsInstance(props["primary_parse_ms"], float)
+        self.assertIsInstance(props["shadow_parse_ms"], float)
+        self.assertNotIn("query", props)
+
+    def test_shadow_emits_analytics_event_with_query_on_mismatch_in_prod(self):
+        # On a mismatch the event flips `matched` to False and attaches the raw
+        # query so the divergent statement can be looked up. The existing
+        # error-tracking capture still fires alongside it.
+        from posthog.hogql import parser as parser_module
+
+        decoy = ast.SelectQuery(select=[ast.Constant(value=999)])
+        real_invoke = parser_module._invoke_parser
+
+        def only_shadow_diverges(backend, rule, statement, start):
+            if backend == "cpp-json":
+                return decoy
+            return real_invoke(backend, rule, statement, start)
+
+        with (
+            patch("posthog.hogql.parser._SHADOW_SAMPLE_RATE", 1.0),
+            patch("posthog.hogql.parser.settings") as mock_settings,
+            patch("posthog.hogql.parser._invoke_parser", side_effect=only_shadow_diverges),
+            patch("posthog.hogql.parser.posthoganalytics") as mock_ph,
+            patch("posthog.hogql.parser.capture_exception") as captured,
+        ):
+            mock_settings.TEST = False
+            node = parse_select(
+                "select shadow_mismatch_probe from events",
+                parser_mode=ParserMode.RUST_PY_WITH_CPP_SHADOW,
+            )
+        self.assertIsInstance(node, ast.SelectQuery)
+        mock_ph.capture.assert_called_once()
+        props = mock_ph.capture.call_args.kwargs["properties"]
+        self.assertFalse(props["matched"])
+        self.assertEqual(props["query"], "select shadow_mismatch_probe from events")
+        captured.assert_called_once()
+        self.assertIsInstance(captured.call_args.args[0], HogQLParserShadowMismatch)
+
+    def test_shadow_event_capture_failure_does_not_break_parse(self):
+        # Telemetry is best-effort: a throwing capture client must never fail
+        # the parse the user is waiting on.
+        with (
+            patch("posthog.hogql.parser._SHADOW_SAMPLE_RATE", 1.0),
+            patch("posthog.hogql.parser.settings") as mock_settings,
+            patch("posthog.hogql.parser.posthoganalytics") as mock_ph,
+        ):
+            mock_settings.TEST = False
+            mock_ph.capture.side_effect = RuntimeError("capture boom")
+            node = parse_select("select a from events", parser_mode=ParserMode.RUST_PY_WITH_CPP_SHADOW)
+        self.assertIsInstance(node, ast.SelectQuery)
+
+    def test_shadow_event_not_emitted_in_test_mode(self):
+        # In TEST the comparison still runs (and raises on divergence), but the
+        # analytics event is skipped: analytics is disabled there, and the
+        # timing re-parse would otherwise tax every parse in the suite.
+        with (
+            patch("posthog.hogql.parser._SHADOW_SAMPLE_RATE", 1.0),
+            patch("posthog.hogql.parser.posthoganalytics") as mock_ph,
+        ):
+            node = parse_select(
+                "select a, b from events",
+                parser_mode=ParserMode.RUST_PY_WITH_CPP_SHADOW,
+            )
+        self.assertIsInstance(node, ast.SelectQuery)
+        mock_ph.capture.assert_not_called()

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7312,11 +7312,12 @@ class HogQLQueryModifiers(BaseModel):
     parserMode: ParserMode | None = Field(
         default=None,
         description=(
-            "HogQL parser backend; absent → `cpp_only`. `*_shadow` modes return the"
-            " primary result and sample-compare against the other parser, reporting"
-            " divergences without failing the request. The `rust_py_*` modes drive the"
-            " same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast`"
-            " dataclass instances directly via PyO3, skipping the JSON round-trip."
+            "HogQL parser backend; absent → `rust_py_with_cpp_shadow`. `*_shadow` modes"
+            " return the primary result and sample-compare against the other parser,"
+            " reporting divergences without failing the request. The `rust_py_*` modes"
+            " drive the same hand-rolled Rust parser as `rust_*` but build"
+            " `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the"
+            " JSON round-trip."
         ),
     )
     personsArgMaxVersion: PersonsArgMaxVersion | None = None

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -426,7 +426,7 @@ export interface HogQLQueryModifiersApi {
     materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationModeApi | null
     optimizeJoinedFilters?: boolean | null
     optimizeProjections?: boolean | null
-    /** HogQL parser backend; absent → `cpp_only`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
+    /** HogQL parser backend; absent → `rust_py_with_cpp_shadow`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
     parserMode?: ParserModeApi | null
     personsArgMaxVersion?: PersonsArgMaxVersionApi | null
     personsJoinMode?: PersonsJoinModeApi | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1556,7 +1556,7 @@ export namespace Schemas {
       materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationMode | null;
       optimizeJoinedFilters?: boolean | null;
       optimizeProjections?: boolean | null;
-      /** HogQL parser backend; absent → `cpp_only`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
+      /** HogQL parser backend; absent → `rust_py_with_cpp_shadow`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
       parserMode?: ParserMode | null;
       personsArgMaxVersion?: PersonsArgMaxVersion | null;
       personsJoinMode?: PersonsJoinMode | null;


### PR DESCRIPTION
## Problem

HogQL has a hand-rolled Rust parser (`rust-py`, which builds AST dataclasses directly via PyO3) available behind the `parserMode` query modifier, but teams that haven't set a modifier still fall back to the cpp-json backend. We want rust-py to be the default for those teams, and we need production visibility into how the two parsers compare (divergence rate and per-parser timing) to monitor the rollout.

## Changes

- `_resolve_parser_mode`: with no `parserMode` modifier set, production now resolves to `rust_py_with_cpp_shadow` (rust-py primary, cpp-json shadow at the existing 1% sample) instead of cpp-json only. The TEST default is intentionally left at `cpp_with_rust_shadow`: rust-py and cpp produce structurally identical ASTs but differ in node spans, and some resolver tests snapshot the full AST including positions, so keeping cpp as the test primary avoids churning those snapshots while rust-json still runs as a 100% shadow. rust-py's own structural parity is covered by `test_parser_rust_py`.
- Shadow comparisons now emit a `hogql_parser_shadow_comparison` analytics event on every sampled run, carrying the rule, both backends, a `matched` flag, and each parser's parse time. The raw query is attached only on a mismatch — so the mismatch rate is a fraction of the total and divergent queries can be looked up without logging every parse. Emission is fire-and-forget on the global client, wrapped so it never raises into a parse, and skipped in TEST (analytics is disabled there).
- Updated the `parserMode` schema description (`absent → rust_py_with_cpp_shadow`) and regenerated `schema.json` / `schema.py`.

## How did you test this code?

I'm an agent and did not do manual UI testing. Automated tests run locally via flox:

- `posthog/hogql/test/test_parser_mode.py` passes, including new tests that the event is emitted on a match (timings present, no query), emitted with the query on a mismatch (alongside the existing error-tracking capture), that a throwing capture client never breaks the parse, and that the event is skipped in TEST.
- Red-green check: with the event emission disabled, the two "emits event" tests fail (`capture` called 0 times); restored, they pass.
- Ran `posthog/hogql/test/test_resolver.py` — this is what surfaced that flipping the *test* primary to rust-py churns position-sensitive AST snapshots, hence keeping the test default on cpp-primary; the resolver suite is green with that decision.
- Verified `_resolve_parser_mode` returns `('cpp-json','rust-json')` under `settings.TEST` and `('rust-py','cpp-json')` in prod.

CI runs the full suite; local full-suite runs hit a shared test-DB migration flake unrelated to these changes.

## Publish to changelog?

no

## Docs update

No user-facing docs reference the parser backend default.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Key decisions:

- Interpreted "rust (python not json)" as the `rust-py` backend (Rust parser building Python AST objects directly via PyO3, vs the JSON-serialize/deserialize path), and the no-modifier default as `rust_py_with_cpp_shadow` so the new shadow telemetry has a comparison leg. The prod-default target was confirmed with the requester before implementing.
- Considered flipping the TEST default to rust-py primary as well (maximum fidelity to prod), but it churns position-sensitive AST snapshots for no correctness gain — rust-py ≡ cpp modulo node spans, and the shadow comparison already ignores spans via `clear_locations`. Kept the test default on cpp-primary; rust-py structural correctness is validated by `test_parser_rust_py` plus the 100% rust-json shadow.
- Chose a single event with a `matched` flag over two pass/fail events, so both the mismatch rate and the failing-query lookup come from one event type. Query attached only on mismatch to bound volume.
- Used the global `posthoganalytics` client keyed on `get_machine_id()` (the existing instance-telemetry pattern). `ph_scoped_capture` was rejected because it creates and shuts down a client per call — far too heavy for the sampled parser hot path; the tradeoff is possible event loss in short-lived Celery workers, acceptable for sampled telemetry.