### PR TITLE
feat(hogql): support dashboard date filters in custom sql

### DIFF
--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -296,6 +296,7 @@ const HogQLRaw: HogQLQuery = {
         dateRange: {
             date_from: '-24h',
         },
+        dateRangeField: 'timestamp',
     },
 }
 

--- a/frontend/src/queries/nodes/DataNode/DateRange.tsx
+++ b/frontend/src/queries/nodes/DataNode/DateRange.tsx
@@ -1,3 +1,5 @@
+import { LemonInput } from '@posthog/lemon-ui'
+
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 
 import {
@@ -44,7 +46,7 @@ export function DateRange<
     }
 
     if (isHogQLQuery(query) || isSessionAttributionExplorerQuery(query)) {
-        return (
+        const dateFilter = (
             <DateFilter
                 dateFrom={query.filters?.dateRange?.date_from ?? undefined}
                 dateTo={query.filters?.dateRange?.date_to ?? undefined}
@@ -63,6 +65,31 @@ export function DateRange<
                 }}
                 allowFixedRangeWithTime
             />
+        )
+
+        if (!isHogQLQuery(query)) {
+            return dateFilter
+        }
+
+        return (
+            <>
+                {dateFilter}
+                <LemonInput
+                    className="max-w-48"
+                    placeholder="Date range field"
+                    value={query.filters?.dateRangeField ?? ''}
+                    onChange={(dateRangeField) => {
+                        const newQuery: Q = {
+                            ...query,
+                            filters: {
+                                ...query.filters,
+                                dateRangeField: dateRangeField || undefined,
+                            },
+                        }
+                        setQuery?.(newQuery)
+                    }}
+                />
+            </>
         )
     }
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -20708,6 +20708,10 @@
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },
+                "dateRangeField": {
+                    "description": "Field used by {filters} and {filters.dateRange} when applying date filters to custom HogQL queries.",
+                    "type": "string"
+                },
                 "filterTestAccounts": {
                     "type": "boolean"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -494,6 +494,8 @@ export interface HogQLFilters {
     properties?: AnyPropertyFilter[]
     dateRange?: DateRange
     filterTestAccounts?: boolean
+    /** Field used by {filters} and {filters.dateRange} when applying date filters to custom HogQL queries. */
+    dateRangeField?: string
 }
 
 export interface HogQLVariable {

--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -62,6 +62,57 @@ class ReplaceFilters(CloningVisitor):
         except Exception:
             return None
 
+    def _date_range_field(self) -> Optional[ast.Field]:
+        if self.filters is None or not self.filters.dateRangeField:
+            return None
+
+        chain = [part.strip() for part in self.filters.dateRangeField.split(".")]
+        if not chain or any(not part for part in chain):
+            raise QueryError("Invalid date range field configured for the 'filters' placeholder.")
+
+        return ast.Field(chain=chain)
+
+    def _date_range_exprs(self, timestamp_field: ast.Field) -> list[ast.Expr]:
+        if self.filters is None:
+            return []
+
+        exprs: list[ast.Expr] = []
+
+        dateTo = self.filters.dateRange.date_to if self.filters.dateRange else None
+        if dateTo is not None:
+            try:
+                parsed_date = isoparse(dateTo)
+                if parsed_date.tzinfo is None:
+                    parsed_date = parsed_date.replace(tzinfo=self.team.timezone_info)
+            except ValueError:
+                parsed_date = relative_date_parse(dateTo, self.team.timezone_info)
+            exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Lt,
+                    left=timestamp_field,
+                    right=ast.Constant(value=parsed_date),
+                )
+            )
+
+        # limit to the last 30d by default
+        dateFrom = self.filters.dateRange.date_from if self.filters.dateRange else None
+        if dateFrom is not None and dateFrom != "all":
+            try:
+                parsed_date = isoparse(dateFrom)
+                if parsed_date.tzinfo is None:
+                    parsed_date = parsed_date.replace(tzinfo=self.team.timezone_info)
+            except ValueError:
+                parsed_date = relative_date_parse(dateFrom, self.team.timezone_info)
+            exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=timestamp_field,
+                    right=ast.Constant(value=parsed_date),
+                )
+            )
+
+        return exprs
+
     def visit_select_query(self, node):
         self.selects.append(node)
         node = super().visit_select_query(node)
