### PR TITLE
fix(dev): use path-style object storage locally

### DIFF
--- a/.env.services
+++ b/.env.services
@@ -34,6 +34,7 @@ KAFKA_HOSTS=kafka:9092
 OBJECT_STORAGE_ENDPOINT=http://objectstorage:19000
 OBJECT_STORAGE_ACCESS_KEY_ID=object_storage_root_user
 OBJECT_STORAGE_SECRET_ACCESS_KEY=object_storage_root_password
+OBJECT_STORAGE_FORCE_PATH_STYLE=true
 
 # Proxy
 IS_BEHIND_PROXY=true


### PR DESCRIPTION
## Problem

Local Rust services can inherit the shared MinIO endpoint from `.env.services`.
Cymbal uses the AWS Rust SDK directly, and without path-style addressing the SDK can construct virtual-hosted bucket URLs that do not resolve against the local `objectstorage` host.

## Changes

Set `OBJECT_STORAGE_FORCE_PATH_STYLE=true` in `.env.services` so local S3-compatible object storage uses path-style addressing by default.

## How did you test this code?

Agent-authored change. I ran:

- `git diff --check`
- Verified the setting is present in `.env.services` and matches the existing hobby Cymbal setting.

## Publish to changelog?

No.

## Docs update

No docs update needed; this only adjusts local development service defaults.

## 🤖 Agent context

Codex investigated a local Cymbal startup failure after the shared environment split. The issue was narrowed to AWS S3 virtual-hosted addressing against the local MinIO endpoint. This PR chooses the shared local environment default because other local S3-compatible clients already force path-style addressing, and the hobby Cymbal configuration already uses the same setting.
