### PR TITLE
fix(tasks): stop stamping hedgehog reaction on interim slack relays

### DIFF
--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -323,7 +323,7 @@ def execute_posthog_code_agent_relay_workflow(
     relay_id: str | None = None,
     user_message_ts: str | None = None,
     delete_progress: bool = True,
-    reaction_emoji: str = "hedgehog",
+    reaction_emoji: str | None = None,
 ) -> str:
     relay_id = relay_id or str(uuid.uuid4())
     workflow_id = f"posthog-code-agent-relay-{run_id}-{relay_id}"

--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -106,7 +106,7 @@ class RelaySlackMessageInput:
     text: str
     user_message_ts: str | None = None
     delete_progress: bool = True
-    reaction_emoji: str = "hedgehog"
+    reaction_emoji: str | None = None
 
 
 @activity.defn
@@ -156,7 +156,8 @@ def relay_slack_message(input: RelaySlackMessageInput) -> None:
     if input.delete_progress:
         handler.delete_progress()
     handler.post_thread_message(f"{mention_prefix}{text}")
-    handler.update_reaction(input.reaction_emoji)
+    if input.reaction_emoji is not None:
+        handler.update_reaction(input.reaction_emoji)
 
     def _record_sent_relay(state: dict[str, Any]) -> None:
         sent_relay_ids = state.get("slack_sent_relay_ids") or []

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -81,9 +81,26 @@ class TestRelaySlackMessage(TestCase):
         mock_delete_progress.assert_called_once()
         mock_post.assert_called_once()
         assert "Which license should I use?" in mock_post.call_args.args[0]
-        mock_update.assert_called_once_with("hedgehog")
+        mock_update.assert_not_called()
         self.task_run.refresh_from_db()
         assert "relay-1" in self.task_run.state.get("slack_sent_relay_ids", [])
+
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.update_reaction")
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.post_thread_message")
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.delete_progress")
+    def test_relay_with_explicit_reaction_updates_reaction(self, mock_delete_progress, mock_post, mock_update):
+        relay_slack_message(
+            RelaySlackMessageInput(
+                run_id=str(self.task_run.id),
+                relay_id="relay-2",
+                text="Could not deliver follow-up",
+                user_message_ts="1234.5",
+                reaction_emoji="x",
+            )
+        )
+
+        mock_post.assert_called_once()
+        mock_update.assert_called_once_with("x")
 
 
 class TestMarkdownToSlackMrkdwn(TestCase):

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -65,42 +65,44 @@ class TestRelaySlackMessage(TestCase):
             mentioning_slack_user_id="U123",
         )
 
+    @parameterized.expand(
+        [
+            ("no_reaction_emoji", "relay-1", "Which license should I use?", None),
+            ("explicit_reaction_emoji", "relay-2", "Could not deliver follow-up", "x"),
+        ]
+    )
     @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.update_reaction")
     @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.post_thread_message")
     @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.delete_progress")
-    def test_relay_posts_message_and_marks_sent(self, mock_delete_progress, mock_post, mock_update):
+    def test_relay_posts_message_and_marks_sent(
+        self,
+        _name,
+        relay_id,
+        text,
+        reaction_emoji,
+        mock_delete_progress,
+        mock_post,
+        mock_update,
+    ):
         relay_slack_message(
             RelaySlackMessageInput(
                 run_id=str(self.task_run.id),
-                relay_id="relay-1",
-                text="Which license should I use?",
+                relay_id=relay_id,
+                text=text,
                 user_message_ts="1234.5",
+                reaction_emoji=reaction_emoji,
             )
         )
 
         mock_delete_progress.assert_called_once()
         mock_post.assert_called_once()
-        assert "Which license should I use?" in mock_post.call_args.args[0]
-        mock_update.assert_not_called()
+        assert text in mock_post.call_args.args[0]
+        if reaction_emoji is None:
+            mock_update.assert_not_called()
+        else:
+            mock_update.assert_called_once_with(reaction_emoji)
         self.task_run.refresh_from_db()
