### PR TITLE
chore(ingestion): drop heatmap extract from analytics event subpipeline

### DIFF
--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -12,7 +12,6 @@ import { IngestionWarningsOutput } from '../common/outputs'
 import { createCreateEventStep } from '../event-processing/create-event-step'
 import { createEmitEventStep } from '../event-processing/emit-event-step'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
-import { createExtractHeatmapDataStep } from '../event-processing/extract-heatmap-data-step'
 import { createHogTransformEventStep } from '../event-processing/hog-transform-event-step'
 import { createNormalizeEventStep } from '../event-processing/normalize-event-step'
 import { createNormalizeProcessPersonFlagStep } from '../event-processing/normalize-process-person-flag-step'
@@ -24,14 +23,7 @@ import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pipeline-builders'
 import { TopHogWrapper, sum, sumOk, sumResult, timer } from '../pipelines/extensions/tophog'
 import { isDropResult } from '../pipelines/results'
-import {
-    AsyncOutput,
-    EVENTS_OUTPUT,
-    EventOutput,
-    HeatmapsOutput,
-    PersonDistinctIdsOutput,
-    PersonsOutput,
-} from './outputs'
+import { AsyncOutput, EVENTS_OUTPUT, EventOutput, PersonDistinctIdsOutput, PersonsOutput } from './outputs'
 
 export interface EventSubpipelineInput {
     message: Message
@@ -42,9 +34,7 @@ export interface EventSubpipelineInput {
 
 export interface EventSubpipelineConfig {
     options: EventPipelineRunnerOptions
-    outputs: IngestionOutputs<
-        EventOutput | HeatmapsOutput | IngestionWarningsOutput | PersonsOutput | PersonDistinctIdsOutput
-    >
+    outputs: IngestionOutputs<EventOutput | IngestionWarningsOutput | PersonsOutput | PersonDistinctIdsOutput>
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     hogTransformer: HogTransformerService
@@ -114,7 +104,6 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
         )
         .pipe(createPrepareEventStep())
         .pipe(createProcessGroupsStep(teamManager, groupTypeManager, groupStore, options))
-        .pipe(createExtractHeatmapDataStep(outputs))
         .pipe(createCreateEventStep(EVENTS_OUTPUT))
         .pipe(
             topHog(


### PR DESCRIPTION
## Problem

Capture now strips `$heatmap_data` from regular analytics events and stamps a `skip_heatmap_processing` header before producing (see #57253). The per-event `extractHeatmapDataStep` inside the analytics `event-subpipeline` already short-circuits on that header, so it runs once per event only to bail out — pure overhead.

## Changes

- Drop `createExtractHeatmapDataStep` from `nodejs/src/ingestion/analytics/event-subpipeline.ts`.
- Remove the now-unused import and trim `HeatmapsOutput` from the subpipeline's `outputs` type union (no other writer in this subpipeline).

Out of scope: the dedicated `$$heatmap` subpipeline and the `HEATMAPS_OUTPUT` registration stay — they still serve the `heatmaps_ingestion` consumer that the same `IngestionConsumer` is wired to in `ingestion-general-server.ts`.

## How did you test this code?

Type-check passes for the ingestion/analytics path (`pnpm build` in `nodejs/` reports no errors under `ingestion/` or `analytics/`; the only failures are pre-existing `@posthog/hogvm` / `@posthog/cyclotron` workspace-package resolution errors in `cdp/`, unrelated to this change). `pnpm lint` clean.

## Publish to changelog?

no