### PR TITLE
fix(mcp): replace agents framework noisy onError default with structured log

### DIFF
--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -1,6 +1,7 @@
 import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 import { McpServer, type ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
 import guidelines from '@shared/guidelines.md'
+import type { Connection } from 'agents'
 import { McpAgent } from 'agents/mcp'
 import type { z } from 'zod'
 
@@ -257,6 +258,42 @@ export class MCP extends McpAgent<Env> {
         }
 
         return this._api
+    }
+
+    /**
+     * Replace the agents framework's default `onError` (in `agents@0.10.2`,
+     * `dist/src-f7-4oW_C.js`), which emits two `console.error` lines for every
+     * unhandled DO error — the real error followed by a literal
+     * `Override onError(error) to handle server errors` hint. The hint clutters
+     * log search and the unstructured pair is hard to bucket on.
+     *
+     * Emit a single structured line (`[MCP] unhandled error`) carrying the
+     * error name, message, and origin (websocket connection vs. server) so
+     * production log filters can group cleanly. The error is re-thrown to
+     * preserve the framework's request/response failure semantics — swallowing
+     * it would leave clients waiting on a response that never arrives.
+     */
+    onError(connection: Connection, error: unknown): void
+    onError(error: unknown): void
+    onError(connectionOrError: unknown, maybeError?: unknown): void {
+        // Mirrors the base class's branching: it only treats the call as the
+        // connection form when *both* args are truthy.
+        const isConnectionForm = !!(connectionOrError && maybeError)
+        const theError: unknown = isConnectionForm ? maybeError : connectionOrError
+        const connection = isConnectionForm ? (connectionOrError as Connection) : undefined
+
+        const errorInfo =
+            theError instanceof Error
+                ? { name: theError.name, message: theError.message, stack: theError.stack }
+                : { name: 'NonError', message: String(theError) }
+
+        console.error('[MCP] unhandled error', {
+            source: connection ? 'connection' : 'server',
+            ...(connection ? { connectionId: connection.id } : {}),
+            ...errorInfo,
+        })
+
+        throw theError
     }
 
     /**


### PR DESCRIPTION
## Problem

The Cloudflare `agents` framework (v0.10.2) ships a default `Agent.onError`
that emits two `console.error` lines for every unhandled DO error:

```
Error on server: <the actual Error>
Override onError(error) to handle server errors
```

The second line is a literal hint to subclasses; nothing actionable happens
when it fires. It still surfaces in Cloudflare Workers logs at
`severity_text=error` for every upstream failure on `mcp1` — DO isolate OOM
resets, OAuth `INVALID_API_KEY`, missing `user:read` scope, `groups_types`
403s, etc. — making error log search noisy and the entries hard to bucket on
since the payload is split across two unstructured lines per failure.

## Changes

Override `onError` on the `MCP` durable-object class in
`services/mcp/src/mcp.ts` to emit a single `[MCP] unhandled error` line with
structured fields (`source`, `connectionId`, `name`, `message`, `stack`).

The branching mirrors the base class exactly (connection form only when both
args are truthy) and the error is still re-thrown — swallowing it would leave
the transport / response cycle hanging because the framework relies on the
throw to fail the request properly.

## How did you test this code?

I'm an agent. No manual testing in production was performed.

- `pnpm typecheck` against `services/mcp` — no errors introduced in `mcp.ts`
  (the only failures are pre-existing missing-`react` / `@posthog/quill` types
  from a partial install, unrelated to this change).
- `pnpm exec oxlint src/mcp.ts` — clean.
- `pnpm exec oxfmt --check src/mcp.ts` — clean.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude (Opus 4.7) via PostHog Code while diagnosing an MCP
incident report. The hint line was traced to the `agents@0.10.2`
`dist/src-f7-4oW_C.js` `onError` default after confirming there's no override
on `MCP extends McpAgent<Env>`. Decisions:

- **Don't swallow the error.** The base class re-throws because the framework
  needs the failure to propagate through the transport so the client gets a
  proper response. Keeping the re-throw preserves that contract; the only
  thing we change is the logging.
- **Single structured line rather than two pairs.** Cloudflare Workers
  Observability records `console.error` payloads as a single log entry, so
  the structured object becomes searchable attributes. That replaces the
  unstructured pair the framework would have emitted.
- **Type-only `Connection` import from `agents`.** `agents/mcp` doesn't
  re-export `Connection`, but `agents` does. `import type` keeps it
  zero-runtime-cost.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*