### PR TITLE
chore(revenue-analytics): add deprecation banner

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5371,13 +5371,13 @@ snapshots:
     scenes-app-project-homepage--project-homepage--light:
         hash: v1.k794b7964.6cb3e0540153212b2c2d73fc8705be0f3a94a263198e20bf267d06d4063271ca.WloFF6QtysCbra2Sb3kyJyIhvQL7YsxCDb1YC7clGYY
     scenes-app-revenue-analytics--revenue-analytics-dashboard--dark:
-        hash: v1.k794b7964.406412e8c95339e9ab64271f6dfc363b2f47123200823722a09ac67cb74e6429.cdUelwHMlacDebp7LAzOnQXGdL0FwZj6Hwt-gQ3eln0
+        hash: v1.k794b7964.7c2a90fe3c3a969c054186bb666664efa891d65d411a546539a968518938ea71.OoOKh-Mc_IiPWTgIV4QNPtACZXPPktfU7bjGk-q-uLE
     scenes-app-revenue-analytics--revenue-analytics-dashboard--light:
-        hash: v1.k794b7964.c051a4f37223f0a82138f8794e15b0ab1e025a9541a3c411b16e8ca18be5cfb5.nrfi0N1WtXiEr1TSdUwn--_vtfWO69Q8hrg3HadUODM
+        hash: v1.k794b7964.e28fe6f60136f350f5339146d7246f21e78586a948bfa29edb6c01926e993a1d.WX2NwRYvLh0q8A6QKLBseHRJ6XKWU76Ak-QfwsPt7c8
     scenes-app-revenue-analytics--revenue-analytics-dashboard-sync-in-progress--dark:
-        hash: v1.k794b7964.8ee2b839d9ef379c3f349724248bdf5123db6b839a50cf40aa631542a4f89b19.bW2pUVufyDzqwviN78DnGFHbcz76eVeQHcJ2WhD3PPE
+        hash: v1.k794b7964.9a09c8b3c4e5162b63d6c9d66d035faad157215ba81ecb5edbaf9dd9920782f5.1ZertlNKsZ0uWQ0FvBTnbSyJrW__9KzCKcIWFTRzQ4E
     scenes-app-revenue-analytics--revenue-analytics-dashboard-sync-in-progress--light:
-        hash: v1.k794b7964.1e436cecf53428fbd470ecc953bc6da7b121ebe09b4903804e9b7e69adb633ea.Xni3NQCYT1_dtFhN-s0uwMuetpLCPebPIB-ic5IyEyo
+        hash: v1.k794b7964.a25e103bc9538a4d856cf368325539c281fcd48f305a74bf7a2b39afdbb482db.PySARFNnAAu2DdxhKRpLDbKxr456rHxKuAn8tru68YE
     scenes-app-revenue-analytics-mrr-breakdown-modal--mrr-breakdown-modal--dark:
         hash: v1.k794b7964.6834f94d3e762233c3f65284296bc844f2a2feecdb181b121ce10144a26a82c7.L7tkJ6-p1ThrdFpU5RMpeNXMg5f5hUB2Q8ZVVadfIK8
     scenes-app-revenue-analytics-mrr-breakdown-modal--mrr-breakdown-modal--light:

--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -71,15 +71,14 @@ export function RevenueAnalyticsScene(): JSX.Element {
                     insights, SQL, and persons/groups profiles.
                     <br />
                     <br />
-                    Removing the dashboard lets us move faster and ship this in a shape that works across the whole
-                    app, rather than maintaining many bespoke dashboards. Each use-case (ecommerce, SaaS, recurring
-                    revenue, one-off, services, multi-tenant) can then build the dashboard it actually needs — or have
-                    PostHog AI and agents via our MCP build it for you.
+                    Removing the dashboard lets us move faster and ship this in a shape that works across the whole app,
+                    rather than maintaining many bespoke dashboards. Each use-case (ecommerce, SaaS, recurring revenue,
+                    one-off, services, multi-tenant) can then build the dashboard it actually needs — or have PostHog AI
+                    and agents via our MCP build it for you.
                     {enabledFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS] && (
                         <>
                             {' '}
-                            In the meantime, check out{' '}
-                            <Link to={urls.customerAnalytics()}>Customer analytics</Link>.
+                            In the meantime, check out <Link to={urls.customerAnalytics()}>Customer analytics</Link>.
                         </>
                     )}
                 </LemonBanner>

