### PR TITLE
chore(devex): drop redundant env exports from start-worker and cymbal

### DIFF
--- a/.semgrep/devex-rules/env-default-belongs-in-env-development.yaml
+++ b/.semgrep/devex-rules/env-default-belongs-in-env-development.yaml
@@ -28,6 +28,7 @@ rules:
               - '/bin/start'
               - '/bin/start-backend'
               - '/bin/start-celery'
+              - '/bin/start-worker'
       pattern-regex: '(?m)^\s*export\s+[A-Z_][A-Z0-9_]*=\$\{[A-Z_][A-Z0-9_]*:-[^}]+\}\s*$'
       metadata:
           category: best-practice

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -113,8 +113,6 @@ case "$RS_SVC" in
     export RUST_LOG=debug,rdkafka=warn
     export RUST_BACKTRACE=1
     export OBJECT_STORAGE_BUCKET=posthog
-    export OBJECT_STORAGE_ACCESS_KEY_ID=object_storage_root_user
-    export OBJECT_STORAGE_SECRET_ACCESS_KEY=object_storage_root_password
     export FRAME_CACHE_TTL_SECONDS=1
     export FRAME_RESULT_TTL_MINUTES=0
     export ASSIGNMENT_RULE_CACHE_TTL_SECS=0

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -4,13 +4,11 @@ set -e
 # this kills all processes when the last one terminates
 trap 'kill $(jobs -p)' EXIT
 
-export CLICKHOUSE_API_USER="api"
-export CLICKHOUSE_API_PASSWORD="apipass"
-export CLICKHOUSE_APP_USER="app"
-export CLICKHOUSE_APP_PASSWORD="apppass"
-export CLICKHOUSE_BILLING_USER="billing"
-export CLICKHOUSE_BILLING_PASSWORD="billingpass"
-
+# Service connection defaults (CLICKHOUSE_*, DATABASE_URL, KAFKA_HOSTS, …)
+# live in .env.services and are loaded by the parent process — bin/start
+# sources them directly, hogli loads them via config.env.files, and the
+# hobby docker stack injects them via docker-compose env_file. Do not
+# re-export them here.
 source ./bin/celery-queues.env
 
 # start celery worker with heartbeat (-B)


### PR DESCRIPTION
## Problem

Two dev-only `start-*` scripts were still hardcoding `export VAR=value` lines whose values matched `.env.services` byte-for-byte. They were left over from before the env-files cleanup that introduced `.env.services` / `.env.development` / `.env.local` as the single source of truth, and slipped past the existing safety net.

**`bin/start-worker`** had six `CLICKHOUSE_*` exports duplicating `.env.services:20-25`.

**`bin/start-rust-service`** (cymbal case) had `OBJECT_STORAGE_ACCESS_KEY_ID` and `OBJECT_STORAGE_SECRET_ACCESS_KEY` exports duplicating `.env.services:35-36`. Cymbal's own `rust/cymbal/src/config.rs:83-87` also already declares matching `#[envconfig(default = …)]` values, so even an uninherited invocation would resolve correctly.

Why these are dead in every invocation path:

| Caller | How `.env.services` reaches the script |
| --- | --- |
| `bin/start` | Sources `.env.services` at line 83 before spawning mprocs/phrocs, which spawns the child (env inherits). |
| `hogli start:worker` / `hogli` mprocs procs | `hogli.yaml:16-23` declares `.env.services` in `config.env.files`; hogli loads it before invoking any `bin_script`. |
| Hobby docker (`docker-compose.base.yml`) | `worker` and `web` services declare `env_file: .env.services`. `start-worker` and `start-rust-service` aren't run in PostHog Cloud prod (prod uses `bin/docker-worker-celery` and per-service Helm-managed entrypoints). |

## Changes

- Delete the six static `CLICKHOUSE_*` exports from `bin/start-worker` and replace them with a comment pointing to the env-file source of truth.
- Delete the two duplicate `OBJECT_STORAGE_*` exports from `bin/start-rust-service`'s `cymbal` case. `OBJECT_STORAGE_BUCKET=posthog` stays because it isn't in `.env.services`.
- Add `/bin/start-worker` to the `env-default-belongs-in-env-development` semgrep rule's `paths.include`, matching the protection already in place for `bin/start`, `bin/start-backend`, and `bin/start-celery`.

I also did a sweep over every other `bin/start-*` and `bin/docker-*` script to look for similar regressions. Everything else has a legitimate reason to stay in-script:

- `start-backend` — `PROMETHEUS_MULTIPROC_DIR=$(mktemp -d)` is a fresh per-run computed value.
- `start-frontend` / `start-frontend-vite` — `DEBUG=0` deliberately overrides any inherited `DEBUG=1` (silences Tailwind logs); `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` is for non-interactive contexts. Both have rationale comments.
- `start-celery` — no static exports, just sources `celery-queues.env`.
- `start-go-service` / other `start-rust-service` cases — per-service `case` blocks with localhost-flavored variations of `KAFKA_HOSTS`, `REDIS_URL`, etc., or bare-default chains like `${DATABASE_URL:-$DEFAULT_PG}`. These intentionally differ from the in-docker hostnames in `.env.services` and shouldn't be promoted to shared defaults.
- `start-mcp-server`, `start-llm-gateway`, `start-stripe-mock`, `start-stripe-app` — service-specific.
- `docker-*` scripts run inside containers where env arrives via docker-compose `env_file`; their static exports (`NGINX_UNIT_*`, eval mode flags, etc.) are container-specific.
- `start-rust-service capture-ai` exports `AI_S3_ACCESS_KEY_ID` / `AI_S3_SECRET_ACCESS_KEY` with the same MinIO values but a *different* env var namespace — that's intentional and stays.

Note: this is a **deduplication** pass — it removes exports that are byte-for-byte equal to `.env.services`. It is **not** a completeness audit that would catch the opposite shape of regression — env vars that are missing from `.env.services` but needed by a service (#59930, which added `OBJECT_STORAGE_FORCE_PATH_STYLE=true` after a local cymbal startup failure, was exactly that kind of bug and would not have been surfaced by this scan).

## How did you test this code?

I'm a Claude Code agent. I did not run the dev stack manually. The change is mechanical (removes eight exports whose values match `.env.services` byte-for-byte, plus one line in the semgrep include list). I verified:

- `bash -n bin/start-worker` and `bash -n bin/start-rust-service` both parse.
- After my edits, `bin/start`, `bin/start-backend`, `bin/start-celery`, and `bin/start-worker` contain no lines matching the semgrep rule's `pattern-regex` other than two pre-existing `nosemgrep`-suppressed lines in `bin/start`.
- All three loading paths (`bin/start`, hogli, docker-compose) already source `.env.services` ahead of both scripts.
- For cymbal specifically, `rust/cymbal/src/config.rs:83-87` declares Rust-side `#[envconfig(default = "object_storage_root_user")]` and `default = "object_storage_root_password"` — so even an unconfigured invocation would resolve correctly.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code at the user's request.

Context: the user noticed `bin/start-worker` was setting `CLICKHOUSE_*` env vars by hand even though `.env.services` already defines them, and asked whether the script had been missed during the env-files migration or whether it was intentionally kept that way for production. Investigation showed it was an oversight — the script doesn't run in prod, and every dev/hobby caller pre-loads `.env.services`. The semgrep rule that backstops this convention only listed `start`, `start-backend`, and `start-celery`, so `start-worker` had no guardrail.

The user then pointed at #59930 ("fix(dev): use path-style object storage locally"), which added `OBJECT_STORAGE_FORCE_PATH_STYLE=true` to `.env.services` for cymbal. Rechecking `start-rust-service` after that pointer, I noticed cymbal's case still exported `OBJECT_STORAGE_ACCESS_KEY_ID` and `OBJECT_STORAGE_SECRET_ACCESS_KEY` — both literal duplicates of `.env.services`. (These were redundant on day one of the env split, independent of #59930 — I just hadn't widened my scan beyond `start-worker` until prompted.) Rolled into this PR.

Decisions along the way:

- Considered tightening the semgrep regex to also catch literal `export VAR="value"` (not just bare-default `${VAR:-default}`), but that would require a lot of new `nosemgrep` exemptions on legitimate overrides (`DEBUG=0` in `start-frontend`, port pins in `docker-server-unit`, etc.). Stuck with the existing regex and just widened the include list.
- Considered also removing `export KAFKA_HOSTS=${KAFKA_HOSTS:-'kafka:9092'}` from `bin/posthog-node:26` since it's bare-default duplication of `.env.services:31`. Left it alone — `posthog-node` is the runtime entrypoint (not a "start" script), runs in prod containers with their own env injection, and bare-defaults are explicitly called out as a legitimate exception in the existing rule.
- Kept other `bin/start-rust-service` and `bin/start-go-service` cases untouched — their per-service `case` blocks intentionally use `localhost:9092`, bare-default chains, or service-namespaced var names that don't duplicate `.env.services`.
