### PR TITLE
fix(mcp-analytics): shorten session id tooltip

### DIFF
--- a/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
@@ -76,13 +76,8 @@ export function MCPSessionDetail(): JSX.Element {
                     <MetaBadge icon={<IconClock />} label={formatDuration(durationMs)} />
                     <Tooltip
                         title={
-                            <div className="flex flex-col gap-1 max-w-xs">
-                                <span className="font-mono break-all">{selectedSession.session_id}</span>
-                                <span>
-                                    Streamable-HTTP transport session id, minted by the MCP server and sent on each
-                                    request via the <span className="font-mono">Mcp-Session-Id</span> header. Used to
-                                    group every tool call from one client connection.
-                                </span>
+                            <div className="max-w-xs break-all">
+                                Session ID: <span className="font-mono">{selectedSession.session_id}</span>
                             </div>
                         }
                     >


### PR DESCRIPTION
## Problem

In the MCP analytics sessions detail panel, the session-id badge tooltip carried a three-sentence explanation of the `Mcp-Session-Id` transport session. It ran long for what is essentially a "here's the full id" affordance.

## Changes

Reduced the tooltip to a single `Session ID: <full id>` line. The badge still shows the shortened, copyable id; the tooltip just reveals the full value without the paragraph.

## How did you test this code?

I'm an agent (Claude Code). This is a JSX text-only change (no logic or types touched). `oxlint`/`oxfmt` ran via the pre-commit hook. The human author iterated on the exact wording in the editor.

## Publish to changelog?

No — staff-only internal product, not customer-facing yet.

## Docs update

No docs change needed. Consider the `skip-inkeep-docs` label.

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). 
Agent-authored; requires human review — do not self-merge.
