### PR TITLE
feat(slack): open posthog code thread follow-ups to any org member

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -973,6 +973,7 @@ def forward_posthog_code_followup_activity(
     import structlog
 
     from posthog.models.integration import Integration, SlackIntegration
+    from posthog.models.organization import OrganizationMembership
 
     from products.slack_app.backend.api import resolve_slack_user
     from products.slack_app.backend.models import SlackThreadTaskMapping
@@ -1000,12 +1001,15 @@ def forward_posthog_code_followup_activity(
     )
     slack = SlackIntegration(integration)
 
-    # The sandbox runs under the original starter's identity, so any thread participant who drives
-    # it inherits those permissions. Require the follow-up sender to be a member of the same
-    # PostHog org as the starter — the same gate applied to new @mentions in
-    # resolve_posthog_code_slack_user_activity. Without this, external participants in shared /
-    # Slack Connect channels could drive a sandbox they shouldn't have access to.
-    if resolve_slack_user(slack, integration, slack_user_id, channel, thread_ts) is None:
+    # The sandbox runs under the original starter's identity with `posthog_mcp_scopes="full"`,
+    # so any thread participant who drives it inherits those permissions. Two gates:
+    #   1. Org membership — same gate as new @mentions in resolve_posthog_code_slack_user_activity.
+    #      Keeps external participants in shared / Slack Connect channels out.
+    #   2. Org membership level >= starter's level — prevents intra-org privilege escalation, where
+    #      a member-level user drives a sandbox auth'd as an admin/owner starter and asks the agent
+    #      to perform actions they couldn't perform themselves.
+    follow_up_user_context = resolve_slack_user(slack, integration, slack_user_id, channel, thread_ts)
+    if follow_up_user_context is None:
         log.info(
             "posthog_code_followup_non_org_member",
             channel=channel,
@@ -1013,6 +1017,38 @@ def forward_posthog_code_followup_activity(
             slack_user_id=slack_user_id,
         )
         return True
+
+    starter = mapping.task.created_by
+    if starter is not None and follow_up_user_context.user.id != starter.id:
+        org_id = integration.team.organization_id
+        level_by_user = dict(
+            OrganizationMembership.objects.filter(
+                organization_id=org_id,
+                user_id__in=[follow_up_user_context.user.id, starter.id],
+            ).values_list("user_id", "level")
+        )
+        follow_up_level = level_by_user.get(follow_up_user_context.user.id)
+        starter_level = level_by_user.get(starter.id)
+        if follow_up_level is None or starter_level is None or follow_up_level < starter_level:
+            log.info(
+                "posthog_code_followup_insufficient_privilege",
+                channel=channel,
+                thread_ts=thread_ts,
+                slack_user_id=slack_user_id,
+                follow_up_user_id=follow_up_user_context.user.id,
+                starter_user_id=starter.id,
+                follow_up_level=follow_up_level,
+                starter_level=starter_level,
+            )
+            slack.client.chat_postMessage(
+                channel=channel,
+                thread_ts=thread_ts,
+                text=(
+                    f"<@{slack_user_id}> This task is running under the starter's PostHog permissions, "
+                    "which are higher than yours. Please start a new thread to run the agent under your own permissions."
+                ),
+            )
+            return True
 
     if task_run.is_terminal:
         return _resume_task_with_new_run(

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -974,6 +974,7 @@ def forward_posthog_code_followup_activity(
 
     from posthog.models.integration import Integration, SlackIntegration
 
+    from products.slack_app.backend.api import resolve_slack_user
     from products.slack_app.backend.models import SlackThreadTaskMapping
     from products.tasks.backend.services.agent_command import send_user_message
     from products.tasks.backend.services.connection_token import create_sandbox_connection_token
@@ -999,18 +1000,17 @@ def forward_posthog_code_followup_activity(
     )
     slack = SlackIntegration(integration)
 
-    if slack_user_id != mapping.mentioning_slack_user_id:
+    # The sandbox runs under the original starter's identity, so any thread participant who drives
+    # it inherits those permissions. Require the follow-up sender to be a member of the same
+    # PostHog org as the starter — the same gate applied to new @mentions in
+    # resolve_posthog_code_slack_user_activity. Without this, external participants in shared /
+    # Slack Connect channels could drive a sandbox they shouldn't have access to.
+    if resolve_slack_user(slack, integration, slack_user_id, channel, thread_ts) is None:
         log.info(
-            "posthog_code_followup_unauthorized_actor",
+            "posthog_code_followup_non_org_member",
             channel=channel,
             thread_ts=thread_ts,
-            expected=mapping.mentioning_slack_user_id,
-            actual=slack_user_id,
-        )
-        slack.client.chat_postMessage(
-            channel=channel,
-            thread_ts=thread_ts,
-            text="Only the person who started this task can send follow-up messages to the agent.",
+            slack_user_id=slack_user_id,
         )
         return True
 

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -426,6 +426,14 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
             status=self.TaskRun.Status.IN_PROGRESS,
             state={"sandbox_url": "https://sandbox.example.com/rpc"},
         )
+        # Treat every Slack sender as an org member by default. Individual tests can override
+        # the patched resolver to simulate a non-org-member sender.
+        resolver_patcher = patch("products.slack_app.backend.api.resolve_slack_user")
+        self.mock_resolve_slack_user = resolver_patcher.start()
+        self.addCleanup(resolver_patcher.stop)
+        self.mock_resolve_slack_user.return_value = SimpleNamespace(
+            user=SimpleNamespace(id=self.user.id), is_team_member=True
+        )
 
     def _create_mapping(self, mentioning_user: str = "U_ALICE") -> SlackThreadTaskMapping:
         return SlackThreadTaskMapping.objects.create(
@@ -527,13 +535,13 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         assert "gh pr checkout https://github.com/org/repo/pull/1" in new_run.state.get("initial_prompt_override", "")
         assert "gh pr checkout https://github.com/org/repo/pull/1" in new_run.state.get("pending_user_message", "")
 
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     @patch("posthog.models.integration.SlackIntegration")
-    def test_terminal_run_unauthorized_user_returns_true_with_error(self, mock_slack_cls):
+    def test_terminal_run_resumes_for_other_thread_participant(self, mock_slack_cls, mock_execute_workflow):
         self.task_run.status = self.TaskRun.Status.COMPLETED
         self.task_run.save()
         self._create_mapping(mentioning_user="U_ALICE")
-        mock_slack_instance = MagicMock()
-        mock_slack_cls.return_value = mock_slack_instance
+        mock_slack_cls.return_value = MagicMock()
 
         inputs = _make_inputs(self.integration.id)
         result = forward_posthog_code_followup_activity(
@@ -541,8 +549,8 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         )
 
         assert result is True
-        call_kwargs = mock_slack_instance.client.chat_postMessage.call_args.kwargs
-        assert "Only the person who started" in call_kwargs["text"]
+        mock_execute_workflow.assert_called_once()
+        assert mock_execute_workflow.call_args.kwargs["task_id"] == str(self.task.id)
 
     @patch("posthog.models.integration.SlackIntegration")
     def test_terminal_run_missing_created_by_returns_true_with_error(self, mock_slack_cls):
@@ -586,20 +594,40 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         )
         assert mapping.task_run_id == self.task_run.id
 
+    @patch("products.tasks.backend.services.connection_token.create_sandbox_connection_token", return_value="jwt-token")
+    @patch("products.tasks.backend.services.agent_command.send_user_message")
     @patch("posthog.models.integration.SlackIntegration")
-    def test_unauthorized_actor_returns_true_with_message(self, mock_slack_cls):
+    def test_other_thread_participant_can_send_followup(self, mock_slack_cls, mock_send, mock_token):
         self._create_mapping(mentioning_user="U_ALICE")
-        mock_slack_instance = MagicMock()
-        mock_slack_cls.return_value = mock_slack_instance
+        mock_slack_cls.return_value = MagicMock()
+        mock_send.return_value = _command_result(
+            success=True,
+            status_code=200,
+            data={"result": {"assistant_message": "thanks"}},
+        )
 
         inputs = _make_inputs(self.integration.id)
         result = forward_posthog_code_followup_activity(
-            inputs, "C123", "1234.5678", "U_BOB", "do something", "1234.5679"
+            inputs, "C123", "1234.5678", "U_BOB", "<@BOT> do something", "1234.5679"
         )
         assert result is True
-        mock_slack_instance.client.chat_postMessage.assert_called_once()
-        call_kwargs = mock_slack_instance.client.chat_postMessage.call_args.kwargs
-        assert "Only the person who started" in call_kwargs["text"]
+        mock_send.assert_called_once_with(self.task_run, "do something", auth_token="jwt-token", timeout=90)
+
+    @patch("products.tasks.backend.services.agent_command.send_user_message")
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_non_org_member_followup_is_dropped(self, mock_slack_cls, mock_send):
+        # External Slack user in a shared channel — resolve_slack_user returns None and posts
+        # an ephemeral rejection. The activity must not forward the message to the sandbox.
+        self._create_mapping(mentioning_user="U_ALICE")
+        mock_slack_cls.return_value = MagicMock()
+        self.mock_resolve_slack_user.return_value = None
+
+        inputs = _make_inputs(self.integration.id)
+        result = forward_posthog_code_followup_activity(
+            inputs, "C123", "1234.5678", "U_EXTERNAL", "<@BOT> do something", "1234.5679"
+        )
+        assert result is True
+        mock_send.assert_not_called()
 
     @patch("posthog.models.integration.SlackIntegration")
     def test_sandbox_not_ready_returns_true_with_message(self, mock_slack_cls):

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -646,6 +646,9 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
             inputs, "C123", "1234.5678", "U_EXTERNAL", "<@BOT> do something", "1234.5679"
         )
         assert result is True
+        # Lock in that the security gate was actually exercised — without this, an early-return
+        # added before the resolver call would silently bypass the check while keeping the test green.
+        self.mock_resolve_slack_user.assert_called_once()
         mock_send.assert_not_called()
 
     @patch("products.tasks.backend.services.agent_command.send_user_message")
@@ -667,6 +670,9 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
             inputs, "C123", "1234.5678", "U_BOB", "<@BOT> do something", "1234.5679"
         )
         assert result is True
+        # Lock in that the resolver was actually called before the level comparison —
+        # protects against a future refactor that early-returns before the gate runs.
+        self.mock_resolve_slack_user.assert_called_once()
         mock_send.assert_not_called()
         post_call = mock_slack_instance.client.chat_postMessage.call_args
         assert post_call is not None

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -6,7 +6,7 @@ from django.apps import apps
 from django.test import TestCase
 
 from posthog.models.integration import Integration
-from posthog.models.organization import Organization
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.user_integration import UserIntegration
@@ -409,6 +409,9 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
+        OrganizationMembership.objects.create(
+            organization=self.org, user=self.user, level=OrganizationMembership.Level.ADMIN
+        )
         self.integration = Integration.objects.create(
             team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
         )
@@ -426,14 +429,20 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
             status=self.TaskRun.Status.IN_PROGRESS,
             state={"sandbox_url": "https://sandbox.example.com/rpc"},
         )
