### PR TITLE
fix(mcp): restore 8787 as default port for local dev

### DIFF
--- a/bin/start-mcp-server
+++ b/bin/start-mcp-server
@@ -9,7 +9,7 @@ pnpm install --frozen-lockfile
 
 if [ "$RUNTIME" = "hono" ]; then
     export REDIS_URL="${REDIS_URL:-redis://localhost:6379}"
-    export PORT="${PORT:-3030}"
+    export PORT="${PORT:-8787}"
     exec pnpm run dev:hono
 else
     if [ ! -f .dev.vars ]; then

--- a/services/mcp/README.md
+++ b/services/mcp/README.md
@@ -327,7 +327,7 @@ Alongside the Cloudflare Workers entry point, the same MCP code runs on Node via
 pnpm run dev:hono
 ```
 
-Defaults to port **3030**, reads config from `.env` (Node-only — separate from `.dev.vars`, which Wrangler reads), and expects a local Redis on port `6379` (used in place of Durable Objects for session state) for local development; production deployments must set `REDIS_URL` to a TLS-encrypted `rediss://` endpoint. Same routes as the CF server — point your client at `http://localhost:3030/mcp`.
+Defaults to port **8787**, reads config from `.env` (Node-only — separate from `.dev.vars`, which Wrangler reads), and expects a local Redis on port `6379` (used in place of Durable Objects for session state) for local development; production deployments must set `REDIS_URL` to a TLS-encrypted `rediss://` endpoint. Same routes as the CF server — point your client at `http://localhost:8787/mcp`.
 
 `bin/start-mcp-server` runs the Wrangler/CF version by default; set `MCP_RUNTIME=hono` to start the Hono runtime instead.
 


### PR DESCRIPTION
## Problem

The Hono runtime default port was set to 3030, which broke local setups that point at 8787 (the original Wrangler default). Existing client configs (`http://localhost:8787/mcp`) silently stopped working.

## Changes

- `bin/start-mcp-server`: default `PORT` falls back to `8787` instead of `3030`.
- `services/mcp/README.md`: docs for the Hono runtime now reference `8787` to match.

## How did you test this code?

I'm an agent. No manual testing was performed. The change is a one-line default in the start script and a matching docs update — verified by inspection against the existing `8787` references throughout `services/mcp/` (package.json, README, `.dev.vars.example`, tests).

## Publish to changelog?

no

## 🤖 Agent context

Authored by an agent in response to a Slack report that `localhost:8787` was no longer responding after the Hono runtime landed (#59900) and the port silently moved to 3030. Picked 8787 to restore parity with the Wrangler default and the rest of the docs/examples, rather than updating every reference to 3030.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*