### PR TITLE
fix(mcp_store): forward x-posthog-* headers through the store proxy

### DIFF
--- a/products/mcp_store/backend/proxy.py
+++ b/products/mcp_store/backend/proxy.py
@@ -276,22 +276,16 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
         **auth_headers,
     }
 
-    # Forward PostHog-namespace headers so the upstream server can identify the
-    # consumer, mode, and version that the caller declared. Without this, the
-    # PostHog MCP cannot resolve single-exec mode for posthog-code-installed
-    # PostHog MCPs (the consumer header never reaches the resolver), and the
-    # `exec` tool comes back as "Tool exec not found". Non-PostHog upstreams
-    # ignore unknown `x-posthog-mcp-*` headers, so this is safe for any server.
-    for ph_header in (
-        "x-posthog-mcp-consumer",
-        "x-posthog-mcp-mode",
-        "x-posthog-mcp-version",
-        "x-posthog-project-id",
-        "x-posthog-read-only",
-    ):
-        value = request.headers.get(ph_header)
-        if value:
-            headers[ph_header] = value
+    # Forward the full `x-posthog-*` namespace so the upstream server can
+    # identify the consumer, mode, and version that the caller declared, plus
+    # any custom PostHog-namespace headers the caller wants to pass through.
+    # Without this, the PostHog MCP cannot resolve single-exec mode for
+    # posthog-code-installed PostHog MCPs (the consumer header never reaches
+    # the resolver) and the `exec` tool comes back as "Tool exec not found".
+    # Non-PostHog upstreams ignore unknown headers in that namespace.
+    for header_name in request.headers:
+        if header_name.lower().startswith("x-posthog-"):
+            headers[header_name] = request.headers[header_name]
 
     mcp_session_id = request.headers.get("mcp-session-id")
     if mcp_session_id:

--- a/products/mcp_store/backend/proxy.py
+++ b/products/mcp_store/backend/proxy.py
@@ -276,6 +276,23 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
         **auth_headers,
     }
 
+    # Forward PostHog-namespace headers so the upstream server can identify the
+    # consumer, mode, and version that the caller declared. Without this, the
+    # PostHog MCP cannot resolve single-exec mode for posthog-code-installed
+    # PostHog MCPs (the consumer header never reaches the resolver), and the
+    # `exec` tool comes back as "Tool exec not found". Non-PostHog upstreams
+    # ignore unknown `x-posthog-mcp-*` headers, so this is safe for any server.
+    for ph_header in (
+        "x-posthog-mcp-consumer",
+        "x-posthog-mcp-mode",
+        "x-posthog-mcp-version",
+        "x-posthog-project-id",
+        "x-posthog-read-only",
+    ):
+        value = request.headers.get(ph_header)
+        if value:
+            headers[ph_header] = value
+
     mcp_session_id = request.headers.get("mcp-session-id")
     if mcp_session_id:
         headers["Mcp-Session-Id"] = mcp_session_id

--- a/products/mcp_store/backend/test/test_proxy.py
+++ b/products/mcp_store/backend/test/test_proxy.py
@@ -167,6 +167,8 @@ class TestMCPProxyEndpoint(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         # Required for PostHog MCP installs through the Store: without
         # `x-posthog-mcp-consumer` reaching the upstream, single-exec mode
         # never resolves and `exec` comes back as "Tool exec not found".
+        # The full `x-posthog-*` namespace forwards so callers can also pass
+        # custom headers through.
         installation = self._create_installation(
             sensitive_configuration={"api_key": "sk-test-key"},
         )
@@ -186,18 +188,22 @@ class TestMCPProxyEndpoint(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "x-posthog-mcp-version": "2",
                 "x-posthog-project-id": "42",
                 "x-posthog-read-only": "true",
+                "x-posthog-custom-future-header": "anything",
                 "x-not-posthog-namespace": "should-not-be-forwarded",
             },
         )
 
         assert response.status_code == 200
         _, kwargs = mock_client.build_request.call_args
-        assert kwargs["headers"]["x-posthog-mcp-consumer"] == "posthog-code"
-        assert kwargs["headers"]["x-posthog-mcp-mode"] == "cli"
-        assert kwargs["headers"]["x-posthog-mcp-version"] == "2"
-        assert kwargs["headers"]["x-posthog-project-id"] == "42"
-        assert kwargs["headers"]["x-posthog-read-only"] == "true"
-        assert "x-not-posthog-namespace" not in kwargs["headers"]
+        # Case-insensitive lookup since Django normalizes to title case.
+        forwarded = {k.lower(): v for k, v in kwargs["headers"].items()}
+        assert forwarded["x-posthog-mcp-consumer"] == "posthog-code"
+        assert forwarded["x-posthog-mcp-mode"] == "cli"
+        assert forwarded["x-posthog-mcp-version"] == "2"
+        assert forwarded["x-posthog-project-id"] == "42"
+        assert forwarded["x-posthog-read-only"] == "true"
+        assert forwarded["x-posthog-custom-future-header"] == "anything"
+        assert "x-not-posthog-namespace" not in forwarded
 
     @patch("products.mcp_store.backend.oauth.refresh_oauth_token")
     @patch("products.mcp_store.backend.proxy.httpx.Client")

