### PR TITLE
chore(ux): expand goodbye tabs modal copy with rationale + feedback link

### DIFF
--- a/frontend/src/layout/scenes/GoodbyeTabsModal.tsx
+++ b/frontend/src/layout/scenes/GoodbyeTabsModal.tsx
@@ -16,8 +16,8 @@ export function GoodbyeTabsModal(): JSX.Element {
         <LemonModal
             isOpen={isOpen}
             onClose={dismiss}
-            title="Goodbye tabs 🪓"
-            description="Tabs were a fun experiment, but they are extremely hard to get right."
+            title="Goodbye tabs 😔"
+            description="Tabs were a fun experiment, but doing them well across an app this size is genuinely hard; your browser already nails it."
             width="32rem"
             footer={
                 <LemonButton type="primary" onClick={dismiss} data-attr="goodbye-tabs-dismiss">
@@ -26,6 +26,27 @@ export function GoodbyeTabsModal(): JSX.Element {
             }
         >
             <div className="deprecated-space-y-2">
+                <div className="text-sm deprecated-space-y-2">
+                    <p className="m-0">
+                        Users expected each tab to fully restore on switch: every input, every scroll position, every
+                        bit of in-memory state. Solving that across an app this size is a huge undertaking, and it
+                        competes with the ongoing work to reduce memory usage.
+                    </p>
+                    <p className="m-0">
+                        Tabs also overrode normal browser behavior: right-click menus on links were replaced with a
+                        custom contextual menu, and links with <code>target="_blank"</code> opened as scene tabs instead
+                        of real browser tabs. Rather than ship a subpar version of something browsers already do
+                        perfectly, we're handing it back to them.
+                    </p>
+                    <p className="m-0">
+                        See the{' '}
+                        <Link to="https://github.com/PostHog/posthog/issues/59856" target="_blank">
+                            GitHub issue
+                        </Link>{' '}
+                        to learn more and share feedback on this decision.
+                    </p>
+                </div>
+                <hr className="mt-2 mb-3 border-border" />
                 {tabs.length === 0 && backendTabsLoading ? (
                     <div className="text-muted">Loading your tabs…</div>
                 ) : tabs.length === 0 ? (


### PR DESCRIPTION
## Problem

The goodbye tabs modal (shown once after #59764 removed scene tabs) only said "Tabs were a fun experiment, but they are extremely hard to get right." Users who relied on tabs had no context for the decision and nowhere to push back.

## Changes

- Reworded the modal description to be less dismissive.
- Added two short paragraphs in the body explaining the two real reasons: per-tab state restoration is a big undertaking that competes with ongoing memory work, and tabs were overriding native browser behavior (right-click menu, `target="_blank"` link handling).
- Added a link out to #59856 so users can leave feedback in one place.
- Inserted a divider between the rationale and the list of their saved tabs so the tab list reads as the actionable part of the modal.

No logic changes; copy + a `<Link>` + an `<hr>`.

## How did you test this code?

I'm an agent. No manual browser testing was performed beyond visually checking the JSX. The claims about what tabs overrode were cross-referenced against the diff in #59764 (custom `SceneTabContextMenu`, `LemonTree` always-mounted radix `ContextMenu`, `Link.tsx` redirecting `target="_blank"` to `newInternalTab`). A speculative "middle-click" claim was dropped after the diff showed middle-click was only used to close tabs on the strip itself, not to override link behavior.

Reviewers should sanity-check the modal renders with the new copy and the GitHub link opens in a new tab.

## Publish to changelog?

No.

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Iterative copy session: drafted from a longer internal note, stripped personal info and team-internal references, verified each "hijacking" claim against the #59764 diff, then tightened punctuation (no em-dashes) and word choice per user preference. The companion discussion issue at #59856 was drafted in the same session and is what the modal now links to.