### PR TITLE
fix(mcp-analytics): show loading state while session tool calls reload

### DIFF
--- a/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
@@ -101,7 +101,7 @@ export function MCPSessionDetail(): JSX.Element {
             </header>
 
             <section className="px-3 py-3" style={{ overflowY: 'scroll', maxHeight: 'calc(100vh - 32rem)' }}>
-                {toolCallsLoading && toolCalls.length === 0 ? (
+                {toolCallsLoading ? (
                     <div className="flex flex-col gap-2">
                         {[0, 1, 2].map((i) => (
                             <LemonSkeleton key={i} className="h-16 w-full" />


### PR DESCRIPTION
## Problem

In the MCP analytics sessions view, selecting a different session left the **previous** session's tool calls on screen until the new ones finished loading. Fetching tool calls can be slow, so users saw stale rows that looked like they belonged to the session they'd just clicked.

## Changes

The detail panel gated its loading skeleton on `toolCallsLoading && toolCalls.length === 0`. kea-loaders keep the previous value until the next request resolves, so on a session switch `toolCalls` still held the old session's rows (length > 0) and the skeleton never showed. Now the skeleton renders whenever `toolCallsLoading` is true, so the panel switches to the loading animation immediately on selection and the stale rows no longer linger.

One-line change in `MCPSessionDetail.tsx`. The header (person, badges, session id) still updates instantly from the already-loaded session record; only the tool-calls body shows the loading state.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I ran:

- `pnpm --filter=@posthog/frontend exec tsc --noEmit` — no errors in any mcp_analytics file (the unrelated `groupAnalyticsTaxonomicGroupsLogic` errors are stale local kea-typegen output for a logic file added on master; CI regenerates typegen).
- `pnpm --filter=@posthog/frontend format` — clean.

The human author observed the original stale-tools behavior in the app and confirmed the loading animation now appears on session switch.

## Publish to changelog?

No — staff-only internal product, not customer-facing yet.

## Docs update

No docs change needed. Consider the `skip-inkeep-docs` label.

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Root cause was kea-loaders' retain-previous-value semantics; the fix shows the skeleton on any in-flight fetch rather than only the first load. No stale flash on switch, because kea dispatches `loadToolCalls` within the same `selectSession` cycle, so `toolCallsLoading` is already true by the time the panel re-renders.

This is a standalone fix branched off master, independent of the sessions pagination work in #59888.

Agent-authored; requires human review — do not self-merge.
