### PR TITLE
chore(ai): clarify search tool prompt to exclude error tracking

### DIFF
--- a/ee/hogai/tools/search.py
+++ b/ee/hogai/tools/search.py
@@ -62,6 +62,8 @@ Use this tool to find PostHog entities using full-text search.
 Full-text search is a more powerful way to find entities than natural language search. It relies on the PostgreSQL full-text search capabilities.
 So the query used in this tool should be a natural language query that is optimized for full-text search, consider tokenizing of the query and using synonyms.
 If you want to search for all entities, you should use kind="all".
+
+Do not use this tool to search error tracking issues, exceptions, or stack traces — use the `search_error_tracking_issues` tool instead, which queries live issues with status, date range, and aggregations.
 """.strip()
 
 INVALID_ENTITY_KIND_PROMPT = """


### PR DESCRIPTION
## Problem

When users ask Max questions like "find checkout stripe errors", the LLM can plausibly call `search(kind="error_tracking", query=...)`. That fails with `INVALID_ENTITY_KIND_PROMPT` because `error_tracking` is not an `EntityKind` — the unified `search` tool only covers Postgres-FTS over saved Django artifacts (insights, dashboards, cohorts, actions, experiments, feature flags, notebooks, surveys, alerts). Error-tracking issues have their own dedicated tool, `search_error_tracking_issues`, which runs a ClickHouse `ErrorTrackingQuery`.

## Changes

Adds one sentence to `SEARCH_TOOL_PROMPT` in `ee/hogai/tools/search.py` pointing the model at `search_error_tracking_issues` for any error / exception / stack-trace query.

## How did you test this code?

I'm an agent — no manual testing performed. The change is prose inside an LLM tool-description string; ran `ruff check` and `ruff format --check` on the file (both clean). No snapshot tests reference this prompt.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code. The user noticed `EntityKind` doesn't include `error_tracking` and asked for the prompt to nudge the model away from that dead end. The smallest viable fix is a one-line directive in the existing tool prompt rather than restructuring tool routing.