--- a/products/mcp_store/backend/test/test_proxy.py
+++ b/products/mcp_store/backend/test/test_proxy.py
@@ -162,6 +162,43 @@ class TestMCPProxyEndpoint(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         _, kwargs = mock_client.build_request.call_args
         assert kwargs["headers"]["Mcp-Session-Id"] == "client-session-xyz"
 
+    @patch("products.mcp_store.backend.proxy.httpx.Client")
+    def test_proxy_forwards_posthog_namespace_headers(self, mock_client_cls):
+        # Required for PostHog MCP installs through the Store: without
+        # `x-posthog-mcp-consumer` reaching the upstream, single-exec mode
+        # never resolves and `exec` comes back as "Tool exec not found".
+        installation = self._create_installation(
+            sensitive_configuration={"api_key": "sk-test-key"},
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.content = b'{"jsonrpc":"2.0","id":1,"result":{}}'
+        mock_client = self._mock_client_with_response(mock_client_cls, mock_response)
+
+        response = self.client.post(
+            self._proxy_url(installation.id),
+            data={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            format="json",
+            headers={
+                "x-posthog-mcp-consumer": "posthog-code",
+                "x-posthog-mcp-mode": "cli",
+                "x-posthog-mcp-version": "2",
+                "x-posthog-project-id": "42",
+                "x-posthog-read-only": "true",
+                "x-not-posthog-namespace": "should-not-be-forwarded",
+            },
+        )
+
+        assert response.status_code == 200
+        _, kwargs = mock_client.build_request.call_args
+        assert kwargs["headers"]["x-posthog-mcp-consumer"] == "posthog-code"
+        assert kwargs["headers"]["x-posthog-mcp-mode"] == "cli"
+        assert kwargs["headers"]["x-posthog-mcp-version"] == "2"
+        assert kwargs["headers"]["x-posthog-project-id"] == "42"
+        assert kwargs["headers"]["x-posthog-read-only"] == "true"
+        assert "x-not-posthog-namespace" not in kwargs["headers"]
+
     @patch("products.mcp_store.backend.oauth.refresh_oauth_token")
     @patch("products.mcp_store.backend.proxy.httpx.Client")
     def test_proxy_refreshes_expired_oauth_token(self, mock_client_cls, mock_refresh):

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -146,6 +146,7 @@ def _refresh_sandbox_mcp(
             token=access_token,
             team_id=task_run.team_id,
             user_id=task.created_by_id,
+            interaction_origin=(task_run.state or {}).get("interaction_origin"),
         )
         if user_mcp_configs:
             mcp_configs = mcp_configs + user_mcp_configs

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -164,6 +164,7 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 token=access_token,
                 team_id=ctx.team_id,
                 user_id=task.created_by_id,
+                interaction_origin=ctx.interaction_origin,
             )
             if user_mcp_configs:
                 mcp_configs = mcp_configs + user_mcp_configs

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -73,9 +73,7 @@ class TestRefreshSandboxMcp:
         mock_ph_configs.assert_called_once_with(
             token="fresh-token", project_id=7, scopes="read_only", interaction_origin=None
         )
-        mock_user_configs.assert_called_once_with(
-            token="fresh-token", team_id=7, user_id=42, interaction_origin=None
-        )
+        mock_user_configs.assert_called_once_with(token="fresh-token", team_id=7, user_id=42, interaction_origin=None)
         mock_send_refresh.assert_called_once()
         _, kwargs = mock_send_refresh.call_args
         assert kwargs["auth_token"] == "jwt"

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -73,7 +73,9 @@ class TestRefreshSandboxMcp:
         mock_ph_configs.assert_called_once_with(
             token="fresh-token", project_id=7, scopes="read_only", interaction_origin=None
         )
-        mock_user_configs.assert_called_once_with(token="fresh-token", team_id=7, user_id=42)
+        mock_user_configs.assert_called_once_with(
+            token="fresh-token", team_id=7, user_id=42, interaction_origin=None
+        )
         mock_send_refresh.assert_called_once()
         _, kwargs = mock_send_refresh.call_args
         assert kwargs["auth_token"] == "jwt"

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -213,6 +213,12 @@ class TestFetchUserMcpServerConfigs(TestCase):
         defaults.update(kwargs)
         return ActiveInstallationInfo(**defaults)
 
+    def _expected_user_headers(self, *, consumer: str = "posthog-code") -> list[dict[str, str]]:
+        return [
+            {"name": "Authorization", "value": f"Bearer {self.TOKEN}"},
+            {"name": "x-posthog-mcp-consumer", "value": consumer},
+        ]
+
     @patch(MOCK_API_URL)
     @patch(MOCK_FACADE)
     def test_builds_configs_from_facade_results(self, mock_facade, mock_api_url) -> None:
@@ -228,9 +234,30 @@ class TestFetchUserMcpServerConfigs(TestCase):
                 type="http",
                 name="Linear",
                 url=f"{self.API_BASE}/api/environments/{self.TEAM_ID}/mcp_server_installations/abc-123/proxy/",
-                headers=[{"name": "Authorization", "value": f"Bearer {self.TOKEN}"}],
+                headers=self._expected_user_headers(),
             )
         ]
