### PR TITLE
fix(batch-exports): Disable browser autofill on S3 credential inputs

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -291,11 +291,18 @@ export function BatchExportsEditFields({
 
                     <div className="flex gap-4">
                         <LemonField name="aws_access_key_id" label="AWS Access Key ID" className="flex-1">
-                            <LemonInput placeholder={isNew ? 'e.g. AKIAIOSFODNN7EXAMPLE' : 'Leave unchanged'} />
+                            <LemonInput
+                                placeholder={isNew ? 'e.g. AKIAIOSFODNN7EXAMPLE' : 'Leave unchanged'}
+                                autoComplete="off"
+                            />
                         </LemonField>
 
                         <LemonField name="aws_secret_access_key" label="AWS Secret Access Key" className="flex-1">
-                            <LemonInput placeholder={isNew ? 'e.g. secret-key' : 'Leave unchanged'} type="password" />
+                            <LemonInput
+                                placeholder={isNew ? 'e.g. secret-key' : 'Leave unchanged'}
+                                type="password"
+                                autoComplete="new-password"
+                            />
                         </LemonField>
 
                         {batchExportConfigForm.encryption == 'aws:kms' && (
@@ -580,7 +587,10 @@ export function BatchExportsEditFields({
                                     label="AWS Access Key ID"
                                     className="flex-1"
                                 >
-                                    <LemonInput placeholder={isNew ? 'e.g. AKIAIOSFODNN7EXAMPLE' : 'Leave unchanged'} />
+                                    <LemonInput
+                                        placeholder={isNew ? 'e.g. AKIAIOSFODNN7EXAMPLE' : 'Leave unchanged'}
+                                        autoComplete="off"
+                                    />
                                 </LemonField>
 
                                 <LemonField
@@ -591,6 +601,7 @@ export function BatchExportsEditFields({
                                     <LemonInput
                                         placeholder={isNew ? 'e.g. secret-key' : 'Leave unchanged'}
                                         type="password"
+                                        autoComplete="new-password"
                                     />
                                 </LemonField>
                             </div>
@@ -631,6 +642,7 @@ export function BatchExportsEditFields({
                                     >
                                         <LemonInput
                                             placeholder={isNew ? 'e.g. AKIAIOSFODNN7EXAMPLE' : 'Leave unchanged'}
+                                            autoComplete="off"
                                         />
                                     </LemonField>
 
@@ -642,6 +654,7 @@ export function BatchExportsEditFields({
                                         <LemonInput
                                             placeholder={isNew ? 'e.g. secret-key' : 'Leave unchanged'}
                                             type="password"
+                                            autoComplete="new-password"
                                         />
                                     </LemonField>
                                 </div>


### PR DESCRIPTION
## Problem

When configuring an S3 batch export (or a Redshift export that uses S3 for COPY staging), the browser/password manager autofills the user's saved email and password into the AWS Access Key ID and AWS Secret Access Key fields. The inputs had no `autoComplete` attribute, so browsers heuristically treated them as login fields.

## Changes

Set explicit autocomplete hints on the AWS credential inputs in `BatchExportEditForm.tsx`:

- `autoComplete="off"` on AWS Access Key ID fields
- `autoComplete="new-password"` on AWS Secret Access Key fields (the hint that stops password managers from offering saved credentials)


## How did you test this code?

Agent-made but simple enough it's just correct.