### PR TITLE
feat(slack-app): block coding-agent task when mentioner has no personal GitHub

### DIFF
--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -11,6 +11,7 @@ from posthog.temporal.ai.posthog_code_slack_interactivity import (
 )
 from posthog.temporal.ai.posthog_code_slack_mention import (
     PostHogCodeSlackMentionWorkflow,
+    block_posthog_code_task_if_no_personal_github_activity,
     classify_posthog_code_task_needs_repo_activity,
     collect_posthog_code_thread_messages_activity,
     create_posthog_code_routing_rule_activity,
@@ -73,6 +74,7 @@ AI_ACTIVITIES = [
     classify_posthog_code_task_needs_repo_activity,
     post_posthog_code_no_repos_activity,
     post_posthog_code_repo_picker_activity,
+    block_posthog_code_task_if_no_personal_github_activity,
     create_posthog_code_task_for_repo_activity,
     forward_posthog_code_followup_activity,
     post_posthog_code_picker_timeout_activity,

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -292,6 +292,9 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                     )
                     return
 
+                if self._selected_repo and await _gate_on_personal_github(inputs, channel, thread_ts, user_id):
+                    return
+
                 await _execute_posthog_code_activity(
                     create_posthog_code_task_for_repo_activity,
                     inputs,
@@ -307,6 +310,9 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
 
             repository = decision.repository
             if not repository:
+                return
+
+            if await _gate_on_personal_github(inputs, channel, thread_ts, user_id):
                 return
 
             await _execute_posthog_code_activity(
@@ -336,6 +342,30 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                 channel,
                 thread_ts,
             )
+
+
+async def _gate_on_personal_github(
+    inputs: "PostHogCodeSlackMentionWorkflowInputs",
+    channel: str,
+    thread_ts: str,
+    user_id: int,
+) -> bool:
+    """Return True when the workflow must abort because the mentioner has no personal GitHub.
+
+    Gated by `workflow.patched` so in-flight workflows started before this code was
+    deployed don't introduce a new activity command on replay and trip nondeterminism.
+    Pre-patch workflows skip the gate entirely and behave as before; post-patch
+    workflows always evaluate it.
+    """
+    if not workflow.patched("posthog-code-block-no-personal-github-2026-05"):
+        return False
+    return await _execute_posthog_code_activity(
+        block_posthog_code_task_if_no_personal_github_activity,
+        inputs,
+        channel,
+        thread_ts,
+        user_id,
+    )
 
 
 async def _execute_posthog_code_activity(activity_fn: Any, *args: Any) -> Any:
@@ -762,6 +792,80 @@ def post_posthog_code_repo_picker_activity(
         workflow_id=workflow_id,
         allow_no_repo=allow_no_repo,
     )
+
+
+@activity.defn
+def block_posthog_code_task_if_no_personal_github_activity(
+    inputs: PostHogCodeSlackMentionWorkflowInputs,
+    channel: str,
+    thread_ts: str,
+    user_id: int,
+) -> bool:
+    """Gate a repo-bound coding-agent task on the mentioner having a personal GitHub.
+
+    Returns True (and posts an in-thread Slack block with a "Connect GitHub" button)
+    when the user has no `UserIntegration` of kind=github; the caller must then skip
+    `create_posthog_code_task_for_repo_activity`. Returns False to let the task proceed.
+
+    The team-level GitHub App can still author commits, but PRs would land under the
+    PostHog app identity instead of the user's. Rather than degrading silently, hold
+    the task and surface the one-click path to the personal integration setup.
+    """
+    from django.conf import settings
+
+    import structlog
+
+    from posthog.models.integration import Integration, SlackIntegration
+    from posthog.models.user_integration import UserIntegration
+
+    log = structlog.get_logger(__name__)
+
+    has_personal_github = UserIntegration.objects.filter(
+        user_id=user_id,
+        kind=UserIntegration.IntegrationKind.GITHUB,
+    ).exists()
+    if has_personal_github:
+        return False
+
+    integration = Integration.objects.select_related("team", "team__organization").get(
+        id=inputs.integration_id,
+        kind="slack-posthog-code",
+        integration_id=inputs.slack_team_id,
+    )
+    slack = SlackIntegration(integration)
+
+    settings_url = f"{settings.SITE_URL}/project/{integration.team_id}/settings/user-personal-integrations"
+    text = (
+        "I can't start this task yet — you haven't connected your personal GitHub. "
+        "Connect it so I can open the pull request as you, then mention me again."
+    )
+    slack.client.chat_postMessage(
+        channel=channel,
+        thread_ts=thread_ts,
+        text=text,
+        blocks=[
+            {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Connect GitHub", "emoji": True},
+                        "url": settings_url,
+                        "style": "primary",
+                    }
+                ],
+            },
+        ],
+    )
+    log.info(
+        "posthog_code_task_blocked_no_personal_github",
+        user_id=user_id,
+        team_id=integration.team_id,
+        channel=channel,
+        thread_ts=thread_ts,
+    )
+    return True
 
 
 @activity.defn

