### PR TITLE
fix(subscriptions): resolve slack integration on re-enable

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -44,6 +44,7 @@ from posthog.temporal.subscriptions.types import ProcessSubscriptionWorkflowInpu
 from posthog.utils import str_to_bool
 
 from ee.tasks.subscriptions.auto_disable import validate_re_enable
+from ee.tasks.subscriptions.slack_subscriptions import resolve_subscription_slack_integration_id
 from ee.tasks.subscriptions.subscription_utils import DEFAULT_MAX_ASSET_COUNT
 
 SUMMARY_QUOTA_CACHE_TTL_SECONDS = 60
@@ -211,12 +212,21 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             else (self.instance.integration_id if self.instance else None)
         )
 
+        is_re_enabling = self.instance is not None and attrs.get("enabled") is True and self.instance.enabled is False
+
+        if is_re_enabling and target_type == Subscription.SubscriptionTarget.SLACK and "integration_id" not in attrs:
+            resolved_id = resolve_subscription_slack_integration_id(
+                self.context["team_id"], target_type, integration_id
+            )
+            if resolved_id and resolved_id != integration_id:
+                integration_id = resolved_id
+                attrs["integration_id"] = resolved_id
+
         # Reject re-enables of subscriptions whose delivery prerequisite is still
         # permanently broken — otherwise the next delivery would just auto-disable
         # them again.
-        is_re_enabling = self.instance is not None and attrs.get("enabled") is True and self.instance.enabled is False
         if is_re_enabling:
-            error_message = validate_re_enable(target_type, integration_id)
+            error_message = validate_re_enable(target_type, integration_id, team_id=self.context["team_id"])
             if error_message:
                 raise ValidationError({"enabled": [error_message]})
 

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -479,7 +479,9 @@ class TestSubscriptionTemporal(APILicensedTest):
         subscription = Subscription.objects.get(pk=subscription_id)
         assert subscription.enabled is True
         assert subscription.integration_id == new_integration.id
