### PR TITLE
chore(experiments): remove experiments-ship-variant-release-mode flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -299,7 +299,6 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_LLM_PROMPTS: 'experiments-llm-prompts', // owner: @jurajmajerik #team-experiments
-    EXPERIMENTS_SHIP_VARIANT_RELEASE_MODE: 'experiments-ship-variant-release-mode', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SYNC_QUERIES: 'experiments-sync-queries', // owner: @andehen #team-experiments
     EXPERIMENTS_TEMPLATES: 'experiments-templates', // owner: @rodrigoi #team-experiments
@@ -417,11 +416,11 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_DASHBOARD_COLORS: 'dashboard-colors', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_DASHBOARD_MODAL_SMART_DEFAULTS: 'product-analytics-dashboard-modal-smart-defaults', // owner: @sam #team-product-analytics
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
-    PRODUCT_ANALYTICS_HOG_CHARTS_TRENDS: 'product-analytics-hog-charts-trends', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL: 'product-analytics-hog-charts-funnel', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_HOG_CHARTS_LIFECYCLE: 'product-analytics-hog-charts-lifecycle', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_HOG_CHARTS_RETENTION: 'product-analytics-hog-charts-retention', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_HOG_CHARTS_STICKINESS: 'product-analytics-hog-charts-stickiness', // owner: @sampennington #team-product-analytics
+    PRODUCT_ANALYTICS_HOG_CHARTS_TRENDS: 'product-analytics-hog-charts-trends', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from 'react'
 import { IconCheckCircle, IconGlobe, IconList } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonLabel, LemonModal, LemonSelect, LemonTextArea, Link } from '@posthog/lemon-ui'
 
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -203,8 +202,6 @@ export function FinishExperimentModal(): JSX.Element {
     const { isFinishExperimentModalOpen } = useValues(modalsLogic)
     const { aggregationLabel } = useValues(groupsModel)
 
-    const showReleaseModeChoice = useFeatureFlag('EXPERIMENTS_SHIP_VARIANT_RELEASE_MODE', 'test')
-
     const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>()
     const [releaseToEveryone, setReleaseToEveryone] = useState<boolean>(false)
 
@@ -228,11 +225,9 @@ export function FinishExperimentModal(): JSX.Element {
         if (isSingleVariantShipped || !selectedVariantKey) {
             endExperimentWithoutShipping()
         } else {
-            // Control variant: preserve pre-flag behavior (prepend catch-all release condition).
-            // Test variant: honor the user's radio choice.
             finishExperiment({
                 selectedVariantKey,
-                releaseToEveryone: showReleaseModeChoice ? releaseToEveryone : true,
+                releaseToEveryone,
             })
         }
     }
@@ -300,12 +295,6 @@ export function FinishExperimentModal(): JSX.Element {
                         <>
                             <div>
                                 <LemonLabel>Variant to keep</LemonLabel>
-                                {!showReleaseModeChoice && (
-                                    <div className="text-sm text-secondary mb-2">
-                                        The selected variant will be rolled out to{' '}
-                                        <b>100% of {aggregationTargetName}</b>.
-                                    </div>
-                                )}
                                 <div className="w-1/2 mt-1">
                                     <LemonSelect
                                         className="w-full"
@@ -329,7 +318,7 @@ export function FinishExperimentModal(): JSX.Element {
                                     />
                                 </div>
                             </div>
-                            {showReleaseModeChoice && selectedVariantKey && (
+                            {selectedVariantKey && (
                                 <div className="flex flex-col gap-2">
                                     <LemonLabel>How to release this variant</LemonLabel>
                                     <div


### PR DESCRIPTION
## Problem

The `experiments-ship-variant-release-mode` flag has shipped to all users.

## Changes

Removed the flag constant and inlined the treatment behavior in the Finish Experiment modal. The release-mode radio (roll out to the experiment population vs. all users) is now always shown, and the legacy "rolled out to 100%" hint is gone.

## How did you test this code?

Agent-authored. No manual testing performed. Ran a repo-wide grep to confirm no remaining references to the flag key or `showReleaseModeChoice`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code. Cleanup assumed the test variant ships; control branch behavior (always `releaseToEveryone: true`) was discarded.