### PR TITLE
chore(mcp): update analytics events

### DIFF
--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -1,13 +1,11 @@
+import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { getPostHogClient } from '@/lib/posthog'
-import {
-    AnalyticsEvent,
-    buildMCPAnalyticsGroups,
-    buildMCPContextProperties,
-    type MCPAnalyticsContext,
-} from '@/lib/posthog/analytics'
+import { buildMCPAnalyticsGroups, buildMCPContextProperties, type MCPAnalyticsContext } from '@/lib/posthog/analytics'
 import type { RequestProperties } from '@/lib/request-properties'
 
 import type { ResolvedState } from './request-state-resolver'
+
+const MCP_SOURCE = 'posthog_mcp_analytics'
 
 function buildBaseProperties(
     state: ResolvedState,
@@ -17,20 +15,36 @@ function buildBaseProperties(
     properties: Record<string, unknown>
     groups: Record<string, string>
 } {
-    const properties: Record<string, unknown> = {
-        mcp_runtime: 'hono',
-        ...(props.mcpClientName ? { mcp_client_name: props.mcpClientName } : {}),
-        ...(props.mcpClientVersion ? { mcp_client_version: props.mcpClientVersion } : {}),
-        ...(props.mcpProtocolVersion ? { mcp_protocol_version: props.mcpProtocolVersion } : {}),
-        ...(props.mcpConsumer ? { mcp_consumer: props.mcpConsumer } : {}),
-        ...(props.transport ? { mcp_transport: props.transport } : {}),
-        ...(props.mcpSessionId ? { mcp_session_id: props.mcpSessionId } : {}),
-        ...(props.mcpConversationId ? { mcp_conversation_id: props.mcpConversationId } : {}),
-        ...(props.mode ? { mcp_mode: props.mode } : {}),
-        ...(state.version !== undefined ? { mcp_version: state.version } : {}),
-        ...(analyticsContext ? buildMCPContextProperties(analyticsContext) : {}),
-    }
     const groups = analyticsContext ? buildMCPAnalyticsGroups(analyticsContext) : {}
+
+    const properties: Record<string, unknown> = {
+        $ai_product: 'mcp',
+        $mcp_source: MCP_SOURCE,
+        $mcp_server_name: MCP_SERVER_NAME,
+        $mcp_server_version: MCP_SERVER_VERSION,
+        $mcp_version: state.version,
+        $mcp_client_name: props.mcpClientName,
+        $mcp_client_version: props.mcpClientVersion,
+        $mcp_client_user_agent: props.clientUserAgent,
+        $mcp_protocol_version: props.mcpProtocolVersion,
+        $mcp_transport: props.transport,
+        $mcp_session_id: props.mcpSessionId,
+        $mcp_conversation_id: props.mcpConversationId,
+        $mcp_consumer: props.mcpConsumer,
+        $mcp_mode: props.mode,
+        $mcp_region: props.region,
+        ...(analyticsContext
+            ? {
+                  $mcp_organization_id: analyticsContext.organizationId,
+                  $mcp_project_id: analyticsContext.projectId,
+                  $mcp_project_uuid: analyticsContext.projectUuid,
+                  $mcp_project_name: analyticsContext.projectName,
+                  ...buildMCPContextProperties(analyticsContext),
+              }
+            : {}),
+        ...(Object.keys(groups).length > 0 ? { $groups: groups } : {}),
+        mcp_runtime: 'hono',
+    }
     return { properties, groups }
 }
 
@@ -44,17 +58,18 @@ export async function trackInitEvent(props: RequestProperties, state: ResolvedSt
 
         getPostHogClient().capture({
             distinctId: state.distinctId,
-            event: AnalyticsEvent.MCP_INIT,
+            event: 'mcp_initialize',
             ...(Object.keys(groups).length > 0 ? { groups } : {}),
             properties: {
                 ...properties,
+                $mcp_duration_ms: initDurationMs ?? 0,
+                $mcp_is_error: false,
                 tool_count: state.allTools.length,
                 has_organization_id: !!props.organizationId,
                 has_project_id: !!props.projectId,
                 read_only: !!props.readOnly,
                 via_sse_redirect: !!props.viaSseRedirect,
                 ...(props.mode ? { mcp_mode_explicit: props.mode } : {}),
-                ...(initDurationMs !== undefined ? { init_duration_ms: initDurationMs } : {}),
                 ...(sessionUuid ? { $session_id: sessionUuid } : {}),
             },
         })
@@ -79,14 +94,14 @@ export async function trackToolCall(
 
         getPostHogClient().capture({
             distinctId: state.distinctId,
-            event: AnalyticsEvent.MCP_TOOL_CALL,
+            event: 'mcp_tool_call',
             ...(Object.keys(groups).length > 0 ? { groups } : {}),
             properties: {
                 ...properties,
-                tool_name: toolName,
                 $mcp_tool_name: toolName,
                 $mcp_duration_ms: durationMs,
                 $mcp_is_error: isError,
+                tool_name: toolName,
                 ...(sessionUuid ? { $session_id: sessionUuid } : {}),
                 ...extraProperties,
             },

--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -1,11 +1,9 @@
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
+import { MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { getPostHogClient } from '@/lib/posthog'
 import { buildMCPAnalyticsGroups, buildMCPContextProperties, type MCPAnalyticsContext } from '@/lib/posthog/analytics'
 import type { RequestProperties } from '@/lib/request-properties'
 
 import type { ResolvedState } from './request-state-resolver'
-
-const MCP_SOURCE = 'posthog_mcp_analytics'
 
 function buildBaseProperties(
     state: ResolvedState,
@@ -19,7 +17,7 @@ function buildBaseProperties(
 
     const properties: Record<string, unknown> = {
         $ai_product: 'mcp',
-        $mcp_source: MCP_SOURCE,
+        $mcp_source: MCP_ANALYTICS_SOURCE,
         $mcp_server_name: MCP_SERVER_NAME,
         $mcp_server_version: MCP_SERVER_VERSION,
         $mcp_version: state.version,
@@ -42,7 +40,6 @@ function buildBaseProperties(
                   ...buildMCPContextProperties(analyticsContext),
               }
             : {}),
-        ...(Object.keys(groups).length > 0 ? { $groups: groups } : {}),
         mcp_runtime: 'hono',
     }
     return { properties, groups }
@@ -69,7 +66,6 @@ export async function trackInitEvent(props: RequestProperties, state: ResolvedSt
                 has_project_id: !!props.projectId,
                 read_only: !!props.readOnly,
                 via_sse_redirect: !!props.viaSseRedirect,
-                ...(props.mode ? { mcp_mode_explicit: props.mode } : {}),
                 ...(sessionUuid ? { $session_id: sessionUuid } : {}),
             },
         })

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -18,6 +18,7 @@ import type {
     ReadResourceRequest,
 } from '@modelcontextprotocol/sdk/types.js'
 
+import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import type { RequestProperties } from '@/lib/request-properties'
 
 import { trackInitEvent } from './analytics'
@@ -229,7 +230,7 @@ class McpDispatcher {
                     resources: { listChanged: false },
                     prompts: { listChanged: false },
                 },
-                serverInfo: { name: 'PostHog', version: '1.0.0' },
+                serverInfo: { name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION },
                 ...(instructions ? { instructions } : {}),
             }
         } catch (error) {

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -1,5 +1,5 @@
 import { ApiClient } from '@/api/client'
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
+import { MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { wrapError } from '@/lib/errors'
 import {
     AnalyticsEvent,
@@ -150,7 +150,7 @@ export class RequestContext {
         const p = props ?? this.props
         return {
             $ai_product: 'mcp',
-            $mcp_source: 'posthog_mcp_analytics',
+            $mcp_source: MCP_ANALYTICS_SOURCE,
             $mcp_server_name: MCP_SERVER_NAME,
             $mcp_server_version: MCP_SERVER_VERSION,
             $mcp_client_name: p.mcpClientName,

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -1,4 +1,5 @@
 import { ApiClient } from '@/api/client'
+import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { wrapError } from '@/lib/errors'
 import {
     AnalyticsEvent,
@@ -148,12 +149,21 @@ export class RequestContext {
     buildClientProperties(props?: RequestProperties): Record<string, unknown> {
         const p = props ?? this.props
         return {
+            $ai_product: 'mcp',
+            $mcp_source: 'posthog_mcp_analytics',
+            $mcp_server_name: MCP_SERVER_NAME,
+            $mcp_server_version: MCP_SERVER_VERSION,
+            $mcp_client_name: p.mcpClientName,
+            $mcp_client_version: p.mcpClientVersion,
+            $mcp_client_user_agent: p.clientUserAgent,
+            $mcp_protocol_version: p.mcpProtocolVersion,
+            $mcp_transport: p.transport,
+            $mcp_session_id: p.mcpSessionId,
+            $mcp_conversation_id: p.mcpConversationId,
+            $mcp_consumer: p.mcpConsumer,
+            $mcp_mode: p.mode,
+            $mcp_region: p.region,
             mcp_runtime: 'hono',
-            ...(p.mcpClientName ? { mcp_client_name: p.mcpClientName } : {}),
-            ...(p.mcpClientVersion ? { mcp_client_version: p.mcpClientVersion } : {}),
-            ...(p.mcpProtocolVersion ? { mcp_protocol_version: p.mcpProtocolVersion } : {}),
-            ...(p.mcpConsumer ? { mcp_consumer: p.mcpConsumer } : {}),
-            ...(p.transport ? { mcp_transport: p.transport } : {}),
         }
     }
 
@@ -184,7 +194,7 @@ export class RequestContext {
                     ...(resolvedProps.sessionId
                         ? { $session_id: await this.getSessionUuid(resolvedProps.sessionId) }
                         : {}),
-                    ...(clientName ? { mcp_oauth_client_name: clientName } : {}),
+                    ...(clientName ? { $mcp_oauth_client_name: clientName } : {}),
                     ...contextProperties,
                     ...previousContextProperties,
                     ...properties,

--- a/services/mcp/src/hono/request-utils.ts
+++ b/services/mcp/src/hono/request-utils.ts
@@ -84,6 +84,7 @@ export async function authenticateAndParse(
 
     props.mcpSessionId = sanitizeHeaderValue(c.req.header('mcp-session-id') || undefined)
     props.mcpConversationId = sanitizeHeaderValue(c.req.header('mcp-conversation-id') || undefined)
+    props.region = props.region || getRegionFromRequest(c.req.raw) || undefined
     if (new URL(c.req.url).searchParams.get('_deprecated') === 'sse') {
         props.viaSseRedirect = true
     }

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -20,3 +20,4 @@ export const getAuthorizationServerUrl = (): string => resolveAuthorizationServe
 
 export const MCP_SERVER_NAME = 'PostHog'
 export const MCP_SERVER_VERSION = '1.0.0'
+export const MCP_ANALYTICS_SOURCE = 'posthog_mcp_analytics'

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -17,3 +17,6 @@ export {
 import { resolveAuthorizationServerUrl } from './oauth-constants'
 
 export const getAuthorizationServerUrl = (): string => resolveAuthorizationServerUrl()
+
+export const MCP_SERVER_NAME = 'PostHog'
+export const MCP_SERVER_VERSION = '1.0.0'

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -11,6 +11,8 @@ import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
 import { MCPClientProfile } from '@/lib/client-detection'
 import {
     getCustomApiBaseUrl,
+    MCP_SERVER_NAME,
+    MCP_SERVER_VERSION,
     POSTHOG_EU_BASE_URL,
     POSTHOG_US_BASE_URL,
     getBaseUrlForRegion,
@@ -86,7 +88,7 @@ export type RequestProperties = {
 
 export class MCP extends McpAgent<Env> {
     server = new McpServer(
-        { name: 'PostHog', version: '1.0.0' },
+        { name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION },
         { instructions: instructionsFormatter.buildV1Instructions() }
     )
 
@@ -712,7 +714,7 @@ export class MCP extends McpAgent<Env> {
             }
         }
 
-        this.server = new McpServer({ name: 'PostHog', version: '1.0.0' }, { instructions })
+        this.server = new McpServer({ name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION }, { instructions })
 
         // Register prompts and resources
         await Promise.all([

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -134,13 +134,18 @@ describe('RequestContext', () => {
                 })
             )
 
-            expect(ctx.buildClientProperties()).toEqual({
+            const result = ctx.buildClientProperties()
+            expect(result).toMatchObject({
+                $ai_product: 'mcp',
+                $mcp_source: 'posthog_mcp_analytics',
+                $mcp_server_name: 'PostHog',
+                $mcp_server_version: '1.0.0',
+                $mcp_client_name: 'claude-code',
+                $mcp_client_version: '2.0',
+                $mcp_protocol_version: '2025-03-26',
+                $mcp_consumer: 'posthog-code',
+                $mcp_transport: 'streamable-http',
                 mcp_runtime: 'hono',
-                mcp_client_name: 'claude-code',
-                mcp_client_version: '2.0',
-                mcp_protocol_version: '2025-03-26',
-                mcp_consumer: 'posthog-code',
-                mcp_transport: 'streamable-http',
             })
         })
 
@@ -157,7 +162,17 @@ describe('RequestContext', () => {
                 })
             )
 
-            expect(ctx.buildClientProperties()).toEqual({ mcp_runtime: 'hono' })
+            const result = ctx.buildClientProperties()
+            expect(result).toMatchObject({
+                $ai_product: 'mcp',
+                $mcp_source: 'posthog_mcp_analytics',
+                $mcp_server_name: 'PostHog',
+                $mcp_server_version: '1.0.0',
+                mcp_runtime: 'hono',
+            })
+            expect(result.$mcp_client_name).toBeUndefined()
+            expect(result.$mcp_consumer).toBeUndefined()
+            expect(result.$mcp_transport).toBeUndefined()
         })
     })
 


### PR DESCRIPTION
This just updates the analytics events to match similar properties to what we were sending from CF.