--- a/posthog/temporal/tests/ai/test_block_missing_user_github.py
+++ b/posthog/temporal/tests/ai/test_block_missing_user_github.py
@@ -1,0 +1,110 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+from posthog.models.user import User
+from posthog.models.user_integration import UserIntegration
+from posthog.temporal.ai.posthog_code_slack_mention import (
+    PostHogCodeSlackMentionWorkflowInputs,
+    block_posthog_code_task_if_no_personal_github_activity,
+)
+
+
+def _make_inputs(integration_id: int, slack_team_id: str = "T_SLACK") -> PostHogCodeSlackMentionWorkflowInputs:
+    return PostHogCodeSlackMentionWorkflowInputs(
+        event={"channel": "C123", "ts": "1234.5678", "user": "U_ALICE", "text": "<@BOT> do something"},
+        integration_id=integration_id,
+        slack_team_id=slack_team_id,
+    )
+
+
+class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="TestOrg")
+        self.team = Team.objects.create(organization=self.org, name="TestTeam")
+        self.user = User.objects.create(email="alice@test.com")
+        self.integration = Integration.objects.create(
+            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
+        )
+
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_returns_true_and_posts_block_when_user_has_no_personal_github(self, mock_slack_cls):
+        mock_slack = MagicMock()
+        mock_slack_cls.return_value = mock_slack
+
+        blocked = block_posthog_code_task_if_no_personal_github_activity(
+            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+        )
+
+        assert blocked is True
+        mock_slack.client.chat_postMessage.assert_called_once()
+        kwargs = mock_slack.client.chat_postMessage.call_args.kwargs
+        assert kwargs["channel"] == "C123"
+        assert kwargs["thread_ts"] == "1234.5678"
+        assert "haven't connected" in kwargs["text"]
+
+        action_block = next(b for b in kwargs["blocks"] if b.get("type") == "actions")
+        button = action_block["elements"][0]
+        assert button["text"]["text"] == "Connect GitHub"
+        assert button["url"].endswith(f"/project/{self.team.id}/settings/user-personal-integrations")
+
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_returns_false_and_posts_nothing_when_user_has_personal_github(self, mock_slack_cls):
+        UserIntegration.objects.create(
+            user=self.user,
+            kind="github",
+            integration_id="gh-1",
+            config={},
+            sensitive_config={"access_token": "tok"},
+        )
+        mock_slack = MagicMock()
+        mock_slack_cls.return_value = mock_slack
+
+        blocked = block_posthog_code_task_if_no_personal_github_activity(
+            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+        )
+
+        assert blocked is False
+        mock_slack.client.chat_postMessage.assert_not_called()
+
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_only_github_kind_counts_as_personal_integration(self, mock_slack_cls):
+        UserIntegration.objects.create(
+            user=self.user,
+            kind="other-service",
+            integration_id="x",
+            config={},
+            sensitive_config={},
+        )
+        mock_slack = MagicMock()
+        mock_slack_cls.return_value = mock_slack
+
+        blocked = block_posthog_code_task_if_no_personal_github_activity(
+            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+        )
+
+        assert blocked is True
+        mock_slack.client.chat_postMessage.assert_called_once()
+
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_another_users_github_integration_does_not_count(self, mock_slack_cls):
+        other_user = User.objects.create(email="bob@test.com")
+        UserIntegration.objects.create(
+            user=other_user,
+            kind="github",
+            integration_id="gh-2",
+            config={},
+            sensitive_config={"access_token": "tok"},
+        )
+        mock_slack = MagicMock()
+        mock_slack_cls.return_value = mock_slack
+
+        blocked = block_posthog_code_task_if_no_personal_github_activity(
+            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+        )
+
+        assert blocked is True
+        mock_slack.client.chat_postMessage.assert_called_once()

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -62,6 +62,7 @@ class TestAITemporalModuleIntegrity:
             "classify_posthog_code_task_needs_repo_activity",
             "post_posthog_code_no_repos_activity",
             "post_posthog_code_repo_picker_activity",