-        assert "relay-1" in self.task_run.state.get("slack_sent_relay_ids", [])
-
-    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.update_reaction")
-    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.post_thread_message")
-    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.delete_progress")
-    def test_relay_with_explicit_reaction_updates_reaction(self, mock_delete_progress, mock_post, mock_update):
-        relay_slack_message(
-            RelaySlackMessageInput(
-                run_id=str(self.task_run.id),
-                relay_id="relay-2",
-                text="Could not deliver follow-up",
-                user_message_ts="1234.5",
-                reaction_emoji="x",
-            )
-        )
-
-        mock_post.assert_called_once()
-        mock_update.assert_called_once_with("x")
+        assert relay_id in self.task_run.state.get("slack_sent_relay_ids", [])
 
 
 class TestMarkdownToSlackMrkdwn(TestCase):


### PR DESCRIPTION
## Problem

When a Slack-launched task runs, the bot manages a reaction on the user's mention message as a status indicator:

| Reaction | Meaning |
| --- | --- |
| `:seedling:` | task received / queued |
| `:eyes:` | agent working |
| `:hedgehog:` | task completed (or PR opened) |
| `:x:` | task failed |

`post_slack_update` is the intended single source of truth for terminal reactions — it only stamps `:hedgehog:` when the run reaches `COMPLETED`, `CANCELLED`, or a PR is opened.

However, every interim agent message posted back into the Slack thread via the `relay_message` endpoint was *also* flipping the reaction to `:hedgehog:`. The endpoint by design only fires for non-terminal runs (it short-circuits on `task_run.is_terminal`), so users were seeing the "done" hedgehog appear repeatedly while the agent was still working.

Root cause: `RelaySlackMessageInput.reaction_emoji` defaulted to `"hedgehog"`, and the `relay_message` endpoint never passed an explicit value, so the default fired on every interim relay.

## Changes

- `RelaySlackMessageInput.reaction_emoji` and `execute_posthog_code_agent_relay_workflow`'s `reaction_emoji` arg now default to `None`.
- `relay_slack_message` only calls `handler.update_reaction(...)` when the caller explicitly passes a reaction.
- `forward_pending_message` (the delivery-failure case that legitimately needs to mark `:x:`) is unchanged — it already passed `reaction_emoji=\"x\"` explicitly.
- Net effect: interim agent relays no longer touch the reaction. `post_slack_update` remains the sole authority on lifecycle reactions.

## How did you test this code?

- Updated the existing `test_relay_posts_message_and_marks_sent` test to assert that an interim relay does *not* call `update_reaction`.
- Added `test_relay_with_explicit_reaction_updates_reaction` to confirm an explicit `reaction_emoji=\"x\"` (the `forward_pending_message` path) still flows through.
- I'm an agent — no manual testing in a live Slack workspace was performed.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) via the PostHog Code sandbox. The user reported that the hedgehog emoji was appearing on their Slack mention before the task was actually done. Traced the reaction lifecycle through `products/slack_app/backend/slack_thread.py:update_reaction`, `products/tasks/backend/temporal/process_task/activities/post_slack_update.py` (intended terminal-state authority), and `products/tasks/backend/temporal/slack_relay/activities.py` (the bug site).

Considered two fixes:

1. Change the relay default to `\"eyes\"` so interim messages reaffirm the working indicator.
2. Make `reaction_emoji` optional (`None`) and only update the reaction when explicitly set.

Picked (2): the existing `forward_pending_message` caller already passes `\"x\"` explicitly, so the parameter is preserved for legitimate state-bearing relays; absence of an arg now means \"don't touch it\" rather than the previous footgun of \"mark as done\". This also avoids redundant Slack API calls (the `update_reaction` flow does a `reactions_remove` per stale emoji plus a `reactions_add`) on every interim message.