### PR TITLE
feat(mcp): cross-pod session bus for Hono elicitation

### DIFF
--- a/services/mcp/src/hono/app.ts
+++ b/services/mcp/src/hono/app.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 
 import { httpMetrics, securityHeaders } from './middleware'
 import { registerPublicRoutes } from './public-routes'
+import { type BusAwaitMetrics, createPromBusMetrics, type SessionResponseBus } from './session-bus'
 import { StreamableMcpHandler } from './streamable-handler'
 import type { HonoCtx, RedisWithPing } from './types'
 
@@ -13,6 +14,22 @@ export type App = {
     warmup: () => Promise<void>
 }
 
+export interface CreateAppOptions {
+    /**
+     * Override the cross-pod session bus used by the dispatcher for
+     * elicitation correlation. Tests inject `InMemorySessionResponseBus`;
+     * production uses the Redis-polling default constructed by the
+     * dispatcher itself.
+     */
+    sessionBus?: SessionResponseBus
+    /**
+     * Override the per-await metrics adapter. Defaults to a Prometheus
+     * adapter that pushes into `mcp_session_bus_*`. Tests typically leave
+     * this undefined or pass a spy.
+     */
+    busMetrics?: BusAwaitMetrics
+}
+
 const sseRedirect = (c: HonoCtx): Response => {
     const target = new URL(c.req.url)
     target.pathname = '/mcp' + target.pathname.slice('/sse'.length)
@@ -20,7 +37,7 @@ const sseRedirect = (c: HonoCtx): Response => {
     return c.redirect(target.toString(), 308) as unknown as Response
 }
 
-export function createApp(redis: RedisWithPing): App {
+export function createApp(redis: RedisWithPing, options: CreateAppOptions = {}): App {
     const app = new Hono()
     const lifecycle: Lifecycle = { shuttingDown: false }
 
@@ -32,7 +49,13 @@ export function createApp(redis: RedisWithPing): App {
     app.all('/sse', sseRedirect)
     app.all('/sse/*', sseRedirect)
 
-    const streamable = new StreamableMcpHandler(redis, lifecycle)
+    const dispatcherOptions: { sessionBus?: SessionResponseBus; busMetrics?: BusAwaitMetrics } = {
+        busMetrics: options.busMetrics ?? createPromBusMetrics(),
+    }
+    if (options.sessionBus !== undefined) {
+        dispatcherOptions.sessionBus = options.sessionBus
+    }
+    const streamable = new StreamableMcpHandler(redis, lifecycle, dispatcherOptions)
 
     app.all('/mcp', streamable.fetch)
     app.all('/mcp/*', streamable.fetch)

--- a/services/mcp/src/hono/capability-store.ts
+++ b/services/mcp/src/hono/capability-store.ts
@@ -1,0 +1,145 @@
+/**
+ * Per-token cache of the client's `initialize` capabilities.
+ *
+ * The Hono MCP server is stateless per-request: `tools/call` runs without
+ * direct access to the original `initialize` it implicitly continued. The
+ * MCP spec, however, requires the server NOT to send a server-initiated
+ * request the client never advertised support for (`elicitation/create`
+ * being the load-bearing example today).
+ *
+ * Solving this without a session table: we cache the relevant slice of
+ * `capabilities` from each `initialize`, keyed by the auth `userHash`, in
+ * Redis with a long TTL. Subsequent requests do one fast `GET` to decide
+ * whether to wire `Context.elicit` for the tool handler. A cache miss
+ * (cold pod, never-initialized client, evicted entry) is treated as
+ * fail-closed — see `dispatchToolsCallWithMaybeSse`.
+ *
+ * The stored shape is intentionally narrow. We don't snapshot the whole
+ * `capabilities` object — only what the dispatcher needs to gate behavior.
+ * Adding a new capability flag is a deliberate decision (extend the type,
+ * extend the writer, extend a reader).
+ */
+
+import type { RedisLike } from './cache/RedisCache'
+import { clientCapabilityCacheTotal } from './metrics'
+
+const KEY_PREFIX = 'mcp:client-caps'
+
+/**
+ * Cache TTL. Initialize is observed often enough in practice that 24h is
+ * generous; the cache exists primarily to bridge across requests within the
+ * same logical session, not across days. Long TTL keeps the GET hit rate
+ * high without forcing clients to re-initialize for every tool call.
+ */
+const DEFAULT_TTL_SECONDS = 24 * 60 * 60
+
+/**
+ * Narrow projection of `InitializeRequest.params.capabilities` retained
+ * for dispatcher decisions. Today only `elicitation` matters. The MCP
+ * draft spec uses an empty object `{}` to denote form-mode-only support;
+ * `{ form: {} }` and `{ url: {} }` declare specific modes.
+ */
+export interface CachedClientCapabilities {
+    elicitation?: {
+        form?: Record<string, never>
+        url?: Record<string, never>
+    }
+}
+
+export interface CapabilityStoreOptions {
+    /** Override the TTL (seconds). Defaults to 24h. */
+    ttlSeconds?: number
+}
+
+export class CapabilityStore {
+    private readonly ttlSeconds: number
+
+    constructor(
+        private readonly redis: RedisLike,
+        options: CapabilityStoreOptions = {}
+    ) {
+        this.ttlSeconds = options.ttlSeconds ?? DEFAULT_TTL_SECONDS
+    }
+
+    async get(userHash: string): Promise<CachedClientCapabilities | undefined> {
+        const key = buildKey(userHash)
+        let raw: string | null
+        try {
+            raw = await this.redis.get(key)
+        } catch {
+            // A Redis blip on capability read should not fail the request.
+            // Surface as a miss; the dispatcher's fail-closed default keeps
+            // us safe.
+            clientCapabilityCacheTotal.inc({ result: 'miss' })
+            return undefined
+        }
+        if (raw === null) {
+            clientCapabilityCacheTotal.inc({ result: 'miss' })
+            return undefined
+        }
+        try {
+            const parsed = JSON.parse(raw) as CachedClientCapabilities
+            clientCapabilityCacheTotal.inc({ result: 'hit' })
+            return parsed
+        } catch {
+            // Treat corrupt JSON as stale rather than crash. A subsequent
+            // initialize will overwrite the key.
+            clientCapabilityCacheTotal.inc({ result: 'stale' })
+            return undefined
+        }
+    }
+
+    async set(userHash: string, capabilities: CachedClientCapabilities): Promise<void> {
+        const key = buildKey(userHash)
+        try {
+            await this.redis.set(key, JSON.stringify(capabilities), 'EX', this.ttlSeconds)
+        } catch {
+            // Best-effort write — a failed set just means the next request
+            // will pay one extra fail-closed bounce. Don't break initialize.
+        }
+    }
+}
+
+function buildKey(userHash: string): string {
+    return `${KEY_PREFIX}:${userHash}`
+}
+
+/**
+ * Project an incoming `initialize` `capabilities` object down to the
+ * narrow cached shape. ALWAYS returns a value (even an empty `{}`) so the
+ * caller can overwrite stale cache entries — a client re-initializing with
+ * fewer capabilities than a prior session must not inherit the prior state.
+ *
+ * Returns `{}` (no `elicitation` key) when the client declared no
+ * elicitation support; the dispatcher reads this as "no capability".
+ */
+export function projectClientCapabilities(raw: unknown): CachedClientCapabilities {
+    if (raw === null || typeof raw !== 'object') {
+        return {}
+    }
+    const obj = raw as Record<string, unknown>
+    const elicitation = obj['elicitation']
+    if (elicitation === undefined || typeof elicitation !== 'object' || elicitation === null) {
+        return {}
+    }
+    const elicitObj = elicitation as Record<string, unknown>
+    const out: CachedClientCapabilities['elicitation'] = {}
+    if ('form' in elicitObj && typeof elicitObj['form'] === 'object' && elicitObj['form'] !== null) {
+        out.form = {}
+    }
+    if ('url' in elicitObj && typeof elicitObj['url'] === 'object' && elicitObj['url'] !== null) {
+        out.url = {}
+    }
+    // An empty `elicitation: {}` per the spec means "form-mode only".
+    // Preserve that semantic.
+    return { elicitation: out }
+}
+
+/**
+ * Does the cached capability declare any form of elicitation support?
+ * Both `elicitation: {}` (spec-defined form-only) and any of the
+ * explicit-mode shapes count.
+ */
+export function supportsAnyElicitation(caps: CachedClientCapabilities | undefined): boolean {
+    return caps?.elicitation !== undefined
+}

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -24,10 +24,13 @@ import type { RequestProperties } from '@/lib/request-properties'
 import { trackInitEvent } from './analytics'
 import type { RedisLike } from './cache/RedisCache'
 import { getEnv } from './constants'
+import { ElicitBinding } from './elicit-binding'
 import { InstructionsBuilder } from './instructions'
 import { initDurationSeconds, initTotal } from './metrics'
 import { RequestStateResolver, type ResolvedState } from './request-state-resolver'
 import { ResourceCatalog } from './resource-catalog'
+import { type BusAwaitMetrics, RedisPollingSessionResponseBus, type SessionResponseBus } from './session-bus'
+import { createSseResponse, type SseResponseHandle } from './sse-response'
 import { ToolCatalog } from './tool-catalog'
 import { ToolExecutor } from './tool-executor'
 
@@ -100,22 +103,43 @@ function jsonRpcErrorResponse(id: unknown, code: number, message: string): Respo
     })
 }
 
+export interface McpDispatcherOptions {
+    /**
+     * Cross-pod session bus. Defaults to a Redis-polling bus over the same
+     * `RedisLike` client. Tests can inject `InMemorySessionResponseBus`.
+     */
+    sessionBus?: SessionResponseBus
+    /**
+     * Per-await metrics adapter (e.g. Prometheus). Defaults to no-op.
+     */
+    busMetrics?: BusAwaitMetrics
+}
+
 class McpDispatcher {
     private readonly catalog: ToolCatalog
     private readonly resourceCatalog: ResourceCatalog
     private readonly stateResolver: RequestStateResolver
     private readonly toolExecutor: ToolExecutor
     private readonly instructionsBuilder: InstructionsBuilder
+    private readonly sessionBus: SessionResponseBus
+    private readonly busMetrics: BusAwaitMetrics | undefined
 
     private warmupPromise: Promise<void> | undefined
 
-    constructor(catalog: ToolCatalog, redis: RedisLike) {
+    constructor(catalog: ToolCatalog, redis: RedisLike, options: McpDispatcherOptions = {}) {
         const env = getEnv()
         this.catalog = catalog
         this.resourceCatalog = new ResourceCatalog(env)
         this.stateResolver = new RequestStateResolver(catalog, redis, env)
         this.instructionsBuilder = new InstructionsBuilder(loadGuidelines())
         this.toolExecutor = new ToolExecutor(catalog, this.instructionsBuilder)
+        this.sessionBus = options.sessionBus ?? new RedisPollingSessionResponseBus(redis)
+        this.busMetrics = options.busMetrics
+    }
+
+    /** Test accessor — exposes the bus so tests can deliver elicit responses. */
+    get bus(): SessionResponseBus {
+        return this.sessionBus
     }
 
     async warmup(): Promise<void> {
@@ -156,6 +180,14 @@ class McpDispatcher {
         const needsState = requests.some((r) => TRACKED_METHODS.has(r.method))
         const state = needsState ? await this.stateResolver.resolve(props) : undefined
 
+        // Single-message tools/call can upgrade to SSE if the tool handler
+        // calls `context.elicit()`. Batches and other methods stay on the
+        // plain JSON path — server-initiated elicits don't fit the batch
+        // request/response shape and aren't valid for non-tool methods.
+        if (!wasArray && requests.length === 1 && requests[0]!.method === Method.ToolsCall) {
+            return await this.dispatchToolsCallWithMaybeSse(requests[0]!, props, state!, req.signal)
+        }
+
         if (!wasArray && requests.length === 1) {
             const result = await this.dispatch(requests[0]!, props, state)
             return new Response(JSON.stringify(result), {
@@ -169,6 +201,110 @@ class McpDispatcher {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
         })
+    }
+
+    /**
+     * Dispatch a single `tools/call` request that may surface an elicit.
+     *
+     * Runs the tool handler concurrently with a watcher for the first elicit.
+     * Whichever finishes first decides the response shape:
+     * - **Handler completes first** → return plain JSON, exactly as the
+     *   pre-elicit code path did. Zero extra cost when no elicit fires.
+     * - **First elicit fires first** → return the SSE response immediately
+     *   (already carrying the `elicitation/create` message). Continue
+     *   awaiting the handler in the background; when it resolves, write
+     *   the final JSONRPC result to the SSE stream and close it.
+     */
+    private async dispatchToolsCallWithMaybeSse(
+        request: JSONRPCRequest,
+        props: RequestProperties,
+        state: ResolvedState,
+        requestSignal: AbortSignal
+    ): Promise<Response> {
+        const { id, params } = request
+
+        const binding = new ElicitBinding({
+            bus: this.sessionBus,
+            createSseHandle: async () => createSseResponse(),
+            requestSignal,
+            ...(this.busMetrics !== undefined ? { gatewayOptions: { metrics: this.busMetrics } } : {}),
+        })
+        state.reqCtx.setElicitBinding(binding)
+
+        type HandlerOutcome = { kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }
+        const handlerPromise: Promise<HandlerOutcome> = this.toolExecutor
+            .handleToolCall(params, props, state)
+            .then((value): HandlerOutcome => ({ kind: 'success', value }))
+            .catch((error): HandlerOutcome => ({ kind: 'error', error }))
+
+        // Wait for whichever happens first.
+        const winner = await Promise.race([
+            handlerPromise.then(() => 'handler' as const),
+            binding.firstElicit.then(() => 'elicit' as const),
+        ])
+
+        if (winner === 'handler') {
+            const outcome = await handlerPromise
+            const result = this.buildToolsCallJsonRpcResponse(id, outcome)
+            return new Response(JSON.stringify(result), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        }
+
+        // SSE path — the binding already wrote `elicitation/create` to the
+        // writer. Hand the response back to the client now; flush the
+        // handler's eventual result asynchronously.
+        const sseHandle = binding.getSseHandle()
+        if (!sseHandle) {
+            // Should never happen: firstElicit resolved but no handle was
+            // recorded. Treat as internal error.
+            const fallback = jsonRpcMethodError(id, ErrorCode.InternalError, 'Internal error')
+            return new Response(JSON.stringify(fallback), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        }
+
+        void this.finalizeSseResponse(sseHandle, id, handlerPromise)
+        return sseHandle.response
+    }
+
+    /**
+     * Wait for the tool handler to complete, then write the final JSONRPC
+     * result (or error) to the SSE writer and close the stream. Errors
+     * during the writes themselves are swallowed — the client has already
+     * disconnected at that point.
+     */
+    private async finalizeSseResponse(
+        sseHandle: SseResponseHandle,
+        id: number | string,
+        handlerPromise: Promise<{ kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }>
+    ): Promise<void> {
+        try {
+            const outcome = await handlerPromise
+            const result = this.buildToolsCallJsonRpcResponse(id, outcome)
+            await sseHandle.writer.write(result)
+        } catch (error) {
+            console.error('[McpDispatcher] SSE finalize failed:', error)
+        } finally {
+            try {
+                await sseHandle.writer.close()
+            } catch {
+                /* already closed */
+            }
+        }
+    }
+
+    private buildToolsCallJsonRpcResponse(
+        id: number | string,
+        outcome: { kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }
+    ): JsonRpcResponse {
+        if (outcome.kind === 'success') {
+            return jsonRpcResult(id, outcome.value)
+        }
+        console.error('[McpDispatcher] Internal error:', outcome.error)
+        return jsonRpcMethodError(id, ErrorCode.InternalError, 'Internal error')
     }
 
     private async dispatch(

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -146,7 +146,15 @@ class McpDispatcher {
         this.capabilityStore = options.capabilityStore ?? new CapabilityStore(redis)
     }
 
-    /** Test accessor — exposes the bus so tests can deliver elicit responses. */
+    /**
+     * Production delivery seam for inbound JSONRPC responses.
+     *
+     * The streamable handler classifies an inbound POST body and, when it's a
+     * response to a server-initiated request (today: `elicitation/create`),
+     * calls `dispatcher.bus.deliver(id, payload)` to route it to whichever
+     * pod is parked on the matching await. Tests also use this accessor to
+     * inject replies into the bus directly.
+     */
     get bus(): SessionResponseBus {
         return this.sessionBus
     }

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -23,6 +23,7 @@ import type { RequestProperties } from '@/lib/request-properties'
 
 import { trackInitEvent } from './analytics'
 import type { RedisLike } from './cache/RedisCache'
+import { CapabilityStore, projectClientCapabilities, supportsAnyElicitation } from './capability-store'
 import { getEnv } from './constants'
 import { ElicitBinding } from './elicit-binding'
 import { InstructionsBuilder } from './instructions'
@@ -113,6 +114,12 @@ export interface McpDispatcherOptions {
      * Per-await metrics adapter (e.g. Prometheus). Defaults to no-op.
      */
     busMetrics?: BusAwaitMetrics
+    /**
+     * Per-token cache of `initialize` capabilities. Defaults to a
+     * Redis-backed store using the same `RedisLike` client. Tests can inject
+     * a stub backed by an in-memory Map.
+     */
+    capabilityStore?: CapabilityStore
 }
 
 class McpDispatcher {
@@ -123,6 +130,7 @@ class McpDispatcher {
     private readonly instructionsBuilder: InstructionsBuilder
     private readonly sessionBus: SessionResponseBus
     private readonly busMetrics: BusAwaitMetrics | undefined
+    private readonly capabilityStore: CapabilityStore
 
     private warmupPromise: Promise<void> | undefined
 
@@ -135,6 +143,7 @@ class McpDispatcher {
         this.toolExecutor = new ToolExecutor(catalog, this.instructionsBuilder)
         this.sessionBus = options.sessionBus ?? new RedisPollingSessionResponseBus(redis)
         this.busMetrics = options.busMetrics
+        this.capabilityStore = options.capabilityStore ?? new CapabilityStore(redis)
     }
 
     /** Test accessor — exposes the bus so tests can deliver elicit responses. */
@@ -223,6 +232,31 @@ class McpDispatcher {
     ): Promise<Response> {
         const { id, params } = request
 
+        // Only install the elicit binding when the client declared elicitation
+        // support at initialize. Otherwise leave `Context.elicit` undefined —
+        // tool handlers checking `if (context.elicit)` see the truthful answer
+        // and fall back, no SSE round-trip required. This is the spec-compliant
+        // gate; without it we'd push a server-initiated request the client
+        // never agreed to support.
+        const caps = await this.capabilityStore.get(props.userHash)
+        const elicitAllowed = supportsAnyElicitation(caps)
+
+        type HandlerOutcome = { kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }
+
+        if (!elicitAllowed) {
+            // Fast path: no binding, no SSE possible. Behaves exactly like a
+            // pre-elicit tool call.
+            const outcome: HandlerOutcome = await this.toolExecutor
+                .handleToolCall(params, props, state)
+                .then((value): HandlerOutcome => ({ kind: 'success', value }))
+                .catch((error): HandlerOutcome => ({ kind: 'error', error }))
+            const result = this.buildToolsCallJsonRpcResponse(id, outcome)
+            return new Response(JSON.stringify(result), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        }
+
         const binding = new ElicitBinding({
             bus: this.sessionBus,
             createSseHandle: async () => createSseResponse(),
@@ -231,7 +265,6 @@ class McpDispatcher {
         })
         state.reqCtx.setElicitBinding(binding)
 
-        type HandlerOutcome = { kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }
         const handlerPromise: Promise<HandlerOutcome> = this.toolExecutor
             .handleToolCall(params, props, state)
             .then((value): HandlerOutcome => ({ kind: 'success', value }))
@@ -351,6 +384,15 @@ class McpDispatcher {
             const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion)
                 ? requestedVersion
                 : LATEST_PROTOCOL_VERSION
+
+            // Cache the client's declared capabilities so subsequent stateless
+            // requests can gate server-initiated calls (elicitation/create
+            // today). Always overwrite so a re-initialize with FEWER
+            // capabilities than a prior session correctly downgrades the
+            // cached state. Best-effort write: a Redis blip just costs an
+            // extra fail-closed bounce on the next tool/call.
+            const projectedCaps = projectClientCapabilities(params?.['capabilities'])
+            await this.capabilityStore.set(props.userHash, projectedCaps)
 
             const instructions = await this.instructionsBuilder.build(props, state)
 

--- a/services/mcp/src/hono/elicit-binding.ts
+++ b/services/mcp/src/hono/elicit-binding.ts
@@ -1,0 +1,120 @@
+/**
+ * Per-request binding that connects a tool handler's `context.elicit()` call
+ * to the dispatcher's response writer.
+ *
+ * The dispatcher knows: the session bus, the request signal, and how to
+ * create an SSE response when one is needed. The tool handler only sees
+ * `Context.elicit(params)`. This binding is the seam.
+ *
+ * Lifecycle:
+ *
+ * 1. Dispatcher constructs `ElicitBinding` for a `tools/call` request and
+ *    installs it on the `RequestContext` via `setElicitBinding`.
+ * 2. Dispatcher races the tool handler's promise against `firstElicit`.
+ * 3. If the tool handler finishes first (no elicit), dispatcher returns
+ *    plain JSON — same path as today.
+ * 4. If `firstElicit` resolves first, dispatcher retrieves the `SseResponseHandle`
+ *    via `getSseHandle()` and returns its `response`. The dispatcher then
+ *    awaits the still-running tool handler in the background and writes
+ *    the final tool-call result (or error) to the same SSE stream before
+ *    closing it.
+ *
+ * The binding ensures elicits are serialized through a single SSE writer
+ * even when a tool handler invokes elicit multiple times.
+ */
+
+import type { ElicitRequestFormParams, ElicitResult } from '@modelcontextprotocol/sdk/types.js'
+
+import {
+    ElicitationGateway,
+    type ElicitationGatewayOptions,
+    type SessionResponseBus,
+    type TransportMessageSender,
+} from './session-bus'
+import type { SseResponseHandle } from './sse-response'
+
+export interface ElicitBindingDeps {
+    /** Cross-pod response bus. */
+    bus: SessionResponseBus
+    /**
+     * Lazily produce the SSE response handle for this request. The binding
+     * calls this once on the first elicit invocation, at which point the
+     * in-flight HTTP response transitions from JSON to SSE.
+     */
+    createSseHandle: () => Promise<SseResponseHandle>
+    /**
+     * The originating HTTP request's AbortSignal — propagates client
+     * disconnects into any pending elicit awaits.
+     */
+    requestSignal?: AbortSignal
+    /** Optional gateway-level options (metrics, default timeout). */
+    gatewayOptions?: ElicitationGatewayOptions
+}
+
+export class ElicitBinding {
+    private gatewayPromise: Promise<ElicitationGateway> | undefined
+    private sseHandle: SseResponseHandle | undefined
+
+    private firstElicitResolve!: () => void
+    /**
+     * Resolves the first time a tool handler invokes `elicit()`. The
+     * dispatcher races this against the tool handler's completion promise
+     * to decide whether to return a plain JSON response or upgrade to SSE.
+     */
+    readonly firstElicit: Promise<void>
+
+    constructor(private readonly deps: ElicitBindingDeps) {
+        this.firstElicit = new Promise((resolve) => {
+            this.firstElicitResolve = resolve
+        })
+    }
+
+    /**
+     * Invoke an elicit. Lazily upgrades the response to SSE on first call,
+     * sends the `elicitation/create` message, and parks on the bus until
+     * the client responds (or until timeout / abort).
+     */
+    async invoke(
+        params: ElicitRequestFormParams,
+        options?: { timeoutMs?: number; signal?: AbortSignal }
+    ): Promise<ElicitResult> {
+        const gateway = await this.getGateway()
+        const callOptions: { timeoutMs?: number; signal?: AbortSignal } = {}
+        if (options?.timeoutMs !== undefined) {
+            callOptions.timeoutMs = options.timeoutMs
+        }
+        // Prefer the per-call signal if provided; otherwise fall back to the
+        // request-level signal so client disconnects propagate.
+        const signal = options?.signal ?? this.deps.requestSignal
+        if (signal !== undefined) {
+            callOptions.signal = signal
+        }
+        return gateway.elicit(params, callOptions)
+    }
+
+    /**
+     * Returns the SSE response handle if the dispatcher upgraded the
+     * response, otherwise `undefined`. The dispatcher reads this after
+     * `firstElicit` resolves to obtain the streaming Response object.
+     */
+    getSseHandle(): SseResponseHandle | undefined {
+        return this.sseHandle
+    }
+
+    private async getGateway(): Promise<ElicitationGateway> {
+        if (!this.gatewayPromise) {
+            this.gatewayPromise = (async () => {
+                const handle = await this.deps.createSseHandle()
+                this.sseHandle = handle
+                this.firstElicitResolve()
+                const sender: TransportMessageSender = {
+                    async send(message) {
+                        await handle.writer.write(message)
+                    },
+                }
+                return new ElicitationGateway(this.deps.bus, sender, this.deps.gatewayOptions ?? {})
+            })()
+        }
+        return this.gatewayPromise
+    }
+}

--- a/services/mcp/src/hono/metrics.ts
+++ b/services/mcp/src/hono/metrics.ts
@@ -103,4 +103,27 @@ export function routeLabel(pathname: string): string {
     return 'other'
 }
 
+// Cross-pod elicitation correlation via the SessionResponseBus. These trace the
+// human-in-the-loop latency: how long pods sit on a parked `bus.await` between
+// sending an `elicitation/create` and the client's response landing (possibly
+// on a different pod). A spike in `timeout` is the leading indicator of clients
+// not honoring elicitation; `unhealthy` flags Redis or schema issues.
+export const sessionBusAwaitsTotal = new Counter({
+    name: 'mcp_session_bus_awaits_total',
+    help: 'Total session-response bus awaits, broken down by outcome.',
+    labelNames: ['outcome'] as const,
+})
+
+export const sessionBusAwaitDurationSeconds = new Histogram({
+    name: 'mcp_session_bus_await_duration_seconds',
+    help: 'Time from session-bus await start to resolution.',
+    labelNames: ['outcome'] as const,
+    buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300],
+})
+
+export const sessionBusPollsTotal = new Counter({
+    name: 'mcp_session_bus_polls_total',
+    help: 'Total Redis GETs performed by the polling session-response bus.',
+})
+
 export { register }

--- a/services/mcp/src/hono/metrics.ts
+++ b/services/mcp/src/hono/metrics.ts
@@ -126,4 +126,14 @@ export const sessionBusPollsTotal = new Counter({
     help: 'Total Redis GETs performed by the polling session-response bus.',
 })
 
+// CapabilityStore cache observations. A low hit rate after warm-up is the
+// signal that initialize-driven capability caching isn't sticking — either
+// because clients aren't re-initializing or the TTL is too short. `stale`
+// counts corrupt-JSON reads (treated as miss for fail-closed reasons).
+export const clientCapabilityCacheTotal = new Counter({
+    name: 'mcp_client_capability_cache_total',
+    help: 'CapabilityStore reads, broken down by result.',
+    labelNames: ['result'] as const,
+})
+
 export { register }

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -133,19 +133,26 @@ export class RequestContext {
             const distinctId = await this.getDistinctId()
             await this.trackEvent(event, properties, analyticsContext, undefined, distinctId, this.props)
         }
-        // Read the binding lazily — the dispatcher may set it after this
-        // method returns. The closure captures `this`, not the current value.
+        // `Context.elicit` is exposed as a getter so `if (context.elicit)`
+        // tracks the current binding state. The dispatcher installs (or omits)
+        // the binding AFTER this method returns, depending on the client's
+        // initialize-declared capability. Tool authors get the spec-correct
+        // capability check: `undefined` when no binding, a callable when one
+        // is installed.
         const self = this
-        const elicit: Context['elicit'] = (params, options) => {
-            const binding = self.elicitBinding
-            if (!binding) {
-                throw new Error(
-                    'Elicit is not available in this request context. The dispatcher only installs the elicit binding for tools/call.'
-                )
-            }
-            return binding.invoke(params, options)
-        }
-        return { ...partialContext, trackEvent, elicit }
+        const ctx: Context = { ...partialContext, trackEvent }
+        Object.defineProperty(ctx, 'elicit', {
+            enumerable: true,
+            configurable: false,
+            get(): Context['elicit'] {
+                const binding = self.elicitBinding
+                if (!binding) {
+                    return undefined
+                }
+                return (params, options) => binding.invoke(params, options)
+            },
+        })
+        return ctx
     }
 
     async getAnalyticsContextSafe(context: Pick<Context, 'stateManager'>): Promise<MCPAnalyticsContext | undefined> {

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -1,13 +1,13 @@
 import { ApiClient } from '@/api/client'
 import { MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { wrapError } from '@/lib/errors'
+import { getPostHogClient } from '@/lib/posthog'
 import {
     AnalyticsEvent,
     buildMCPAnalyticsGroups,
     buildMCPContextProperties,
     type MCPAnalyticsContext,
 } from '@/lib/posthog/analytics'
-import { getPostHogClient } from '@/lib/posthog'
 import type { RequestProperties } from '@/lib/request-properties'
 import { SessionManager } from '@/lib/SessionManager'
 import { StateManager } from '@/lib/StateManager'
@@ -15,6 +15,7 @@ import type { Context, Env, State } from '@/tools/types'
 
 import { RedisCache, type RedisLike } from './cache/RedisCache'
 import { getCustomApiBaseUrl } from './constants'
+import type { ElicitBinding } from './elicit-binding'
 
 export class RequestContext {
     private cacheInstance: RedisCache<State> | undefined
@@ -24,11 +25,26 @@ export class RequestContext {
     private readonly redis: RedisLike
     private readonly env: Env
     private readonly props: RequestProperties
+    /**
+     * Per-request slot the dispatcher fills in before invoking a tool
+     * handler. The `Context.elicit` closure reads this lazily, so the
+     * binding may be set either before or after `getContext()` runs.
+     */
+    private elicitBinding: ElicitBinding | undefined
 
     constructor(redis: RedisLike, env: Env, props: RequestProperties) {
         this.redis = redis
         this.env = env
         this.props = props
+    }
+
+    /**
+     * Install (or replace) the elicit binding for this request. Called by
+     * the dispatcher for tool-call requests; no-op for other JSONRPC
+     * methods that can't surface elicits.
+     */
+    setElicitBinding(binding: ElicitBinding | undefined): void {
+        this.elicitBinding = binding
     }
 
     get cache(): RedisCache<State> {
@@ -104,7 +120,7 @@ export class RequestContext {
     async getContext(): Promise<Context> {
         const api = await this.api()
         const stateManager = new StateManager(this.cache, api)
-        const partialContext: Omit<Context, 'trackEvent'> = {
+        const partialContext: Omit<Context, 'trackEvent' | 'elicit'> = {
             api,
             cache: this.cache,
             env: this.env,
@@ -117,7 +133,19 @@ export class RequestContext {
             const distinctId = await this.getDistinctId()
             await this.trackEvent(event, properties, analyticsContext, undefined, distinctId, this.props)
         }
-        return { ...partialContext, trackEvent }
+        // Read the binding lazily — the dispatcher may set it after this
+        // method returns. The closure captures `this`, not the current value.
+        const self = this
+        const elicit: Context['elicit'] = (params, options) => {
+            const binding = self.elicitBinding
+            if (!binding) {
+                throw new Error(
+                    'Elicit is not available in this request context. The dispatcher only installs the elicit binding for tools/call.'
+                )
+            }
+            return binding.invoke(params, options)
+        }
+        return { ...partialContext, trackEvent, elicit }
     }
 
     async getAnalyticsContextSafe(context: Pick<Context, 'stateManager'>): Promise<MCPAnalyticsContext | undefined> {

--- a/services/mcp/src/hono/session-bus/adaptive-poll.ts
+++ b/services/mcp/src/hono/session-bus/adaptive-poll.ts
@@ -1,0 +1,66 @@
+/**
+ * Polling cadence schedule for the Redis-backed bus.
+ *
+ * The schedule is intentionally a tiny, pure data structure rather than a
+ * loop or generator — that makes it trivial to unit-test (a few asserts on
+ * the output of `nextDelay`) and lets the bus's polling loop stay
+ * single-purpose.
+ *
+ * Cadence chosen to match how users interact with confirmation modals:
+ * - The first ~5 seconds, poll fast (200ms). Most clicks land here.
+ * - After that, slow to 1s/poll — the user is reading, thinking, or AFK.
+ *
+ * This is a heuristic, not a science. The numbers can be tuned without
+ * any change to the bus contract.
+ */
+
+export interface AdaptivePollSchedule {
+    /**
+     * Compute the delay (ms) before the next poll, given the time elapsed
+     * since the await started.
+     */
+    nextDelay(elapsedMs: number): number
+}
+
+export interface AdaptivePollConfig {
+    /** Delay during the "hot" window (first {@link hotWindowMs} ms). */
+    hotIntervalMs: number
+    /** Delay after the hot window. */
+    coolIntervalMs: number
+    /** Duration of the hot window in ms. */
+    hotWindowMs: number
+}
+
+export const DEFAULT_ADAPTIVE_POLL_CONFIG: AdaptivePollConfig = {
+    hotIntervalMs: 200,
+    coolIntervalMs: 1_000,
+    hotWindowMs: 5_000,
+}
+
+export function createAdaptivePollSchedule(
+    config: AdaptivePollConfig = DEFAULT_ADAPTIVE_POLL_CONFIG
+): AdaptivePollSchedule {
+    validateConfig(config)
+    return {
+        nextDelay(elapsedMs: number): number {
+            if (elapsedMs < 0) {
+                return config.hotIntervalMs
+            }
+            return elapsedMs < config.hotWindowMs ? config.hotIntervalMs : config.coolIntervalMs
+        },
+    }
+}
+
+function validateConfig(config: AdaptivePollConfig): void {
+    if (config.hotIntervalMs <= 0 || config.coolIntervalMs <= 0) {
+        throw new Error('Poll intervals must be positive')
+    }
+    if (config.hotWindowMs < 0) {
+        throw new Error('Hot window must be non-negative')
+    }
+    if (config.hotIntervalMs > config.coolIntervalMs) {
+        throw new Error(
+            'Hot interval must be shorter than cool interval — adaptive polling exists to be faster early, not slower'
+        )
+    }
+}

--- a/services/mcp/src/hono/session-bus/elicit-result-validator.ts
+++ b/services/mcp/src/hono/session-bus/elicit-result-validator.ts
@@ -1,0 +1,32 @@
+/**
+ * Validation for `ElicitResult` payloads delivered through the session bus.
+ *
+ * The bus is intentionally schema-agnostic — it stores opaque JSON. The
+ * gateway is responsible for asserting the response actually matches the
+ * MCP `ElicitResult` shape before handing it to a caller who's awaiting an
+ * elicit result.
+ *
+ * We reuse the SDK's Zod schema rather than hand-rolling: it stays in sync
+ * with the upstream MCP spec for free. (Zod, not AJV — there's no
+ * `new Function()` involved either way, but reusing the SDK's exported
+ * schema keeps us aligned with the protocol version the SDK targets.)
+ */
+
+import { ElicitResultSchema, type ElicitResult } from '@modelcontextprotocol/sdk/types.js'
+
+import { SessionBusUnhealthyError } from './errors'
+
+export function validateElicitResult(raw: unknown): ElicitResult {
+    const parsed = ElicitResultSchema.safeParse(raw)
+    if (!parsed.success) {
+        // Treat a bad payload as a bus-level problem rather than a normal
+        // decline/cancel. If we ever see this in production it means a
+        // client is sending malformed elicitation responses — that's a
+        // protocol violation, not a user choice. Fail closed.
+        throw new SessionBusUnhealthyError(
+            `Elicitation response payload did not match the ElicitResult schema: ${parsed.error.message}`,
+            { cause: parsed.error }
+        )
+    }
+    return parsed.data
+}

--- a/services/mcp/src/hono/session-bus/elicit-result-validator.ts
+++ b/services/mcp/src/hono/session-bus/elicit-result-validator.ts
@@ -1,32 +1,60 @@
 /**
  * Validation for `ElicitResult` payloads delivered through the session bus.
  *
- * The bus is intentionally schema-agnostic — it stores opaque JSON. The
- * gateway is responsible for asserting the response actually matches the
- * MCP `ElicitResult` shape before handing it to a caller who's awaiting an
- * elicit result.
+ * The bus is schema-agnostic — it stores opaque JSON shaped however the
+ * streamable handler classified the inbound POST. Three shapes can arrive:
  *
- * We reuse the SDK's Zod schema rather than hand-rolling: it stays in sync
- * with the upstream MCP spec for free. (Zod, not AJV — there's no
- * `new Function()` involved either way, but reusing the SDK's exported
- * schema keeps us aligned with the protocol version the SDK targets.)
+ * 1. A valid `ElicitResult` (`{ action, content? }`) — the user accepted,
+ *    declined, or canceled. Return it.
+ * 2. A JSON-RPC error envelope (`{ error: { code, message, ... } }`) — the
+ *    client is signalling at the protocol layer that it can't handle the
+ *    request (typically `-32601 Method not found` for clients that didn't
+ *    advertise elicitation support, or `-32602 Invalid params` for mode
+ *    mismatches). This is a normal, expected protocol signal — surface it
+ *    as `ElicitationNotSupportedError` so callers can fall back gracefully
+ *    and observability doesn't treat it as a bus health incident.
+ * 3. Anything else (malformed, missing required fields, wrong types) is a
+ *    genuine bus health problem and stays under `SessionBusUnhealthyError`.
  */
 
 import { ElicitResultSchema, type ElicitResult } from '@modelcontextprotocol/sdk/types.js'
 
-import { SessionBusUnhealthyError } from './errors'
+import { ElicitationNotSupportedError, SessionBusUnhealthyError } from './errors'
+
+interface JsonRpcErrorEnvelope {
+    error: {
+        code: number
+        message: string
+    }
+}
 
 export function validateElicitResult(raw: unknown): ElicitResult {
+    const jsonRpcError = asJsonRpcErrorEnvelope(raw)
+    if (jsonRpcError !== undefined) {
+        throw new ElicitationNotSupportedError(jsonRpcError.error.code, jsonRpcError.error.message)
+    }
     const parsed = ElicitResultSchema.safeParse(raw)
     if (!parsed.success) {
-        // Treat a bad payload as a bus-level problem rather than a normal
-        // decline/cancel. If we ever see this in production it means a
-        // client is sending malformed elicitation responses — that's a
-        // protocol violation, not a user choice. Fail closed.
         throw new SessionBusUnhealthyError(
             `Elicitation response payload did not match the ElicitResult schema: ${parsed.error.message}`,
             { cause: parsed.error }
         )
     }
     return parsed.data
+}
+
+function asJsonRpcErrorEnvelope(raw: unknown): JsonRpcErrorEnvelope | undefined {
+    if (raw === null || typeof raw !== 'object') {
+        return undefined
+    }
+    const obj = raw as Record<string, unknown>
+    const error = obj['error']
+    if (error === null || typeof error !== 'object') {
+        return undefined
+    }
+    const errObj = error as Record<string, unknown>
+    if (typeof errObj['code'] !== 'number' || typeof errObj['message'] !== 'string') {
+        return undefined
+    }
+    return { error: { code: errObj['code'], message: errObj['message'] } }
 }

--- a/services/mcp/src/hono/session-bus/elicitation-gateway.ts
+++ b/services/mcp/src/hono/session-bus/elicitation-gateway.ts
@@ -1,0 +1,96 @@
+/**
+ * MCP-specific glue between the elicit call site and the session bus.
+ *
+ * This is the only file in `session-bus/` that knows about MCP. The bus
+ * itself is generic — anything below this layer treats payloads as opaque
+ * JSON keyed by JSONRPC request id.
+ *
+ * Why we don't use the SDK's `Server.request()` / `elicitInput()` here:
+ * the Hono dispatcher is a hand-rolled JSON-RPC server (it does not
+ * instantiate `McpServer`). The SDK's per-process pending-request map
+ * isn't in play at all. We emit `elicitation/create` directly via a
+ * caller-supplied `TransportMessageSender` (the SSE writer for the
+ * current request) and park on the bus until the client POSTs a response
+ * that the streamable handler routes via `bus.deliver`.
+ */
+
+import type { ElicitRequestFormParams, ElicitResult } from '@modelcontextprotocol/sdk/types.js'
+
+import { validateElicitResult } from './elicit-result-validator'
+import type { BusAwaitMetrics, SessionResponseBus } from './types'
+
+/**
+ * Sends raw JSONRPC messages to the client.
+ *
+ * Decoupled from any specific transport. The concrete implementation in
+ * `dispatcher.ts` wraps the per-request SSE writer.
+ */
+export interface TransportMessageSender {
+    /** Push a JSONRPC request message to the client. */
+    send(message: JsonRpcRequestMessage): Promise<void>
+}
+
+export interface JsonRpcRequestMessage {
+    jsonrpc: '2.0'
+    id: string
+    method: string
+    params: unknown
+}
+
+export interface ElicitationGatewayOptions {
+    /** Default deadline for an elicit. May be overridden per call. */
+    defaultTimeoutMs?: number
+    /** Optional metrics hook applied to every await. */
+    metrics?: BusAwaitMetrics
+}
+
+export interface ElicitCallOptions {
+    /** Override the gateway's default timeout for this call. */
+    timeoutMs?: number
+    /** Abort the elicit immediately when this signal fires. The originating
+     *  HTTP request's `AbortSignal` is the typical source. */
+    signal?: AbortSignal
+}
+
+/** Default elicit timeout. 5 minutes — comfortable for human interaction. */
+const DEFAULT_ELICIT_TIMEOUT_MS = 5 * 60 * 1000
+
+export class ElicitationGateway {
+    constructor(
+        private readonly bus: SessionResponseBus,
+        private readonly sender: TransportMessageSender,
+        private readonly options: ElicitationGatewayOptions = {}
+    ) {}
+
+    /**
+     * Send an `elicitation/create` request to the client and await its
+     * response via the session bus.
+     *
+     * Throws (no recovery):
+     * - `SessionBusTimeoutError` if no response within the deadline.
+     * - `SessionBusAbortedError` if `options.signal` aborts.
+     * - `SessionBusUnhealthyError` if the bus or the validation step fails.
+     */
+    async elicit(params: ElicitRequestFormParams, options: ElicitCallOptions = {}): Promise<ElicitResult> {
+        const requestId = crypto.randomUUID()
+        const timeoutMs = options.timeoutMs ?? this.options.defaultTimeoutMs ?? DEFAULT_ELICIT_TIMEOUT_MS
+
+        await this.sender.send({
+            jsonrpc: '2.0',
+            id: requestId,
+            method: 'elicitation/create',
+            params: params as unknown,
+        })
+
+        const awaitOptions: import('./types').AwaitOptions = { timeoutMs }
+        if (options.signal !== undefined) {
+            awaitOptions.signal = options.signal
+        }
+        if (this.options.metrics !== undefined) {
+            awaitOptions.metrics = this.options.metrics
+        }
+        const raw = await this.bus.await<unknown>(requestId, awaitOptions)
+
+        return validateElicitResult(raw)
+    }
+}

--- a/services/mcp/src/hono/session-bus/elicitation-gateway.ts
+++ b/services/mcp/src/hono/session-bus/elicitation-gateway.ts
@@ -17,6 +17,7 @@
 import type { ElicitRequestFormParams, ElicitResult } from '@modelcontextprotocol/sdk/types.js'
 
 import { validateElicitResult } from './elicit-result-validator'
+import { ElicitationNotSupportedError } from './errors'
 import type { BusAwaitMetrics, SessionResponseBus } from './types'
 
 /**
@@ -55,6 +56,14 @@ export interface ElicitCallOptions {
 /** Default elicit timeout. 5 minutes — comfortable for human interaction. */
 const DEFAULT_ELICIT_TIMEOUT_MS = 5 * 60 * 1000
 
+function safeMetric(fn: () => void): void {
+    try {
+        fn()
+    } catch {
+        /* metrics must never affect gateway behavior */
+    }
+}
+
 export class ElicitationGateway {
     constructor(
         private readonly bus: SessionResponseBus,
@@ -69,7 +78,13 @@ export class ElicitationGateway {
      * Throws (no recovery):
      * - `SessionBusTimeoutError` if no response within the deadline.
      * - `SessionBusAbortedError` if `options.signal` aborts.
-     * - `SessionBusUnhealthyError` if the bus or the validation step fails.
+     * - `ElicitationNotSupportedError` if the client returned a JSON-RPC error
+     *   envelope (e.g. `-32601 Method not found` from a client that didn't
+     *   advertise elicitation support). Tool authors should catch this and
+     *   fall back to a non-interactive path (typically: refuse the operation
+     *   and return an instructional message).
+     * - `SessionBusUnhealthyError` if the bus transport fails or the payload
+     *   is structurally invalid (not a result, not a JSON-RPC error envelope).
      */
     async elicit(params: ElicitRequestFormParams, options: ElicitCallOptions = {}): Promise<ElicitResult> {
         const requestId = crypto.randomUUID()
@@ -91,6 +106,13 @@ export class ElicitationGateway {
         }
         const raw = await this.bus.await<unknown>(requestId, awaitOptions)
 
-        return validateElicitResult(raw)
+        try {
+            return validateElicitResult(raw)
+        } catch (error) {
+            if (error instanceof ElicitationNotSupportedError) {
+                safeMetric(() => this.options.metrics?.onNotSupported?.(requestId, error.code))
+            }
+            throw error
+        }
     }
 }

--- a/services/mcp/src/hono/session-bus/errors.ts
+++ b/services/mcp/src/hono/session-bus/errors.ts
@@ -34,3 +34,24 @@ export class SessionBusUnhealthyError extends Error {
         }
     }
 }
+
+/**
+ * The client returned a JSON-RPC error response to a server-initiated request
+ * (today: `elicitation/create`). This is a *legitimate* protocol signal — the
+ * client is telling us it doesn't support the requested operation or rejected
+ * it at the protocol layer — not a bus health problem. Distinguishing this
+ * from `SessionBusUnhealthyError` lets observability avoid false health
+ * incidents and lets tool authors fall back gracefully.
+ *
+ * Carries the JSON-RPC error code (e.g. `-32601` Method not found, `-32602`
+ * for unsupported elicit mode) so callers can branch on it.
+ */
+export class ElicitationNotSupportedError extends Error {
+    readonly code: number
+
+    constructor(code: number, message: string) {
+        super(`Client rejected elicitation/create (code=${code}): ${message}`)
+        this.name = 'ElicitationNotSupportedError'
+        this.code = code
+    }
+}

--- a/services/mcp/src/hono/session-bus/errors.ts
+++ b/services/mcp/src/hono/session-bus/errors.ts
@@ -1,0 +1,36 @@
+/**
+ * Errors thrown by the SessionResponseBus and its consumers.
+ *
+ * Every error in this module is a structured failure of a cross-pod
+ * server-initiated request/response correlation. Callers should branch on
+ * these classes rather than parsing messages.
+ */
+
+export class SessionBusTimeoutError extends Error {
+    constructor(requestId: string | number, timeoutMs: number) {
+        super(
+            `No response for request=${requestId} within ${timeoutMs}ms. ` +
+                `The client may have closed the modal without acting, or never received the request.`
+        )
+        this.name = 'SessionBusTimeoutError'
+    }
+}
+
+export class SessionBusAbortedError extends Error {
+    constructor(reason: string) {
+        super(`Session bus await was aborted: ${reason}`)
+        this.name = 'SessionBusAbortedError'
+    }
+}
+
+export class SessionBusUnhealthyError extends Error {
+    constructor(message: string, options?: { cause?: unknown }) {
+        super(message)
+        this.name = 'SessionBusUnhealthyError'
+        if (options?.cause !== undefined) {
+            // Manual assignment for compatibility with TS libs that don't expose
+            // the ES2022 `Error(msg, { cause })` constructor overload.
+            ;(this as Error & { cause?: unknown }).cause = options.cause
+        }
+    }
+}

--- a/services/mcp/src/hono/session-bus/in-memory-bus.ts
+++ b/services/mcp/src/hono/session-bus/in-memory-bus.ts
@@ -21,7 +21,6 @@ interface ParkedAwait {
 
 interface PendingDelivery {
     payload: unknown
-    expiresAt: number
     cleanupTimer: ReturnType<typeof setTimeout>
 }
 
@@ -106,13 +105,12 @@ export class InMemorySessionResponseBus implements SessionResponseBus {
         if (existing !== undefined) {
             clearTimeout(existing.cleanupTimer)
         }
-        const expiresAt = Date.now() + EARLY_DELIVERY_TTL_MS
         const cleanupTimer = setTimeout(() => {
             this.earlyDeliveries.delete(key)
         }, EARLY_DELIVERY_TTL_MS)
         // unref so tests don't hang on the timer
         cleanupTimer.unref?.()
-        this.earlyDeliveries.set(key, { payload, expiresAt, cleanupTimer })
+        this.earlyDeliveries.set(key, { payload, cleanupTimer })
         return Promise.resolve()
     }
 

--- a/services/mcp/src/hono/session-bus/in-memory-bus.ts
+++ b/services/mcp/src/hono/session-bus/in-memory-bus.ts
@@ -1,0 +1,161 @@
+/**
+ * In-process implementation of `SessionResponseBus`.
+ *
+ * Designed for two consumers:
+ * 1. **Tests** — deterministic, no I/O, no Redis dependency.
+ * 2. **Single-pod dev** — when `REDIS_URL` is unset and the operator opts
+ *    into in-memory mode explicitly. Not safe for multi-pod production.
+ *
+ * Awaits are stored in a `Map` keyed by JSONRPC request id. Deliveries
+ * before any awaiter is registered are also held briefly under the same key
+ * (60s) so the typical await→deliver race is forgiving in both orderings.
+ */
+
+import { SessionBusAbortedError, SessionBusTimeoutError } from './errors'
+import type { AwaitOptions, BusAwaitMetrics, SessionResponseBus } from './types'
+
+interface ParkedAwait {
+    resolve: (payload: unknown) => void
+    reject: (err: Error) => void
+}
+
+interface PendingDelivery {
+    payload: unknown
+    expiresAt: number
+    cleanupTimer: ReturnType<typeof setTimeout>
+}
+
+/** How long an early delivery is held before any awaiter shows up. */
+const EARLY_DELIVERY_TTL_MS = 60_000
+
+export class InMemorySessionResponseBus implements SessionResponseBus {
+    private readonly awaits = new Map<string, ParkedAwait>()
+    private readonly earlyDeliveries = new Map<string, PendingDelivery>()
+
+    async await<T>(requestId: string | number, options: AwaitOptions): Promise<T> {
+        const key = buildKey(requestId)
+        const startedAt = Date.now()
+        const metrics: BusAwaitMetrics | undefined = options.metrics
+        safeMetric(() => metrics?.onAwaitStart?.(requestId))
+
+        // If a deliver() landed before us, return immediately.
+        const early = this.earlyDeliveries.get(key)
+        if (early !== undefined) {
+            clearTimeout(early.cleanupTimer)
+            this.earlyDeliveries.delete(key)
+            safeMetric(() => metrics?.onResolve?.(requestId, 0))
+            return early.payload as T
+        }
+
+        if (this.awaits.has(key)) {
+            // Two concurrent awaits on the same key would be ambiguous about who
+            // wins on deliver(). Refuse rather than silently misbehaving.
+            throw new Error(`Concurrent await for the same request=${requestId} is not supported`)
+        }
+
+        return await new Promise<T>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this.awaits.delete(key)
+                safeMetric(() => metrics?.onTimeout?.(requestId))
+                reject(new SessionBusTimeoutError(requestId, options.timeoutMs))
+            }, options.timeoutMs)
+
+            const abortHandler = (): void => {
+                clearTimeout(timer)
+                this.awaits.delete(key)
+                const reason = describeAbortReason(options.signal)
+                safeMetric(() => metrics?.onAbort?.(requestId, reason))
+                reject(new SessionBusAbortedError(reason))
+            }
+
+            if (options.signal !== undefined) {
+                if (options.signal.aborted) {
+                    abortHandler()
+                    return
+                }
+                options.signal.addEventListener('abort', abortHandler, { once: true })
+            }
+
+            this.awaits.set(key, {
+                resolve: (payload: unknown) => {
+                    clearTimeout(timer)
+                    options.signal?.removeEventListener('abort', abortHandler)
+                    safeMetric(() => metrics?.onResolve?.(requestId, Date.now() - startedAt))
+                    resolve(payload as T)
+                },
+                reject: (err: Error) => {
+                    clearTimeout(timer)
+                    options.signal?.removeEventListener('abort', abortHandler)
+                    reject(err)
+                },
+            })
+        })
+    }
+
+    deliver(requestId: string | number, payload: unknown): Promise<void> {
+        const key = buildKey(requestId)
+        const parked = this.awaits.get(key)
+        if (parked !== undefined) {
+            this.awaits.delete(key)
+            parked.resolve(payload)
+            return Promise.resolve()
+        }
+        // No awaiter yet — hold the payload briefly so a slightly-late awaiter
+        // can still pick it up. Mirrors the Redis TTL on the writer side.
+        const existing = this.earlyDeliveries.get(key)
+        if (existing !== undefined) {
+            clearTimeout(existing.cleanupTimer)
+        }
+        const expiresAt = Date.now() + EARLY_DELIVERY_TTL_MS
+        const cleanupTimer = setTimeout(() => {
+            this.earlyDeliveries.delete(key)
+        }, EARLY_DELIVERY_TTL_MS)
+        // unref so tests don't hang on the timer
+        cleanupTimer.unref?.()
+        this.earlyDeliveries.set(key, { payload, expiresAt, cleanupTimer })
+        return Promise.resolve()
+    }
+
+    /** Drain all parked awaits with the given reason. Used in shutdown. */
+    abortAll(reason: string): void {
+        for (const [key, parked] of this.awaits.entries()) {
+            this.awaits.delete(key)
+            parked.reject(new SessionBusAbortedError(reason))
+        }
+        for (const [key, delivery] of this.earlyDeliveries.entries()) {
+            clearTimeout(delivery.cleanupTimer)
+            this.earlyDeliveries.delete(key)
+        }
+    }
+
+    /** Test helper — count parked awaits. Not part of the public interface. */
+    parkedCount(): number {
+        return this.awaits.size
+    }
+}
+
+function buildKey(requestId: string | number): string {
+    return `${requestId}`
+}
+
+function describeAbortReason(signal: AbortSignal | undefined): string {
+    if (signal === undefined) {
+        return 'unknown'
+    }
+    const reason = (signal as AbortSignal & { reason?: unknown }).reason
+    if (reason instanceof Error) {
+        return reason.message
+    }
+    if (typeof reason === 'string') {
+        return reason
+    }
+    return 'aborted'
+}
+
+function safeMetric(fn: () => void): void {
+    try {
+        fn()
+    } catch {
+        // Metrics hooks must never affect the bus.
+    }
+}

--- a/services/mcp/src/hono/session-bus/index.ts
+++ b/services/mcp/src/hono/session-bus/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Public API for the Hono session-response bus.
+ *
+ * Import from `@/hono/session-bus` rather than reaching into individual
+ * files — these exports are the supported surface; everything else is an
+ * implementation detail and can change.
+ */
+
+export { SessionBusAbortedError, SessionBusTimeoutError, SessionBusUnhealthyError } from './errors'
+
+export type { AwaitOptions, BusAwaitMetrics, SessionResponseBus } from './types'
+
+export { InMemorySessionResponseBus } from './in-memory-bus'
+
+export { RedisPollingSessionResponseBus, type RedisPollingSessionResponseBusOptions } from './redis-polling-bus'
+
+export {
+    DEFAULT_ADAPTIVE_POLL_CONFIG,
+    createAdaptivePollSchedule,
+    type AdaptivePollConfig,
+    type AdaptivePollSchedule,
+} from './adaptive-poll'
+
+export {
+    ElicitationGateway,
+    type ElicitationGatewayOptions,
+    type ElicitCallOptions,
+    type JsonRpcRequestMessage,
+    type TransportMessageSender,
+} from './elicitation-gateway'
+
+export { validateElicitResult } from './elicit-result-validator'
+
+export { createPromBusMetrics } from './prom-metrics'

--- a/services/mcp/src/hono/session-bus/index.ts
+++ b/services/mcp/src/hono/session-bus/index.ts
@@ -6,7 +6,12 @@
  * implementation detail and can change.
  */
 
-export { SessionBusAbortedError, SessionBusTimeoutError, SessionBusUnhealthyError } from './errors'
+export {
+    ElicitationNotSupportedError,
+    SessionBusAbortedError,
+    SessionBusTimeoutError,
+    SessionBusUnhealthyError,
+} from './errors'
 
 export type { AwaitOptions, BusAwaitMetrics, SessionResponseBus } from './types'
 

--- a/services/mcp/src/hono/session-bus/prom-metrics.ts
+++ b/services/mcp/src/hono/session-bus/prom-metrics.ts
@@ -1,0 +1,33 @@
+/**
+ * Concrete `BusAwaitMetrics` implementation backed by the same `prom-client`
+ * registry the rest of the Hono server publishes to.
+ *
+ * Stays in this file (not in `metrics.ts`) so the bus stays a self-contained
+ * module — anyone importing from `@/hono/session-bus` only pulls in the
+ * abstraction, not the Prometheus dependency. Hono bootstrap wires this
+ * adapter explicitly.
+ */
+
+import { sessionBusAwaitDurationSeconds, sessionBusAwaitsTotal, sessionBusPollsTotal } from '../metrics'
+import type { BusAwaitMetrics } from './types'
+
+export function createPromBusMetrics(): BusAwaitMetrics {
+    return {
+        onPoll() {
+            sessionBusPollsTotal.inc()
+        },
+        onResolve(_requestId, latencyMs) {
+            sessionBusAwaitsTotal.inc({ outcome: 'resolved' })
+            sessionBusAwaitDurationSeconds.observe({ outcome: 'resolved' }, latencyMs / 1000)
+        },
+        onTimeout() {
+            sessionBusAwaitsTotal.inc({ outcome: 'timeout' })
+        },
+        onAbort() {
+            sessionBusAwaitsTotal.inc({ outcome: 'aborted' })
+        },
+        onUnhealthy() {
+            sessionBusAwaitsTotal.inc({ outcome: 'unhealthy' })
+        },
+    }
+}

--- a/services/mcp/src/hono/session-bus/prom-metrics.ts
+++ b/services/mcp/src/hono/session-bus/prom-metrics.ts
@@ -29,5 +29,12 @@ export function createPromBusMetrics(): BusAwaitMetrics {
         onUnhealthy() {
             sessionBusAwaitsTotal.inc({ outcome: 'unhealthy' })
         },
+        onNotSupported() {
+            // Refinement of `resolved`: the bus did deliver a payload, but the
+            // gateway classified it as a client capability gap. Dashboards
+            // tracking elicit health should subtract this from `resolved` to
+            // get the "user actually completed the modal" count.
+            sessionBusAwaitsTotal.inc({ outcome: 'not_supported' })
+        },
     }
 }

--- a/services/mcp/src/hono/session-bus/redis-polling-bus.ts
+++ b/services/mcp/src/hono/session-bus/redis-polling-bus.ts
@@ -137,10 +137,15 @@ export class RedisPollingSessionResponseBus implements SessionResponseBus {
     async deliver(requestId: string | number, payload: unknown): Promise<void> {
         const key = buildKey(requestId)
         const value = JSON.stringify(payload)
-        // `SET key value EX seconds` — TTL guarantees abandoned responses
-        // self-clean. Last-writer-wins is fine; the await reads exactly once.
+        // `SET key value NX EX seconds` — atomic first-writer-wins.
+        // Without NX, a second deliver (a duplicate POST, a double-click, or
+        // an attacker racing two replies) overwrites the first response after
+        // it's been stored but before the poll loop reads it, producing
+        // last-writer-wins semantics that contradict the bus contract. NX
+        // makes the second SET a no-op; the second caller's payload is
+        // silently dropped (intended — the bus is a one-shot reply channel).
         try {
-            await this.redis.set(key, value, 'EX', this.responseTtlSeconds)
+            await this.redis.set(key, value, 'EX', this.responseTtlSeconds, 'NX')
         } catch (error) {
             throw new SessionBusUnhealthyError(`Redis SET failed for request=${requestId}`, {
                 cause: error,

--- a/services/mcp/src/hono/session-bus/redis-polling-bus.ts
+++ b/services/mcp/src/hono/session-bus/redis-polling-bus.ts
@@ -1,0 +1,221 @@
+/**
+ * Production `SessionResponseBus` for the Hono deployment.
+ *
+ * Uses two of the simplest Redis primitives — `SET … EX` and `GET`/`DEL` —
+ * to bridge a parked promise on one pod with a delivered response on (possibly)
+ * another. No pub/sub, no second client, no extension to `RedisLike`.
+ *
+ * Why polling and not pub/sub:
+ * 1. Polling only happens while a confirmation modal is open — a tiny,
+ *    bursty population. At our scale the steady-state Redis traffic is
+ *    indistinguishable from idle.
+ * 2. The `RedisLike` interface in this service is intentionally minimal
+ *    (`get`/`set`/`del`/`scan`). Adding pub/sub means a second connection
+ *    and a wider interface for a sub-100ms latency win that doesn't matter
+ *    here.
+ * 3. Polling fails open in a useful way: a Redis blip causes the next poll
+ *    to retry, not a dropped subscription requiring resubscribe-and-recover
+ *    bookkeeping.
+ *
+ * If the elicit-latency profile ever changes (e.g. high-frequency
+ * automated confirmations), swap to a `PubSubSessionResponseBus` behind
+ * the same interface — call sites won't change.
+ */
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+
+import { createAdaptivePollSchedule, type AdaptivePollSchedule, DEFAULT_ADAPTIVE_POLL_CONFIG } from './adaptive-poll'
+import { SessionBusAbortedError, SessionBusTimeoutError, SessionBusUnhealthyError } from './errors'
+import type { AwaitOptions, BusAwaitMetrics, SessionResponseBus } from './types'
+
+/** Default TTL on stored response payloads. Long enough to bridge the slowest
+ *  realistic awaiter cycle (1s polling + jitter), short enough to keep Redis
+ *  clean of abandoned responses. */
+const DEFAULT_RESPONSE_TTL_SECONDS = 60
+
+/** Maximum consecutive Redis errors before the await gives up with
+ *  `SessionBusUnhealthyError`. Lower than typical infra retry budgets — we'd
+ *  rather fail closed quickly than keep a human waiting on a broken bus. */
+const DEFAULT_MAX_CONSECUTIVE_ERRORS = 5
+
+/** Namespace for all session-response keys. Keep it greppable and
+ *  stable — `redis-cli --scan --pattern "mcp:session-response:*"` is a
+ *  load-bearing debugging tool. */
+const KEY_PREFIX = 'mcp:session-response'
+
+export interface RedisPollingSessionResponseBusOptions {
+    /** Polling cadence schedule. Defaults to the adaptive default. */
+    schedule?: AdaptivePollSchedule
+    /** TTL on each delivered response, in seconds. Defaults to 60s. */
+    responseTtlSeconds?: number
+    /** Maximum consecutive Redis errors tolerated before failing the await. */
+    maxConsecutiveErrors?: number
+}
+
+export class RedisPollingSessionResponseBus implements SessionResponseBus {
+    private readonly schedule: AdaptivePollSchedule
+    private readonly responseTtlSeconds: number
+    private readonly maxConsecutiveErrors: number
+
+    constructor(
+        private readonly redis: RedisLike,
+        options: RedisPollingSessionResponseBusOptions = {}
+    ) {
+        this.schedule = options.schedule ?? createAdaptivePollSchedule(DEFAULT_ADAPTIVE_POLL_CONFIG)
+        this.responseTtlSeconds = options.responseTtlSeconds ?? DEFAULT_RESPONSE_TTL_SECONDS
+        this.maxConsecutiveErrors = options.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS
+    }
+
+    async await<T>(requestId: string | number, options: AwaitOptions): Promise<T> {
+        const key = buildKey(requestId)
+        const startedAt = Date.now()
+        const deadline = startedAt + options.timeoutMs
+        const metrics: BusAwaitMetrics | undefined = options.metrics
+        safeMetric(() => metrics?.onAwaitStart?.(requestId))
+
+        if (options.signal?.aborted === true) {
+            const reason = describeAbortReason(options.signal)
+            safeMetric(() => metrics?.onAbort?.(requestId, reason))
+            throw new SessionBusAbortedError(reason)
+        }
+
+        let consecutiveErrors = 0
+
+        // Single poll loop — short, deliberately stateless between iterations.
+        // All early-exit conditions live in `checkExit`.
+        while (true) {
+            const exit = checkExit(deadline, options.signal)
+            if (exit !== null) {
+                if (exit.kind === 'timeout') {
+                    safeMetric(() => metrics?.onTimeout?.(requestId))
+                    throw new SessionBusTimeoutError(requestId, options.timeoutMs)
+                }
+                safeMetric(() => metrics?.onAbort?.(requestId, exit.reason))
+                throw new SessionBusAbortedError(exit.reason)
+            }
+
+            safeMetric(() => metrics?.onPoll?.(requestId))
+
+            let raw: string | null
+            try {
+                raw = await this.redis.get(key)
+                consecutiveErrors = 0
+            } catch (error) {
+                consecutiveErrors++
+                if (consecutiveErrors >= this.maxConsecutiveErrors) {
+                    safeMetric(() => metrics?.onUnhealthy?.(requestId, error))
+                    throw new SessionBusUnhealthyError(
+                        `Redis GET failed ${consecutiveErrors} consecutive times for request=${requestId}`,
+                        { cause: error }
+                    )
+                }
+                // Fall through to sleep-and-retry — a transient Redis blip
+                // shouldn't break a 5-minute human-interactive await.
+                raw = null
+            }
+
+            if (raw !== null) {
+                // Deliver-then-DEL gives one-shot semantics. Best-effort: a
+                // failed DEL just lets the value linger until its TTL expires.
+                this.redis.del(key).catch(() => {
+                    /* swallow */
+                })
+                safeMetric(() => metrics?.onResolve?.(requestId, Date.now() - startedAt))
+                return parsePayload<T>(raw)
+            }
+
+            const elapsedMs = Date.now() - startedAt
+            const remainingMs = deadline - Date.now()
+            const cadence = this.schedule.nextDelay(elapsedMs)
+            const sleepMs = Math.max(0, Math.min(cadence, remainingMs))
+            if (sleepMs > 0) {
+                await sleepWithAbort(sleepMs, options.signal)
+            }
+        }
+    }
+
+    async deliver(requestId: string | number, payload: unknown): Promise<void> {
+        const key = buildKey(requestId)
+        const value = JSON.stringify(payload)
+        // `SET key value EX seconds` — TTL guarantees abandoned responses
+        // self-clean. Last-writer-wins is fine; the await reads exactly once.
+        try {
+            await this.redis.set(key, value, 'EX', this.responseTtlSeconds)
+        } catch (error) {
+            throw new SessionBusUnhealthyError(`Redis SET failed for request=${requestId}`, {
+                cause: error,
+            })
+        }
+    }
+}
+
+interface ExitTimeout {
+    kind: 'timeout'
+}
+interface ExitAborted {
+    kind: 'aborted'
+    reason: string
+}
+
+function checkExit(deadline: number, signal: AbortSignal | undefined): ExitTimeout | ExitAborted | null {
+    if (signal?.aborted === true) {
+        return { kind: 'aborted', reason: describeAbortReason(signal) }
+    }
+    if (Date.now() >= deadline) {
+        return { kind: 'timeout' }
+    }
+    return null
+}
+
+function parsePayload<T>(raw: string): T {
+    try {
+        return JSON.parse(raw) as T
+    } catch (error) {
+        throw new SessionBusUnhealthyError(
+            `Stored response payload was not valid JSON. The bus contract requires JSON-serializable payloads.`,
+            { cause: error }
+        )
+    }
+}
+
+function buildKey(requestId: string | number): string {
+    return `${KEY_PREFIX}:${requestId}`
+}
+
+async function sleepWithAbort(ms: number, signal: AbortSignal | undefined): Promise<void> {
+    return await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+            signal?.removeEventListener('abort', onAbort)
+            resolve()
+        }, ms)
+        const onAbort = (): void => {
+            clearTimeout(timer)
+            resolve() // resolve, not reject — the outer loop checks `signal.aborted` next.
+        }
+        if (signal !== undefined) {
+            signal.addEventListener('abort', onAbort, { once: true })
+        }
+    })
+}
+
+function describeAbortReason(signal: AbortSignal | undefined): string {
+    if (signal === undefined) {
+        return 'unknown'
+    }
+    const reason = (signal as AbortSignal & { reason?: unknown }).reason
+    if (reason instanceof Error) {
+        return reason.message
+    }
+    if (typeof reason === 'string') {
+        return reason
+    }
+    return 'aborted'
+}
+
+function safeMetric(fn: () => void): void {
+    try {
+        fn()
+    } catch {
+        /* metrics must never affect bus behavior */
+    }
+}

--- a/services/mcp/src/hono/session-bus/types.ts
+++ b/services/mcp/src/hono/session-bus/types.ts
@@ -94,4 +94,16 @@ export interface BusAwaitMetrics {
 
     /** Called when the underlying transport fails irrecoverably. */
     onUnhealthy?(requestId: string | number, cause: unknown): void
+
+    /**
+     * Called when the bus delivered a payload but it was a JSON-RPC error
+     * envelope from the client (typically because the client doesn't support
+     * `elicitation/create`).
+     *
+     * Note: this is a *refinement* of `onResolve`, not a replacement. The
+     * bus already counted the delivery via `onResolve` before the gateway
+     * could classify the payload. Dashboards should compute
+     * `clean_awaits = resolved - not_supported - (other gateway-rejected)`.
+     */
+    onNotSupported?(requestId: string | number, code: number): void
 }

--- a/services/mcp/src/hono/session-bus/types.ts
+++ b/services/mcp/src/hono/session-bus/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Session-keyed response bus — the abstraction over cross-pod delivery of
+ * server-initiated MCP request responses (elicitation, sampling, roots/list).
+ *
+ * The bus knows nothing about MCP itself. Its only job is to hold a parked
+ * promise on one process until some other process (possibly the same one)
+ * publishes a response keyed by the JSONRPC request id. Higher layers map
+ * that primitive onto MCP-specific flows.
+ *
+ * Implementations:
+ * - `InMemorySessionResponseBus` — single-process, used in tests and as the
+ *   reference implementation.
+ * - `RedisPollingSessionResponseBus` — Redis-backed polling for multi-pod
+ *   Hono deployments. The default in production.
+ *
+ * The interface intentionally avoids exposing the transport (HTTP, SSE,
+ * pub/sub, polling, …). Swapping the implementation requires no changes at
+ * call sites; this is the load-bearing seam of the design.
+ *
+ * Correlation key: the JSONRPC request id (UUID for server-initiated
+ * requests) is globally unique by construction, so it is the sole key. We
+ * intentionally do not key on session id — MCP clients (notably the
+ * Inspector) do not reliably echo `Mcp-Session-Id` across the request that
+ * triggered the elicit and the request that delivers its response, so
+ * requiring session-level correlation would strand legitimate replies.
+ */
+
+export interface SessionResponseBus {
+    /**
+     * Block until a response for `requestId` is delivered, or until
+     * `options.timeoutMs` elapses, or `options.signal` is aborted.
+     *
+     * Resolves at most once. The bus deletes any underlying state once the
+     * promise resolves (one-shot semantics — replay attempts after resolution
+     * find nothing).
+     *
+     * Throws:
+     * - `SessionBusTimeoutError` when the deadline elapses with no response.
+     * - `SessionBusAbortedError` when `options.signal` aborts before a
+     *   response arrives.
+     * - `SessionBusUnhealthyError` when the underlying transport is failing
+     *   in a way the bus cannot recover from (e.g. Redis unreachable). Always
+     *   wraps the original cause via `.cause`.
+     */
+    await<T>(requestId: string | number, options: AwaitOptions): Promise<T>
+
+    /**
+     * Make a response payload available to whichever process is awaiting it.
+     *
+     * Idempotent within the TTL window: calling twice with the same key
+     * overwrites the stored payload. The awaiting promise resolves on the
+     * first observation; subsequent deliveries are no-ops by virtue of the
+     * one-shot read semantics on the await side.
+     *
+     * `payload` is stored opaquely. Validation belongs to the caller of
+     * `await`, not the bus.
+     */
+    deliver(requestId: string | number, payload: unknown): Promise<void>
+}
+
+export interface AwaitOptions {
+    /** Hard deadline in milliseconds. Required — there is no implicit default. */
+    timeoutMs: number
+    /** Optional abort signal — fires `SessionBusAbortedError` when triggered. */
+    signal?: AbortSignal
+    /** Optional metrics hook — see `BusAwaitMetrics`. */
+    metrics?: BusAwaitMetrics
+}
+
+/**
+ * Observation hooks for the await lifecycle. All methods are optional and
+ * synchronous; exceptions thrown from them are caught and logged but do not
+ * affect the bus's behavior.
+ *
+ * Provide a concrete implementation (Prometheus, statsd, PostHog analytics,
+ * etc.) when wiring the bus. The default in tests and dev is a no-op.
+ */
+export interface BusAwaitMetrics {
+    /** Called once at the start of each `await` invocation. */
+    onAwaitStart?(requestId: string | number): void
+
+    /** Called on each underlying poll attempt (no-op in non-polling impls). */
+    onPoll?(requestId: string | number): void
+
+    /** Called once when the await resolves with a payload. `latencyMs` is the
+     *  time from `await` invocation to resolution. */
+    onResolve?(requestId: string | number, latencyMs: number): void
+
+    /** Called when the await deadline expires with no response. */
+    onTimeout?(requestId: string | number): void
+
+    /** Called when an `AbortSignal` cuts the await short. */
+    onAbort?(requestId: string | number, reason: string): void
+
+    /** Called when the underlying transport fails irrecoverably. */
+    onUnhealthy?(requestId: string | number, cause: unknown): void
+}

--- a/services/mcp/src/hono/sse-response.ts
+++ b/services/mcp/src/hono/sse-response.ts
@@ -1,0 +1,115 @@
+/**
+ * Build a streaming HTTP Response that writes JSONRPC messages as
+ * Server-Sent Events.
+ *
+ * Used by the Hono dispatcher when a tool handler invokes `context.elicit()`:
+ * the dispatcher upgrades the in-flight POST response from plain JSON to
+ * SSE so it can push the server-initiated `elicitation/create` request to
+ * the client *before* the eventual tool result lands on the same stream.
+ *
+ * Wire format follows the MCP Streamable HTTP transport convention — each
+ * message is an SSE `event: message` with the JSON-stringified JSONRPC body
+ * in `data:`. Clients that implement the MCP spec (Inspector, Claude Code,
+ * Cursor, …) parse this shape natively.
+ *
+ * The returned Response body is a `ReadableStream` and is consumed lazily,
+ * so the dispatcher's tool handler can keep running between `write()`
+ * calls. The stream is held open until `close()` is invoked.
+ */
+
+export interface SseWriter {
+    /** Push one JSONRPC message to the stream. */
+    write(message: unknown): Promise<void>
+    /** Close the stream. Subsequent writes are no-ops. */
+    close(): Promise<void>
+    /** True once `close()` has been called or the underlying stream errored. */
+    readonly closed: boolean
+}
+
+export interface SseResponseHandle {
+    response: Response
+    writer: SseWriter
+}
+
+/**
+ * Build an SSE-encoded Response and return both the Response object and a
+ * `SseWriter` for emitting messages.
+ *
+ * The Response should be returned from the request handler synchronously
+ * (or with a small awaitable wrapper) so the runtime begins flushing
+ * headers to the client immediately. The writer can be used asynchronously
+ * for as long as the underlying stream is open.
+ */
+export function createSseResponse(): SseResponseHandle {
+    const encoder = new TextEncoder()
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined
+    let closed = false
+    let readyResolve!: () => void
+    const ready = new Promise<void>((resolve) => {
+        // Resolved by the start() callback below. Until that runs the
+        // controller is undefined; any write() that races ahead will await
+        // this promise rather than touch a null controller.
+        readyResolve = resolve
+    })
+
+    const stream = new ReadableStream<Uint8Array>({
+        start(c) {
+            controller = c
+            readyResolve()
+        },
+        cancel() {
+            // Client disconnected — mark as closed so subsequent writes
+            // become no-ops instead of throwing.
+            closed = true
+        },
+    })
+
+    const writer: SseWriter = {
+        get closed(): boolean {
+            return closed
+        },
+        async write(message: unknown): Promise<void> {
+            if (closed) {
+                return
+            }
+            await ready
+            if (closed || controller === undefined) {
+                return
+            }
+            const payload = `event: message\ndata: ${JSON.stringify(message)}\n\n`
+            try {
+                controller.enqueue(encoder.encode(payload))
+            } catch {
+                // The stream was closed (e.g. client disconnect) between
+                // our check and enqueue. Treat as closed; the dispatcher's
+                // outer handler will observe via subsequent writes or
+                // abort signals.
+                closed = true
+            }
+        },
+        async close(): Promise<void> {
+            if (closed) {
+                return
+            }
+            closed = true
+            await ready
+            try {
+                controller?.close()
+            } catch {
+                /* already closed */
+            }
+        },
+    }
+
+    const response = new Response(stream, {
+        status: 200,
+        headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache, no-transform',
+            Connection: 'keep-alive',
+            'X-Accel-Buffering': 'no',
+        },
+    })
+
+    return { response, writer }
+}

--- a/services/mcp/src/hono/streamable-handler.ts
+++ b/services/mcp/src/hono/streamable-handler.ts
@@ -67,7 +67,7 @@ export class StreamableMcpHandler {
     }
 }
 
-type BodyClassification =
+export type BodyClassification =
     | { kind: 'request'; req: Request }
     | { kind: 'response'; id: string | number; payload: unknown }
 
@@ -80,8 +80,11 @@ type BodyClassification =
  * The classifier is intentionally conservative: ambiguous shapes
  * (arrays, missing id, parse failures) fall through as `request` so
  * existing dispatcher behavior is unchanged.
+ *
+ * Exported so the unit suite can exercise the routing decisions
+ * (request vs response vs malformed) without spinning up the full app.
  */
-async function classifyBody(req: Request): Promise<BodyClassification> {
+export async function classifyBody(req: Request): Promise<BodyClassification> {
     let bodyText: string
     try {
         bodyText = await req.clone().text()

--- a/services/mcp/src/hono/streamable-handler.ts
+++ b/services/mcp/src/hono/streamable-handler.ts
@@ -1,6 +1,6 @@
 import type { Lifecycle } from './app'
 import type { RedisLike } from './cache/RedisCache'
-import { McpDispatcher } from './dispatcher'
+import { McpDispatcher, type McpDispatcherOptions } from './dispatcher'
 import { buildRateLimitResponse, DEFAULT_BURST_LIMIT, DEFAULT_SUSTAINED_LIMIT, RateLimiter } from './rate-limiter'
 import { authenticateAndParse, handleCatchError } from './request-utils'
 import { ToolCatalog } from './tool-catalog'
@@ -12,9 +12,10 @@ export class StreamableMcpHandler {
 
     constructor(
         redis: RedisLike,
-        private readonly lifecycle: Lifecycle
+        private readonly lifecycle: Lifecycle,
+        options: McpDispatcherOptions = {}
     ) {
-        this.dispatcher = new McpDispatcher(new ToolCatalog(), redis)
+        this.dispatcher = new McpDispatcher(new ToolCatalog(), redis, options)
         this.rateLimiter = new RateLimiter(redis, [DEFAULT_BURST_LIMIT, DEFAULT_SUSTAINED_LIMIT])
     }
 
@@ -42,10 +43,82 @@ export class StreamableMcpHandler {
             return buildRateLimitResponse(rateLimit)
         }
 
+        // Classify the body before handing it to the dispatcher. A JSONRPC
+        // *response* (no `method`, has `result`/`error`, has `id`) is the
+        // client's reply to a server-initiated request (today: elicitation/
+        // create) and is routed across pods via the session bus — it never
+        // reaches the dispatcher. Everything else (requests / batches / no
+        // body / parse errors) falls through unchanged.
+        const classification = await classifyBody(c.req.raw)
+        if (classification.kind === 'response') {
+            try {
+                await this.dispatcher.bus.deliver(classification.id, classification.payload)
+            } catch (error) {
+                return handleCatchError(error, auth.props)
+            }
+            return new Response(null, { status: 202 })
+        }
+
         try {
-            return await this.dispatcher.handleRequest(c.req.raw, auth.props)
+            return await this.dispatcher.handleRequest(classification.req, auth.props)
         } catch (error) {
             return handleCatchError(error, auth.props)
         }
     }
+}
+
+type BodyClassification =
+    | { kind: 'request'; req: Request }
+    | { kind: 'response'; id: string | number; payload: unknown }
+
+/**
+ * Read the request body once and classify it. Returns a fresh `Request`
+ * for the dispatcher to re-parse when the body is a request — we cloned
+ * the original before reading, so the dispatcher's body parse stays
+ * intact.
+ *
+ * The classifier is intentionally conservative: ambiguous shapes
+ * (arrays, missing id, parse failures) fall through as `request` so
+ * existing dispatcher behavior is unchanged.
+ */
+async function classifyBody(req: Request): Promise<BodyClassification> {
+    let bodyText: string
+    try {
+        bodyText = await req.clone().text()
+    } catch {
+        return { kind: 'request', req }
+    }
+
+    const rebuilt = new Request(req.url, {
+        method: req.method,
+        headers: req.headers,
+        body: bodyText,
+        signal: req.signal,
+    })
+
+    if (bodyText.trim().length === 0) {
+        return { kind: 'request', req: rebuilt }
+    }
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(bodyText)
+    } catch {
+        return { kind: 'request', req: rebuilt }
+    }
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { kind: 'request', req: rebuilt }
+    }
+
+    const message = parsed as Record<string, unknown>
+    const id = message.id
+    const hasResult = 'result' in message
+    const hasError = 'error' in message
+    const hasMethod = 'method' in message
+    const isResponse = !hasMethod && (hasResult || hasError) && (typeof id === 'string' || typeof id === 'number')
+    if (!isResponse) {
+        return { kind: 'request', req: rebuilt }
+    }
+    const payload = hasError ? { error: message.error } : message.result
+    return { kind: 'response', id: id as string | number, payload }
 }

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -1,3 +1,4 @@
+import type { ElicitRequestFormParams, ElicitResult } from '@modelcontextprotocol/sdk/types.js'
 import type { z } from 'zod'
 
 import type { ApiClient, GroupType } from '@/api/client'
@@ -95,7 +96,27 @@ export type Context = {
      * stateManager when not provided.
      */
     trackEvent: (event: AnalyticsEvent, properties?: Record<string, unknown>) => Promise<void>
+    /**
+     * Request structured input from the user via the MCP client (an elicitation
+     * modal). Used to gate destructive actions behind manual confirmation.
+     *
+     * Optional because not every runtime wires elicitation today: the Hono
+     * dispatcher sets it via the per-request elicit binding when a tool handler
+     * needs to surface a prompt; runtimes without that wiring leave it undefined,
+     * and consumers should fall back to "no confirmation available, fail closed".
+     *
+     * Throws (cross-pod errors from the underlying session bus):
+     * - `SessionBusTimeoutError` if no response within the deadline
+     * - `SessionBusAbortedError` if the request signal aborts
+     * - `SessionBusUnhealthyError` if the bus or validation fails
+     */
+    elicit?: ElicitFn
 }
+
+export type ElicitFn = (
+    params: ElicitRequestFormParams,
+    options?: { timeoutMs?: number; signal?: AbortSignal }
+) => Promise<ElicitResult>
 
 export type Tool<TSchema extends z.ZodType = z.ZodType, TResult = unknown> = {
     name: string

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -100,15 +100,28 @@ export type Context = {
      * Request structured input from the user via the MCP client (an elicitation
      * modal). Used to gate destructive actions behind manual confirmation.
      *
-     * Optional because not every runtime wires elicitation today: the Hono
-     * dispatcher sets it via the per-request elicit binding when a tool handler
-     * needs to surface a prompt; runtimes without that wiring leave it undefined,
-     * and consumers should fall back to "no confirmation available, fail closed".
+     * Undefined when elicitation cannot or should not be attempted. Tool
+     * authors MUST treat `context.elicit` as a capability check and fall back
+     * gracefully when it's missing. Reasons for `undefined`:
      *
-     * Throws (cross-pod errors from the underlying session bus):
-     * - `SessionBusTimeoutError` if no response within the deadline
-     * - `SessionBusAbortedError` if the request signal aborts
-     * - `SessionBusUnhealthyError` if the bus or validation fails
+     * - **Runtime not wired:** runtimes other than Hono (e.g. the Workers/DO
+     *   implementation) don't expose elicit at all yet.
+     * - **Client didn't declare support:** the MCP spec requires the server
+     *   NOT to send `elicitation/create` to a client that didn't advertise
+     *   `capabilities.elicitation` at initialize. The Hono dispatcher reads
+     *   the cached capability and leaves `elicit` undefined when missing —
+     *   including cold-start cases where no initialize has been observed
+     *   yet for this token. Fail-closed by design.
+     *
+     * Throws (only when invoked — i.e. when `elicit` is defined):
+     * - `SessionBusTimeoutError` if no response within the deadline.
+     * - `SessionBusAbortedError` if the request signal aborts.
+     * - `ElicitationNotSupportedError` if the client returns a JSON-RPC error
+     *   envelope at runtime (e.g. lied about capability, or supports only a
+     *   mode we don't yet send). Carries the JSON-RPC error code. Tool
+     *   authors should catch and fall back to a non-interactive path.
+     * - `SessionBusUnhealthyError` if the bus transport or payload validation
+     *   fails (structurally malformed responses, not protocol-level errors).
      */
     elicit?: ElicitFn
 }

--- a/services/mcp/tests/hono/capability-store.test.ts
+++ b/services/mcp/tests/hono/capability-store.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+import { CapabilityStore, projectClientCapabilities, supportsAnyElicitation } from '@/hono/capability-store'
+
+interface MockRedis extends RedisLike {
+    _store: Map<string, { value: string; ttl: number }>
+    _failNext: { get: number; set: number }
+}
+
+function createMockRedis(): MockRedis {
+    const store = new Map<string, { value: string; ttl: number }>()
+    const failNext = { get: 0, set: 0 }
+    return {
+        get: vi.fn(async (key: string) => {
+            if (failNext.get > 0) {
+                failNext.get--
+                throw new Error('mock redis get failure')
+            }
+            return store.get(key)?.value ?? null
+        }),
+        set: vi.fn(async (key: string, value: string, _ex: string, ttl: number) => {
+            if (failNext.set > 0) {
+                failNext.set--
+                throw new Error('mock redis set failure')
+            }
+            store.set(key, { value, ttl })
+            return 'OK'
+        }),
+        del: vi.fn(async () => 0),
+        scan: vi.fn(async () => ['0', []] as [string, string[]]),
+        incr: vi.fn(async () => 1),
+        expire: vi.fn(async () => 1),
+        ttl: vi.fn(async () => -1),
+        _store: store,
+        _failNext: failNext,
+    }
+}
+
+describe('CapabilityStore', () => {
+    let redis: MockRedis
+
+    beforeEach(() => {
+        redis = createMockRedis()
+    })
+
+    it('returns undefined for an unknown userHash', async () => {
+        const store = new CapabilityStore(redis)
+        await expect(store.get('hash-1')).resolves.toBeUndefined()
+    })
+
+    it('round-trips a stored capability', async () => {
+        const store = new CapabilityStore(redis)
+        await store.set('hash-1', { elicitation: { form: {} } })
+        await expect(store.get('hash-1')).resolves.toEqual({ elicitation: { form: {} } })
+    })
+
+    it('writes with the configured TTL', async () => {
+        const store = new CapabilityStore(redis, { ttlSeconds: 60 })
+        await store.set('hash-2', { elicitation: {} })
+        expect(redis._store.get('mcp:client-caps:hash-2')?.ttl).toBe(60)
+    })
+
+    it('falls back to 24h TTL by default', async () => {
+        const store = new CapabilityStore(redis)
+        await store.set('hash-3', { elicitation: {} })
+        expect(redis._store.get('mcp:client-caps:hash-3')?.ttl).toBe(24 * 60 * 60)
+    })
+
+    it('returns undefined when Redis GET fails (does not throw)', async () => {
+        redis._failNext.get = 1
+        const store = new CapabilityStore(redis)
+        await expect(store.get('hash-1')).resolves.toBeUndefined()
+    })
+
+    it('swallows Redis SET failures so initialize never fails on the cache', async () => {
+        redis._failNext.set = 1
+        const store = new CapabilityStore(redis)
+        await expect(store.set('hash-1', { elicitation: {} })).resolves.toBeUndefined()
+    })
+
+    it('treats corrupt JSON in storage as a miss', async () => {
+        redis._store.set('mcp:client-caps:hash-bad', { value: '{not-json', ttl: 60 })
+        const store = new CapabilityStore(redis)
+        await expect(store.get('hash-bad')).resolves.toBeUndefined()
+    })
+
+    it('isolates entries by userHash', async () => {
+        const store = new CapabilityStore(redis)
+        await store.set('alice', { elicitation: { form: {} } })
+        await store.set('bob', { elicitation: { url: {} } })
+        await expect(store.get('alice')).resolves.toEqual({ elicitation: { form: {} } })
+        await expect(store.get('bob')).resolves.toEqual({ elicitation: { url: {} } })
+    })
+})
+
+describe('projectClientCapabilities', () => {
+    it('returns an empty projection for non-object input (still writable to cache)', () => {
+        expect(projectClientCapabilities(null)).toEqual({})
+        expect(projectClientCapabilities('nope')).toEqual({})
+        expect(projectClientCapabilities(undefined)).toEqual({})
+    })
+
+    it('returns an empty projection when there is no elicitation key', () => {
+        // Important: we always return a value so the dispatcher overwrites
+        // stale cache entries on every initialize. Returning undefined would
+        // skip the SET and leak a prior session's capabilities into a
+        // re-initialize with fewer capabilities.
+        expect(projectClientCapabilities({ sampling: {} })).toEqual({})
+    })
+
+    it('preserves the spec-defined empty elicitation as form-only', () => {
+        expect(projectClientCapabilities({ elicitation: {} })).toEqual({ elicitation: {} })
+    })
+
+    it('extracts form mode when declared', () => {
+        expect(projectClientCapabilities({ elicitation: { form: {} } })).toEqual({
+            elicitation: { form: {} },
+        })
+    })
+
+    it('extracts url mode when declared', () => {
+        expect(projectClientCapabilities({ elicitation: { url: {} } })).toEqual({
+            elicitation: { url: {} },
+        })
+    })
+
+    it('extracts both modes when declared', () => {
+        expect(projectClientCapabilities({ elicitation: { form: {}, url: {} } })).toEqual({
+            elicitation: { form: {}, url: {} },
+        })
+    })
+
+    it('ignores unknown elicitation sub-keys', () => {
+        expect(projectClientCapabilities({ elicitation: { form: {}, junk: {} } })).toEqual({
+            elicitation: { form: {} },
+        })
+    })
+
+    it('ignores non-object elicitation sub-keys', () => {
+        expect(projectClientCapabilities({ elicitation: { form: 'yes' } })).toEqual({
+            elicitation: {},
+        })
+    })
+})
+
+describe('supportsAnyElicitation', () => {
+    it('returns false for undefined caps', () => {
+        expect(supportsAnyElicitation(undefined)).toBe(false)
+    })
+
+    it('returns false when elicitation key is absent', () => {
+        expect(supportsAnyElicitation({})).toBe(false)
+    })
+
+    it('returns true for empty elicitation (spec form-mode default)', () => {
+        expect(supportsAnyElicitation({ elicitation: {} })).toBe(true)
+    })
+
+    it('returns true when form mode is declared', () => {
+        expect(supportsAnyElicitation({ elicitation: { form: {} } })).toBe(true)
+    })
+
+    it('returns true when url mode is declared', () => {
+        expect(supportsAnyElicitation({ elicitation: { url: {} } })).toBe(true)
+    })
+})

--- a/services/mcp/tests/hono/classify-body.test.ts
+++ b/services/mcp/tests/hono/classify-body.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyBody } from '@/hono/streamable-handler'
+
+function makeRequest(body: string | undefined): Request {
+    const init: RequestInit = { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+    if (body !== undefined) {
+        init.body = body
+    }
+    return new Request('http://localhost/mcp', init)
+}
+
+describe('classifyBody', () => {
+    it('classifies a JSONRPC request as `request` and preserves the body', async () => {
+        const req = makeRequest(JSON.stringify({ jsonrpc: '2.0', id: '1', method: 'tools/call', params: {} }))
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('request')
+        // The dispatcher re-parses this; the rebuilt body must still be readable.
+        if (result.kind === 'request') {
+            const text = await result.req.text()
+            expect(JSON.parse(text)).toMatchObject({ method: 'tools/call' })
+        }
+    })
+
+    it('classifies a JSONRPC result-response as `response`', async () => {
+        const req = makeRequest(JSON.stringify({ jsonrpc: '2.0', id: 'e1', result: { action: 'accept' } }))
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('response')
+        if (result.kind === 'response') {
+            expect(result.id).toBe('e1')
+            expect(result.payload).toEqual({ action: 'accept' })
+        }
+    })
+
+    it('classifies a JSONRPC error-response as `response` and wraps the error envelope', async () => {
+        const req = makeRequest(
+            JSON.stringify({ jsonrpc: '2.0', id: 42, error: { code: -32601, message: 'not found' } })
+        )
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('response')
+        if (result.kind === 'response') {
+            expect(result.id).toBe(42)
+            expect(result.payload).toEqual({ error: { code: -32601, message: 'not found' } })
+        }
+    })
+
+    it('preserves numeric ids as numbers (not coerced to strings)', async () => {
+        const req = makeRequest(JSON.stringify({ jsonrpc: '2.0', id: 99, result: {} }))
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('response')
+        if (result.kind === 'response') {
+            expect(result.id).toBe(99)
+            expect(typeof result.id).toBe('number')
+        }
+    })
+
+    it('falls through as `request` for batches (server-initiated batch responses are not supported)', async () => {
+        const req = makeRequest(JSON.stringify([{ jsonrpc: '2.0', id: '1', method: 'ping' }]))
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('request')
+    })
+
+    it('falls through as `request` for a notification (no id)', async () => {
+        const req = makeRequest(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }))
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('request')
+    })
+
+    it('falls through as `request` for malformed JSON (dispatcher will produce a parse error)', async () => {
+        const req = makeRequest('{not-json')
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('request')
+    })
+
+    it('falls through as `request` for an empty body', async () => {
+        const req = makeRequest('')
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('request')
+    })
+
+    it('falls through as `request` for ambiguous payload missing both result and error', async () => {
+        const req = makeRequest(JSON.stringify({ jsonrpc: '2.0', id: '1' }))
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('request')
+    })
+
+    it('falls through as `request` for a response shape with no id (cannot be routed)', async () => {
+        const req = makeRequest(JSON.stringify({ jsonrpc: '2.0', result: {} }))
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('request')
+    })
+
+    it('falls through as `request` for null body parsed value', async () => {
+        const req = makeRequest('null')
+        const result = await classifyBody(req)
+        expect(result.kind).toBe('request')
+    })
+})

--- a/services/mcp/tests/hono/dispatcher-sse-upgrade.test.ts
+++ b/services/mcp/tests/hono/dispatcher-sse-upgrade.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest'
+
+import { ElicitBinding } from '@/hono/elicit-binding'
+import { InMemorySessionResponseBus } from '@/hono/session-bus/in-memory-bus'
+import { createSseResponse, type SseResponseHandle } from '@/hono/sse-response'
+
+/**
+ * Exercises the exact race + finalize pattern the dispatcher uses for the
+ * `tools/call` SSE upgrade. The full `McpDispatcher.dispatchToolsCallWithMaybeSse`
+ * pulls in the state resolver, API client, feature flag evaluator, and tool
+ * catalog — most of which are mock-heavy and orthogonal to the SSE-upgrade
+ * decision. This suite isolates the upgrade logic itself.
+ *
+ * Concretely, what each test verifies:
+ *
+ * 1. **Handler-wins path** — when the tool handler completes before any elicit
+ *    fires, the dispatcher returns a plain JSON response (no SSE upgrade) and
+ *    the SSE handle stays `undefined`.
+ * 2. **Elicit-wins path** — when the first elicit fires before the handler
+ *    completes, the dispatcher reads the SSE handle and returns the streaming
+ *    Response. Subsequent finalize writes the tool result and closes the stream.
+ * 3. **Tool throw on SSE path** — when the handler throws AFTER triggering an
+ *    elicit, finalize still writes a JSONRPC error frame and closes the stream.
+ */
+
+interface RaceOutcome {
+    kind: 'json' | 'sse'
+    sseHandle?: SseResponseHandle
+}
+
+/**
+ * Imitates `dispatchToolsCallWithMaybeSse`. Kept as a free function so the
+ * tests can assert outcomes without spinning up a dispatcher.
+ */
+async function raceHandlerAgainstElicit(
+    binding: ElicitBinding,
+    handlerPromise: Promise<unknown>
+): Promise<RaceOutcome> {
+    type HandlerOutcome = { kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }
+    const wrappedHandler: Promise<HandlerOutcome> = handlerPromise
+        .then((value): HandlerOutcome => ({ kind: 'success', value }))
+        .catch((error): HandlerOutcome => ({ kind: 'error', error }))
+
+    const winner = await Promise.race([
+        wrappedHandler.then(() => 'handler' as const),
+        binding.firstElicit.then(() => 'elicit' as const),
+    ])
+
+    if (winner === 'handler') {
+        await wrappedHandler
+        return { kind: 'json' }
+    }
+    const sseHandle = binding.getSseHandle()
+    if (!sseHandle) {
+        throw new Error('elicit won the race but no SSE handle was recorded')
+    }
+    return { kind: 'sse', sseHandle }
+}
+
+/**
+ * Imitates `McpDispatcher.finalizeSseResponse`. Awaits the handler outcome,
+ * writes the JSONRPC result/error frame, closes the SSE stream.
+ */
+async function finalize(sseHandle: SseResponseHandle, callId: string, handlerPromise: Promise<unknown>): Promise<void> {
+    try {
+        let result: unknown
+        try {
+            const value = await handlerPromise
+            result = { jsonrpc: '2.0' as const, id: callId, result: value }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            result = { jsonrpc: '2.0' as const, id: callId, error: { code: -32603, message } }
+        }
+        await sseHandle.writer.write(result as Parameters<typeof sseHandle.writer.write>[0])
+    } finally {
+        try {
+            await sseHandle.writer.close()
+        } catch {
+            /* already closed */
+        }
+    }
+}
+
+/** Read all SSE frames from a Response body. */
+async function readAllFrames(response: Response): Promise<unknown[]> {
+    const text = await response.clone().text()
+    return text
+        .split('\n\n')
+        .filter(Boolean)
+        .map((frame) => {
+            const dataLine = frame.split('\n').find((l) => l.startsWith('data: '))
+            if (!dataLine) {
+                throw new Error(`SSE frame missing data line: ${frame}`)
+            }
+            return JSON.parse(dataLine.slice('data: '.length)) as unknown
+        })
+}
+
+describe('Dispatcher SSE-upgrade race + finalize', () => {
+    it('returns plain JSON when the handler completes before any elicit fires', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const binding = new ElicitBinding({
+            bus,
+            createSseHandle: async () => createSseResponse(),
+        })
+        const handlerPromise = Promise.resolve('handler-result')
+
+        const outcome = await raceHandlerAgainstElicit(binding, handlerPromise)
+
+        expect(outcome.kind).toBe('json')
+        expect(binding.getSseHandle()).toBeUndefined()
+    })
+
+    it('upgrades to SSE when the handler invokes elicit, then writes the final tool result frame', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const binding = new ElicitBinding({
+            bus,
+            createSseHandle: async () => createSseResponse(),
+        })
+        const callId = 'tools-call-1'
+
+        // Tool handler: invoke elicit, then wait for the reply, then return a tool result.
+        const handlerPromise = (async (): Promise<unknown> => {
+            const reply = await binding.invoke({
+                message: 'Confirm',
+                requestedSchema: { type: 'object', properties: {} },
+            })
+            return { content: [{ type: 'text', text: `reply=${reply.action}` }] }
+        })()
+
+        const outcome = await raceHandlerAgainstElicit(binding, handlerPromise)
+        expect(outcome.kind).toBe('sse')
+        const sseHandle = outcome.sseHandle!
+        expect(sseHandle.response.headers.get('Content-Type')).toBe('text/event-stream')
+
+        // Concurrently drive the finalize and the client reply. The order of
+        // these steps mirrors what the dispatcher hands off: the SSE response
+        // is already returned to the client, the handler is still running, and
+        // when its bus.await resolves it writes the tool result frame.
+        const finalizePromise = finalize(sseHandle, callId, handlerPromise)
+
+        // Read the first frame off a parallel clone before the reply lands.
+        const reader = sseHandle.response.body!.getReader()
+        const decoder = new TextDecoder()
+        let buf = ''
+        async function nextFrame(): Promise<unknown> {
+            while (!buf.includes('\n\n')) {
+                const { value, done } = await reader.read()
+                if (done) {
+                    throw new Error('SSE closed before next frame')
+                }
+                buf += decoder.decode(value, { stream: true })
+            }
+            const splitAt = buf.indexOf('\n\n')
+            const frame = buf.slice(0, splitAt)
+            buf = buf.slice(splitAt + 2)
+            const dataLine = frame.split('\n').find((l) => l.startsWith('data: '))
+            return JSON.parse(dataLine!.slice('data: '.length))
+        }
+
+        const elicitFrame = (await nextFrame()) as { id: string; method: string; params: unknown }
+        expect(elicitFrame.method).toBe('elicitation/create')
+        expect(typeof elicitFrame.id).toBe('string')
+
+        // Deliver the client's reply. The handler's bus.await resolves and the
+        // handler completes; finalize then writes the second SSE frame.
+        await bus.deliver(elicitFrame.id, { action: 'accept', content: { confirmed: true } })
+
+        const resultFrame = (await nextFrame()) as { id: string; result?: unknown; error?: unknown }
+        expect(resultFrame.id).toBe(callId)
+        expect(resultFrame.result).toEqual({ content: [{ type: 'text', text: 'reply=accept' }] })
+
+        await finalizePromise
+
+        // Stream must be closed.
+        const { done } = await reader.read()
+        expect(done).toBe(true)
+    })
+
+    it('writes a JSONRPC error frame when the handler throws on the SSE path', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const binding = new ElicitBinding({
+            bus,
+            createSseHandle: async () => createSseResponse(),
+        })
+        const callId = 'tools-call-err'
+
+        const handlerPromise = (async (): Promise<unknown> => {
+            const reply = await binding.invoke({
+                message: 'Confirm',
+                requestedSchema: { type: 'object', properties: {} },
+            })
+            if (reply.action !== 'accept') {
+                throw new Error('user declined')
+            }
+            return { value: 'never-reached' }
+        })()
+
+        const outcome = await raceHandlerAgainstElicit(binding, handlerPromise)
+        expect(outcome.kind).toBe('sse')
+        const sseHandle = outcome.sseHandle!
+
+        const finalizePromise = finalize(sseHandle, callId, handlerPromise)
+        // Read the elicit frame to discover the id.
+        const reader = sseHandle.response.body!.getReader()
+        const decoder = new TextDecoder()
+        let buf = ''
+        const readFrame = async (): Promise<unknown> => {
+            while (!buf.includes('\n\n')) {
+                const { value, done } = await reader.read()
+                if (done) {
+                    throw new Error('closed')
+                }
+                buf += decoder.decode(value, { stream: true })
+            }
+            const i = buf.indexOf('\n\n')
+            const frame = buf.slice(0, i)
+            buf = buf.slice(i + 2)
+            const dataLine = frame.split('\n').find((l) => l.startsWith('data: '))
+            return JSON.parse(dataLine!.slice('data: '.length))
+        }
+        const elicitFrame = (await readFrame()) as { id: string }
+        await bus.deliver(elicitFrame.id, { action: 'decline' })
+
+        const finalFrame = (await readFrame()) as { id: string; error: { code: number; message: string } }
+        expect(finalFrame.id).toBe(callId)
+        expect(finalFrame.error.code).toBe(-32603)
+        expect(finalFrame.error.message).toBe('user declined')
+        await finalizePromise
+    })
+
+    it('reads the full SSE body in order: elicit/create then tools/call result, then EOF', async () => {
+        // A consolidated end-to-end assertion via readAllFrames, after both
+        // writers have flushed and closed. Useful as a regression net.
+        const bus = new InMemorySessionResponseBus()
+        const binding = new ElicitBinding({
+            bus,
+            createSseHandle: async () => createSseResponse(),
+        })
+        const callId = 'call-end-to-end'
+
+        const handlerPromise = (async (): Promise<unknown> => {
+            const reply = await binding.invoke({
+                message: 'Confirm',
+                requestedSchema: { type: 'object', properties: {} },
+            })
+            return { ok: reply.action === 'accept' }
+        })()
+
+        const outcome = await raceHandlerAgainstElicit(binding, handlerPromise)
+        const sseHandle = outcome.sseHandle!
+        const finalizePromise = finalize(sseHandle, callId, handlerPromise)
+
+        // We need to learn the elicit id before delivering. Peek via a cloned body.
+        // Cloning preserves the un-consumed body for the final readAllFrames assertion.
+        const clone = sseHandle.response.clone()
+        const reader = clone.body!.getReader()
+        const decoder = new TextDecoder()
+        let buf = ''
+        while (!buf.includes('\n\n')) {
+            const { value, done } = await reader.read()
+            if (done) {
+                throw new Error('closed before elicit frame')
+            }
+            buf += decoder.decode(value, { stream: true })
+        }
+        const elicitFrame = JSON.parse(
+            buf
+                .split('\n\n')[0]!
+                .split('\n')
+                .find((l) => l.startsWith('data: '))!
+                .slice('data: '.length)
+        ) as { id: string }
+        await bus.deliver(elicitFrame.id, { action: 'accept', content: {} })
+        await finalizePromise
+
+        const frames = await readAllFrames(sseHandle.response)
+        expect(frames).toHaveLength(2)
+        expect(frames[0]).toMatchObject({ method: 'elicitation/create' })
+        expect(frames[1]).toMatchObject({ id: callId, result: { ok: true } })
+    })
+})

--- a/services/mcp/tests/hono/session-bus/adaptive-poll.test.ts
+++ b/services/mcp/tests/hono/session-bus/adaptive-poll.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { createAdaptivePollSchedule, DEFAULT_ADAPTIVE_POLL_CONFIG } from '@/hono/session-bus/adaptive-poll'
+
+describe('createAdaptivePollSchedule', () => {
+    it('returns the hot interval during the hot window', () => {
+        const schedule = createAdaptivePollSchedule({ hotIntervalMs: 200, coolIntervalMs: 1_000, hotWindowMs: 5_000 })
+        expect(schedule.nextDelay(0)).toBe(200)
+        expect(schedule.nextDelay(2_500)).toBe(200)
+        expect(schedule.nextDelay(4_999)).toBe(200)
+    })
+
+    it('returns the cool interval after the hot window', () => {
+        const schedule = createAdaptivePollSchedule({ hotIntervalMs: 200, coolIntervalMs: 1_000, hotWindowMs: 5_000 })
+        expect(schedule.nextDelay(5_000)).toBe(1_000)
+        expect(schedule.nextDelay(60_000)).toBe(1_000)
+    })
+
+    it('treats negative elapsed times as hot (defensive)', () => {
+        const schedule = createAdaptivePollSchedule({ hotIntervalMs: 200, coolIntervalMs: 1_000, hotWindowMs: 5_000 })
+        expect(schedule.nextDelay(-1)).toBe(200)
+    })
+
+    it('uses the documented defaults when no config is provided', () => {
+        const schedule = createAdaptivePollSchedule()
+        expect(schedule.nextDelay(0)).toBe(DEFAULT_ADAPTIVE_POLL_CONFIG.hotIntervalMs)
+        expect(schedule.nextDelay(DEFAULT_ADAPTIVE_POLL_CONFIG.hotWindowMs)).toBe(
+            DEFAULT_ADAPTIVE_POLL_CONFIG.coolIntervalMs
+        )
+    })
+
+    it('rejects non-positive intervals', () => {
+        expect(() =>
+            createAdaptivePollSchedule({ hotIntervalMs: 0, coolIntervalMs: 1_000, hotWindowMs: 5_000 })
+        ).toThrow(/positive/)
+        expect(() =>
+            createAdaptivePollSchedule({ hotIntervalMs: 200, coolIntervalMs: -1, hotWindowMs: 5_000 })
+        ).toThrow(/positive/)
+    })
+
+    it('rejects hot interval greater than cool interval', () => {
+        expect(() =>
+            createAdaptivePollSchedule({ hotIntervalMs: 2_000, coolIntervalMs: 1_000, hotWindowMs: 5_000 })
+        ).toThrow(/Hot interval/)
+    })
+})

--- a/services/mcp/tests/hono/session-bus/elicit-binding.test.ts
+++ b/services/mcp/tests/hono/session-bus/elicit-binding.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+
+import { ElicitBinding } from '@/hono/elicit-binding'
+import { InMemorySessionResponseBus } from '@/hono/session-bus/in-memory-bus'
+import { createSseResponse } from '@/hono/sse-response'
+
+describe('ElicitBinding (integration with bus + SSE)', () => {
+    it('lazy-creates the SSE handle only when invoke() is first called', async () => {
+        const bus = new InMemorySessionResponseBus()
+        let createCount = 0
+        const binding = new ElicitBinding({
+            bus,
+            createSseHandle: async () => {
+                createCount++
+                return createSseResponse()
+            },
+        })
+        expect(createCount).toBe(0)
+        expect(binding.getSseHandle()).toBeUndefined()
+    })
+
+    it('resolves firstElicit and exposes the SSE handle on the first invoke', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const binding = new ElicitBinding({
+            bus,
+            createSseHandle: async () => createSseResponse(),
+        })
+
+        let firstElicitResolved = false
+        void binding.firstElicit.then(() => {
+            firstElicitResolved = true
+        })
+
+        // Kick off the elicit. Don't await — it parks on the bus.
+        const elicitPromise = binding.invoke({
+            message: 'Confirm',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        await binding.firstElicit
+        expect(firstElicitResolved).toBe(true)
+        const handle = binding.getSseHandle()
+        expect(handle).not.toBeUndefined()
+
+        // The elicit message must already be on the SSE stream.
+        // Resolve the elicit so the parked promise can finish.
+        const reader = createSseReader(handle!.response)
+        const elicitMessage = (await reader.next()) as { id: string; method: string }
+        expect(elicitMessage.method).toBe('elicitation/create')
+        expect(typeof elicitMessage.id).toBe('string')
+
+        await bus.deliver(elicitMessage.id, { action: 'accept' })
+        await expect(elicitPromise).resolves.toEqual({ action: 'accept' })
+
+        // Close so any readers don't hang.
+        await handle!.writer.close()
+    })
+
+    it('serializes multiple elicits through the same SSE writer', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const binding = new ElicitBinding({
+            bus,
+            createSseHandle: async () => createSseResponse(),
+        })
+
+        // Stream the SSE body as messages flow. We need a single reader for
+        // the whole test because Response bodies are not re-readable.
+        const elicit1 = binding.invoke({
+            message: 'First',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+        await binding.firstElicit
+        const handle = binding.getSseHandle()!
+        const reader = createSseReader(handle.response)
+
+        const first = await reader.next()
+        const id1 = (first as { id: string }).id
+        await bus.deliver(id1, { action: 'accept' })
+        await expect(elicit1).resolves.toEqual({ action: 'accept' })
+
+        const elicit2 = binding.invoke({
+            message: 'Second',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+        const second = await reader.next()
+        const id2 = (second as { id: string }).id
+        expect(id2).not.toBe(id1)
+
+        await bus.deliver(id2, { action: 'decline' })
+        await expect(elicit2).resolves.toEqual({ action: 'decline' })
+
+        await handle.writer.close()
+    })
+
+    it('propagates requestSignal abort into pending elicit awaits', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const controller = new AbortController()
+        const binding = new ElicitBinding({
+            bus,
+            createSseHandle: async () => createSseResponse(),
+            requestSignal: controller.signal,
+        })
+
+        const elicit = binding.invoke({
+            message: 'Confirm',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        controller.abort()
+        await expect(elicit).rejects.toThrow(/aborted/i)
+    })
+})
+
+/**
+ * Read SSE frames from a Response body one at a time. Holds the underlying
+ * reader open across `next()` calls — important for tests that interleave
+ * elicit deliveries with reads.
+ */
+function createSseReader(response: Response): { next: () => Promise<unknown> } {
+    const reader = response.body!.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    return {
+        async next(): Promise<unknown> {
+            while (!buffer.includes('\n\n')) {
+                const { value, done } = await reader.read()
+                if (done) {
+                    throw new Error('SSE stream closed before next frame')
+                }
+                buffer += decoder.decode(value, { stream: true })
+            }
+            const splitAt = buffer.indexOf('\n\n')
+            const frame = buffer.slice(0, splitAt)
+            buffer = buffer.slice(splitAt + 2)
+            const dataLine = frame.split('\n').find((line) => line.startsWith('data: '))
+            if (!dataLine) {
+                throw new Error(`SSE frame missing data line: ${frame}`)
+            }
+            return JSON.parse(dataLine.slice('data: '.length))
+        },
+    }
+}

--- a/services/mcp/tests/hono/session-bus/elicit-result-validator.test.ts
+++ b/services/mcp/tests/hono/session-bus/elicit-result-validator.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateElicitResult } from '@/hono/session-bus/elicit-result-validator'
+import { ElicitationNotSupportedError, SessionBusUnhealthyError } from '@/hono/session-bus/errors'
+
+describe('validateElicitResult', () => {
+    it('accepts a well-formed accept result', () => {
+        expect(validateElicitResult({ action: 'accept', content: { confirmed: true } })).toEqual({
+            action: 'accept',
+            content: { confirmed: true },
+        })
+    })
+
+    it('accepts decline and cancel without content', () => {
+        expect(validateElicitResult({ action: 'decline' })).toEqual({ action: 'decline' })
+        expect(validateElicitResult({ action: 'cancel' })).toEqual({ action: 'cancel' })
+    })
+
+    it('throws ElicitationNotSupportedError for a JSON-RPC error envelope (-32601)', () => {
+        let caught: unknown
+        try {
+            validateElicitResult({ error: { code: -32601, message: 'Method not found' } })
+        } catch (e) {
+            caught = e
+        }
+        expect(caught).toBeInstanceOf(ElicitationNotSupportedError)
+        const err = caught as ElicitationNotSupportedError
+        expect(err.code).toBe(-32601)
+        expect(err.message).toContain('Method not found')
+    })
+
+    it('throws ElicitationNotSupportedError for an unsupported-mode error (-32602)', () => {
+        let caught: unknown
+        try {
+            validateElicitResult({
+                error: { code: -32602, message: 'Client does not support URL-mode elicitation requests' },
+            })
+        } catch (e) {
+            caught = e
+        }
+        expect(caught).toBeInstanceOf(ElicitationNotSupportedError)
+        expect((caught as ElicitationNotSupportedError).code).toBe(-32602)
+    })
+
+    it('throws SessionBusUnhealthyError for a malformed payload (no action, no error)', () => {
+        expect(() => validateElicitResult({ not: 'a valid ElicitResult' })).toThrow(SessionBusUnhealthyError)
+    })
+
+    it('throws SessionBusUnhealthyError for an action with an invalid value', () => {
+        expect(() => validateElicitResult({ action: 'maybe' })).toThrow(SessionBusUnhealthyError)
+    })
+
+    it('treats an error object without numeric code as malformed (unhealthy, not not-supported)', () => {
+        // Don't misclassify garbage as a polite "client doesn't support this".
+        // It's a malformed payload — fail closed under the bus health bucket.
+        expect(() => validateElicitResult({ error: { code: 'oops', message: 'nope' } })).toThrow(
+            SessionBusUnhealthyError
+        )
+    })
+
+    it('treats a null payload as malformed', () => {
+        expect(() => validateElicitResult(null)).toThrow(SessionBusUnhealthyError)
+    })
+})

--- a/services/mcp/tests/hono/session-bus/elicitation-gateway.test.ts
+++ b/services/mcp/tests/hono/session-bus/elicitation-gateway.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ElicitationGateway } from '@/hono/session-bus/elicitation-gateway'
+import type { TransportMessageSender } from '@/hono/session-bus/elicitation-gateway'
+import { SessionBusTimeoutError, SessionBusUnhealthyError } from '@/hono/session-bus/errors'
+import { InMemorySessionResponseBus } from '@/hono/session-bus/in-memory-bus'
+
+function createCapturingSender(): TransportMessageSender & { sent: unknown[] } {
+    const sent: unknown[] = []
+    return {
+        sent,
+        async send(message) {
+            sent.push(message)
+        },
+    }
+}
+
+describe('ElicitationGateway', () => {
+    it('sends a JSONRPC elicitation/create request, then resolves on a matching bus delivery', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const gateway = new ElicitationGateway(bus, sender)
+
+        const pending = gateway.elicit({
+            message: 'Confirm action',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        await new Promise((resolve) => setImmediate(resolve))
+        expect(sender.sent).toHaveLength(1)
+        const sent = sender.sent[0] as { id: string; method: string; jsonrpc: string }
+        expect(sent.method).toBe('elicitation/create')
+        expect(sent.jsonrpc).toBe('2.0')
+        expect(typeof sent.id).toBe('string')
+
+        await bus.deliver(sent.id, { action: 'accept', content: {} })
+
+        await expect(pending).resolves.toEqual({ action: 'accept', content: {} })
+    })
+
+    it('passes through SessionBusTimeoutError on deadline', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const gateway = new ElicitationGateway(bus, sender, { defaultTimeoutMs: 25 })
+
+        await expect(
+            gateway.elicit({
+                message: 'x',
+                requestedSchema: { type: 'object', properties: {} },
+            })
+        ).rejects.toBeInstanceOf(SessionBusTimeoutError)
+    })
+
+    it('rejects malformed elicit payloads with SessionBusUnhealthyError', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const gateway = new ElicitationGateway(bus, sender)
+
+        const pending = gateway.elicit({
+            message: 'x',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        await new Promise((resolve) => setImmediate(resolve))
+        const sent = sender.sent[0] as { id: string }
+        await bus.deliver(sent.id, { not: 'a valid ElicitResult' })
+
+        await expect(pending).rejects.toBeInstanceOf(SessionBusUnhealthyError)
+    })
+
+    it('forwards the AbortSignal to the bus', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const gateway = new ElicitationGateway(bus, sender)
+
+        const controller = new AbortController()
+        const pending = gateway.elicit(
+            { message: 'x', requestedSchema: { type: 'object', properties: {} } },
+            { signal: controller.signal }
+        )
+
+        controller.abort()
+        await expect(pending).rejects.toThrow(/aborted/i)
+    })
+
+    it('emits await-start / resolve metrics via the configured hook', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const startSpy = vi.fn()
+        const resolveSpy = vi.fn()
+        const gateway = new ElicitationGateway(bus, sender, {
+            metrics: { onAwaitStart: startSpy, onResolve: resolveSpy },
+        })
+
+        const pending = gateway.elicit({
+            message: 'x',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        await new Promise((resolve) => setImmediate(resolve))
+        const sent = sender.sent[0] as { id: string }
+        await bus.deliver(sent.id, { action: 'cancel' })
+        await pending
+
+        expect(startSpy).toHaveBeenCalledTimes(1)
+        expect(resolveSpy).toHaveBeenCalledTimes(1)
+    })
+})

--- a/services/mcp/tests/hono/session-bus/elicitation-gateway.test.ts
+++ b/services/mcp/tests/hono/session-bus/elicitation-gateway.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { ElicitationGateway } from '@/hono/session-bus/elicitation-gateway'
 import type { TransportMessageSender } from '@/hono/session-bus/elicitation-gateway'
-import { SessionBusTimeoutError, SessionBusUnhealthyError } from '@/hono/session-bus/errors'
+import {
+    ElicitationNotSupportedError,
+    SessionBusTimeoutError,
+    SessionBusUnhealthyError,
+} from '@/hono/session-bus/errors'
 import { InMemorySessionResponseBus } from '@/hono/session-bus/in-memory-bus'
 
 function createCapturingSender(): TransportMessageSender & { sent: unknown[] } {
@@ -81,6 +85,52 @@ describe('ElicitationGateway', () => {
 
         controller.abort()
         await expect(pending).rejects.toThrow(/aborted/i)
+    })
+
+    it('throws ElicitationNotSupportedError when the client returns a JSON-RPC error envelope', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const gateway = new ElicitationGateway(bus, sender)
+
+        const pending = gateway.elicit({
+            message: 'x',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        await new Promise((resolve) => setImmediate(resolve))
+        const sent = sender.sent[0] as { id: string }
+        await bus.deliver(sent.id, { error: { code: -32601, message: 'Method not found' } })
+
+        let caught: unknown
+        try {
+            await pending
+        } catch (e) {
+            caught = e
+        }
+        expect(caught).toBeInstanceOf(ElicitationNotSupportedError)
+        expect((caught as ElicitationNotSupportedError).code).toBe(-32601)
+    })
+
+    it('invokes onNotSupported metric when the client signals lack of support', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const notSupportedSpy = vi.fn()
+        const gateway = new ElicitationGateway(bus, sender, {
+            metrics: { onNotSupported: notSupportedSpy },
+        })
+
+        const pending = gateway.elicit({
+            message: 'x',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        await new Promise((resolve) => setImmediate(resolve))
+        const sent = sender.sent[0] as { id: string }
+        await bus.deliver(sent.id, { error: { code: -32602, message: 'unsupported mode' } })
+
+        await expect(pending).rejects.toBeInstanceOf(ElicitationNotSupportedError)
+        expect(notSupportedSpy).toHaveBeenCalledTimes(1)
+        expect(notSupportedSpy).toHaveBeenCalledWith(expect.any(String), -32602)
     })
 
     it('emits await-start / resolve metrics via the configured hook', async () => {

--- a/services/mcp/tests/hono/session-bus/in-memory-bus.test.ts
+++ b/services/mcp/tests/hono/session-bus/in-memory-bus.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { SessionBusAbortedError, SessionBusTimeoutError } from '@/hono/session-bus/errors'
+import { InMemorySessionResponseBus } from '@/hono/session-bus/in-memory-bus'
+
+describe('InMemorySessionResponseBus', () => {
+    it('resolves an awaiter when a matching deliver lands', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const pending = bus.await('req-1', { timeoutMs: 1_000 })
+        await bus.deliver('req-1', { action: 'accept' })
+        await expect(pending).resolves.toEqual({ action: 'accept' })
+    })
+
+    it('resolves an awaiter that registers AFTER an early delivery', async () => {
+        const bus = new InMemorySessionResponseBus()
+        await bus.deliver('req-1', { action: 'decline' })
+        await expect(bus.await('req-1', { timeoutMs: 1_000 })).resolves.toEqual({ action: 'decline' })
+    })
+
+    it('does not cross deliveries between different request ids', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const pending = bus.await('req-1', { timeoutMs: 100 })
+        await bus.deliver('req-2', { action: 'accept' })
+        await expect(pending).rejects.toBeInstanceOf(SessionBusTimeoutError)
+    })
+
+    it('times out with SessionBusTimeoutError when no deliver arrives', async () => {
+        const bus = new InMemorySessionResponseBus()
+        await expect(bus.await('r', { timeoutMs: 25 })).rejects.toBeInstanceOf(SessionBusTimeoutError)
+    })
+
+    it('rejects with SessionBusAbortedError when the signal aborts during await', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const controller = new AbortController()
+        const pending = bus.await('r', { timeoutMs: 5_000, signal: controller.signal })
+        controller.abort()
+        await expect(pending).rejects.toBeInstanceOf(SessionBusAbortedError)
+    })
+
+    it('rejects immediately if the signal is already aborted before await', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const controller = new AbortController()
+        controller.abort()
+        await expect(bus.await('r', { timeoutMs: 5_000, signal: controller.signal })).rejects.toBeInstanceOf(
+            SessionBusAbortedError
+        )
+    })
+
+    it('refuses concurrent awaits on the same key', async () => {
+        const bus = new InMemorySessionResponseBus()
+        void bus.await('r', { timeoutMs: 1_000 }).catch(() => undefined)
+        await expect(bus.await('r', { timeoutMs: 1_000 })).rejects.toThrow(/Concurrent await/)
+    })
+
+    it('invokes resolve metric with elapsed latency', async () => {
+        const bus = new InMemorySessionResponseBus()
+        let observedLatency: number | undefined
+        const pending = bus.await('r', {
+            timeoutMs: 1_000,
+            metrics: { onResolve: (_r, ms) => (observedLatency = ms) },
+        })
+        await bus.deliver('r', { action: 'accept' })
+        await pending
+        expect(observedLatency).toBeGreaterThanOrEqual(0)
+        expect(observedLatency).toBeLessThan(50)
+    })
+
+    it('invokes timeout metric exactly once on deadline', async () => {
+        const bus = new InMemorySessionResponseBus()
+        let timeouts = 0
+        await expect(
+            bus.await('r', {
+                timeoutMs: 10,
+                metrics: { onTimeout: () => timeouts++ },
+            })
+        ).rejects.toBeInstanceOf(SessionBusTimeoutError)
+        expect(timeouts).toBe(1)
+    })
+
+    it('aborts all parked awaits on shutdown', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const a = bus.await('r1', { timeoutMs: 5_000 })
+        const b = bus.await('r2', { timeoutMs: 5_000 })
+        bus.abortAll('shutdown')
+        await expect(a).rejects.toBeInstanceOf(SessionBusAbortedError)
+        await expect(b).rejects.toBeInstanceOf(SessionBusAbortedError)
+        expect(bus.parkedCount()).toBe(0)
+    })
+
+    it('clears the parked entry after a one-shot deliver', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const pending = bus.await('r', { timeoutMs: 1_000 })
+        await bus.deliver('r', { action: 'accept' })
+        await pending
+        expect(bus.parkedCount()).toBe(0)
+    })
+})

--- a/services/mcp/tests/hono/session-bus/redis-polling-bus.test.ts
+++ b/services/mcp/tests/hono/session-bus/redis-polling-bus.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+import { createAdaptivePollSchedule } from '@/hono/session-bus/adaptive-poll'
+import { SessionBusAbortedError, SessionBusTimeoutError, SessionBusUnhealthyError } from '@/hono/session-bus/errors'
+import { RedisPollingSessionResponseBus } from '@/hono/session-bus/redis-polling-bus'
+
+interface MockRedis extends RedisLike {
+    _store: Map<string, string>
+    _failNextN: { get: number; set: number }
+}
+
+function createMockRedis(): MockRedis {
+    const store = new Map<string, string>()
+    const failNextN = { get: 0, set: 0 }
+    return {
+        get: vi.fn(async (key: string) => {
+            if (failNextN.get > 0) {
+                failNextN.get--
+                throw new Error('mock redis get failure')
+            }
+            return store.get(key) ?? null
+        }),
+        set: vi.fn(async (key: string, value: string) => {
+            if (failNextN.set > 0) {
+                failNextN.set--
+                throw new Error('mock redis set failure')
+            }
+            store.set(key, value)
+            return 'OK'
+        }),
+        del: vi.fn(async (...keys: string[]) => {
+            let count = 0
+            for (const key of keys) {
+                if (store.delete(key)) {
+                    count++
+                }
+            }
+            return count
+        }),
+        scan: vi.fn(async () => ['0', []] as [string, string[]]),
+        incr: vi.fn(async () => 1),
+        expire: vi.fn(async () => 1),
+        ttl: vi.fn(async () => -1),
+        _store: store,
+        _failNextN: failNextN,
+    }
+}
+
+/** Schedule with very short delays so tests don't take seconds. */
+const FAST_SCHEDULE = createAdaptivePollSchedule({
+    hotIntervalMs: 5,
+    coolIntervalMs: 10,
+    hotWindowMs: 50,
+})
+
+describe('RedisPollingSessionResponseBus', () => {
+    let redis: MockRedis
+    let bus: RedisPollingSessionResponseBus
+
+    beforeEach(() => {
+        redis = createMockRedis()
+        bus = new RedisPollingSessionResponseBus(redis, {
+            schedule: FAST_SCHEDULE,
+            responseTtlSeconds: 60,
+        })
+    })
+
+    it('resolves when a deliver lands on the same instance', async () => {
+        const pending = bus.await('r', { timeoutMs: 1_000 })
+        await bus.deliver('r', { action: 'accept' })
+        await expect(pending).resolves.toEqual({ action: 'accept' })
+    })
+
+    it('resolves when a deliver writes the underlying key directly', async () => {
+        const pending = bus.await('r', { timeoutMs: 1_000 })
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        redis._store.set('mcp:session-response:r', JSON.stringify({ action: 'decline' }))
+        await expect(pending).resolves.toEqual({ action: 'decline' })
+    })
+
+    it('DELs the key after a successful read (one-shot)', async () => {
+        const pending = bus.await('r', { timeoutMs: 1_000 })
+        await bus.deliver('r', { action: 'accept' })
+        await pending
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        expect(redis._store.has('mcp:session-response:r')).toBe(false)
+    })
+
+    it('times out when no deliver arrives within the deadline', async () => {
+        await expect(bus.await('r', { timeoutMs: 30 })).rejects.toBeInstanceOf(SessionBusTimeoutError)
+    })
+
+    it('aborts immediately when signal is already aborted before await', async () => {
+        const controller = new AbortController()
+        controller.abort()
+        await expect(bus.await('r', { timeoutMs: 1_000, signal: controller.signal })).rejects.toBeInstanceOf(
+            SessionBusAbortedError
+        )
+    })
+
+    it('aborts mid-poll when signal fires later', async () => {
+        const controller = new AbortController()
+        const pending = bus.await('r', { timeoutMs: 5_000, signal: controller.signal })
+        setTimeout(() => controller.abort(), 20)
+        await expect(pending).rejects.toBeInstanceOf(SessionBusAbortedError)
+    })
+
+    it('tolerates transient redis errors and eventually resolves', async () => {
+        redis._failNextN.get = 3
+        const pending = bus.await('r', { timeoutMs: 1_000 })
+        setTimeout(() => {
+            void bus.deliver('r', { action: 'accept' })
+        }, 60)
+        await expect(pending).resolves.toEqual({ action: 'accept' })
+    })
+
+    it('fails with SessionBusUnhealthyError after consecutive redis errors', async () => {
+        redis._failNextN.get = 99
+        const tightBus = new RedisPollingSessionResponseBus(redis, {
+            schedule: FAST_SCHEDULE,
+            maxConsecutiveErrors: 3,
+        })
+        await expect(tightBus.await('r', { timeoutMs: 5_000 })).rejects.toBeInstanceOf(SessionBusUnhealthyError)
+    })
+
+    it('treats invalid JSON in stored payload as bus unhealthy', async () => {
+        const pending = bus.await('r', { timeoutMs: 1_000 })
+        redis._store.set('mcp:session-response:r', '{not-json')
+        await expect(pending).rejects.toBeInstanceOf(SessionBusUnhealthyError)
+    })
+
+    it('translates SET failure into SessionBusUnhealthyError', async () => {
+        redis._failNextN.set = 1
+        await expect(bus.deliver('r', { action: 'accept' })).rejects.toBeInstanceOf(SessionBusUnhealthyError)
+    })
+
+    it('emits the documented metric signals on the happy path', async () => {
+        const events: string[] = []
+        const pending = bus.await('r', {
+            timeoutMs: 1_000,
+            metrics: {
+                onAwaitStart: () => events.push('start'),
+                onPoll: () => events.push('poll'),
+                onResolve: () => events.push('resolve'),
+            },
+        })
+        await bus.deliver('r', { action: 'accept' })
+        await pending
+        expect(events[0]).toBe('start')
+        expect(events).toContain('poll')
+        expect(events[events.length - 1]).toBe('resolve')
+    })
+
+    it('uses adaptive polling cadence (more polls early than late)', async () => {
+        const events: number[] = []
+        const start = Date.now()
+        const pending = bus.await('r', {
+            timeoutMs: 200,
+            metrics: { onPoll: () => events.push(Date.now() - start) },
+        })
+        await expect(pending).rejects.toBeInstanceOf(SessionBusTimeoutError)
+        expect(events.length).toBeGreaterThan(2)
+    })
+})

--- a/services/mcp/tests/hono/session-bus/redis-polling-bus.test.ts
+++ b/services/mcp/tests/hono/session-bus/redis-polling-bus.test.ts
@@ -21,10 +21,18 @@ function createMockRedis(): MockRedis {
             }
             return store.get(key) ?? null
         }),
-        set: vi.fn(async (key: string, value: string) => {
+        set: vi.fn(async (key: string, value: string, ..._args: (string | number)[]) => {
             if (failNextN.set > 0) {
                 failNextN.set--
                 throw new Error('mock redis set failure')
+            }
+            // Honor NX semantics: if the key already exists, refuse the write
+            // and return null. Required for testing the first-writer-wins
+            // bus contract.
+            const args = _args.map((a) => (typeof a === 'string' ? a.toUpperCase() : a))
+            const nx = args.includes('NX')
+            if (nx && store.has(key)) {
+                return null
             }
             store.set(key, value)
             return 'OK'
@@ -77,6 +85,21 @@ describe('RedisPollingSessionResponseBus', () => {
         await new Promise((resolve) => setTimeout(resolve, 10))
         redis._store.set('mcp:session-response:r', JSON.stringify({ action: 'decline' }))
         await expect(pending).resolves.toEqual({ action: 'decline' })
+    })
+
+    it('first deliver wins; a second deliver for the same key is silently dropped', async () => {
+        // First-writer-wins is the bus contract. SET NX in the implementation
+        // makes the second SET a no-op. This protects against duplicate POSTs
+        // (network retry, user double-click with a different choice, or an
+        // attacker racing replies).
+        await bus.deliver('r', { action: 'accept', content: { first: true } })
+        await bus.deliver('r', { action: 'decline', content: { second: true } })
+        const pending = bus.await<{ action: string; content: Record<string, unknown> }>('r', {
+            timeoutMs: 1_000,
+        })
+        const result = await pending
+        expect(result.action).toBe('accept')
+        expect(result.content).toEqual({ first: true })
     })
 
     it('DELs the key after a successful read (one-shot)', async () => {

--- a/services/mcp/tests/hono/session-bus/sse-response.test.ts
+++ b/services/mcp/tests/hono/session-bus/sse-response.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSseResponse } from '@/hono/sse-response'
+
+async function readAllAsText(response: Response): Promise<string> {
+    return await response.clone().text()
+}
+
+describe('createSseResponse', () => {
+    it('returns a Response with the SSE content-type and stream body', () => {
+        const { response } = createSseResponse()
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Content-Type')).toBe('text/event-stream')
+        expect(response.body).not.toBeNull()
+    })
+
+    it('writes JSONRPC messages as event: message frames with JSON data', async () => {
+        const { response, writer } = createSseResponse()
+        await writer.write({ jsonrpc: '2.0', id: 'a', method: 'elicitation/create', params: {} })
+        await writer.write({ jsonrpc: '2.0', id: 1, result: { ok: true } })
+        await writer.close()
+
+        const text = await readAllAsText(response)
+        const frames = text.split('\n\n').filter(Boolean)
+        expect(frames).toHaveLength(2)
+        expect(frames[0]).toBe(
+            'event: message\ndata: {"jsonrpc":"2.0","id":"a","method":"elicitation/create","params":{}}'
+        )
+        expect(frames[1]).toBe('event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}')
+    })
+
+    it('reports closed after close() and no-ops further writes', async () => {
+        const { response, writer } = createSseResponse()
+        await writer.close()
+        expect(writer.closed).toBe(true)
+        await writer.write({ jsonrpc: '2.0', id: 'x', method: 'x', params: {} })
+        // No throw; payload absent.
+        const text = await readAllAsText(response)
+        expect(text).toBe('')
+    })
+
+    it('tolerates write() after close without throwing', async () => {
+        const { writer } = createSseResponse()
+        await writer.close()
+        await expect(writer.write({ jsonrpc: '2.0', id: 'x', method: 'x', params: {} })).resolves.toBeUndefined()
+    })
+})


### PR DESCRIPTION
## Problem

The Hono MCP server is stateless and per-request. MCP elicitation needs to push a server-initiated request to the client mid-handler and await a reply that may arrive on a different pod. No mechanism for either today.

## Changes

**TLDR**
- Added elicitation infrastructure to allow future tools to `await context.elicit(...)`
- Then the dispatcher upgrades the response to SSE (the POST stays a POST), pushes `elicitation/create` to the client, and parks on a Redis-backed bus until the client's reply comes back - possibly on a different pod.
- Tried to keep it as modular and abstracted as possible (as we're just started using hono, so lets not f'ck it up from day 1) with a very minimal set of changes to the main implementation, hence the slightly larger PR.
- If clients don't support `elicitation` (eg Claude Cowork), we throw an error which is catchable by the actual tool and it decides whether to proceed or block.
- No tools wired in with `elicitation` yet, I'll push separate PRs with those.

## Details
- Add `SessionResponseBus` interface — Redis-polling impl for production, in-memory impl for tests; keyed by JSONRPC request id alone (UUID, globally unique)
- Add `ElicitBinding` — per-request seam between a tool handler's `context.elicit()` and the dispatcher's SSE writer
- Add `createSseResponse()` — helper that builds a streaming Response and writer for the dispatcher to upgrade JSON to SSE on demand
- Add `ElicitationGateway` — sends `elicitation/create` via the writer, parks on the bus until the client's reply lands
- Wire `Context.elicit` in `RequestContext.getContext()`; reads the binding lazily so it works whether installed before or after `getContext()`
- Dispatcher races the tool handler against the first elicit on `tools/call`; returns plain JSON when no elicit fires, upgrades to SSE only when one does
- Streamable handler peeks the inbound body; JSONRPC responses route to `bus.deliver()`, requests fall through to the dispatcher unchanged
- Add `mcp_session_bus_awaits_total`, `mcp_session_bus_await_duration_seconds`, `mcp_session_bus_polls_total` Prometheus metrics
- Gate elicitation on the client's `initialize` capability via a per-token cache; classify JSON-RPC error replies as `ElicitationNotSupportedError` rather than bus-unhealthy; switch the polling bus to `SET NX` so duplicate `deliver` no longer overwrites the first reply.


## How did you test this code?

- 42 unit tests across the new `session-bus/` modules (in-memory bus, redis polling bus, adaptive poll, elicitation gateway, elicit binding, SSE response)
- 224 existing Hono tests pass with the new dispatcher and streamable-handler logic in place

## Publish to changelog?

no