+            "block_posthog_code_task_if_no_personal_github_activity",
             "create_posthog_code_task_for_repo_activity",
             "forward_posthog_code_followup_activity",
             "post_posthog_code_picker_timeout_activity",

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -844,6 +844,27 @@ def select_repository(
     if explicit_repo:
         return RepoDecision(mode="auto", repository=explicit_repo, reason="explicit_mention", llm_found_match=False)
 
+    # Walk the most recent thread messages newest-first for an explicit `org/repo`
+    # token. Follow-up mentions often drop the repo because the requester already
+    # stated it earlier in the thread — e.g. after a personal-GitHub connect prompt,
+    # the re-mention is just "should be there now". Picking up the most recent
+    # explicit reference matches that intent without waiting on the rule-matcher or
+    # the picker. Capped at the last few messages so long threads don't reach back
+    # to an unrelated repo from much earlier in the conversation.
+    _THREAD_SCAN_LIMIT = 10
+    for msg in reversed(thread_messages[-_THREAD_SCAN_LIMIT:]):
+        thread_text = msg.get("text") or ""
+        if not thread_text or thread_text == event_text:
+            continue
+        repo_from_thread = _extract_explicit_repo(thread_text, all_repos)
+        if repo_from_thread:
+            return RepoDecision(
+                mode="auto",
+                repository=repo_from_thread,
+                reason="thread_explicit_mention",
+                llm_found_match=False,
+            )
+
     if user_id and channel:
         from posthog.models.user_repo_preference import UserRepoPreference
 

--- a/products/slack_app/backend/tests/test_guess_repository.py
+++ b/products/slack_app/backend/tests/test_guess_repository.py
@@ -470,6 +470,96 @@ class TestSelectRepository:
         assert decision.reason == "no_rule_match"
         assert decision.llm_found_match is False
 
+    @patch("products.slack_app.backend.api._match_repo_rule", return_value=None)
+    def test_thread_explicit_repo_picked_up_when_event_text_has_none(self, _mock_match):
+        thread_messages = [
+            {"user": "Dev", "text": "fix posthog/posthog-js please"},
+            {"user": "Bot", "text": "I can't start this task yet — connect your personal GitHub."},
+            {"user": "Dev", "text": "should be there now"},
+        ]
+
+        decision = select_repository(
+            event_text="should be there now",
+            thread_messages=thread_messages,
+            integration=self.slack_integration,
+            all_repos=["posthog/posthog", "posthog/posthog-js", "posthog/plugin-server"],
+        )
+
+        assert decision.mode == "auto"
+        assert decision.repository == "posthog/posthog-js"
+        assert decision.reason == "thread_explicit_mention"
+        assert decision.llm_found_match is False
+
+    @patch("products.slack_app.backend.api._match_repo_rule", return_value=None)
+    def test_thread_newest_explicit_repo_wins(self, _mock_match):
+        thread_messages = [
+            {"user": "Dev", "text": "originally about posthog/posthog"},
+            {"user": "Dev", "text": "actually let's do posthog/posthog-js"},
+            {"user": "Dev", "text": "go please"},
+        ]
+
+        decision = select_repository(
+            event_text="go please",
+            thread_messages=thread_messages,
+            integration=self.slack_integration,
+            all_repos=["posthog/posthog", "posthog/posthog-js", "posthog/plugin-server"],
+        )
+
+        assert decision.repository == "posthog/posthog-js"
+        assert decision.reason == "thread_explicit_mention"
+
+    @patch("products.slack_app.backend.api._match_repo_rule", return_value=None)
+    def test_thread_explicit_repo_ignored_when_not_connected(self, _mock_match):
+        thread_messages = [
+            {"user": "Dev", "text": "fix vojtechbartos/personal-fork"},
+            {"user": "Dev", "text": "should be there now"},
+        ]
+
+        decision = select_repository(
+            event_text="should be there now",
+            thread_messages=thread_messages,
+            integration=self.slack_integration,
+            all_repos=["posthog/posthog", "posthog/posthog-js"],
+        )
+
+        assert decision.mode == "picker"
+        assert decision.reason == "no_rule_match"
+
+    @patch("products.slack_app.backend.api._match_repo_rule", return_value=None)
+    def test_thread_scan_caps_at_recent_messages(self, _mock_match):
+        # 11 filler messages newer than the repo mention push it past the 10-message
+        # newest-first window, so the scan should not reach it.
+        thread_messages = [{"user": "Dev", "text": "fix posthog/posthog-js"}] + [
+            {"user": "Dev", "text": f"chatter {i}"} for i in range(11)
+        ]
+
+        decision = select_repository(
+            event_text="and another thing",
+            thread_messages=thread_messages,
+            integration=self.slack_integration,
+            all_repos=["posthog/posthog", "posthog/posthog-js"],
+        )
+
+        assert decision.mode == "picker"
+        assert decision.reason == "no_rule_match"
+
+    def test_event_text_explicit_repo_takes_precedence_over_thread(self):
+        thread_messages = [
+            {"user": "Dev", "text": "earlier mention posthog/posthog"},
+            {"user": "Dev", "text": "fix posthog/posthog-js now"},
+        ]
+
+        decision = select_repository(
+            event_text="fix posthog/posthog-js now",
+            thread_messages=thread_messages,
+            integration=self.slack_integration,
+            all_repos=["posthog/posthog", "posthog/posthog-js"],
+        )
+
+        # Event text wins on its own (explicit_mention), not via thread scan.
+        assert decision.repository == "posthog/posthog-js"
+        assert decision.reason == "explicit_mention"
+
     def test_no_repos_picker(self):
         decision = select_repository(
             event_text="add yolo to readme",


### PR DESCRIPTION
## Problem

@PostHog mentions with a repo silently fall back to the team-level GitHub App when the user has no personal integration, so PRs land under the PostHog app identity instead of the user.

## Changes

- **Block** repo-bound tasks when the mentioner has no `UserIntegration(kind=github)`. Post an in-thread Slack block with a "Connect GitHub" button to the personal-integrations settings page; abort task creation. No-repo tasks (analytics, chat) stay unrestricted. Gated by `workflow.patched(...)` for in-flight workflows.
- **Pick up the repo from recent thread messages.** In `select_repository`, when `event_text` has no `org/repo`, scan the last 10 thread messages newest-first for an explicit token. Lets follow-ups like "should be there now" resolve to the repo named earlier in the thread.

## How did you test this code?

Manually tested in Slack end-to-end (mention without personal GitHub → block message → connect → re-mention picks up the original repo).

Automated tests (added by agent): 4 in `test_block_missing_user_github.py`, 5 in `test_guess_repository.py::TestSelectRepository`. All local runs green.

## Showcase

<img width="606" height="651" alt="Screenshot 2026-05-25 at 16 06 11" src="https://github.com/user-attachments/assets/d6baf975-4444-4f1e-9f01-d5801e899175" />


## Publish to changelog?

no

## 🤖 Agent context

Replaces closed PR #59443. Hard block, not warn (per #posthog-code). Gate fires post-picker so "No repo needed" stays a valid escape hatch. Button goes to settings, not OAuth, so non-code uses of PostHog Code aren't forced through GitHub auth. Thread scan is unscoped/deterministic to match the existing all-users contract on `_match_repo_rule` / `classify_task_needs_repo`.