### PR TITLE
fix(customer-analytics): reject malformed tags query param with 400

### DIFF
--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -736,15 +736,25 @@ class TestAccountViewSet(APIBaseTest):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(response.json()["count"], 1)
 
-    def test_list_ignores_malformed_tags_param(self):
+    @parameterized.expand(
+        [
+            ("not_json", "not-json"),
+            ("bare_token", "billing"),
+            ("json_string", '"billing"'),
+            ("json_object", '{"name":"billing"}'),
+            ("list_of_ints", "[1, 2]"),
+            ("mixed_list", '["billing", 1]'),
+        ]
+    )
+    def test_list_rejects_malformed_tags_param(self, _name, tags_value):
         Tag.objects.create(name="billing", team=self.team)
         self._create_account(name="Account A")
         self._create_account(name="Account B")
 
-        response = self.client.get(f"{self.endpoint_base}?tags=not-json")
+        response = self.client.get(f"{self.endpoint_base}?tags={tags_value}")
 
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(response.json()["count"], 2)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertIn("Must be a JSON-encoded list of strings.", str(response.json()))
 
     def test_list_ignores_empty_tags_array(self):
         self._create_account(name="Account A")

--- a/products/customer_analytics/backend/api/views.py
+++ b/products/customer_analytics/backend/api/views.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 
 from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from rest_framework import viewsets
+from rest_framework.exceptions import ValidationError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.tagged_item import TaggedItemViewSetMixin
@@ -89,7 +90,8 @@ class AccountViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContr
                 required=False,
                 description=(
                     'JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. '
-                    "Returns accounts that have any of the listed tags."
+                    "Returns accounts that have any of the listed tags. "
+                    "Malformed values (not a JSON-encoded list of strings) return a 400."
                 ),
             ),
             OpenApiParameter(
@@ -146,10 +148,12 @@ class AccountViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContr
         if tags_param:
             try:
                 tags_list = json.loads(tags_param)
-                if isinstance(tags_list, list) and tags_list:
-                    queryset = queryset.filter(tagged_items__tag__name__in=tags_list).distinct()
             except json.JSONDecodeError:
-                pass
+                raise ValidationError({"tags": "Must be a JSON-encoded list of strings."})
+            if not isinstance(tags_list, list) or not all(isinstance(t, str) for t in tags_list):
+                raise ValidationError({"tags": "Must be a JSON-encoded list of strings."})
+            if tags_list:
+                queryset = queryset.filter(tagged_items__tag__name__in=tags_list).distinct()
 
         # An unset role is serialized as JSON null, which `_properties__role__isnull`
         # does not match; probing the nested `id` matches every unassigned

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -374,7 +374,7 @@ export type AccountsListParams = {
      */
     search?: string
     /**
-     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags.
+     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags. Malformed values (not a JSON-encoded list of strings) return a 400.
      */
     tags?: string
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -40392,7 +40392,7 @@ export namespace Schemas {
      */
     search?: string;
     /**
-     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags.
+     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags. Malformed values (not a JSON-encoded list of strings) return a 400.
      */
     tags?: string;
     };

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -38,7 +38,7 @@ export const AccountsListQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            'JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags.'
+            'JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags. Malformed values (not a JSON-encoded list of strings) return a 400.'
         ),
 })
 


### PR DESCRIPTION
## Problem

`AccountViewSet.safely_get_queryset` (`products/customer_analytics/backend/api/views.py`) JSON-decoded the `tags` query string and, on `JSONDecodeError`, fell back to the team-scoped queryset with no tag filter applied. Callers passing a malformed value (forgotten `[...]`, single bare token, unquoted string, double-encoded JSON, etc.) got back every account in the team with a 200 and no error signal.

For a Customer Analytics account list this is a footgun — combined with pagination it's easy to miss visually, can surface accounts a caller didn't intend to see, and it hides real client bugs. A regression test (`test_list_ignores_malformed_tags_param`) pinned this behavior.

## Changes

- `safely_get_queryset` now raises `ValidationError({"tags": "Must be a JSON-encoded list of strings."})` (→ 400) on either a JSON decode error or a parsed value that isn't a `list[str]`.
- Empty list `[]` continues to be treated as "no filter applied" and returns 200 — the `test_list_ignores_empty_tags_array` invariant is preserved.
- `OpenApiParameter` description for `tags` now states that malformed values return a 400 — flows into generated frontend types and MCP schemas.
- The pinning regression test was renamed and parameterized as `test_list_rejects_malformed_tags_param`, covering: not-json, bare token, JSON string, JSON object, list of ints, mixed list.

Kept the JSON-in-querystring wire format as-is. The issue suggested switching to a DRF filter backend / repeated-key `?tag=foo&tag=bar` shape — that's a contract change affecting existing callers and the generated OpenAPI/MCP surface, out of scope for this bug fix.

## How did you test this code?

I'm an agent. Automated checks I ran in this environment:

- `ruff check` and `ruff format --check` on both edited files — clean.
- `python3 -m py_compile` on both files — syntax OK.
- Standalone simulation of the new validation logic against the parameterized test inputs plus the unchanged-behavior cases (`[]`, `["billing","urgent"]`) — all matched expected outcomes (400 for the malformed set, no-filter for `[]`, filter applied for the valid list).

I did **not** run the Django test suite locally — the sandbox didn't have a bootstrapped Python venv for this repo. Leaving that to CI, where the updated parameterized test will run against the real viewset and DRF stack.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) via a PostHog Code task. The task brief framed the issue and pointed at `products/customer_analytics/backend/api/views.py:92`.

Decisions:

- **Validate strictly, raise `ValidationError`.** Matches the issue's suggested approach and DRF's standard 400-on-bad-input contract; surfaced via `rest_framework.exceptions.ValidationError` so DRF renders the JSON error body.
- **Kept `[]` as no-filter.** It's a valid `list[str]` and the existing `test_list_ignores_empty_tags_array` documents that intent. Treating it as 400 would break callers that conditionally build the array.
- **Did not switch to a DRF filter backend / repeated-key shape.** The issue suggested this as a "consider" — it's a wire-format change affecting existing frontend callers and the generated TypeScript/MCP surface. Out of scope for a bug fix; can be revisited if/when this endpoint gets broader work.
- **Parameterized the test** rather than copy-pasting six near-identical methods, following the convention used elsewhere in this file and in CLAUDE.md.