### PR TITLE
fix(surveys): clean up hosted survey translations picker

### DIFF
--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -70,7 +70,6 @@ export function SurveyTranslations(): JSX.Element {
                             }}
                             placeholder="Add a translation (e.g. 'fr', 'French', 'fr-CA')"
                             allowCustomValues
-                            autoFocus={validKeys.length === 0}
                             value={[]}
                             data-attr="survey-translation-add"
                         />
@@ -105,7 +104,7 @@ export function SurveyTranslations(): JSX.Element {
                         type={editingLanguage === null ? 'primary' : 'secondary'}
                         onClick={() => selectLanguage(null)}
                     >
-                        {getSurveyLanguageName(baseLanguage)} <span className="text-muted ml-1">(original)</span>
+                        {getSurveyLanguageName(baseLanguage)} (original)
                     </LemonButton>
 
                     {validKeys.map((lang) => {


### PR DESCRIPTION
## Problem

Two small UI issues on the hosted survey translations panel:

1. The **"English (original)"** language button (shown as primary when no translation is being edited) wrapped `(original)` in a `text-muted` span. Against the primary-yellow background that muted gray is low-contrast and reads as a broken label.
2. The **"Add a translation"** picker had `autoFocus={validKeys.length === 0}`, so the first time a user opens the editor (no translations yet), the input grabs focus and immediately opens the `LemonInputSelect` popover, dumping the full `COMMON_LANGUAGES` list over the rest of the form.

## Changes

- Drop the `text-muted` span around `(original)` so the label reads consistently regardless of the button's primary/secondary state.
- Remove `autoFocus` from the language picker so the editor mounts in a neutral state.

## How did you test this code?

I'm an agent — I did not manually exercise the UI. No automated tests were run for this change; the file has no targeted unit tests for the picker focus/label behavior. A reviewer should open the hosted survey editor, confirm the picker does not auto-open, and that the "English (original)" button label is legible in both primary and secondary states.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7).
- Considered fixing the same file in the wizard (`wizard/steps/TranslationsSection.tsx`) but it already lacks both issues — only `SurveyTranslations.tsx` (used by `HostedSurveyEdit` and `SurveyEdit`) needed changes.
- Considered downgrading the original-language button from primary to secondary instead of fixing the label, but that breaks the "active language" affordance once translations are added, so the smaller change (drop the muted span) was preferred.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*