### PR TITLE
fix(auth): match SSO logins to active users only

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -18,6 +18,7 @@ import structlog
 import posthoganalytics
 from rest_framework import exceptions, generics, permissions, response, serializers, status
 from rest_framework.request import Request
+from social_core.exceptions import AuthException
 from social_core.pipeline.partial import partial
 from social_django.strategy import DjangoStrategy
 from webauthn.helpers import base64url_to_bytes
@@ -891,6 +892,39 @@ def process_social_domain_jit_provisioning_signup(
                 )
 
     return user
+
+
+def social_associate_user_by_active_email(backend, details, user=None, *args, **kwargs):
+    """
+    Variant of ``social_core.pipeline.social_auth.associate_by_email`` that disambiguates by
+    ``is_active`` only when an email matches more than one account.
+
+    ``social_django``'s ``get_users_by_email`` matches case-insensitively but ignores
+    ``is_active``. Legacy mixed-case duplicates (e.g. an active ``john@x.com`` plus a
+    deactivated ``John@x.com``) therefore make the upstream step see >1 match and raise
+    "associated with another account", locking the active user out of SSO. We resolve that to
+    the single active account instead.
+
+    A *sole* match is passed through unchanged — including a deactivated one — to preserve
+    upstream behaviour: ``do_complete``'s ``is_active`` gate still blocks an inactive user,
+    rather than the pipeline falling through to JIT provisioning (which would mint a fresh
+    active account and defeat the deactivation).
+    """
+    if user:
+        return None
+
+    email = details.get("email")
+    if not email:
+        return None
+
+    users = list(backend.strategy.storage.user.get_users_by_email(email))
+    if len(users) <= 1:
+        return {"user": users[0], "is_new": False} if users else None
+
+    active_users = [candidate for candidate in users if candidate.is_active]
+    if len(active_users) == 1:
+        return {"user": active_users[0], "is_new": False}
+    raise AuthException(backend, "The given email address is associated with another account")
 
 
 @partial

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -18,8 +18,14 @@ from django.utils import timezone
 
 from parameterized import parameterized
 from rest_framework import status
+from social_core.exceptions import AuthException
+from social_django.models import UserSocialAuth
 
-from posthog.api.signup import _save_session_with_recovery, process_social_invite_signup
+from posthog.api.signup import (
+    _save_session_with_recovery,
+    process_social_invite_signup,
+    social_associate_user_by_active_email,
+)
 from posthog.cloud_utils import TEST_clear_instance_license_cache
 from posthog.constants import AvailableFeature
 from posthog.models import Organization, Team, User
@@ -3022,3 +3028,55 @@ class TestSignupResendInvite(APIBaseTest):
         # Bob still has a fresh bucket
         bob_ok = self.client.post("/api/signup/resend-invite", {"email": "bob@acme.com"})
         self.assertEqual(bob_ok.status_code, status.HTTP_200_OK)
+
+
+class TestSocialAssociateUserByActiveEmail(APIBaseTest):
+    def _backend(self):
+        backend = mock.MagicMock()
+        backend.name = "google-oauth2"
+        backend.strategy.storage.user = UserSocialAuth
+        return backend
+
+    def _make_user(self, email: str, *, is_active: bool = True) -> User:
+        # create_user lowercases the email; create with a unique placeholder, then write the
+        # exact casing via .update() to reproduce a legacy mixed-case row without colliding on
+        # the lowercased form (the DB unique index is case-sensitive, so variants can coexist).
+        user = User.objects.create_user(email=f"ph-{uuid.uuid4().hex}@example.com", password=None, first_name="T")
+        User.objects.filter(pk=user.pk).update(email=email, is_active=is_active)
+        user.refresh_from_db()
+        return user
+
+    def test_skips_when_user_already_resolved(self):
+        existing = self._make_user("taken@example.com")
+        result = social_associate_user_by_active_email(self._backend(), {"email": "taken@example.com"}, user=existing)
+        self.assertIsNone(result)
+
+    @parameterized.expand([("no_email_key", {}), ("no_matching_user", {"email": "nobody@example.com"})])
+    def test_returns_none_for_unresolvable_details(self, _name, details):
+        self.assertIsNone(social_associate_user_by_active_email(self._backend(), details))
+
+    def test_matches_single_active_user(self):
+        user = self._make_user("solo@example.com")
+        result = social_associate_user_by_active_email(self._backend(), {"email": "solo@example.com"})
+        self.assertEqual(result, {"user": user, "is_new": False})
+
+    def test_passes_through_sole_inactive_user(self):
+        # A sole match is returned even if inactive, so do_complete's is_active gate blocks the
+        # login rather than JIT provisioning minting a fresh active account for a deactivated user.
+        inactive = self._make_user("gone@example.com", is_active=False)
+        result = social_associate_user_by_active_email(self._backend(), {"email": "gone@example.com"})
+        self.assertEqual(result, {"user": inactive, "is_new": False})
+
+    def test_resolves_to_active_when_inactive_case_variant_exists(self):
+        # Active survivor is matched even though a deactivated capitalized duplicate shares the
+        # email case-insensitively — this is the lockout fix.
+        active = self._make_user("john@example.com", is_active=True)
+        self._make_user("John@example.com", is_active=False)
+        result = social_associate_user_by_active_email(self._backend(), {"email": "John@example.com"})
+        self.assertEqual(result, {"user": active, "is_new": False})
+
+    def test_raises_when_multiple_active_case_variants(self):
+        self._make_user("amy@example.com", is_active=True)
+        self._make_user("Amy@example.com", is_active=True)
+        with self.assertRaises(AuthException):
+            social_associate_user_by_active_email(self._backend(), {"email": "amy@example.com"})

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -246,7 +246,7 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.auth_allowed",
     "ee.api.authentication.social_auth_allowed",
     "social_core.pipeline.social_auth.social_user",
-    "social_core.pipeline.social_auth.associate_by_email",
+    "posthog.api.signup.social_associate_user_by_active_email",
     "posthog.api.signup.social_create_user",
     "social_core.pipeline.social_auth.associate_user",
     "social_core.pipeline.social_auth.load_extra_data",


### PR DESCRIPTION
## Problem

Users who have a deactivated, different-cased duplicate of their email (legacy mixed-case accounts) are locked out of SSO. The email-association step counts the inactive duplicate as a second match and refuses the login.

## Changes

- Replace the stock `associate_by_email` SSO pipeline step with one that only considers active users, so deactivating a redundant case-variant resolves the login to a single account.
- Preserve existing behavior otherwise, including raising when two active accounts share an email.

## How did you test this code?

- 6 unit tests added: single active match, inactive case-variant ignored, multiple active still raises, plus already-resolved / no-email / no-match guards.

## Publish to changelog?

no