--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -60,16 +60,28 @@ export function RevenueAnalyticsScene(): JSX.Element {
                     actions={<RevenueAnalyticsViewStatusIcon />}
                 />
 
-                <LemonBanner type="info" className="mb-4">
-                    <strong>Revenue analytics is currently in maintenance mode.</strong> This product is not being
-                    actively developed at the moment, so bug reports and fixes might be few and far between. Revenue
-                    analytics will be re-released in the future as part of{' '}
-                    {enabledFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS] ? (
-                        <Link to={urls.customerAnalytics()}>Customer analytics</Link>
-                    ) : (
-                        <Link to={urls.settings('user-feature-previews')}>Customer analytics (early access)</Link>
+                <LemonBanner type="warning" className="mb-4">
+                    <strong>Revenue analytics is being deprecated.</strong> We'll remove this page on or after June
+                    30th, 2026.
+                    <br />
+                    <br />
+                    We're not stepping away from revenue in PostHog — we're rethinking how it should work. We don't
+                    believe a single, opinionated Revenue analytics dashboard is the right shape for it. Instead, we're
+                    focusing on exposing revenue properties on persons and groups so you can use them everywhere:
+                    insights, SQL, and persons/groups profiles.
+                    <br />
+                    <br />
+                    Removing the dashboard lets us move faster and ship this in a shape that works across the whole
+                    app, rather than maintaining many bespoke dashboards. Each use-case (ecommerce, SaaS, recurring
+                    revenue, one-off, services, multi-tenant) can then build the dashboard it actually needs — or have
+                    PostHog AI and agents via our MCP build it for you.
+                    {enabledFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS] && (
+                        <>
+                            {' '}
+                            In the meantime, check out{' '}
+                            <Link to={urls.customerAnalytics()}>Customer analytics</Link>.
+                        </>
                     )}
-                    .
                 </LemonBanner>
 
                 {sourceRunningForTheFirstTime && (


### PR DESCRIPTION
## Problem

Revenue analytics as a standalone dashboard hasn't been the right shape for how teams actually want to look at revenue in PostHog. Maintaining many bespoke dashboards (ecommerce, SaaS, recurring, one-off, services, multi-tenant) slows us down and still leaves each team short of what they need. We want to refocus on exposing revenue properties for persons and groups across insights, SQL, and persons/groups profiles so that each use-case can build the view it actually wants — including via PostHog AI and MCP agents — and we want to give users notice before we remove the existing page.

## Changes

Replaced the maintenance-mode banner on the Revenue analytics scene with a `warning`-type `LemonBanner` announcing that the dashboard will be removed on or after June 30th, 2026. The banner frames the change as a refocus (revenue properties on persons/groups across insights, SQL, and profiles; per-use-case dashboards via PostHog AI / MCP) rather than a feature retreat. The existing Customer analytics link (when the feature flag is on) is preserved.

## How did you test this code?

I'm an agent (Claude Code via PostHog Code). No manual browser testing was performed. The change is localized to JSX inside `RevenueAnalyticsScene.tsx` and uses the same `LemonBanner` component that was already mounted at that location.

## Publish to changelog?

no

## Docs update

n/a — internal product deprecation notice, no public docs change required as part of this PR.

## 🤖 Agent context

Authored by Claude Code (PostHog Code agent). Tools used: Read/Edit for the scene file, ToolSearch + git_signed_commit for the signed commit.

Decisions:
- Used the existing `LemonBanner` slot rather than introducing a new component — keeps the change minimal and matches the prior maintenance-mode placement.
- Switched the banner `type` from `info` to `warning` to make the removal date visible without being alarming.
- Did not link out to a customer-facing announcement URL — earlier draft included one but it was speculative, so it was removed to avoid inventing URLs.
- Kept the Customer analytics link intact behind its existing feature flag check.