-        # Treat every Slack sender as an org member by default. Individual tests can override
-        # the patched resolver to simulate a non-org-member sender.
+        # Treat every Slack sender as the starter (Alice) by default — same user, same level, so
+        # the privilege-level gate is a no-op. Individual tests override the patched resolver to
+        # simulate a non-org-member sender or a lower-privileged sender.
         resolver_patcher = patch("products.slack_app.backend.api.resolve_slack_user")
         self.mock_resolve_slack_user = resolver_patcher.start()
         self.addCleanup(resolver_patcher.stop)
         self.mock_resolve_slack_user.return_value = SimpleNamespace(
-            user=SimpleNamespace(id=self.user.id), is_team_member=True
+            user=SimpleNamespace(id=self.user.id), slack_email="alice@test.com"
         )
+
+    def _create_other_org_member(self, email: str, level: int) -> User:
+        other = User.objects.create(email=email)
+        OrganizationMembership.objects.create(organization=self.org, user=other, level=level)
+        return other
 
     def _create_mapping(self, mentioning_user: str = "U_ALICE") -> SlackThreadTaskMapping:
         return SlackThreadTaskMapping.objects.create(
@@ -542,6 +551,11 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         self.task_run.save()
         self._create_mapping(mentioning_user="U_ALICE")
         mock_slack_cls.return_value = MagicMock()
+        # Bob is a different user at the same org level as Alice (admin).
+        bob = self._create_other_org_member("bob@test.com", OrganizationMembership.Level.ADMIN)
+        self.mock_resolve_slack_user.return_value = SimpleNamespace(
+            user=SimpleNamespace(id=bob.id), slack_email="bob@test.com"
+        )
 
         inputs = _make_inputs(self.integration.id)
         result = forward_posthog_code_followup_activity(
@@ -600,6 +614,11 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
     def test_other_thread_participant_can_send_followup(self, mock_slack_cls, mock_send, mock_token):
         self._create_mapping(mentioning_user="U_ALICE")
         mock_slack_cls.return_value = MagicMock()
+        # Bob is a different user at the same org level as Alice (admin).
+        bob = self._create_other_org_member("bob@test.com", OrganizationMembership.Level.ADMIN)
+        self.mock_resolve_slack_user.return_value = SimpleNamespace(
+            user=SimpleNamespace(id=bob.id), slack_email="bob@test.com"
+        )
         mock_send.return_value = _command_result(
             success=True,
             status_code=200,
@@ -628,6 +647,30 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         )
         assert result is True
         mock_send.assert_not_called()
+
+    @patch("products.tasks.backend.services.agent_command.send_user_message")
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_lower_privileged_followup_is_rejected(self, mock_slack_cls, mock_send):
+        # Bob is a MEMBER, the starter (Alice) is ADMIN. The agent runs with Alice's PostHog MCP
+        # scopes, so allowing Bob to drive it would let him perform admin actions through the
+        # sandbox he couldn't perform under his own identity.
+        self._create_mapping(mentioning_user="U_ALICE")
+        mock_slack_instance = MagicMock()
+        mock_slack_cls.return_value = mock_slack_instance
+        bob = self._create_other_org_member("bob@test.com", OrganizationMembership.Level.MEMBER)
+        self.mock_resolve_slack_user.return_value = SimpleNamespace(
+            user=SimpleNamespace(id=bob.id), slack_email="bob@test.com"
+        )
+
+        inputs = _make_inputs(self.integration.id)
+        result = forward_posthog_code_followup_activity(
+            inputs, "C123", "1234.5678", "U_BOB", "<@BOT> do something", "1234.5679"
+        )
+        assert result is True
+        mock_send.assert_not_called()
+        post_call = mock_slack_instance.client.chat_postMessage.call_args
+        assert post_call is not None
+        assert "higher than yours" in post_call.kwargs["text"]
 
     @patch("posthog.models.integration.SlackIntegration")
     def test_sandbox_not_ready_returns_true_with_message(self, mock_slack_cls):


### PR DESCRIPTION
## Problem

Only the Slack user who first @-mentioned the PostHog Code bot in a thread could send follow-ups. That blocks pairing and handoffs in shared channels.

## Changes

Dropped the per-starter gate in `forward_posthog_code_followup_activity`. Replaced it with two narrower gates: (1) `resolve_slack_user` checks the sender is a member of the integration's PostHog org; (2) the sender's `OrganizationMembership.level` must be >= the starter's, since the sandbox runs under the starter's identity with `posthog_mcp_scopes="full"`.

## How did you test this code?

I'm an agent, no manual Slack testing. Added unit tests for the non-org-member rejection, the lower-privilege rejection, and rewrote the existing rejection tests to cover the same-level cross-user resume / forward paths. Did not run locally (no Python env); CI will.

## Publish to changelog?

no

## Docs update

N/A

## 🤖 Agent context

Decisions worth flagging for review:

- Dropped the per-user gate entirely instead of a per-thread allowlist. The Slack channel is already the access boundary, so blocking thread participation was friction without security value.
- Two gates on follow-ups: org membership (keeps external Slack Connect users out) and level >= starter's (prevents intra-org privilege escalation). The membership-level gate was added after hex-security-app flagged that a member-level user could drive an admin's sandbox.
- Terminate-task button (`posthog/temporal/ai/posthog_code_slack_interactivity.py:88`) and repo-picker dropdown (`products/slack_app/backend/api.py:1483`) are still gated to the starter. Worth a follow-up.
- When a non-starter resumes a terminal run, `SlackThreadContext.mentioning_slack_user_id` is updated to the new sender, so subsequent bot replies ping them. The DB mapping is unchanged.