### PR TITLE
fix: when not set use isNotSet

### DIFF
--- a/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
@@ -1,8 +1,42 @@
 import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
+import { BREAKDOWN_NULL_DISPLAY } from 'scenes/web-analytics/common'
 
 import { ProductIntentContext, ProductKey, WebStatsBreakdown } from '~/queries/schema/schema-general'
-import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, RecordingUniversalFilters } from '~/types'
+import {
+    AnyPropertyFilter,
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyOperator,
+    RecordingUniversalFilters,
+} from '~/types'
+
+/**
+ * Build a property filter for a breakdown value. When the value is the
+ * BREAKDOWN_NULL_DISPLAY placeholder ("(none)"), the property isn't literally
+ * set to "(none)" — it just isn't set — so use IsNotSet instead of an exact
+ * match.
+ */
+const buildBreakdownPropertyFilter = (
+    key: string,
+    type: PropertyFilterType.Event | PropertyFilterType.Session | PropertyFilterType.Person,
+    value: string
+): AnyPropertyFilter => {
+    if (value === BREAKDOWN_NULL_DISPLAY) {
+        return {
+            key,
+            type,
+            value: null,
+            operator: PropertyOperator.IsNotSet,
+        } as AnyPropertyFilter
+    }
+    return {
+        key,
+        type,
+        value: [value],
+        operator: PropertyOperator.Exact,
+    } as AnyPropertyFilter
+}
 
 /**
  * Map breakdown types to their corresponding property filter type
@@ -127,24 +161,21 @@ export const ReplayButton = ({ date_from, date_to, breakdownBy, value }: ReplayB
                     {
                         type: FilterLogicalOperator.And,
                         values: [
-                            {
-                                key: '$entry_utm_source',
-                                type: PropertyFilterType.Session,
-                                value: [values[0] || ''],
-                                operator: PropertyOperator.Exact,
-                            },
-                            {
-                                key: '$entry_utm_medium',
-                                type: PropertyFilterType.Session,
-                                value: [values[1] || ''],
-                                operator: PropertyOperator.Exact,
-                            },
-                            {
-                                key: '$entry_utm_campaign',
-                                type: PropertyFilterType.Session,
-                                value: [values[2] || ''],
-                                operator: PropertyOperator.Exact,
-                            },
+                            buildBreakdownPropertyFilter(
+                                '$entry_utm_source',
+                                PropertyFilterType.Session,
+                                values[0] || ''
+                            ),
+                            buildBreakdownPropertyFilter(
+                                '$entry_utm_medium',
+                                PropertyFilterType.Session,
+                                values[1] || ''
+                            ),
+                            buildBreakdownPropertyFilter(
+                                '$entry_utm_campaign',
+                                PropertyFilterType.Session,
+                                values[2] || ''
+                            ),
                         ],
                     },
                 ],
@@ -203,14 +234,7 @@ export const ReplayButton = ({ date_from, date_to, breakdownBy, value }: ReplayB
             values: [
                 {
                     type: FilterLogicalOperator.And,
-                    values: [
-                        {
-                            key: key,
-                            type: type,
-                            value: [value],
-                            operator: PropertyOperator.Exact,
-                        },
-                    ],
+                    values: [buildBreakdownPropertyFilter(key, type, value)],
                 },
             ],
         },

--- a/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
@@ -164,17 +164,17 @@ export const ReplayButton = ({ date_from, date_to, breakdownBy, value }: ReplayB
                             buildBreakdownPropertyFilter(
                                 '$entry_utm_source',
                                 PropertyFilterType.Session,
-                                values[0] || ''
+                                values[0] ?? BREAKDOWN_NULL_DISPLAY
                             ),
                             buildBreakdownPropertyFilter(
                                 '$entry_utm_medium',
                                 PropertyFilterType.Session,
-                                values[1] || ''
+                                values[1] ?? BREAKDOWN_NULL_DISPLAY
                             ),
                             buildBreakdownPropertyFilter(
                                 '$entry_utm_campaign',
                                 PropertyFilterType.Session,
-                                values[2] || ''
+                                values[2] ?? BREAKDOWN_NULL_DISPLAY
                             ),
                         ],
                     },


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/58035 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/60304) 
On the web analytics Source / Medium / Campaign panel, clicking View recordings on a row with (none) builds a literal = "(none)" filter, which matches no recordings because the underlying property isn't set to that string.

## Changes

Route (none) breakdown values through an IsNotSet filter instead of an exact match, in both the combined UTM panel and the generic single-property fallback in ReplayButton.tsx. 

Think we should use isNotSet, as it might be an important distinction 

## How did you test this code?

ran locally 

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Chose IsNotSet over silently skipping the filter (which is what the in-page click-to-filter path in WebAnalyticsTile.tsx does) so the replay view reproduces what the row actually represents — confirmed this asymmetry with the human author before committing.