### PR TITLE
fix(insights): correct percent-stack bar chart labels and y-axis

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1851,7 +1851,7 @@ snapshots:
     filters-taxonomic-filter-headless--properties--dark:
         hash: v1.k794b7964.4ee695e5751c6f73e9742ab0cfeecf61b5adfe829cf3a0d49ab2877cae8b212f.jPN9l5TDgLRy9NzHenXHCU903UDg8-GdeGpf4PXt7aA
     filters-taxonomic-filter-headless--properties--light:
-        hash: v1.k794b7964.7af6b884e5d826df422db99e4a99d2172f3316561a499dbe386ea098b1fc54a9.rti2DMpqC0WEtd_AtG838vQlgQMHfwjBAR4uLN_HnUk
+        hash: v1.k794b7964.afa422fd784363e602da5668ab488a823260acba8c2b1168dc85bcbf434d3ddf.Wjl32UIE5KhBda_SpJYwXKZ2FGmnlFbtzv4uKDaJRIs
     filters-taxonomic-filter-headless--suggested-filters-with-recents--dark:
         hash: v1.k794b7964.c3a6cd419610bc486261efa753816547f080f00c838bde0b8720cf12067b3b22.nxBtExiDfJ3USkhV9RY1VPU_U2dGyEYCMFbhvtOcuVs
     filters-taxonomic-filter-headless--suggested-filters-with-recents--light:
@@ -1968,6 +1968,10 @@ snapshots:
         hash: v1.k794b7964.68689d02aa245c2ccd04888b1c2bc578136eda4117f2fff911bde3f5c276b9da.svBnhEDDJ61_Vp6T3AUEjT3wlS2aamf9o-YNooKTRlw
     insights-trendsbarchart--compare--light:
         hash: v1.k794b7964.08db5d36c08b26300a7cd09fddd8f02e9ba973ffcf42e556e7f8ae01a27e907b.jN5qaeiDphtPJ90-0-bNC0jmD0MVkSCj6zjO8XzvZkI
+    insights-trendsbarchart--percent-stack-breakdown--dark:
+        hash: v1.k794b7964.b7e405e7536059add287822bbcae51772fab8005ac1f864ee3c65495eaeec4a9.0o8Vkv9xYOCBk1d35UNO2_kA2Oy9iajzneJBiTlq6vg
+    insights-trendsbarchart--percent-stack-breakdown--light:
+        hash: v1.k794b7964.02fcdcf3d83d1d4a1c0e28e097e1affbecb5d89f803d658bfe90ad49da0bd444.Mqj_tHvOG038o4BV0jE89RHVuDXjLZiYAluTs8Hx1pg
     insights-trendslifecyclechart--stacked--dark:
         hash: v1.k794b7964.f01dae4d665fea93c451e5bb48d6409d586c89856ffb1fff155937c7eb9119d9.coUQ2-TFqEqeP38cPDoiz5RbwkfznST9H3pR5TRbpvg
     insights-trendslifecyclechart--stacked--light:
@@ -4711,7 +4715,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-historical-trends-edit--light:
         hash: v1.k794b7964.fa67675b6f95f0ae9c46eb0e803f9db69702419bb4ccc2d21ea973f9fe49d9cc.Zz4siV83g7nIXf96Nfvy6eN5rRtzwO3CEmv24KSztlA
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--dark:
-        hash: v1.k794b7964.945ed16d72ed2ec67559ed2a478237267bf3fae0ec5437202145e4bbddaa99c2.Pl63KVs13EuxFB41jKCVv-dOTSP27veYuLRl7pFf7UQ
+        hash: v1.k794b7964.2a18d8ba3f9634f9d7c9ece2ad8ee2f6716706ecbb30595102d003ca8ad27184.y6n_yOa8fbdhe6yHOtjclzfTFAJ9hj0Da0VbQIhaj2M
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.test.tsx
@@ -263,10 +263,14 @@ describe('TimeSeriesBarChart', () => {
                     }}
                 />
             )
