### PR TITLE
fix(experiments): clarify matured users label covers retention

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -87,7 +87,7 @@ export function SettingsTab(): JSX.Element {
                 <h2 className="font-semibold text-lg">Conversion windows</h2>
                 <div className="flex items-center gap-2">
                     <LemonCheckbox
-                        label="Require completed conversion window"
+                        label="Require completed conversion or retention window"
                         checked={experiment.only_count_matured_users ?? false}
                         onChange={(checked) => {
                             updateExperiment({ only_count_matured_users: checked })


### PR DESCRIPTION
## Problem

The "Require completed conversion window" checkbox in experiment settings also applies to retention metrics, but the label only mentions conversion.

## Changes

Renamed the label to "Require completed conversion or retention window" to match the helper text below it.

## How did you test this code?

Agent-authored. Verified the string change in the SettingsTab component; no other behavior touched.

## 🤖 Agent context

Copy-only change. Sibling investigation surfaced that toggling this setting no longer triggers a metric reload after #57714 — that will be addressed in a follow-up PR.