-        assert subscription.integration_id == get_slack_integration_for_team(self.team.id).id
+        team_slack_integration = get_slack_integration_for_team(self.team.id)
+        assert team_slack_integration is not None
+        assert subscription.integration_id == team_slack_integration.id
 
     def test_patch_enabled_true_rejected_for_webhook_subscription(self):
         """Webhook delivery is not supported, so a webhook subscription auto-disables on

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -436,8 +436,9 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert create_response.status_code == status.HTTP_201_CREATED
         subscription_id = create_response.json()["id"]
 
-        # Auto-disable: clear integration and disable the subscription
+        # Auto-disable: clear integration FK and disable the subscription
         Subscription.objects.filter(pk=subscription_id).update(enabled=False, integration=None)
+        integration.delete()
 
         response = self.client.patch(
             f"/api/projects/{self.team.id}/subscriptions/{subscription_id}",
@@ -446,6 +447,39 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["attr"] == "enabled"
         assert "Reconnect Slack" in response.json()["detail"]
+
+    def test_patch_enabled_true_backfills_slack_integration_on_re_enable(self):
+        """Re-enable via `{enabled: true}` should work when the subscription lost its
+        integration FK but the team has Slack connected again — mirrors delivery's
+        get_slack_integration_for_team fallback and the edit modal's auto-select."""
+        old_integration = Integration.objects.create(team=self.team, kind="slack", config={})
+        create_response = self._create_subscription(
+            target_type="slack",
+            target_value="C1234|#general",
+            integration_id=old_integration.id,
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+        subscription_id = create_response.json()["id"]
+
+        new_integration = Integration.objects.create(team=self.team, kind="slack", config={"reconnected": True})
+        Subscription.objects.filter(pk=subscription_id).update(enabled=False, integration=None)
+        old_integration.delete()
+
+        with patch("ee.api.subscription.sync_connect") as temporal_mock:
+            temporal_mock.return_value.start_workflow = AsyncMock()
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/subscriptions/{subscription_id}",
+                {"enabled": True},
+            )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()["enabled"] is True
+        assert response.json()["integration_id"] == new_integration.id
+
+        subscription = Subscription.objects.get(pk=subscription_id)
+        assert subscription.enabled is True
+        assert subscription.integration_id == new_integration.id
+        assert subscription.integration_id == get_slack_integration_for_team(self.team.id).id
 
     def test_patch_enabled_true_rejected_for_webhook_subscription(self):
         """Webhook delivery is not supported, so a webhook subscription auto-disables on

--- a/ee/tasks/subscriptions/auto_disable.py
+++ b/ee/tasks/subscriptions/auto_disable.py
@@ -8,6 +8,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.subscription import Subscription
 
 from ee.tasks.subscriptions import SUPPORTED_TARGET_TYPES
+from ee.tasks.subscriptions.slack_subscriptions import resolve_subscription_slack_integration_id
 
 
 class DisableReason(NamedTuple):
@@ -38,20 +39,34 @@ SLACK_PERMISSION_REVOKED_DISABLE_REASON = DisableReason(
 logger = structlog.get_logger(__name__)
 
 
-def get_subscription_disable_reason(target_type: str | None, integration_id: int | None) -> DisableReason | None:
+def get_subscription_disable_reason(
+    target_type: str | None,
+    integration_id: int | None,
+    *,
+    team_id: int | None = None,
+) -> DisableReason | None:
     """Single source of truth for "what target configuration is permanently broken"."""
     if not target_type:
         return None
     if target_type not in SUPPORTED_TARGET_TYPES:
         return UNSUPPORTED_TARGET_DISABLE_REASON
-    if target_type == Subscription.SubscriptionTarget.SLACK and not integration_id:
-        return SLACK_DISCONNECTED_DISABLE_REASON
+    if target_type == Subscription.SubscriptionTarget.SLACK:
+        effective_integration_id = integration_id
+        if team_id is not None:
+            effective_integration_id = resolve_subscription_slack_integration_id(team_id, target_type, integration_id)
+        if not effective_integration_id:
+            return SLACK_DISCONNECTED_DISABLE_REASON
     return None
 
 
-def validate_re_enable(target_type: str | None, integration_id: int | None) -> str | None:
+def validate_re_enable(
+    target_type: str | None,
+    integration_id: int | None,
+    *,
+    team_id: int | None = None,
+) -> str | None:
     """API-serializer wrapper — returns the user-facing rejection message, or None if re-enable is OK."""
-    reason = get_subscription_disable_reason(target_type, integration_id)
+    reason = get_subscription_disable_reason(target_type, integration_id, team_id=team_id)
     if reason is None:
         return None
     return reason.user_message.format(target_type=target_type)

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -100,6 +100,39 @@ def get_slack_integration_for_team(team_id: int) -> Integration | None:
     return Integration.objects.filter(team_id=team_id, kind="slack").first()
 
 
+def resolve_subscription_slack_integration(
+    *,
+    team_id: int,
+    integration_id: int | None = None,
+    integration: Integration | None = None,
+) -> Integration | None:
+    """Resolve which Slack integration a subscription should use.
+
+    Prefers the subscription's FK when it points to a Slack integration; otherwise
+    falls back to the team's connected Slack integration (lowest id). Used by delivery,
+    re-enable validation, and serializer backfill so all paths agree.
+    """
+    if integration is not None and integration.kind == "slack":
+        return integration
+    if integration_id is not None:
+        loaded = Integration.objects.filter(pk=integration_id, team_id=team_id, kind="slack").first()
+        if loaded:
+            return loaded
+    return get_slack_integration_for_team(team_id)
+
+
+def resolve_subscription_slack_integration_id(
+    team_id: int,
+    target_type: str | None,
+    integration_id: int | None,
+) -> int | None:
+    """Effective Slack integration_id for subscription checks when only the FK is available."""
+    if target_type != Subscription.SubscriptionTarget.SLACK:
+        return integration_id
+    resolved = resolve_subscription_slack_integration(team_id=team_id, integration_id=integration_id)
+    return resolved.id if resolved else None
+
+
 def send_slack_subscription_report(
     subscription: Subscription,
     assets: list[ExportedAsset],
@@ -107,7 +140,9 @@ def send_slack_subscription_report(
     is_new_subscription: bool = False,
 ) -> None:
     """Send Slack subscription report."""
-    integration = get_slack_integration_for_team(subscription.team_id)
+    integration = resolve_subscription_slack_integration(
+        team_id=subscription.team_id, integration_id=subscription.integration_id
+    )
 
     if not integration:
         # TODO: Write error to subscription...

--- a/ee/tasks/subscriptions/test_auto_disable.py
+++ b/ee/tasks/subscriptions/test_auto_disable.py
@@ -5,11 +5,13 @@ from django.utils import timezone
 
 from parameterized import parameterized
 
+from posthog.models.integration import Integration
 from posthog.models.subscription import Subscription
 
 from ee.tasks.subscriptions.auto_disable import (
     SLACK_DISCONNECTED_DISABLE_REASON,
     disable_invalid_subscription,
+    get_subscription_disable_reason,
     send_notifications_for_disabled_subscription,
     validate_re_enable,
 )
@@ -44,6 +46,17 @@ class TestValidateReEnable:
 
 
 class TestDisableInvalidSubscription(APIBaseTest):
+    def test_validate_re_enable_resolves_team_slack_when_integration_id_missing(self):
+        Integration.objects.create(team=self.team, kind="slack", config={})
+        assert validate_re_enable("slack", None, team_id=self.team.id) is None
+
+    def test_get_subscription_disable_reason_resolves_team_slack_when_integration_id_missing(self):
+        Integration.objects.create(team=self.team, kind="slack", config={})
+        assert get_subscription_disable_reason("slack", None, team_id=self.team.id) is None
+
+    def test_get_subscription_disable_reason_still_rejects_without_team_slack(self):
+        assert get_subscription_disable_reason("slack", None, team_id=self.team.id) == SLACK_DISCONNECTED_DISABLE_REASON
+
     def _make_subscription(self, **overrides) -> Subscription:
         defaults = {
             "team": self.team,

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -127,9 +127,10 @@ async def validate_subscription_for_delivery(subscription_id: int) -> Subscripti
         await LOGGER.ainfo("validate_subscription.already_disabled_skipping", subscription_id=subscription_id)
         return SubscriptionAbortInfo()
 
-    reason = get_subscription_disable_reason(
-        subscription.target_type, subscription.integration_id, team_id=subscription.team_id
-    )
+    reason = await database_sync_to_async(
+        get_subscription_disable_reason,
+        thread_sensitive=False,
+    )(subscription.target_type, subscription.integration_id, team_id=subscription.team_id)
     if reason is None:
         return None
 

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -46,7 +46,7 @@ from ee.tasks.subscriptions.auto_disable import (
 )
 from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_report
 from ee.tasks.subscriptions.slack_subscriptions import (
-    get_slack_integration_for_team,
+    resolve_subscription_slack_integration,
     send_slack_message_with_integration_async,
 )
 
@@ -127,7 +127,9 @@ async def validate_subscription_for_delivery(subscription_id: int) -> Subscripti
         await LOGGER.ainfo("validate_subscription.already_disabled_skipping", subscription_id=subscription_id)
         return SubscriptionAbortInfo()
 
-    reason = get_subscription_disable_reason(subscription.target_type, subscription.integration_id)
+    reason = get_subscription_disable_reason(
+        subscription.target_type, subscription.integration_id, team_id=subscription.team_id
+    )
     if reason is None:
         return None
 
@@ -431,21 +433,10 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> DeliverSubs
 
     elif subscription.target_type == "slack":
         try:
-            integration = subscription.integration
-            if integration is None:
-                integration = await database_sync_to_async(get_slack_integration_for_team, thread_sensitive=False)(
-                    subscription.team_id
-                )
-            elif integration.kind != "slack":
-                LOGGER.warn(
-                    "deliver_subscription.invalid_integration_kind",
-                    subscription_id=subscription.id,
-                    integration_id=integration.id,
-                    kind=integration.kind,
-                )
-                integration = await database_sync_to_async(get_slack_integration_for_team, thread_sensitive=False)(
-                    subscription.team_id
-                )
+            integration = await database_sync_to_async(
+                resolve_subscription_slack_integration,
+                thread_sensitive=False,
+            )(team_id=subscription.team_id, integration=subscription.integration)
 
             if not integration:
                 LOGGER.warning(


### PR DESCRIPTION
## Problem

Slack subscriptions can lose their `integration_id` when the linked integration is deleted (`SET_NULL` on disconnect). If Slack is reconnected at the team level, re-enabling from the subscriptions list or detail page fails with "no integration configured" even though delivery would succeed.

Opening the edit modal and saving without changes works because `IntegrationChoice` auto-selects the team's Slack integration and persists it — the list/detail re-enable path only sends `{ enabled: true }` and never backfills the FK.

## Changes

- Add `resolve_subscription_slack_integration()` in `slack_subscriptions.py` as the single source of truth for resolving which Slack integration a subscription should use (FK if valid, else team's connected integration)
- Wire it into delivery, pre-delivery validation, re-enable validation, and serializer backfill on re-enable PATCH
- Fix the rejection test to actually delete the integration (previous setup only cleared the subscription FK while Slack was still connected)

## How did you test this code?

Automated tests (agent-run, no manual UI verification):

```bash
bin/hogli test ee/tasks/subscriptions/test_auto_disable.py \
  ee/api/test/test_subscription.py::TestSubscriptionTemporal::test_patch_enabled_true_rejected_when_slack_integration_missing \
  ee/api/test/test_subscription.py::TestSubscriptionTemporal::test_patch_enabled_true_backfills_slack_integration_on_re_enable
```

All 18 tests passed.

## Publish to changelog?

no

## Docs update

No docs update needed — bug fix to existing subscription re-enable behavior.

## 🤖 Agent context

- **Agent:** Cursor (Composer)
- **Problem:** User reported Slack subscription re-enable failing from list/detail with "no integration configured", but succeeding after opening edit modal and saving unchanged
- **Root cause:** `integration_id` null on subscription row while team Slack exists; edit modal auto-fills via `IntegrationChoice`, re-enable PATCH does not
- **Approach:** Centralized resolution in `resolve_subscription_slack_integration()` rather than duplicating `get_slack_integration_for_team` fallback in the serializer — delivery and validation already had parallel logic that could drift
- **Rejected:** Frontend-only fix (patching `integration_id` in `toggleSubscriptionEnabled`) — backend is the right place since delivery already falls back and validation was incorrectly stricter

Made with [Cursor](https://cursor.com)