-            const texts = chart.valueLabels().map((l) => l.text)
-            // Only assert a's labels since b is the larger segment and we just want to confirm
-            // the share-of-band conversion went through the formatter.
-            expect(texts).toEqual(expect.arrayContaining(['10%', '20%', '30%']))
+            // a's shares are [0.1, 0.2, 0.3]; b's are [0.9, 0.8, 0.7]. Sort so the assertion
+            // doesn't depend on render order.
+            expect(
+                chart
+                    .valueLabels()
+                    .map((l) => l.text)
+                    .sort()
+            ).toEqual(['10%', '20%', '30%', '70%', '80%', '90%'].sort())
         })
     })
 

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.test.tsx
@@ -245,10 +245,15 @@ describe('TimeSeriesBarChart', () => {
             expect(chart.yTicks().some((t) => /\d+%/.test(t))).toBe(true)
         })
 
-        it('formats value labels as percentages when yAxis.format=percentage_scaled with 0-1 data', () => {
+        it('formats value labels as each segment fraction (0..1) in percent layout', () => {
+            // Two series with totals (10, 100, 1000); a's share is 0.1, 0.2, 0.3 of each band.
+            // The `percentage_scaled` formatter takes 0..1 input so the labels render as "10%, 20%, 30%".
             const { chart } = renderHogChart(
                 <TimeSeriesBarChart
-                    series={[{ key: 'a', label: 'A', data: [0.1, 0.2, 0.3] }]}
+                    series={[
+                        { key: 'a', label: 'A', data: [1, 20, 300] },
+                        { key: 'b', label: 'B', data: [9, 80, 700] },
+                    ]}
                     labels={LABELS}
                     theme={THEME}
                     config={{
@@ -258,7 +263,10 @@ describe('TimeSeriesBarChart', () => {
                     }}
                 />
             )
-            expect(chart.valueLabels().map((l) => l.text)).toEqual(['10%', '20%', '30%'])
+            const texts = chart.valueLabels().map((l) => l.text)
+            // Only assert a's labels since b is the larger segment and we just want to confirm
+            // the share-of-band conversion went through the formatter.
+            expect(texts).toEqual(expect.arrayContaining(['10%', '20%', '30%']))
         })
     })
 

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
@@ -287,10 +287,18 @@ describe('ValueLabels', () => {
         })
     })
 
-    it('isPercent on context is informational — consumers supply their own formatter', () => {
-        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [0.25, 0.5, 0.75] }]
-        const ctx = makeContext(series, { isPercent: true, labels: ['Mon', 'Tue', 'Wed'] })
+    it('in percent layout, formatter receives each segment fraction (0..1), not raw data', () => {
+        // Two series with raw counts 20 and 15 (band total 35). In percent layout the formatter
+        // must receive the share of the band — 20/35 ≈ 0.571 and 15/35 ≈ 0.429 — not the raw
+        // counts. We position the segments on different bands so collision avoidance doesn't drop
+        // either label.
+        const series: ResolvedSeries[] = [
+            { key: 'a', label: 'A', color: '#f00', data: [20, 0] },
+            { key: 'b', label: 'B', color: '#0f0', data: [0, 15] },
+        ]
+        const ctx = makeContext(series, { isPercent: true, labels: ['Mon', 'Tue'] })
         const { container } = renderInChart(ctx, <ValueLabels valueFormatter={(v) => `${(v * 100).toFixed(1)}%`} />)
-        expect(labelDivs(container).map((d) => d.textContent)).toEqual(['25.0%', '50.0%', '75.0%'])
+        // Each band has a single non-zero segment, so its share of the band is 100%.
+        expect(labelDivs(container).map((d) => d.textContent)).toEqual(['100.0%', '100.0%'])
     })
 })

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
@@ -288,17 +288,36 @@ describe('ValueLabels', () => {
     })
 
     it('in percent layout, formatter receives each segment fraction (0..1), not raw data', () => {
-        // Two series with raw counts 20 and 15 (band total 35). In percent layout the formatter
-        // must receive the share of the band — 20/35 ≈ 0.571 and 15/35 ≈ 0.429 — not the raw
-        // counts. We position the segments on different bands so collision avoidance doesn't drop
-        // either label.
+        // Both series have non-zero values in both bands so we exercise the `raw / total`
+        // division, not the trivial single-segment-per-band 100% path.
+        // Band totals: Mon = 100, Tue = 100. Expected fractions: a = [0.2, 0.6], b = [0.8, 0.4].
         const series: ResolvedSeries[] = [
-            { key: 'a', label: 'A', color: '#f00', data: [20, 0] },
-            { key: 'b', label: 'B', color: '#0f0', data: [0, 15] },
+            { key: 'a', label: 'A', color: '#f00', data: [20, 60] },
+            { key: 'b', label: 'B', color: '#0f0', data: [80, 40] },
         ]
-        const ctx = makeContext(series, { isPercent: true, labels: ['Mon', 'Tue'] })
-        const { container } = renderInChart(ctx, <ValueLabels valueFormatter={(v) => `${(v * 100).toFixed(1)}%`} />)
-        // Each band has a single non-zero segment, so its share of the band is 100%.
-        expect(labelDivs(container).map((d) => d.textContent)).toEqual(['100.0%', '100.0%'])
+        // Custom yScale on 0..1 (matches percent layout) so segment centers don't collide.
+        const percentScales: ChartScales = {
+            x: xScale,
+            y: (v: number) => 368 - v * 352,
+            yTicks: () => [0, 0.5, 1],
+        }
+        // Stacked tops per series in 0..1 space — matches d3.stackOffsetExpand output.
+        const positionByKey: Record<string, number[]> = {
+            a: [0.2, 0.6],
+            b: [1.0, 1.0],
+        }
+        const resolvePositionValue: ResolveValueFn = (s, i) => positionByKey[s.key]?.[i] ?? 0
+        const ctx = makeContext(series, {
+            isPercent: true,
+            labels: ['Mon', 'Tue'],
+            scales: percentScales,
+            resolvePositionValue,
+        })
+        const { container } = renderInChart(ctx, <ValueLabels valueFormatter={(v) => `${(v * 100).toFixed(0)}%`} />)
+        expect(
+            labelDivs(container)
+                .map((d) => d.textContent)
+                .sort()
+        ).toEqual(['20%', '40%', '60%', '80%'])
     })
 })

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -156,9 +156,11 @@ function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
     const out: Candidate[] = []
 
     // In percent layout each band sums to 1, so we need the band total to convert each segment's
