### PR TITLE
fix(ingestion): sanitize null bytes from group_key before postgres query

### DIFF
--- a/nodejs/src/ingestion/event-processing/process-groups-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-groups-step.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { Properties } from '~/plugin-scaffold'
 
 import { PreIngestionEvent, ProjectId, Team, TeamId } from '../../types'
+import { sanitizeString } from '../../utils/db/utils'
 import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { TeamManager } from '../../utils/team-manager'
@@ -110,7 +111,7 @@ async function upsertGroup(
             teamId,
             projectId,
             groupTypeIndex,
-            groupKey.toString(),
+            sanitizeString(groupKey.toString()),
             groupPropertiesToSet || {},
             timestamp
         )


### PR DESCRIPTION
## Problem

Events with null bytes (`\x00`) in `$group_key` cause PostgreSQL to reject the query with `invalid byte sequence for encoding "UTF8": 0x00`. This surfaces as a query error on the `fetchGroup` SELECT before the upsert ever runs.

The CDP path (`groups-manager.service.ts`) already sanitized group keys via `sanitizeString`, but the ingestion pipeline path was missing the same guard.

## Changes

- Apply `sanitizeString` to `$group_key` in `upsertGroup` before passing it to the group store, so both the fetch-before-upsert and the write use the sanitized key.

## How did you test this code?

Agent-authored. The `sanitizeString` utility (which replaces `\u0000` with `\uFFFD`) is already used and tested elsewhere in the codebase (distinct_id, token, session_id, CDP group keys). No new logic was introduced.

## Publish to changelog?

No

## 🤖 Agent context

Authored with Claude Code (claude-sonnet-4-6). Investigation started from a production error log showing `invalid byte sequence for encoding "UTF8": 0x00` on `fetchGroup`. Identified that the CDP path already had `sanitizeString` on group keys but the ingestion pipeline path did not. Applied the same sanitization at `upsertGroup` call site so the key is clean before it reaches any Postgres query.