@@ -83,7 +134,9 @@ class ReplaceFilters(CloningVisitor):
     def visit_placeholder(self, node):
         no_filters = self.filters is None or not self.filters.model_fields_set
 
-        if node.chain == ["filters"]:
+        if node.chain == ["filters"] or node.chain == ["filters", "dateRange"]:
+            date_range_only = node.chain == ["filters", "dateRange"]
+            placeholder = "filters.dateRange" if date_range_only else "filters"
             last_select = self.selects[-1]
             last_join = last_select.select_from
             found_events = False
@@ -108,9 +161,13 @@ class ReplaceFilters(CloningVisitor):
                         break
                 last_join = last_join.next_join
 
-            if not any([found_events, found_sessions, found_logs, found_traces, found_groups]):
+            date_range_field = self._date_range_field()
+            if (
+                not any([found_events, found_sessions, found_logs, found_traces, found_groups])
+                and date_range_field is None
+            ):
                 raise QueryError(
-                    f"Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions, logs, traces or groups table."
+                    f"Cannot use '{placeholder}' placeholder in a SELECT clause that does not select from the events, sessions, logs, traces or groups table."
                 )
 
             if no_filters:
@@ -119,7 +176,13 @@ class ReplaceFilters(CloningVisitor):
             assert self.filters is not None
 
             exprs: list[ast.Expr] = []
