### PR TITLE
fix(capture): collapse unmatched path labels to "unknown"

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1724,7 +1724,6 @@ dependencies = [
  "chrono",
  "common-alloc",
  "common-continuous-profiling",
- "common-metrics",
  "common-redis",
  "common-types",
  "envconfig",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -25,7 +25,6 @@ lifecycle = { path = "../common/lifecycle" }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 common-alloc = { path = "../common/alloc" }
-common-metrics = { path = "../common/metrics" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
 common-redis = { path = "../common/redis" }
 common-types = { path = "../common/types" }

--- a/rust/capture/src/metrics_middleware.rs
+++ b/rust/capture/src/metrics_middleware.rs
@@ -9,8 +9,9 @@ use axum::{
     response::IntoResponse,
     routing::Router,
 };
-use common_metrics::normalize_unmatched_path;
 use metrics::gauge;
+
+const UNMATCHED_PATH_LABEL: &str = "unknown";
 
 // Global atomic counter for active connections
 static ACTIVE_CONNECTIONS: AtomicUsize = AtomicUsize::new(0);
@@ -41,7 +42,7 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse 
     let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
         matched_path.as_str().to_owned()
     } else {
-        normalize_unmatched_path(req.uri().path())
+        UNMATCHED_PATH_LABEL.to_owned()
     };
 
     let method = req.method().clone();
@@ -90,7 +91,7 @@ where
                 let path = if let Some(matched) = req.extensions().get::<MatchedPath>() {
                     matched.as_str().to_owned()
                 } else {
-                    normalize_unmatched_path(req.uri().path())
+                    UNMATCHED_PATH_LABEL.to_owned()
                 };
                 let client_ip = req
                     .headers()


### PR DESCRIPTION
## Problem

The capture HTTP metrics middleware emits a `path` label on `http_requests_total`, `http_requests_duration_seconds`, `middleware_pass_total`, and `middleware_request_timed_out_total`. For requests that don't match a registered route, the middleware fell back to `normalize_unmatched_path`, which keeps the first path segment as the label value. That still produces one new label per distinct first segment (scanner probes, typos, arbitrary client paths), inflating series cardinality and making the resulting Prometheus output noisy and expensive to query.

## Changes

In `rust/capture/src/metrics_middleware.rs`, both `track_metrics` and `apply_request_timeout` now report `path="unknown"` whenever axum's `MatchedPath` is not set. Matched routes continue to report their literal route template (e.g. `/i/v0/e/`, `/batch`, `/s`), so the supported surface area stays observable while unsupported URLs collapse into a single label.

`common_metrics::normalize_unmatched_path` is intentionally left in place — it is still used by `common/metrics` and `common/serve_metrics`, which can be revisited separately.

## How did you test this code?

I'm an agent. I ran `cargo check -p capture` to confirm the change compiles. No new automated tests were added; the existing middleware paths are exercised by the surrounding suite.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code. The starting point was an observation that the capture `path` label in `http_requests_total` had unbounded cardinality from unmatched URLs. I considered (and rejected) removing `normalize_unmatched_path` from `common_metrics` outright — other crates still consume it, and the brief was limited to capture. Settled on a per-crate fix with a single named constant (`UNMATCHED_PATH_LABEL`) so both middleware functions stay consistent.