### PR TITLE
chore(activity-logging): extract tagged-item related-object logging to a registry

### DIFF
--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -340,9 +340,7 @@ class RelatedObjectActivityLogger:
     """
 
     scope: str
-    resolve_name: Callable[[TaggedItem, Optional[str]], Optional[str]] = (
-        lambda tagged_item, default_name: default_name
-    )
+    resolve_name: Callable[[TaggedItem, Optional[str]], Optional[str]] = lambda tagged_item, default_name: default_name
 
 
 RELATED_OBJECT_ACTIVITY_LOGGERS: dict[str, RelatedObjectActivityLogger] = {

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -1,5 +1,5 @@
 import dataclasses
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any, Literal, Optional, cast
 
 from django.db import models
@@ -330,6 +330,32 @@ def handle_tag_change(sender, scope, before_update, after_update, activity, user
     )
 
 
+@dataclasses.dataclass(frozen=True)
+class RelatedObjectActivityLogger:
+    """How to mirror a TaggedItem activity onto a related object's activity stream.
+
+    `scope` is used as both the `log_activity(scope=...)` and `Change.type` value.
+    `resolve_name` derives the display name for the activity row; the default
+    just returns the precomputed `related_object_name`.
+    """
+
+    scope: str
+    resolve_name: Callable[[TaggedItem, Optional[str]], Optional[str]] = (
+        lambda tagged_item, default_name: default_name
+    )
+
+
+RELATED_OBJECT_ACTIVITY_LOGGERS: dict[str, RelatedObjectActivityLogger] = {
+    "ticket": RelatedObjectActivityLogger(
+        scope="Ticket",
+        resolve_name=lambda tagged_item, default_name: (
+            f"Ticket #{tagged_item.ticket.ticket_number}" if tagged_item.ticket else default_name
+        ),
+    ),
+    "account": RelatedObjectActivityLogger(scope="Account"),
+}
+
+
 @mutable_receiver(model_activity_signal, sender=TaggedItem)
 def handle_tagged_item_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
@@ -337,84 +363,62 @@ def handle_tagged_item_change(
     # Use after_update for create/update, before_update for delete
     tagged_item = after_update or before_update
 
-    if tagged_item and tagged_item.tag:
-        related_object_type, related_object_id, related_object_name = get_tagged_item_related_object_info(tagged_item)
+    if not tagged_item or not tagged_item.tag:
+        return
 
-        context = TaggedItemContext(
-            tag_name=tagged_item.tag.name,
-            tag_id=str(tagged_item.tag.id),
-            team_id=tagged_item.tag.team_id,
-            related_object_type=related_object_type,
-            related_object_id=related_object_id,
-            related_object_name=related_object_name,
-        )
+    related_object_type, related_object_id, related_object_name = get_tagged_item_related_object_info(tagged_item)
 
+    context = TaggedItemContext(
+        tag_name=tagged_item.tag.name,
+        tag_id=str(tagged_item.tag.id),
+        team_id=tagged_item.tag.team_id,
+        related_object_type=related_object_type,
+        related_object_id=related_object_id,
+        related_object_name=related_object_name,
+    )
+
+    team = tagged_item.tag.team
+    organization_id = team.organization_id if team else None
+    team_id = tagged_item.tag.team_id
+
+    log_activity(
+        organization_id=organization_id,
+        team_id=team_id,
+        user=user,
+        was_impersonated=was_impersonated,
+        item_id=tagged_item.id,
+        scope=scope,
+        activity=activity,
+        detail=Detail(
+            changes=changes_between(scope, previous=before_update, current=after_update),
+            name=tagged_item.tag.name,
+            context=context,
+        ),
+    )
+
+    # Mirror the tag change onto the related object's own activity stream
+    # (e.g. so a tag added to a Ticket shows up on that ticket's timeline).
+    related_logger = RELATED_OBJECT_ACTIVITY_LOGGERS.get(related_object_type or "")
+    if related_logger and related_object_id:
+        tag_action: Literal["created", "deleted"] = "created" if activity == "created" else "deleted"
         log_activity(
-            organization_id=tagged_item.tag.team.organization_id if tagged_item.tag and tagged_item.tag.team else None,
-            team_id=tagged_item.tag.team_id if tagged_item.tag else None,
+            organization_id=organization_id,
+            team_id=team_id,
             user=user,
             was_impersonated=was_impersonated,
-            item_id=tagged_item.id,
-            scope=scope,
-            activity=activity,
+            item_id=related_object_id,
+            scope=related_logger.scope,
+            activity="updated",
             detail=Detail(
-                changes=changes_between(scope, previous=before_update, current=after_update),
-                name=tagged_item.tag.name if tagged_item.tag else None,
-                context=context,
+                name=related_logger.resolve_name(tagged_item, related_object_name),
+                changes=[
+                    Change(
+                        type=related_logger.scope,
+                        field="tag",
+                        action=tag_action,
+                        after=tagged_item.tag.name if activity == "created" else None,
+                        before=tagged_item.tag.name if activity == "deleted" else None,
+                    )
+                ],
             ),
         )
-
-        # Also log to the related object's activity stream for Ticket
-        if related_object_type == "ticket" and related_object_id:
-            ticket = tagged_item.ticket
-            ticket_name = f"Ticket #{ticket.ticket_number}" if ticket else related_object_name
-            tag_action: Literal["created", "deleted"] = "created" if activity == "created" else "deleted"
-            log_activity(
-                organization_id=tagged_item.tag.team.organization_id
-                if tagged_item.tag and tagged_item.tag.team
-                else None,
-                team_id=tagged_item.tag.team_id if tagged_item.tag else None,
-                user=user,
-                was_impersonated=was_impersonated,
-                item_id=related_object_id,
-                scope="Ticket",
-                activity="updated",
-                detail=Detail(
-                    name=ticket_name,
-                    changes=[
-                        Change(
-                            type="Ticket",
-                            field="tag",
-                            action=tag_action,
-                            after=tagged_item.tag.name if activity == "created" else None,
-                            before=tagged_item.tag.name if activity == "deleted" else None,
-                        )
-                    ],
-                ),
-            )
-
-        if related_object_type == "account" and related_object_id:
-            account_tag_action: Literal["created", "deleted"] = "created" if activity == "created" else "deleted"
-            log_activity(
-                organization_id=tagged_item.tag.team.organization_id
-                if tagged_item.tag and tagged_item.tag.team
-                else None,
-                team_id=tagged_item.tag.team_id if tagged_item.tag else None,
-                user=user,
-                was_impersonated=was_impersonated,
-                item_id=related_object_id,
-                scope="Account",
-                activity="updated",
-                detail=Detail(
-                    name=related_object_name,
-                    changes=[
-                        Change(
-                            type="Account",
-                            field="tag",
-                            action=account_tag_action,
-                            after=tagged_item.tag.name if activity == "created" else None,
-                            before=tagged_item.tag.name if activity == "deleted" else None,
-                        )
-                    ],
-                ),
-            )


### PR DESCRIPTION
## Problem

`handle_tagged_item_change` in `posthog/api/tagged_item.py` had two back-to-back ~25-line branches that mirrored a tag change onto the related object's own activity stream — one for `Ticket`, one for `Account`. The blocks differed only in scope name, `Change.type`, and how the display name was derived, so:

- Every additional taggable model with activity logging would copy the same block.
- A future fix to the `before` / `after` logic for `updated` activities was likely to be applied to one branch and not the others.
- The duplicated `if tagged_item.tag and tagged_item.tag.team else None` guards compounded the noise.

## Changes

Introduces a small `RelatedObjectActivityLogger` dataclass and a module-level `RELATED_OBJECT_ACTIVITY_LOGGERS: dict[str, RelatedObjectActivityLogger]` registry keyed by `related_object_type`. Each entry owns its `scope` (used as both `log_activity(scope=...)` and `Change.type`) and an optional `resolve_name` callable. Ticket overrides naming to `Ticket #<number>`; Account uses the default (`related_object_name`).

The two inline `if related_object_type == "..."` blocks collapse to a single registry lookup + shared `log_activity` call, so the `tag_action` derivation and `before` / `after` assignment exist in exactly one place. Adding a third taggable scope is now a one-line registry entry.

The outer `if tagged_item and tagged_item.tag` is reshaped into an early return, which lets the per-call `tagged_item.tag.team.organization_id if tagged_item.tag and tagged_item.tag.team else None` chains collapse to a single `organization_id` / `team_id` computed once near the top.

This is a behavior-preserving refactor — emitted `ActivityLog` rows for both Ticket and Account scopes are identical to today.

## How did you test this code?

Authored by an agent. No manual testing was performed.

Automated checks I actually ran:

- `python3 -c "import ast; ast.parse(...)"` on the modified file — parses clean.
- Smoke-tested the new dataclass in isolation: default `resolve_name` returns the supplied default; Ticket override returns `Ticket #<n>` when `tagged_item.ticket` is truthy and falls back otherwise; the frozen dataclass rejects mutation.

`hogli test posthog/test/activity_logging/test_tag_activity_logging.py` and `ruff` were not available in this sandbox, so they were not run locally. CI will exercise the existing test suite — none of the existing assertions touch Ticket or Account, so the refactor relies on visual parity with the previous blocks for those two scopes.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Opus 4.7 via PostHog Code, in response to a refactor request that called out the duplicated Ticket and Account branches in `handle_tagged_item_change`.

Design choices:

- Registry lives in `posthog/api/tagged_item.py` next to the only consumer, rather than `posthog/models/activity_logging/tag_utils.py`, since the dataclass references `Change` / `Detail` / `log_activity` primitives that are already imported there and `tag_utils.py` is otherwise free of activity-log dependencies.
- `resolve_name` is a `Callable[[TaggedItem, Optional[str]], Optional[str]]` rather than e.g. an attribute name, so the Ticket case can keep its `f"Ticket #{ticket_number}"` formatting and any future related object with non-trivial naming drops in without changing the dispatch logic.
- Kept the registry intentionally minimal — `scope` + `resolve_name`. Did not generalise to all nine `RELATED_OBJECTS`, since adding entries that weren't previously logged would change behavior.

Agent-authored PR — please review thoroughly. Do not self-merge.