+
+    @parameterized.expand(
+        [
+            ("slack", "slack"),
+            ("posthog_code", "posthog-code"),
+            (None, "posthog-code"),
+        ]
+    )
+    @patch(MOCK_API_URL)
+    @patch(MOCK_FACADE)
+    def test_consumer_header_reflects_interaction_origin(
+        self, interaction_origin: str | None, expected_consumer: str, mock_facade, mock_api_url
+    ) -> None:
+        mock_api_url.return_value = self.API_BASE
+        mock_facade.return_value = [self._make_installation()]
+
+        configs = get_user_mcp_server_configs(
+            self.TOKEN, self.TEAM_ID, self.USER_ID, interaction_origin=interaction_origin
+        )
+
+        assert configs[0].headers == self._expected_user_headers(consumer=expected_consumer)
 
     @patch(MOCK_API_URL)
     @patch(MOCK_FACADE)

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -239,16 +239,25 @@ def get_user_mcp_server_configs(
     token: str,
     team_id: int,
     user_id: int,
+    *,
+    interaction_origin: str | None = None,
 ) -> list[McpServerConfig]:
     """Fetch the user's MCP Store installations and return sandbox configs.
 
     Uses the mcp_store facade to get active installations, then builds
     McpServerConfig entries with full proxy URLs and auth headers.
 
+    The `x-posthog-mcp-consumer` header is set on every config so the agent's
+    identity propagates through the MCP Store proxy to whichever upstream MCP
+    the user installed. The PostHog MCP needs this to resolve single-exec mode
+    (without it, calls to `exec` fail with "Tool exec not found"); non-PostHog
+    upstreams ignore the header.
+
     Returns an empty list on errors (non-fatal).
     """
     installations = get_active_installations(team_id, user_id)
     api_base = get_sandbox_api_url().rstrip("/")
+    consumer = _resolve_mcp_consumer(interaction_origin)
 
     configs: list[McpServerConfig] = []
     for installation in installations:
@@ -257,7 +266,10 @@ def get_user_mcp_server_configs(
                 type="http",
                 name=installation.name,
                 url=f"{api_base}{installation.proxy_path}",
-                headers=[{"name": "Authorization", "value": f"Bearer {token}"}],
+                headers=[
+                    {"name": "Authorization", "value": f"Bearer {token}"},
+                    {"name": "x-posthog-mcp-consumer", "value": consumer},
+                ],
             )
         )
 


### PR DESCRIPTION
## Problem

PostHog Code tasks using a Store-installed PostHog MCP hit `Tool exec not found` on every `exec` call. The Store proxy drops `x-posthog-mcp-consumer`, so `useSingleExec` resolves false upstream. The built-in config path (`get_sandbox_ph_mcp_configs`) was already setting the header.

## Changes

- Proxy forwards `x-posthog-mcp-*` from the incoming request. Non-PostHog upstreams ignore unknown headers in that namespace.
- `get_user_mcp_server_configs` now sets the consumer from `interaction_origin`, matching `get_sandbox_ph_mcp_configs`.

## How did you test this code?

I'm an agent. Added `test_proxy_forwards_posthog_namespace_headers` covering forwarded vs non-forwarded headers, and parameterized `test_consumer_header_reflects_interaction_origin` over `slack`, `posthog_code`, and `None`. CI will validate.

## Publish to changelog?

no

## Docs update

N/A

## 🤖 Agent context

Considered loosening the upstream resolver to force single-exec on `isPostHogCodeConsumer()` alone (independent of the `mcp-single-exec-tool` flag), but the flag is a deliberate rollout gate for other coding-agent paths. Fixing both ends keeps the contract explicit.