-    // raw value into the fraction d3 uses for placement (`raw / total`).
+    // raw value into the fraction d3 uses for placement (`raw / total`). Match the d3 stack's own
+    // denominator — every non-excluded stacked series — even if some have `valueLabel: false`,
+    // since those still contribute to the visual stack height.
     const visibleForTotal = isPercent
-        ? series.filter((s) => !s.visibility?.excluded && s.visibility?.valueLabel !== false)
+        ? series.filter((s) => !s.visibility?.excluded && !s.fill?.lowerData && !s.overlay)
         : []
 
     for (let sIdx = 0; sIdx < series.length; sIdx++) {

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -32,6 +32,9 @@ interface Candidate {
     width: number
     color: string
     above: boolean
+    /** Anchor the label centered on `(x, y)` instead of offset by `above`. Used for percent-stack
+     *  segments so the topmost label doesn't render above the chart top. */
+    centered: boolean
 }
 
 function defaultLocaleFormatter(v: number): string {
@@ -59,7 +62,8 @@ function pushCandidate(
     text: string,
     categoricalCoord: number,
     valueCoord: number,
-    above: boolean
+    above: boolean,
+    centered: boolean = false
 ): void {
     const textWidth = ctx ? ctx.measureText(text).width : text.length * 6
     const width = textWidth + LABEL_HORIZONTAL_CHROME
@@ -72,6 +76,7 @@ function pushCandidate(
         width,
         color,
         above,
+        centered,
     })
 }
 
@@ -147,8 +152,14 @@ function buildStackTotal(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
 }
 
 function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2D | null): Candidate[] {
-    const { series, labels, scales, resolvePositionValue, valueFormatter, isHorizontal } = args
+    const { series, labels, scales, resolvePositionValue, valueFormatter, isHorizontal, isPercent } = args
     const out: Candidate[] = []
+
+    // In percent layout each band sums to 1, so we need the band total to convert each segment's
+    // raw value into the fraction d3 uses for placement (`raw / total`).
+    const visibleForTotal = isPercent
+        ? series.filter((s) => !s.visibility?.excluded && s.visibility?.valueLabel !== false)
+        : []
 
     for (let sIdx = 0; sIdx < series.length; sIdx++) {
         const s = series[sIdx]
@@ -165,11 +176,33 @@ function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
             if (typeof yValue !== 'number' || !isFinite(yValue)) {
                 continue
             }
+
+            let displayValue = rawValue
+            let positionValue = yValue
+            let above = yValue >= 0
+            let centered = false
+
+            if (isPercent) {
+                const total = bandTotal(visibleForTotal, dIdx)
+                if (total == null || total === 0) {
+                    continue
+                }
+                const fraction = rawValue / total
+                // Pass the fraction (0..1) so consumers can use the same percentage formatter
+                // (`percentage_scaled`, BarChart's default tick formatter, etc.) they already use
+                // for the value axis.
+                displayValue = fraction
+                // `yValue` here is the stacked top in 0..1 space; subtract half the segment's
+                // height to land at the segment center.
+                positionValue = yValue - fraction / 2
+                centered = true
+            }
+
             // Pass `s.key` so grouped bar charts (compare-against-previous) anchor each
             // label on its own bar rather than the band center between bars. Other chart
             // types ignore the second arg and fall back to the band/point center.
             const categoricalCoord = scales.x(labels[dIdx], s.key)
-            const valueCoord = yScale(yValue)
+            const valueCoord = yScale(positionValue)
             if (categoricalCoord == null || !isFinite(categoricalCoord) || !isFinite(valueCoord)) {
                 continue
             }
@@ -180,10 +213,11 @@ function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
                 `${s.key}-${dIdx}`,
                 sIdx,
                 s.color,
-                valueFormatter(rawValue, sIdx, dIdx),
+                valueFormatter(displayValue, sIdx, dIdx),
                 categoricalCoord,
                 valueCoord,
-                yValue >= 0
+                above,
+                centered
             )
         }
     }
