### PR TITLE
feat(alerts): add alert timeliness SLO instrumentation

### DIFF
--- a/posthog/slo/types.py
+++ b/posthog/slo/types.py
@@ -13,6 +13,7 @@ class SloOperation(StrEnum):
     SUBSCRIPTION_CREATE = "subscription_create"
     SUBSCRIPTION_DELETE = "subscription_delete"
     ALERT_CHECK = "alert_check"
+    ALERT_CHECK_TIMELINESS = "alert_check_timeliness"
     QUERY_SERVICE = "query_service"
 
 

--- a/posthog/temporal/alerts/__init__.py
+++ b/posthog/temporal/alerts/__init__.py
@@ -1,5 +1,6 @@
 from posthog.temporal.alerts.activities import (
     cleanup_alert_checks,
+    emit_alert_timeliness_slo,
     evaluate_alert,
     notify_alert,
     prepare_alert,
@@ -22,6 +23,7 @@ WORKFLOWS = [
 
 ACTIVITIES = [
     retrieve_due_alerts,
+    emit_alert_timeliness_slo,
     prepare_alert,
     evaluate_alert,
     notify_alert,

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -14,6 +14,8 @@ from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import CH_TRANSIENT_ERRORS
 from posthog.exceptions_capture import capture_exception
 from posthog.schema_migrations.upgrade_manager import upgrade_query
+from posthog.slo.events import emit_slo_completed, emit_slo_started
+from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloStartedProperties
 from posthog.sync import database_sync_to_async
 from posthog.tasks.alerts.investigation_notifications import run_investigation_notification_safety_net
 from posthog.tasks.alerts.schedule_restriction import is_utc_datetime_blocked, next_unblocked_utc
@@ -28,8 +30,10 @@ from posthog.tasks.alerts.utils import (
     validate_alert_config,
 )
 from posthog.temporal.alerts.investigation import claim_investigation_slot, should_trigger_investigation
+from posthog.temporal.alerts.timeliness import build_alert_timeliness_completion
 from posthog.temporal.alerts.types import (
     AlertInfo,
+    EmitAlertTimelinessSloActivityInputs,
     EvaluateAlertActivityInputs,
     EvaluateAlertResult,
     NotifyAlertActivityInputs,
@@ -39,6 +43,7 @@ from posthog.temporal.alerts.types import (
     SkipReason,
 )
 from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.utils import get_instance_region
 
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration
 from products.notifications.backend.facade.api import (
@@ -78,7 +83,7 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
             .filter(insight__deleted=False)
             .annotate(_interval_order=calculation_interval_order)
             .order_by("_interval_order", F("next_check_at").asc(nulls_first=True))
-            .only("id", "team_id", "calculation_interval", "insight_id")
+            .only("id", "team_id", "calculation_interval", "insight_id", "next_check_at")
         )
 
         return [
@@ -88,12 +93,73 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
                 distinct_id=str(a.id),
                 calculation_interval=a.calculation_interval,
                 insight_id=a.insight_id,
+                scheduled_check_at=a.next_check_at.isoformat() if a.next_check_at else None,
             )
             for a in alerts
         ]
 
     async with Heartbeater():
         return await get_alerts()
+
+
+@temporalio.activity.defn
+async def emit_alert_timeliness_slo(inputs: EmitAlertTimelinessSloActivityInputs) -> None:
+    """Best-effort alert scheduler-lag SLO emission.
+
+    Observability must not block alert execution, so malformed timing inputs or
+    analytics failures are captured/logged and then swallowed by this activity.
+    """
+
+    try:
+        actual_check_start_at = datetime.now(UTC)
+        outcome, timeliness_props = build_alert_timeliness_completion(
+            calculation_interval=inputs.calculation_interval,
+            scheduled_check_at=inputs.scheduled_check_at,
+            actual_check_start_at=actual_check_start_at,
+        )
+        base_properties = {
+            "correlation_id": inputs.correlation_id,
+            "workflow_id": inputs.workflow_id,
+            "workflow_type": inputs.workflow_type,
+            "calculation_interval": inputs.calculation_interval,
+            "insight_id": inputs.insight_id,
+            "region": get_instance_region(),
+            "scheduled_due_at": timeliness_props["scheduled_due_at"],
+            "actual_check_start_at": timeliness_props["actual_check_start_at"],
+        }
+
+        emit_slo_started(
+            distinct_id=inputs.distinct_id,
+            properties=SloStartedProperties(
+                operation=SloOperation.ALERT_CHECK_TIMELINESS,
+                area=SloArea.ANALYTIC_PLATFORM,
+                team_id=inputs.team_id,
+                resource_id=inputs.alert_id,
+            ),
+            extra_properties=base_properties,
+        )
+        emit_slo_completed(
+            distinct_id=inputs.distinct_id,
+            properties=SloCompletedProperties(
+                operation=SloOperation.ALERT_CHECK_TIMELINESS,
+                area=SloArea.ANALYTIC_PLATFORM,
+                team_id=inputs.team_id,
+                outcome=outcome,
+                resource_id=inputs.alert_id,
+                duration_ms=float(timeliness_props["evaluation_lag_ms"]),
+            ),
+            extra_properties={**base_properties, **timeliness_props},
+        )
+    except Exception as err:
+        logger.exception("alert_timeliness_slo_emit_failed", alert_id=inputs.alert_id)
+        capture_exception(
+            err,
+            additional_properties={
+                "alert_configuration_id": inputs.alert_id,
+                "insight_id": inputs.insight_id,
+                "team_id": inputs.team_id,
+            },
+        )
 
 
 @temporalio.activity.defn

--- a/posthog/temporal/alerts/retry_policy.py
+++ b/posthog/temporal/alerts/retry_policy.py
@@ -11,6 +11,13 @@ ALERT_PREPARE_RETRY_POLICY = RetryPolicy(
     maximum_attempts=3,
 )
 
+ALERT_TIMELINESS_RETRY_POLICY = RetryPolicy(
+    initial_interval=dt.timedelta(seconds=1),
+    maximum_interval=dt.timedelta(seconds=1),
+    backoff_coefficient=1.0,
+    maximum_attempts=1,
+)
+
 ALERT_EVALUATE_RETRY_POLICY = RetryPolicy(
     initial_interval=dt.timedelta(seconds=1),
     maximum_interval=dt.timedelta(seconds=30),

--- a/posthog/temporal/alerts/timeliness.py
+++ b/posthog/temporal/alerts/timeliness.py
@@ -1,0 +1,81 @@
+from datetime import UTC, datetime
+from typing import TypedDict
+
+from posthog.schema import AlertCalculationInterval
+
+from posthog.slo.types import SloOutcome
+
+ALERT_TIMELINESS_THRESHOLD_RATIO = 0.05
+ALERT_TIMELINESS_MIN_THRESHOLD_SECONDS = 60
+ALERT_TIMELINESS_MAX_THRESHOLD_SECONDS = 120
+
+_ALERT_INTERVAL_SECONDS = {
+    "every_minute": 60,
+    AlertCalculationInterval.EVERY_15_MINUTES.value: 15 * 60,
+    AlertCalculationInterval.HOURLY.value: 60 * 60,
+    AlertCalculationInterval.DAILY.value: 24 * 60 * 60,
+    AlertCalculationInterval.WEEKLY.value: 7 * 24 * 60 * 60,
+    # Calendar months vary; the 120s cap means the exact long-interval value
+    # does not affect the threshold, but keep a deterministic value for tests.
+    AlertCalculationInterval.MONTHLY.value: 30 * 24 * 60 * 60,
+}
+
+
+class AlertTimelinessProperties(TypedDict):
+    scheduled_due_at: str
+    actual_check_start_at: str
+    evaluation_lag_ms: int
+    timeliness_threshold_ms: int
+    is_late: bool
+
+
+def alert_timeliness_threshold_ms(calculation_interval: str | None) -> int:
+    """Return the allowed scheduler lag for an alert check in milliseconds.
+
+    The agreed PostHog timeliness SLO is 5% of the alert interval, clamped
+    between one scheduler tick (60s) and 120s. Unknown intervals use the max
+    cap so a schema drift does not accidentally create an over-lenient target.
+    """
+
+    if calculation_interval is None:
+        return ALERT_TIMELINESS_MAX_THRESHOLD_SECONDS * 1000
+
+    interval_seconds = _ALERT_INTERVAL_SECONDS.get(calculation_interval)
+    if interval_seconds is None:
+        return ALERT_TIMELINESS_MAX_THRESHOLD_SECONDS * 1000
+
+    threshold_seconds = interval_seconds * ALERT_TIMELINESS_THRESHOLD_RATIO
+    threshold_seconds = max(ALERT_TIMELINESS_MIN_THRESHOLD_SECONDS, threshold_seconds)
+    threshold_seconds = min(ALERT_TIMELINESS_MAX_THRESHOLD_SECONDS, threshold_seconds)
+    return int(threshold_seconds * 1000)
+
+
+def parse_scheduled_check_at(scheduled_check_at: str) -> datetime:
+    parsed = datetime.fromisoformat(scheduled_check_at.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def build_alert_timeliness_completion(
+    *,
+    calculation_interval: str | None,
+    scheduled_check_at: str,
+    actual_check_start_at: datetime,
+) -> tuple[SloOutcome, AlertTimelinessProperties]:
+    scheduled_due_at = parse_scheduled_check_at(scheduled_check_at)
+    actual_check_start_at = actual_check_start_at.astimezone(UTC)
+    evaluation_lag_ms = max(0, int((actual_check_start_at - scheduled_due_at).total_seconds() * 1000))
+    threshold_ms = alert_timeliness_threshold_ms(calculation_interval)
+    is_late = evaluation_lag_ms > threshold_ms
+
+    return (
+        SloOutcome.FAILURE if is_late else SloOutcome.SUCCESS,
+        {
+            "scheduled_due_at": scheduled_due_at.isoformat(),
+            "actual_check_start_at": actual_check_start_at.isoformat(),
+            "evaluation_lag_ms": evaluation_lag_ms,
+            "timeliness_threshold_ms": threshold_ms,
+            "is_late": is_late,
+        },
+    )

--- a/posthog/temporal/alerts/types.py
+++ b/posthog/temporal/alerts/types.py
@@ -29,6 +29,7 @@ class AlertInfo:
     distinct_id: str
     calculation_interval: str | None
     insight_id: int
+    scheduled_check_at: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -38,12 +39,26 @@ class CheckAlertWorkflowInputs:
     distinct_id: str
     calculation_interval: str | None
     insight_id: int
+    scheduled_check_at: str | None = None
     slo: SloConfig | None = None
 
 
 @dataclasses.dataclass(frozen=True)
 class PrepareAlertActivityInputs:
     alert_id: str
+
+
+@dataclasses.dataclass(frozen=True)
+class EmitAlertTimelinessSloActivityInputs:
+    alert_id: str
+    team_id: int
+    distinct_id: str
+    calculation_interval: str | None
+    insight_id: int
+    scheduled_check_at: str
+    workflow_id: str
+    workflow_type: str
+    correlation_id: str
 
 
 @dataclasses.dataclass(frozen=True)

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -12,6 +12,7 @@ from posthog.schema import AlertState
 from posthog.slo.types import SloArea, SloConfig, SloOperation
 from posthog.temporal.alerts.activities import (
     cleanup_alert_checks,
+    emit_alert_timeliness_slo,
     evaluate_alert,
     notify_alert,
     prepare_alert,
@@ -22,9 +23,11 @@ from posthog.temporal.alerts.retry_policy import (
     ALERT_EVALUATE_RETRY_POLICY,
     ALERT_NOTIFY_RETRY_POLICY,
     ALERT_PREPARE_RETRY_POLICY,
+    ALERT_TIMELINESS_RETRY_POLICY,
 )
 from posthog.temporal.alerts.types import (
     CheckAlertWorkflowInputs,
+    EmitAlertTimelinessSloActivityInputs,
     EvaluateAlertActivityInputs,
     NotifyAlertActivityInputs,
     PrepareAction,
@@ -62,6 +65,12 @@ class ScheduleDueAlertChecksWorkflow(PostHogWorkflow):
         # rejects the duplicate start.
         tasks = []
         for alert in alerts:
+            slo_properties = {
+                "calculation_interval": alert.calculation_interval,
+                "insight_id": alert.insight_id,
+                "scheduled_check_at": alert.scheduled_check_at,
+            }
+
             task = temporalio.workflow.execute_child_workflow(
                 CheckAlertWorkflow.run,
                 CheckAlertWorkflowInputs(
@@ -70,20 +79,15 @@ class ScheduleDueAlertChecksWorkflow(PostHogWorkflow):
                     distinct_id=alert.distinct_id,
                     calculation_interval=alert.calculation_interval,
                     insight_id=alert.insight_id,
+                    scheduled_check_at=alert.scheduled_check_at,
                     slo=SloConfig(
                         operation=SloOperation.ALERT_CHECK,
                         area=SloArea.ANALYTIC_PLATFORM,
                         team_id=alert.team_id,
                         resource_id=alert.alert_id,
                         distinct_id=alert.distinct_id,
-                        start_properties={
-                            "calculation_interval": alert.calculation_interval,
-                            "insight_id": alert.insight_id,
-                        },
-                        completion_properties={
-                            "calculation_interval": alert.calculation_interval,
-                            "insight_id": alert.insight_id,
-                        },
+                        start_properties=slo_properties.copy(),
+                        completion_properties=slo_properties.copy(),
                     ),
                 ),
                 id=f"check-alert-{alert.alert_id}",
@@ -127,6 +131,8 @@ class CheckAlertWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: CheckAlertWorkflowInputs) -> None:
+        await self._emit_alert_timeliness_slo(inputs)
+
         new_state: AlertState | None = None
         skip_reason: str | None = None
         caught_error: BaseException | None = None
@@ -205,6 +211,42 @@ class CheckAlertWorkflow(PostHogWorkflow):
         # Re-raise after cleanup completes. Same Temporal SDK quirk as ProcessSubscriptionWorkflow
         if caught_error:
             raise caught_error
+
+    async def _emit_alert_timeliness_slo(self, inputs: CheckAlertWorkflowInputs) -> None:
+        """Emit scheduler-lag SLO before normal alert execution.
+
+        Timeliness is intentionally separate from execution success: a late
+        successful alert check is a timeliness failure. Initial checks with no
+        stored due timestamp are excluded from the timeliness denominator.
+        """
+
+        if not inputs.scheduled_check_at:
+            return
+
+        info = temporalio.workflow.info()
+        try:
+            await temporalio.workflow.execute_activity(
+                emit_alert_timeliness_slo,
+                EmitAlertTimelinessSloActivityInputs(
+                    alert_id=inputs.alert_id,
+                    team_id=inputs.team_id,
+                    distinct_id=inputs.distinct_id,
+                    calculation_interval=inputs.calculation_interval,
+                    insight_id=inputs.insight_id,
+                    scheduled_check_at=inputs.scheduled_check_at,
+                    workflow_id=info.workflow_id,
+                    workflow_type=info.workflow_type,
+                    correlation_id=f"{info.run_id}:timeliness",
+                ),
+                start_to_close_timeout=dt.timedelta(seconds=30),
+                schedule_to_close_timeout=dt.timedelta(seconds=30),
+                retry_policy=ALERT_TIMELINESS_RETRY_POLICY,
+            )
+        except Exception as err:
+            temporalio.workflow.logger.warning(
+                "alert_timeliness_slo_activity_failed",
+                extra={"alert_id": inputs.alert_id, "error": str(err)},
+            )
 
 
 @temporalio.workflow.defn(name="run-investigation-safety-net")

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -24,8 +24,16 @@ from posthog.schema import (
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.models import Insight, User
 from posthog.tasks.alerts.utils import AlertEvaluationResult
-from posthog.temporal.alerts.activities import cleanup_alert_checks, evaluate_alert, notify_alert, prepare_alert
+from posthog.temporal.alerts.activities import (
+    cleanup_alert_checks,
+    emit_alert_timeliness_slo,
+    evaluate_alert,
+    notify_alert,
+    prepare_alert,
+    retrieve_due_alerts,
+)
 from posthog.temporal.alerts.types import (
+    EmitAlertTimelinessSloActivityInputs,
     EvaluateAlertActivityInputs,
     NotifyAlertActivityInputs,
     PrepareAction,
@@ -133,6 +141,74 @@ async def _create_alert_check(
         )
 
     return await _create()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+class TestRetrieveDueAlerts:
+    @freeze_time("2024-06-03T10:00:00Z")
+    async def test_includes_original_due_timestamp_before_evaluation_can_mutate_next_check_at(self, ateam) -> None:
+        due_at = datetime(2024, 6, 3, 9, 58, tzinfo=UTC)
+        due_alert = await _create_alert(
+            ateam,
+            calculation_interval=AlertCalculationInterval.HOURLY.value,
+            next_check_at=due_at,
+        )
+        initial_alert = await _create_alert(ateam, next_check_at=None)
+
+        env = ActivityEnvironment()
+        alerts = await env.run(retrieve_due_alerts)
+
+        by_id = {alert.alert_id: alert for alert in alerts}
+        assert by_id[str(due_alert.id)].scheduled_check_at == due_at.isoformat()
+        assert by_id[str(initial_alert.id)].scheduled_check_at is None
+
+
+def _timeliness_inputs(*, scheduled_check_at: str = "2024-06-03T09:58:00+00:00") -> EmitAlertTimelinessSloActivityInputs:
+    return EmitAlertTimelinessSloActivityInputs(
+        alert_id="alert-1",
+        team_id=1,
+        distinct_id="alert-1",
+        calculation_interval=AlertCalculationInterval.HOURLY.value,
+        insight_id=2,
+        scheduled_check_at=scheduled_check_at,
+        workflow_id="check-alert-alert-1",
+        workflow_type="check-alert",
+        correlation_id="run-1:timeliness",
+    )
+
+
+@pytest.mark.asyncio
+class TestEmitAlertTimelinessSlo:
+    @freeze_time("2024-06-03T10:00:01Z")
+    @patch("posthog.slo.events.posthoganalytics")
+    async def test_emits_failure_when_check_starts_after_threshold(self, mock_slo_analytics) -> None:
+        env = ActivityEnvironment()
+        await env.run(emit_alert_timeliness_slo, _timeliness_inputs())
+
+        completed = [
+            c
+            for c in mock_slo_analytics.capture.call_args_list
+            if c.kwargs.get("event") == "slo_operation_completed"
+        ]
+        assert len(completed) == 1
+        props = completed[0].kwargs["properties"]
+        assert props["operation"] == "alert_check_timeliness"
+        assert props["outcome"] == "failure"
+        assert props["is_late"] is True
+        assert props["evaluation_lag_ms"] == 121_000
+        assert props["timeliness_threshold_ms"] == 120_000
+        assert props["duration_ms"] == 121_000.0
+        assert props["region"] is not None
+
+    @patch("posthog.temporal.alerts.activities.capture_exception")
+    @patch("posthog.slo.events.posthoganalytics")
+    async def test_malformed_timestamp_does_not_raise_or_emit(self, mock_slo_analytics, mock_capture_exception) -> None:
+        env = ActivityEnvironment()
+        await env.run(emit_alert_timeliness_slo, _timeliness_inputs(scheduled_check_at="not-a-timestamp"))
+
+        assert mock_slo_analytics.capture.call_count == 0
+        mock_capture_exception.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -183,8 +183,9 @@ def _timeliness_inputs(
 @pytest.mark.asyncio
 class TestEmitAlertTimelinessSlo:
     @freeze_time("2024-06-03T10:00:01Z")
+    @patch("posthog.temporal.alerts.activities.get_instance_region", return_value="US")
     @patch("posthog.slo.events.posthoganalytics")
-    async def test_emits_failure_when_check_starts_after_threshold(self, mock_slo_analytics) -> None:
+    async def test_emits_failure_when_check_starts_after_threshold(self, mock_slo_analytics, _mock_region) -> None:
         env = ActivityEnvironment()
         await env.run(emit_alert_timeliness_slo, _timeliness_inputs())
 

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -164,7 +164,9 @@ class TestRetrieveDueAlerts:
         assert by_id[str(initial_alert.id)].scheduled_check_at is None
 
 
-def _timeliness_inputs(*, scheduled_check_at: str = "2024-06-03T09:58:00+00:00") -> EmitAlertTimelinessSloActivityInputs:
+def _timeliness_inputs(
+    *, scheduled_check_at: str = "2024-06-03T09:58:00+00:00"
+) -> EmitAlertTimelinessSloActivityInputs:
     return EmitAlertTimelinessSloActivityInputs(
         alert_id="alert-1",
         team_id=1,
@@ -187,9 +189,7 @@ class TestEmitAlertTimelinessSlo:
         await env.run(emit_alert_timeliness_slo, _timeliness_inputs())
 
         completed = [
-            c
-            for c in mock_slo_analytics.capture.call_args_list
-            if c.kwargs.get("event") == "slo_operation_completed"
+            c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
         ]
         assert len(completed) == 1
         props = completed[0].kwargs["properties"]

--- a/posthog/temporal/tests/test_alerts_timeliness.py
+++ b/posthog/temporal/tests/test_alerts_timeliness.py
@@ -1,0 +1,76 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from posthog.schema import AlertCalculationInterval
+
+from posthog.slo.types import SloOutcome
+from posthog.temporal.alerts.timeliness import alert_timeliness_threshold_ms, build_alert_timeliness_completion
+
+
+@pytest.mark.parametrize(
+    "calculation_interval,expected_ms",
+    [
+        ("every_minute", 60_000),
+        (AlertCalculationInterval.EVERY_15_MINUTES.value, 60_000),
+        (AlertCalculationInterval.HOURLY.value, 120_000),
+        (AlertCalculationInterval.DAILY.value, 120_000),
+        (AlertCalculationInterval.WEEKLY.value, 120_000),
+        (AlertCalculationInterval.MONTHLY.value, 120_000),
+        ("unexpected_interval", 120_000),
+        (None, 120_000),
+    ],
+)
+def test_alert_timeliness_threshold_is_five_percent_clamped(calculation_interval: str | None, expected_ms: int) -> None:
+    assert alert_timeliness_threshold_ms(calculation_interval) == expected_ms
+
+
+def test_timeliness_completion_succeeds_at_threshold() -> None:
+    scheduled = datetime(2024, 6, 3, 10, 0, tzinfo=UTC)
+
+    outcome, props = build_alert_timeliness_completion(
+        calculation_interval=AlertCalculationInterval.EVERY_15_MINUTES.value,
+        scheduled_check_at=scheduled.isoformat(),
+        actual_check_start_at=scheduled + timedelta(seconds=60),
+    )
+
+    assert outcome == SloOutcome.SUCCESS
+    assert props["evaluation_lag_ms"] == 60_000
+    assert props["timeliness_threshold_ms"] == 60_000
+    assert props["is_late"] is False
+
+
+def test_timeliness_completion_fails_when_late_even_if_execution_can_succeed() -> None:
+    scheduled = datetime(2024, 6, 3, 10, 0, tzinfo=UTC)
+
+    outcome, props = build_alert_timeliness_completion(
+        calculation_interval=AlertCalculationInterval.HOURLY.value,
+        scheduled_check_at=scheduled.isoformat(),
+        actual_check_start_at=scheduled + timedelta(seconds=121),
+    )
+
+    assert outcome == SloOutcome.FAILURE
+    assert props["evaluation_lag_ms"] == 121_000
+    assert props["timeliness_threshold_ms"] == 120_000
+    assert props["is_late"] is True
+
+
+@pytest.mark.parametrize(
+    "scheduled_check_at",
+    [
+        "2024-06-03T10:00:00Z",
+        "2024-06-03T10:00:00+00:00",
+        "2024-06-03T12:00:00+02:00",
+        "2024-06-03T10:00:00",
+    ],
+)
+def test_timeliness_completion_parses_supported_timestamp_shapes(scheduled_check_at: str) -> None:
+    outcome, props = build_alert_timeliness_completion(
+        calculation_interval=AlertCalculationInterval.HOURLY.value,
+        scheduled_check_at=scheduled_check_at,
+        actual_check_start_at=datetime(2024, 6, 3, 10, 1, tzinfo=UTC),
+    )
+
+    assert outcome == SloOutcome.SUCCESS
+    assert props["scheduled_due_at"] == "2024-06-03T10:00:00+00:00"
+    assert props["evaluation_lag_ms"] == 60_000

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -1,5 +1,6 @@
 import uuid
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -25,7 +26,7 @@ from posthog.schema import (
 from posthog.models import Insight, User
 from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
 from posthog.tasks.alerts.utils import AlertEvaluationResult
-from posthog.temporal.alerts.activities import evaluate_alert, notify_alert, prepare_alert
+from posthog.temporal.alerts.activities import emit_alert_timeliness_slo, evaluate_alert, notify_alert, prepare_alert
 from posthog.temporal.alerts.schedule import create_schedule_due_alert_checks_schedule
 from posthog.temporal.alerts.types import CheckAlertWorkflowInputs, SkipReason
 from posthog.temporal.alerts.workflows import CheckAlertWorkflow
@@ -33,7 +34,12 @@ from posthog.temporal.common.slo_interceptor import SloInterceptor
 
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration
 
-CHECK_ALERT_ACTIVITIES: list[Callable[..., Any]] = [prepare_alert, evaluate_alert, notify_alert]
+CHECK_ALERT_ACTIVITIES: list[Callable[..., Any]] = [
+    emit_alert_timeliness_slo,
+    prepare_alert,
+    evaluate_alert,
+    notify_alert,
+]
 
 
 def test_schedule_is_registered_in_init_schedules():
@@ -111,7 +117,15 @@ def _slo_config(alert: AlertConfiguration) -> SloConfig:
     )
 
 
-async def _run_check_alert_workflow(alert_id: str, slo: SloConfig, team_id: int, insight_id: int) -> None:
+async def _run_check_alert_workflow(
+    alert_id: str,
+    slo: SloConfig,
+    team_id: int,
+    insight_id: int,
+    *,
+    calculation_interval: str = AlertCalculationInterval.DAILY.value,
+    scheduled_check_at: str | None = None,
+) -> None:
     """Spin up a WorkflowEnvironment + Worker and execute CheckAlertWorkflow.
 
     Caller patches the boundaries (check_alert_for_insight, send_notifications_for_breaches)
@@ -132,8 +146,9 @@ async def _run_check_alert_workflow(alert_id: str, slo: SloConfig, team_id: int,
                     alert_id=alert_id,
                     team_id=team_id,
                     distinct_id=alert_id,
-                    calculation_interval=AlertCalculationInterval.DAILY.value,
+                    calculation_interval=calculation_interval,
                     insight_id=insight_id,
+                    scheduled_check_at=scheduled_check_at,
                     slo=slo,
                 ),
                 id=f"check-alert-{uuid.uuid4()}",
@@ -141,9 +156,14 @@ async def _run_check_alert_workflow(alert_id: str, slo: SloConfig, team_id: int,
             )
 
 
-def _completed_slo_props(mock_slo_analytics: MagicMock) -> dict:
+def _completed_slo_props(
+    mock_slo_analytics: MagicMock, operation: SloOperation = SloOperation.ALERT_CHECK
+) -> dict:
     completed = [
-        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+        c
+        for c in mock_slo_analytics.capture.call_args_list
+        if c.kwargs.get("event") == "slo_operation_completed"
+        and c.kwargs["properties"].get("operation") == operation
     ]
     assert len(completed) == 1, f"expected 1 SLO completion event, got {len(completed)}"
     return completed[0].kwargs["properties"]
@@ -187,6 +207,93 @@ async def test_check_alert_workflow_firing_drives_full_chain_with_slo(
     assert completed_props["outcome"] == SloOutcome.SUCCESS
     assert completed_props["alert_state"] == AlertState.FIRING
     assert completed_props["calculation_interval"] == alert_with_subscriber.calculation_interval
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_check_alert_workflow_late_success_emits_timeliness_failure(
+    mock_slo_analytics: MagicMock,
+    alert_with_subscriber: AlertConfiguration,
+) -> None:
+    evaluation_result = AlertEvaluationResult(value=5.0, breaches=None)
+    scheduled_check_at = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+
+    with patch("posthog.temporal.alerts.activities.check_alert_for_insight", return_value=evaluation_result):
+        await _run_check_alert_workflow(
+            alert_id=str(alert_with_subscriber.id),
+            slo=_slo_config(alert_with_subscriber),
+            team_id=alert_with_subscriber.team_id,
+            insight_id=alert_with_subscriber.insight_id,
+            calculation_interval=AlertCalculationInterval.HOURLY.value,
+            scheduled_check_at=scheduled_check_at,
+        )
+
+    execution_props = _completed_slo_props(mock_slo_analytics, SloOperation.ALERT_CHECK)
+    assert execution_props["outcome"] == SloOutcome.SUCCESS
+    assert execution_props["alert_state"] == AlertState.NOT_FIRING
+
+    timeliness_props = _completed_slo_props(mock_slo_analytics, SloOperation.ALERT_CHECK_TIMELINESS)
+    assert timeliness_props["outcome"] == SloOutcome.FAILURE
+    assert timeliness_props["is_late"] is True
+    assert timeliness_props["timeliness_threshold_ms"] == 120_000
+    assert timeliness_props["evaluation_lag_ms"] > 120_000
+    assert timeliness_props["duration_ms"] == timeliness_props["evaluation_lag_ms"]
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_check_alert_workflow_no_due_check_excluded_from_timeliness_denominator(
+    mock_slo_analytics: MagicMock,
+    alert_with_subscriber: AlertConfiguration,
+) -> None:
+    evaluation_result = AlertEvaluationResult(value=5.0, breaches=None)
+
+    with patch("posthog.temporal.alerts.activities.check_alert_for_insight", return_value=evaluation_result):
+        await _run_check_alert_workflow(
+            alert_id=str(alert_with_subscriber.id),
+            slo=_slo_config(alert_with_subscriber),
+            team_id=alert_with_subscriber.team_id,
+            insight_id=alert_with_subscriber.insight_id,
+            scheduled_check_at=None,
+        )
+
+    _completed_slo_props(mock_slo_analytics, SloOperation.ALERT_CHECK)
+    timeliness_completed = [
+        c
+        for c in mock_slo_analytics.capture.call_args_list
+        if c.kwargs.get("event") == "slo_operation_completed"
+        and c.kwargs["properties"].get("operation") == SloOperation.ALERT_CHECK_TIMELINESS
+    ]
+    assert timeliness_completed == []
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_check_alert_workflow_on_time_due_check_emits_timeliness_success(
+    mock_slo_analytics: MagicMock,
+    alert_with_subscriber: AlertConfiguration,
+) -> None:
+    evaluation_result = AlertEvaluationResult(value=5.0, breaches=None)
+    scheduled_check_at = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
+
+    with patch("posthog.temporal.alerts.activities.check_alert_for_insight", return_value=evaluation_result):
+        await _run_check_alert_workflow(
+            alert_id=str(alert_with_subscriber.id),
+            slo=_slo_config(alert_with_subscriber),
+            team_id=alert_with_subscriber.team_id,
+            insight_id=alert_with_subscriber.insight_id,
+            calculation_interval=AlertCalculationInterval.HOURLY.value,
+            scheduled_check_at=scheduled_check_at,
+        )
+
+    timeliness_props = _completed_slo_props(mock_slo_analytics, SloOperation.ALERT_CHECK_TIMELINESS)
+    assert timeliness_props["outcome"] == SloOutcome.SUCCESS
+    assert timeliness_props["is_late"] is False
+    assert timeliness_props["timeliness_threshold_ms"] == 120_000
+    assert timeliness_props["evaluation_lag_ms"] <= 120_000
 
 
 @pytest.mark.parametrize(

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -156,14 +156,11 @@ async def _run_check_alert_workflow(
             )
 
 
-def _completed_slo_props(
-    mock_slo_analytics: MagicMock, operation: SloOperation = SloOperation.ALERT_CHECK
-) -> dict:
+def _completed_slo_props(mock_slo_analytics: MagicMock, operation: SloOperation = SloOperation.ALERT_CHECK) -> dict:
     completed = [
         c
         for c in mock_slo_analytics.capture.call_args_list
-        if c.kwargs.get("event") == "slo_operation_completed"
-        and c.kwargs["properties"].get("operation") == operation
+        if c.kwargs.get("event") == "slo_operation_completed" and c.kwargs["properties"].get("operation") == operation
     ]
     assert len(completed) == 1, f"expected 1 SLO completion event, got {len(completed)}"
     return completed[0].kwargs["properties"]

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -30,6 +30,11 @@ locals {
       slo     = 99.95 # error budget = 0.05%
       regions = ["US", "EU"]
     }
+    alert_check_timeliness = {
+      name    = "Alert check timeliness"
+      slo     = 99.95 # error budget = 0.05%
+      regions = ["US", "EU"]
+    }
     query_service = {
       name    = "Query service"
       slo     = 99.95 # error budget = 0.05%


### PR DESCRIPTION
## Problem

Alert check execution currently tells us whether an alert check eventually completed, but it does not separately show whether the scheduler started the check close to when it was due. For due-work systems, timeliness is a different reliability question from execution success: a check can succeed and still be operationally late.

## Changes

- Add a separate `alert_check_timeliness` SLO operation for alert scheduler lag.
- Snapshot each alert's scheduled due time before scheduling state is advanced, then pass it through the check workflow.
- Emit timeliness SLO events from a dedicated best-effort Temporal activity so observability work does not block alert execution.
- Exclude initial checks without a stored due timestamp from the timeliness denominator.
- Add dashboard configuration for the new SLO operation.
- Add tests for threshold calculation, timestamp handling, due-time snapshotting, activity emission, and workflow behavior.

## How did you test this code?

I am an agent and only ran the automated/static checks listed below.

- `/tmp/posthog-alert-slo-venv/bin/ruff check posthog/slo/types.py posthog/temporal/alerts/__init__.py posthog/temporal/alerts/activities.py posthog/temporal/alerts/retry_policy.py posthog/temporal/alerts/timeliness.py posthog/temporal/alerts/types.py posthog/temporal/alerts/workflows.py posthog/temporal/tests/test_alerts_activities.py posthog/temporal/tests/test_alerts_timeliness.py posthog/temporal/tests/test_alerts_workflows.py`
- `python3 -m py_compile posthog/slo/types.py posthog/temporal/alerts/__init__.py posthog/temporal/alerts/activities.py posthog/temporal/alerts/retry_policy.py posthog/temporal/alerts/timeliness.py posthog/temporal/alerts/types.py posthog/temporal/alerts/workflows.py posthog/temporal/tests/test_alerts_activities.py posthog/temporal/tests/test_alerts_timeliness.py posthog/temporal/tests/test_alerts_workflows.py`
- `git diff --check`

Not run locally because this VM does not have the project test runner or Terraform CLI installed:

- Focused pytest/Temporal tests
- Terraform formatting/checks

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Do not publish to changelog.

## Docs update

No docs update needed; this is internal observability instrumentation.

## 🤖 Agent context

This PR was authored with Hermes Agent assistance.

Key decisions:

- Model alert check timeliness as a separate scheduler-lag SLO rather than overloading alert execution success.
- Emit timeliness observability from an activity instead of directly from workflow code, to avoid workflow replay side effects.
- Make the timeliness activity best-effort and bounded so alert execution continues even if observability emission fails.
- Remove the Temporal patch gate after review because these workflows self-recover quickly and the simpler payload flow is easier to maintain.
- Avoid including production metrics or operational counts in this PR description.
