### PR TITLE
fix(legal-docs): move sender to send_document, use owner on create

### DIFF
--- a/products/legal_documents/backend/logic/__init__.py
+++ b/products/legal_documents/backend/logic/__init__.py
@@ -314,7 +314,7 @@ def create_pandadoc_envelope(document: LegalDocument) -> str | None:
         created = client.create_document_from_template(
             template_id=template_id,
             name=f"PostHog {document.document_type} — {document.company_name}",
-            sender_email=POSTHOG_SIGNING_EMAIL,
+            owner_email=POSTHOG_SIGNING_EMAIL,
             recipients=[
                 pandadoc_client.PandaDocRecipient(
                     email=POSTHOG_SIGNING_EMAIL, role=pandadoc_client.PandaDocRole.POSTHOG
@@ -370,6 +370,7 @@ def send_pandadoc_envelope(document: LegalDocument) -> bool:
                 f"You can also forward this document to reassign it if needed.\n\n"
                 f"- The PostHog Team"
             ),
+            sender_email=POSTHOG_SIGNING_EMAIL,
         )
         return True
     except pandadoc_client.PandaDocError as exc:

--- a/products/legal_documents/backend/logic/pandadoc.py
+++ b/products/legal_documents/backend/logic/pandadoc.py
@@ -121,7 +121,7 @@ class PandaDocClient:
         template_id: str,
         name: str,
         recipients: list[PandaDocRecipient],
-        sender_email: str | None = None,
+        owner_email: str | None = None,
         tokens: dict[str, str] | None = None,
         metadata: dict[str, str] | None = None,
     ) -> PandaDocDocument:
@@ -129,8 +129,9 @@ class PandaDocClient:
         Create a new document from a PandaDoc template. The returned document is in
         `document.uploaded` state — call `send_document` to dispatch the signing email.
 
-        `sender_email` is the email address that will be used to send the signing
-        envelope. Defaults to the email address that owns the API key.
+        `owner_email` sets the PandaDoc user who owns the document inside the workspace.
+        It does *not* affect the "From" identity in signing emails — that's controlled
+        by `sender_email` on `send_document`.
 
         `tokens` is a flat {name: value} map that maps onto the template's token
         placeholders (`[Client.Company]`, `[Client.StreetAddress]`, etc.). Only
@@ -143,8 +144,8 @@ class PandaDocClient:
             "recipients": [_serialize_recipient(r) for r in recipients],
         }
 
-        if sender_email:
-            payload["sender"] = {"email": sender_email}
+        if owner_email:
+            payload["owner"] = {"email": owner_email}
         if tokens:
             payload["tokens"] = [{"name": name, "value": value} for name, value in tokens.items()]
         if metadata:
@@ -157,14 +158,25 @@ class PandaDocClient:
             name=data.get("name", name),
         )
 
-    def send_document(self, *, document_id: str, subject: str, message: str) -> None:
+    def send_document(
+        self,
+        *,
+        document_id: str,
+        subject: str,
+        message: str,
+        sender_email: str | None = None,
+    ) -> None:
         """
         Trigger the signing envelope email. PandaDoc returns 200/202 with a body we don't use.
+
+        `sender_email` controls the "From" identity recipients see in the signing
+        email. Without it, PandaDoc falls back to the owner of the API key — the
+        `sender` set during document creation does not affect the send-time email.
         """
-        self._post(
-            f"/public/v1/documents/{document_id}/send",
-            {"subject": subject, "message": message, "silent": False},
-        )
+        payload: dict[str, Any] = {"subject": subject, "message": message, "silent": False}
+        if sender_email:
+            payload["sender"] = {"email": sender_email}
+        self._post(f"/public/v1/documents/{document_id}/send", payload)
 
     @contextmanager
     def stream_document(self, *, document_id: str) -> Iterator[IO[bytes]]:

--- a/products/legal_documents/backend/tests/test_pandadoc.py
+++ b/products/legal_documents/backend/tests/test_pandadoc.py
@@ -36,7 +36,7 @@ class TestPandaDocClient(TestCase):
                 recipients=[pandadoc.PandaDocRecipient(email="ada@acme.example", role=pandadoc.PandaDocRole.CLIENT)],
                 tokens={"Client.Company": "Acme, Inc.", "Client.StreetAddress": "1 Analytics Way"},
                 metadata={"legal_document_id": "lid-1"},
-                sender_email="privacy@posthog.com",
+                owner_email="privacy@posthog.com",
             )
 
         mock_post.assert_called_once()
@@ -55,12 +55,13 @@ class TestPandaDocClient(TestCase):
             ],
         )
         self.assertEqual(body["metadata"], {"legal_document_id": "lid-1"})