@@ -200,11 +234,12 @@ interface Rect {
 function labelRect(c: Candidate, isHorizontal: boolean): Rect {
     if (isHorizontal) {
         const halfH = LABEL_HEIGHT / 2
-        const left = c.above ? c.x : c.x - c.width
+        const halfW = c.width / 2
+        const left = c.centered ? c.x - halfW : c.above ? c.x : c.x - c.width
         return { left, right: left + c.width, top: c.y - halfH, bottom: c.y + halfH }
     }
     const halfW = c.width / 2
-    const top = c.above ? c.y - LABEL_HEIGHT : c.y
+    const top = c.centered ? c.y - LABEL_HEIGHT / 2 : c.above ? c.y - LABEL_HEIGHT : c.y
     return { left: c.x - halfW, right: c.x + halfW, top, bottom: top + LABEL_HEIGHT }
 }
 
@@ -278,6 +313,9 @@ const LABEL_STYLE_BASE: React.CSSProperties = {
 }
 
 function transformFor(c: Candidate, isHorizontal: boolean): string {
+    if (c.centered) {
+        return 'translate(-50%, -50%)'
+    }
     if (isHorizontal) {
         return c.above ? 'translateY(-50%)' : 'translate(-100%, -50%)'
     }

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
@@ -341,3 +341,115 @@ const AGGREGATED_COMPARE_BREAKDOWN_INSIGHT = {
 export const AggregatedCompareBreakdown: Story = {
     render: () => renderTrendsBarChart(AGGREGATED_COMPARE_BREAKDOWN_INSIGHT),
 }
+
+// Stacked bar in 100% mode with value labels enabled. Pre-fix this snapshot showed a 0%–1%
+// y-axis, raw-count value labels (e.g. "22,865%"), and a clipped top-segment label. After
+// the fix the y-axis runs 0%–100%, labels show each segment's share, and the topmost label
+// sits inside its segment.
+const PERCENT_STACK_BREAKDOWN_INSIGHT = {
+    id: 202,
+    short_id: 'barPercentStack',
+    name: 'Pageviews by browser (100% stacked)',
+    derived_name: 'Pageview count',
+    filters: {},
+    last_refresh: '2023-07-11T12:00:00Z',
+    refreshing: false,
+    saved: true,
+    is_sample: false,
+    description: '',
+    tags: [],
+    favorited: false,
+    created_at: '2023-07-11T12:00:00Z',
+    updated_at: '2023-07-11T12:00:00Z',
+    last_modified_at: '2023-07-11T12:00:00Z',
+    dashboards: [],
+    dashboard_tiles: [],
+    result: [
+        {
+            action: ACTION,
+            label: 'Chrome',
+            count: 14000,
+            data: [4000, 3500, 3000, 1500, 1200, 600, 200],
+            labels: CURRENT_LABELS,
+            days: CURRENT_DAYS,
+            breakdown_value: 'Chrome',
+            filter: {
+                date_from: '2023-07-04T00:00:00Z',
+                date_to: '2023-07-10T23:59:59Z',
+                display: 'ActionsBar',
+                insight: 'TRENDS',
+                interval: 'day',
+            },
+        },
+        {
+            action: ACTION,
+            label: 'Safari',
+            count: 6500,
+            data: [400, 800, 1500, 1800, 1500, 400, 100],
+            labels: CURRENT_LABELS,
+            days: CURRENT_DAYS,
+            breakdown_value: 'Safari',
+            filter: {
+                date_from: '2023-07-04T00:00:00Z',
+                date_to: '2023-07-10T23:59:59Z',
+                display: 'ActionsBar',
+                insight: 'TRENDS',
+                interval: 'day',
+            },
+        },
+        {
+            action: ACTION,
+            label: 'Firefox',
+            count: 2200,
+            data: [200, 250, 300, 500, 500, 350, 100],
+            labels: CURRENT_LABELS,
+            days: CURRENT_DAYS,
+            breakdown_value: 'Firefox',
+            filter: {
+                date_from: '2023-07-04T00:00:00Z',
+                date_to: '2023-07-10T23:59:59Z',
+                display: 'ActionsBar',
+                insight: 'TRENDS',
+                interval: 'day',
+            },
+        },
+        {
+            action: ACTION,
+            label: 'Edge',
+            count: 900,
+            data: [80, 120, 150, 200, 200, 100, 50],
+            labels: CURRENT_LABELS,
+            days: CURRENT_DAYS,
+            breakdown_value: 'Edge',
+            filter: {
+                date_from: '2023-07-04T00:00:00Z',
+                date_to: '2023-07-10T23:59:59Z',
+                display: 'ActionsBar',
+                insight: 'TRENDS',
+                interval: 'day',
+            },
+        },
+    ],
+    query: {
+        kind: 'InsightVizNode',
+        source: {
+            dateRange: { date_from: '2023-07-04', date_to: '2023-07-10' },
+            filterTestAccounts: false,
+            interval: 'day',
+            kind: 'TrendsQuery',
+            series: [{ event: '$pageview', kind: 'EventsNode', math: 'total', name: '$pageview' }],
+            trendsFilter: {
+                display: 'ActionsBar',
+                showPercentStackView: true,
+                showValuesOnSeries: true,
+            },
+            breakdownFilter: { breakdown: '$browser', breakdown_type: 'event' },
+            version: 2,
+        },
+        full: true,
+    },
+}
+
+export const PercentStackBreakdown: Story = {
+    render: () => renderTrendsBarChart(PERCENT_STACK_BREAKDOWN_INSIGHT),
+}

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -11,6 +11,7 @@ import {
     ValueLabels,
 } from 'lib/hog-charts'
 import type { BarChartConfig, PointClickData, TimeSeriesBarChartConfig, TooltipContext } from 'lib/hog-charts'
+import { percentage } from 'lib/utils'
 import { formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -129,7 +130,14 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
     }, [isAggregated, indexedResults, getTrendsColor, getTrendsHidden, currentPeriodResult?.labels])
 
     const valueLabelFormatter = useCallback(
-        (value: number) => formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency),
+        (value: number) => {
+            // In percent layout the chart computes each segment's share of its band and passes
+            // a 0..1 fraction here, so we render it directly as a percentage.
+            if (isPercentStackView) {
+                return percentage(value)
+            }
+            return formatPercentStackAxisValue(trendsFilter, value, false, baseCurrency)
+        },
         [trendsFilter, isPercentStackView, baseCurrency]
     )
 

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -12,7 +12,7 @@ import {
 } from 'lib/hog-charts'
 import type { BarChartConfig, PointClickData, TimeSeriesBarChartConfig, TooltipContext } from 'lib/hog-charts'
 import { percentage } from 'lib/utils'
-import { formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -136,7 +136,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
             if (isPercentStackView) {
                 return percentage(value)
             }
-            return formatPercentStackAxisValue(trendsFilter, value, false, baseCurrency)
+            return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
         },
         [trendsFilter, isPercentStackView, baseCurrency]
     )

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
@@ -201,13 +201,15 @@ describe('buildTrendsBarTimeSeriesConfig', () => {
         })
     })
 
