### PR TITLE
feat(mcp): roll out single-exec mode to all coding agents

### DIFF
--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -28,16 +28,14 @@ export interface ResolvedState {
 
 export function resolveModeAndVersion(args: {
     mode: McpMode | undefined
-    singleExecFlagOn: boolean
     clientProfile: MCPClientProfile
     flagVersion: number | undefined
     clientVersion: number | undefined
 }): { useSingleExec: boolean; version: number } {
-    const { mode, singleExecFlagOn, clientProfile, flagVersion, clientVersion } = args
+    const { mode, clientProfile, flagVersion, clientVersion } = args
     const useSingleExec =
         mode === 'cli' ||
         (mode !== 'tools' &&
-            singleExecFlagOn &&
             (clientProfile.isCodingAgent() ||
                 clientProfile.isPostHogCodeConsumer() ||
                 clientProfile.isVibeCodingClient()))
@@ -47,7 +45,7 @@ export function resolveModeAndVersion(args: {
 
 // ─── Resolver ───
 
-const SYSTEM_FLAGS = ['mcp-version-2', 'mcp-single-exec-tool'] as const
+const SYSTEM_FLAGS = ['mcp-version-2'] as const
 
 export class RequestStateResolver {
     private readonly catalog: ToolCatalog
@@ -93,7 +91,6 @@ export class RequestStateResolver {
         ])
 
         const flagVersion = allFlags['mcp-version-2'] ? 2 : undefined
-        const singleExecFlagOn = !!allFlags['mcp-single-exec-tool']
         const toolFeatureFlags = toolFlagKeys.length > 0
             ? Object.fromEntries(toolFlagKeys.map((k) => [k, !!allFlags[k]]))
             : undefined
@@ -110,7 +107,6 @@ export class RequestStateResolver {
 
         const { useSingleExec, version } = resolveModeAndVersion({
             mode,
-            singleExecFlagOn,
             clientProfile,
             flagVersion,
             clientVersion,

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -570,7 +570,6 @@ export class MCP extends McpAgent<Env> {
         // User-level flags resolve in parallel with cache seeding. Tool flags are
         // deferred until orgId is known so org-group rollouts evaluate correctly.
         const flagPromise = this.resolveVersionFlag()
-        const singleExecPromise = this.resolveSingleExecFlag()
 
         // Seed cache with header-provided IDs before any fetches
         if (organizationId) {
@@ -605,10 +604,9 @@ export class MCP extends McpAgent<Env> {
         const flagGroups = flagAnalyticsContext ? buildMCPAnalyticsGroups(flagAnalyticsContext) : undefined
         const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion, flagGroups)
 
-        const [flagVersion, toolFeatureFlags, singleExecFlagOn, _apiKey] = await Promise.all([
+        const [flagVersion, toolFeatureFlags, _apiKey] = await Promise.all([
             flagPromise,
             toolFlagsPromise,
-            singleExecPromise,
             // Trigger OAuth introspection so the OAuth client name is cached before the useSingleExec decision below
             context.stateManager.getApiKey(),
         ])
@@ -624,7 +622,6 @@ export class MCP extends McpAgent<Env> {
 
         const { useSingleExec, version } = this.resolveModeAndVersion({
             mode,
-            singleExecFlagOn,
             clientProfile,
             flagVersion,
             clientVersion,
@@ -877,21 +874,19 @@ export class MCP extends McpAgent<Env> {
      * wrapped client's reported name. Vibe-coding platforms (Lovable, Replit)
      * are detected by OAuth client name since they typically connect through a
      * generic MCP client wrapper. An explicit `mode` from the caller (header
-     * `x-posthog-mcp-mode` or query param `mode`) wins over the flag +
-     * client-profile heuristic.
+     * `x-posthog-mcp-mode` or query param `mode`) wins over the client-profile
+     * heuristic.
      */
     private resolveModeAndVersion(args: {
         mode: McpMode | undefined
-        singleExecFlagOn: boolean
         clientProfile: MCPClientProfile
         flagVersion: number | undefined
         clientVersion: number | undefined
     }): { useSingleExec: boolean; version: number } {
-        const { mode, singleExecFlagOn, clientProfile, flagVersion, clientVersion } = args
+        const { mode, clientProfile, flagVersion, clientVersion } = args
         const useSingleExec =
             mode === 'cli' ||
             (mode !== 'tools' &&
-                singleExecFlagOn &&
                 (clientProfile.isCodingAgent() ||
                     clientProfile.isPostHogCodeConsumer() ||
                     clientProfile.isVibeCodingClient()))
@@ -909,15 +904,6 @@ export class MCP extends McpAgent<Env> {
             return (await isFeatureFlagEnabled('mcp-version-2', distinctId)) ? 2 : undefined
         } catch {
             return undefined
-        }
-    }
-
-    private async resolveSingleExecFlag(): Promise<boolean> {
-        try {
-            const distinctId = await this.getDistinctId()
-            return !!(await isFeatureFlagEnabled('mcp-single-exec-tool', distinctId))
-        } catch {
-            return false
         }
     }
 

--- a/services/mcp/tests/unit/protocol-types.test.ts
+++ b/services/mcp/tests/unit/protocol-types.test.ts
@@ -10,7 +10,6 @@ describe('resolveModeAndVersion', () => {
 
     const base = {
         mode: undefined as undefined,
-        singleExecFlagOn: false,
         clientProfile: profile(),
         flagVersion: undefined as number | undefined,
         clientVersion: undefined as number | undefined,
@@ -27,38 +26,34 @@ describe('resolveModeAndVersion', () => {
         })
     })
 
-    it('explicit mode=tools disables single exec even when flag is on for a coding agent', () => {
+    it('explicit mode=tools disables single exec even for a coding agent', () => {
         const result = resolveModeAndVersion({
             ...base,
             mode: 'tools',
-            singleExecFlagOn: true,
             clientProfile: profile({ clientName: 'claude-code' }),
         })
         expect(result.useSingleExec).toBe(false)
     })
 
-    it('coding agent with flag on activates single exec', () => {
+    it('coding agent activates single exec', () => {
         const result = resolveModeAndVersion({
             ...base,
-            singleExecFlagOn: true,
             clientProfile: profile({ clientName: 'claude-code' }),
         })
         expect(result).toEqual({ useSingleExec: true, version: 2 })
     })
 
-    it('non-coding agent with flag on does NOT activate single exec', () => {
+    it('non-coding agent does NOT activate single exec', () => {
         const result = resolveModeAndVersion({
             ...base,
-            singleExecFlagOn: true,
             clientProfile: profile({ clientName: 'some-dashboard-client' }),
         })
         expect(result.useSingleExec).toBe(false)
     })
 
-    it('flag on + PostHog code consumer activates single exec', () => {
+    it('PostHog code consumer activates single exec', () => {
         const result = resolveModeAndVersion({
             ...base,
-            singleExecFlagOn: true,
             clientProfile: profile({ consumer: 'posthog-code' }),
         })
         expect(result.useSingleExec).toBe(true)


### PR DESCRIPTION
## Problem

The CLI tool was rolled out to everyone, so let's clean the flag.

## Changes

- Drop the `mcp-single-exec-tool` flag lookup from both code paths that resolve mode/version: the Hono `RequestStateResolver` and the legacy `MCP` durable object's `init()`.
- Simplify `resolveModeAndVersion` so single-exec activates purely on the client-profile heuristic (or an explicit `mode=cli`); `mode=tools` still wins as a kill switch.
- Remove the now-unused `resolveSingleExecFlag` helper and drop `'mcp-single-exec-tool'` from `SYSTEM_FLAGS`.
- Update the `resolveModeAndVersion` unit tests to match the new signature.

The flag itself can be archived in PostHog separately once this ships.

## How did you test this code?

I'm an agent. I ran:

- `pnpm vitest run tests/unit/protocol-types.test.ts` — 10/10 pass.
- `pnpm test:hono tests/hono/tool-executor.test.ts` — 8/8 pass.
- `pnpm typecheck` on `services/mcp` — no new errors on the changed files (pre-existing module-resolution noise in unrelated `ui-apps` / `@posthog/quill` files only).

No manual testing of the live MCP server.

## Publish to changelog?

no

## Docs update

No docs reference the gating flag.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). The user asked to remove the `mcp-single-exec` gate and roll the functionality out to everyone. I located the flag (real key: `mcp-single-exec-tool`) in `services/mcp/src/mcp.ts` and `services/mcp/src/hono/request-state-resolver.ts`, then traced `singleExecFlagOn` through both `resolveModeAndVersion` implementations to confirm the client-profile heuristic on its own is the desired behavior post-rollout. Tests in `services/mcp/tests/unit/protocol-types.test.ts` were updated in place to drop the now-meaningless `singleExecFlagOn` axis.

Reviewer-facing decisions:

- The two `resolveModeAndVersion` helpers (the pure one in `request-state-resolver.ts` and the method on the `MCP` DO class) were kept in lockstep. They duplicate logic today; I did not consolidate them in this PR to keep the diff scoped to the flag removal.
- `isFeatureFlagEnabled` import in `mcp.ts` is retained because `resolveVersionFlag` still uses it for `mcp-version-2`.
- Did not touch the PostHog feature-flag registry — that lives outside this repo and can be archived independently once this is shipped to confirm there's no lingering caller.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*