### PR TITLE
fix(llma): fix tagger saves failing on fractional % and blank tags

### DIFF
--- a/products/llm_analytics/backend/api/taggers.py
+++ b/products/llm_analytics/backend/api/taggers.py
@@ -53,8 +53,11 @@ class TagDefinitionSerializer(serializers.Serializer):
 
 class TaggerConditionSerializer(serializers.Serializer):
     id = serializers.CharField(max_length=100, help_text="Stable identifier for this condition")
-    rollout_percentage = serializers.IntegerField(
-        default=100, min_value=0, max_value=100, help_text="Percentage of matching events to apply this condition to"
+    rollout_percentage = serializers.FloatField(
+        default=100,
+        min_value=0,
+        max_value=100,
+        help_text="Percentage of matching events to apply this condition to",
     )
     properties = serializers.ListField(
         child=serializers.DictField(),

--- a/products/llm_analytics/backend/api/test/test_taggers.py
+++ b/products/llm_analytics/backend/api/test/test_taggers.py
@@ -337,6 +337,22 @@ class TestTaggersApi(APIBaseTest):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    @parameterized.expand([("fractional", 33.3), ("slider_minimum", 0.1), ("whole", 50)])
+    def test_can_save_fractional_rollout_percentage(self, _name: str, rollout_percentage: float):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/taggers/",
+            {
+                "name": "Feature Tagger",
+                "tagger_config": _make_tagger_config(),
+                "conditions": [{"id": "cond-1", "rollout_percentage": rollout_percentage, "properties": []}],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        tagger = Tagger.objects.get(id=response.data["id"])
+        assert tagger.conditions[0]["rollout_percentage"] == rollout_percentage
+
     def test_patch_tagger_type_without_fresh_config_is_rejected(self):
         tagger = Tagger.objects.create(
             name="LLM tagger",

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
@@ -359,9 +359,29 @@ describe('llmTaggerLogic', () => {
                 expect(errors.tagger_config.prompt).toBe('Prompt is required')
             })
 
-            it('reports error when tag name is empty', async () => {
+            it('does not block save when a blank tag row coexists with a named tag', async () => {
+                // "Add tag" appends a blank row and submit strips blank rows, so a blank row must
+                // not invalidate the whole form — otherwise unrelated edits (conditions, enabled,
+                // sampling) silently fail to save until the row is removed.
+                logic.actions.setTaggerFormValues({
+                    name: 'Valid Tagger',
+                    tagger_config: {
+                        prompt: 'Tag this',
+                        tags: [
+                            { name: 'billing', description: '' },
+                            { name: '', description: '' },
+                        ],
+                        min_tags: 0,
+                        max_tags: null,
+                    },
+                })
                 const errors = await submitAndGetErrors()
-                expect(errors.tagger_config.tags).toEqual([{ name: 'All tags must have a name' }])
+                expect(errors.tagger_config.tags).toBeUndefined()
+            })
+
+            it('reports error when every tag row is blank', async () => {
+                const errors = await submitAndGetErrors()
+                expect(errors.tagger_config.tags).toEqual([{ name: 'At least one tag is required' }])
             })
 
             it('reports error when no tags exist', async () => {

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
@@ -245,19 +245,16 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
                               prompt: !('prompt' in values.tagger_config && values.tagger_config.prompt)
                                   ? 'Prompt is required'
                                   : undefined,
-                              // kea-forms expects per-tag errors as an array matching tags[]. The
-                              // array type does not allow `undefined` slots, so use `{}` for
-                              // tags with no error. Synthesize a single-entry error for the
-                              // empty-tags case so the form stays invalid (the UI guardrail
-                              // blocks reaching this state, but a programmatic removeTag could).
+                              // Blank tag rows are stripped on submit (see below), so they must not
+                              // block saving — otherwise the empty row that "Add tag" appends silently
+                              // invalidates the whole form, and unrelated edits (conditions, enabled,
+                              // sampling) appear unsavable until the row is removed. Only require that
+                              // at least one named tag survives the strip. The single-entry array is
+                              // how kea-forms keeps the form invalid for the no-named-tags case.
                               tags:
-                                  values.tagger_config.tags.length === 0
+                                  values.tagger_config.tags.filter((t) => t.name.trim()).length === 0
                                       ? [{ name: 'At least one tag is required' }]
-                                      : values.tagger_config.tags.some((t) => !t.name.trim())
-                                        ? values.tagger_config.tags.map((t) =>
-                                              !t.name.trim() ? { name: 'All tags must have a name' } : {}
-                                          )
-                                        : undefined,
+                                      : undefined,
                           },
             }),
             submit: async (values: TaggerForm) => {


### PR DESCRIPTION
## Problem

An internal dogfooder reported that the AI evals tagger configuration silently failed to save in several cases. There are two independent root causes:

1. **Fractional sampling percentage.** The sampling-percentage slider uses `0.1` steps, but the API field (`TaggerConditionSerializer.rollout_percentage`) was an `IntegerField`. Any fractional value (e.g. `33.3`, or the slider's `0.1` minimum) returned a 400 and failed the whole save.
2. **Blank tag rows.** "Add tag" appends an empty tag row, and form validation invalidated the *entire* form whenever any tag name was blank. Because the form is submitted as one all-or-nothing request, a single half-added tag row silently blocked every other edit (conditions, enable/disable, sampling) from saving — which presented to the user as a phantom "can't add more than 14 tags" limit. Removing the blank row let saves go through again, since the submit handler already strips blank tags.

## Changes

- **Backend:** `rollout_percentage` changed from `IntegerField` to `FloatField` (`min_value=0`, `max_value=100`). This matches the frontend slider, the `.toFixed(2)` display, and the sibling evaluations endpoint (which stores conditions as a permissive `ListField(child=DictField())` and never hit this). Whole-number values still work; fractional values now persist. Generated TS/zod types are unchanged (already typed as `number`).
- **Frontend:** tagger form validation no longer fails on blank tag rows. It now requires only that at least one *named* tag survives the strip that submit already performs, so a blank/half-added row can't block unrelated edits.

## How did you test this code?

I'm an agent (Claude Code). Automated tests added and run:

- **Backend** — added parameterized `test_can_save_fractional_rollout_percentage` (`33.3`, `0.1`, `50`); all 22 tagger API tests pass.
- **Frontend** — added `llmTaggerLogic` validation tests (blank row alongside a named tag does not block; all-blank still errors); all 37 tests pass.

I also reproduced both behaviors against a local dev stack: 15 unique named tags returned `201` (confirming there is no backend tag limit), and a `33.3` sampling percentage returned `201` with the fix in place.

## Publish to changelog?

no

## Docs update

No docs impact.

## 🤖 Agent context

- Authored with Claude Code (Opus), human-directed.
- Investigation root-caused two distinct issues rather than one. The reported symptoms ("can't save 15 tags", "conditions won't save", "enable/disable buggy") were largely a single all-or-nothing-form failure mode triggered by the blank tag row; the sampling-percentage failure is a separate backend type mismatch.
- For the percentage fix, `FloatField` was chosen over forcing integer slider steps, because fractional sampling is a real capability and the evaluations endpoint already treats the value as a float. For the tag fix, validation was aligned to the submit handler's existing blank-strip rather than introducing per-row blocking.
- Confidence is high on both fixes (reproduced live + covered by tests).