-        self.assertEqual(body["sender"], {"email": "privacy@posthog.com"})
+        self.assertEqual(body["owner"], {"email": "privacy@posthog.com"})
+        self.assertNotIn("sender", body)
         self.assertEqual(result.id, "doc_123")
 
     @override_settings(PANDADOC_API_KEY="key", PANDADOC_API_BASE_URL="https://api.pandadoc.com")
-    def test_create_document_omits_sender_when_not_provided(self) -> None:
-        # When `sender_email` is None we leave the field off so PandaDoc falls
+    def test_create_document_omits_owner_when_not_provided(self) -> None:
+        # When `owner_email` is None we leave the field off so PandaDoc falls
         # back to the API key's owning user.
         fake_response = MagicMock()
         fake_response.status_code = 201
@@ -77,6 +78,7 @@ class TestPandaDocClient(TestCase):
             )
 
         body = mock_post.call_args.kwargs["json"]
+        self.assertNotIn("owner", body)
         self.assertNotIn("sender", body)
 
     @override_settings(PANDADOC_API_KEY="key", PANDADOC_API_BASE_URL="https://api.pandadoc.com")
@@ -115,6 +117,42 @@ class TestPandaDocClient(TestCase):
             with self.assertRaises(pandadoc.PandaDocError):
                 with client.stream_document(document_id="doc_123"):
                     pass
+
+    @override_settings(PANDADOC_API_KEY="key", PANDADOC_API_BASE_URL="https://api.pandadoc.com")
+    def test_send_document_includes_sender_when_provided(self) -> None:
+        # PandaDoc only honors the configured sender identity if `sender` is on
+        # the /send call — the `sender` set at create time controls ownership,
+        # not the email "From" name. Without it, recipients see the API key owner.
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.content = b""
+
+        with patch(
+            "products.legal_documents.backend.logic.pandadoc.requests.post", return_value=fake_response
+        ) as mock_post:
+            pandadoc.PandaDocClient().send_document(
+                document_id="doc_123",
+                subject="s",
+                message="m",
+                sender_email="privacy@posthog.com",
+            )
+
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "https://api.pandadoc.com/public/v1/documents/doc_123/send")
+        self.assertEqual(kwargs["json"]["sender"], {"email": "privacy@posthog.com"})
+
+    @override_settings(PANDADOC_API_KEY="key", PANDADOC_API_BASE_URL="https://api.pandadoc.com")
+    def test_send_document_omits_sender_when_not_provided(self) -> None:
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.content = b""
+
+        with patch(
+            "products.legal_documents.backend.logic.pandadoc.requests.post", return_value=fake_response
+        ) as mock_post:
+            pandadoc.PandaDocClient().send_document(document_id="doc_123", subject="s", message="m")
+
+        self.assertNotIn("sender", mock_post.call_args.kwargs["json"])
 
     @override_settings(PANDADOC_API_KEY="key")
     def test_non_2xx_response_raises(self) -> None:

--- a/products/legal_documents/backend/tests/test_pandadoc.py
+++ b/products/legal_documents/backend/tests/test_pandadoc.py
@@ -121,8 +121,9 @@ class TestPandaDocClient(TestCase):
     @override_settings(PANDADOC_API_KEY="key", PANDADOC_API_BASE_URL="https://api.pandadoc.com")
     def test_send_document_includes_sender_when_provided(self) -> None:
         # PandaDoc only honors the configured sender identity if `sender` is on
-        # the /send call — the `sender` set at create time controls ownership,
-        # not the email "From" name. Without it, recipients see the API key owner.
+        # the /send call — `owner` at create time controls workspace ownership
+        # inside PandaDoc, not the email "From" name. Without `sender` on /send,
+        # recipients see the API key owner.
         fake_response = MagicMock()
         fake_response.status_code = 200
         fake_response.content = b""


### PR DESCRIPTION
The PandaDoc API distinguishes between two separate concepts that were previously conflated under a single `sender_email` parameter:

- **Document ownership** (`owner`) — which workspace user owns the document inside PandaDoc
- **Signing email identity** (`sender`) — the "From" address recipients see when the signing envelope is dispatched

Previously, `sender_email` was passed during document creation, but PandaDoc does not use the `sender` field at create time to control the signing email's "From" identity. That field must be passed on the `/send` call instead.

This fixes the behavior by:
- Renaming `sender_email` → `owner_email` on `create_document_from_template` and setting it as `owner` in the request payload
- Adding a `sender_email` parameter to `send_document` that sets `sender` in the `/send` payload, which is where PandaDoc actually honors it
- Passing `POSTHOG_SIGNING_EMAIL` as `owner_email` during document creation and as `sender_email` during the send step