### PR TITLE
fix(clickhouse): handle missing posthog_instancesetting table during migrations

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -147,17 +147,21 @@ def get_hedged_app_queries_enabled() -> bool:
 def _get_hedged_app_queries_enabled(_ttl: int) -> bool:
     from posthog.models.instance_setting import get_instance_setting
 
-    return get_instance_setting("CLICKHOUSE_HEDGED_APP_QUERIES")
+    try:
+        return get_instance_setting("CLICKHOUSE_HEDGED_APP_QUERIES")
+    except Exception:
+        return False
 
 
 @lru_cache(maxsize=1)
 def _get_kill_switch_level(_ttl: int) -> KillSwitchLevel:
     from posthog.models.instance_setting import get_instance_setting
 
-    value = get_instance_setting("CLICKHOUSE_KILL_SWITCH")
     try:
+        value = get_instance_setting("CLICKHOUSE_KILL_SWITCH")
         return KillSwitchLevel(value)
-    except ValueError:
+    except Exception:
+        # posthog_instancesetting may not exist yet during initial Postgres migrations
         return KillSwitchLevel.OFF
 
 


### PR DESCRIPTION
## Problem

When Postgres and ClickHouse migrations run in parallel (the default in bin/migrate), ClickHouse migration 0019 calls sync_execute which hits get_kill_switch_level -> InstanceSetting.objects.filter(...) before the posthog_instancesetting table has been created, causing a ProgrammingError.

## Changes

Wrap the instance-setting reads in _get_kill_switch_level and _get_hedged_app_queries_enabled with broad exception handling so they fall back to safe defaults (OFF / False) when the table is not yet available.


