### PR TITLE
feat(dashboards): add MCP tools to create and edit text tiles

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -3334,22 +3334,18 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.json()["text"]["body"], "Just a divider")
 
-    def test_create_text_tile_rejects_empty_body(self):
+    @parameterized.expand(
+        [
+            ("empty", ""),
+            ("over_max_length", "x" * 4001),
+        ]
+    )
+    def test_create_text_tile_rejects_invalid_body(self, _name, body):
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
 
         response = self.client.post(
             f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/create_text_tile/",
-            {"body": ""},
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_create_text_tile_rejects_body_over_4000_chars(self):
-        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
-
-        response = self.client.post(
-            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/create_text_tile/",
-            {"body": "x" * 4001},
+            {"body": body},
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -3411,7 +3407,29 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
 
         tile.refresh_from_db()
         self.assertEqual(tile.layouts["sm"], {"x": 1, "y": 2, "w": 6, "h": 1})
-        self.assertEqual(tile.text.body, "new body")
+        text.refresh_from_db()
+        self.assertEqual(text.body, "new body")
+
+    @parameterized.expand(
+        [
+            ("null", None),
+            ("empty", ""),
+        ]
+    )
+    def test_update_text_tile_rejects_empty_or_null_body(self, _name, body):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        text = Text.objects.create(body="original", team=self.team)
+        tile = DashboardTile.objects.create(dashboard=dashboard, text=text)
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
+            {"tile_id": tile.pk, "body": body},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        text.refresh_from_db()
+        self.assertEqual(text.body, "original")
 
     def test_update_text_tile_rejects_insight_tile(self):
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
@@ -3425,28 +3443,25 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_update_text_tile_with_unknown_id_returns_404(self):
-        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
-
-        response = self.client.patch(
-            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
-            {"tile_id": 9999999, "body": "x"},
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_update_text_tile_on_other_dashboard_returns_404(self):
+    def _make_unknown_tile_id_args(self):
         dashboard_a = Dashboard.objects.create(team=self.team, name="A")
         dashboard_b = Dashboard.objects.create(team=self.team, name="B")
         text = Text.objects.create(body="A's tile", team=self.team)
         tile_on_a = DashboardTile.objects.create(dashboard=dashboard_a, text=text)
+        return [
+            ("unknown_tile_id", dashboard_a.pk, 9999999),
+            ("tile_on_other_dashboard", dashboard_b.pk, tile_on_a.pk),
+        ]
 
-        response = self.client.patch(
-            f"/api/environments/{self.team.pk}/dashboards/{dashboard_b.pk}/update_text_tile/",
-            {"tile_id": tile_on_a.pk, "body": "should fail"},
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+    def test_update_text_tile_returns_404_for_unknown_tile(self):
+        for name, dashboard_pk, tile_id in self._make_unknown_tile_id_args():
+            with self.subTest(name):
+                response = self.client.patch(
+                    f"/api/environments/{self.team.pk}/dashboards/{dashboard_pk}/update_text_tile/",
+                    {"tile_id": tile_id, "body": "should fail"},
+                    content_type="application/json",
+                )
+                self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_add_insight_to_multiple_dashboards_via_patch(self):
         dashboard1 = Dashboard.objects.create(team=self.team, name="Dashboard 1")

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -3369,7 +3369,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             layouts={"sm": {"x": 0, "y": 0, "w": 6, "h": 1}},
         )
 
-        response = self.client.patch(
+        response = self.client.post(
             f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
             {
                 "tile_id": tile.pk,
@@ -3398,7 +3398,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             layouts={"sm": {"x": 1, "y": 2, "w": 6, "h": 1}},
         )
 
-        response = self.client.patch(
+        response = self.client.post(
             f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
             {"tile_id": tile.pk, "body": "new body"},
             content_type="application/json",
@@ -3421,7 +3421,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         text = Text.objects.create(body="original", team=self.team)
         tile = DashboardTile.objects.create(dashboard=dashboard, text=text)
 
-        response = self.client.patch(
+        response = self.client.post(
             f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
             {"tile_id": tile.pk, "body": body},
             content_type="application/json",
@@ -3436,7 +3436,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         insight = Insight.objects.create(team=self.team, name="Insight 1")
         tile = DashboardTile.objects.create(dashboard=dashboard, insight=insight)
 
-        response = self.client.patch(
+        response = self.client.post(
             f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
             {"tile_id": tile.pk, "body": "should fail"},
             content_type="application/json",
@@ -3456,7 +3456,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
     def test_update_text_tile_returns_404_for_unknown_tile(self):
         for name, dashboard_pk, tile_id in self._make_unknown_tile_id_args():
             with self.subTest(name):
-                response = self.client.patch(
+                response = self.client.post(
                     f"/api/environments/{self.team.pk}/dashboards/{dashboard_pk}/update_text_tile/",
                     {"tile_id": tile_id, "body": "should fail"},
                     content_type="application/json",

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -3299,6 +3299,155 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(insight_tile.layouts["sm"]["x"], 6)
         self.assertEqual(insight_tile.layouts["sm"]["y"], 0)
 
+    def test_create_text_tile_adds_markdown_tile_to_dashboard(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/create_text_tile/",
+            {
+                "body": "## Section heading\n\nIntro markdown.",
+                "layouts": {"sm": {"x": 0, "y": 0, "w": 12, "h": 1}},
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertIsNotNone(body["id"])
+        self.assertIsNone(body["insight"])
+        self.assertEqual(body["text"]["body"], "## Section heading\n\nIntro markdown.")
+        self.assertEqual(body["layouts"]["sm"], {"x": 0, "y": 0, "w": 12, "h": 1})
+
+        dashboard_response = self.client.get(f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/")
+        self.assertEqual(dashboard_response.status_code, status.HTTP_200_OK)
+        tiles = dashboard_response.json()["tiles"]
+        self.assertEqual(len(tiles), 1)
+        self.assertEqual(tiles[0]["text"]["body"], "## Section heading\n\nIntro markdown.")
+
+    def test_create_text_tile_without_layouts_uses_default(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/create_text_tile/",
+            {"body": "Just a divider"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["text"]["body"], "Just a divider")
+
+    def test_create_text_tile_rejects_empty_body(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/create_text_tile/",
+            {"body": ""},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_text_tile_rejects_body_over_4000_chars(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/create_text_tile/",
+            {"body": "x" * 4001},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_text_tile_on_deleted_dashboard_returns_404(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard", deleted=True)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/create_text_tile/",
+            {"body": "Some text"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_text_tile_updates_body_and_layout(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        text = Text.objects.create(body="original", team=self.team, created_by=self.user)
+        tile = DashboardTile.objects.create(
+            dashboard=dashboard,
+            text=text,
+            layouts={"sm": {"x": 0, "y": 0, "w": 6, "h": 1}},
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
+            {
+                "tile_id": tile.pk,
+                "body": "## Updated heading",
+                "layouts": {"sm": {"x": 0, "y": 5, "w": 12, "h": 2}},
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["text"]["body"], "## Updated heading")
+        self.assertEqual(body["layouts"]["sm"], {"x": 0, "y": 5, "w": 12, "h": 2})
+
+        text.refresh_from_db()
+        tile.refresh_from_db()
+        self.assertEqual(text.body, "## Updated heading")
+        self.assertEqual(text.last_modified_by, self.user)
+        self.assertEqual(tile.layouts["sm"], {"x": 0, "y": 5, "w": 12, "h": 2})
+
+    def test_update_text_tile_leaves_omitted_fields_unchanged(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        text = Text.objects.create(body="original", team=self.team)
+        tile = DashboardTile.objects.create(
+            dashboard=dashboard,
+            text=text,
+            layouts={"sm": {"x": 1, "y": 2, "w": 6, "h": 1}},
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
+            {"tile_id": tile.pk, "body": "new body"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        tile.refresh_from_db()
+        self.assertEqual(tile.layouts["sm"], {"x": 1, "y": 2, "w": 6, "h": 1})
+        self.assertEqual(tile.text.body, "new body")
+
+    def test_update_text_tile_rejects_insight_tile(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        insight = Insight.objects.create(team=self.team, name="Insight 1")
+        tile = DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
+            {"tile_id": tile.pk, "body": "should fail"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_text_tile_with_unknown_id_returns_404(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/update_text_tile/",
+            {"tile_id": 9999999, "body": "x"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_text_tile_on_other_dashboard_returns_404(self):
+        dashboard_a = Dashboard.objects.create(team=self.team, name="A")
+        dashboard_b = Dashboard.objects.create(team=self.team, name="B")
+        text = Text.objects.create(body="A's tile", team=self.team)
+        tile_on_a = DashboardTile.objects.create(dashboard=dashboard_a, text=text)
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard_b.pk}/update_text_tile/",
+            {"tile_id": tile_on_a.pk, "body": "should fail"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_add_insight_to_multiple_dashboards_via_patch(self):
         dashboard1 = Dashboard.objects.create(team=self.team, name="Dashboard 1")
         dashboard2 = Dashboard.objects.create(team=self.team, name="Dashboard 2")

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1780,7 +1780,7 @@ class DashboardsViewSet(
         request=UpdateTextTileRequestSerializer,
         responses={200: DashboardTileSerializer},
     )
-    @action(methods=["PATCH"], detail=True, required_scopes=["dashboard:write"])
+    @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
     def update_text_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Update the markdown body, layout, or color of an existing text tile on a dashboard."""
         dashboard = self.get_object()

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -172,6 +172,77 @@ class CopyDashboardTileRequestSerializer(serializers.Serializer):
     tileId = serializers.IntegerField(help_text="Dashboard tile id to copy.")
 
 
+class TileLayoutBoxSerializer(serializers.Serializer):
+    x = serializers.IntegerField(required=False, help_text="Column position in the dashboard grid (0-indexed).")
+    y = serializers.IntegerField(required=False, help_text="Row position in the dashboard grid (0-indexed).")
+    w = serializers.IntegerField(
+        required=False, help_text="Width in grid columns. The desktop grid is 12 columns wide."
+    )
+    h = serializers.IntegerField(required=False, help_text="Height in grid rows.")
+
+
+class TileLayoutsSerializer(serializers.Serializer):
+    sm = TileLayoutBoxSerializer(
+        required=False,
+        help_text="Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",
+    )
+    xs = TileLayoutBoxSerializer(
+        required=False,
+        help_text="Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+    )
+
+
+class CreateTextTileRequestSerializer(serializers.Serializer):
+    body = serializers.CharField(
+        max_length=4000,
+        required=True,
+        allow_blank=False,
+        help_text=(
+            "Markdown body for the text tile. Supports headings, lists, and inline formatting. "
+            "Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters."
+        ),
+        error_messages={"max_length": "Text body cannot exceed 4000 characters"},
+    )
+    layouts = TileLayoutsSerializer(
+        required=False,
+        help_text=(
+            "Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard "
+            "using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1)."
+        ),
+    )
+    color = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').",
+    )
+
+
+class UpdateTextTileRequestSerializer(serializers.Serializer):
+    tile_id = serializers.IntegerField(
+        required=True,
+        help_text="ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.",
+    )
+    body = serializers.CharField(
+        max_length=4000,
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.",
+        error_messages={"max_length": "Text body cannot exceed 4000 characters"},
+    )
+    layouts = TileLayoutsSerializer(
+        required=False,
+        help_text="New grid layout per breakpoint. Omit to leave the layout unchanged.",
+    )
+    color = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="New accent color name, or null to clear. Omit to leave unchanged.",
+    )
+
+
 class CanEditDashboard(BasePermission):
     message = "You don't have edit permissions for this dashboard."
 
@@ -1651,6 +1722,95 @@ class DashboardsViewSet(
         DashboardTile.objects.bulk_update(tile_map.values(), ["layouts"])
 
         return Response(DashboardSerializer(dashboard, context=self.get_serializer_context()).data)
+
+    @extend_schema(
+        request=CreateTextTileRequestSerializer,
+        responses={201: DashboardTileSerializer},
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
+    def create_text_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Add a markdown text tile to a dashboard.
+
+        Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
+        or annotations between insight tiles to give the dashboard structure.
+        """
+        dashboard = self.get_object()
+        if dashboard.deleted:
+            raise exceptions.NotFound()
+        if not self.user_permissions.dashboard(dashboard).can_edit:
+            raise exceptions.PermissionDenied("You don't have edit permissions for this dashboard.")
+
+        serializer = CreateTextTileRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated = serializer.validated_data
+
+        user = cast(User, request.user)
+        with transaction.atomic():
+            text = Text.objects.create(
+                body=validated["body"],
+                team=dashboard.team,
+                created_by=user,
+                last_modified_at=now(),
+            )
+            tile_data: dict[str, Any] = {}
+            if "layouts" in validated:
+                tile_data["layouts"] = validated["layouts"]
+            if "color" in validated:
+                tile_data["color"] = validated["color"]
+            tile, _ = DashboardSerializer._upsert_tile(dashboard, tile_data, text=text)
+
+        return Response(
+            DashboardTileSerializer(tile, context=self.get_serializer_context()).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @extend_schema(
+        request=UpdateTextTileRequestSerializer,
+        responses={200: DashboardTileSerializer},
+    )
+    @action(methods=["PATCH"], detail=True, required_scopes=["dashboard:write"])
+    def update_text_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Update the markdown body, layout, or color of an existing text tile on a dashboard."""
+        dashboard = self.get_object()
+        if dashboard.deleted:
+            raise exceptions.NotFound()
+        if not self.user_permissions.dashboard(dashboard).can_edit:
+            raise exceptions.PermissionDenied("You don't have edit permissions for this dashboard.")
+
+        serializer = UpdateTextTileRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated = serializer.validated_data
+
+        tile = get_object_or_404(
+            DashboardTile,
+            id=validated["tile_id"],
+            dashboard=dashboard,
+            dashboard__team__project_id=self.team.project_id,
+        )
+        if tile.text is None:
+            raise exceptions.ValidationError("Tile is not a text tile.")
+
+        user = cast(User, request.user)
+        with transaction.atomic():
+            text = tile.text
+            if "body" in validated:
+                text.body = validated["body"]
+            text.last_modified_by = user
+            text.last_modified_at = now()
+            text.save()
+
+            tile_updates: list[str] = []
+            if "layouts" in validated:
+                tile.layouts = validated["layouts"]
+                tile_updates.append("layouts")
+            if "color" in validated:
+                tile.color = validated["color"]
+                tile_updates.append("color")
+            if tile_updates:
+                tile.save(update_fields=tile_updates)
+
+        tile.refresh_from_db()
+        return Response(DashboardTileSerializer(tile, context=self.get_serializer_context()).data)
 
     @extend_schema(
         parameters=[

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -211,10 +211,12 @@ class CreateTextTileRequestSerializer(serializers.Serializer):
         ),
     )
     color = serializers.CharField(
+        max_length=400,
         required=False,
         allow_null=True,
         allow_blank=True,
         help_text="Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').",
+        error_messages={"max_length": "Color cannot exceed 400 characters"},
     )
 
 
@@ -226,8 +228,8 @@ class UpdateTextTileRequestSerializer(serializers.Serializer):
     body = serializers.CharField(
         max_length=4000,
         required=False,
-        allow_null=True,
-        allow_blank=True,
+        allow_null=False,
+        allow_blank=False,
         help_text="New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.",
         error_messages={"max_length": "Text body cannot exceed 4000 characters"},
     )
@@ -236,10 +238,12 @@ class UpdateTextTileRequestSerializer(serializers.Serializer):
         help_text="New grid layout per breakpoint. Omit to leave the layout unchanged.",
     )
     color = serializers.CharField(
+        max_length=400,
         required=False,
         allow_null=True,
         allow_blank=True,
-        help_text="New accent color name, or null to clear. Omit to leave unchanged.",
+        help_text="New accent color name, empty string or null to clear. Omit to leave unchanged.",
+        error_messages={"max_length": "Color cannot exceed 400 characters"},
     )
 
 

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -194,6 +194,7 @@ class TileLayoutsSerializer(serializers.Serializer):
 
 class CreateTextTileRequestSerializer(serializers.Serializer):
     body = serializers.CharField(
+        min_length=1,
         max_length=4000,
         required=True,
         allow_blank=False,
@@ -201,7 +202,10 @@ class CreateTextTileRequestSerializer(serializers.Serializer):
             "Markdown body for the text tile. Supports headings, lists, and inline formatting. "
             "Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters."
         ),
-        error_messages={"max_length": "Text body cannot exceed 4000 characters"},
+        error_messages={
+            "min_length": "Text body cannot be empty",
+            "max_length": "Text body cannot exceed 4000 characters",
+        },
     )
     layouts = TileLayoutsSerializer(
         required=False,
@@ -226,12 +230,16 @@ class UpdateTextTileRequestSerializer(serializers.Serializer):
         help_text="ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.",
     )
     body = serializers.CharField(
+        min_length=1,
         max_length=4000,
         required=False,
         allow_null=False,
         allow_blank=False,
         help_text="New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.",
-        error_messages={"max_length": "Text body cannot exceed 4000 characters"},
+        error_messages={
+            "min_length": "Text body cannot be empty",
+            "max_length": "Text body cannot exceed 4000 characters",
+        },
     )
     layouts = TileLayoutsSerializer(
         required=False,

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -422,6 +422,6732 @@ export interface CopyDashboardTileRequestApi {
     tileId: number
 }
 
+export interface TileLayoutBoxApi {
+    /** Column position in the dashboard grid (0-indexed). */
+    x?: number
+    /** Row position in the dashboard grid (0-indexed). */
+    y?: number
+    /** Width in grid columns. The desktop grid is 12 columns wide. */
+    w?: number
+    /** Height in grid rows. */
+    h?: number
+}
+
+export interface TileLayoutsApi {
+    /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+    sm?: TileLayoutBoxApi
+    /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+    xs?: TileLayoutBoxApi
+}
+
+export interface CreateTextTileRequestApi {
+    /**
+     * Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.
+     * @maxLength 4000
+     */
+    body: string
+    /** Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1). */
+    layouts?: TileLayoutsApi
+    /**
+     * Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').
+     * @nullable
+     */
+    color?: string | null
+}
+
+export type InsightVizNodeApiKind = (typeof InsightVizNodeApiKind)[keyof typeof InsightVizNodeApiKind]
+
+export const InsightVizNodeApiKind = {
+    InsightVizNode: 'InsightVizNode',
+} as const
+
+export type BreakdownTypeApi = (typeof BreakdownTypeApi)[keyof typeof BreakdownTypeApi]
+
+export const BreakdownTypeApi = {
+    Cohort: 'cohort',
+    Person: 'person',
+    Event: 'event',
+    EventMetadata: 'event_metadata',
+    Group: 'group',
+    Session: 'session',
+    Hogql: 'hogql',
+    DataWarehouse: 'data_warehouse',
+    DataWarehousePersonProperty: 'data_warehouse_person_property',
+    RevenueAnalytics: 'revenue_analytics',
+} as const
+
+export type MultipleBreakdownTypeApi = (typeof MultipleBreakdownTypeApi)[keyof typeof MultipleBreakdownTypeApi]
+
+export const MultipleBreakdownTypeApi = {
+    Person: 'person',
+    Event: 'event',
+    EventMetadata: 'event_metadata',
+    Group: 'group',
+    Session: 'session',
+    Hogql: 'hogql',
+    Cohort: 'cohort',
+    RevenueAnalytics: 'revenue_analytics',
+    DataWarehouse: 'data_warehouse',
+    DataWarehousePersonProperty: 'data_warehouse_person_property',
+} as const
+
+export interface BreakdownApi {
+    group_type_index?: number | null
+    histogram_bin_count?: number | null
+    normalize_url?: boolean | null
+    property: string | number
+    type?: MultipleBreakdownTypeApi | null
+}
+
+export interface BreakdownFilterApi {
+    breakdown?: string | (string | number)[] | number | null
+    breakdown_group_type_index?: number | null
+    breakdown_hide_other_aggregation?: boolean | null
+    breakdown_histogram_bin_count?: number | null
+    breakdown_limit?: number | null
+    breakdown_normalize_url?: boolean | null
+    breakdown_path_cleaning?: boolean | null
+    breakdown_type?: BreakdownTypeApi | null
+    breakdowns?: BreakdownApi[] | null
+}
+
+export interface CompareFilterApi {
+    /** Whether to compare the current date range to a previous date range. */
+    compare?: boolean | null
+    /** The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago. */
+    compare_to?: string | null
+}
+
+export interface ActionConversionGoalApi {
+    actionId: number
+}
+
+export interface CustomEventConversionGoalApi {
+    customEventName: string
+}
+
+export interface DateRangeApi {
+    /** Start of the date range. Accepts ISO 8601 timestamps (e.g., 2024-01-15T00:00:00Z) or relative formats: -7d (7 days ago), -2w (2 weeks ago), -1m (1 month ago),
+  -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
+    date_from?: string | null
+    /** End of the date range. Same format as date_from. Omit or null for "now". */
+    date_to?: string | null
+    /** Whether the date_from and date_to should be used verbatim. Disables rounding to the start and end of period. */
+    explicitDate?: boolean | null
+}
+
+export type IntervalTypeApi = (typeof IntervalTypeApi)[keyof typeof IntervalTypeApi]
+
+export const IntervalTypeApi = {
+    Second: 'second',
+    Minute: 'minute',
+    Hour: 'hour',
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+} as const
+
+export type BounceRatePageViewModeApi = (typeof BounceRatePageViewModeApi)[keyof typeof BounceRatePageViewModeApi]
+
+export const BounceRatePageViewModeApi = {
+    CountPageviews: 'count_pageviews',
+    UniqUrls: 'uniq_urls',
+    UniqPageScreenAutocaptures: 'uniq_page_screen_autocaptures',
+} as const
+
+export type FilterLogicalOperatorApi = (typeof FilterLogicalOperatorApi)[keyof typeof FilterLogicalOperatorApi]
+
+export const FilterLogicalOperatorApi = {
+    And: 'AND',
+    Or: 'OR',
+} as const
+
+export type CustomChannelFieldApi = (typeof CustomChannelFieldApi)[keyof typeof CustomChannelFieldApi]
+
+export const CustomChannelFieldApi = {
+    UtmSource: 'utm_source',
+    UtmMedium: 'utm_medium',
+    UtmCampaign: 'utm_campaign',
+    ReferringDomain: 'referring_domain',
+    Url: 'url',
+    Pathname: 'pathname',
+    Hostname: 'hostname',
+} as const
+
+export type CustomChannelOperatorApi = (typeof CustomChannelOperatorApi)[keyof typeof CustomChannelOperatorApi]
+
+export const CustomChannelOperatorApi = {
+    Exact: 'exact',
+    IsNot: 'is_not',
+    IsSet: 'is_set',
+    IsNotSet: 'is_not_set',
+    Icontains: 'icontains',
+    NotIcontains: 'not_icontains',
+    Regex: 'regex',
+    NotRegex: 'not_regex',
+} as const
+
+export interface CustomChannelConditionApi {
+    id: string
+    key: CustomChannelFieldApi
+    op: CustomChannelOperatorApi
+    value?: string | string[] | null
+}
+
+export interface CustomChannelRuleApi {
+    channel_type: string
+    combiner: FilterLogicalOperatorApi
+    id: string
+    items: CustomChannelConditionApi[]
+}
+
+export interface DataWarehouseEventsModifierApi {
+    distinct_id_field: string
+    id_field: string
+    table_name: string
+    timestamp_field: string
+}
+
+export type InCohortViaApi = (typeof InCohortViaApi)[keyof typeof InCohortViaApi]
+
+export const InCohortViaApi = {
+    Auto: 'auto',
+    Leftjoin: 'leftjoin',
+    Subquery: 'subquery',
+    LeftjoinConjoined: 'leftjoin_conjoined',
+} as const
+
+export type InlineCohortCalculationApi = (typeof InlineCohortCalculationApi)[keyof typeof InlineCohortCalculationApi]
+
+export const InlineCohortCalculationApi = {
+    Off: 'off',
+    Auto: 'auto',
+    Always: 'always',
+} as const
+
+export type MaterializationModeApi = (typeof MaterializationModeApi)[keyof typeof MaterializationModeApi]
+
+export const MaterializationModeApi = {
+    Auto: 'auto',
+    LegacyNullAsString: 'legacy_null_as_string',
+    LegacyNullAsNull: 'legacy_null_as_null',
+    Disabled: 'disabled',
+} as const
+
+export type MaterializedColumnsOptimizationModeApi =
+    (typeof MaterializedColumnsOptimizationModeApi)[keyof typeof MaterializedColumnsOptimizationModeApi]
+
+export const MaterializedColumnsOptimizationModeApi = {
+    Disabled: 'disabled',
+    Optimized: 'optimized',
+} as const
+
+export type ParserModeApi = (typeof ParserModeApi)[keyof typeof ParserModeApi]
+
+export const ParserModeApi = {
+    CppOnly: 'cpp_only',
+    CppWithRustShadow: 'cpp_with_rust_shadow',
+    RustWithCppShadow: 'rust_with_cpp_shadow',
+    RustOnly: 'rust_only',
+    RustPyOnly: 'rust_py_only',
+    RustPyWithCppShadow: 'rust_py_with_cpp_shadow',
+} as const
+
+export type PersonsArgMaxVersionApi = (typeof PersonsArgMaxVersionApi)[keyof typeof PersonsArgMaxVersionApi]
+
+export const PersonsArgMaxVersionApi = {
+    Auto: 'auto',
+    V1: 'v1',
+    V2: 'v2',
+} as const
+
+export type PersonsJoinModeApi = (typeof PersonsJoinModeApi)[keyof typeof PersonsJoinModeApi]
+
+export const PersonsJoinModeApi = {
+    Inner: 'inner',
+    Left: 'left',
+} as const
+
+export type PersonsOnEventsModeApi = (typeof PersonsOnEventsModeApi)[keyof typeof PersonsOnEventsModeApi]
+
+export const PersonsOnEventsModeApi = {
+    Disabled: 'disabled',
+    PersonIdNoOverridePropertiesOnEvents: 'person_id_no_override_properties_on_events',
+    PersonIdOverridePropertiesOnEvents: 'person_id_override_properties_on_events',
+    PersonIdOverridePropertiesJoined: 'person_id_override_properties_joined',
+} as const
+
+export type PropertyGroupsModeApi = (typeof PropertyGroupsModeApi)[keyof typeof PropertyGroupsModeApi]
+
+export const PropertyGroupsModeApi = {
+    Enabled: 'enabled',
+    Disabled: 'disabled',
+    Optimized: 'optimized',
+} as const
+
+export type SessionTableVersionApi = (typeof SessionTableVersionApi)[keyof typeof SessionTableVersionApi]
+
+export const SessionTableVersionApi = {
+    Auto: 'auto',
+    V1: 'v1',
+    V2: 'v2',
+    V3: 'v3',
+} as const
+
+export type SessionsV2JoinModeApi = (typeof SessionsV2JoinModeApi)[keyof typeof SessionsV2JoinModeApi]
+
+export const SessionsV2JoinModeApi = {
+    String: 'string',
+    Uuid: 'uuid',
+} as const
+
+export interface HogQLQueryModifiersApi {
+    bounceRateDurationSeconds?: number | null
+    bounceRatePageViewMode?: BounceRatePageViewModeApi | null
+    convertToProjectTimezone?: boolean | null
+    customChannelTypeRules?: CustomChannelRuleApi[] | null
+    dataWarehouseEventsModifiers?: DataWarehouseEventsModifierApi[] | null
+    debug?: boolean | null
+    /** If these are provided, the query will fail if these skip indexes are not used */
+    forceClickhouseDataSkippingIndexes?: string[] | null
+    formatCsvAllowDoubleQuotes?: boolean | null
+    inCohortVia?: InCohortViaApi | null
+    inlineCohortCalculation?: InlineCohortCalculationApi | null
+    materializationMode?: MaterializationModeApi | null
+    materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationModeApi | null
+    optimizeJoinedFilters?: boolean | null
+    optimizeProjections?: boolean | null
+    /** HogQL parser backend; absent → `cpp_only`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
+    parserMode?: ParserModeApi | null
+    personsArgMaxVersion?: PersonsArgMaxVersionApi | null
+    personsJoinMode?: PersonsJoinModeApi | null
+    personsOnEventsMode?: PersonsOnEventsModeApi | null
+    propertyGroupsMode?: PropertyGroupsModeApi | null
+    s3TableUseInvalidColumns?: boolean | null
+    /** Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter. */
+    sessionIdPushdown?: boolean | null
+    /** Pre-filter raw_sessions aggregation by `session_id_v7 IN (cheap pre-aggregation that only materializes the columns referenced by the outer-WHERE session predicate)`. Useful when the breakdown/SELECT pulls in many session columns (e.g. `$channel_type`) but the filter only references one (e.g. `$entry_current_url`). */
+    sessionPropertyPreAggregation?: boolean | null
+    sessionTableVersion?: SessionTableVersionApi | null
+    sessionsV2JoinMode?: SessionsV2JoinModeApi | null
+    timings?: boolean | null
+    useMaterializedViews?: boolean | null
+    usePreaggregatedIntermediateResults?: boolean | null
+    /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
+    usePreaggregatedTableTransforms?: boolean | null
+    useWebAnalyticsPreAggregatedTables?: boolean | null
+}
+
+export type PropertyOperatorApi = (typeof PropertyOperatorApi)[keyof typeof PropertyOperatorApi]
+
+export const PropertyOperatorApi = {
+    Exact: 'exact',
+    IsNot: 'is_not',
+    Icontains: 'icontains',
+    NotIcontains: 'not_icontains',
+    Regex: 'regex',
+    NotRegex: 'not_regex',
+    Gt: 'gt',
+    Gte: 'gte',
+    Lt: 'lt',
+    Lte: 'lte',
+    IsSet: 'is_set',
+    IsNotSet: 'is_not_set',
+    IsDateExact: 'is_date_exact',
+    IsDateBefore: 'is_date_before',
+    IsDateAfter: 'is_date_after',
+    Between: 'between',
+    NotBetween: 'not_between',
+    Min: 'min',
+    Max: 'max',
+    In: 'in',
+    NotIn: 'not_in',
+    IsCleanedPathExact: 'is_cleaned_path_exact',
+    FlagEvaluatesTo: 'flag_evaluates_to',
+    SemverEq: 'semver_eq',
+    SemverNeq: 'semver_neq',
+    SemverGt: 'semver_gt',
+    SemverGte: 'semver_gte',
+    SemverLt: 'semver_lt',
+    SemverLte: 'semver_lte',
+    SemverTilde: 'semver_tilde',
+    SemverCaret: 'semver_caret',
+    SemverWildcard: 'semver_wildcard',
+    IcontainsMulti: 'icontains_multi',
+    NotIcontainsMulti: 'not_icontains_multi',
+} as const
+
+export interface EventPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator?: PropertyOperatorApi | null
+    /** Event properties */
+    type?: 'event'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface PersonPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Person properties */
+    type?: 'person'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type Key10Api = (typeof Key10Api)[keyof typeof Key10Api]
+
+export const Key10Api = {
+    TagName: 'tag_name',
+    Text: 'text',
+    Href: 'href',
+    Selector: 'selector',
+} as const
+
+export interface ElementPropertyFilterApi {
+    key: Key10Api
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'element'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface EventMetadataPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'event_metadata'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface SessionPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'session'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface CohortPropertyFilterApi {
+    cohort_name?: string | null
+    key?: 'id'
+    label?: string | null
+    operator?: PropertyOperatorApi | null
+    type?: 'cohort'
+    value: number
+}
+
+export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
+
+export const DurationTypeApi = {
+    Duration: 'duration',
+    ActiveSeconds: 'active_seconds',
+    InactiveSeconds: 'inactive_seconds',
+} as const
+
+export interface RecordingPropertyFilterApi {
+    key: DurationTypeApi | string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'recording'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface LogEntryPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'log_entry'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type GroupPropertyFilterApiGroupKeyNames = { [key: string]: string } | null
+
+export interface GroupPropertyFilterApi {
+    group_key_names?: GroupPropertyFilterApiGroupKeyNames
+    group_type_index?: number | null
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'group'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface FeaturePropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Event property with "$feature/" prepended */
+    type?: 'feature'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface FlagPropertyFilterApi {
+    /** The key should be the flag ID */
+    key: string
+    label?: string | null
+    /** Only flag_evaluates_to operator is allowed for flag dependencies */
+    operator?: 'flag_evaluates_to'
+    /** Feature flag dependency */
+    type?: 'flag'
+    /** The value can be true, false, or a variant name */
+    value: boolean | string
+}
+
+export interface HogQLPropertyFilterApi {
+    key: string
+    label?: string | null
+    type?: 'hogql'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export const EmptyPropertyFilterApiValue = {
+    type: 'empty',
+} as const
+export type EmptyPropertyFilterApi = typeof EmptyPropertyFilterApiValue
+
+export interface DataWarehousePropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'data_warehouse'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface DataWarehousePersonPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'data_warehouse_person_property'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface ErrorTrackingIssueFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'error_tracking_issue'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
+
+export const LogPropertyFilterTypeApi = {
+    Log: 'log',
+    LogAttribute: 'log_attribute',
+    LogResourceAttribute: 'log_resource_attribute',
+} as const
+
+export interface LogPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type: LogPropertyFilterTypeApi
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type SpanPropertyFilterTypeApi = (typeof SpanPropertyFilterTypeApi)[keyof typeof SpanPropertyFilterTypeApi]
+
+export const SpanPropertyFilterTypeApi = {
+    Span: 'span',
+    SpanAttribute: 'span_attribute',
+    SpanResourceAttribute: 'span_resource_attribute',
+} as const
+
+export interface SpanPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type: SpanPropertyFilterTypeApi
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface RevenueAnalyticsPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'revenue_analytics'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface WorkflowVariablePropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'workflow_variable'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface PropertyGroupFilterValueApi {
+    type: FilterLogicalOperatorApi
+    values: (
+        | PropertyGroupFilterValueApi
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | ElementPropertyFilterApi
+        | EventMetadataPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+        | RecordingPropertyFilterApi
+        | LogEntryPropertyFilterApi
+        | GroupPropertyFilterApi
+        | FeaturePropertyFilterApi
+        | FlagPropertyFilterApi
+        | HogQLPropertyFilterApi
+        | EmptyPropertyFilterApi
+        | DataWarehousePropertyFilterApi
+        | DataWarehousePersonPropertyFilterApi
+        | ErrorTrackingIssueFilterApi
+        | LogPropertyFilterApi
+        | SpanPropertyFilterApi
+        | RevenueAnalyticsPropertyFilterApi
+        | WorkflowVariablePropertyFilterApi
+    )[]
+}
+
+export interface PropertyGroupFilterApi {
+    type: FilterLogicalOperatorApi
+    values: PropertyGroupFilterValueApi[]
+}
+
+export interface BoxPlotDatumApi {
+    day: string
+    label: string
+    max: number
+    mean: number
+    median: number
+    min: number
+    p25: number
+    p75: number
+    series_index?: number | null
+    series_label?: string | null
+}
+
+export interface ClickhouseQueryProgressApi {
+    active_cpu_time: number
+    bytes_read: number
+    estimated_rows_total: number
+    rows_read: number
+    time_elapsed: number
+}
+
+export interface QueryStatusApi {
+    /** Whether the query is still running. Will be true if the query is complete, even if it errored. Either result or error will be set. */
+    complete?: boolean | null
+    dashboard_id?: number | null
+    /** When did the query execution task finish (whether successfully or not). */
+    end_time?: string | null
+    /** If the query failed, this will be set to true. More information can be found in the error_message field. */
+    error?: boolean | null
+    error_message?: string | null
+    expiration_time?: string | null
+    id: string
+    insight_id?: number | null
+    labels?: string[] | null
+    /** When was the query execution task picked up by a worker. */
+    pickup_time?: string | null
+    /** ONLY async queries use QueryStatus. */
+    query_async?: true
+    query_progress?: ClickhouseQueryProgressApi | null
+    results?: unknown
+    /** When was query execution task enqueued. */
+    start_time?: string | null
+    task_id?: string | null
+    team_id: number
+}
+
+export interface ResolvedDateRangeResponseApi {
+    date_from: string
+    date_to: string
+}
+
+export interface QueryTimingApi {
+    /** Key. Shortened to 'k' to save on data. */
+    k: string
+    /** Time in seconds. Shortened to 't' to save on data. */
+    t: number
+}
+
+export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
+
+export interface TrendsQueryResponseApi {
+    boxplot_data?: BoxPlotDatumApi[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Wether more breakdown values are available. */
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: TrendsQueryResponseApiResultsItem[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export type BaseMathTypeApi = (typeof BaseMathTypeApi)[keyof typeof BaseMathTypeApi]
+
+export const BaseMathTypeApi = {
+    Total: 'total',
+    Dau: 'dau',
+    WeeklyActive: 'weekly_active',
+    MonthlyActive: 'monthly_active',
+    UniqueSession: 'unique_session',
+    FirstTimeForUser: 'first_time_for_user',
+    FirstMatchingEventForUser: 'first_matching_event_for_user',
+} as const
+
+export type FunnelMathTypeApi = (typeof FunnelMathTypeApi)[keyof typeof FunnelMathTypeApi]
+
+export const FunnelMathTypeApi = {
+    Total: 'total',
+    FirstTimeForUser: 'first_time_for_user',
+    FirstTimeForUserWithFilters: 'first_time_for_user_with_filters',
+} as const
+
+export type PropertyMathTypeApi = (typeof PropertyMathTypeApi)[keyof typeof PropertyMathTypeApi]
+
+export const PropertyMathTypeApi = {
+    Avg: 'avg',
+    Sum: 'sum',
+    Min: 'min',
+    Max: 'max',
+    Median: 'median',
+    P75: 'p75',
+    P90: 'p90',
+    P95: 'p95',
+    P99: 'p99',
+} as const
+
+export type CountPerActorMathTypeApi = (typeof CountPerActorMathTypeApi)[keyof typeof CountPerActorMathTypeApi]
+
+export const CountPerActorMathTypeApi = {
+    AvgCountPerActor: 'avg_count_per_actor',
+    MinCountPerActor: 'min_count_per_actor',
+    MaxCountPerActor: 'max_count_per_actor',
+    MedianCountPerActor: 'median_count_per_actor',
+    P75CountPerActor: 'p75_count_per_actor',
+    P90CountPerActor: 'p90_count_per_actor',
+    P95CountPerActor: 'p95_count_per_actor',
+    P99CountPerActor: 'p99_count_per_actor',
+} as const
+
+export type ExperimentMetricMathTypeApi = (typeof ExperimentMetricMathTypeApi)[keyof typeof ExperimentMetricMathTypeApi]
+
+export const ExperimentMetricMathTypeApi = {
+    Total: 'total',
+    Sum: 'sum',
+    UniqueSession: 'unique_session',
+    Min: 'min',
+    Max: 'max',
+    Avg: 'avg',
+    Dau: 'dau',
+    UniqueGroup: 'unique_group',
+    Hogql: 'hogql',
+} as const
+
+export type CalendarHeatmapMathTypeApi = (typeof CalendarHeatmapMathTypeApi)[keyof typeof CalendarHeatmapMathTypeApi]
+
+export const CalendarHeatmapMathTypeApi = {
+    Total: 'total',
+    Dau: 'dau',
+} as const
+
+export type MathGroupTypeIndexApi = (typeof MathGroupTypeIndexApi)[keyof typeof MathGroupTypeIndexApi]
+
+export const MathGroupTypeIndexApi = {
+    Number0: 0,
+    Number1: 1,
+    Number2: 2,
+    Number3: 3,
+    Number4: 4,
+} as const
+
+export type CurrencyCodeApi = (typeof CurrencyCodeApi)[keyof typeof CurrencyCodeApi]
+
+export const CurrencyCodeApi = {
+    Aed: 'AED',
+    Afn: 'AFN',
+    All: 'ALL',
+    Amd: 'AMD',
+    Ang: 'ANG',
+    Aoa: 'AOA',
+    Ars: 'ARS',
+    Aud: 'AUD',
+    Awg: 'AWG',
+    Azn: 'AZN',
+    Bam: 'BAM',
+    Bbd: 'BBD',
+    Bdt: 'BDT',
+    Bgn: 'BGN',
+    Bhd: 'BHD',
+    Bif: 'BIF',
+    Bmd: 'BMD',
+    Bnd: 'BND',
+    Bob: 'BOB',
+    Brl: 'BRL',
+    Bsd: 'BSD',
+    Btc: 'BTC',
+    Btn: 'BTN',
+    Bwp: 'BWP',
+    Byn: 'BYN',
+    Bzd: 'BZD',
+    Cad: 'CAD',
+    Cdf: 'CDF',
+    Chf: 'CHF',
+    Clp: 'CLP',
+    Cny: 'CNY',
+    Cop: 'COP',
+    Crc: 'CRC',
+    Cve: 'CVE',
+    Czk: 'CZK',
+    Djf: 'DJF',
+    Dkk: 'DKK',
+    Dop: 'DOP',
+    Dzd: 'DZD',
+    Egp: 'EGP',
+    Ern: 'ERN',
+    Etb: 'ETB',
+    Eur: 'EUR',
+    Fjd: 'FJD',
+    Gbp: 'GBP',
+    Gel: 'GEL',
+    Ghs: 'GHS',
+    Gip: 'GIP',
+    Gmd: 'GMD',
+    Gnf: 'GNF',
+    Gtq: 'GTQ',
+    Gyd: 'GYD',
+    Hkd: 'HKD',
+    Hnl: 'HNL',
+    Hrk: 'HRK',
+    Htg: 'HTG',
+    Huf: 'HUF',
+    Idr: 'IDR',
+    Ils: 'ILS',
+    Inr: 'INR',
+    Iqd: 'IQD',
+    Irr: 'IRR',
+    Isk: 'ISK',
+    Jmd: 'JMD',
+    Jod: 'JOD',
+    Jpy: 'JPY',
+    Kes: 'KES',
+    Kgs: 'KGS',
+    Khr: 'KHR',
+    Kmf: 'KMF',
+    Krw: 'KRW',
+    Kwd: 'KWD',
+    Kyd: 'KYD',
+    Kzt: 'KZT',
+    Lak: 'LAK',
+    Lbp: 'LBP',
+    Lkr: 'LKR',
+    Lrd: 'LRD',
+    Ltl: 'LTL',
+    Lvl: 'LVL',
+    Lsl: 'LSL',
+    Lyd: 'LYD',
+    Mad: 'MAD',
+    Mdl: 'MDL',
+    Mga: 'MGA',
+    Mkd: 'MKD',
+    Mmk: 'MMK',
+    Mnt: 'MNT',
+    Mop: 'MOP',
+    Mru: 'MRU',
+    Mtl: 'MTL',
+    Mur: 'MUR',
+    Mvr: 'MVR',
+    Mwk: 'MWK',
+    Mxn: 'MXN',
+    Myr: 'MYR',
+    Mzn: 'MZN',
+    Nad: 'NAD',
+    Ngn: 'NGN',
+    Nio: 'NIO',
+    Nok: 'NOK',
+    Npr: 'NPR',
+    Nzd: 'NZD',
+    Omr: 'OMR',
+    Pab: 'PAB',
+    Pen: 'PEN',
+    Pgk: 'PGK',
+    Php: 'PHP',
+    Pkr: 'PKR',
+    Pln: 'PLN',
+    Pyg: 'PYG',
+    Qar: 'QAR',
+    Ron: 'RON',
+    Rsd: 'RSD',
+    Rub: 'RUB',
+    Rwf: 'RWF',
+    Sar: 'SAR',
+    Sbd: 'SBD',
+    Scr: 'SCR',
+    Sdg: 'SDG',
+    Sek: 'SEK',
+    Sgd: 'SGD',
+    Srd: 'SRD',
+    Ssp: 'SSP',
+    Stn: 'STN',
+    Syp: 'SYP',
+    Szl: 'SZL',
+    Thb: 'THB',
+    Tjs: 'TJS',
+    Tmt: 'TMT',
+    Tnd: 'TND',
+    Top: 'TOP',
+    Try: 'TRY',
+    Ttd: 'TTD',
+    Twd: 'TWD',
+    Tzs: 'TZS',
+    Uah: 'UAH',
+    Ugx: 'UGX',
+    Usd: 'USD',
+    Uyu: 'UYU',
+    Uzs: 'UZS',
+    Ves: 'VES',
+    Vnd: 'VND',
+    Vuv: 'VUV',
+    Wst: 'WST',
+    Xaf: 'XAF',
+    Xcd: 'XCD',
+    Xof: 'XOF',
+    Xpf: 'XPF',
+    Yer: 'YER',
+    Zar: 'ZAR',
+    Zmw: 'ZMW',
+} as const
+
+export interface RevenueCurrencyPropertyConfigApi {
+    property?: string | null
+    static?: CurrencyCodeApi | null
+}
+
+export type EventsNodeApiResponse = { [key: string]: unknown } | null
+
+export interface EventsNodeApi {
+    custom_name?: string | null
+    /** The event or `null` for all events. */
+    event?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    kind?: 'EventsNode'
+    limit?: number | null
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Columns to order by */
+    orderBy?: string[] | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: EventsNodeApiResponse
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ActionsNodeApiResponse = { [key: string]: unknown } | null
+
+export interface ActionsNodeApi {
+    custom_name?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    id: number
+    kind?: 'ActionsNode'
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: ActionsNodeApiResponse
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type DataWarehouseNodeApiResponse = { [key: string]: unknown } | null
+
+export interface DataWarehouseNodeApi {
+    custom_name?: string | null
+    distinct_id_field: string
+    dw_source_type?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    id: string
+    id_field: string
+    kind?: 'DataWarehouseNode'
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: DataWarehouseNodeApiResponse
+    table_name: string
+    timestamp_field: string
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type GroupNodeApiResponse = { [key: string]: unknown } | null
+
+export interface GroupNodeApi {
+    custom_name?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    kind?: 'GroupNode'
+    limit?: number | null
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    /** Entities to combine in this group */
+    nodes: (EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi)[]
+    /** Group of entities combined with AND/OR operator */
+    operator: FilterLogicalOperatorApi
+    optionalInFunnel?: boolean | null
+    /** Columns to order by */
+    orderBy?: string[] | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: GroupNodeApiResponse
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface QueryLogTagsApi {
+    /** Name of the query, preferably unique. For example web_analytics_vitals */
+    name?: string | null
+    /** Product responsible for this query. Use string, there's no need to churn the Schema when we add a new product * */
+    productKey?: string | null
+    /** Scene where this query is shown in the UI. Use string, there's no need to churn the Schema when we add a new Scene * */
+    scene?: string | null
+}
+
+export type AggregationAxisFormatApi = (typeof AggregationAxisFormatApi)[keyof typeof AggregationAxisFormatApi]
+
+export const AggregationAxisFormatApi = {
+    Numeric: 'numeric',
+    Duration: 'duration',
+    DurationMs: 'duration_ms',
+    Percentage: 'percentage',
+    PercentageScaled: 'percentage_scaled',
+    Currency: 'currency',
+    Short: 'short',
+} as const
+
+export type DetailedResultsAggregationTypeApi =
+    (typeof DetailedResultsAggregationTypeApi)[keyof typeof DetailedResultsAggregationTypeApi]
+
+export const DetailedResultsAggregationTypeApi = {
+    Total: 'total',
+    Average: 'average',
+    Median: 'median',
+} as const
+
+export type ChartDisplayTypeApi = (typeof ChartDisplayTypeApi)[keyof typeof ChartDisplayTypeApi]
+
+export const ChartDisplayTypeApi = {
+    Auto: 'Auto',
+    ActionsLineGraph: 'ActionsLineGraph',
+    ActionsBar: 'ActionsBar',
+    ActionsUnstackedBar: 'ActionsUnstackedBar',
+    ActionsStackedBar: 'ActionsStackedBar',
+    ActionsAreaGraph: 'ActionsAreaGraph',
+    ActionsLineGraphCumulative: 'ActionsLineGraphCumulative',
+    BoldNumber: 'BoldNumber',
+    ActionsPie: 'ActionsPie',
+    ActionsBarValue: 'ActionsBarValue',
+    ActionsTable: 'ActionsTable',
+    WorldMap: 'WorldMap',
+    CalendarHeatmap: 'CalendarHeatmap',
+    TwoDimensionalHeatmap: 'TwoDimensionalHeatmap',
+    BoxPlot: 'BoxPlot',
+} as const
+
+export interface TrendsFormulaNodeApi {
+    /** Optional user-defined name for the formula */
+    custom_name?: string | null
+    formula: string
+}
+
+export type PositionApi = (typeof PositionApi)[keyof typeof PositionApi]
+
+export const PositionApi = {
+    Start: 'start',
+    End: 'end',
+} as const
+
+export interface GoalLineApi {
+    borderColor?: string | null
+    displayIfCrossed?: boolean | null
+    displayLabel?: boolean | null
+    label: string
+    position?: PositionApi | null
+    value: number
+}
+
+export type ResultCustomizationByApi = (typeof ResultCustomizationByApi)[keyof typeof ResultCustomizationByApi]
+
+export const ResultCustomizationByApi = {
+    Value: 'value',
+    Position: 'position',
+} as const
+
+export type DataColorTokenApi = (typeof DataColorTokenApi)[keyof typeof DataColorTokenApi]
+
+export const DataColorTokenApi = {
+    Preset1: 'preset-1',
+    Preset2: 'preset-2',
+    Preset3: 'preset-3',
+    Preset4: 'preset-4',
+    Preset5: 'preset-5',
+    Preset6: 'preset-6',
+    Preset7: 'preset-7',
+    Preset8: 'preset-8',
+    Preset9: 'preset-9',
+    Preset10: 'preset-10',
+    Preset11: 'preset-11',
+    Preset12: 'preset-12',
+    Preset13: 'preset-13',
+    Preset14: 'preset-14',
+    Preset15: 'preset-15',
+} as const
+
+export interface ResultCustomizationByValueApi {
+    assignmentBy?: 'value'
+    color?: DataColorTokenApi | null
+    hidden?: boolean | null
+}
+
+export interface ResultCustomizationByPositionApi {
+    assignmentBy?: 'position'
+    color?: DataColorTokenApi | null
+    hidden?: boolean | null
+}
+
+export type YAxisScaleTypeApi = (typeof YAxisScaleTypeApi)[keyof typeof YAxisScaleTypeApi]
+
+export const YAxisScaleTypeApi = {
+    Log10: 'log10',
+    Linear: 'linear',
+} as const
+
+/**
+ * Customizations for the appearance of result datasets.
+ */
+export type TrendsFilterApiResultCustomizations =
+    | { [key: string]: ResultCustomizationByValueApi }
+    | { [key: string]: ResultCustomizationByPositionApi }
+    | null
+
+export interface TrendsFilterApi {
+    /** Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
+
+  - `numeric` (default): raw numbers, e.g. `1,234`.
+  - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+  - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+  - `percentage`: values are already in the 0-100 range; appends `%`.
+  - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+  - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+  - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
+    aggregationAxisFormat?: AggregationAxisFormatApi | null
+    /** Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself. */
+    aggregationAxisPostfix?: string | null
+    /** Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself. */
+    aggregationAxisPrefix?: string | null
+    breakdown_histogram_bin_count?: number | null
+    confidenceLevel?: number | null
+    /** Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency. */
+    decimalPlaces?: number | null
+    /** detailed results table */
+    detailedResultsAggregationType?: DetailedResultsAggregationTypeApi | null
+    display?: ChartDisplayTypeApi | null
+    excludeBoxPlotOutliers?: boolean | null
+    formula?: string | null
+    /** List of formulas with optional custom names. Takes precedence over formula/formulas if set. */
+    formulaNodes?: TrendsFormulaNodeApi[] | null
+    formulas?: string[] | null
+    /** Goal Lines */
+    goalLines?: GoalLineApi[] | null
+    hiddenLegendIndexes?: number[] | null
+    hideWeekends?: boolean | null
+    minDecimalPlaces?: number | null
+    movingAverageIntervals?: number | null
+    /** Wether result datasets are associated by their values or by their order. */
+    resultCustomizationBy?: ResultCustomizationByApi | null
+    /** Customizations for the appearance of result datasets. */
+    resultCustomizations?: TrendsFilterApiResultCustomizations
+    showAlertThresholdLines?: boolean | null
+    showConfidenceIntervals?: boolean | null
+    showLabelsOnSeries?: boolean | null
+    showLegend?: boolean | null
+    showMovingAverage?: boolean | null
+    showMultipleYAxes?: boolean | null
+    showPercentStackView?: boolean | null
+    showTrendLines?: boolean | null
+    showValuesOnSeries?: boolean | null
+    smoothingIntervals?: number | null
+    yAxisScaleType?: YAxisScaleTypeApi | null
+}
+
+export interface TrendsQueryApi {
+    /** Groups aggregation */
+    aggregation_group_type_index?: number | null
+    /** Breakdown of the events and actions */
+    breakdownFilter?: BreakdownFilterApi | null
+    /** Compare to date range */
+    compareFilter?: CompareFilterApi | null
+    /** Whether we should be comparing against a specific conversion goal */
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi | null
+    /** Exclude internal and test users by applying the respective filters */
+    filterTestAccounts?: boolean | null
+    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
+    interval?: IntervalTypeApi | null
+    kind?: 'TrendsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Property filters for all series */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | PropertyGroupFilterApi
+        | null
+    response?: TrendsQueryResponseApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    /** Events and actions to include */
+    series: (GroupNodeApi | EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi)[]
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi | null
+    /** Properties specific to the trends insight */
+    trendsFilter?: TrendsFilterApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type BreakdownAttributionTypeApi = (typeof BreakdownAttributionTypeApi)[keyof typeof BreakdownAttributionTypeApi]
+
+export const BreakdownAttributionTypeApi = {
+    FirstTouch: 'first_touch',
+    LastTouch: 'last_touch',
+    AllEvents: 'all_events',
+    Step: 'step',
+} as const
+
+export type FunnelExclusionEventsNodeApiResponse = { [key: string]: unknown } | null
+
+export interface FunnelExclusionEventsNodeApi {
+    custom_name?: string | null
+    /** The event or `null` for all events. */
+    event?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    funnelFromStep: number
+    funnelToStep: number
+    kind?: 'EventsNode'
+    limit?: number | null
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Columns to order by */
+    orderBy?: string[] | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: FunnelExclusionEventsNodeApiResponse
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type FunnelExclusionActionsNodeApiResponse = { [key: string]: unknown } | null
+
+export interface FunnelExclusionActionsNodeApi {
+    custom_name?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    funnelFromStep: number
+    funnelToStep: number
+    id: number
+    kind?: 'ActionsNode'
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: FunnelExclusionActionsNodeApiResponse
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type StepOrderValueApi = (typeof StepOrderValueApi)[keyof typeof StepOrderValueApi]
+
+export const StepOrderValueApi = {
+    Strict: 'strict',
+    Unordered: 'unordered',
+    Ordered: 'ordered',
+} as const
+
+export type FunnelStepReferenceApi = (typeof FunnelStepReferenceApi)[keyof typeof FunnelStepReferenceApi]
+
+export const FunnelStepReferenceApi = {
+    Total: 'total',
+    Previous: 'previous',
+} as const
+
+export type FunnelVizTypeApi = (typeof FunnelVizTypeApi)[keyof typeof FunnelVizTypeApi]
+
+export const FunnelVizTypeApi = {
+    Steps: 'steps',
+    TimeToConvert: 'time_to_convert',
+    Trends: 'trends',
+    Flow: 'flow',
+} as const
+
+export type FunnelConversionWindowTimeUnitApi =
+    (typeof FunnelConversionWindowTimeUnitApi)[keyof typeof FunnelConversionWindowTimeUnitApi]
+
+export const FunnelConversionWindowTimeUnitApi = {
+    Second: 'second',
+    Minute: 'minute',
+    Hour: 'hour',
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+} as const
+
+export type FunnelLayoutApi = (typeof FunnelLayoutApi)[keyof typeof FunnelLayoutApi]
+
+export const FunnelLayoutApi = {
+    Horizontal: 'horizontal',
+    Vertical: 'vertical',
+} as const
+
+/**
+ * Customizations for the appearance of result datasets.
+ */
+export type FunnelsFilterApiResultCustomizations = { [key: string]: ResultCustomizationByValueApi } | null
+
+export interface FunnelsFilterApi {
+    binCount?: number | null
+    breakdownAttributionType?: BreakdownAttributionTypeApi | null
+    breakdownAttributionValue?: number | null
+    /** Breakdown table sorting. Format: 'column_key' or '-column_key' (descending) */
+    breakdownSorting?: string | null
+    /** For data warehouse based funnel insights when the aggregation target can't be mapped to persons or groups. */
+    customAggregationTarget?: boolean | null
+    exclusions?: (FunnelExclusionEventsNodeApi | FunnelExclusionActionsNodeApi)[] | null
+    funnelAggregateByHogQL?: string | null
+    funnelFromStep?: number | null
+    funnelOrderType?: StepOrderValueApi | null
+    funnelStepReference?: FunnelStepReferenceApi | null
+    /** To select the range of steps for trends & time to convert funnels, 0-indexed */
+    funnelToStep?: number | null
+    funnelVizType?: FunnelVizTypeApi | null
+    funnelWindowInterval?: number | null
+    funnelWindowIntervalUnit?: FunnelConversionWindowTimeUnitApi | null
+    /** Goal Lines */
+    goalLines?: GoalLineApi[] | null
+    hiddenLegendBreakdowns?: string[] | null
+    layout?: FunnelLayoutApi | null
+    /** Customizations for the appearance of result datasets. */
+    resultCustomizations?: FunnelsFilterApiResultCustomizations
+    /** Display linear regression trend lines on the chart (only for historical trends viz) */
+    showTrendLines?: boolean | null
+    showValuesOnSeries?: boolean | null
+    useUdf?: boolean | null
+}
+
+export interface FunnelsQueryResponseApi {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export type FunnelsDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
+
+export interface FunnelsDataWarehouseNodeApi {
+    aggregation_target_field: string
+    custom_name?: string | null
+    dw_source_type?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    id: string
+    id_field: string
+    kind?: 'FunnelsDataWarehouseNode'
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: FunnelsDataWarehouseNodeApiResponse
+    table_name: string
+    timestamp_field: string
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface FunnelsQueryApi {
+    /** Groups aggregation */
+    aggregation_group_type_index?: number | null
+    /** Breakdown of the events and actions */
+    breakdownFilter?: BreakdownFilterApi | null
+    /** Colors used in the insight's visualization */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi | null
+    /** Exclude internal and test users by applying the respective filters */
+    filterTestAccounts?: boolean | null
+    /** Properties specific to the funnels insight */
+    funnelsFilter?: FunnelsFilterApi | null
+    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
+    interval?: IntervalTypeApi | null
+    kind?: 'FunnelsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Property filters for all series */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | PropertyGroupFilterApi
+        | null
+    response?: FunnelsQueryResponseApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    /** Events and actions to include */
+    series: (GroupNodeApi | EventsNodeApi | ActionsNodeApi | FunnelsDataWarehouseNodeApi)[]
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface RetentionValueApi {
+    aggregation_value?: number | null
+    count: number
+    label?: string | null
+}
+
+export interface RetentionResultApi {
+    /** Optional breakdown value for retention cohorts */
+    breakdown_value?: string | number | null
+    date: string
+    label: string
+    values: RetentionValueApi[]
+}
+
+export interface RetentionQueryResponseApi {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: RetentionResultApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export type AggregationPropertyType1Api = (typeof AggregationPropertyType1Api)[keyof typeof AggregationPropertyType1Api]
+
+export const AggregationPropertyType1Api = {
+    Event: 'event',
+    Person: 'person',
+    DataWarehouse: 'data_warehouse',
+} as const
+
+export type AggregationTypeApi = (typeof AggregationTypeApi)[keyof typeof AggregationTypeApi]
+
+export const AggregationTypeApi = {
+    Count: 'count',
+    Sum: 'sum',
+    Avg: 'avg',
+} as const
+
+export type RetentionDashboardDisplayTypeApi =
+    (typeof RetentionDashboardDisplayTypeApi)[keyof typeof RetentionDashboardDisplayTypeApi]
+
+export const RetentionDashboardDisplayTypeApi = {
+    TableOnly: 'table_only',
+    GraphOnly: 'graph_only',
+    All: 'all',
+} as const
+
+export type MeanRetentionCalculationApi = (typeof MeanRetentionCalculationApi)[keyof typeof MeanRetentionCalculationApi]
+
+export const MeanRetentionCalculationApi = {
+    Simple: 'simple',
+    Weighted: 'weighted',
+    None: 'none',
+} as const
+
+export type RetentionPeriodApi = (typeof RetentionPeriodApi)[keyof typeof RetentionPeriodApi]
+
+export const RetentionPeriodApi = {
+    Hour: 'Hour',
+    Day: 'Day',
+    Week: 'Week',
+    Month: 'Month',
+} as const
+
+export type RetentionReferenceApi = (typeof RetentionReferenceApi)[keyof typeof RetentionReferenceApi]
+
+export const RetentionReferenceApi = {
+    Total: 'total',
+    Previous: 'previous',
+} as const
+
+export type RetentionTypeApi = (typeof RetentionTypeApi)[keyof typeof RetentionTypeApi]
+
+export const RetentionTypeApi = {
+    RetentionRecurring: 'retention_recurring',
+    RetentionFirstTime: 'retention_first_time',
+    RetentionFirstEverOccurrence: 'retention_first_ever_occurrence',
+} as const
+
+export type RetentionEntityKindApi = (typeof RetentionEntityKindApi)[keyof typeof RetentionEntityKindApi]
+
+export const RetentionEntityKindApi = {
+    ActionsNode: 'ActionsNode',
+    EventsNode: 'EventsNode',
+} as const
+
+export type EntityTypeApi = (typeof EntityTypeApi)[keyof typeof EntityTypeApi]
+
+export const EntityTypeApi = {
+    Actions: 'actions',
+    Events: 'events',
+    DataWarehouse: 'data_warehouse',
+    NewEntity: 'new_entity',
+    Groups: 'groups',
+} as const
+
+export interface RetentionEntityApi {
+    /** Data warehouse field used as the actor identifier */
+    aggregation_target_field?: string | null
+    custom_name?: string | null
+    id?: string | number | null
+    kind?: RetentionEntityKindApi | null
+    name?: string | null
+    order?: number | null
+    /** filters on the event */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    /** Data warehouse table name */
+    table_name?: string | null
+    /** Data warehouse timestamp field */
+    timestamp_field?: string | null
+    type?: EntityTypeApi | null
+    uuid?: string | null
+}
+
+export type TimeWindowModeApi = (typeof TimeWindowModeApi)[keyof typeof TimeWindowModeApi]
+
+export const TimeWindowModeApi = {
+    StrictCalendarDates: 'strict_calendar_dates',
+    '24HourWindows': '24_hour_windows',
+} as const
+
+export interface RetentionFilterApi {
+    /** The property to aggregate when aggregationType is sum or avg */
+    aggregationProperty?: string | null
+    /** The type of property to aggregate on (event, person or data_warehouse). Defaults to event. */
+    aggregationPropertyType?: AggregationPropertyType1Api | null
+    /** The aggregation type to use for retention */
+    aggregationType?: AggregationTypeApi | null
+    /** Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations. */
+    cohortLabelStartIndex?: number | null
+    cumulative?: boolean | null
+    /** For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups. */
+    customAggregationTarget?: boolean | null
+    dashboardDisplay?: RetentionDashboardDisplayTypeApi | null
+    /** controls the display of the retention graph */
+    display?: ChartDisplayTypeApi | null
+    goalLines?: GoalLineApi[] | null
+    meanRetentionCalculation?: MeanRetentionCalculationApi | null
+    minimumOccurrences?: number | null
+    period?: RetentionPeriodApi | null
+    /** Custom brackets for retention calculations */
+    retentionCustomBrackets?: number[] | null
+    /** Whether retention is with regard to initial cohort size, or that of the previous period. */
+    retentionReference?: RetentionReferenceApi | null
+    retentionType?: RetentionTypeApi | null
+    returningEntity?: RetentionEntityApi | null
+    /** The selected interval to display across all cohorts (null = show all intervals for each cohort) */
+    selectedInterval?: number | null
+    showTrendLines?: boolean | null
+    targetEntity?: RetentionEntityApi | null
+    /** The time window mode to use for retention calculations */
+    timeWindowMode?: TimeWindowModeApi | null
+    totalIntervals?: number | null
+}
+
+export interface RetentionQueryApi {
+    /** Groups aggregation */
+    aggregation_group_type_index?: number | null
+    /** Breakdown of the events and actions */
+    breakdownFilter?: BreakdownFilterApi | null
+    /** Colors used in the insight's visualization */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi | null
+    /** Exclude internal and test users by applying the respective filters */
+    filterTestAccounts?: boolean | null
+    kind?: 'RetentionQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Property filters for all series */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | PropertyGroupFilterApi
+        | null
+    response?: RetentionQueryResponseApi | null
+    /** Properties specific to the retention insight */
+    retentionFilter: RetentionFilterApi
+    /** Sampling rate */
+    samplingFactor?: number | null
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type FunnelPathTypeApi = (typeof FunnelPathTypeApi)[keyof typeof FunnelPathTypeApi]
+
+export const FunnelPathTypeApi = {
+    FunnelPathBeforeStep: 'funnel_path_before_step',
+    FunnelPathBetweenSteps: 'funnel_path_between_steps',
+    FunnelPathAfterStep: 'funnel_path_after_step',
+} as const
+
+export interface FunnelPathsFilterApi {
+    funnelPathType?: FunnelPathTypeApi | null
+    funnelSource: FunnelsQueryApi
+    funnelStep?: number | null
+}
+
+export type PathTypeApi = (typeof PathTypeApi)[keyof typeof PathTypeApi]
+
+export const PathTypeApi = {
+    Pageview: '$pageview',
+    Screen: '$screen',
+    CustomEvent: 'custom_event',
+    Hogql: 'hogql',
+} as const
+
+export interface PathCleaningFilterApi {
+    alias?: string | null
+    order?: number | null
+    regex?: string | null
+}
+
+export interface PathsFilterApi {
+    edgeLimit?: number | null
+    endPoint?: string | null
+    excludeEvents?: string[] | null
+    includeEventTypes?: PathTypeApi[] | null
+    localPathCleaningFilters?: PathCleaningFilterApi[] | null
+    maxEdgeWeight?: number | null
+    minEdgeWeight?: number | null
+    /** Relevant only within actors query */
+    pathDropoffKey?: string | null
+    /** Relevant only within actors query */
+    pathEndKey?: string | null
+    pathGroupings?: string[] | null
+    pathReplacements?: boolean | null
+    /** Relevant only within actors query */
+    pathStartKey?: string | null
+    pathsHogQLExpression?: string | null
+    showFullUrls?: boolean | null
+    startPoint?: string | null
+    stepLimit?: number | null
+}
+
+export interface PathsLinkApi {
+    average_conversion_time: number
+    source: string
+    target: string
+    value: number
+}
+
+export interface PathsQueryResponseApi {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: PathsLinkApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface PathsQueryApi {
+    /** Groups aggregation */
+    aggregation_group_type_index?: number | null
+    /** Colors used in the insight's visualization */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi | null
+    /** Exclude internal and test users by applying the respective filters */
+    filterTestAccounts?: boolean | null
+    /** Used for displaying paths in relation to funnel steps. */
+    funnelPathsFilter?: FunnelPathsFilterApi | null
+    kind?: 'PathsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Properties specific to the paths insight */
+    pathsFilter: PathsFilterApi
+    /** Property filters for all series */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | PropertyGroupFilterApi
+        | null
+    response?: PathsQueryResponseApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type StickinessQueryResponseApiResultsItem = { [key: string]: unknown }
+
+export interface StickinessQueryResponseApi {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: StickinessQueryResponseApiResultsItem[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export type StickinessComputationModeApi =
+    (typeof StickinessComputationModeApi)[keyof typeof StickinessComputationModeApi]
+
+export const StickinessComputationModeApi = {
+    NonCumulative: 'non_cumulative',
+    Cumulative: 'cumulative',
+} as const
+
+export type StickinessOperatorApi = (typeof StickinessOperatorApi)[keyof typeof StickinessOperatorApi]
+
+export const StickinessOperatorApi = {
+    Gte: 'gte',
+    Lte: 'lte',
+    Exact: 'exact',
+} as const
+
+export interface StickinessCriteriaApi {
+    operator: StickinessOperatorApi
+    /** @minimum 1 */
+    value: number
+}
+
+/**
+ * Customizations for the appearance of result datasets.
+ */
+export type StickinessFilterApiResultCustomizations =
+    | { [key: string]: ResultCustomizationByValueApi }
+    | { [key: string]: ResultCustomizationByPositionApi }
+    | null
+
+export interface StickinessFilterApi {
+    computedAs?: StickinessComputationModeApi | null
+    display?: ChartDisplayTypeApi | null
+    hiddenLegendIndexes?: number[] | null
+    /** Whether result datasets are associated by their values or by their order. */
+    resultCustomizationBy?: ResultCustomizationByApi | null
+    /** Customizations for the appearance of result datasets. */
+    resultCustomizations?: StickinessFilterApiResultCustomizations
+    showLegend?: boolean | null
+    showMultipleYAxes?: boolean | null
+    showValuesOnSeries?: boolean | null
+    stickinessCriteria?: StickinessCriteriaApi | null
+}
+
+export interface StickinessQueryApi {
+    /** Compare to date range */
+    compareFilter?: CompareFilterApi | null
+    /** Colors used in the insight's visualization */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi | null
+    /** Exclude internal and test users by applying the respective filters */
+    filterTestAccounts?: boolean | null
+    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
+    interval?: IntervalTypeApi | null
+    /** How many intervals comprise a period. Only used for cohorts, otherwise default 1. */
+    intervalCount?: number | null
+    kind?: 'StickinessQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Property filters for all series */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | PropertyGroupFilterApi
+        | null
+    response?: StickinessQueryResponseApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    /** Events and actions to include */
+    series: (EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi)[]
+    /** Properties specific to the stickiness insight */
+    stickinessFilter?: StickinessFilterApi | null
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type LifecycleToggleApi = (typeof LifecycleToggleApi)[keyof typeof LifecycleToggleApi]
+
+export const LifecycleToggleApi = {
+    New: 'new',
+    Resurrecting: 'resurrecting',
+    Returning: 'returning',
+    Dormant: 'dormant',
+} as const
+
+export interface LifecycleFilterApi {
+    showLegend?: boolean | null
+    showValuesOnSeries?: boolean | null
+    stacked?: boolean | null
+    toggledLifecycles?: LifecycleToggleApi[] | null
+}
+
+export type LifecycleQueryResponseApiResultsItem = { [key: string]: unknown }
+
+export interface LifecycleQueryResponseApi {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: LifecycleQueryResponseApiResultsItem[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export type LifecycleDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
+
+export interface LifecycleDataWarehouseNodeApi {
+    aggregation_target_field: string
+    created_at_field: string
+    custom_name?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    id: string
+    kind?: 'LifecycleDataWarehouseNode'
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: LifecycleDataWarehouseNodeApiResponse
+    table_name: string
+    timestamp_field: string
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface LifecycleQueryApi {
+    /** Groups aggregation */
+    aggregation_group_type_index?: number | null
+    /** For data warehouse based lifecycle insights when the aggregation target can't be mapped to persons or groups. */
+    customAggregationTarget?: boolean | null
+    /** Colors used in the insight's visualization */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi | null
+    /** Exclude internal and test users by applying the respective filters */
+    filterTestAccounts?: boolean | null
+    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
+    interval?: IntervalTypeApi | null
+    kind?: 'LifecycleQuery'
+    /** Properties specific to the lifecycle insight */
+    lifecycleFilter?: LifecycleFilterApi | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Property filters for all series */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | PropertyGroupFilterApi
+        | null
+    response?: LifecycleQueryResponseApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    /** Events and actions to include */
+    series: (EventsNodeApi | ActionsNodeApi | LifecycleDataWarehouseNodeApi)[]
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type WebStatsBreakdownApi = (typeof WebStatsBreakdownApi)[keyof typeof WebStatsBreakdownApi]
+
+export const WebStatsBreakdownApi = {
+    Page: 'Page',
+    InitialPage: 'InitialPage',
+    ExitPage: 'ExitPage',
+    ExitClick: 'ExitClick',
+    PreviousPage: 'PreviousPage',
+    ScreenName: 'ScreenName',
+    InitialChannelType: 'InitialChannelType',
+    InitialReferringDomain: 'InitialReferringDomain',
+    InitialReferringURL: 'InitialReferringURL',
+    InitialUTMSource: 'InitialUTMSource',
+    InitialUTMCampaign: 'InitialUTMCampaign',
+    InitialUTMMedium: 'InitialUTMMedium',
+    InitialUTMTerm: 'InitialUTMTerm',
+    InitialUTMContent: 'InitialUTMContent',
+    InitialUTMSourceMediumCampaign: 'InitialUTMSourceMediumCampaign',
+    Browser: 'Browser',
+    Os: 'OS',
+    Viewport: 'Viewport',
+    DeviceType: 'DeviceType',
+    Country: 'Country',
+    Region: 'Region',
+    City: 'City',
+    Timezone: 'Timezone',
+    Language: 'Language',
+    FrustrationMetrics: 'FrustrationMetrics',
+} as const
+
+export type WebAnalyticsOrderByFieldsApi =
+    (typeof WebAnalyticsOrderByFieldsApi)[keyof typeof WebAnalyticsOrderByFieldsApi]
+
+export const WebAnalyticsOrderByFieldsApi = {
+    Visitors: 'Visitors',
+    Views: 'Views',
+    AvgTimeOnPage: 'AvgTimeOnPage',
+    Clicks: 'Clicks',
+    BounceRate: 'BounceRate',
+    AverageScrollPercentage: 'AverageScrollPercentage',
+    ScrollGt80Percentage: 'ScrollGt80Percentage',
+    TotalConversions: 'TotalConversions',
+    UniqueConversions: 'UniqueConversions',
+    ConversionRate: 'ConversionRate',
+    ConvertingUsers: 'ConvertingUsers',
+    RageClicks: 'RageClicks',
+    DeadClicks: 'DeadClicks',
+    Errors: 'Errors',
+} as const
+
+export type WebAnalyticsOrderByDirectionApi =
+    (typeof WebAnalyticsOrderByDirectionApi)[keyof typeof WebAnalyticsOrderByDirectionApi]
+
+export const WebAnalyticsOrderByDirectionApi = {
+    Asc: 'ASC',
+    Desc: 'DESC',
+} as const
+
+export interface SamplingRateApi {
+    denominator?: number | null
+    numerator: number
+}
+
+export interface WebStatsTableQueryResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+    usedPreAggregatedTables?: boolean | null
+}
+
+export interface WebAnalyticsSamplingApi {
+    enabled?: boolean | null
+    forceSamplingRate?: SamplingRateApi | null
+}
+
+export interface WebStatsTableQueryApi {
+    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+    aggregation_group_type_index?: number | null
+    breakdownBy: WebStatsBreakdownApi
+    compareFilter?: CompareFilterApi | null
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi | null
+    doPathCleaning?: boolean | null
+    filterTestAccounts?: boolean | null
+    includeAvgTimeOnPage?: boolean | null
+    includeBounceRate?: boolean | null
+    includeHost?: boolean | null
+    includeRevenue?: boolean | null
+    includeScrollDepth?: boolean | null
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+    interval?: IntervalTypeApi | null
+    kind?: 'WebStatsTableQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+    )[]
+    response?: WebStatsTableQueryResponseApi | null
+    sampling?: WebAnalyticsSamplingApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    tags?: QueryLogTagsApi | null
+    useSessionsTable?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type WebAnalyticsItemKindApi = (typeof WebAnalyticsItemKindApi)[keyof typeof WebAnalyticsItemKindApi]
+
+export const WebAnalyticsItemKindApi = {
+    Unit: 'unit',
+    DurationS: 'duration_s',
+    Percentage: 'percentage',
+    Currency: 'currency',
+} as const
+
+export interface WebOverviewItemApi {
+    changeFromPreviousPct?: number | null
+    isIncreaseBad?: boolean | null
+    key: string
+    kind: WebAnalyticsItemKindApi
+    previous?: number | null
+    usedPreAggregatedTables?: boolean | null
+    value?: number | null
+}
+
+export interface WebOverviewQueryResponseApi {
+    dateFrom?: string | null
+    dateTo?: string | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: WebOverviewItemApi[]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    usedLazyPrecompute?: boolean | null
+    usedPreAggregatedTables?: boolean | null
+}
+
+export interface WebOverviewQueryApi {
+    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+    aggregation_group_type_index?: number | null
+    compareFilter?: CompareFilterApi | null
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi | null
+    doPathCleaning?: boolean | null
+    filterTestAccounts?: boolean | null
+    includeRevenue?: boolean | null
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+    interval?: IntervalTypeApi | null
+    kind?: 'WebOverviewQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+    )[]
+    response?: WebOverviewQueryResponseApi | null
+    sampling?: WebAnalyticsSamplingApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    tags?: QueryLogTagsApi | null
+    useSessionsTable?: boolean | null
+    /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
+    useWebAnalyticsPrecompute?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface ActionsPieApi {
+    disableHoverOffset?: boolean | null
+    hideAggregation?: boolean | null
+}
+
+export interface RetentionApi {
+    hideLineGraph?: boolean | null
+    hideSizeColumn?: boolean | null
+    useSmallLayout?: boolean | null
+}
+
+export interface VizSpecificOptionsApi {
+    ActionsPie?: ActionsPieApi | null
+    RETENTION?: RetentionApi | null
+}
+
+export interface InsightVizNodeApi {
+    /** Query is embedded inside another bordered component */
+    embedded?: boolean | null
+    /** Show with most visual options enabled. Used in insight scene. */
+    full?: boolean | null
+    hidePersonsModal?: boolean | null
+    hideTooltipOnScroll?: boolean | null
+    kind: InsightVizNodeApiKind
+    showCorrelationTable?: boolean | null
+    showFilters?: boolean | null
+    showHeader?: boolean | null
+    showLastComputation?: boolean | null
+    showLastComputationRefresh?: boolean | null
+    showResults?: boolean | null
+    showTable?: boolean | null
+    source:
+        | TrendsQueryApi
+        | FunnelsQueryApi
+        | RetentionQueryApi
+        | PathsQueryApi
+        | StickinessQueryApi
+        | LifecycleQueryApi
+        | WebStatsTableQueryApi
+        | WebOverviewQueryApi
+    suppressSessionAnalysisWarning?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+    vizSpecificOptions?: VizSpecificOptionsApi | null
+}
+
+export type DataTableNodeViewPropsContextTypeApi =
+    (typeof DataTableNodeViewPropsContextTypeApi)[keyof typeof DataTableNodeViewPropsContextTypeApi]
+
+export const DataTableNodeViewPropsContextTypeApi = {
+    EventDefinition: 'event_definition',
+    TeamColumns: 'team_columns',
+} as const
+
+export interface DataTableNodeViewPropsContextApi {
+    eventDefinitionId?: string | null
+    type: DataTableNodeViewPropsContextTypeApi
+}
+
+export type DataTableNodeApiKind = (typeof DataTableNodeApiKind)[keyof typeof DataTableNodeApiKind]
+
+export const DataTableNodeApiKind = {
+    DataTableNode: 'DataTableNode',
+} as const
+
+export interface ResponseApi {
+    columns: unknown[]
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql: string
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Cursor for fetching the next page of results */
+    nextCursor?: string | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[][]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types: string[]
+}
+
+export interface Response1Api {
+    columns: unknown[]
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql: string
+    limit: number
+    missing_actors_count?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset: number
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[][]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: string[] | null
+}
+
+export interface Response2Api {
+    columns: unknown[]
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql: string
+    kind?: 'GroupsQuery'
+    limit: number
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset: number
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[][]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types: string[]
+}
+
+export interface HogQLNoticeApi {
+    end?: number | null
+    fix?: string | null
+    message: string
+    start?: number | null
+}
+
+export type QueryIndexUsageApi = (typeof QueryIndexUsageApi)[keyof typeof QueryIndexUsageApi]
+
+export const QueryIndexUsageApi = {
+    Undecisive: 'undecisive',
+    No: 'no',
+    Partial: 'partial',
+    Yes: 'yes',
+} as const
+
+export interface HogQLMetadataResponseApi {
+    ch_table_names?: string[] | null
+    errors: HogQLNoticeApi[]
+    isUsingIndices?: QueryIndexUsageApi | null
+    isValid?: boolean | null
+    notices: HogQLNoticeApi[]
+    query?: string | null
+    table_names?: string[] | null
+    warnings: HogQLNoticeApi[]
+}
+
+export interface Response3Api {
+    /** Executed ClickHouse query */
+    clickhouse?: string | null
+    /** Returned columns */
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Query explanation output */
+    explain?: string[] | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Query metadata output */
+    metadata?: HogQLMetadataResponseApi | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Input query string */
+    query?: string | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    /** Types of returned columns */
+    types?: unknown[] | null
+}
+
+export interface Response4Api {
+    dateFrom?: string | null
+    dateTo?: string | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: WebOverviewItemApi[]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    usedLazyPrecompute?: boolean | null
+    usedPreAggregatedTables?: boolean | null
+}
+
+export interface Response5Api {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+    usedPreAggregatedTables?: boolean | null
+}
+
+export interface Response6Api {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface WebVitalsPathBreakdownResultItemApi {
+    path: string
+    value: number
+}
+
+export interface WebVitalsPathBreakdownResultApi {
+    good: WebVitalsPathBreakdownResultItemApi[]
+    needs_improvements: WebVitalsPathBreakdownResultItemApi[]
+    poor: WebVitalsPathBreakdownResultItemApi[]
+}
+
+export interface Response8Api {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    /**
+     * @minItems 1
+     * @maxItems 1
+     */
+    results: WebVitalsPathBreakdownResultApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface Response9Api {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface Response10Api {
+    columns: unknown[]
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql: string
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[][]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types: string[]
+}
+
+export interface Response11Api {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface Response12Api {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface RevenueAnalyticsMRRQueryResultItemApi {
+    churn: unknown
+    contraction: unknown
+    expansion: unknown
+    new: unknown
+    total: unknown
+}
+
+export interface Response13Api {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: RevenueAnalyticsMRRQueryResultItemApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export type RevenueAnalyticsOverviewItemKeyApi =
+    (typeof RevenueAnalyticsOverviewItemKeyApi)[keyof typeof RevenueAnalyticsOverviewItemKeyApi]
+
+export const RevenueAnalyticsOverviewItemKeyApi = {
+    Revenue: 'revenue',
+    PayingCustomerCount: 'paying_customer_count',
+    AvgRevenuePerCustomer: 'avg_revenue_per_customer',
+} as const
+
+export interface RevenueAnalyticsOverviewItemApi {
+    key: RevenueAnalyticsOverviewItemKeyApi
+    value: number
+}
+
+export interface Response14Api {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: RevenueAnalyticsOverviewItemApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface Response15Api {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface Response16Api {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface MarketingAnalyticsItemApi {
+    changeFromPreviousPct?: number | null
+    hasComparison?: boolean | null
+    isIncreaseBad?: boolean | null
+    key: string
+    kind: WebAnalyticsItemKindApi
+    previous?: number | string | null
+    value?: number | string | null
+}
+
+export interface Response18Api {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: MarketingAnalyticsItemApi[][]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export type Response19ApiResults = { [key: string]: MarketingAnalyticsItemApi }
+
+export interface Response19Api {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: Response19ApiResults
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface Response20Api {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: MarketingAnalyticsItemApi[][]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface VolumeBucketApi {
+    label: string
+    value: number
+}
+
+export interface ErrorTrackingIssueAggregationsApi {
+    occurrences: number
+    sessions: number
+    users: number
+    volumeRange?: number[] | null
+    volume_buckets: VolumeBucketApi[]
+}
+
+export type ErrorTrackingIssueAssigneeTypeApi =
+    (typeof ErrorTrackingIssueAssigneeTypeApi)[keyof typeof ErrorTrackingIssueAssigneeTypeApi]
+
+export const ErrorTrackingIssueAssigneeTypeApi = {
+    User: 'user',
+    Role: 'role',
+} as const
+
+export interface ErrorTrackingIssueAssigneeApi {
+    id: string | number
+    type: ErrorTrackingIssueAssigneeTypeApi
+}
+
+export interface ErrorTrackingIssueCohortApi {
+    id: number
+    name: string
+}
+
+export type IntegrationKindApi = (typeof IntegrationKindApi)[keyof typeof IntegrationKindApi]
+
+export const IntegrationKindApi = {
+    Slack: 'slack',
+    SlackPosthogCode: 'slack-posthog-code',
+    Salesforce: 'salesforce',
+    Hubspot: 'hubspot',
+    GooglePubsub: 'google-pubsub',
+    GoogleCloudServiceAccount: 'google-cloud-service-account',
+    GoogleCloudStorage: 'google-cloud-storage',
+    GoogleAds: 'google-ads',
+    GoogleSheets: 'google-sheets',
+    LinkedinAds: 'linkedin-ads',
+    Snapchat: 'snapchat',
+    Stripe: 'stripe',
+    Intercom: 'intercom',
+    Email: 'email',
+    Twilio: 'twilio',
+    Linear: 'linear',
+    Github: 'github',
+    Gitlab: 'gitlab',
+    MetaAds: 'meta-ads',
+    Clickup: 'clickup',
+    RedditAds: 'reddit-ads',
+    Databricks: 'databricks',
+    TiktokAds: 'tiktok-ads',
+    BingAds: 'bing-ads',
+    Vercel: 'vercel',
+    AzureBlob: 'azure-blob',
+    Firebase: 'firebase',
+    Jira: 'jira',
+    PinterestAds: 'pinterest-ads',
+    CustomerioApp: 'customerio-app',
+    CustomerioWebhook: 'customerio-webhook',
+    CustomerioTrack: 'customerio-track',
+} as const
+
+export interface ErrorTrackingExternalReferenceIntegrationApi {
+    display_name: string
+    id: number
+    kind: IntegrationKindApi
+}
+
+export interface ErrorTrackingExternalReferenceApi {
+    external_url: string
+    id: string
+    integration: ErrorTrackingExternalReferenceIntegrationApi
+}
+
+export interface FirstEventApi {
+    distinct_id: string
+    properties: string
+    timestamp: string
+    uuid: string
+}
+
+export interface LastEventApi {
+    distinct_id: string
+    properties: string
+    timestamp: string
+    uuid: string
+}
+
+export type ErrorTrackingIssueStatusApi = (typeof ErrorTrackingIssueStatusApi)[keyof typeof ErrorTrackingIssueStatusApi]
+
+export const ErrorTrackingIssueStatusApi = {
+    Archived: 'archived',
+    Active: 'active',
+    Resolved: 'resolved',
+    PendingRelease: 'pending_release',
+    Suppressed: 'suppressed',
+} as const
+
+export interface ErrorTrackingIssueApi {
+    aggregations?: ErrorTrackingIssueAggregationsApi | null
+    assignee?: ErrorTrackingIssueAssigneeApi | null
+    cohort?: ErrorTrackingIssueCohortApi | null
+    description?: string | null
+    external_issues?: ErrorTrackingExternalReferenceApi[] | null
+    first_event?: FirstEventApi | null
+    first_seen: string
+    function?: string | null
+    id: string
+    last_event?: LastEventApi | null
+    last_seen: string
+    library?: string | null
+    name?: string | null
+    source?: string | null
+    status: ErrorTrackingIssueStatusApi
+}
+
+export interface Response21Api {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: ErrorTrackingIssueApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface PopulationApi {
+    both: number
+    exception_only: number
+    neither: number
+    success_only: number
+}
+
+export interface ErrorTrackingCorrelatedIssueApi {
+    assignee?: ErrorTrackingIssueAssigneeApi | null
+    cohort?: ErrorTrackingIssueCohortApi | null
+    description?: string | null
+    event: string
+    external_issues?: ErrorTrackingExternalReferenceApi[] | null
+    first_seen: string
+    id: string
+    last_seen: string
+    library?: string | null
+    name?: string | null
+    odds_ratio: number
+    population: PopulationApi
+    status: ErrorTrackingIssueStatusApi
+}
+
+export interface Response22Api {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: ErrorTrackingCorrelatedIssueApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export type ExperimentSignificanceCodeApi =
+    (typeof ExperimentSignificanceCodeApi)[keyof typeof ExperimentSignificanceCodeApi]
+
+export const ExperimentSignificanceCodeApi = {
+    Significant: 'significant',
+    NotEnoughExposure: 'not_enough_exposure',
+    LowWinProbability: 'low_win_probability',
+    HighLoss: 'high_loss',
+    HighPValue: 'high_p_value',
+} as const
+
+export interface ExperimentVariantFunnelsBaseStatsApi {
+    failure_count: number
+    key: string
+    success_count: number
+}
+
+export type Response23ApiCredibleIntervals = { [key: string]: number[] }
+
+export type Response23ApiInsightItemItem = { [key: string]: unknown }
+
+export type Response23ApiProbability = { [key: string]: number }
+
+export interface Response23Api {
+    credible_intervals: Response23ApiCredibleIntervals
+    expected_loss: number
+    funnels_query?: FunnelsQueryApi | null
+    insight: Response23ApiInsightItemItem[][]
+    kind?: 'ExperimentFunnelsQuery'
+    probability: Response23ApiProbability
+    significance_code: ExperimentSignificanceCodeApi
+    significant: boolean
+    stats_version?: number | null
+    variants: ExperimentVariantFunnelsBaseStatsApi[]
+}
+
+export interface ExperimentVariantTrendsBaseStatsApi {
+    absolute_exposure: number
+    count: number
+    exposure: number
+    key: string
+}
+
+export type Response24ApiCredibleIntervals = { [key: string]: number[] }
+
+export type Response24ApiInsightItem = { [key: string]: unknown }
+
+export type Response24ApiProbability = { [key: string]: number }
+
+export interface Response24Api {
+    count_query?: TrendsQueryApi | null
+    credible_intervals: Response24ApiCredibleIntervals
+    exposure_query?: TrendsQueryApi | null
+    insight: Response24ApiInsightItem[]
+    kind?: 'ExperimentTrendsQuery'
+    p_value: number
+    probability: Response24ApiProbability
+    significance_code: ExperimentSignificanceCodeApi
+    significant: boolean
+    stats_version?: number | null
+    variants: ExperimentVariantTrendsBaseStatsApi[]
+}
+
+export type AIEventTypeApi = (typeof AIEventTypeApi)[keyof typeof AIEventTypeApi]
+
+export const AIEventTypeApi = {
+    AiGeneration: '$ai_generation',
+    AiEmbedding: '$ai_embedding',
+    AiSpan: '$ai_span',
+    AiTrace: '$ai_trace',
+    AiMetric: '$ai_metric',
+    AiFeedback: '$ai_feedback',
+    AiEvaluation: '$ai_evaluation',
+    AiTag: '$ai_tag',
+    AiTraceSummary: '$ai_trace_summary',
+    AiGenerationSummary: '$ai_generation_summary',
+    AiTraceClusters: '$ai_trace_clusters',
+    AiGenerationClusters: '$ai_generation_clusters',
+} as const
+
+export type LLMTraceEventApiProperties = { [key: string]: unknown }
+
+export interface LLMTraceEventApi {
+    createdAt: string
+    event: AIEventTypeApi | string
+    id: string
+    properties: LLMTraceEventApiProperties
+}
+
+export type LLMTracePersonApiProperties = { [key: string]: unknown }
+
+export interface LLMTracePersonApi {
+    created_at: string
+    distinct_id: string
+    properties: LLMTracePersonApiProperties
+    uuid: string
+}
+
+export interface LLMTraceApi {
+    aiSessionId?: string | null
+    createdAt: string
+    distinctId: string
+    errorCount?: number | null
+    events: LLMTraceEventApi[]
+    id: string
+    inputCost?: number | null
+    inputState?: unknown
+    inputTokens?: number | null
+    isSupportTrace?: boolean | null
+    outputCost?: number | null
+    outputState?: unknown
+    outputTokens?: number | null
+    person?: LLMTracePersonApi | null
+    requestCost?: number | null
+    tools?: string[] | null
+    totalCost?: number | null
+    totalLatency?: number | null
+    traceName?: string | null
+    webSearchCost?: number | null
+}
+
+export interface Response25Api {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: LLMTraceApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface Response26Api {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export type TaxonomicFilterGroupTypeApi = (typeof TaxonomicFilterGroupTypeApi)[keyof typeof TaxonomicFilterGroupTypeApi]
+
+export const TaxonomicFilterGroupTypeApi = {
+    Metadata: 'metadata',
+    Actions: 'actions',
+    Cohorts: 'cohorts',
+    CohortsWithAll: 'cohorts_with_all',
+    DataWarehouse: 'data_warehouse',
+    DataWarehouseProperties: 'data_warehouse_properties',
+    DataWarehousePersonProperties: 'data_warehouse_person_properties',
+    Elements: 'elements',
+    Events: 'events',
+    InternalEvents: 'internal_events',
+    InternalEventProperties: 'internal_event_properties',
+    EventProperties: 'event_properties',
+    EventFeatureFlags: 'event_feature_flags',
+    EventMetadata: 'event_metadata',
+    NumericalEventProperties: 'numerical_event_properties',
+    PersonProperties: 'person_properties',
+    PageviewUrls: 'pageview_urls',
+    PageviewEvents: 'pageview_events',
+    Screens: 'screens',
+    ScreenEvents: 'screen_events',
+    EmailAddresses: 'email_addresses',
+    AutocaptureEvents: 'autocapture_events',
+    CustomEvents: 'custom_events',
+    Wildcard: 'wildcard',
+    Groups: 'groups',
+    Persons: 'persons',
+    FeatureFlags: 'feature_flags',
+    Insights: 'insights',
+    Experiments: 'experiments',
+    Plugins: 'plugins',
+    Dashboards: 'dashboards',
+    NameGroups: 'name_groups',
+    SessionProperties: 'session_properties',
+    HogqlExpression: 'hogql_expression',
+    Notebooks: 'notebooks',
+    LogEntries: 'log_entries',
+    ErrorTrackingIssues: 'error_tracking_issues',
+    Logs: 'logs',
+    LogAttributes: 'log_attributes',
+    LogResourceAttributes: 'log_resource_attributes',
+    Spans: 'spans',
+    SpanAttributes: 'span_attributes',
+    SpanResourceAttributes: 'span_resource_attributes',
+    Replay: 'replay',
+    ReplaySavedFilters: 'replay_saved_filters',
+    RevenueAnalyticsProperties: 'revenue_analytics_properties',
+    Resources: 'resources',
+    ErrorTrackingProperties: 'error_tracking_properties',
+    ActivityLogProperties: 'activity_log_properties',
+    MaxAiContext: 'max_ai_context',
+    WorkflowVariables: 'workflow_variables',
+    SuggestedFilters: 'suggested_filters',
+    RecentFilters: 'recent_filters',
+    PinnedFilters: 'pinned_filters',
+    Empty: 'empty',
+} as const
+
+export type HrefMatchingApi = (typeof HrefMatchingApi)[keyof typeof HrefMatchingApi]
+
+export const HrefMatchingApi = {
+    Contains: 'contains',
+    Exact: 'exact',
+    Regex: 'regex',
+} as const
+
+export type TextMatchingApi = (typeof TextMatchingApi)[keyof typeof TextMatchingApi]
+
+export const TextMatchingApi = {
+    Contains: 'contains',
+    Exact: 'exact',
+    Regex: 'regex',
+} as const
+
+export type UrlMatchingApi = (typeof UrlMatchingApi)[keyof typeof UrlMatchingApi]
+
+export const UrlMatchingApi = {
+    Contains: 'contains',
+    Exact: 'exact',
+    Regex: 'regex',
+} as const
+
+export interface EventsQueryActionStepApi {
+    event?: string | null
+    href?: string | null
+    href_matching?: HrefMatchingApi | null
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    selector?: string | null
+    tag_name?: string | null
+    text?: string | null
+    text_matching?: TextMatchingApi | null
+    url?: string | null
+    url_matching?: UrlMatchingApi | null
+}
+
+export interface EventsQueryResponseApi {
+    columns: unknown[]
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql: string
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Cursor for fetching the next page of results */
+    nextCursor?: string | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[][]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types: string[]
+}
+
+export type CompareApi = (typeof CompareApi)[keyof typeof CompareApi]
+
+export const CompareApi = {
+    Current: 'current',
+    Previous: 'previous',
+} as const
+
+export interface ActorsQueryResponseApi {
+    columns: unknown[]
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql: string
+    limit: number
+    missing_actors_count?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset: number
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[][]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: string[] | null
+}
+
+export interface InsightActorsQueryApi {
+    breakdown?: string | string[] | number | null
+    compare?: CompareApi | null
+    day?: string | number | null
+    includeRecordings?: boolean | null
+    /** An interval selected out of available intervals in source query. */
+    interval?: number | null
+    kind?: 'InsightActorsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    response?: ActorsQueryResponseApi | null
+    series?: number | null
+    source:
+        | TrendsQueryApi
+        | FunnelsQueryApi
+        | RetentionQueryApi
+        | PathsQueryApi
+        | StickinessQueryApi
+        | LifecycleQueryApi
+        | WebStatsTableQueryApi
+        | WebOverviewQueryApi
+    status?: string | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface EventsQueryApi {
+    /** Show events matching a given action */
+    actionId?: number | null
+    /** Show events matching action steps directly, used when no actionId is provided (e.g. previewing unsaved actions). Ignored if actionId is set. */
+    actionSteps?: EventsQueryActionStepApi[] | null
+    /** Only fetch events that happened after this timestamp */
+    after?: string | null
+    /** Only fetch events that happened before this timestamp */
+    before?: string | null
+    /** Limit to events matching this string */
+    event?: string | null
+    /** Filter to events matching any of these event names */
+    events?: string[] | null
+    /** Filter test accounts */
+    filterTestAccounts?: boolean | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | PropertyGroupFilterApi
+              | PropertyGroupFilterValueApi
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    kind?: 'EventsQuery'
+    /** Number of rows to return */
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Number of rows to skip before returning rows */
+    offset?: number | null
+    /** Columns to order by */
+    orderBy?: string[] | null
+    /** Show events for a given person */
+    personId?: string | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: EventsQueryResponseApi | null
+    /** Return a limited set of data. Required. */
+    select: string[]
+    /** source for querying events for insights */
+    source?: InsightActorsQueryApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+    /** HogQL filters to apply on returned data */
+    where?: string[] | null
+}
+
+export type PersonsNodeApiResponse = { [key: string]: unknown } | null
+
+export interface PersonsNodeApi {
+    cohort?: number | null
+    distinctId?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    kind?: 'PersonsNode'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: PersonsNodeApiResponse
+    search?: string | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface FunnelsActorsQueryApi {
+    /** Index of the step for which we want to get the timestamp for, per person. Positive for converted persons, negative for dropped of persons. */
+    funnelStep?: number | null
+    /** The breakdown value for which to get persons for. This is an array for person and event properties, a string for groups and an integer for cohorts. */
+    funnelStepBreakdown?: number | string | (number | string)[] | null
+    funnelTrendsDropOff?: boolean | null
+    /** Used together with `funnelTrendsDropOff` for funnels time conversion date for the persons modal. */
+    funnelTrendsEntrancePeriodStart?: string | null
+    includeRecordings?: boolean | null
+    kind?: 'FunnelsActorsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    response?: ActorsQueryResponseApi | null
+    source: FunnelsQueryApi
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type FunnelCorrelationResultsTypeApi =
+    (typeof FunnelCorrelationResultsTypeApi)[keyof typeof FunnelCorrelationResultsTypeApi]
+
+export const FunnelCorrelationResultsTypeApi = {
+    Events: 'events',
+    Properties: 'properties',
+    EventWithProperties: 'event_with_properties',
+} as const
+
+export type CorrelationTypeApi = (typeof CorrelationTypeApi)[keyof typeof CorrelationTypeApi]
+
+export const CorrelationTypeApi = {
+    Success: 'success',
+    Failure: 'failure',
+} as const
+
+export type EventDefinitionApiProperties = { [key: string]: unknown }
+
+export interface EventDefinitionApi {
+    elements: unknown[]
+    event: string
+    properties: EventDefinitionApiProperties
+}
+
+export interface EventOddsRatioSerializedApi {
+    correlation_type: CorrelationTypeApi
+    event: EventDefinitionApi
+    failure_count: number
+    odds_ratio: number
+    success_count: number
+}
+
+export interface FunnelCorrelationResultApi {
+    events: EventOddsRatioSerializedApi[]
+    skewed: boolean
+}
+
+export interface FunnelCorrelationResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: FunnelCorrelationResultApi
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface FunnelCorrelationQueryApi {
+    funnelCorrelationEventExcludePropertyNames?: string[] | null
+    funnelCorrelationEventNames?: string[] | null
+    funnelCorrelationExcludeEventNames?: string[] | null
+    funnelCorrelationExcludeNames?: string[] | null
+    funnelCorrelationNames?: string[] | null
+    funnelCorrelationType: FunnelCorrelationResultsTypeApi
+    kind?: 'FunnelCorrelationQuery'
+    response?: FunnelCorrelationResponseApi | null
+    source: FunnelsActorsQueryApi
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface FunnelCorrelationActorsQueryApi {
+    funnelCorrelationPersonConverted?: boolean | null
+    funnelCorrelationPersonEntity?: EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi | null
+    funnelCorrelationPropertyValues?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    includeRecordings?: boolean | null
+    kind?: 'FunnelCorrelationActorsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    response?: ActorsQueryResponseApi | null
+    source: FunnelCorrelationQueryApi
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ExperimentEventExposureConfigApiResponse = { [key: string]: unknown } | null
+
+export interface ExperimentEventExposureConfigApi {
+    event: string
+    kind?: 'ExperimentEventExposureConfig'
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | ElementPropertyFilterApi
+        | EventMetadataPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+        | RecordingPropertyFilterApi
+        | LogEntryPropertyFilterApi
+        | GroupPropertyFilterApi
+        | FeaturePropertyFilterApi
+        | FlagPropertyFilterApi
+        | HogQLPropertyFilterApi
+        | EmptyPropertyFilterApi
+        | DataWarehousePropertyFilterApi
+        | DataWarehousePersonPropertyFilterApi
+        | ErrorTrackingIssueFilterApi
+        | LogPropertyFilterApi
+        | SpanPropertyFilterApi
+        | RevenueAnalyticsPropertyFilterApi
+        | WorkflowVariablePropertyFilterApi
+    )[]
+    response?: ExperimentEventExposureConfigApiResponse
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type MultipleVariantHandlingApi = (typeof MultipleVariantHandlingApi)[keyof typeof MultipleVariantHandlingApi]
+
+export const MultipleVariantHandlingApi = {
+    Exclude: 'exclude',
+    FirstSeen: 'first_seen',
+} as const
+
+export type ExperimentMetricGoalApi = (typeof ExperimentMetricGoalApi)[keyof typeof ExperimentMetricGoalApi]
+
+export const ExperimentMetricGoalApi = {
+    Increase: 'increase',
+    Decrease: 'decrease',
+} as const
+
+export type ExperimentDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
+
+export interface ExperimentDataWarehouseNodeApi {
+    custom_name?: string | null
+    data_warehouse_join_key: string
+    events_join_key: string
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    kind?: 'ExperimentDataWarehouseNode'
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: ExperimentDataWarehouseNodeApiResponse
+    table_name: string
+    timestamp_field: string
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ExperimentMeanMetricApiResponse = { [key: string]: unknown } | null
+
+export interface ExperimentMeanMetricApi {
+    breakdownFilter?: BreakdownFilterApi | null
+    conversion_window?: number | null
+    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
+    fingerprint?: string | null
+    goal?: ExperimentMetricGoalApi | null
+    ignore_zeros?: boolean | null
+    isSharedMetric?: boolean | null
+    kind?: 'ExperimentMetric'
+    lower_bound_percentile?: number | null
+    metric_type?: 'mean'
+    name?: string | null
+    response?: ExperimentMeanMetricApiResponse
+    sharedMetricId?: number | null
+    source: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
+    upper_bound_percentile?: number | null
+    uuid?: string | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ExperimentFunnelMetricApiResponse = { [key: string]: unknown } | null
+
+export interface ExperimentFunnelMetricApi {
+    breakdownFilter?: BreakdownFilterApi | null
+    conversion_window?: number | null
+    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
+    fingerprint?: string | null
+    funnel_order_type?: StepOrderValueApi | null
+    goal?: ExperimentMetricGoalApi | null
+    isSharedMetric?: boolean | null
+    kind?: 'ExperimentMetric'
+    metric_type?: 'funnel'
+    name?: string | null
+    response?: ExperimentFunnelMetricApiResponse
+    series: (EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi)[]
+    sharedMetricId?: number | null
+    uuid?: string | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ExperimentRatioMetricApiResponse = { [key: string]: unknown } | null
+
+export interface ExperimentRatioMetricApi {
+    breakdownFilter?: BreakdownFilterApi | null
+    conversion_window?: number | null
+    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
+    denominator: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
+    fingerprint?: string | null
+    goal?: ExperimentMetricGoalApi | null
+    isSharedMetric?: boolean | null
+    kind?: 'ExperimentMetric'
+    metric_type?: 'ratio'
+    name?: string | null
+    numerator: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
+    response?: ExperimentRatioMetricApiResponse
+    sharedMetricId?: number | null
+    uuid?: string | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type StartHandlingApi = (typeof StartHandlingApi)[keyof typeof StartHandlingApi]
+
+export const StartHandlingApi = {
+    FirstSeen: 'first_seen',
+    LastSeen: 'last_seen',
+} as const
+
+export type ExperimentRetentionMetricApiResponse = { [key: string]: unknown } | null
+
+export interface ExperimentRetentionMetricApi {
+    breakdownFilter?: BreakdownFilterApi | null
+    completion_event: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
+    conversion_window?: number | null
+    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
+    fingerprint?: string | null
+    goal?: ExperimentMetricGoalApi | null
+    isSharedMetric?: boolean | null
+    kind?: 'ExperimentMetric'
+    metric_type?: 'retention'
+    name?: string | null
+    response?: ExperimentRetentionMetricApiResponse
+    retention_window_end: number
+    retention_window_start: number
+    retention_window_unit: FunnelConversionWindowTimeUnitApi
+    sharedMetricId?: number | null
+    start_event: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
+    start_handling: StartHandlingApi
+    uuid?: string | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type PrecomputationModeApi = (typeof PrecomputationModeApi)[keyof typeof PrecomputationModeApi]
+
+export const PrecomputationModeApi = {
+    Precomputed: 'precomputed',
+    Direct: 'direct',
+} as const
+
+export interface SessionDataApi {
+    event_uuid: string
+    person_id: string
+    session_id: string
+    timestamp: string
+}
+
+export type ExperimentStatsValidationFailureApi =
+    (typeof ExperimentStatsValidationFailureApi)[keyof typeof ExperimentStatsValidationFailureApi]
+
+export const ExperimentStatsValidationFailureApi = {
+    NotEnoughExposures: 'not-enough-exposures',
+    BaselineMeanIsZero: 'baseline-mean-is-zero',
+    NotEnoughMetricData: 'not-enough-metric-data',
+} as const
+
+export interface ExperimentStatsBaseValidatedApi {
+    covariate_sum?: number | null
+    covariate_sum_product?: number | null
+    covariate_sum_squares?: number | null
+    denominator_sum?: number | null
+    denominator_sum_squares?: number | null
+    key: string
+    number_of_samples: number
+    numerator_denominator_sum_product?: number | null
+    step_counts?: number[] | null
+    step_sessions?: SessionDataApi[][] | null
+    sum: number
+    sum_squares: number
+    validation_failures?: ExperimentStatsValidationFailureApi[] | null
+}
+
+export interface ExperimentVariantResultFrequentistApi {
+    confidence_interval?: number[] | null
+    covariate_sum?: number | null
+    covariate_sum_product?: number | null
+    covariate_sum_squares?: number | null
+    denominator_sum?: number | null
+    denominator_sum_squares?: number | null
+    key: string
+    method?: 'frequentist'
+    number_of_samples: number
+    numerator_denominator_sum_product?: number | null
+    p_value?: number | null
+    significant?: boolean | null
+    step_counts?: number[] | null
+    step_sessions?: SessionDataApi[][] | null
+    sum: number
+    sum_squares: number
+    validation_failures?: ExperimentStatsValidationFailureApi[] | null
+}
+
+export interface ExperimentVariantResultBayesianApi {
+    chance_to_win?: number | null
+    covariate_sum?: number | null
+    covariate_sum_product?: number | null
+    covariate_sum_squares?: number | null
+    credible_interval?: number[] | null
+    denominator_sum?: number | null
+    denominator_sum_squares?: number | null
+    key: string
+    method?: 'bayesian'
+    number_of_samples: number
+    numerator_denominator_sum_product?: number | null
+    significant?: boolean | null
+    step_counts?: number[] | null
+    step_sessions?: SessionDataApi[][] | null
+    sum: number
+    sum_squares: number
+    validation_failures?: ExperimentStatsValidationFailureApi[] | null
+}
+
+export interface ExperimentBreakdownResultApi {
+    /** Control variant stats for this breakdown */
+    baseline: ExperimentStatsBaseValidatedApi
+    /** The breakdown values as an array (e.g., ["MacOS", "Chrome"] for multi-breakdown, ["Chrome"] for single) Although `BreakdownKeyType` could be an array, we only use the array form for the breakdown_value. The way `BreakdownKeyType` is defined is problematic. It should be treated as a primitive and allow for the types using it to define if it's and array or an optional value. */
+    breakdown_value: (string | number)[]
+    /** Test variant results with statistical comparisons for this breakdown */
+    variants: ExperimentVariantResultFrequentistApi[] | ExperimentVariantResultBayesianApi[]
+}
+
+export type ExperimentQueryResponseApiCredibleIntervals = { [key: string]: number[] } | null
+
+export type ExperimentQueryResponseApiInsight = { [key: string]: unknown }[] | null
+
+export type ExperimentQueryResponseApiProbability = { [key: string]: number } | null
+
+export interface ExperimentQueryResponseApi {
+    baseline?: ExperimentStatsBaseValidatedApi | null
+    /** Results grouped by breakdown value. When present, baseline and variant_results contain aggregated data. */
+    breakdown_results?: ExperimentBreakdownResultApi[] | null
+    clickhouse_sql?: string | null
+    credible_intervals?: ExperimentQueryResponseApiCredibleIntervals
+    hogql?: string | null
+    insight?: ExperimentQueryResponseApiInsight
+    /** Whether exposures were served from the precomputation system */
+    is_precomputed?: boolean | null
+    kind?: 'ExperimentQuery'
+    metric?:
+        | ExperimentMeanMetricApi
+        | ExperimentFunnelMetricApi
+        | ExperimentRatioMetricApi
+        | ExperimentRetentionMetricApi
+        | null
+    p_value?: number | null
+    probability?: ExperimentQueryResponseApiProbability
+    significance_code?: ExperimentSignificanceCodeApi | null
+    significant?: boolean | null
+    stats_version?: number | null
+    variant_results?: ExperimentVariantResultFrequentistApi[] | ExperimentVariantResultBayesianApi[] | null
+    variants?: ExperimentVariantTrendsBaseStatsApi[] | ExperimentVariantFunnelsBaseStatsApi[] | null
+}
+
+export interface ExperimentQueryApi {
+    experiment_id?: number | null
+    kind?: 'ExperimentQuery'
+    metric:
+        | ExperimentMeanMetricApi
+        | ExperimentFunnelMetricApi
+        | ExperimentRatioMetricApi
+        | ExperimentRetentionMetricApi
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    name?: string | null
+    precomputation_mode?: PrecomputationModeApi | null
+    response?: ExperimentQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface ExperimentActorsQueryApi {
+    /** Exposure configuration for filtering events. Defines when users were first exposed to the experiment. */
+    exposureConfig?: ExperimentEventExposureConfigApi | ActionsNodeApi | null
+    /** Feature flag key for breakdown filtering. */
+    featureFlagKey?: string | null
+    /** Index of the step for which we want to get actors for, per experiment variant. Positive for converted persons, negative for dropped off persons. */
+    funnelStep?: number | null
+    /** The variant key for filtering actors. For experiments, this filters by feature flag variant (e.g., 'control', 'test'). */
+    funnelStepBreakdown?: number | string | (number | string)[] | null
+    includeRecordings?: boolean | null
+    kind?: 'ExperimentActorsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** How to handle users with multiple variant exposures. */
+    multipleVariantHandling?: MultipleVariantHandlingApi | null
+    response?: ActorsQueryResponseApi | null
+    source: ExperimentQueryApi
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface StickinessActorsQueryApi {
+    compare?: CompareApi | null
+    day?: string | number | null
+    includeRecordings?: boolean | null
+    kind?: 'StickinessActorsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    operator?: StickinessOperatorApi | null
+    response?: ActorsQueryResponseApi | null
+    series?: number | null
+    source: StickinessQueryApi
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface HogQLFiltersApi {
+    dateRange?: DateRangeApi | null
+    filterTestAccounts?: boolean | null
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+}
+
+export interface HogQLQueryResponseApi {
+    /** Executed ClickHouse query */
+    clickhouse?: string | null
+    /** Returned columns */
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Query explanation output */
+    explain?: string[] | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Query metadata output */
+    metadata?: HogQLMetadataResponseApi | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Input query string */
+    query?: string | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    /** Types of returned columns */
+    types?: unknown[] | null
+}
+
+export interface HogQLVariableApi {
+    code_name: string
+    isNull?: boolean | null
+    value?: unknown
+    variableId: string
+}
+
+/**
+ * Constant values that can be referenced with the {placeholder} syntax in the query
+ */
+export type HogQLQueryApiValues = { [key: string]: unknown } | null
+
+/**
+ * Variables to be substituted into the query
+ */
+export type HogQLQueryApiVariables = { [key: string]: HogQLVariableApi } | null
+
+export interface HogQLQueryApi {
+    /** Optional direct external data source id for running against a specific source */
+    connectionId?: string | null
+    explain?: boolean | null
+    filters?: HogQLFiltersApi | null
+    kind?: 'HogQLQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Client provided name of the query */
+    name?: string | null
+    query: string
+    response?: HogQLQueryResponseApi | null
+    /** Run the selected connection query directly without translating it through HogQL first */
+    sendRawQuery?: boolean | null
+    tags?: QueryLogTagsApi | null
+    /** Constant values that can be referenced with the {placeholder} syntax in the query */
+    values?: HogQLQueryApiValues
+    /** Variables to be substituted into the query */
+    variables?: HogQLQueryApiVariables
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface ActorsQueryApi {
+    /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
+    fixedProperties?:
+        | (PersonPropertyFilterApi | CohortPropertyFilterApi | HogQLPropertyFilterApi | EmptyPropertyFilterApi)[]
+        | null
+    kind?: 'ActorsQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    orderBy?: string[] | null
+    /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
+    properties?:
+        | (PersonPropertyFilterApi | CohortPropertyFilterApi | HogQLPropertyFilterApi | EmptyPropertyFilterApi)[]
+        | PropertyGroupFilterValueApi
+        | null
+    response?: ActorsQueryResponseApi | null
+    search?: string | null
+    select?: string[] | null
+    source?:
+        | InsightActorsQueryApi
+        | FunnelsActorsQueryApi
+        | FunnelCorrelationActorsQueryApi
+        | ExperimentActorsQueryApi
+        | StickinessActorsQueryApi
+        | HogQLQueryApi
+        | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface GroupsQueryResponseApi {
+    columns: unknown[]
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql: string
+    kind?: 'GroupsQuery'
+    limit: number
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset: number
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[][]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types: string[]
+}
+
+export interface GroupsQueryApi {
+    group_type_index: number
+    kind?: 'GroupsQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    orderBy?: string[] | null
+    properties?: (GroupPropertyFilterApi | HogQLPropertyFilterApi)[] | null
+    response?: GroupsQueryResponseApi | null
+    search?: string | null
+    select?: string[] | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface WebExternalClicksTableQueryResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface WebExternalClicksTableQueryApi {
+    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+    aggregation_group_type_index?: number | null
+    compareFilter?: CompareFilterApi | null
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi | null
+    doPathCleaning?: boolean | null
+    filterTestAccounts?: boolean | null
+    includeRevenue?: boolean | null
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+    interval?: IntervalTypeApi | null
+    kind?: 'WebExternalClicksTableQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+    )[]
+    response?: WebExternalClicksTableQueryResponseApi | null
+    sampling?: WebAnalyticsSamplingApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    stripQueryParams?: boolean | null
+    tags?: QueryLogTagsApi | null
+    useSessionsTable?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface WebGoalsQueryResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface WebGoalsQueryApi {
+    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+    aggregation_group_type_index?: number | null
+    compareFilter?: CompareFilterApi | null
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi | null
+    doPathCleaning?: boolean | null
+    filterTestAccounts?: boolean | null
+    includeRevenue?: boolean | null
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+    interval?: IntervalTypeApi | null
+    kind?: 'WebGoalsQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+    )[]
+    response?: WebGoalsQueryResponseApi | null
+    sampling?: WebAnalyticsSamplingApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    tags?: QueryLogTagsApi | null
+    useSessionsTable?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface WebVitalsQueryApi {
+    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+    aggregation_group_type_index?: number | null
+    compareFilter?: CompareFilterApi | null
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi | null
+    doPathCleaning?: boolean | null
+    filterTestAccounts?: boolean | null
+    includeRevenue?: boolean | null
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+    interval?: IntervalTypeApi | null
+    kind?: 'WebVitalsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+    )[]
+    response?: WebGoalsQueryResponseApi | null
+    sampling?: WebAnalyticsSamplingApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    source:
+        | TrendsQueryApi
+        | FunnelsQueryApi
+        | RetentionQueryApi
+        | PathsQueryApi
+        | StickinessQueryApi
+        | LifecycleQueryApi
+        | WebStatsTableQueryApi
+        | WebOverviewQueryApi
+    tags?: QueryLogTagsApi | null
+    useSessionsTable?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type WebVitalsMetricApi = (typeof WebVitalsMetricApi)[keyof typeof WebVitalsMetricApi]
+
+export const WebVitalsMetricApi = {
+    Inp: 'INP',
+    Lcp: 'LCP',
+    Cls: 'CLS',
+    Fcp: 'FCP',
+} as const
+
+export type WebVitalsPercentileApi = (typeof WebVitalsPercentileApi)[keyof typeof WebVitalsPercentileApi]
+
+export const WebVitalsPercentileApi = {
+    P75: 'p75',
+    P90: 'p90',
+    P99: 'p99',
+} as const
+
+export interface WebVitalsPathBreakdownQueryResponseApi {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    /**
+     * @minItems 1
+     * @maxItems 1
+     */
+    results: WebVitalsPathBreakdownResultApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface WebVitalsPathBreakdownQueryApi {
+    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+    aggregation_group_type_index?: number | null
+    compareFilter?: CompareFilterApi | null
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi | null
+    doPathCleaning?: boolean | null
+    filterTestAccounts?: boolean | null
+    includeRevenue?: boolean | null
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+    interval?: IntervalTypeApi | null
+    kind?: 'WebVitalsPathBreakdownQuery'
+    metric: WebVitalsMetricApi
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
+    percentile: WebVitalsPercentileApi
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+    )[]
+    response?: WebVitalsPathBreakdownQueryResponseApi | null
+    sampling?: WebAnalyticsSamplingApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    tags?: QueryLogTagsApi | null
+    /**
+     * @minItems 2
+     * @maxItems 2
+     */
+    thresholds: number[]
+    useSessionsTable?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface FiltersApi {
+    dateRange?: DateRangeApi | null
+    properties?: SessionPropertyFilterApi[] | null
+}
+
+export type SessionAttributionGroupByApi =
+    (typeof SessionAttributionGroupByApi)[keyof typeof SessionAttributionGroupByApi]
+
+export const SessionAttributionGroupByApi = {
+    ChannelType: 'ChannelType',
+    Medium: 'Medium',
+    Source: 'Source',
+    Campaign: 'Campaign',
+    AdIds: 'AdIds',
+    ReferringDomain: 'ReferringDomain',
+    InitialURL: 'InitialURL',
+} as const
+
+export interface SessionAttributionExplorerQueryResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface SessionAttributionExplorerQueryApi {
+    filters?: FiltersApi | null
+    groupBy: SessionAttributionGroupByApi[]
+    kind?: 'SessionAttributionExplorerQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    response?: SessionAttributionExplorerQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface SessionsQueryResponseApi {
+    columns: unknown[]
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql: string
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[][]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types: string[]
+}
+
+export interface SessionsQueryApi {
+    /** Filter sessions by action - sessions that contain events matching this action */
+    actionId?: number | null
+    /** Only fetch sessions that started after this timestamp */
+    after?: string | null
+    /** Only fetch sessions that started before this timestamp */
+    before?: string | null
+    /** Filter sessions by event name - sessions that contain this event */
+    event?: string | null
+    /** Event property filters - filters sessions that contain events matching these properties */
+    eventProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    /** Filter test accounts */
+    filterTestAccounts?: boolean | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | PropertyGroupFilterApi
+              | PropertyGroupFilterValueApi
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    kind?: 'SessionsQuery'
+    /** Number of rows to return */
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Number of rows to skip before returning rows */
+    offset?: number | null
+    /** Columns to order by */
+    orderBy?: string[] | null
+    /** Show sessions for a given person */
+    personId?: string | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: SessionsQueryResponseApi | null
+    /** Return a limited set of data. Required. */
+    select: string[]
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+    /** HogQL filters to apply on returned data */
+    where?: string[] | null
+}
+
+export interface RevenueAnalyticsBreakdownApi {
+    property: string
+    type?: 'revenue_analytics'
+}
+
+export type SimpleIntervalTypeApi = (typeof SimpleIntervalTypeApi)[keyof typeof SimpleIntervalTypeApi]
+
+export const SimpleIntervalTypeApi = {
+    Day: 'day',
+    Month: 'month',
+} as const
+
+export interface RevenueAnalyticsGrossRevenueQueryResponseApi {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface RevenueAnalyticsGrossRevenueQueryApi {
+    breakdown: RevenueAnalyticsBreakdownApi[]
+    dateRange?: DateRangeApi | null
+    interval: SimpleIntervalTypeApi
+    kind?: 'RevenueAnalyticsGrossRevenueQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    properties: RevenueAnalyticsPropertyFilterApi[]
+    response?: RevenueAnalyticsGrossRevenueQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface RevenueAnalyticsMetricsQueryResponseApi {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface RevenueAnalyticsMetricsQueryApi {
+    breakdown: RevenueAnalyticsBreakdownApi[]
+    dateRange?: DateRangeApi | null
+    interval: SimpleIntervalTypeApi
+    kind?: 'RevenueAnalyticsMetricsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    properties: RevenueAnalyticsPropertyFilterApi[]
+    response?: RevenueAnalyticsMetricsQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface RevenueAnalyticsMRRQueryResponseApi {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: RevenueAnalyticsMRRQueryResultItemApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface RevenueAnalyticsMRRQueryApi {
+    breakdown: RevenueAnalyticsBreakdownApi[]
+    dateRange?: DateRangeApi | null
+    interval: SimpleIntervalTypeApi
+    kind?: 'RevenueAnalyticsMRRQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    properties: RevenueAnalyticsPropertyFilterApi[]
+    response?: RevenueAnalyticsMRRQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface RevenueAnalyticsOverviewQueryResponseApi {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: RevenueAnalyticsOverviewItemApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface RevenueAnalyticsOverviewQueryApi {
+    dateRange?: DateRangeApi | null
+    kind?: 'RevenueAnalyticsOverviewQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    properties: RevenueAnalyticsPropertyFilterApi[]
+    response?: RevenueAnalyticsOverviewQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type RevenueAnalyticsTopCustomersGroupByApi =
+    (typeof RevenueAnalyticsTopCustomersGroupByApi)[keyof typeof RevenueAnalyticsTopCustomersGroupByApi]
+
+export const RevenueAnalyticsTopCustomersGroupByApi = {
+    Month: 'month',
+    All: 'all',
+} as const
+
+export interface RevenueAnalyticsTopCustomersQueryResponseApi {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface RevenueAnalyticsTopCustomersQueryApi {
+    dateRange?: DateRangeApi | null
+    groupBy: RevenueAnalyticsTopCustomersGroupByApi
+    kind?: 'RevenueAnalyticsTopCustomersQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    properties: RevenueAnalyticsPropertyFilterApi[]
+    response?: RevenueAnalyticsTopCustomersQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface RevenueExampleEventsQueryResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface RevenueExampleEventsQueryApi {
+    kind?: 'RevenueExampleEventsQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    response?: RevenueExampleEventsQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface RevenueExampleDataWarehouseTablesQueryResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface RevenueExampleDataWarehouseTablesQueryApi {
+    kind?: 'RevenueExampleDataWarehouseTablesQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    response?: RevenueExampleDataWarehouseTablesQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ConversionGoalFilter1ApiResponse = { [key: string]: unknown } | null
+
+export type ConversionGoalFilter1ApiSchemaMap = { [key: string]: string | unknown }
+
+export interface ConversionGoalFilter1Api {
+    conversion_goal_id: string
+    conversion_goal_name: string
+    custom_name?: string | null
+    /** The event or `null` for all events. */
+    event?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    kind?: 'EventsNode'
+    limit?: number | null
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Columns to order by */
+    orderBy?: string[] | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: ConversionGoalFilter1ApiResponse
+    schema_map: ConversionGoalFilter1ApiSchemaMap
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ConversionGoalFilter2ApiResponse = { [key: string]: unknown } | null
+
+export type ConversionGoalFilter2ApiSchemaMap = { [key: string]: string | unknown }
+
+export interface ConversionGoalFilter2Api {
+    conversion_goal_id: string
+    conversion_goal_name: string
+    custom_name?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    id: number
+    kind?: 'ActionsNode'
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: ConversionGoalFilter2ApiResponse
+    schema_map: ConversionGoalFilter2ApiSchemaMap
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ConversionGoalFilter3ApiResponse = { [key: string]: unknown } | null
+
+export type ConversionGoalFilter3ApiSchemaMap = { [key: string]: string | unknown }
+
+export interface ConversionGoalFilter3Api {
+    conversion_goal_id: string
+    conversion_goal_name: string
+    custom_name?: string | null
+    distinct_id_field: string
+    dw_source_type?: string | null
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    id: string
+    id_field: string
+    kind?: 'DataWarehouseNode'
+    math?:
+        | BaseMathTypeApi
+        | FunnelMathTypeApi
+        | PropertyMathTypeApi
+        | CountPerActorMathTypeApi
+        | ExperimentMetricMathTypeApi
+        | CalendarHeatmapMathTypeApi
+        | 'unique_group'
+        | 'hogql'
+        | null
+    math_group_type_index?: MathGroupTypeIndexApi | null
+    math_hogql?: string | null
+    math_multiplier?: number | null
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
+    math_property_type?: string | null
+    name?: string | null
+    optionalInFunnel?: boolean | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: ConversionGoalFilter3ApiResponse
+    schema_map: ConversionGoalFilter3ApiSchemaMap
+    table_name: string
+    timestamp_field: string
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type MarketingAnalyticsDrillDownLevelApi =
+    (typeof MarketingAnalyticsDrillDownLevelApi)[keyof typeof MarketingAnalyticsDrillDownLevelApi]
+
+export const MarketingAnalyticsDrillDownLevelApi = {
+    Channel: 'channel',
+    Source: 'source',
+    Campaign: 'campaign',
+    AdGroup: 'ad_group',
+    Ad: 'ad',
+    Medium: 'medium',
+    Content: 'content',
+    Term: 'term',
+} as const
+
+export interface IntegrationFilterApi {
+    /** Selected integration source IDs to filter by (e.g., table IDs or source map IDs) */
+    integrationSourceIds?: string[] | null
+}
+
+export type MarketingAnalyticsOrderByEnumApi =
+    (typeof MarketingAnalyticsOrderByEnumApi)[keyof typeof MarketingAnalyticsOrderByEnumApi]
+
+export const MarketingAnalyticsOrderByEnumApi = {
+    Asc: 'ASC',
+    Desc: 'DESC',
+} as const
+
+export interface MarketingAnalyticsTableQueryResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: MarketingAnalyticsItemApi[][]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface MarketingAnalyticsTableQueryApi {
+    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+    aggregation_group_type_index?: number | null
+    /** Compare to date range */
+    compareFilter?: CompareFilterApi | null
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi | null
+    doPathCleaning?: boolean | null
+    /** Draft conversion goal that can be set in the UI without saving */
+    draftConversionGoal?: ConversionGoalFilter1Api | ConversionGoalFilter2Api | ConversionGoalFilter3Api | null
+    /** Drill-down hierarchy level: channel, source, or campaign (default) */
+    drillDownLevel?: MarketingAnalyticsDrillDownLevelApi | null
+    /** Filter test accounts */
+    filterTestAccounts?: boolean | null
+    includeRevenue?: boolean | null
+    /** Filter by integration type */
+    integrationFilter?: IntegrationFilterApi | null
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+    interval?: IntervalTypeApi | null
+    kind?: 'MarketingAnalyticsTableQuery'
+    /** Number of rows to return */
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Number of rows to skip before returning rows */
+    offset?: number | null
+    /** Columns to order by - similar to EventsQuery format */
+    orderBy?: (string | MarketingAnalyticsOrderByEnumApi)[][] | null
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+    )[]
+    response?: MarketingAnalyticsTableQueryResponseApi | null
+    sampling?: WebAnalyticsSamplingApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    /** Return a limited set of data. Will use default columns if empty. */
+    select?: string[] | null
+    tags?: QueryLogTagsApi | null
+    useSessionsTable?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type MarketingAnalyticsAggregatedQueryResponseApiResults = { [key: string]: MarketingAnalyticsItemApi }
+
+export interface MarketingAnalyticsAggregatedQueryResponseApi {
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: MarketingAnalyticsAggregatedQueryResponseApiResults
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface MarketingAnalyticsAggregatedQueryApi {
+    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+    aggregation_group_type_index?: number | null
+    compareFilter?: CompareFilterApi | null
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi | null
+    doPathCleaning?: boolean | null
+    /** Draft conversion goal that can be set in the UI without saving */
+    draftConversionGoal?: ConversionGoalFilter1Api | ConversionGoalFilter2Api | ConversionGoalFilter3Api | null
+    /** Drill-down hierarchy level: channel, source, or campaign (default) */
+    drillDownLevel?: MarketingAnalyticsDrillDownLevelApi | null
+    filterTestAccounts?: boolean | null
+    includeRevenue?: boolean | null
+    /** Filter by integration IDs */
+    integrationFilter?: IntegrationFilterApi | null
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+    interval?: IntervalTypeApi | null
+    kind?: 'MarketingAnalyticsAggregatedQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+    )[]
+    response?: MarketingAnalyticsAggregatedQueryResponseApi | null
+    sampling?: WebAnalyticsSamplingApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    /** Return a limited set of data. Will use default columns if empty. */
+    select?: string[] | null
+    tags?: QueryLogTagsApi | null
+    useSessionsTable?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface NonIntegratedConversionsTableQueryResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: MarketingAnalyticsItemApi[][]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface NonIntegratedConversionsTableQueryApi {
+    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+    aggregation_group_type_index?: number | null
+    /** Compare to date range */
+    compareFilter?: CompareFilterApi | null
+    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
+    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi | null
+    doPathCleaning?: boolean | null
+    /** Draft conversion goal that can be set in the UI without saving */
+    draftConversionGoal?: ConversionGoalFilter1Api | ConversionGoalFilter2Api | ConversionGoalFilter3Api | null
+    /** Filter test accounts */
+    filterTestAccounts?: boolean | null
+    includeRevenue?: boolean | null
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+    interval?: IntervalTypeApi | null
+    kind?: 'NonIntegratedConversionsTableQuery'
+    /** Number of rows to return */
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Number of rows to skip before returning rows */
+    offset?: number | null
+    /** Columns to order by */
+    orderBy?: (string | MarketingAnalyticsOrderByEnumApi)[][] | null
+    properties: (
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+    )[]
+    response?: NonIntegratedConversionsTableQueryResponseApi | null
+    sampling?: WebAnalyticsSamplingApi | null
+    /** Sampling rate */
+    samplingFactor?: number | null
+    /** Return a limited set of data. Will use default columns if empty. */
+    select?: string[] | null
+    tags?: QueryLogTagsApi | null
+    useSessionsTable?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ErrorTrackingOrderByApi = (typeof ErrorTrackingOrderByApi)[keyof typeof ErrorTrackingOrderByApi]
+
+export const ErrorTrackingOrderByApi = {
+    LastSeen: 'last_seen',
+    FirstSeen: 'first_seen',
+    Occurrences: 'occurrences',
+    Users: 'users',
+    Sessions: 'sessions',
+} as const
+
+export type OrderDirection2Api = (typeof OrderDirection2Api)[keyof typeof OrderDirection2Api]
+
+export const OrderDirection2Api = {
+    Asc: 'ASC',
+    Desc: 'DESC',
+} as const
+
+export interface ErrorTrackingPendingFingerprintIssueStateUpdateApi {
+    assigned_role_id?: string | null
+    assigned_user_id?: number | null
+    fingerprint: string
+    /** ISO 8601 datetime string. */
+    first_seen: string
+    is_deleted: number
+    issue_description?: string | null
+    issue_id: string
+    issue_name?: string | null
+    issue_status: string
+    /** Client-stamped monotonic version (`Date.now()` ms at mutation success). */
+    version: number
+}
+
+export interface ErrorTrackingQueryResponseApi {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: ErrorTrackingIssueApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface ErrorTrackingQueryApi {
+    assignee?: ErrorTrackingIssueAssigneeApi | null
+    /** Date range to filter results. */
+    dateRange: DateRangeApi
+    filterGroup?: PropertyGroupFilterApi | null
+    /** Whether to filter out test accounts. */
+    filterTestAccounts?: boolean | null
+    groupKey?: string | null
+    groupTypeIndex?: number | null
+    /** Filter to a specific error tracking issue by ID. */
+    issueId?: string | null
+    kind?: 'ErrorTrackingQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Field to sort results by. */
+    orderBy: ErrorTrackingOrderByApi
+    /** Sort direction. */
+    orderDirection?: OrderDirection2Api | null
+    /** Pending fingerprint issue state updates UNIONed into the fingerprint issue state subquery (V3 only). The backend caps the list at 50 entries; extras are dropped silently. */
+    pendingFingerprintIssueStateUpdates?: ErrorTrackingPendingFingerprintIssueStateUpdateApi[] | null
+    personId?: string | null
+    response?: ErrorTrackingQueryResponseApi | null
+    /** Free-text search across exception type, message, and stack frames. */
+    searchQuery?: string | null
+    /** Filter by issue status. */
+    status?: ErrorTrackingIssueStatusApi | string | null
+    tags?: QueryLogTagsApi | null
+    /** Use V2 query path (ClickHouse postgres connector join instead of separate Postgres queries) */
+    useQueryV2?: boolean | null
+    /** Use V3 query path (denormalized ClickHouse table, no Postgres joins) */
+    useQueryV3?: boolean | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+    volumeResolution: number
+    withAggregations?: boolean | null
+    withFirstEvent?: boolean | null
+    withLastEvent?: boolean | null
+}
+
+export interface ErrorTrackingIssueCorrelationQueryResponseApi {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: ErrorTrackingCorrelatedIssueApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface ErrorTrackingIssueCorrelationQueryApi {
+    events: string[]
+    kind?: 'ErrorTrackingIssueCorrelationQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    response?: ErrorTrackingIssueCorrelationQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ExperimentFunnelsQueryResponseApiCredibleIntervals = { [key: string]: number[] }
+
+export type ExperimentFunnelsQueryResponseApiInsightItemItem = { [key: string]: unknown }
+
+export type ExperimentFunnelsQueryResponseApiProbability = { [key: string]: number }
+
+export interface ExperimentFunnelsQueryResponseApi {
+    credible_intervals: ExperimentFunnelsQueryResponseApiCredibleIntervals
+    expected_loss: number
+    funnels_query?: FunnelsQueryApi | null
+    insight: ExperimentFunnelsQueryResponseApiInsightItemItem[][]
+    kind?: 'ExperimentFunnelsQuery'
+    probability: ExperimentFunnelsQueryResponseApiProbability
+    significance_code: ExperimentSignificanceCodeApi
+    significant: boolean
+    stats_version?: number | null
+    variants: ExperimentVariantFunnelsBaseStatsApi[]
+}
+
+export interface ExperimentFunnelsQueryApi {
+    experiment_id?: number | null
+    fingerprint?: string | null
+    funnels_query: FunnelsQueryApi
+    kind?: 'ExperimentFunnelsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    name?: string | null
+    response?: ExperimentFunnelsQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    uuid?: string | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type ExperimentTrendsQueryResponseApiCredibleIntervals = { [key: string]: number[] }
+
+export type ExperimentTrendsQueryResponseApiInsightItem = { [key: string]: unknown }
+
+export type ExperimentTrendsQueryResponseApiProbability = { [key: string]: number }
+
+export interface ExperimentTrendsQueryResponseApi {
+    count_query?: TrendsQueryApi | null
+    credible_intervals: ExperimentTrendsQueryResponseApiCredibleIntervals
+    exposure_query?: TrendsQueryApi | null
+    insight: ExperimentTrendsQueryResponseApiInsightItem[]
+    kind?: 'ExperimentTrendsQuery'
+    p_value: number
+    probability: ExperimentTrendsQueryResponseApiProbability
+    significance_code: ExperimentSignificanceCodeApi
+    significant: boolean
+    stats_version?: number | null
+    variants: ExperimentVariantTrendsBaseStatsApi[]
+}
+
+export interface ExperimentTrendsQueryApi {
+    count_query: TrendsQueryApi
+    experiment_id?: number | null
+    exposure_query?: TrendsQueryApi | null
+    fingerprint?: string | null
+    kind?: 'ExperimentTrendsQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    name?: string | null
+    response?: ExperimentTrendsQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    uuid?: string | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface TracesQueryResponseApi {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: LLMTraceApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface TracesQueryApi {
+    dateRange?: DateRangeApi | null
+    filterSupportTraces?: boolean | null
+    filterTestAccounts?: boolean | null
+    groupKey?: string | null
+    groupTypeIndex?: number | null
+    kind?: 'TracesQuery'
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Person who performed the event */
+    personId?: string | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    /** Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias. */
+    randomOrder?: boolean | null
+    response?: TracesQueryResponseApi | null
+    showColumnConfigurator?: boolean | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface TraceQueryResponseApi {
+    columns?: string[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: LLMTraceApi[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+}
+
+export interface TraceQueryApi {
+    dateRange?: DateRangeApi | null
+    kind?: 'TraceQuery'
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    /** Properties configurable in the interface */
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+    response?: TraceQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    traceId: string
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type EndpointsUsageBreakdownApi = (typeof EndpointsUsageBreakdownApi)[keyof typeof EndpointsUsageBreakdownApi]
+
+export const EndpointsUsageBreakdownApi = {
+    Endpoint: 'Endpoint',
+    MaterializationType: 'MaterializationType',
+    ApiKey: 'ApiKey',
+    Status: 'Status',
+} as const
+
+export type MaterializationTypeApi = (typeof MaterializationTypeApi)[keyof typeof MaterializationTypeApi]
+
+export const MaterializationTypeApi = {
+    Materialized: 'materialized',
+    Inline: 'inline',
+} as const
+
+export type EndpointsUsageOrderByFieldApi =
+    (typeof EndpointsUsageOrderByFieldApi)[keyof typeof EndpointsUsageOrderByFieldApi]
+
+export const EndpointsUsageOrderByFieldApi = {
+    Requests: 'requests',
+    BytesRead: 'bytes_read',
+    CpuSeconds: 'cpu_seconds',
+    AvgQueryDurationMs: 'avg_query_duration_ms',
+    ErrorRate: 'error_rate',
+} as const
+
+export type EndpointsUsageOrderByDirectionApi =
+    (typeof EndpointsUsageOrderByDirectionApi)[keyof typeof EndpointsUsageOrderByDirectionApi]
+
+export const EndpointsUsageOrderByDirectionApi = {
+    Asc: 'ASC',
+    Desc: 'DESC',
+} as const
+
+export interface EndpointsUsageTableQueryResponseApi {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+}
+
+export interface EndpointsUsageTableQueryApi {
+    breakdownBy: EndpointsUsageBreakdownApi
+    dateRange?: DateRangeApi | null
+    /** Filter to specific endpoints by name */
+    endpointNames?: string[] | null
+    kind?: 'EndpointsUsageTableQuery'
+    limit?: number | null
+    /** Filter by materialization type */
+    materializationType?: MaterializationTypeApi | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    orderBy?: (EndpointsUsageOrderByFieldApi | EndpointsUsageOrderByDirectionApi)[] | null
+    response?: EndpointsUsageTableQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type DataTableNodeApiResponse =
+    | { [key: string]: unknown }
+    | ResponseApi
+    | Response1Api
+    | Response2Api
+    | Response3Api
+    | Response4Api
+    | Response5Api
+    | Response6Api
+    | Response8Api
+    | Response9Api
+    | Response10Api
+    | Response11Api
+    | Response12Api
+    | Response13Api
+    | Response14Api
+    | Response15Api
+    | Response16Api
+    | Response18Api
+    | Response19Api
+    | Response20Api
+    | Response21Api
+    | Response22Api
+    | Response23Api
+    | Response24Api
+    | Response25Api
+    | Response26Api
+    | null
+
+export interface DataTableNodeApi {
+    /** Can the user click on column headers to sort the table? (default: true) */
+    allowSorting?: boolean | null
+    /** Columns shown in the table, unless the `source` provides them. */
+    columns?: string[] | null
+    /** Context for the table, used by components like ColumnConfigurator */
+    context?: DataTableNodeViewPropsContextApi | null
+    /** Context key for universal column configuration (e.g., "survey:123") */
+    contextKey?: string | null
+    /** Default columns to use when resetting column configuration */
+    defaultColumns?: string[] | null
+    /** Uses the embedded version of LemonTable */
+    embedded?: boolean | null
+    /** Can expand row to show raw event data (default: true) */
+    expandable?: boolean | null
+    /** Show with most visual options enabled. Used in scenes. */
+    full?: boolean | null
+    /** Columns that aren't shown in the table, even if in columns or returned data */
+    hiddenColumns?: string[] | null
+    kind: DataTableNodeApiKind
+    /** Columns that are sticky when scrolling horizontally */
+    pinnedColumns?: string[] | null
+    /** Link properties via the URL (default: false) */
+    propertiesViaUrl?: boolean | null
+    response?: DataTableNodeApiResponse
+    /** Render date-time columns (timestamp, created_at, last_seen, last_seen_at, session_start, session_end) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources. */
+    showAbsoluteTime?: boolean | null
+    /** Show the kebab menu at the end of the row */
+    showActions?: boolean | null
+    /** Show a button to configure the table's columns if possible */
+    showColumnConfigurator?: boolean | null
+    /** Show count of total and filtered results */
+    showCount?: boolean | null
+    /** Show date range selector */
+    showDateRange?: boolean | null
+    /** Show the time it takes to run a query */
+    showElapsedTime?: boolean | null
+    /** Include an event filter above the table (EventsNode only) */
+    showEventFilter?: boolean | null
+    /** Include an events filter above the table to filter by multiple events (EventsQuery only) */
+    showEventsFilter?: boolean | null
+    /** Show the export button */
+    showExport?: boolean | null
+    /** Include a HogQL query editor above HogQL tables */
+    showHogQLEditor?: boolean | null
+    /** Show a button to open the current query as a new insight. (default: true) */
+    showOpenEditorButton?: boolean | null
+    /** Show a button to configure and persist the table's default columns if possible */
+    showPersistentColumnConfigurator?: boolean | null
+    /** Include a property filter above the table */
+    showPropertyFilter?: boolean | TaxonomicFilterGroupTypeApi[] | null
+    /** Show a recording column for events with session recordings */
+    showRecordingColumn?: boolean | null
+    /** Show a reload button */
+    showReload?: boolean | null
+    /** Show a results table */
+    showResultsTable?: boolean | null
+    /** Show saved filters feature for this table (requires uniqueKey) */
+    showSavedFilters?: boolean | null
+    /** Shows a list of saved queries */
+    showSavedQueries?: boolean | null
+    /** Include a free text search field (PersonsNode only) */
+    showSearch?: boolean | null
+    /** Show actors query options and back to source */
+    showSourceQueryOptions?: boolean | null
+    /** Show table views feature for this table (requires uniqueKey) */
+    showTableViews?: boolean | null
+    /** Show filter to exclude test accounts */
+    showTestAccountFilters?: boolean | null
+    /** Show a detailed query timing breakdown */
+    showTimings?: boolean | null
+    /** Source of the events */
+    source:
+        | EventsNodeApi
+        | EventsQueryApi
+        | PersonsNodeApi
+        | ActorsQueryApi
+        | GroupsQueryApi
+        | HogQLQueryApi
+        | WebOverviewQueryApi
+        | WebStatsTableQueryApi
+        | WebExternalClicksTableQueryApi
+        | WebGoalsQueryApi
+        | WebVitalsQueryApi
+        | WebVitalsPathBreakdownQueryApi
+        | SessionAttributionExplorerQueryApi
+        | SessionsQueryApi
+        | RevenueAnalyticsGrossRevenueQueryApi
+        | RevenueAnalyticsMetricsQueryApi
+        | RevenueAnalyticsMRRQueryApi
+        | RevenueAnalyticsOverviewQueryApi
+        | RevenueAnalyticsTopCustomersQueryApi
+        | RevenueExampleEventsQueryApi
+        | RevenueExampleDataWarehouseTablesQueryApi
+        | MarketingAnalyticsTableQueryApi
+        | MarketingAnalyticsAggregatedQueryApi
+        | NonIntegratedConversionsTableQueryApi
+        | ErrorTrackingQueryApi
+        | ErrorTrackingIssueCorrelationQueryApi
+        | ExperimentFunnelsQueryApi
+        | ExperimentTrendsQueryApi
+        | TracesQueryApi
+        | TraceQueryApi
+        | EndpointsUsageTableQueryApi
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export interface HeatmapGradientStopApi {
+    color: string
+    value: number
+}
+
+export type GradientScaleModeApi = (typeof GradientScaleModeApi)[keyof typeof GradientScaleModeApi]
+
+export const GradientScaleModeApi = {
+    Absolute: 'absolute',
+    Relative: 'relative',
+} as const
+
+export type HeatmapSortOrderApi = (typeof HeatmapSortOrderApi)[keyof typeof HeatmapSortOrderApi]
+
+export const HeatmapSortOrderApi = {
+    Asc: 'asc',
+    Desc: 'desc',
+} as const
+
+export interface HeatmapSettingsApi {
+    gradient?: HeatmapGradientStopApi[] | null
+    gradientPreset?: string | null
+    gradientScaleMode?: GradientScaleModeApi | null
+    nullLabel?: string | null
+    nullValue?: string | null
+    sortColumn?: string | null
+    sortOrder?: HeatmapSortOrderApi | null
+    valueColumn?: string | null
+    xAxisColumn?: string | null
+    xAxisLabel?: string | null
+    yAxisColumn?: string | null
+    yAxisLabel?: string | null
+}
+
+export type ScaleApi = (typeof ScaleApi)[keyof typeof ScaleApi]
+
+export const ScaleApi = {
+    Linear: 'linear',
+    Logarithmic: 'logarithmic',
+} as const
+
+export interface YAxisSettingsApi {
+    label?: string | null
+    scale?: ScaleApi | null
+    showGridLines?: boolean | null
+    showTicks?: boolean | null
+    /** Whether the Y axis should start at zero */
+    startAtZero?: boolean | null
+}
+
+export type DisplayTypeApi = (typeof DisplayTypeApi)[keyof typeof DisplayTypeApi]
+
+export const DisplayTypeApi = {
+    Auto: 'auto',
+    Line: 'line',
+    Bar: 'bar',
+    Area: 'area',
+} as const
+
+export type YAxisPositionApi = (typeof YAxisPositionApi)[keyof typeof YAxisPositionApi]
+
+export const YAxisPositionApi = {
+    Left: 'left',
+    Right: 'right',
+} as const
+
+export interface ChartSettingsDisplayApi {
+    color?: string | null
+    displayType?: DisplayTypeApi | null
+    label?: string | null
+    trendLine?: boolean | null
+    yAxisPosition?: YAxisPositionApi | null
+}
+
+export type StyleApi = (typeof StyleApi)[keyof typeof StyleApi]
+
+export const StyleApi = {
+    None: 'none',
+    Number: 'number',
+    Short: 'short',
+    Percent: 'percent',
+} as const
+
+export interface ChartSettingsFormattingApi {
+    decimalPlaces?: number | null
+    prefix?: string | null
+    style?: StyleApi | null
+    suffix?: string | null
+}
+
+export interface SettingsApi {
+    display?: ChartSettingsDisplayApi | null
+    formatting?: ChartSettingsFormattingApi | null
+}
+
+export interface ChartAxisApi {
+    column: string
+    settings?: SettingsApi | null
+}
+
+/**
+ * Per-breakdown-value color customizations. Keyed by the raw breakdown column value.
+ */
+export type ChartSettingsApiResultCustomizations = { [key: string]: ResultCustomizationByValueApi } | null
+
+export interface ChartSettingsApi {
+    goalLines?: GoalLineApi[] | null
+    heatmap?: HeatmapSettingsApi | null
+    leftYAxisSettings?: YAxisSettingsApi | null
+    /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
+    resultCustomizations?: ChartSettingsApiResultCustomizations
+    rightYAxisSettings?: YAxisSettingsApi | null
+    seriesBreakdownColumn?: string | null
+    showLegend?: boolean | null
+    showNullsAsZero?: boolean | null
+    showPieTotal?: boolean | null
+    showTotalRow?: boolean | null
+    showValuesOnSeries?: boolean | null
+    showXAxisBorder?: boolean | null
+    showXAxisTicks?: boolean | null
+    showYAxisBorder?: boolean | null
+    /** Whether we fill the bars to 100% in stacked mode */
+    stackBars100?: boolean | null
+    xAxis?: ChartAxisApi | null
+    xAxisLabel?: string | null
+    yAxis?: ChartAxisApi[] | null
+    /** Deprecated: use `[left|right]YAxisSettings`. Whether the Y axis should start at zero */
+    yAxisAtZero?: boolean | null
+}
+
+export type DataVisualizationNodeApiKind =
+    (typeof DataVisualizationNodeApiKind)[keyof typeof DataVisualizationNodeApiKind]
+
+export const DataVisualizationNodeApiKind = {
+    DataVisualizationNode: 'DataVisualizationNode',
+} as const
+
+export type ColorModeApi = (typeof ColorModeApi)[keyof typeof ColorModeApi]
+
+export const ColorModeApi = {
+    Light: 'light',
+    Dark: 'dark',
+} as const
+
+export interface ConditionalFormattingRuleApi {
+    bytecode: unknown[]
+    color: string
+    colorMode?: ColorModeApi | null
+    columnName: string
+    id: string
+    input: string
+    templateId: string
+}
+
+export interface TableSettingsApi {
+    columns?: ChartAxisApi[] | null
+    conditionalFormatting?: ConditionalFormattingRuleApi[] | null
+    pinnedColumns?: string[] | null
+    transpose?: boolean | null
+}
+
+export interface DataVisualizationNodeApi {
+    chartSettings?: ChartSettingsApi | null
+    display?: ChartDisplayTypeApi | null
+    kind: DataVisualizationNodeApiKind
+    source: HogQLQueryApi
+    tableSettings?: TableSettingsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+export type HogQueryApiKind = (typeof HogQueryApiKind)[keyof typeof HogQueryApiKind]
+
+export const HogQueryApiKind = {
+    HogQuery: 'HogQuery',
+} as const
+
+export interface HogQueryResponseApi {
+    bytecode?: unknown[] | null
+    coloredBytecode?: unknown[] | null
+    results: unknown
+    stdout?: string | null
+}
+
+export interface HogQueryApi {
+    code?: string | null
+    kind: HogQueryApiKind
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    response?: HogQueryResponseApi | null
+    tags?: QueryLogTagsApi | null
+    /** version of the node, used for schema migrations */
+    version?: number | null
+}
+
+/**
+ * The query definition for this insight. The `kind` field determines the query type:
+- `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
+- `DataVisualizationNode` — SQL insights using HogQL
+- `DataTableNode` — raw data tables
+- `HogQuery` — Hog language queries
+ */
+export type _InsightQuerySchemaApi = InsightVizNodeApi | DataTableNodeApi | DataVisualizationNodeApi | HogQueryApi
+
+export interface DashboardTileBasicApi {
+    readonly id: number
+    readonly dashboard_id: number
+    /** @nullable */
+    deleted?: boolean | null
+}
+
+/**
+ * @nullable
+ */
+export type InsightApiResolvedDateRange = {
+    readonly date_from?: string
+    readonly date_to?: string
+} | null
+
+/**
+ * Simplified serializer to speed response times when loading large amounts of objects.
+ */
+export interface InsightApi {
+    readonly id: number
+    readonly short_id: string
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    name?: string | null
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    derived_name?: string | null
+    query?: _InsightQuerySchemaApi | null
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     * @nullable
+     */
+    order?: number | null
+    deleted?: boolean
+    /**
+          DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+          A dashboard ID for each of the dashboards that this insight is displayed on.
+           */
+    dashboards?: number[]
+    /**
+      A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+       */
+    readonly dashboard_tiles: readonly DashboardTileBasicApi[]
+    /**
+     *
+      The datetime this insight's results were generated.
+      If added to one or more dashboards the insight can be refreshed separately on each.
+      Returns the appropriate last_refresh datetime for the context the insight is viewed in
+      (see from_dashboard query parameter).
+
+     * @nullable
+     */
+    readonly last_refresh: string | null
+    /**
+     * The target age of the cached results for this insight.
+     * @nullable
+     */
+    readonly cache_target_age: string | null
+    /**
+     *
+      The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+      by querying the database.
+
+     * @nullable
+     */
+    readonly next_allowed_client_refresh: string | null
+    readonly result: unknown
+    /** @nullable */
+    readonly hasMore: boolean | null
+    /** @nullable */
+    readonly columns: readonly string[] | null
+    /** @nullable */
+    readonly created_at: string | null
+    readonly created_by: UserBasicApi
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    description?: string | null
+    readonly updated_at: string
+    tags?: unknown[]
+    favorited?: boolean
+    readonly last_modified_at: string
+    readonly last_modified_by: UserBasicApi
+    readonly is_sample: boolean
+    readonly effective_restriction_level: EffectivePrivilegeLevelEnumApi
+    readonly effective_privilege_level: EffectivePrivilegeLevelEnumApi
+    /**
+     * The effective access level the user has for this object
+     * @nullable
+     */
+    readonly user_access_level: string | null
+    /**
+     * The timezone this chart is displayed in.
+     * @nullable
+     */
+    readonly timezone: string | null
+    readonly is_cached: boolean
+    readonly query_status: unknown
+    /** @nullable */
+    readonly hogql: string | null
+    /** @nullable */
+    readonly types: readonly unknown[] | null
+    /** @nullable */
+    readonly resolved_date_range: InsightApiResolvedDateRange
+    _create_in_folder?: string
+    readonly alerts: readonly unknown[]
+    /** @nullable */
+    readonly last_viewed_at: string | null
+}
+
+export interface TextApi {
+    readonly id: number
+    readonly created_by: UserBasicApi
+    readonly last_modified_by: UserBasicApi
+    /**
+     * @maxLength 4000
+     * @nullable
+     */
+    body?: string | null
+    readonly dashboard_tiles: readonly DashboardTileBasicApi[]
+    readonly last_modified_at: string
+    team: number
+}
+
+/**
+ * * `left` - left
+ * `right` - right
+ */
+export type PlacementEnumApi = (typeof PlacementEnumApi)[keyof typeof PlacementEnumApi]
+
+export const PlacementEnumApi = {
+    Left: 'left',
+    Right: 'right',
+} as const
+
+/**
+ * * `primary` - Primary
+ * `secondary` - Secondary
+ */
+export type StyleEnumApi = (typeof StyleEnumApi)[keyof typeof StyleEnumApi]
+
+export const StyleEnumApi = {
+    Primary: 'primary',
+    Secondary: 'secondary',
+} as const
+
+export interface ButtonTileApi {
+    readonly id: string
+    readonly created_by: UserBasicApi
+    readonly last_modified_by: UserBasicApi
+    /** @maxLength 2000 */
+    url: string
+    /** @maxLength 200 */
+    text: string
+    placement?: PlacementEnumApi
+    readonly dashboard_tiles: readonly DashboardTileBasicApi[]
+    style?: StyleEnumApi
+    readonly last_modified_at: string
+    team: number
+}
+
+export interface DashboardTileApi {
+    id?: number
+    insight: InsightApi
+    text: TextApi
+    button_tile: ButtonTileApi
+    layouts?: unknown
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    color?: string | null
+    filters_overrides?: unknown
+    /** @nullable */
+    show_description?: boolean | null
+    /** @nullable */
+    transparent_background?: boolean | null
+}
+
 export interface ReorderTilesRequestApi {
     /**
      * Array of tile IDs in the desired display order (top to bottom, left to right).
@@ -454,6 +7180,24 @@ export interface DashboardTileResultApi {
 export interface RunInsightsResponseApi {
     /** Results for each insight tile on the dashboard. */
     results: DashboardTileResultApi[]
+}
+
+export interface PatchedUpdateTextTileRequestApi {
+    /** ID of the dashboard tile to update. Use dashboard-get to look up tile IDs. */
+    tile_id?: number
+    /**
+     * New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.
+     * @maxLength 4000
+     * @nullable
+     */
+    body?: string | null
+    /** New grid layout per breakpoint. Omit to leave the layout unchanged. */
+    layouts?: TileLayoutsApi
+    /**
+     * New accent color name, or null to clear. Omit to leave unchanged.
+     * @nullable
+     */
+    color?: string | null
 }
 
 /**
@@ -673,6 +7417,18 @@ export const DashboardsCopyTileCreateFormat = {
     Txt: 'txt',
 } as const
 
+export type DashboardsCreateTextTileCreateParams = {
+    format?: DashboardsCreateTextTileCreateFormat
+}
+
+export type DashboardsCreateTextTileCreateFormat =
+    (typeof DashboardsCreateTextTileCreateFormat)[keyof typeof DashboardsCreateTextTileCreateFormat]
+
+export const DashboardsCreateTextTileCreateFormat = {
+    Json: 'json',
+    Txt: 'txt',
+} as const
+
 export type DashboardsMoveTilePartialUpdateParams = {
     format?: DashboardsMoveTilePartialUpdateFormat
 }
@@ -784,6 +7540,18 @@ export type DashboardsStreamTilesRetrieveLayoutSize =
 export const DashboardsStreamTilesRetrieveLayoutSize = {
     Sm: 'sm',
     Xs: 'xs',
+} as const
+
+export type DashboardsUpdateTextTilePartialUpdateParams = {
+    format?: DashboardsUpdateTextTilePartialUpdateFormat
+}
+
+export type DashboardsUpdateTextTilePartialUpdateFormat =
+    (typeof DashboardsUpdateTextTilePartialUpdateFormat)[keyof typeof DashboardsUpdateTextTilePartialUpdateFormat]
+
+export const DashboardsUpdateTextTilePartialUpdateFormat = {
+    Json: 'json',
+    Txt: 'txt',
 } as const
 
 export type DashboardsBulkUpdateTagsCreateParams = {

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7184,9 +7184,9 @@ export interface RunInsightsResponseApi {
     results: DashboardTileResultApi[]
 }
 
-export interface PatchedUpdateTextTileRequestApi {
+export interface UpdateTextTileRequestApi {
     /** ID of the dashboard tile to update. Use dashboard-get to look up tile IDs. */
-    tile_id?: number
+    tile_id: number
     /**
      * New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.
      * @minLength 1
@@ -7545,14 +7545,14 @@ export const DashboardsStreamTilesRetrieveLayoutSize = {
     Xs: 'xs',
 } as const
 
-export type DashboardsUpdateTextTilePartialUpdateParams = {
-    format?: DashboardsUpdateTextTilePartialUpdateFormat
+export type DashboardsUpdateTextTileCreateParams = {
+    format?: DashboardsUpdateTextTileCreateFormat
 }
 
-export type DashboardsUpdateTextTilePartialUpdateFormat =
-    (typeof DashboardsUpdateTextTilePartialUpdateFormat)[keyof typeof DashboardsUpdateTextTilePartialUpdateFormat]
+export type DashboardsUpdateTextTileCreateFormat =
+    (typeof DashboardsUpdateTextTileCreateFormat)[keyof typeof DashboardsUpdateTextTileCreateFormat]
 
-export const DashboardsUpdateTextTilePartialUpdateFormat = {
+export const DashboardsUpdateTextTileCreateFormat = {
     Json: 'json',
     Txt: 'txt',
 } as const

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -443,6 +443,7 @@ export interface TileLayoutsApi {
 export interface CreateTextTileRequestApi {
     /**
      * Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.
+     * @minLength 1
      * @maxLength 4000
      */
     body: string
@@ -7188,6 +7189,7 @@ export interface PatchedUpdateTextTileRequestApi {
     tile_id?: number
     /**
      * New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.
+     * @minLength 1
      * @maxLength 4000
      */
     body?: string

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -450,6 +450,7 @@ export interface CreateTextTileRequestApi {
     layouts?: TileLayoutsApi
     /**
      * Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').
+     * @maxLength 400
      * @nullable
      */
     color?: string | null
@@ -7188,13 +7189,13 @@ export interface PatchedUpdateTextTileRequestApi {
     /**
      * New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.
      * @maxLength 4000
-     * @nullable
      */
-    body?: string | null
+    body?: string
     /** New grid layout per breakpoint. Omit to leave the layout unchanged. */
     layouts?: TileLayoutsApi
     /**
-     * New accent color name, or null to clear. Omit to leave unchanged.
+     * New accent color name, empty string or null to clear. Omit to leave unchanged.
+     * @maxLength 400
      * @nullable
      */
     color?: string | null

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -513,6 +513,11 @@ export interface BreakdownFilterApi {
     breakdowns?: BreakdownApi[] | null
 }
 
+export interface CalendarHeatmapFilterApi {
+    /** When true and the series math is `dau`/`unique_users`, each user contributes to the (day-of-week, hour) bucket of their session's first event only — matching the web overview session-start attribution. When false (default), the user contributes to every bucket they have any event in. No effect on `total` math (event counts are unchanged either way). */
+    bucketBySessionStart?: boolean | null
+}
+
 export interface CompareFilterApi {
     /** Whether to compare the current date range to a previous date range. */
     compare?: boolean | null
@@ -649,6 +654,7 @@ export type ParserModeApi = (typeof ParserModeApi)[keyof typeof ParserModeApi]
 export const ParserModeApi = {
     CppOnly: 'cpp_only',
     CppWithRustShadow: 'cpp_with_rust_shadow',
+    CppWithRustPyShadow: 'cpp_with_rust_py_shadow',
     RustWithCppShadow: 'rust_with_cpp_shadow',
     RustOnly: 'rust_only',
     RustPyOnly: 'rust_py_only',
@@ -719,7 +725,7 @@ export interface HogQLQueryModifiersApi {
     materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationModeApi | null
     optimizeJoinedFilters?: boolean | null
     optimizeProjections?: boolean | null
-    /** HogQL parser backend; absent → `cpp_only`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
+    /** HogQL parser backend; absent → `cpp_with_rust_py_shadow` (cpp is primary, rust-py runs as a sampled shadow). `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
     parserMode?: ParserModeApi | null
     personsArgMaxVersion?: PersonsArgMaxVersionApi | null
     personsJoinMode?: PersonsJoinModeApi | null
@@ -1070,6 +1076,19 @@ export interface QueryTimingApi {
     t: number
 }
 
+export interface DataWarehouseSyncWarningApi {
+    /** Human-readable warning shown to the user */
+    message: string
+    /** Name of the ExternalDataSchema responsible for syncing the table */
+    schema_name: string
+    /** Source type, e.g. "Stripe", "Hubspot" */
+    source_type: string
+    /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */
+    status: string
+    /** Name of the warehouse table the warning refers to */
+    table_name: string
+}
+
 export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
 
 export interface TrendsQueryResponseApi {
@@ -1089,6 +1108,8 @@ export interface TrendsQueryResponseApi {
     results: TrendsQueryResponseApiResultsItem[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type BaseMathTypeApi = (typeof BaseMathTypeApi)[keyof typeof BaseMathTypeApi]
@@ -1835,6 +1856,10 @@ export interface TrendsFilterApi {
     showTrendLines?: boolean | null
     showValuesOnSeries?: boolean | null
     smoothingIntervals?: number | null
+    /** Custom label rendered under the X axis. */
+    xAxisLabel?: string | null
+    /** Custom label rendered alongside the Y axis. */
+    yAxisLabel?: string | null
     yAxisScaleType?: YAxisScaleTypeApi | null
 }
 
@@ -1843,6 +1868,8 @@ export interface TrendsQueryApi {
     aggregation_group_type_index?: number | null
     /** Breakdown of the events and actions */
     breakdownFilter?: BreakdownFilterApi | null
+    /** Properties specific to the calendar heatmap display variant. Only consulted when `trendsFilter.display === ChartDisplayType.CalendarHeatmap`; ignored otherwise. */
+    calendarHeatmapFilter?: CalendarHeatmapFilterApi | null
     /** Compare to date range */
     compareFilter?: CompareFilterApi | null
     /** Whether we should be comparing against a specific conversion goal */
@@ -2164,6 +2191,8 @@ export interface FunnelsQueryResponseApi {
     results: unknown
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type FunnelsDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
@@ -2333,11 +2362,13 @@ export interface RetentionQueryResponseApi {
     results: RetentionResultApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
-export type AggregationPropertyType1Api = (typeof AggregationPropertyType1Api)[keyof typeof AggregationPropertyType1Api]
+export type AggregationPropertyTypeApi = (typeof AggregationPropertyTypeApi)[keyof typeof AggregationPropertyTypeApi]
 
-export const AggregationPropertyType1Api = {
+export const AggregationPropertyTypeApi = {
     Event: 'event',
     Person: 'person',
     DataWarehouse: 'data_warehouse',
@@ -2461,7 +2492,7 @@ export interface RetentionFilterApi {
     /** The property to aggregate when aggregationType is sum or avg */
     aggregationProperty?: string | null
     /** The type of property to aggregate on (event, person or data_warehouse). Defaults to event. */
-    aggregationPropertyType?: AggregationPropertyType1Api | null
+    aggregationPropertyType?: AggregationPropertyTypeApi | null
     /** The aggregation type to use for retention */
     aggregationType?: AggregationTypeApi | null
     /** Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations. */
@@ -2614,6 +2645,8 @@ export interface PathsQueryResponseApi {
     results: PathsLinkApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface PathsQueryApi {
@@ -2683,6 +2716,8 @@ export interface StickinessQueryResponseApi {
     results: StickinessQueryResponseApiResultsItem[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type StickinessComputationModeApi =
@@ -2816,6 +2851,8 @@ export interface LifecycleQueryResponseApi {
     results: LifecycleQueryResponseApiResultsItem[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type LifecycleDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
@@ -3039,7 +3076,10 @@ export interface WebStatsTableQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    usedLazyPrecompute?: boolean | null
     usedPreAggregatedTables?: boolean | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface WebAnalyticsSamplingApi {
@@ -3083,6 +3123,8 @@ export interface WebStatsTableQueryApi {
     samplingFactor?: number | null
     tags?: QueryLogTagsApi | null
     useSessionsTable?: boolean | null
+    /** Opt this specific query into the web stats table precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
+    useWebAnalyticsPrecompute?: boolean | null
     /** version of the node, used for schema migrations */
     version?: number | null
 }
@@ -3125,6 +3167,8 @@ export interface WebOverviewQueryResponseApi {
     timings?: QueryTimingApi[] | null
     usedLazyPrecompute?: boolean | null
     usedPreAggregatedTables?: boolean | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface WebOverviewQueryApi {
@@ -3248,6 +3292,8 @@ export interface ResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types: string[]
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response1Api {
@@ -3270,6 +3316,8 @@ export interface Response1Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: string[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response2Api {
@@ -3292,6 +3340,8 @@ export interface Response2Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types: string[]
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface HogQLNoticeApi {
@@ -3350,6 +3400,8 @@ export interface Response3Api {
     timings?: QueryTimingApi[] | null
     /** Types of returned columns */
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response4Api {
@@ -3371,6 +3423,8 @@ export interface Response4Api {
     timings?: QueryTimingApi[] | null
     usedLazyPrecompute?: boolean | null
     usedPreAggregatedTables?: boolean | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response5Api {
@@ -3393,7 +3447,10 @@ export interface Response5Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    usedLazyPrecompute?: boolean | null
     usedPreAggregatedTables?: boolean | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response6Api {
@@ -3416,6 +3473,36 @@ export interface Response6Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
+}
+
+export interface Response7Api {
+    columns?: unknown[] | null
+    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+    error?: string | null
+    hasMore?: boolean | null
+    /** Generated HogQL query. */
+    hogql?: string | null
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi | null
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi | null
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi | null
+    results: unknown[]
+    samplingRate?: SamplingRateApi | null
+    /** Measured timings for different parts of the query generation process */
+    timings?: QueryTimingApi[] | null
+    types?: unknown[] | null
+    /** Whether the response was served from the lazy precompute path. */
+    usedLazyPrecompute?: boolean | null
+    /** Whether the response was served from a precomputed table. */
+    usedPreAggregatedTables?: boolean | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface WebVitalsPathBreakdownResultItemApi {
@@ -3447,6 +3534,9 @@ export interface Response8Api {
     results: WebVitalsPathBreakdownResultApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    usedLazyPrecompute?: boolean | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response9Api {
@@ -3468,6 +3558,8 @@ export interface Response9Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response10Api {
@@ -3489,6 +3581,8 @@ export interface Response10Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types: string[]
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response11Api {
@@ -3506,6 +3600,8 @@ export interface Response11Api {
     results: unknown[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response12Api {
@@ -3523,6 +3619,8 @@ export interface Response12Api {
     results: unknown
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface RevenueAnalyticsMRRQueryResultItemApi {
@@ -3548,6 +3646,8 @@ export interface Response13Api {
     results: RevenueAnalyticsMRRQueryResultItemApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type RevenueAnalyticsOverviewItemKeyApi =
@@ -3578,6 +3678,8 @@ export interface Response14Api {
     results: RevenueAnalyticsOverviewItemApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response15Api {
@@ -3595,6 +3697,8 @@ export interface Response15Api {
     results: unknown
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response16Api {
@@ -3616,6 +3720,8 @@ export interface Response16Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface MarketingAnalyticsItemApi {
@@ -3648,6 +3754,8 @@ export interface Response18Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type Response19ApiResults = { [key: string]: MarketingAnalyticsItemApi }
@@ -3667,6 +3775,8 @@ export interface Response19Api {
     samplingRate?: SamplingRateApi | null
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response20Api {
@@ -3689,6 +3799,8 @@ export interface Response20Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface VolumeBucketApi {
@@ -3831,6 +3943,8 @@ export interface Response21Api {
     results: ErrorTrackingIssueApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface PopulationApi {
@@ -3874,6 +3988,8 @@ export interface Response22Api {
     results: ErrorTrackingCorrelatedIssueApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type ExperimentSignificanceCodeApi =
@@ -3910,6 +4026,8 @@ export interface Response23Api {
     significant: boolean
     stats_version?: number | null
     variants: ExperimentVariantFunnelsBaseStatsApi[]
+    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface ExperimentVariantTrendsBaseStatsApi {
@@ -3937,6 +4055,8 @@ export interface Response24Api {
     significant: boolean
     stats_version?: number | null
     variants: ExperimentVariantTrendsBaseStatsApi[]
+    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type AIEventTypeApi = (typeof AIEventTypeApi)[keyof typeof AIEventTypeApi]
@@ -4015,6 +4135,8 @@ export interface Response25Api {
     results: LLMTraceApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response26Api {
@@ -4036,6 +4158,8 @@ export interface Response26Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type TaxonomicFilterGroupTypeApi = (typeof TaxonomicFilterGroupTypeApi)[keyof typeof TaxonomicFilterGroupTypeApi]
@@ -4179,6 +4303,8 @@ export interface EventsQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types: string[]
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export type CompareApi = (typeof CompareApi)[keyof typeof CompareApi]
@@ -4208,6 +4334,8 @@ export interface ActorsQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: string[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface InsightActorsQueryApi {
@@ -4469,6 +4597,8 @@ export interface FunnelCorrelationResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface FunnelCorrelationQueryApi {
@@ -4662,12 +4792,14 @@ export interface ExperimentMeanMetricApi {
     ignore_zeros?: boolean | null
     isSharedMetric?: boolean | null
     kind?: 'ExperimentMetric'
+    /** Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). */
     lower_bound_percentile?: number | null
     metric_type?: 'mean'
     name?: string | null
     response?: ExperimentMeanMetricApiResponse
     sharedMetricId?: number | null
     source: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
+    /** Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). */
     upper_bound_percentile?: number | null
     uuid?: string | null
     /** version of the node, used for schema migrations */
@@ -4695,6 +4827,14 @@ export interface ExperimentFunnelMetricApi {
     version?: number | null
 }
 
+export interface ExperimentMetricOutlierHandlingApi {
+    ignore_zeros?: boolean | null
+    /** Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). */
+    lower_bound_percentile?: number | null
+    /** Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). */
+    upper_bound_percentile?: number | null
+}
+
 export type ExperimentRatioMetricApiResponse = { [key: string]: unknown } | null
 
 export interface ExperimentRatioMetricApi {
@@ -4702,6 +4842,7 @@ export interface ExperimentRatioMetricApi {
     conversion_window?: number | null
     conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
     denominator: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
+    denominator_outlier_handling?: ExperimentMetricOutlierHandlingApi | null
     fingerprint?: string | null
     goal?: ExperimentMetricGoalApi | null
     isSharedMetric?: boolean | null
@@ -4709,6 +4850,7 @@ export interface ExperimentRatioMetricApi {
     metric_type?: 'ratio'
     name?: string | null
     numerator: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
+    numerator_outlier_handling?: ExperimentMetricOutlierHandlingApi | null
     response?: ExperimentRatioMetricApiResponse
     sharedMetricId?: number | null
     uuid?: string | null
@@ -4866,6 +5008,8 @@ export interface ExperimentQueryResponseApi {
     stats_version?: number | null
     variant_results?: ExperimentVariantResultFrequentistApi[] | ExperimentVariantResultBayesianApi[] | null
     variants?: ExperimentVariantTrendsBaseStatsApi[] | ExperimentVariantFunnelsBaseStatsApi[] | null
+    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface ExperimentQueryApi {
@@ -4982,6 +5126,8 @@ export interface HogQLQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Types of returned columns */
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface HogQLVariableApi {
@@ -5076,6 +5222,8 @@ export interface GroupsQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types: string[]
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface GroupsQueryApi {
@@ -5115,6 +5263,8 @@ export interface WebExternalClicksTableQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface WebExternalClicksTableQueryApi {
@@ -5172,6 +5322,12 @@ export interface WebGoalsQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Whether the response was served from the lazy precompute path. */
+    usedLazyPrecompute?: boolean | null
+    /** Whether the response was served from a precomputed table. */
+    usedPreAggregatedTables?: boolean | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface WebGoalsQueryApi {
@@ -5204,6 +5360,8 @@ export interface WebGoalsQueryApi {
     samplingFactor?: number | null
     tags?: QueryLogTagsApi | null
     useSessionsTable?: boolean | null
+    /** Opt this specific query into the web_goals_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
+    useWebAnalyticsPrecompute?: boolean | null
     /** version of the node, used for schema migrations */
     version?: number | null
 }
@@ -5285,6 +5443,9 @@ export interface WebVitalsPathBreakdownQueryResponseApi {
     results: WebVitalsPathBreakdownResultApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    usedLazyPrecompute?: boolean | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface WebVitalsPathBreakdownQueryApi {
@@ -5323,6 +5484,8 @@ export interface WebVitalsPathBreakdownQueryApi {
      */
     thresholds: number[]
     useSessionsTable?: boolean | null
+    /** Opt this specific query into the web vitals path breakdown precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
+    useWebAnalyticsPrecompute?: boolean | null
     /** version of the node, used for schema migrations */
     version?: number | null
 }
@@ -5364,6 +5527,8 @@ export interface SessionAttributionExplorerQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface SessionAttributionExplorerQueryApi {
@@ -5399,6 +5564,8 @@ export interface SessionsQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types: string[]
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface SessionsQueryApi {
@@ -5537,6 +5704,8 @@ export interface RevenueAnalyticsGrossRevenueQueryResponseApi {
     results: unknown[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface RevenueAnalyticsGrossRevenueQueryApi {
@@ -5568,6 +5737,8 @@ export interface RevenueAnalyticsMetricsQueryResponseApi {
     results: unknown
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface RevenueAnalyticsMetricsQueryApi {
@@ -5599,6 +5770,8 @@ export interface RevenueAnalyticsMRRQueryResponseApi {
     results: RevenueAnalyticsMRRQueryResultItemApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface RevenueAnalyticsMRRQueryApi {
@@ -5629,6 +5802,8 @@ export interface RevenueAnalyticsOverviewQueryResponseApi {
     results: RevenueAnalyticsOverviewItemApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface RevenueAnalyticsOverviewQueryApi {
@@ -5666,6 +5841,8 @@ export interface RevenueAnalyticsTopCustomersQueryResponseApi {
     results: unknown
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface RevenueAnalyticsTopCustomersQueryApi {
@@ -5700,6 +5877,8 @@ export interface RevenueExampleEventsQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface RevenueExampleEventsQueryApi {
@@ -5733,6 +5912,8 @@ export interface RevenueExampleDataWarehouseTablesQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface RevenueExampleDataWarehouseTablesQueryApi {
@@ -6055,6 +6236,8 @@ export interface MarketingAnalyticsTableQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface MarketingAnalyticsTableQueryApi {
@@ -6122,6 +6305,8 @@ export interface MarketingAnalyticsAggregatedQueryResponseApi {
     samplingRate?: SamplingRateApi | null
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface MarketingAnalyticsAggregatedQueryApi {
@@ -6184,6 +6369,8 @@ export interface NonIntegratedConversionsTableQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface NonIntegratedConversionsTableQueryApi {
@@ -6280,6 +6467,8 @@ export interface ErrorTrackingQueryResponseApi {
     results: ErrorTrackingIssueApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface ErrorTrackingQueryApi {
@@ -6341,6 +6530,8 @@ export interface ErrorTrackingIssueCorrelationQueryResponseApi {
     results: ErrorTrackingCorrelatedIssueApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface ErrorTrackingIssueCorrelationQueryApi {
@@ -6371,6 +6562,8 @@ export interface ExperimentFunnelsQueryResponseApi {
     significant: boolean
     stats_version?: number | null
     variants: ExperimentVariantFunnelsBaseStatsApi[]
+    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface ExperimentFunnelsQueryApi {
@@ -6406,6 +6599,8 @@ export interface ExperimentTrendsQueryResponseApi {
     significant: boolean
     stats_version?: number | null
     variants: ExperimentVariantTrendsBaseStatsApi[]
+    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface ExperimentTrendsQueryApi {
@@ -6442,6 +6637,8 @@ export interface TracesQueryResponseApi {
     results: LLMTraceApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface TracesQueryApi {
@@ -6509,6 +6706,8 @@ export interface TraceQueryResponseApi {
     results: LLMTraceApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface TraceQueryApi {
@@ -6602,6 +6801,8 @@ export interface EndpointsUsageTableQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface EndpointsUsageTableQueryApi {
@@ -6632,6 +6833,7 @@ export type DataTableNodeApiResponse =
     | Response4Api
     | Response5Api
     | Response6Api
+    | Response7Api
     | Response8Api
     | Response9Api
     | Response10Api

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -13,15 +13,18 @@ import type {
     BulkUpdateTagsResponseApi,
     CopyDashboardTemplateApi,
     CopyDashboardTileRequestApi,
+    CreateTextTileRequestApi,
     DashboardApi,
     DashboardCollaboratorApi,
     DashboardTemplateApi,
     DashboardTemplatesListParams,
+    DashboardTileApi,
     DashboardsAnalyzeRefreshResultCreateParams,
     DashboardsBulkUpdateTagsCreateParams,
     DashboardsCopyTileCreateParams,
     DashboardsCreateFromTemplateJsonCreateParams,
     DashboardsCreateParams,
+    DashboardsCreateTextTileCreateParams,
     DashboardsCreateUnlistedDashboardCreateParams,
     DashboardsDestroyParams,
     DashboardsListParams,
@@ -33,6 +36,7 @@ import type {
     DashboardsSnapshotCreateParams,
     DashboardsStreamTilesRetrieveParams,
     DashboardsUpdateParams,
+    DashboardsUpdateTextTilePartialUpdateParams,
     DataColorThemeApi,
     DataColorThemesListParams,
     PaginatedDashboardBasicListApi,
@@ -40,6 +44,7 @@ import type {
     PaginatedDataColorThemeListApi,
     PatchedDashboardApi,
     PatchedDataColorThemeApi,
+    PatchedUpdateTextTileRequestApi,
     ReorderTilesRequestApi,
     RunInsightsResponseApi,
     SharingConfigurationApi,
@@ -519,6 +524,47 @@ export const dashboardsCopyTileCreate = async (
     })
 }
 
+export const getDashboardsCreateTextTileCreateUrl = (
+    projectId: string,
+    id: number,
+    params?: DashboardsCreateTextTileCreateParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/dashboards/${id}/create_text_tile/?${stringifiedParams}`
+        : `/api/projects/${projectId}/dashboards/${id}/create_text_tile/`
+}
+
+/**
+ * Add a markdown text tile to a dashboard.
+
+Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
+or annotations between insight tiles to give the dashboard structure.
+ */
+export const dashboardsCreateTextTileCreate = async (
+    projectId: string,
+    id: number,
+    createTextTileRequestApi: CreateTextTileRequestApi,
+    params?: DashboardsCreateTextTileCreateParams,
+    options?: RequestInit
+): Promise<DashboardTileApi> => {
+    return apiMutator<DashboardTileApi>(getDashboardsCreateTextTileCreateUrl(projectId, id, params), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(createTextTileRequestApi),
+    })
+}
+
 export const getDashboardsMoveTilePartialUpdateUrl = (
     projectId: string,
     id: number,
@@ -695,6 +741,44 @@ export const dashboardsStreamTilesRetrieve = async (
     return apiMutator<void>(getDashboardsStreamTilesRetrieveUrl(projectId, id, params), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getDashboardsUpdateTextTilePartialUpdateUrl = (
+    projectId: string,
+    id: number,
+    params?: DashboardsUpdateTextTilePartialUpdateParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/dashboards/${id}/update_text_tile/?${stringifiedParams}`
+        : `/api/projects/${projectId}/dashboards/${id}/update_text_tile/`
+}
+
+/**
+ * Update the markdown body, layout, or color of an existing text tile on a dashboard.
+ */
+export const dashboardsUpdateTextTilePartialUpdate = async (
+    projectId: string,
+    id: number,
+    patchedUpdateTextTileRequestApi?: PatchedUpdateTextTileRequestApi,
+    params?: DashboardsUpdateTextTilePartialUpdateParams,
+    options?: RequestInit
+): Promise<DashboardTileApi> => {
+    return apiMutator<DashboardTileApi>(getDashboardsUpdateTextTilePartialUpdateUrl(projectId, id, params), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedUpdateTextTileRequestApi),
     })
 }
 

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -36,7 +36,7 @@ import type {
     DashboardsSnapshotCreateParams,
     DashboardsStreamTilesRetrieveParams,
     DashboardsUpdateParams,
-    DashboardsUpdateTextTilePartialUpdateParams,
+    DashboardsUpdateTextTileCreateParams,
     DataColorThemeApi,
     DataColorThemesListParams,
     PaginatedDashboardBasicListApi,
@@ -44,10 +44,10 @@ import type {
     PaginatedDataColorThemeListApi,
     PatchedDashboardApi,
     PatchedDataColorThemeApi,
-    PatchedUpdateTextTileRequestApi,
     ReorderTilesRequestApi,
     RunInsightsResponseApi,
     SharingConfigurationApi,
+    UpdateTextTileRequestApi,
 } from './api.schemas'
 
 // https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
@@ -744,10 +744,10 @@ export const dashboardsStreamTilesRetrieve = async (
     })
 }
 
-export const getDashboardsUpdateTextTilePartialUpdateUrl = (
+export const getDashboardsUpdateTextTileCreateUrl = (
     projectId: string,
     id: number,
-    params?: DashboardsUpdateTextTilePartialUpdateParams
+    params?: DashboardsUpdateTextTileCreateParams
 ) => {
     const normalizedParams = new URLSearchParams()
 
@@ -767,18 +767,18 @@ export const getDashboardsUpdateTextTilePartialUpdateUrl = (
 /**
  * Update the markdown body, layout, or color of an existing text tile on a dashboard.
  */
-export const dashboardsUpdateTextTilePartialUpdate = async (
+export const dashboardsUpdateTextTileCreate = async (
     projectId: string,
     id: number,
-    patchedUpdateTextTileRequestApi?: PatchedUpdateTextTileRequestApi,
-    params?: DashboardsUpdateTextTilePartialUpdateParams,
+    updateTextTileRequestApi: UpdateTextTileRequestApi,
+    params?: DashboardsUpdateTextTileCreateParams,
     options?: RequestInit
 ): Promise<DashboardTileApi> => {
-    return apiMutator<DashboardTileApi>(getDashboardsUpdateTextTilePartialUpdateUrl(projectId, id, params), {
+    return apiMutator<DashboardTileApi>(getDashboardsUpdateTextTileCreateUrl(projectId, id, params), {
         ...options,
-        method: 'PATCH',
+        method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(patchedUpdateTextTileRequestApi),
+        body: JSON.stringify(updateTextTileRequestApi),
     })
 }
 

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -243,6 +243,49 @@ export const DashboardsCopyTileCreateBody = /* @__PURE__ */ zod.object({
     tileId: zod.number().describe('Dashboard tile id to copy.'),
 })
 
+/**
+ * Add a markdown text tile to a dashboard.
+
+Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
+or annotations between insight tiles to give the dashboard structure.
+ */
+export const dashboardsCreateTextTileCreateBodyBodyMax = 4000
+
+export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
+    body: zod
+        .string()
+        .max(dashboardsCreateTextTileCreateBodyBodyMax)
+        .describe(
+            'Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.'
+        ),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+            xs: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+        })
+        .optional()
+        .describe(
+            'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
+        ),
+    color: zod.string().nullish().describe("Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."),
+})
+
 export const dashboardsMoveTilePartialUpdateBodyNameMax = 400
 
 export const dashboardsMoveTilePartialUpdateBodyDeleteInsightsDefault = false
@@ -329,6 +372,47 @@ export const DashboardsSnapshotCreateBody = /* @__PURE__ */ zod
         _create_in_folder: zod.string().optional(),
     })
     .describe('Serializer mixin that handles tags for objects.')
+
+/**
+ * Update the markdown body, layout, or color of an existing text tile on a dashboard.
+ */
+export const dashboardsUpdateTextTilePartialUpdateBodyBodyMax = 4000
+
+export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.object({
+    tile_id: zod
+        .number()
+        .optional()
+        .describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
+    body: zod
+        .string()
+        .max(dashboardsUpdateTextTilePartialUpdateBodyBodyMax)
+        .nullish()
+        .describe('New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+            xs: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+        })
+        .optional()
+        .describe('New grid layout per breakpoint. Omit to leave the layout unchanged.'),
+    color: zod.string().nullish().describe('New accent color name, or null to clear. Omit to leave unchanged.'),
+})
 
 /**
  * Bulk update tags on multiple objects.

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -383,19 +383,16 @@ export const DashboardsSnapshotCreateBody = /* @__PURE__ */ zod
 /**
  * Update the markdown body, layout, or color of an existing text tile on a dashboard.
  */
-export const dashboardsUpdateTextTilePartialUpdateBodyBodyMax = 4000
+export const dashboardsUpdateTextTileCreateBodyBodyMax = 4000
 
-export const dashboardsUpdateTextTilePartialUpdateBodyColorMax = 400
+export const dashboardsUpdateTextTileCreateBodyColorMax = 400
 
-export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.object({
-    tile_id: zod
-        .number()
-        .optional()
-        .describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
+export const DashboardsUpdateTextTileCreateBody = /* @__PURE__ */ zod.object({
+    tile_id: zod.number().describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
     body: zod
         .string()
         .min(1)
-        .max(dashboardsUpdateTextTilePartialUpdateBodyBodyMax)
+        .max(dashboardsUpdateTextTileCreateBodyBodyMax)
         .optional()
         .describe('New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.'),
     layouts: zod
@@ -423,7 +420,7 @@ export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.obj
         .describe('New grid layout per breakpoint. Omit to leave the layout unchanged.'),
     color: zod
         .string()
-        .max(dashboardsUpdateTextTilePartialUpdateBodyColorMax)
+        .max(dashboardsUpdateTextTileCreateBodyColorMax)
         .nullish()
         .describe('New accent color name, empty string or null to clear. Omit to leave unchanged.'),
 })

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -251,6 +251,8 @@ or annotations between insight tiles to give the dashboard structure.
  */
 export const dashboardsCreateTextTileCreateBodyBodyMax = 4000
 
+export const dashboardsCreateTextTileCreateBodyColorMax = 400
+
 export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
     body: zod
         .string()
@@ -283,7 +285,11 @@ export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
         ),
-    color: zod.string().nullish().describe("Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."),
+    color: zod
+        .string()
+        .max(dashboardsCreateTextTileCreateBodyColorMax)
+        .nullish()
+        .describe("Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."),
 })
 
 export const dashboardsMoveTilePartialUpdateBodyNameMax = 400
@@ -378,6 +384,8 @@ export const DashboardsSnapshotCreateBody = /* @__PURE__ */ zod
  */
 export const dashboardsUpdateTextTilePartialUpdateBodyBodyMax = 4000
 
+export const dashboardsUpdateTextTilePartialUpdateBodyColorMax = 400
+
 export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.object({
     tile_id: zod
         .number()
@@ -386,7 +394,7 @@ export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.obj
     body: zod
         .string()
         .max(dashboardsUpdateTextTilePartialUpdateBodyBodyMax)
-        .nullish()
+        .optional()
         .describe('New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.'),
     layouts: zod
         .object({
@@ -411,7 +419,11 @@ export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.obj
         })
         .optional()
         .describe('New grid layout per breakpoint. Omit to leave the layout unchanged.'),
-    color: zod.string().nullish().describe('New accent color name, or null to clear. Omit to leave unchanged.'),
+    color: zod
+        .string()
+        .max(dashboardsUpdateTextTilePartialUpdateBodyColorMax)
+        .nullish()
+        .describe('New accent color name, empty string or null to clear. Omit to leave unchanged.'),
 })
 
 /**

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -256,6 +256,7 @@ export const dashboardsCreateTextTileCreateBodyColorMax = 400
 export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
     body: zod
         .string()
+        .min(1)
         .max(dashboardsCreateTextTileCreateBodyBodyMax)
         .describe(
             'Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.'
@@ -393,6 +394,7 @@ export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.obj
         .describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
     body: zod
         .string()
+        .min(1)
         .max(dashboardsUpdateTextTilePartialUpdateBodyBodyMax)
         .optional()
         .describe('New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.'),

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -75,6 +75,26 @@ tools:
                 - tiles.*.insight.last_viewed_at
                 - tiles.*.insight.timezone
                 - tiles.*.insight.resolved_date_range
+    dashboard-create-text-tile:
+        operation: dashboards_create_text_tile_create
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{id}'
+        title: Create dashboard text tile
+        description: >
+            Add a markdown text tile to a dashboard. Text tiles render as markdown blocks — useful as section headings,
+            dividers, or annotations between insight tiles to give a dashboard structure. The desktop grid is 12 columns
+            wide; a typical heading uses a thin full-width banner (e.g. `layouts.sm = {x: 0, y: 0, w: 12, h: 1}`). If
+            `layouts` is omitted, the tile is placed using the default layout — use dashboard-reorder-tiles afterwards
+            if you need precise placement.
+        param_overrides:
+            id:
+                cast: string-int
     dashboard-delete:
         operation: dashboards_destroy
         enabled: true
@@ -168,26 +188,6 @@ tools:
         param_overrides:
             id:
                 cast: string-int
-    dashboard-create-text-tile:
-        operation: dashboards_create_text_tile_create
-        enabled: true
-        scopes:
-            - dashboard:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        enrich_url: '{id}'
-        title: Create dashboard text tile
-        description: >
-            Add a markdown text tile to a dashboard. Text tiles render as markdown blocks — useful as section
-            headings, dividers, or annotations between insight tiles to give a dashboard structure. The desktop grid
-            is 12 columns wide; a typical heading uses a thin full-width banner (e.g. `layouts.sm = {x: 0, y: 0, w:
-            12, h: 1}`). If `layouts` is omitted, the tile is placed using the default layout — use
-            dashboard-reorder-tiles afterwards if you need precise placement.
-        param_overrides:
-            id:
-                cast: string-int
     dashboard-reorder-tiles:
         operation: dashboards_reorder_tiles_create
         enabled: true
@@ -203,25 +203,6 @@ tools:
             Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. Computes a
             2-column grid layout (6 columns wide, 5 rows tall per tile). First, use dashboard-get to see current tile
             IDs.
-    dashboard-update-text-tile:
-        operation: dashboards_update_text_tile_partial_update
-        enabled: true
-        scopes:
-            - dashboard:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: true
-        enrich_url: '{id}'
-        title: Update dashboard text tile
-        description: >
-            Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the
-            DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are
-            updated; omitted fields are left unchanged. To remove a text tile from a dashboard, use dashboard-update
-            with the tile's `deleted: true` flag instead.
-        param_overrides:
-            id:
-                cast: string-int
     dashboard-templates-copy-between-projects-create:
         operation: dashboard_templates_copy_between_projects_create
         enabled: false
@@ -301,6 +282,25 @@ tools:
                 - tiles.*.insight.alerts
                 - tiles.*.insight.timezone
                 - tiles.*.insight.resolved_date_range
+    dashboard-update-text-tile:
+        operation: dashboards_update_text_tile_partial_update
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: '{id}'
+        title: Update dashboard text tile
+        description: >
+            Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the DashboardTile
+            id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted
+            fields are left unchanged. To remove a text tile from a dashboard, use dashboard-update with the tile's
+            `deleted: true` flag instead.
+        param_overrides:
+            id:
+                cast: string-int
     dashboards-analyze-refresh-result-create:
         operation: dashboards_analyze_refresh_result_create
         enabled: false

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -283,7 +283,7 @@ tools:
                 - tiles.*.insight.timezone
                 - tiles.*.insight.resolved_date_range
     dashboard-update-text-tile:
-        operation: dashboards_update_text_tile_partial_update
+        operation: dashboards_update_text_tile_create
         enabled: true
         scopes:
             - dashboard:write

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -84,7 +84,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        enrich_url: '{id}'
+        enrich_url: '{params.id}'
         title: Create dashboard text tile
         description: >
             Add a markdown text tile to a dashboard. Text tiles render as markdown blocks — useful as section headings,
@@ -291,13 +291,12 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
-        enrich_url: '{id}'
+        enrich_url: '{params.id}'
         title: Update dashboard text tile
         description: >
             Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the DashboardTile
             id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted
-            fields are left unchanged. To remove a text tile from a dashboard, use dashboard-update with the tile's
-            `deleted: true` flag instead.
+            fields are left unchanged.
         param_overrides:
             id:
                 cast: string-int

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -168,6 +168,26 @@ tools:
         param_overrides:
             id:
                 cast: string-int
+    dashboard-create-text-tile:
+        operation: dashboards_create_text_tile_create
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{id}'
+        title: Create dashboard text tile
+        description: >
+            Add a markdown text tile to a dashboard. Text tiles render as markdown blocks — useful as section
+            headings, dividers, or annotations between insight tiles to give a dashboard structure. The desktop grid
+            is 12 columns wide; a typical heading uses a thin full-width banner (e.g. `layouts.sm = {x: 0, y: 0, w:
+            12, h: 1}`). If `layouts` is omitted, the tile is placed using the default layout — use
+            dashboard-reorder-tiles afterwards if you need precise placement.
+        param_overrides:
+            id:
+                cast: string-int
     dashboard-reorder-tiles:
         operation: dashboards_reorder_tiles_create
         enabled: true
@@ -183,6 +203,25 @@ tools:
             Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. Computes a
             2-column grid layout (6 columns wide, 5 rows tall per tile). First, use dashboard-get to see current tile
             IDs.
+    dashboard-update-text-tile:
+        operation: dashboards_update_text_tile_partial_update
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: '{id}'
+        title: Update dashboard text tile
+        description: >
+            Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the
+            DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are
+            updated; omitted fields are left unchanged. To remove a text tile from a dashboard, use dashboard-update
+            with the tile's `deleted: true` flag instead.
+        param_overrides:
+            id:
+                cast: string-int
     dashboard-templates-copy-between-projects-create:
         operation: dashboard_templates_copy_between_projects_create
         enabled: false

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -212,8 +212,8 @@ tools:
     dashboards-update:
         operation: dashboards_update
         enabled: false
-    dashboards-update-text-tile-partial-update:
-        operation: dashboards_update_text_tile_partial_update
+    dashboards-update-text-tile-create:
+        operation: dashboards_update_text_tile_create
         enabled: false
     delete-secret-token-backup-partial-update:
         operation: organizations_projects_delete_secret_token_backup_partial_update

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -164,6 +164,9 @@ tools:
     dashboards-create-from-template-json-create:
         operation: dashboards_create_from_template_json_create
         enabled: false
+    dashboards-create-text-tile-create:
+        operation: dashboards_create_text_tile_create
+        enabled: false
     dashboards-create-unlisted-dashboard-create:
         operation: dashboards_create_unlisted_dashboard_create
         enabled: false
@@ -208,6 +211,9 @@ tools:
         enabled: false
     dashboards-update:
         operation: dashboards_update
+        enabled: false
+    dashboards-update-text-tile-partial-update:
+        operation: dashboards_update_text_tile_partial_update
         enabled: false
     delete-secret-token-backup-partial-update:
         operation: organizations_projects_delete_secret_token_backup_partial_update

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1049,6 +1049,21 @@
             "readOnlyHint": false
         }
     },
+    "dashboard-create-text-tile": {
+        "description": "Add a markdown text tile to a dashboard. Text tiles render as markdown blocks — useful as section headings, dividers, or annotations between insight tiles to give a dashboard structure. The desktop grid is 12 columns wide; a typical heading uses a thin full-width banner (e.g. `layouts.sm = {x: 0, y: 0, w: 12, h: 1}`). If `layouts` is omitted, the tile is placed using the default layout — use dashboard-reorder-tiles afterwards if you need precise placement.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Create dashboard text tile",
+        "title": "Create dashboard text tile",
+        "required_scopes": ["dashboard:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "dashboard-delete": {
         "description": "Delete a dashboard by ID. The dashboard will be soft-deleted and no longer appear in lists.",
         "category": "Dashboards",
@@ -1115,6 +1130,21 @@
         "feature": "dashboards",
         "summary": "Update dashboard",
         "title": "Update dashboard",
+        "required_scopes": ["dashboard:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-update-text-tile": {
+        "description": "Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted fields are left unchanged. To remove a text tile from a dashboard, use dashboard-update with the tile's `deleted: true` flag instead.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Update dashboard text tile",
+        "title": "Update dashboard text tile",
         "required_scopes": ["dashboard:write"],
         "new_mcp": true,
         "annotations": {

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1140,7 +1140,7 @@
         }
     },
     "dashboard-update-text-tile": {
-        "description": "Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted fields are left unchanged. To remove a text tile from a dashboard, use dashboard-update with the tile's `deleted: true` flag instead.",
+        "description": "Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted fields are left unchanged.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Update dashboard text tile",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1066,6 +1066,21 @@
             "readOnlyHint": false
         }
     },
+    "dashboard-create-text-tile": {
+        "description": "Add a markdown text tile to a dashboard. Text tiles render as markdown blocks — useful as section headings, dividers, or annotations between insight tiles to give a dashboard structure. The desktop grid is 12 columns wide; a typical heading uses a thin full-width banner (e.g. `layouts.sm = {x: 0, y: 0, w: 12, h: 1}`). If `layouts` is omitted, the tile is placed using the default layout — use dashboard-reorder-tiles afterwards if you need precise placement.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Create dashboard text tile",
+        "title": "Create dashboard text tile",
+        "required_scopes": ["dashboard:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "dashboard-delete": {
         "description": "Delete a dashboard by ID. The dashboard will be soft-deleted and no longer appear in lists.",
         "category": "Dashboards",
@@ -1132,6 +1147,21 @@
         "feature": "dashboards",
         "summary": "Update dashboard",
         "title": "Update dashboard",
+        "required_scopes": ["dashboard:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-update-text-tile": {
+        "description": "Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted fields are left unchanged. To remove a text tile from a dashboard, use dashboard-update with the tile's `deleted: true` flag instead.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Update dashboard text tile",
+        "title": "Update dashboard text tile",
         "required_scopes": ["dashboard:write"],
         "new_mcp": true,
         "annotations": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1157,7 +1157,7 @@
         }
     },
     "dashboard-update-text-tile": {
-        "description": "Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted fields are left unchanged. To remove a text tile from a dashboard, use dashboard-update with the tile's `deleted: true` flag instead.",
+        "description": "Update the markdown body, layout, or color of an existing text tile on a dashboard. Pass the DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted fields are left unchanged.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Update dashboard text tile",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6805,6 +6805,52 @@ export namespace Schemas {
       Other: 'other',
     } as const;
 
+    /**
+     * * `left` - left
+    * `right` - right
+     */
+    export type PlacementEnum = typeof PlacementEnum[keyof typeof PlacementEnum];
+
+
+    export const PlacementEnum = {
+      Left: 'left',
+      Right: 'right',
+    } as const;
+
+    export interface DashboardTileBasic {
+      readonly id: number;
+      readonly dashboard_id: number;
+      /** @nullable */
+      deleted?: boolean | null;
+    }
+
+    /**
+     * * `primary` - Primary
+    * `secondary` - Secondary
+     */
+    export type StyleEnum = typeof StyleEnum[keyof typeof StyleEnum];
+
+
+    export const StyleEnum = {
+      Primary: 'primary',
+      Secondary: 'secondary',
+    } as const;
+
+    export interface ButtonTile {
+      readonly id: string;
+      readonly created_by: UserBasic;
+      readonly last_modified_by: UserBasic;
+      /** @maxLength 2000 */
+      url: string;
+      /** @maxLength 200 */
+      text: string;
+      placement?: PlacementEnum;
+      readonly dashboard_tiles: readonly DashboardTileBasic[];
+      style?: StyleEnum;
+      readonly last_modified_at: string;
+      team: number;
+    }
+
     export interface CIMDVerificationToken {
       readonly id: string;
       /** @maxLength 40 */
@@ -8805,6 +8851,41 @@ export namespace Schemas {
       text: string;
     }
 
+    export interface TileLayoutBox {
+      /** Column position in the dashboard grid (0-indexed). */
+      x?: number;
+      /** Row position in the dashboard grid (0-indexed). */
+      y?: number;
+      /** Width in grid columns. The desktop grid is 12 columns wide. */
+      w?: number;
+      /** Height in grid rows. */
+      h?: number;
+    }
+
+    export interface TileLayouts {
+      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+      sm?: TileLayoutBox;
+      /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+      xs?: TileLayoutBox;
+    }
+
+    export interface CreateTextTileRequest {
+      /**
+         * Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.
+         * @minLength 1
+         * @maxLength 4000
+         */
+      body: string;
+      /** Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1). */
+      layouts?: TileLayouts;
+      /**
+         * Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').
+         * @maxLength 400
+         * @nullable
+         */
+      color?: string | null;
+    }
+
     /**
      * * `web` - web
     * `api` - api
@@ -9125,80 +9206,57 @@ export namespace Schemas {
       is_featured?: boolean;
     }
 
-    export interface DashboardTileBasic {
-      readonly id: number;
-      readonly dashboard_id: number;
-      /** @nullable */
-      deleted?: boolean | null;
-    }
-
-    /**
-     * InsightSerializer restricted to identifiers + result only.
-     */
-    export interface InsightResult {
-      readonly id: number;
-      readonly short_id: string;
-      /** @nullable */
-      readonly name: string | null;
-      /** @nullable */
-      readonly derived_name: string | null;
-      readonly result: unknown;
-    }
-
-    /**
-     * DashboardTileSerializer restricted to tile id + insight result fields.
-     */
-    export interface DashboardTileResult {
-      id?: number;
-      insight: InsightResult;
-    }
-
-    export interface DataColorTheme {
-      readonly id: number;
-      /** @maxLength 100 */
-      name: string;
-      colors?: unknown;
-      readonly is_global: boolean;
-      /** @nullable */
-      readonly created_at: string | null;
-      readonly created_by: UserBasic;
-    }
-
-    /**
-     * * `Cancelled` - Cancelled
-    * `Completed` - Completed
-    * `Failed` - Failed
-    * `Running` - Running
-     */
-    export type DataModelingJobStatusEnum = typeof DataModelingJobStatusEnum[keyof typeof DataModelingJobStatusEnum];
+    export type InsightVizNodeKind = typeof InsightVizNodeKind[keyof typeof InsightVizNodeKind];
 
 
-    export const DataModelingJobStatusEnum = {
-      Cancelled: 'Cancelled',
-      Completed: 'Completed',
-      Failed: 'Failed',
-      Running: 'Running',
+    export const InsightVizNodeKind = {
+      InsightVizNode: 'InsightVizNode',
     } as const;
 
-    export interface DataModelingJob {
-      readonly id: string;
-      /** @nullable */
-      readonly saved_query_id: string | null;
-      readonly status: DataModelingJobStatusEnum;
-      readonly rows_materialized: number;
-      /** @nullable */
-      readonly error: string | null;
-      readonly created_at: string;
-      readonly last_run_at: string;
-      /** @nullable */
-      readonly workflow_id: string | null;
-      /** @nullable */
-      readonly workflow_run_id: string | null;
-      /**
-         * Total rows expected to be materialized
-         * @nullable
-         */
-      readonly rows_expected: number | null;
+    export interface Retention {
+      hideLineGraph?: boolean | null;
+      hideSizeColumn?: boolean | null;
+      useSmallLayout?: boolean | null;
+    }
+
+    export interface VizSpecificOptions {
+      ActionsPie?: ActionsPie | null;
+      RETENTION?: Retention | null;
+    }
+
+    export interface InsightVizNode {
+      /** Query is embedded inside another bordered component */
+      embedded?: boolean | null;
+      /** Show with most visual options enabled. Used in insight scene. */
+      full?: boolean | null;
+      hidePersonsModal?: boolean | null;
+      hideTooltipOnScroll?: boolean | null;
+      kind: InsightVizNodeKind;
+      showCorrelationTable?: boolean | null;
+      showFilters?: boolean | null;
+      showHeader?: boolean | null;
+      showLastComputation?: boolean | null;
+      showLastComputationRefresh?: boolean | null;
+      showResults?: boolean | null;
+      showTable?: boolean | null;
+      source: TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | WebStatsTableQuery | WebOverviewQuery;
+      suppressSessionAnalysisWarning?: boolean | null;
+      /** version of the node, used for schema migrations */
+      version?: number | null;
+      vizSpecificOptions?: VizSpecificOptions | null;
+    }
+
+    export type DataTableNodeViewPropsContextType = typeof DataTableNodeViewPropsContextType[keyof typeof DataTableNodeViewPropsContextType];
+
+
+    export const DataTableNodeViewPropsContextType = {
+      EventDefinition: 'event_definition',
+      TeamColumns: 'team_columns',
+    } as const;
+
+    export interface DataTableNodeViewPropsContext {
+      eventDefinitionId?: string | null;
+      type: DataTableNodeViewPropsContextType;
     }
 
     export type DataTableNodeKind = typeof DataTableNodeKind[keyof typeof DataTableNodeKind];
@@ -10031,21 +10089,6 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
-    }
-
-    export type DataTableNodeResponse = { [key: string]: unknown } | Response | Response1 | Response2 | Response3 | Response4 | Response5 | Response6 | Response7 | Response8 | Response9 | Response10 | Response11 | Response12 | Response13 | Response14 | Response15 | Response16 | Response18 | Response19 | Response20 | Response21 | Response22 | Response23 | Response24 | Response25 | Response26 | null;
-
-    export type DataTableNodeViewPropsContextType = typeof DataTableNodeViewPropsContextType[keyof typeof DataTableNodeViewPropsContextType];
-
-
-    export const DataTableNodeViewPropsContextType = {
-      EventDefinition: 'event_definition',
-      TeamColumns: 'team_columns',
-    } as const;
-
-    export interface DataTableNodeViewPropsContext {
-      eventDefinitionId?: string | null;
-      type: DataTableNodeViewPropsContextType;
     }
 
     export type TaxonomicFilterGroupType = typeof TaxonomicFilterGroupType[keyof typeof TaxonomicFilterGroupType];
@@ -11445,6 +11488,8 @@ export namespace Schemas {
       version?: number | null;
     }
 
+    export type DataTableNodeResponse = { [key: string]: unknown } | Response | Response1 | Response2 | Response3 | Response4 | Response5 | Response6 | Response7 | Response8 | Response9 | Response10 | Response11 | Response12 | Response13 | Response14 | Response15 | Response16 | Response18 | Response19 | Response20 | Response21 | Response22 | Response23 | Response24 | Response25 | Response26 | null;
+
     export interface DataTableNode {
       /** Can the user click on column headers to sort the table? (default: true) */
       allowSorting?: boolean | null;
@@ -11545,6 +11590,250 @@ export namespace Schemas {
       tableSettings?: TableSettings | null;
       /** version of the node, used for schema migrations */
       version?: number | null;
+    }
+
+    export type HogQueryKind = typeof HogQueryKind[keyof typeof HogQueryKind];
+
+
+    export const HogQueryKind = {
+      HogQuery: 'HogQuery',
+    } as const;
+
+    export interface HogQueryResponse {
+      bytecode?: unknown[] | null;
+      coloredBytecode?: unknown[] | null;
+      results: unknown;
+      stdout?: string | null;
+    }
+
+    export interface HogQuery {
+      code?: string | null;
+      kind: HogQueryKind;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      response?: HogQueryResponse | null;
+      tags?: QueryLogTags | null;
+      /** version of the node, used for schema migrations */
+      version?: number | null;
+    }
+
+    /**
+     * The query definition for this insight. The `kind` field determines the query type:
+    - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
+    - `DataVisualizationNode` — SQL insights using HogQL
+    - `DataTableNode` — raw data tables
+    - `HogQuery` — Hog language queries
+     */
+    export type _InsightQuerySchema = InsightVizNode | DataTableNode | DataVisualizationNode | HogQuery;
+
+    /**
+     * @nullable
+     */
+    export type InsightResolvedDateRange = {
+      readonly date_from?: string;
+      readonly date_to?: string;
+    } | null;
+
+    /**
+     * Simplified serializer to speed response times when loading large amounts of objects.
+     */
+    export interface Insight {
+      readonly id: number;
+      readonly short_id: string;
+      /**
+         * @maxLength 400
+         * @nullable
+         */
+      name?: string | null;
+      /**
+         * @maxLength 400
+         * @nullable
+         */
+      derived_name?: string | null;
+      query?: _InsightQuerySchema | null;
+      /**
+         * @minimum -2147483648
+         * @maximum 2147483647
+         * @nullable
+         */
+      order?: number | null;
+      deleted?: boolean;
+      /**
+              DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+              A dashboard ID for each of the dashboards that this insight is displayed on.
+               */
+      dashboards?: number[];
+      /**
+          A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+           */
+      readonly dashboard_tiles: readonly DashboardTileBasic[];
+      /**
+         *
+          The datetime this insight's results were generated.
+          If added to one or more dashboards the insight can be refreshed separately on each.
+          Returns the appropriate last_refresh datetime for the context the insight is viewed in
+          (see from_dashboard query parameter).
+
+         * @nullable
+         */
+      readonly last_refresh: string | null;
+      /**
+         * The target age of the cached results for this insight.
+         * @nullable
+         */
+      readonly cache_target_age: string | null;
+      /**
+         *
+          The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+          by querying the database.
+
+         * @nullable
+         */
+      readonly next_allowed_client_refresh: string | null;
+      readonly result: unknown;
+      /** @nullable */
+      readonly hasMore: boolean | null;
+      /** @nullable */
+      readonly columns: readonly string[] | null;
+      /** @nullable */
+      readonly created_at: string | null;
+      readonly created_by: UserBasic;
+      /**
+         * @maxLength 400
+         * @nullable
+         */
+      description?: string | null;
+      readonly updated_at: string;
+      tags?: unknown[];
+      favorited?: boolean;
+      readonly last_modified_at: string;
+      readonly last_modified_by: UserBasic;
+      readonly is_sample: boolean;
+      readonly effective_restriction_level: EffectivePrivilegeLevelEnum;
+      readonly effective_privilege_level: EffectivePrivilegeLevelEnum;
+      /**
+         * The effective access level the user has for this object
+         * @nullable
+         */
+      readonly user_access_level: string | null;
+      /**
+         * The timezone this chart is displayed in.
+         * @nullable
+         */
+      readonly timezone: string | null;
+      readonly is_cached: boolean;
+      readonly query_status: unknown;
+      /** @nullable */
+      readonly hogql: string | null;
+      /** @nullable */
+      readonly types: readonly unknown[] | null;
+      /** @nullable */
+      readonly resolved_date_range: InsightResolvedDateRange;
+      _create_in_folder?: string;
+      readonly alerts: readonly unknown[];
+      /** @nullable */
+      readonly last_viewed_at: string | null;
+    }
+
+    export interface Text {
+      readonly id: number;
+      readonly created_by: UserBasic;
+      readonly last_modified_by: UserBasic;
+      /**
+         * @maxLength 4000
+         * @nullable
+         */
+      body?: string | null;
+      readonly dashboard_tiles: readonly DashboardTileBasic[];
+      readonly last_modified_at: string;
+      team: number;
+    }
+
+    export interface DashboardTile {
+      id?: number;
+      insight: Insight;
+      text: Text;
+      button_tile: ButtonTile;
+      layouts?: unknown;
+      /**
+         * @maxLength 400
+         * @nullable
+         */
+      color?: string | null;
+      filters_overrides?: unknown;
+      /** @nullable */
+      show_description?: boolean | null;
+      /** @nullable */
+      transparent_background?: boolean | null;
+    }
+
+    /**
+     * InsightSerializer restricted to identifiers + result only.
+     */
+    export interface InsightResult {
+      readonly id: number;
+      readonly short_id: string;
+      /** @nullable */
+      readonly name: string | null;
+      /** @nullable */
+      readonly derived_name: string | null;
+      readonly result: unknown;
+    }
+
+    /**
+     * DashboardTileSerializer restricted to tile id + insight result fields.
+     */
+    export interface DashboardTileResult {
+      id?: number;
+      insight: InsightResult;
+    }
+
+    export interface DataColorTheme {
+      readonly id: number;
+      /** @maxLength 100 */
+      name: string;
+      colors?: unknown;
+      readonly is_global: boolean;
+      /** @nullable */
+      readonly created_at: string | null;
+      readonly created_by: UserBasic;
+    }
+
+    /**
+     * * `Cancelled` - Cancelled
+    * `Completed` - Completed
+    * `Failed` - Failed
+    * `Running` - Running
+     */
+    export type DataModelingJobStatusEnum = typeof DataModelingJobStatusEnum[keyof typeof DataModelingJobStatusEnum];
+
+
+    export const DataModelingJobStatusEnum = {
+      Cancelled: 'Cancelled',
+      Completed: 'Completed',
+      Failed: 'Failed',
+      Running: 'Running',
+    } as const;
+
+    export interface DataModelingJob {
+      readonly id: string;
+      /** @nullable */
+      readonly saved_query_id: string | null;
+      readonly status: DataModelingJobStatusEnum;
+      readonly rows_materialized: number;
+      /** @nullable */
+      readonly error: string | null;
+      readonly created_at: string;
+      readonly last_run_at: string;
+      /** @nullable */
+      readonly workflow_id: string | null;
+      /** @nullable */
+      readonly workflow_run_id: string | null;
+      /**
+         * Total rows expected to be materialized
+         * @nullable
+         */
+      readonly rows_expected: number | null;
     }
 
     export interface DataWarehouseModelPath {
@@ -18675,31 +18964,6 @@ export namespace Schemas {
       version?: number | null;
     }
 
-    export type HogQueryKind = typeof HogQueryKind[keyof typeof HogQueryKind];
-
-
-    export const HogQueryKind = {
-      HogQuery: 'HogQuery',
-    } as const;
-
-    export interface HogQueryResponse {
-      bytecode?: unknown[] | null;
-      coloredBytecode?: unknown[] | null;
-      results: unknown;
-      stdout?: string | null;
-    }
-
-    export interface HogQuery {
-      code?: string | null;
-      kind: HogQueryKind;
-      /** Modifiers used when performing the query */
-      modifiers?: HogQLQueryModifiers | null;
-      response?: HogQueryResponse | null;
-      tags?: QueryLogTags | null;
-      /** version of the node, used for schema migrations */
-      version?: number | null;
-    }
-
     export interface PageURL {
       url: string;
     }
@@ -19636,164 +19900,6 @@ export namespace Schemas {
       source: string;
       /** Optional tag whitelist. Leave empty to allow any tag returned by the Hog code. */
       tags?: TagDefinition[];
-    }
-
-    /**
-     * @nullable
-     */
-    export type InsightResolvedDateRange = {
-      readonly date_from?: string;
-      readonly date_to?: string;
-    } | null;
-
-    export type InsightVizNodeKind = typeof InsightVizNodeKind[keyof typeof InsightVizNodeKind];
-
-
-    export const InsightVizNodeKind = {
-      InsightVizNode: 'InsightVizNode',
-    } as const;
-
-    export interface Retention {
-      hideLineGraph?: boolean | null;
-      hideSizeColumn?: boolean | null;
-      useSmallLayout?: boolean | null;
-    }
-
-    export interface VizSpecificOptions {
-      ActionsPie?: ActionsPie | null;
-      RETENTION?: Retention | null;
-    }
-
-    export interface InsightVizNode {
-      /** Query is embedded inside another bordered component */
-      embedded?: boolean | null;
-      /** Show with most visual options enabled. Used in insight scene. */
-      full?: boolean | null;
-      hidePersonsModal?: boolean | null;
-      hideTooltipOnScroll?: boolean | null;
-      kind: InsightVizNodeKind;
-      showCorrelationTable?: boolean | null;
-      showFilters?: boolean | null;
-      showHeader?: boolean | null;
-      showLastComputation?: boolean | null;
-      showLastComputationRefresh?: boolean | null;
-      showResults?: boolean | null;
-      showTable?: boolean | null;
-      source: TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | WebStatsTableQuery | WebOverviewQuery;
-      suppressSessionAnalysisWarning?: boolean | null;
-      /** version of the node, used for schema migrations */
-      version?: number | null;
-      vizSpecificOptions?: VizSpecificOptions | null;
-    }
-
-    /**
-     * The query definition for this insight. The `kind` field determines the query type:
-    - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
-    - `DataVisualizationNode` — SQL insights using HogQL
-    - `DataTableNode` — raw data tables
-    - `HogQuery` — Hog language queries
-     */
-    export type _InsightQuerySchema = InsightVizNode | DataTableNode | DataVisualizationNode | HogQuery;
-
-    /**
-     * Simplified serializer to speed response times when loading large amounts of objects.
-     */
-    export interface Insight {
-      readonly id: number;
-      readonly short_id: string;
-      /**
-         * @maxLength 400
-         * @nullable
-         */
-      name?: string | null;
-      /**
-         * @maxLength 400
-         * @nullable
-         */
-      derived_name?: string | null;
-      query?: _InsightQuerySchema | null;
-      /**
-         * @minimum -2147483648
-         * @maximum 2147483647
-         * @nullable
-         */
-      order?: number | null;
-      deleted?: boolean;
-      /**
-              DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-              A dashboard ID for each of the dashboards that this insight is displayed on.
-               */
-      dashboards?: number[];
-      /**
-          A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-           */
-      readonly dashboard_tiles: readonly DashboardTileBasic[];
-      /**
-         *
-          The datetime this insight's results were generated.
-          If added to one or more dashboards the insight can be refreshed separately on each.
-          Returns the appropriate last_refresh datetime for the context the insight is viewed in
-          (see from_dashboard query parameter).
-
-         * @nullable
-         */
-      readonly last_refresh: string | null;
-      /**
-         * The target age of the cached results for this insight.
-         * @nullable
-         */
-      readonly cache_target_age: string | null;
-      /**
-         *
-          The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-          by querying the database.
-
-         * @nullable
-         */
-      readonly next_allowed_client_refresh: string | null;
-      readonly result: unknown;
-      /** @nullable */
-      readonly hasMore: boolean | null;
-      /** @nullable */
-      readonly columns: readonly string[] | null;
-      /** @nullable */
-      readonly created_at: string | null;
-      readonly created_by: UserBasic;
-      /**
-         * @maxLength 400
-         * @nullable
-         */
-      description?: string | null;
-      readonly updated_at: string;
-      tags?: unknown[];
-      favorited?: boolean;
-      readonly last_modified_at: string;
-      readonly last_modified_by: UserBasic;
-      readonly is_sample: boolean;
-      readonly effective_restriction_level: EffectivePrivilegeLevelEnum;
-      readonly effective_privilege_level: EffectivePrivilegeLevelEnum;
-      /**
-         * The effective access level the user has for this object
-         * @nullable
-         */
-      readonly user_access_level: string | null;
-      /**
-         * The timezone this chart is displayed in.
-         * @nullable
-         */
-      readonly timezone: string | null;
-      readonly is_cached: boolean;
-      readonly query_status: unknown;
-      /** @nullable */
-      readonly hogql: string | null;
-      /** @nullable */
-      readonly types: readonly unknown[] | null;
-      /** @nullable */
-      readonly resolved_date_range: InsightResolvedDateRange;
-      _create_in_folder?: string;
-      readonly alerts: readonly unknown[];
-      /** @nullable */
-      readonly last_viewed_at: string | null;
     }
 
     /**
@@ -37719,6 +37825,25 @@ export namespace Schemas {
       target_language?: string;
     }
 
+    export interface UpdateTextTileRequest {
+      /** ID of the dashboard tile to update. Use dashboard-get to look up tile IDs. */
+      tile_id: number;
+      /**
+         * New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.
+         * @minLength 1
+         * @maxLength 4000
+         */
+      body?: string;
+      /** New grid layout per breakpoint. Omit to leave the layout unchanged. */
+      layouts?: TileLayouts;
+      /**
+         * New accent color name, empty string or null to clear. Omit to leave unchanged.
+         * @maxLength 400
+         * @nullable
+         */
+      color?: string | null;
+    }
+
     /**
      * Optional structured plan of events the wizard intends to instrument. Schema is workflow-specific.
      * @nullable
@@ -38866,6 +38991,18 @@ export namespace Schemas {
       Txt: 'txt',
     } as const;
 
+    export type EnvironmentsDashboardsCreateTextTileCreateParams = {
+    format?: EnvironmentsDashboardsCreateTextTileCreateFormat;
+    };
+
+    export type EnvironmentsDashboardsCreateTextTileCreateFormat = typeof EnvironmentsDashboardsCreateTextTileCreateFormat[keyof typeof EnvironmentsDashboardsCreateTextTileCreateFormat];
+
+
+    export const EnvironmentsDashboardsCreateTextTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
     export type EnvironmentsDashboardsMoveTilePartialUpdateParams = {
     format?: EnvironmentsDashboardsMoveTilePartialUpdateFormat;
     };
@@ -38977,6 +39114,18 @@ export namespace Schemas {
     export const EnvironmentsDashboardsStreamTilesRetrieveLayoutSize = {
       Sm: 'sm',
       Xs: 'xs',
+    } as const;
+
+    export type EnvironmentsDashboardsUpdateTextTileCreateParams = {
+    format?: EnvironmentsDashboardsUpdateTextTileCreateFormat;
+    };
+
+    export type EnvironmentsDashboardsUpdateTextTileCreateFormat = typeof EnvironmentsDashboardsUpdateTextTileCreateFormat[keyof typeof EnvironmentsDashboardsUpdateTextTileCreateFormat];
+
+
+    export const EnvironmentsDashboardsUpdateTextTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
     } as const;
 
     export type EnvironmentsDashboardsBulkUpdateTagsCreateParams = {
@@ -43848,6 +43997,18 @@ export namespace Schemas {
       Txt: 'txt',
     } as const;
 
+    export type DashboardsCreateTextTileCreateParams = {
+    format?: DashboardsCreateTextTileCreateFormat;
+    };
+
+    export type DashboardsCreateTextTileCreateFormat = typeof DashboardsCreateTextTileCreateFormat[keyof typeof DashboardsCreateTextTileCreateFormat];
+
+
+    export const DashboardsCreateTextTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
     export type DashboardsMoveTilePartialUpdateParams = {
     format?: DashboardsMoveTilePartialUpdateFormat;
     };
@@ -43959,6 +44120,18 @@ export namespace Schemas {
     export const DashboardsStreamTilesRetrieveLayoutSize = {
       Sm: 'sm',
       Xs: 'xs',
+    } as const;
+
+    export type DashboardsUpdateTextTileCreateParams = {
+    format?: DashboardsUpdateTextTileCreateFormat;
+    };
+
+    export type DashboardsUpdateTextTileCreateFormat = typeof DashboardsUpdateTextTileCreateFormat[keyof typeof DashboardsUpdateTextTileCreateFormat];
+
+
+    export const DashboardsUpdateTextTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
     } as const;
 
     export type DashboardsBulkUpdateTagsCreateParams = {

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -186,6 +186,7 @@ export const dashboardsCreateTextTileCreateBodyColorMax = 400
 export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
     body: zod
         .string()
+        .min(1)
         .max(dashboardsCreateTextTileCreateBodyBodyMax)
         .describe(
             'Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.'
@@ -309,6 +310,7 @@ export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.obj
         .describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
     body: zod
         .string()
+        .min(1)
         .max(dashboardsUpdateTextTilePartialUpdateBodyBodyMax)
         .optional()
         .describe('New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.'),

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 7 enabled ops
+ * PostHog API - MCP 9 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -160,6 +160,62 @@ export const DashboardsDestroyQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
 })
 
+/**
+ * Add a markdown text tile to a dashboard.
+
+Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
+or annotations between insight tiles to give the dashboard structure.
+ */
+export const DashboardsCreateTextTileCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const DashboardsCreateTextTileCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const dashboardsCreateTextTileCreateBodyBodyMax = 4000
+
+export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
+    body: zod
+        .string()
+        .max(dashboardsCreateTextTileCreateBodyBodyMax)
+        .describe(
+            'Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.'
+        ),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+            xs: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+        })
+        .optional()
+        .describe(
+            'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
+        ),
+    color: zod.string().nullish().describe("Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."),
+})
+
 export const DashboardsReorderTilesCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this dashboard.'),
     project_id: zod
@@ -218,4 +274,58 @@ export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.obje
         .describe(
             'Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
         ),
+})
+
+/**
+ * Update the markdown body, layout, or color of an existing text tile on a dashboard.
+ */
+export const DashboardsUpdateTextTilePartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const DashboardsUpdateTextTilePartialUpdateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const dashboardsUpdateTextTilePartialUpdateBodyBodyMax = 4000
+
+export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.object({
+    tile_id: zod
+        .number()
+        .optional()
+        .describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
+    body: zod
+        .string()
+        .max(dashboardsUpdateTextTilePartialUpdateBodyBodyMax)
+        .nullish()
+        .describe('New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+            xs: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+        })
+        .optional()
+        .describe('New grid layout per breakpoint. Omit to leave the layout unchanged.'),
+    color: zod.string().nullish().describe('New accent color name, or null to clear. Omit to leave unchanged.'),
 })

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -181,6 +181,8 @@ export const DashboardsCreateTextTileCreateQueryParams = /* @__PURE__ */ zod.obj
 
 export const dashboardsCreateTextTileCreateBodyBodyMax = 4000
 
+export const dashboardsCreateTextTileCreateBodyColorMax = 400
+
 export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
     body: zod
         .string()
@@ -213,7 +215,11 @@ export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
         ),
-    color: zod.string().nullish().describe("Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."),
+    color: zod
+        .string()
+        .max(dashboardsCreateTextTileCreateBodyColorMax)
+        .nullish()
+        .describe("Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."),
 })
 
 export const DashboardsReorderTilesCreateParams = /* @__PURE__ */ zod.object({
@@ -294,6 +300,8 @@ export const DashboardsUpdateTextTilePartialUpdateQueryParams = /* @__PURE__ */ 
 
 export const dashboardsUpdateTextTilePartialUpdateBodyBodyMax = 4000
 
+export const dashboardsUpdateTextTilePartialUpdateBodyColorMax = 400
+
 export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.object({
     tile_id: zod
         .number()
@@ -302,7 +310,7 @@ export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.obj
     body: zod
         .string()
         .max(dashboardsUpdateTextTilePartialUpdateBodyBodyMax)
-        .nullish()
+        .optional()
         .describe('New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.'),
     layouts: zod
         .object({
@@ -327,5 +335,9 @@ export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.obj
         })
         .optional()
         .describe('New grid layout per breakpoint. Omit to leave the layout unchanged.'),
-    color: zod.string().nullish().describe('New accent color name, or null to clear. Omit to leave unchanged.'),
+    color: zod
+        .string()
+        .max(dashboardsUpdateTextTilePartialUpdateBodyColorMax)
+        .nullish()
+        .describe('New accent color name, empty string or null to clear. Omit to leave unchanged.'),
 })

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -286,7 +286,7 @@ export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.obje
 /**
  * Update the markdown body, layout, or color of an existing text tile on a dashboard.
  */
-export const DashboardsUpdateTextTilePartialUpdateParams = /* @__PURE__ */ zod.object({
+export const DashboardsUpdateTextTileCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this dashboard.'),
     project_id: zod
         .string()
@@ -295,23 +295,20 @@ export const DashboardsUpdateTextTilePartialUpdateParams = /* @__PURE__ */ zod.o
         ),
 })
 
-export const DashboardsUpdateTextTilePartialUpdateQueryParams = /* @__PURE__ */ zod.object({
+export const DashboardsUpdateTextTileCreateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
 })
 
-export const dashboardsUpdateTextTilePartialUpdateBodyBodyMax = 4000
+export const dashboardsUpdateTextTileCreateBodyBodyMax = 4000
 
-export const dashboardsUpdateTextTilePartialUpdateBodyColorMax = 400
+export const dashboardsUpdateTextTileCreateBodyColorMax = 400
 
-export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.object({
-    tile_id: zod
-        .number()
-        .optional()
-        .describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
+export const DashboardsUpdateTextTileCreateBody = /* @__PURE__ */ zod.object({
+    tile_id: zod.number().describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
     body: zod
         .string()
         .min(1)
-        .max(dashboardsUpdateTextTilePartialUpdateBodyBodyMax)
+        .max(dashboardsUpdateTextTileCreateBodyBodyMax)
         .optional()
         .describe('New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.'),
     layouts: zod
@@ -339,7 +336,7 @@ export const DashboardsUpdateTextTilePartialUpdateBody = /* @__PURE__ */ zod.obj
         .describe('New grid layout per breakpoint. Omit to leave the layout unchanged.'),
     color: zod
         .string()
-        .max(dashboardsUpdateTextTilePartialUpdateBodyColorMax)
+        .max(dashboardsUpdateTextTileCreateBodyColorMax)
         .nullish()
         .describe('New accent color name, empty string or null to clear. Omit to leave unchanged.'),
 })

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -4,6 +4,8 @@ import { z } from 'zod'
 import type { Schemas } from '@/api/generated'
 import {
     DashboardsCreateBody,
+    DashboardsCreateTextTileCreateBody,
+    DashboardsCreateTextTileCreateParams,
     DashboardsDestroyParams,
     DashboardsListQueryParams,
     DashboardsPartialUpdateBody,
@@ -14,6 +16,8 @@ import {
     DashboardsRetrieveQueryParams,
     DashboardsRunInsightsRetrieveParams,
     DashboardsRunInsightsRetrieveQueryParams,
+    DashboardsUpdateTextTilePartialUpdateBody,
+    DashboardsUpdateTextTilePartialUpdateParams,
 } from '@/generated/dashboards/api'
 import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
@@ -238,6 +242,37 @@ const dashboardInsightsRun = (): ToolBase<
     },
 })
 
+const DashboardCreateTextTileSchema = DashboardsCreateTextTileCreateParams.omit({ project_id: true })
+    .extend(DashboardsCreateTextTileCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsCreateTextTileCreateParams.shape['id']) })
+
+const dashboardCreateTextTile = (): ToolBase<
+    typeof DashboardCreateTextTileSchema,
+    WithPostHogUrl<Schemas.DashboardTile>
+> => ({
+    name: 'dashboard-create-text-tile',
+    schema: DashboardCreateTextTileSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardCreateTextTileSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.body !== undefined) {
+            body['body'] = params.body
+        }
+        if (params.layouts !== undefined) {
+            body['layouts'] = params.layouts
+        }
+        if (params.color !== undefined) {
+            body['color'] = params.color
+        }
+        const result = await context.api.request<Schemas.DashboardTile>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/create_text_tile/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
+    },
+})
+
 const DashboardReorderTilesSchema = DashboardsReorderTilesCreateParams.omit({ project_id: true }).extend(
     DashboardsReorderTilesCreateBody.shape
 )
@@ -254,6 +289,40 @@ const dashboardReorderTiles = (): ToolBase<typeof DashboardReorderTilesSchema, W
         const result = await context.api.request<Schemas.Dashboard>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/reorder_tiles/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
+    },
+})
+
+const DashboardUpdateTextTileSchema = DashboardsUpdateTextTilePartialUpdateParams.omit({ project_id: true })
+    .extend(DashboardsUpdateTextTilePartialUpdateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsUpdateTextTilePartialUpdateParams.shape['id']) })
+
+const dashboardUpdateTextTile = (): ToolBase<
+    typeof DashboardUpdateTextTileSchema,
+    WithPostHogUrl<Schemas.DashboardTile>
+> => ({
+    name: 'dashboard-update-text-tile',
+    schema: DashboardUpdateTextTileSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardUpdateTextTileSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.tile_id !== undefined) {
+            body['tile_id'] = params.tile_id
+        }
+        if (params.body !== undefined) {
+            body['body'] = params.body
+        }
+        if (params.layouts !== undefined) {
+            body['layouts'] = params.layouts
+        }
+        if (params.color !== undefined) {
+            body['color'] = params.color
+        }
+        const result = await context.api.request<Schemas.DashboardTile>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/update_text_tile/`,
             body,
         })
         return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
@@ -389,7 +458,9 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-delete': dashboardDelete,
     'dashboard-get': dashboardGet,
     'dashboard-insights-run': dashboardInsightsRun,
+    'dashboard-create-text-tile': dashboardCreateTextTile,
     'dashboard-reorder-tiles': dashboardReorderTiles,
+    'dashboard-update-text-tile': dashboardUpdateTextTile,
     'dashboard-update': dashboardUpdate,
     'dashboards-get-all': dashboardsGetAll,
 }

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -16,8 +16,8 @@ import {
     DashboardsRetrieveQueryParams,
     DashboardsRunInsightsRetrieveParams,
     DashboardsRunInsightsRetrieveQueryParams,
-    DashboardsUpdateTextTilePartialUpdateBody,
-    DashboardsUpdateTextTilePartialUpdateParams,
+    DashboardsUpdateTextTileCreateBody,
+    DashboardsUpdateTextTileCreateParams,
 } from '@/generated/dashboards/api'
 import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
@@ -384,9 +384,9 @@ const dashboardUpdate = (): ToolBase<typeof DashboardUpdateSchema, WithPostHogUr
     },
 })
 
-const DashboardUpdateTextTileSchema = DashboardsUpdateTextTilePartialUpdateParams.omit({ project_id: true })
-    .extend(DashboardsUpdateTextTilePartialUpdateBody.shape)
-    .extend({ id: z.preprocess(castStringToInt, DashboardsUpdateTextTilePartialUpdateParams.shape['id']) })
+const DashboardUpdateTextTileSchema = DashboardsUpdateTextTileCreateParams.omit({ project_id: true })
+    .extend(DashboardsUpdateTextTileCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsUpdateTextTileCreateParams.shape['id']) })
 
 const dashboardUpdateTextTile = (): ToolBase<
     typeof DashboardUpdateTextTileSchema,
@@ -410,7 +410,7 @@ const dashboardUpdateTextTile = (): ToolBase<
             body['color'] = params.color
         }
         const result = await context.api.request<Schemas.DashboardTile>({
-            method: 'PATCH',
+            method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/update_text_tile/`,
             body,
         })

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -112,6 +112,37 @@ const dashboardCreate = (): ToolBase<typeof DashboardCreateSchema, WithPostHogUr
     },
 })
 
+const DashboardCreateTextTileSchema = DashboardsCreateTextTileCreateParams.omit({ project_id: true })
+    .extend(DashboardsCreateTextTileCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsCreateTextTileCreateParams.shape['id']) })
+
+const dashboardCreateTextTile = (): ToolBase<
+    typeof DashboardCreateTextTileSchema,
+    WithPostHogUrl<Schemas.DashboardTile>
+> => ({
+    name: 'dashboard-create-text-tile',
+    schema: DashboardCreateTextTileSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardCreateTextTileSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.body !== undefined) {
+            body['body'] = params.body
+        }
+        if (params.layouts !== undefined) {
+            body['layouts'] = params.layouts
+        }
+        if (params.color !== undefined) {
+            body['color'] = params.color
+        }
+        const result = await context.api.request<Schemas.DashboardTile>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/create_text_tile/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
+    },
+})
+
 const DashboardDeleteSchema = DashboardsDestroyParams.omit({ project_id: true }).extend({
     id: z.preprocess(castStringToInt, DashboardsDestroyParams.shape['id']),
 })
@@ -242,37 +273,6 @@ const dashboardInsightsRun = (): ToolBase<
     },
 })
 
-const DashboardCreateTextTileSchema = DashboardsCreateTextTileCreateParams.omit({ project_id: true })
-    .extend(DashboardsCreateTextTileCreateBody.shape)
-    .extend({ id: z.preprocess(castStringToInt, DashboardsCreateTextTileCreateParams.shape['id']) })
-
-const dashboardCreateTextTile = (): ToolBase<
-    typeof DashboardCreateTextTileSchema,
-    WithPostHogUrl<Schemas.DashboardTile>
-> => ({
-    name: 'dashboard-create-text-tile',
-    schema: DashboardCreateTextTileSchema,
-    handler: async (context: Context, params: z.infer<typeof DashboardCreateTextTileSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.body !== undefined) {
-            body['body'] = params.body
-        }
-        if (params.layouts !== undefined) {
-            body['layouts'] = params.layouts
-        }
-        if (params.color !== undefined) {
-            body['color'] = params.color
-        }
-        const result = await context.api.request<Schemas.DashboardTile>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/create_text_tile/`,
-            body,
-        })
-        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
-    },
-})
-
 const DashboardReorderTilesSchema = DashboardsReorderTilesCreateParams.omit({ project_id: true }).extend(
     DashboardsReorderTilesCreateBody.shape
 )
@@ -289,40 +289,6 @@ const dashboardReorderTiles = (): ToolBase<typeof DashboardReorderTilesSchema, W
         const result = await context.api.request<Schemas.Dashboard>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/reorder_tiles/`,
-            body,
-        })
-        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
-    },
-})
-
-const DashboardUpdateTextTileSchema = DashboardsUpdateTextTilePartialUpdateParams.omit({ project_id: true })
-    .extend(DashboardsUpdateTextTilePartialUpdateBody.shape)
-    .extend({ id: z.preprocess(castStringToInt, DashboardsUpdateTextTilePartialUpdateParams.shape['id']) })
-
-const dashboardUpdateTextTile = (): ToolBase<
-    typeof DashboardUpdateTextTileSchema,
-    WithPostHogUrl<Schemas.DashboardTile>
-> => ({
-    name: 'dashboard-update-text-tile',
-    schema: DashboardUpdateTextTileSchema,
-    handler: async (context: Context, params: z.infer<typeof DashboardUpdateTextTileSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.tile_id !== undefined) {
-            body['tile_id'] = params.tile_id
-        }
-        if (params.body !== undefined) {
-            body['body'] = params.body
-        }
-        if (params.layouts !== undefined) {
-            body['layouts'] = params.layouts
-        }
-        if (params.color !== undefined) {
-            body['color'] = params.color
-        }
-        const result = await context.api.request<Schemas.DashboardTile>({
-            method: 'PATCH',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/update_text_tile/`,
             body,
         })
         return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
@@ -418,6 +384,40 @@ const dashboardUpdate = (): ToolBase<typeof DashboardUpdateSchema, WithPostHogUr
     },
 })
 
+const DashboardUpdateTextTileSchema = DashboardsUpdateTextTilePartialUpdateParams.omit({ project_id: true })
+    .extend(DashboardsUpdateTextTilePartialUpdateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsUpdateTextTilePartialUpdateParams.shape['id']) })
+
+const dashboardUpdateTextTile = (): ToolBase<
+    typeof DashboardUpdateTextTileSchema,
+    WithPostHogUrl<Schemas.DashboardTile>
+> => ({
+    name: 'dashboard-update-text-tile',
+    schema: DashboardUpdateTextTileSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardUpdateTextTileSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.tile_id !== undefined) {
+            body['tile_id'] = params.tile_id
+        }
+        if (params.body !== undefined) {
+            body['body'] = params.body
+        }
+        if (params.layouts !== undefined) {
+            body['layouts'] = params.layouts
+        }
+        if (params.color !== undefined) {
+            body['color'] = params.color
+        }
+        const result = await context.api.request<Schemas.DashboardTile>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/update_text_tile/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
+    },
+})
+
 const DashboardsGetAllSchema = DashboardsListQueryParams.omit({ format: true }).extend({
     limit: z.preprocess(castStringToInt, DashboardsListQueryParams.shape['limit']).optional(),
     offset: z.preprocess(castStringToInt, DashboardsListQueryParams.shape['offset']).optional(),
@@ -455,12 +455,12 @@ const dashboardsGetAll = (): ToolBase<
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-create': dashboardCreate,
+    'dashboard-create-text-tile': dashboardCreateTextTile,
     'dashboard-delete': dashboardDelete,
     'dashboard-get': dashboardGet,
     'dashboard-insights-run': dashboardInsightsRun,
-    'dashboard-create-text-tile': dashboardCreateTextTile,
     'dashboard-reorder-tiles': dashboardReorderTiles,
-    'dashboard-update-text-tile': dashboardUpdateTextTile,
     'dashboard-update': dashboardUpdate,
+    'dashboard-update-text-tile': dashboardUpdateTextTile,
     'dashboards-get-all': dashboardsGetAll,
 }

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -139,7 +139,7 @@ const dashboardCreateTextTile = (): ToolBase<
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/create_text_tile/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
+        return await withPostHogUrl(context, result, `/dashboard/${params.id}`)
     },
 })
 
@@ -414,7 +414,7 @@ const dashboardUpdateTextTile = (): ToolBase<
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/update_text_tile/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
+        return await withPostHogUrl(context, result, `/dashboard/${params.id}`)
     },
 })
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-create-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-create-text-tile.json
@@ -4,6 +4,7 @@
         "body": {
             "description": "Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.",
             "maxLength": 4000,
+            "minLength": 1,
             "type": "string"
         },
         "color": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-create-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-create-text-tile.json
@@ -9,6 +9,7 @@
         "color": {
             "anyOf": [
                 {
+                    "maxLength": 400,
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-create-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-create-text-tile.json
@@ -1,0 +1,77 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "body": {
+            "description": "Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.",
+            "maxLength": 4000,
+            "type": "string"
+        },
+        "color": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."
+        },
+        "id": {
+            "description": "A unique integer value identifying this dashboard.",
+            "type": "number"
+        },
+        "layouts": {
+            "description": "Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).",
+            "properties": {
+                "sm": {
+                    "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                "xs": {
+                    "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": ["id", "body"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-update-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-update-text-tile.json
@@ -4,6 +4,7 @@
         "body": {
             "description": "New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.",
             "maxLength": 4000,
+            "minLength": 1,
             "type": "string"
         },
         "color": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-update-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-update-text-tile.json
@@ -78,6 +78,6 @@
             "type": "number"
         }
     },
-    "required": ["id"],
+    "required": ["id", "tile_id"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-update-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-update-text-tile.json
@@ -2,27 +2,21 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "body": {
-            "anyOf": [
-                {
-                    "maxLength": 4000,
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "description": "New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters."
+            "description": "New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.",
+            "maxLength": 4000,
+            "type": "string"
         },
         "color": {
             "anyOf": [
                 {
+                    "maxLength": 400,
                     "type": "string"
                 },
                 {
                     "type": "null"
                 }
             ],
-            "description": "New accent color name, or null to clear. Omit to leave unchanged."
+            "description": "New accent color name, empty string or null to clear. Omit to leave unchanged."
         },
         "id": {
             "description": "A unique integer value identifying this dashboard.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-update-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-update-text-tile.json
@@ -1,0 +1,88 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "body": {
+            "anyOf": [
+                {
+                    "maxLength": 4000,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters."
+        },
+        "color": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "New accent color name, or null to clear. Omit to leave unchanged."
+        },
+        "id": {
+            "description": "A unique integer value identifying this dashboard.",
+            "type": "number"
+        },
+        "layouts": {
+            "description": "New grid layout per breakpoint. Omit to leave the layout unchanged.",
+            "properties": {
+                "sm": {
+                    "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                "xs": {
+                    "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "tile_id": {
+            "description": "ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.",
+            "type": "number"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

PostHog dashboards support text tiles (markdown blocks used as section headings, dividers, and annotations) but the MCP surface only exposed insight-tile workflows. Agents had no way to add structure to a dashboard they were building.

Today, the only path to create or update a text tile via the API is a deeply nested `PATCH /dashboards/:id/` payload with a `tiles: [{ text: { body: ... }, ... }]` array. That shape is awkward to expose to an LLM through `dashboard-update`, both because the schema is complex and because the same tool then has to multiplex tile mutations against dashboard-level edits.

Refs #58307

## Changes

Adds two dedicated viewset actions on `DashboardsViewSet` and matching MCP tool entries:

- `POST /dashboards/:id/create_text_tile/` → `dashboard-create-text-tile`
  Body: `{ body: string, layouts?: { sm?, xs? }, color? }`. Creates a `Text` row and a `DashboardTile` referencing it, scoped to the dashboard's team. Returns a `DashboardTileSerializer` (tile-scoped, not the whole dashboard).
- `PATCH /dashboards/:id/update_text_tile/` → `dashboard-update-text-tile`
  Body: `{ tile_id: int, body?, layouts?, color? }`. Updates only the fields that are passed (omitted fields are preserved), and bumps `last_modified_by`/`last_modified_at`. Refuses non-text tiles with a 400.

Both actions are guarded by `dashboard:write` scope, check `can_edit` on the dashboard, return 404 for deleted dashboards, and run the text + tile writes inside a single transaction. Returning a single tile (rather than the whole dashboard) keeps the LLM context footprint small.

The new request serializers are typed end-to-end — `TileLayoutBoxSerializer` and `TileLayoutsSerializer` give the generated OpenAPI / Zod / MCP schemas a typed `layouts` shape instead of a `JSONField`.

Deletion is intentionally **not** a new tool: `dashboard-update` already handles `{ tiles: [{ id, deleted: true }] }`, so a separate tool would be redundant surface area.

## How did you test this code?

I'm an agent (Claude Code via the PostHog Code agent). I ran:

- `ruff check` and `ruff format` on the changed Python files — clean
- YAML parse check on `products/dashboards/mcp/tools.yaml` — valid, both new tool entries resolve to the expected operation IDs (`dashboards_create_text_tile_create`, `dashboards_update_text_tile_partial_update`)

Added new unit tests under `posthog/api/test/dashboards/test_dashboard.py`:

- `test_create_text_tile_adds_markdown_tile_to_dashboard`
- `test_create_text_tile_without_layouts_uses_default`
- `test_create_text_tile_rejects_empty_body`
- `test_create_text_tile_rejects_body_over_4000_chars`
- `test_create_text_tile_on_deleted_dashboard_returns_404`
- `test_update_text_tile_updates_body_and_layout`
- `test_update_text_tile_leaves_omitted_fields_unchanged`
- `test_update_text_tile_rejects_insight_tile`
- `test_update_text_tile_with_unknown_id_returns_404`
- `test_update_text_tile_on_other_dashboard_returns_404`

I did **not** run the Django/pytest suite locally (the cloud agent environment didn't have a working Python venv pinned to 3.12.12); CI will run the full backend suite plus `build:openapi` to verify the generated MCP/Zod schemas.

## Publish to changelog?

Yes — agents can now structure dashboards they create with markdown section tiles via the MCP.

## Docs update

No new user-facing docs needed; the MCP tool descriptions are self-documenting and inherited by the generated tool list.

## 🤖 Agent context

Authored by Claude (PostHog Code agent).

Design decisions:

- **Dedicated viewset actions over `dashboard-update` param overrides.** The existing `dashboards_partial_update` path supports text-tile mutations, but exposing the nested `tiles[].text.body` shape to an LLM via `param_overrides` would have required hand-writing a Zod schema. Two small, single-purpose endpoints match the existing tile-action precedent (`copy_tile`, `move_tile`, `reorder_tiles`) and yield clean, atomic MCP tools.
- **Return a single tile, not the whole dashboard.** Existing tile actions (`copy_tile`, `reorder_tiles`) return the entire `DashboardSerializer`. For text-tile changes that's overkill — returning `DashboardTileSerializer` keeps the response small for the LLM and the human alike.
- **Typed `layouts` serializer.** `JSONField` would have produced `Record<string, unknown>` in the generated types. The typed `TileLayoutBoxSerializer` / `TileLayoutsSerializer` give callers a real schema with field-level `help_text`.
- **No new delete tool.** Soft-delete already works through `dashboard-update` with `{tiles: [{id, deleted: true}]}`.
- **`update_text_tile` rejects insight tiles** with a 400 rather than silently doing nothing, since a wrong `tile_id` is far more likely an agent mistake worth surfacing than a desired no-op.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*