### PR TITLE
fix(docs): use projectId in Nuxt sourcemaps config

### DIFF
--- a/docs/onboarding/error-tracking/nuxt.tsx
+++ b/docs/onboarding/error-tracking/nuxt.tsx
@@ -75,7 +75,7 @@ export const getNuxt37Steps = (ctx: OnboardingComponentsContext): StepDefinition
                                       },
                                       sourcemaps: {
                                         enabled: true,
-                                        project: '<ph_project_id>', // Your project ID from PostHog settings https://app.posthog.com/settings/environment#variables
+                                        projectId: '<ph_project_id>', // Your project ID from PostHog settings https://app.posthog.com/settings/environment#variables
                                         personalApiKey: '<ph_personal_api_key>', // Your personal API key from PostHog settings https://app.posthog.com/settings/user-api-keys (requires organization:read and error_tracking:write scopes)
                                         releaseName: 'my-application', // Optional: defaults to git repository name
                                         releaseVersion: '1.0.0', // Optional: defaults to current git commit

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
@@ -77,10 +77,10 @@ const nuxtModuleConfig = (apiKey: string, host: string, teamId: string): string 
     },
     sourcemaps: {
       enabled: true,
-      envId: '${teamId}', // Your environment ID (project ID)
+      projectId: '${teamId}', // Your environment ID (project ID)
       personalApiKey: '<ph_personal_api_key>', // Your personal API key from PostHog settings
-      project: 'my-application', // Optional: Project name, defaults to git repository name
-      version: '1.0.0', // Optional: Release version, defaults to current git commit
+      releaseName: 'my-application', // Optional: Release name, defaults to git repository name
+      releaseVersion: '1.0.0', // Optional: Release version, defaults to current git commit
     },
   },
 })`


### PR DESCRIPTION
## Problem

Fixes #57371.

The Nuxt error tracking docs still showed `sourcemaps.project` for the PostHog project ID. In the current `@posthog/nuxt` sourcemaps config, the project ID field is `projectId`; `project` is a deprecated alias for the release name.

## Changes

- Update the Nuxt error tracking docs to use `sourcemaps.projectId`
- Update the Nuxt onboarding source maps snippet to use the current `projectId`, `releaseName`, and `releaseVersion` keys

## Validation

- `git diff --check`