-            if self.filters.properties is not None:
+            if self.filters.properties is not None and not date_range_only:
+                if date_range_field is not None and not any(
+                    [found_events, found_sessions, found_logs, found_traces, found_groups]
+                ):
+                    raise QueryError(
+                        "Cannot apply property filters to a custom HogQL query using dateRangeField. Use {filters.dateRange} to apply only dashboard date filters."
+                    )
                 if found_sessions:
                     session_properties = [p for p in self.filters.properties if isinstance(p, SessionPropertyFilter)]
                     non_session_properties = [
@@ -136,46 +199,22 @@ class ReplaceFilters(CloningVisitor):
                 else:
                     exprs.append(property_to_expr(self.filters.properties, self.team, scope="event"))
 
-            timestamp_field = ast.Field(chain=["$start_timestamp"])
-            if found_events or found_logs or found_traces:
-                timestamp_field = ast.Field(chain=["timestamp"])
-            if found_groups:
-                timestamp_field = ast.Field(chain=["created_at"])
+            timestamp_field = date_range_field or ast.Field(chain=["$start_timestamp"])
+            if date_range_field is None:
+                if found_events or found_logs or found_traces:
+                    timestamp_field = ast.Field(chain=["timestamp"])
+                if found_groups:
+                    timestamp_field = ast.Field(chain=["created_at"])
 
-            dateTo = self.filters.dateRange.date_to if self.filters.dateRange else None
-            if dateTo is not None:
-                try:
-                    parsed_date = isoparse(dateTo)
-                    if parsed_date.tzinfo is None:
-                        parsed_date = parsed_date.replace(tzinfo=self.team.timezone_info)
-                except ValueError:
-                    parsed_date = relative_date_parse(dateTo, self.team.timezone_info)
-                exprs.append(
-                    ast.CompareOperation(
-                        op=ast.CompareOperationOp.Lt,
-                        left=timestamp_field,
-                        right=ast.Constant(value=parsed_date),
+            exprs.extend(self._date_range_exprs(timestamp_field))
+
+            if self.filters.filterTestAccounts and not date_range_only:
+                if date_range_field is not None and not any(
+                    [found_events, found_sessions, found_logs, found_traces, found_groups]
+                ):
+                    raise QueryError(
+                        "Cannot apply test account filters to a custom HogQL query using dateRangeField. Use {filters.dateRange} to apply only dashboard date filters."
                     )
-                )
-
-            # limit to the last 30d by default
-            dateFrom = self.filters.dateRange.date_from if self.filters.dateRange else None
-            if dateFrom is not None and dateFrom != "all":
-                try:
-                    parsed_date = isoparse(dateFrom)
-                    if parsed_date.tzinfo is None:
-                        parsed_date = parsed_date.replace(tzinfo=self.team.timezone_info)
-                except ValueError:
-                    parsed_date = relative_date_parse(dateFrom, self.team.timezone_info)
-                exprs.append(
-                    ast.CompareOperation(
-                        op=ast.CompareOperationOp.GtEq,
-                        left=timestamp_field,
-                        right=ast.Constant(value=parsed_date),
-                    )
-                )
-
-            if self.filters.filterTestAccounts:
                 for prop in self.team.test_account_filters or []:
                     exprs.append(property_to_expr(prop, self.team))
 

--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -271,7 +271,7 @@ class ReplaceFilters(CloningVisitor):
             chain_str = ".".join(str(c) for c in node.chain)
             raise QueryError(
                 f"Unsupported filters placeholder `{{{chain_str}}}`. "
-                "Supported filters placeholders are: `{filters}`, `{filters.dateRange.from}`, `{filters.dateRange.to}`."
+                "Supported filters placeholders are: `{filters}`, `{filters.dateRange}`, `{filters.dateRange.from}`, `{filters.dateRange.to}`."
             )
 
         return super().visit_placeholder(node)

--- a/posthog/hogql/test/test_filters.py
+++ b/posthog/hogql/test/test_filters.py
@@ -72,7 +72,7 @@ class TestFilters(BaseTest):
 
         with self.assertRaisesMessage(
             QueryError,
-            "Cannot use 'filters' placeholder in a SELECT clause that does not select from",
+            "Cannot use 'filters.dateRange' placeholder in a SELECT clause that does not select from",
         ):
             replace_filters(select, HogQLFilters(dateRange=DateRange(date_from="2020-02-02")), self.team)
 
@@ -141,6 +141,78 @@ class TestFilters(BaseTest):
             "and(less(timestamp, toDateTime('2020-02-03 18:59:59.000000')), "
             f"greaterOrEquals(timestamp, toDateTime('2020-02-02 00:00:00.000000'))) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
+
+    def test_replace_filters_date_range_field_for_custom_query(self):
+        select = replace_filters(
+            self._parse_select("SELECT count() FROM custom_table WHERE {filters.dateRange}"),
+            HogQLFilters(
+                dateRange=DateRange(date_from="2020-02-02", date_to="2020-02-03"),
+                dateRangeField="snapshot_date",
+            ),
+            self.team,
+        )
+
+        self.assertEqual(
+            self._print_ast(select),
+            "SELECT count() FROM custom_table WHERE "
+            "and(less(snapshot_date, toDateTime('2020-02-03 00:00:00.000000')), "
+            f"greaterOrEquals(snapshot_date, toDateTime('2020-02-02 00:00:00.000000'))) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+        )
+
+    def test_replace_filters_date_range_field_supports_standard_filters_placeholder(self):
+        select = replace_filters(
+            self._parse_select("SELECT count() FROM custom_table WHERE {filters}"),
+            HogQLFilters(dateRange=DateRange(date_from="2020-02-02"), dateRangeField="snapshot_date"),
+            self.team,
+        )
+
+        self.assertEqual(
+            self._print_ast(select),
+            f"SELECT count() FROM custom_table WHERE greaterOrEquals(snapshot_date, toDateTime('2020-02-02 00:00:00.000000')) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+        )
+
+    def test_replace_filters_date_range_requires_field_for_custom_query(self):
+        select = self._parse_select("SELECT count() FROM custom_table WHERE {filters.dateRange}")
+
+        with self.assertRaisesMessage(
+            QueryError,
+            "Cannot use 'filters.dateRange' placeholder in a SELECT clause that does not select from",
+        ):
+            replace_filters(select, HogQLFilters(dateRange=DateRange(date_from="2020-02-02")), self.team)
+
+    def test_replace_filters_date_range_field_rejects_property_filters_for_custom_query(self):
+        select = self._parse_select("SELECT count() FROM custom_table WHERE {filters}")
+
+        with self.assertRaisesMessage(
+            QueryError,
+            "Cannot apply property filters to a custom HogQL query using dateRangeField.",
+        ):
+            replace_filters(
+                select,
+                HogQLFilters(
+                    dateRange=DateRange(date_from="2020-02-02"),
+                    dateRangeField="snapshot_date",
+                    properties=[EventPropertyFilter(key="random_uuid", operator="exact", value="123", type="event")],
+                ),
+                self.team,
+            )
+
+    def test_replace_filters_date_range_field_rejects_test_account_filters_for_custom_query(self):
+        select = self._parse_select("SELECT count() FROM custom_table WHERE {filters}")
+
+        with self.assertRaisesMessage(
+            QueryError,
+            "Cannot apply test account filters to a custom HogQL query using dateRangeField.",
+        ):
+            replace_filters(
+                select,
+                HogQLFilters(
+                    dateRange=DateRange(date_from="2020-02-02"),
+                    dateRangeField="snapshot_date",
+                    filterTestAccounts=True,
+                ),
+                self.team,
+            )
 
     def test_replace_filters_event_property(self):
         select = replace_filters(

--- a/posthog/hogql/test/test_filters.py
+++ b/posthog/hogql/test/test_filters.py
@@ -72,7 +72,7 @@ class TestFilters(BaseTest):
 
         with self.assertRaisesMessage(
             QueryError,
-            "Cannot use 'filters.dateRange' placeholder in a SELECT clause that does not select from",
+            "Cannot use 'filters' placeholder in a SELECT clause that does not select from",
         ):
             replace_filters(select, HogQLFilters(dateRange=DateRange(date_from="2020-02-02")), self.team)
 

--- a/posthog/hogql_queries/test/test_hogql_dashboard_filters.py
+++ b/posthog/hogql_queries/test/test_hogql_dashboard_filters.py
@@ -25,6 +25,15 @@ class TestHogQLDashboardFilters(BaseTest):
 
         assert query_runner.query.filters == HogQLFilters(dateRange=DateRange(date_from="-14d", date_to=None))
 
+    def test_date_from_override_preserves_date_range_field(self):
+        query_runner = self._create_hogql_runner(filters=HogQLFilters(dateRangeField="snapshot_date"))
+        query_runner.apply_dashboard_filters(DashboardFilter(date_from="-14d"))
+
+        assert query_runner.query.filters == HogQLFilters(
+            dateRange=DateRange(date_from="-14d", date_to=None),
+            dateRangeField="snapshot_date",
+        )
+
     def test_date_from_and_date_to_override_updates_whole_date_range(self):
         query_runner = self._create_hogql_runner(
             filters=HogQLFilters(dateRange=DateRange(date_from="-7d", date_to=None))

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -15113,6 +15113,12 @@ class HogQLFilters(BaseModel):
         extra="forbid",
     )
     dateRange: DateRange | None = None
+    dateRangeField: str | None = Field(
+        default=None,
+        description=(
+            "Field used by {filters} and {filters.dateRange} when applying date filters to custom HogQL queries."
+        ),
+    )
     filterTestAccounts: bool | None = None
     properties: (
         list[


### PR DESCRIPTION
## Problem

Dashboard date filters can be applied to HogQL insights with `{filters}`, but custom SQL queries that read from data warehouse tables do not have a reliable default timestamp column. This makes dashboard-level date controls harder to use for custom SQL insights unless authors manually wire `{filters.dateRange.from}` and `{filters.dateRange.to}` into every query.

## Changes

- Adds `dateRangeField` to `HogQLFilters` so a HogQL query can declare which field should receive dashboard date filters.
- Adds support for `{filters.dateRange}` as a date-only placeholder that uses the query's native timestamp field or the configured `dateRangeField`.
- Allows `{filters}` to apply date filters to custom SQL when `dateRangeField` is configured.
- Rejects property filters and test-account filters for custom SQL `dateRangeField` usage, so unsupported dashboard filters do not silently produce misleading SQL.
- Adds a small date range field input next to the HogQL date picker and updates the HogQL example query.
- Addresses review feedback by restoring the existing `{filters}` error assertion and adding `{filters.dateRange}` to the unsupported-placeholder help text.

No screenshot included: the UI change is a compact text input in the existing query result controls.

## How did you test this code?

I am an agent and ran the following automated checks:

```bash
pnpm install --frozen-lockfile
uv sync
pnpm --filter=@posthog/frontend typegen:write
pnpm schema:build
.venv/bin/ruff check posthog/hogql/filters.py posthog/hogql/test/test_filters.py posthog/hogql_queries/test/test_hogql_dashboard_filters.py posthog/schema.py
.venv/bin/ruff format --check posthog/hogql/filters.py posthog/hogql/test/test_filters.py posthog/hogql_queries/test/test_hogql_dashboard_filters.py posthog/schema.py
pnpm exec oxfmt --check frontend/src/queries/examples.ts frontend/src/queries/nodes/DataNode/DateRange.tsx frontend/src/queries/schema/schema-general.ts frontend/src/queries/schema.json
pnpm --filter '@posthog/quill...' build
pnpm --filter=@posthog/hogvm build
NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter=@posthog/frontend typescript:check
```

After the review-fix commit, I reran:

```bash
pnpm schema:build
.venv/bin/ruff check posthog/hogql/filters.py posthog/hogql/test/test_filters.py posthog/hogql_queries/test/test_hogql_dashboard_filters.py posthog/schema.py
.venv/bin/ruff format --check posthog/hogql/filters.py posthog/hogql/test/test_filters.py posthog/hogql_queries/test/test_hogql_dashboard_filters.py posthog/schema.py
pnpm exec oxfmt --check frontend/src/queries/examples.ts frontend/src/queries/nodes/DataNode/DateRange.tsx frontend/src/queries/schema/schema-general.ts frontend/src/queries/schema.json
git diff --check
```

I also attempted the focused Python tests:

```bash
./bin/hogli test posthog/hogql/test/test_filters.py::TestFilters::test_raises_when_filters_and_not_events_or_sessions posthog/hogql/test/test_filters.py::TestFilters::test_replace_filters_date_range_field_for_custom_query posthog/hogql/test/test_filters.py::TestFilters::test_replace_filters_date_range_field_supports_standard_filters_placeholder posthog/hogql/test/test_filters.py::TestFilters::test_replace_filters_date_range_requires_field_for_custom_query posthog/hogql/test/test_filters.py::TestFilters::test_replace_filters_date_range_field_rejects_property_filters_for_custom_query posthog/hogql/test/test_filters.py::TestFilters::test_replace_filters_date_range_field_rejects_test_account_filters_for_custom_query posthog/hogql_queries/test/test_hogql_dashboard_filters.py::TestHogQLDashboardFilters::test_date_from_override_preserves_date_range_field
```

Those tests could not complete in this local environment because the Postgres host alias `db` is not available: `django.db.utils.OperationalError: [Errno -3] Temporary failure in name resolution`.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update included.

## 🤖 Agent context

This PR was authored by Codex. The implementation was chosen after investigating the existing HogQL dashboard filter path: dashboard filters are already passed into `HogQLQueryRunner`, and `{filters}` is replaced in `posthog/hogql/filters.py`, but the current replacement logic only knows native PostHog tables with canonical timestamp fields.

I avoided automatically injecting date predicates into arbitrary SQL because custom warehouse tables do not have a universal timestamp column. Instead, the query can explicitly declare a `dateRangeField`. With that field present, `{filters.dateRange}` applies only date filters, and `{filters}` applies date filters while rejecting dashboard property/test-account filters for custom SQL so the behavior is explicit and not misleading.
