### PR TITLE
feat(subscriptions): show failure reason in delivery history tooltip

### DIFF
--- a/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
+++ b/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
@@ -53,7 +53,11 @@ function deliveryStatusTag(row: SubscriptionDeliveryApi): JSX.Element {
             tagType = 'default'
     }
     const failureMessage = (row.error as { message?: unknown } | null)?.message
-    if (row.status === SubscriptionDeliveryStatusEnumApi.Failed && typeof failureMessage === 'string') {
+    if (
+        row.status === SubscriptionDeliveryStatusEnumApi.Failed &&
+        typeof failureMessage === 'string' &&
+        failureMessage
+    ) {
         return (
             <Tooltip title={failureMessage}>
                 <LemonTag type={tagType} className="cursor-help">

--- a/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
+++ b/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
@@ -52,8 +52,8 @@ function deliveryStatusTag(row: SubscriptionDeliveryApi): JSX.Element {
             label = row.status
             tagType = 'default'
     }
-    const failureMessage = (row.error as { message: string; type: string } | null)?.message
-    if (row.status === SubscriptionDeliveryStatusEnumApi.Failed && failureMessage) {
+    const failureMessage = (row.error as { message?: unknown } | null)?.message
+    if (row.status === SubscriptionDeliveryStatusEnumApi.Failed && typeof failureMessage === 'string') {
         return (
             <Tooltip title={failureMessage}>
                 <LemonTag type={tagType} className="cursor-help">

--- a/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
+++ b/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
@@ -28,9 +28,6 @@ import { TARGET_TYPE_LABEL } from './subscriptionLabels'
 type DeliveryListStatusFilter =
     (typeof SubscriptionDeliveriesListStatusByValue)[keyof typeof SubscriptionDeliveriesListStatusByValue]
 
-/** Shape of `SubscriptionDelivery.error`, written by `posthog/temporal/subscriptions/activities.py`. */
-type SubscriptionDeliveryError = { message: string; type: string }
-
 function deliveryStatusTag(row: SubscriptionDeliveryApi): JSX.Element {
     let label: string
     let tagType: 'success' | 'danger' | 'warning' | 'default'
@@ -55,7 +52,7 @@ function deliveryStatusTag(row: SubscriptionDeliveryApi): JSX.Element {
             label = row.status
             tagType = 'default'
     }
-    const failureMessage = (row.error as SubscriptionDeliveryError | null)?.message
+    const failureMessage = (row.error as { message: string; type: string } | null)?.message
     if (row.status === SubscriptionDeliveryStatusEnumApi.Failed && failureMessage) {
         return (
             <Tooltip title={failureMessage}>

--- a/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
+++ b/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
@@ -1,5 +1,13 @@
 import { IconSend } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonSelect, LemonTable, LemonTableColumns, LemonTag } from '@posthog/lemon-ui'
+import {
+    LemonButton,
+    LemonDivider,
+    LemonSelect,
+    LemonTable,
+    LemonTableColumns,
+    LemonTag,
+    Tooltip,
+} from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 
@@ -20,10 +28,19 @@ import { TARGET_TYPE_LABEL } from './subscriptionLabels'
 type DeliveryListStatusFilter =
     (typeof SubscriptionDeliveriesListStatusByValue)[keyof typeof SubscriptionDeliveriesListStatusByValue]
 
-function deliveryStatusTag(status: SubscriptionDeliveryApi['status']): JSX.Element {
+/** Backend writes `{message: str, type: str}` to `SubscriptionDelivery.error`; schema types it as `unknown`. */
+function getDeliveryErrorMessage(error: SubscriptionDeliveryApi['error']): string | null {
+    if (!error || typeof error !== 'object') {
+        return null
+    }
+    const message = (error as { message?: unknown }).message
+    return typeof message === 'string' && message.length > 0 ? message : null
+}
+
+function deliveryStatusTag(row: SubscriptionDeliveryApi): JSX.Element {
     let label: string
     let tagType: 'success' | 'danger' | 'warning' | 'default'
-    switch (status) {
+    switch (row.status) {
         case SubscriptionDeliveryStatusEnumApi.Starting:
             label = 'Starting'
             tagType = 'default'
@@ -41,8 +58,19 @@ function deliveryStatusTag(status: SubscriptionDeliveryApi['status']): JSX.Eleme
             tagType = 'warning'
             break
         default:
-            label = status
+            label = row.status
             tagType = 'default'
+    }
+    const errorMessage =
+        row.status === SubscriptionDeliveryStatusEnumApi.Failed ? getDeliveryErrorMessage(row.error) : null
+    if (errorMessage) {
+        return (
+            <Tooltip title={errorMessage}>
+                <LemonTag type={tagType} className="cursor-help">
+                    {label}
+                </LemonTag>
+            </Tooltip>
+        )
     }
     return <LemonTag type={tagType}>{label}</LemonTag>
 }
@@ -114,7 +142,7 @@ function buildDeliveryColumns(): LemonTableColumns<SubscriptionDeliveryApi> {
             title: 'Status',
             key: 'status',
             className: DELIVERY_TABLE_CELL_CLASS,
-            render: (_v, row) => deliveryStatusTag(row.status),
+            render: (_v, row) => deliveryStatusTag(row),
         },
         {
             title: 'Trigger',

--- a/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
+++ b/frontend/src/scenes/subscriptions/components/SubscriptionDeliveryHistory.tsx
@@ -28,14 +28,8 @@ import { TARGET_TYPE_LABEL } from './subscriptionLabels'
 type DeliveryListStatusFilter =
     (typeof SubscriptionDeliveriesListStatusByValue)[keyof typeof SubscriptionDeliveriesListStatusByValue]
 
-/** Backend writes `{message: str, type: str}` to `SubscriptionDelivery.error`; schema types it as `unknown`. */
-function getDeliveryErrorMessage(error: SubscriptionDeliveryApi['error']): string | null {
-    if (!error || typeof error !== 'object') {
-        return null
-    }
-    const message = (error as { message?: unknown }).message
-    return typeof message === 'string' && message.length > 0 ? message : null
-}
+/** Shape of `SubscriptionDelivery.error`, written by `posthog/temporal/subscriptions/activities.py`. */
+type SubscriptionDeliveryError = { message: string; type: string }
 
 function deliveryStatusTag(row: SubscriptionDeliveryApi): JSX.Element {
     let label: string
@@ -61,11 +55,10 @@ function deliveryStatusTag(row: SubscriptionDeliveryApi): JSX.Element {
             label = row.status
             tagType = 'default'
     }
-    const errorMessage =
-        row.status === SubscriptionDeliveryStatusEnumApi.Failed ? getDeliveryErrorMessage(row.error) : null
-    if (errorMessage) {
+    const failureMessage = (row.error as SubscriptionDeliveryError | null)?.message
+    if (row.status === SubscriptionDeliveryStatusEnumApi.Failed && failureMessage) {
         return (
-            <Tooltip title={errorMessage}>
+            <Tooltip title={failureMessage}>
                 <LemonTag type={tagType} className="cursor-help">
                     {label}
                 </LemonTag>


### PR DESCRIPTION
## Problem

When a subscription delivery fails, the delivery history shows a red "Failed" status badge but no reason. Users have to dig through Temporal logs or backend records to learn _why_ a delivery failed (SMTP timeout, webhook 5xx, asset export failure, etc.). The reason is already captured in `SubscriptionDelivery.error` and exposed by the serializer — it just isn't surfaced in the UI.

## Changes

- In `SubscriptionDeliveryHistory`, when a row's `status === 'failed'` and `row.error.message` is a non-empty string, wrap the "Failed" `LemonTag` in a `<Tooltip>` displaying the message.
- The status tag picks up a `cursor-help` affordance when the tooltip is available, hinting that there's more info on hover.
- Schema types `row.error` as `unknown`; a small narrowing helper safely extracts `message` so we don't render junk if the shape ever drifts.
- Non-failed statuses, and failed rows with no recorded error payload, render exactly as before.

## How did you test this code?

I'm an agent. I didn't run manual or automated tests in this environment — the frontend `node_modules` isn't installed here so `typescript:check` and lint/format couldn't run against this file (the workspace's separate `products/workflows` package also has unrelated unresolved-module errors that show up first).

What I verified by reading:

- `SubscriptionDeliveryApi.error` is already serialized to the frontend (`SubscriptionDeliverySerializer.fields` in `ee/api/subscription.py`), so no backend or codegen change is needed.
- The runtime shape is `{message: str, type: str}` — see `posthog/temporal/subscriptions/activities.py` and `workflows.py` where every `error=` write conforms to that shape.
- Story fixtures in `subscriptionStoryFixtures.ts` already include failed rows with `error: { message: '...' }`, so the existing `WithDeliveries` story will exercise the new tooltip path visually.

Suggested manual check before merge: open the Subscriptions story `Scenes-App/Subscriptions/Subscription delivery history → WithDeliveries` and hover any "Failed" badge — the tooltip should show "SMTP timeout", "HTTP 502 from webhook", "Export timed out", etc.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- I considered three placements for the error reason: (a) inline next to the badge (rejected — clutters the table for the common case), (b) an expanded row similar to the existing AI-summary expand (rejected — the expand affordance is already overloaded for `change_summary` and would need a disambiguation rule), (c) a hover tooltip on the badge itself (chosen — matches the user's request, zero layout impact, discoverable via the `danger` color cue + `cursor-help`).
- I narrowed `row.error` defensively because the OpenAPI schema declares it as `unknown` rather than a concrete `{message, type}` object. Doing the narrowing in a tiny helper keeps the switch statement readable and avoids leaking `any`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*