-    it('forces percentage format when isPercentStackView is true', () => {
+    it('forces percentage_scaled format when isPercentStackView is true', () => {
+        // BarChart percent layout puts the value scale on 0..1, so the y-tick formatter
+        // expects 0..1 input rather than the 0..100 input of the regular `percentage` format.
         const cfg = buildTrendsBarTimeSeriesConfig({
             isPercentStackView: true,
             isGrouped: false,
             trendsFilter: { aggregationAxisFormat: 'currency' },
         })
-        expect(cfg.yAxis?.format).toBe('percentage')
+        expect(cfg.yAxis?.format).toBe('percentage_scaled')
     })
 
     it('maps schema goal lines through the shared adapter', () => {

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -5,7 +5,7 @@ import { buildTheme } from 'lib/charts/utils/theme'
 import { DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from 'lib/hog-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipConfig, TooltipContext } from 'lib/hog-charts'
 import { percentage } from 'lib/utils'
-import { formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -111,7 +111,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             if (isPercentStackView) {
                 return percentage(value)
             }
-            return formatPercentStackAxisValue(trendsFilter, value, false, baseCurrency)
+            return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
         },
         [trendsFilter, isPercentStackView, baseCurrency]
     )

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { buildTheme } from 'lib/charts/utils/theme'
 import { DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from 'lib/hog-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipConfig, TooltipContext } from 'lib/hog-charts'
+import { percentage } from 'lib/utils'
 import { formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -104,7 +105,14 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
     )
 
     const valueLabelFormatter = useCallback(
-        (value: number) => formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency),
+        (value: number) => {
+            // In percent layout the chart computes each segment's share of its band and passes
+            // a 0..1 fraction here, so we render it directly as a percentage.
+            if (isPercentStackView) {
+                return percentage(value)
+            }
+            return formatPercentStackAxisValue(trendsFilter, value, false, baseCurrency)
+        },
         [trendsFilter, isPercentStackView, baseCurrency]
     )
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
@@ -407,7 +407,7 @@ describe('trendsChartTransforms', () => {
                 tooltip: TOOLTIP,
                 showCrosshair: false,
             })
-            expect(config.yAxis).toMatchObject({ format: 'percentage', scale: 'linear', showGrid: true })
+            expect(config.yAxis).toMatchObject({ format: 'percentage_scaled', scale: 'linear', showGrid: true })
             expect(config.percentStackView).toBe(true)
             expect(config.tooltip).toBe(TOOLTIP)
             expect(config.showCrosshair).toBe(false)

--- a/products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat.test.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat.test.ts
@@ -45,10 +45,12 @@ describe('trendsFilterToYFormatterConfig', () => {
         expect(trendsFilterToYFormatterConfig(trendsFilter, false)).toEqual({ format: 'numeric' })
     })
 
-    it('returns a percentage config when isPercentStackView is true, ignoring the trends filter', () => {
+    it('returns a percentage_scaled config when isPercentStackView is true, ignoring the trends filter', () => {
+        // BarChart percent layout puts the value scale on 0..1, so we use the 0..1 formatter
+        // (`percentage_scaled`) instead of the 0..100 `percentage` formatter.
         const trendsFilter: TrendsFilter = { aggregationAxisFormat: 'currency', aggregationAxisPrefix: '$' }
         expect(trendsFilterToYFormatterConfig(trendsFilter, true, 'USD' as CurrencyCode)).toEqual({
-            format: 'percentage',
+            format: 'percentage_scaled',
         })
     })
 })
@@ -70,9 +72,10 @@ describe('trends y-tick formatter end-to-end', () => {
     })
 
     it('formats percent-stack values regardless of the underlying trends filter', () => {
+        // Input is a 0..1 fraction (d3's percent scale), so 0.5 → "50%".
         const trendsFilter: TrendsFilter = { aggregationAxisFormat: 'currency' }
         const fmt = buildYTickFormatter(trendsFilterToYFormatterConfig(trendsFilter, true, 'USD' as CurrencyCode))
-        expect(fmt(50)).toBe('50%')
+        expect(fmt(0.5)).toBe('50%')
     })
 })
 
@@ -102,8 +105,8 @@ describe('buildTrendsYAxisConfig', () => {
         expect(cfg).toMatchObject({ format: 'duration', prefix: '~', decimalPlaces: 2, currency: 'USD' })
     })
 
-    it('forces percentage format when isPercentStackView is true', () => {
+    it('forces percentage_scaled format when isPercentStackView is true', () => {
         const trendsFilter: TrendsFilter = { aggregationAxisFormat: 'currency', aggregationAxisPrefix: '$' }
-        expect(buildTrendsYAxisConfig(trendsFilter, true, 'USD' as CurrencyCode).format).toBe('percentage')
+        expect(buildTrendsYAxisConfig(trendsFilter, true, 'USD' as CurrencyCode).format).toBe('percentage_scaled')
     })
 })

--- a/products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat.ts
@@ -8,7 +8,8 @@ export function trendsFilterToYFormatterConfig(
     baseCurrency?: CurrencyCode
 ): YFormatterConfig {
     if (isPercentStackView) {
-        return { format: 'percentage' }
+        // BarChart's percent layout puts the value scale on 0..1, so use the 0..1 formatter.
+        return { format: 'percentage_scaled' }
     }
     return {
         format: trendsFilter?.aggregationAxisFormat ?? 'numeric',


### PR DESCRIPTION
## Problem

In the hog-charts-backed trends bar chart, the percent-stack (100%) view was rendering bad values:

- Y-axis ticks read 0%–1% instead of 0%–100%.
- Per-segment value labels showed raw counts run through a percent formatter, producing things like `22,865%` instead of `84.4%`.
- The topmost segment's label rendered above the chart top and was clipped.

## Changes

- Switch trends bar/line y-axis to `percentage_scaled` (0..1 input) so d3's percent ticks render as 0%–100%.
- In `ValueLabels`, when the chart is in percent layout, compute each segment's share of its band and pass that fraction (0..1) to the formatter instead of the raw datum.
- Anchor percent-layout labels at the segment center (not the segment top), so the topmost label no longer clips above the plot area.
- Update `TrendsBarChart` and `TrendsLineChart` value-label formatters to render the fraction directly via `percentage()` in percent stack view.
- Update tests for the new percent-stack contract.

Before / after:

| Before | After |
| --- | --- |
| `22,865%` labels, y-axis at 0%–1%, top label clipped | sensible `%` labels, y-axis 0%–100%, labels inside their segments |

## How did you test this code?

I'm an agent. I ran the affected jest suites locally:

- `frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx`
- `frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx`
- `frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.test.tsx`
- `products/product_analytics/frontend/insights/trends/TrendsBarChart/`
- `products/product_analytics/frontend/insights/trends/TrendsLineChart/`
- `products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat.test.ts`

All 1171 tests across the touched packages pass. I also opened a trends pageview-by-browser insight in percent-stack mode locally and confirmed the y-axis renders 0%–100% and segment labels show plausible percentages.

## Publish to changelog?

## 🤖 Agent context

Authored by Claude Code. The fix touches two layers:

1. `hog-charts/overlays/ValueLabels.tsx` — added per-segment fraction computation gated by `axis.isPercent`, and a `centered` candidate flag so percent-layout labels are vertically centered on the segment (the existing `above` semantics put the top label above the chart top edge).
2. Trends adapters — switched the y-axis format helper to `percentage_scaled` and overrode the value-label formatter to use `percentage(value)` (0..1 input). I kept `formatPercentStackAxisValue` untouched because the chart.js LineGraph still relies on its existing 0–100 contract.

Considered but rejected: changing `formatPercentStackAxisValue` itself — would have broken the chart.js LineGraph callers that still pass 0–100 values from `chartjs-plugin-stacked100`.