### PR TITLE
feat(customer-analytics): account notebooks

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3975,13 +3975,13 @@ snapshots:
     scenes-app-batchexports--runs-with-data--light:
         hash: v1.k794b7964.f4a8d5cc4f5447f093d5ddbbcd8572e13f7297a7db8a89504f9290226e60a2bc._CkUe6i49hMMGaDUNDHeNZDgaVp5DJQCay44V8WqfR4
     scenes-app-customer-analytics-accounts--default--dark:
-        hash: v1.k794b7964.fd9405867e8535a41514151b501adebee6e68e397c6639b8659b16e5321a4eb1.OhMniev44ZDEnT5QywBOE08-CGReq52bQG-8OeOweLQ
+        hash: v1.k794b7964.b64ab80fac4a73cee1ff6a383ad9f40961b061f38c606014b38c683ce6f399fb.BGLWJjIrm8jKJ0cgbg0N8-tr7KL675JJqN_9SkLCgmA
     scenes-app-customer-analytics-accounts--default--light:
-        hash: v1.k794b7964.4ef351ff95ff81eb5fd835e24660aef0ddf95264339a4b3a98794daf14a846f4.JwzzYwyVeNkrpI_vncMRDJeTrqkOts_oIX4eTKCBALc
+        hash: v1.k794b7964.21d11055ac489c5d965e0d3256ce0986ca896c1fc92ecb21c47a22bca77c929b.bVU8oCCiqYQT14HPANB_-ghcaWBP16m1TJF4N2H5drs
     scenes-app-customer-analytics-accounts--empty--dark:
-        hash: v1.k794b7964.0955aeed4cb1f5a282fca7174abd372c33241408d833fe3f151785980e75ebea.PSbb0da1CRNWCZR8qZnoY6DELEAs6LAuH9xDObSCtp0
+        hash: v1.k794b7964.1db26d99c1ac9c7ea882bae7d36a3d4fcc234e21d8cd28cc1ededb941a687cdf.OcbjFe5xD5bLFViFj0meBcCEoxa2bhK9VzJRPF0dQHo
     scenes-app-customer-analytics-accounts--empty--light:
-        hash: v1.k794b7964.bbe7c2ee845832842f8ea2092505b75ef75ab3efc51c7697f90ba7c25025d65a.Ttybs24_wfKgqh879lBbYHH-WqV9XgZJtSEJbc6csh0
+        hash: v1.k794b7964.924b1f7107778ab02e2986a600cb325ffd6c3d7a1f1828cd2dcd4b5cc51e5b91.GGu3igWGbRQbv3o129YtgLqk_EcmpDePG3KDI4UhklE
     scenes-app-customer-analytics-accounts--feature-gate-off--dark:
         hash: v1.k794b7964.7750bce37ad591ab773135ad1a9b8738ac790727774c03d3aa7b5abbfc42fab0.KbXf74dR5pSVh6Wc8mSjrNGqL8LbTcsMl78W7WVvTXU
     scenes-app-customer-analytics-accounts--feature-gate-off--light:

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -438,11 +438,18 @@ environments_router.register(
     ["team_id"],
 )
 
-environments_router.register(
+environment_accounts_router = environments_router.register(
     r"accounts",
     customer_analytics.AccountViewSet,
     "environment_accounts",
     ["team_id"],
+)
+
+environment_accounts_router.register(
+    r"notebooks",
+    customer_analytics.AccountNotebookViewSet,
+    "environment_account_notebooks",
+    ["team_id", "account_id"],
 )
 
 projects_router.register(

--- a/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
+++ b/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
@@ -943,7 +943,8 @@
   '''
   SELECT "posthog_resourcenotebook"."id",
          "posthog_resourcenotebook"."notebook_id",
-         "posthog_resourcenotebook"."group_id"
+         "posthog_resourcenotebook"."group_id",
+         "posthog_resourcenotebook"."account_id"
   FROM "posthog_resourcenotebook"
   WHERE "posthog_resourcenotebook"."notebook_id" = '00000000000000000000000000000000'::uuid
   '''
@@ -952,7 +953,8 @@
   '''
   SELECT "posthog_resourcenotebook"."id",
          "posthog_resourcenotebook"."notebook_id",
-         "posthog_resourcenotebook"."group_id"
+         "posthog_resourcenotebook"."group_id",
+         "posthog_resourcenotebook"."account_id"
   FROM "posthog_resourcenotebook"
   WHERE "posthog_resourcenotebook"."notebook_id" = '00000000000000000000000000000000'::uuid
   '''

--- a/products/customer_analytics/backend/api/serializers.py
+++ b/products/customer_analytics/backend/api/serializers.py
@@ -8,6 +8,7 @@ from posthog.api.tagged_item import TaggedItemSerializerMixin
 
 from products.customer_analytics.backend.models import Account, CustomerJourney, CustomerProfileConfig
 from products.customer_analytics.backend.models.account import AccountProperties
+from products.notebooks.backend.models import ResourceNotebook
 
 _ACCOUNT_ASSIGNMENT_SCHEMA = {
     "type": "object",
@@ -150,6 +151,12 @@ class AccountSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
         required=False,
         help_text="Tag names attached to the account. Pass a list to replace existing tags.",
     )
+    notebooks = serializers.SerializerMethodField(
+        help_text=(
+            "Short IDs of the internal notebooks linked to this account, used to persist investigations, "
+            "call notes, and other free-form context. Empty list if no notebooks have been created for the account."
+        )
+    )
 
     class Meta:
         model = Account
@@ -159,16 +166,26 @@ class AccountSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
             "external_id",
             "properties",
             "tags",
+            "notebooks",
             "created_at",
             "created_by",
             "updated_at",
         ]
         read_only_fields = [
             "id",
+            "notebooks",
             "created_at",
             "created_by",
             "updated_at",
         ]
+
+    @extend_schema_field({"type": "array", "items": {"type": "string"}})
+    def get_notebooks(self, obj: Account) -> list[str]:
+        return list(
+            ResourceNotebook.objects.filter(account=obj)
+            .select_related("notebook")
+            .values_list("notebook__short_id", flat=True)
+        )
 
     def validate_properties(self, value):
         if value is None:

--- a/products/customer_analytics/backend/api/serializers.py
+++ b/products/customer_analytics/backend/api/serializers.py
@@ -9,7 +9,7 @@ from posthog.api.tagged_item import TaggedItemSerializerMixin
 
 from products.customer_analytics.backend.models import Account, CustomerJourney, CustomerProfileConfig
 from products.customer_analytics.backend.models.account import AccountProperties
-from products.notebooks.backend.models import Notebook, ResourceNotebook
+from products.notebooks.backend.models import Notebook
 
 _ACCOUNT_ASSIGNMENT_SCHEMA = {
     "type": "object",
@@ -182,11 +182,7 @@ class AccountSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
 
     @extend_schema_field({"type": "array", "items": {"type": "string"}})
     def get_notebooks(self, obj: Account) -> list[str]:
-        return list(
-            ResourceNotebook.objects.filter(account=obj)
-            .select_related("notebook")
-            .values_list("notebook__short_id", flat=True)
-        )
+        return [link.notebook.short_id for link in obj.notebooks.all()]
 
     def validate_properties(self, value):
         if value is None:

--- a/products/customer_analytics/backend/api/serializers.py
+++ b/products/customer_analytics/backend/api/serializers.py
@@ -4,11 +4,12 @@ from drf_spectacular.utils import extend_schema_field
 from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers
 
+from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin
 
 from products.customer_analytics.backend.models import Account, CustomerJourney, CustomerProfileConfig
 from products.customer_analytics.backend.models.account import AccountProperties
-from products.notebooks.backend.models import ResourceNotebook
+from products.notebooks.backend.models import Notebook, ResourceNotebook
 
 _ACCOUNT_ASSIGNMENT_SCHEMA = {
     "type": "object",
@@ -225,3 +226,48 @@ def _format_pydantic_errors(exc: PydanticValidationError) -> list[str]:
         loc = ".".join(str(part) for part in err["loc"])
         messages.append(f"{loc}: {err['msg']}" if loc else err["msg"])
     return messages
+
+
+class AccountNotebookSerializer(serializers.ModelSerializer):
+    created_by = UserBasicSerializer(read_only=True)
+    last_modified_by = UserBasicSerializer(read_only=True)
+    title = serializers.CharField(
+        max_length=256,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Human-readable title of the account notebook.",
+    )
+    content = serializers.JSONField(
+        required=False,
+        allow_null=True,
+        help_text="Notebook content as a ProseMirror JSON document structure.",
+    )
+    text_content = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Plain text representation of the notebook content for search.",
+    )
+
+    class Meta:
+        model = Notebook
+        fields = [
+            "id",
+            "short_id",
+            "title",
+            "content",
+            "text_content",
+            "created_at",
+            "created_by",
+            "last_modified_at",
+            "last_modified_by",
+        ]
+        read_only_fields = [
+            "id",
+            "short_id",
+            "created_at",
+            "created_by",
+            "last_modified_at",
+            "last_modified_by",
+        ]

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -773,10 +773,10 @@ class TestAccountViewSet(APIBaseTest):
             account.tagged_items.create(tag=billing_tag)
             account.tagged_items.create(tag=urgent_tag)
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             # Query budget for a tag-filtered account list. Constant regardless of result count
-            # because tagged_items is prefetched once. If a query is added, please confirm it
-            # does not scale with the number of accounts before raising the limit:
+            # because tagged_items and notebooks are prefetched once. If a query is added, please
+            # confirm it does not scale with the number of accounts before raising the limit:
             # 1: load Django session
             # 2: load authenticated user
             # 3: load user's current organization
@@ -787,7 +787,8 @@ class TestAccountViewSet(APIBaseTest):
             # 8: load constance instance setting (rate limit config)
             # 9: COUNT(*) for pagination
             # 10: SELECT page of accounts filtered by tag name
-            # 11: prefetch tagged_items + tag for the page (the prefetch that prevents N+1)
+            # 11: prefetch resourcenotebook (joined with notebook) for the page
+            # 12: prefetch tagged_items + tag for the page (the prefetch that prevents N+1)
             response = self.client.get(f'{self.endpoint_base}?tags=["billing","urgent"]')
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -975,6 +975,144 @@ class TestAccountViewSet(APIBaseTest):
         self.assertEqual(result["notebooks"], [notebook.short_id])
 
 
+class TestAccountNotebookViewSet(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.account = Account.objects.unscoped().create(team=self.team, name="Acme Corp")
+        self.endpoint_base = f"/api/environments/{self.team.id}/accounts/{self.account.id}/notebooks/"
+
+    def test_create_account_notebook_uses_internal_visibility(self):
+        from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+        response = self.client.post(
+            self.endpoint_base,
+            {"title": "Q3 call", "content": {"type": "doc", "content": []}},
+            format="json",
+        )
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
+        data = response.json()
+        self.assertIn("short_id", data)
+        self.assertEqual(data["title"], "Q3 call")
+
+        # nosemgrep: idor-lookup-without-team (test assertion)
+        notebook = Notebook.objects.get(short_id=data["short_id"])
+        self.assertEqual(notebook.team, self.team)
+        self.assertEqual(notebook.visibility, Notebook.Visibility.INTERNAL)
+        self.assertEqual(notebook.created_by, self.user)
+
+        self.assertTrue(
+            ResourceNotebook.objects.filter(notebook=notebook, account=self.account).exists(),
+        )
+
+    def test_list_returns_only_notebooks_for_account(self):
+        from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+        account_notebook = Notebook.objects.create(
+            team=self.team, title="Account note", content={}, visibility=Notebook.Visibility.INTERNAL
+        )
+        ResourceNotebook.objects.create(notebook=account_notebook, account=self.account)
+
+        other_account = Account.objects.unscoped().create(team=self.team, name="Other")
+        other_notebook = Notebook.objects.create(
+            team=self.team, title="Other note", content={}, visibility=Notebook.Visibility.INTERNAL
+        )
+        ResourceNotebook.objects.create(notebook=other_notebook, account=other_account)
+
+        Notebook.objects.create(team=self.team, title="Standalone", content={}, visibility=Notebook.Visibility.DEFAULT)
+
+        response = self.client.get(self.endpoint_base)
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        short_ids = [n["short_id"] for n in response.json()["results"]]
+        self.assertEqual(short_ids, [account_notebook.short_id])
+
+    def test_retrieve_returns_notebook_for_account(self):
+        from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+        notebook = Notebook.objects.create(
+            team=self.team, title="Note", content={"foo": "bar"}, visibility=Notebook.Visibility.INTERNAL
+        )
+        ResourceNotebook.objects.create(notebook=notebook, account=self.account)
+
+        response = self.client.get(f"{self.endpoint_base}{notebook.short_id}/")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        data = response.json()
+        self.assertEqual(data["short_id"], notebook.short_id)
+        self.assertEqual(data["title"], "Note")
+        self.assertEqual(data["content"], {"foo": "bar"})
+
+    def test_retrieve_notebook_not_linked_to_account_returns_404(self):
+        from products.notebooks.backend.models import Notebook
+
+        unrelated = Notebook.objects.create(
+            team=self.team, title="Unrelated", content={}, visibility=Notebook.Visibility.DEFAULT
+        )
+
+        response = self.client.get(f"{self.endpoint_base}{unrelated.short_id}/")
+
+        self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
+
+    def test_destroy_notebook_for_account(self):
+        from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+        notebook = Notebook.objects.create(
+            team=self.team, title="Note", content={}, visibility=Notebook.Visibility.INTERNAL
+        )
+        ResourceNotebook.objects.create(notebook=notebook, account=self.account)
+        notebook_pk = notebook.pk
+
+        response = self.client.delete(f"{self.endpoint_base}{notebook.short_id}/")
+
+        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+        # nosemgrep: idor-lookup-without-team (test assertion)
+        self.assertFalse(Notebook.objects.filter(pk=notebook_pk).exists())
+        self.assertFalse(ResourceNotebook.objects.filter(account=self.account).exists())
+
+    def test_create_for_unknown_account_returns_404(self):
+        bad_url = f"/api/environments/{self.team.id}/accounts/00000000-0000-0000-0000-000000000000/notebooks/"
+
+        response = self.client.post(bad_url, {"title": "X"}, format="json")
+
+        self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
+
+    def test_other_team_account_is_not_accessible(self):
+        other_team = Team.objects.create(organization=self.organization)
+        other_account = Account.objects.unscoped().create(team=other_team, name="Other team")
+
+        url = f"/api/environments/{self.team.id}/accounts/{other_account.id}/notebooks/"
+        response = self.client.post(url, {"title": "X"}, format="json")
+
+        self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
+
+    def test_internal_account_notebooks_do_not_appear_in_notebooks_list(self):
+        from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+        notebook = Notebook.objects.create(
+            team=self.team, title="Account note", content={}, visibility=Notebook.Visibility.INTERNAL
+        )
+        ResourceNotebook.objects.create(notebook=notebook, account=self.account)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/notebooks/")
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        short_ids = [n["short_id"] for n in response.json()["results"]]
+        self.assertNotIn(notebook.short_id, short_ids)
+
+    def test_authentication_required(self):
+        self.client.logout()
+
+        for method, url in [
+            ("GET", self.endpoint_base),
+            ("POST", self.endpoint_base),
+            ("GET", f"{self.endpoint_base}abc123/"),
+            ("DELETE", f"{self.endpoint_base}abc123/"),
+        ]:
+            with self.subTest(method=method, url=url):
+                response = getattr(self.client, method.lower())(url, format="json")
+                self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+
 @pytest.mark.ee
 class TestCustomerAnalyticsAccessControl(APIBaseTest):
     """Resource-level access control tests for customer journeys and accounts.

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -1113,6 +1113,26 @@ class TestAccountNotebookViewSet(APIBaseTest):
                 response = getattr(self.client, method.lower())(url, format="json")
                 self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
 
+    def test_list_excludes_non_internal_notebooks_linked_to_account(self):
+        from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+        internal_notebook = Notebook.objects.create(
+            team=self.team, title="Internal", content={}, visibility=Notebook.Visibility.INTERNAL
+        )
+        ResourceNotebook.objects.create(notebook=internal_notebook, account=self.account)
+
+        default_notebook = Notebook.objects.create(
+            team=self.team, title="Default", content={}, visibility=Notebook.Visibility.DEFAULT
+        )
+        ResourceNotebook.objects.create(notebook=default_notebook, account=self.account)
+
+        response = self.client.get(self.endpoint_base)
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        short_ids = [n["short_id"] for n in response.json()["results"]]
+        self.assertIn(internal_notebook.short_id, short_ids)
+        self.assertNotIn(default_notebook.short_id, short_ids)
+
 
 @pytest.mark.ee
 class TestCustomerAnalyticsAccessControl(APIBaseTest):
@@ -1347,3 +1367,28 @@ class TestCustomerAnalyticsAccessControl(APIBaseTest):
 
         response = self.client.get(self.accounts_url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # -- Account notebooks inherit object-level access from the parent account --
+
+    def test_account_notebooks_404_when_parent_account_access_denied(self):
+        from ee.models.rbac.access_control import AccessControl
+
+        AccessControl.objects.create(
+            team=self.team,
+            resource="account",
+            resource_id=str(self.account.id),
+            access_level="none",
+            organization_member=OrganizationMembership.objects.get(
+                user=self.viewer_user, organization=self.organization
+            ),
+        )
+        self._set_access_level(self.viewer_user, resource="account", access_level="viewer")
+        self.client.force_login(self.viewer_user)
+
+        url = f"{self.accounts_url}{self.account.id}/notebooks/"
+
+        list_response = self.client.get(url)
+        self.assertEqual(list_response.status_code, status.HTTP_404_NOT_FOUND)
+
+        create_response = self.client.post(url, {"title": "x"}, format="json")
+        self.assertEqual(create_response.status_code, status.HTTP_404_NOT_FOUND)

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -933,6 +933,47 @@ class TestAccountViewSet(APIBaseTest):
         response = self.client.get(f"/api/environments/{self.team.id}/accounts/?csm=7")
         assert [r["name"] for r in response.json()["results"]] == ["MyAccount"]
 
+    def test_retrieve_returns_empty_notebooks_when_none_linked(self):
+        account = self._create_account()
+
+        response = self.client.get(f"{self.endpoint_base}{account.id}/")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(response.json()["notebooks"], [])
+
+    def test_retrieve_returns_all_linked_notebooks(self):
+        from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+        account = self._create_account()
+        notebook_a = Notebook.objects.create(
+            team=self.team, title="A", content=[], visibility=Notebook.Visibility.INTERNAL
+        )
+        notebook_b = Notebook.objects.create(
+            team=self.team, title="B", content=[], visibility=Notebook.Visibility.INTERNAL
+        )
+        ResourceNotebook.objects.create(notebook=notebook_a, account=account)
+        ResourceNotebook.objects.create(notebook=notebook_b, account=account)
+
+        response = self.client.get(f"{self.endpoint_base}{account.id}/")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(set(response.json()["notebooks"]), {notebook_a.short_id, notebook_b.short_id})
+
+    def test_list_includes_notebooks_field(self):
+        from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+        account = self._create_account()
+        notebook = Notebook.objects.create(
+            team=self.team, title="Existing", content=[], visibility=Notebook.Visibility.INTERNAL
+        )
+        ResourceNotebook.objects.create(notebook=notebook, account=account)
+
+        response = self.client.get(self.endpoint_base)
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        result = next(r for r in response.json()["results"] if r["id"] == str(account.id))
+        self.assertEqual(result["notebooks"], [notebook.short_id])
+
 
 @pytest.mark.ee
 class TestCustomerAnalyticsAccessControl(APIBaseTest):

--- a/products/customer_analytics/backend/api/views.py
+++ b/products/customer_analytics/backend/api/views.py
@@ -1,7 +1,7 @@
 import json
 
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 from django.shortcuts import get_object_or_404
 
 from drf_spectacular.types import OpenApiTypes
@@ -147,7 +147,9 @@ class AccountViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContr
         return super().list(request, *args, **kwargs)
 
     def safely_get_queryset(self, queryset):
-        queryset = queryset.filter(team_id=self.team.id)
+        queryset = queryset.filter(team_id=self.team.id).prefetch_related(
+            Prefetch("notebooks", queryset=ResourceNotebook.objects.select_related("notebook"))
+        )
 
         search = self.request.query_params.get("search", "").strip()
         if search:

--- a/products/customer_analytics/backend/api/views.py
+++ b/products/customer_analytics/backend/api/views.py
@@ -1,9 +1,12 @@
 import json
 
+from django.db import transaction
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
 
-from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
-from rest_framework import viewsets
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import mixins, viewsets
 from rest_framework.exceptions import ValidationError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -12,8 +15,14 @@ from posthog.api.utils import log_activity_from_viewset
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 
 from products.customer_analytics.backend.models import Account, CustomerJourney, CustomerProfileConfig
+from products.notebooks.backend.models import Notebook, ResourceNotebook
 
-from .serializers import AccountSerializer, CustomerJourneySerializer, CustomerProfileConfigSerializer
+from .serializers import (
+    AccountNotebookSerializer,
+    AccountSerializer,
+    CustomerJourneySerializer,
+    CustomerProfileConfigSerializer,
+)
 from .utils import log_customer_profile_config_activity
 
 
@@ -210,3 +219,58 @@ class AccountViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContr
     def perform_destroy(self, instance):
         log_activity_from_viewset(self, instance, activity="deleted", name=instance.name)
         super().perform_destroy(instance)
+
+
+@extend_schema(
+    tags=["customer_analytics"],
+    parameters=[
+        OpenApiParameter(
+            name="account_id",
+            type=OpenApiTypes.UUID,
+            location=OpenApiParameter.PATH,
+            description="UUID of the parent account.",
+        ),
+    ],
+)
+class AccountNotebookViewSet(
+    TeamAndOrgViewSetMixin,
+    AccessControlViewSetMixin,
+    mixins.CreateModelMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    scope_object = "account"
+    serializer_class = AccountNotebookSerializer
+    queryset = Notebook.objects.all()
+    lookup_field = "short_id"
+    filter_rewrite_rules = {"account_id": "resources__account_id"}
+
+    def _get_account(self) -> Account:
+        return get_object_or_404(
+            Account.objects.unscoped().filter(team_id=self.team.id),
+            id=self.parents_query_dict["account_id"],
+        )
+
+    def safely_get_queryset(self, queryset):
+        return (
+            queryset.filter(deleted=False)
+            .select_related("created_by", "last_modified_by")
+            .order_by("-last_modified_at")
+        )
+
+    @transaction.atomic
+    def perform_create(self, serializer):
+        account = self._get_account()
+        notebook = serializer.save(
+            team=self.team,
+            created_by=self.request.user,
+            last_modified_by=self.request.user,
+            visibility=Notebook.Visibility.INTERNAL,
+        )
+        ResourceNotebook.objects.create(notebook=notebook, account=account)
+
+    @transaction.atomic
+    def perform_destroy(self, instance: Notebook):
+        instance.delete()

--- a/products/customer_analytics/backend/api/views.py
+++ b/products/customer_analytics/backend/api/views.py
@@ -250,14 +250,15 @@ class AccountNotebookViewSet(
     filter_rewrite_rules = {"account_id": "resources__account_id"}
 
     def _get_account(self) -> Account:
-        return get_object_or_404(
+        queryset = self.user_access_control.filter_queryset_by_access_level(
             Account.objects.unscoped().filter(team_id=self.team.id),
-            id=self.parents_query_dict["account_id"],
         )
+        return get_object_or_404(queryset, id=self.parents_query_dict["account_id"])
 
     def safely_get_queryset(self, queryset):
+        self._get_account()
         return (
-            queryset.filter(deleted=False)
+            queryset.filter(deleted=False, visibility=Notebook.Visibility.INTERNAL)
             .select_related("created_by", "last_modified_by")
             .order_by("-last_modified_at")
         )

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
@@ -47,6 +47,15 @@ export function AccountsTable(): JSX.Element {
                 ),
         },
         {
+            title: 'Notebooks',
+            key: 'notebooks',
+            dataIndex: 'notebooks',
+            render: (_, account) => {
+                const count = account.notebooks?.length ?? 0
+                return count > 0 ? <span>{count}</span> : <span className="text-muted">—</span>
+            },
+        },
+        {
             title: 'CSM',
             key: 'csm',
             render: (_, account) => <AssigneeCell assignment={account.properties?.csm ?? null} />,

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -76,6 +76,92 @@ export interface PaginatedAccountListApi {
 }
 
 /**
+ * * `engineering` - Engineering
+ * `data` - Data
+ * `product` - Product Management
+ * `founder` - Founder
+ * `leadership` - Leadership
+ * `marketing` - Marketing
+ * `sales` - Sales / Success
+ * `other` - Other
+ */
+export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
+
+export const RoleAtOrganizationEnumApi = {
+    Engineering: 'engineering',
+    Data: 'data',
+    Product: 'product',
+    Founder: 'founder',
+    Leadership: 'leadership',
+    Marketing: 'marketing',
+    Sales: 'sales',
+    Other: 'other',
+} as const
+
+export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
+
+export const BlankEnumApi = {
+    '': '',
+} as const
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: RoleAtOrganizationEnumApi | BlankEnumApi | null
+}
+
+export interface AccountNotebookApi {
+    readonly id: string
+    readonly short_id: string
+    /**
+     * Human-readable title of the account notebook.
+     * @maxLength 256
+     * @nullable
+     */
+    title?: string | null
+    /** Notebook content as a ProseMirror JSON document structure. */
+    content?: unknown
+    /**
+     * Plain text representation of the notebook content for search.
+     * @nullable
+     */
+    text_content?: string | null
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    readonly last_modified_at: string
+    readonly last_modified_by: UserBasicApi
+}
+
+export interface PaginatedAccountNotebookListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: AccountNotebookApi[]
+}
+
+/**
  * Typed account properties: assignment fields (csm, account_executive, account_owner) and external system identifiers (stripe_customer_id, hubspot_deal_id, billing_id, sfdc_id, zendesk_id). Defaults to an empty object. Unknown keys are rejected.
  * @nullable
  */
@@ -335,6 +421,17 @@ export interface PatchedGroupUsageMetricApi {
 }
 
 export type AccountsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type AccountsNotebooksListParams = {
     /**
      * Number of results to return per page.
      */

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -464,7 +464,7 @@ export type AccountsListParams = {
      */
     search?: string
     /**
-     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags.
+     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags. Malformed values (not a JSON-encoded list of strings) return a 400.
      */
     tags?: string
 }

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -39,6 +39,9 @@ export type AccountApiProperties = {
     zendesk_id?: string | null
 } | null
 
+/**
+ * A Customer Analytics account — a logical grouping used to assign customer-success ownership.
+ */
 export interface AccountApi {
     readonly id: string
     /**
@@ -57,6 +60,8 @@ export interface AccountApi {
      * @nullable
      */
     properties?: AccountApiProperties
+    /** Tag names attached to the account. Pass a list to replace existing tags. */
+    tags?: string[]
     /** Short IDs of the internal notebooks linked to this account, used to persist investigations, call notes, and other free-form context. Empty list if no notebooks have been created for the account. */
     readonly notebooks: readonly string[]
     readonly created_at: string
@@ -193,6 +198,9 @@ export type PatchedAccountApiProperties = {
     zendesk_id?: string | null
 } | null
 
+/**
+ * A Customer Analytics account — a logical grouping used to assign customer-success ownership.
+ */
 export interface PatchedAccountApi {
     readonly id?: string
     /**
@@ -211,6 +219,8 @@ export interface PatchedAccountApi {
      * @nullable
      */
     properties?: PatchedAccountApiProperties
+    /** Tag names attached to the account. Pass a list to replace existing tags. */
+    tags?: string[]
     /** Short IDs of the internal notebooks linked to this account, used to persist investigations, call notes, and other free-form context. Empty list if no notebooks have been created for the account. */
     readonly notebooks?: readonly string[]
     readonly created_at?: string
@@ -422,6 +432,22 @@ export interface PatchedGroupUsageMetricApi {
 
 export type AccountsListParams = {
     /**
+     * Filter by account executive. Use 'unassigned' or an integer user id.
+     */
+    account_executive?: string
+    /**
+     * Filter by account owner. Use 'unassigned' or an integer user id.
+     */
+    account_owner?: string
+    /**
+     * When true, returns only accounts where CSM, account executive, and account owner are all unset.
+     */
+    all_roles_unassigned?: boolean
+    /**
+     * Filter by CSM. Use 'unassigned' for accounts with no CSM, or an integer user id.
+     */
+    csm?: string
+    /**
      * Number of results to return per page.
      */
     limit?: number
@@ -429,6 +455,18 @@ export type AccountsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+    /**
+     * Sort order. Defaults to '-created_at'.
+     */
+    ordering?: string
+    /**
+     * Case-insensitive substring search across account name and external ID.
+     */
+    search?: string
+    /**
+     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags.
+     */
+    tags?: string
 }
 
 export type AccountsNotebooksListParams = {

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -39,9 +39,6 @@ export type AccountApiProperties = {
     zendesk_id?: string | null
 } | null
 
-/**
- * A Customer Analytics account — a logical grouping used to assign customer-success ownership.
- */
 export interface AccountApi {
     readonly id: string
     /**
@@ -60,8 +57,8 @@ export interface AccountApi {
      * @nullable
      */
     properties?: AccountApiProperties
-    /** Tag names attached to the account. Pass a list to replace existing tags. */
-    tags?: string[]
+    /** Short IDs of the internal notebooks linked to this account, used to persist investigations, call notes, and other free-form context. Empty list if no notebooks have been created for the account. */
+    readonly notebooks: readonly string[]
     readonly created_at: string
     /** @nullable */
     readonly created_by: number | null
@@ -110,9 +107,6 @@ export type PatchedAccountApiProperties = {
     zendesk_id?: string | null
 } | null
 
-/**
- * A Customer Analytics account — a logical grouping used to assign customer-success ownership.
- */
 export interface PatchedAccountApi {
     readonly id?: string
     /**
@@ -131,8 +125,8 @@ export interface PatchedAccountApi {
      * @nullable
      */
     properties?: PatchedAccountApiProperties
-    /** Tag names attached to the account. Pass a list to replace existing tags. */
-    tags?: string[]
+    /** Short IDs of the internal notebooks linked to this account, used to persist investigations, call notes, and other free-form context. Empty list if no notebooks have been created for the account. */
+    readonly notebooks?: readonly string[]
     readonly created_at?: string
     /** @nullable */
     readonly created_by?: number | null
@@ -342,22 +336,6 @@ export interface PatchedGroupUsageMetricApi {
 
 export type AccountsListParams = {
     /**
-     * Filter by account executive. Use 'unassigned' or an integer user id.
-     */
-    account_executive?: string
-    /**
-     * Filter by account owner. Use 'unassigned' or an integer user id.
-     */
-    account_owner?: string
-    /**
-     * When true, returns only accounts where CSM, account executive, and account owner are all unset.
-     */
-    all_roles_unassigned?: boolean
-    /**
-     * Filter by CSM. Use 'unassigned' for accounts with no CSM, or an integer user id.
-     */
-    csm?: string
-    /**
      * Number of results to return per page.
      */
     limit?: number
@@ -365,18 +343,6 @@ export type AccountsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
-    /**
-     * Sort order. Defaults to '-created_at'.
-     */
-    ordering?: string
-    /**
-     * Case-insensitive substring search across account name and external ID.
-     */
-    search?: string
-    /**
-     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags. Malformed values (not a JSON-encoded list of strings) return a 400.
-     */
-    tags?: string
 }
 
 export type CustomerJourneysListParams = {

--- a/products/customer_analytics/frontend/generated/api.ts
+++ b/products/customer_analytics/frontend/generated/api.ts
@@ -10,7 +10,9 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  */
 import type {
     AccountApi,
+    AccountNotebookApi,
     AccountsListParams,
+    AccountsNotebooksListParams,
     CustomerJourneyApi,
     CustomerJourneysListParams,
     CustomerProfileConfigApi,
@@ -18,6 +20,7 @@ import type {
     GroupUsageMetricApi,
     GroupsTypesMetricsListParams,
     PaginatedAccountListApi,
+    PaginatedAccountNotebookListApi,
     PaginatedCustomerJourneyListApi,
     PaginatedCustomerProfileConfigListApi,
     PaginatedGroupUsageMetricListApi,
@@ -83,6 +86,88 @@ export const accountsCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(accountApi),
+    })
+}
+
+export const getAccountsNotebooksListUrl = (
+    projectId: string,
+    accountId: string,
+    params?: AccountsNotebooksListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/environments/${projectId}/accounts/${accountId}/notebooks/?${stringifiedParams}`
+        : `/api/environments/${projectId}/accounts/${accountId}/notebooks/`
+}
+
+export const accountsNotebooksList = async (
+    projectId: string,
+    accountId: string,
+    params?: AccountsNotebooksListParams,
+    options?: RequestInit
+): Promise<PaginatedAccountNotebookListApi> => {
+    return apiMutator<PaginatedAccountNotebookListApi>(getAccountsNotebooksListUrl(projectId, accountId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getAccountsNotebooksCreateUrl = (projectId: string, accountId: string) => {
+    return `/api/environments/${projectId}/accounts/${accountId}/notebooks/`
+}
+
+export const accountsNotebooksCreate = async (
+    projectId: string,
+    accountId: string,
+    accountNotebookApi?: NonReadonly<AccountNotebookApi>,
+    options?: RequestInit
+): Promise<AccountNotebookApi> => {
+    return apiMutator<AccountNotebookApi>(getAccountsNotebooksCreateUrl(projectId, accountId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(accountNotebookApi),
+    })
+}
+
+export const getAccountsNotebooksRetrieveUrl = (projectId: string, accountId: string, shortId: string) => {
+    return `/api/environments/${projectId}/accounts/${accountId}/notebooks/${shortId}/`
+}
+
+export const accountsNotebooksRetrieve = async (
+    projectId: string,
+    accountId: string,
+    shortId: string,
+    options?: RequestInit
+): Promise<AccountNotebookApi> => {
+    return apiMutator<AccountNotebookApi>(getAccountsNotebooksRetrieveUrl(projectId, accountId, shortId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getAccountsNotebooksDestroyUrl = (projectId: string, accountId: string, shortId: string) => {
+    return `/api/environments/${projectId}/accounts/${accountId}/notebooks/${shortId}/`
+}
+
+export const accountsNotebooksDestroy = async (
+    projectId: string,
+    accountId: string,
+    shortId: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getAccountsNotebooksDestroyUrl(projectId, accountId, shortId), {
+        ...options,
+        method: 'DELETE',
     })
 }
 

--- a/products/customer_analytics/frontend/generated/api.zod.ts
+++ b/products/customer_analytics/frontend/generated/api.zod.ts
@@ -58,6 +58,18 @@ export const AccountsCreateBody = /* @__PURE__ */ zod
     })
     .describe('A Customer Analytics account — a logical grouping used to assign customer-success ownership.')
 
+export const accountsNotebooksCreateBodyTitleMax = 256
+
+export const AccountsNotebooksCreateBody = /* @__PURE__ */ zod.object({
+    title: zod
+        .string()
+        .max(accountsNotebooksCreateBodyTitleMax)
+        .nullish()
+        .describe('Human-readable title of the account notebook.'),
+    content: zod.unknown().optional().describe('Notebook content as a ProseMirror JSON document structure.'),
+    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+})
+
 export const accountsUpdateBodyNameMax = 400
 
 export const accountsUpdateBodyExternalIdMax = 400

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -74,6 +74,63 @@ tools:
                     JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts
                     that have any of the listed tags.
         feature_flag: customer-analytics-csp
+    accounts-notebooks-create:
+        operation: accounts_notebooks_create
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create account notebook
+        description: >
+            Create a notebook attached to a Customer Analytics account. Use for persisting investigations, call notes,
+            and other free-form context. Provide `title` and optional `content` (ProseMirror JSON document structure).
+            The notebook is created with internal visibility so it does not appear in the global notebooks list.
+        feature_flag: customer-analytics-csp
+    accounts-notebooks-destroy:
+        operation: accounts_notebooks_destroy
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Delete account notebook
+        description: |
+            Permanently delete an account notebook by its `short_id`.
+        feature_flag: customer-analytics-csp
+    accounts-notebooks-list:
+        operation: accounts_notebooks_list
+        enabled: true
+        scopes:
+            - account:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List account notebooks
+        description: >
+            List notebooks attached to a Customer Analytics account, ordered by most recently modified. Each result
+            includes the notebook `short_id`, `title`, `content`, and authorship metadata.
+        feature_flag: customer-analytics-csp
+    accounts-notebooks-retrieve:
+        operation: accounts_notebooks_retrieve
+        enabled: true
+        scopes:
+            - account:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get account notebook
+        description: >
+            Fetch a single account notebook by its `short_id`. Returns the full notebook including `content` (ProseMirror
+            JSON document structure) and authorship metadata.
+        feature_flag: customer-analytics-csp
     accounts-partial-update:
         operation: accounts_partial_update
         enabled: true

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -73,8 +73,8 @@ tools:
                 description: >
                     JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts
                     that have any of the listed tags.
-        feature_flag: customer-analytics-csp
         mcp_version: 1
+        feature_flag: customer-analytics-csp
     accounts-notebooks-create:
         operation: accounts_notebooks_create
         enabled: true
@@ -117,8 +117,8 @@ tools:
         description: >
             List notebooks attached to a Customer Analytics account, ordered by most recently modified. Each result
             includes the notebook `short_id`, `title`, `content`, and authorship metadata.
-        feature_flag: customer-analytics-csp
         mcp_version: 1
+        feature_flag: customer-analytics-csp
     accounts-notebooks-retrieve:
         operation: accounts_notebooks_retrieve
         enabled: true
@@ -130,10 +130,10 @@ tools:
             idempotent: true
         title: Get account notebook
         description: >
-            Fetch a single account notebook by its `short_id`. Returns the full notebook including `content` (ProseMirror
-            JSON document structure) and authorship metadata.
-        feature_flag: customer-analytics-csp
+            Fetch a single account notebook by its `short_id`. Returns the full notebook including `content`
+            (ProseMirror JSON document structure) and authorship metadata.
         mcp_version: 1
+        feature_flag: customer-analytics-csp
     accounts-partial-update:
         operation: accounts_partial_update
         enabled: true
@@ -173,8 +173,8 @@ tools:
             Fetch a single Customer Analytics account by id. Returns the full account including typed `properties` (csm,
             account_executive, account_owner assignments plus stripe_customer_id, hubspot_deal_id, billing_id, sfdc_id,
             zendesk_id external identifiers) and `tags`.
-        feature_flag: customer-analytics-csp
         mcp_version: 1
+        feature_flag: customer-analytics-csp
     accounts-update:
         operation: accounts_update
         enabled: false

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -74,6 +74,7 @@ tools:
                     JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts
                     that have any of the listed tags.
         feature_flag: customer-analytics-csp
+        mcp_version: 1
     accounts-notebooks-create:
         operation: accounts_notebooks_create
         enabled: true
@@ -117,6 +118,7 @@ tools:
             List notebooks attached to a Customer Analytics account, ordered by most recently modified. Each result
             includes the notebook `short_id`, `title`, `content`, and authorship metadata.
         feature_flag: customer-analytics-csp
+        mcp_version: 1
     accounts-notebooks-retrieve:
         operation: accounts_notebooks_retrieve
         enabled: true
@@ -131,6 +133,7 @@ tools:
             Fetch a single account notebook by its `short_id`. Returns the full notebook including `content` (ProseMirror
             JSON document structure) and authorship metadata.
         feature_flag: customer-analytics-csp
+        mcp_version: 1
     accounts-partial-update:
         operation: accounts_partial_update
         enabled: true
@@ -171,6 +174,7 @@ tools:
             account_executive, account_owner assignments plus stripe_customer_id, hubspot_deal_id, billing_id, sfdc_id,
             zendesk_id external identifiers) and `tags`.
         feature_flag: customer-analytics-csp
+        mcp_version: 1
     accounts-update:
         operation: accounts_update
         enabled: false

--- a/products/notebooks/backend/migrations/0004_resourcenotebook_account.py
+++ b/products/notebooks/backend/migrations/0004_resourcenotebook_account.py
@@ -1,0 +1,96 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("customer_analytics", "0005_account"),
+        ("notebooks", "0003_add_kernel_timeouts"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveConstraint(
+                    model_name="resourcenotebook",
+                    name="exactly_one_notebook_related_resource",
+                ),
+                migrations.AlterUniqueTogether(
+                    name="resourcenotebook",
+                    unique_together=set(),
+                ),
+                migrations.AddField(
+                    model_name="resourcenotebook",
+                    name="account",
+                    field=models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="notebooks",
+                        to="customer_analytics.account",
+                    ),
+                ),
+                migrations.AlterUniqueTogether(
+                    name="resourcenotebook",
+                    unique_together={("notebook", "group", "account")},
+                ),
+                migrations.AddConstraint(
+                    model_name="resourcenotebook",
+                    constraint=models.UniqueConstraint(
+                        condition=models.Q(("account__isnull", False)),
+                        fields=("notebook", "account"),
+                        name="unique_notebook_account",
+                    ),
+                ),
+                migrations.AddConstraint(
+                    model_name="resourcenotebook",
+                    constraint=models.CheckConstraint(
+                        condition=models.Q(
+                            models.Q(("group__isnull", False), ("account__isnull", True)),
+                            models.Q(("group__isnull", True), ("account__isnull", False)),
+                            _connector="OR",
+                        ),
+                        name="exactly_one_notebook_related_resource",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE "posthog_resourcenotebook"
+                        ADD COLUMN "account_id" uuid NULL
+                        CONSTRAINT "posthog_resourcenotebook_account_id_fk"
+                        REFERENCES "customer_analytics_account"("id")
+                        DEFERRABLE INITIALLY DEFERRED; -- existing-table-constraint-ignore
+                        SET CONSTRAINTS "posthog_resourcenotebook_account_id_fk" IMMEDIATE; -- existing-table-constraint-ignore
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE "posthog_resourcenotebook" DROP COLUMN IF EXISTS "account_id";
+                    """,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE "posthog_resourcenotebook" DROP CONSTRAINT IF EXISTS "exactly_one_notebook_related_resource";
+                        ALTER TABLE "posthog_resourcenotebook" ADD CONSTRAINT "exactly_one_notebook_related_resource" CHECK ( /* -- existing-table-constraint-ignore */
+                            (
+                                (group_id IS NOT NULL AND account_id IS NULL) OR /* -- not-null-ignore */
+                                (group_id IS NULL AND account_id IS NOT NULL) /* -- not-null-ignore */
+                            )
+                        ) NOT VALID;
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE "posthog_resourcenotebook" DROP CONSTRAINT IF EXISTS "exactly_one_notebook_related_resource";
+                        ALTER TABLE "posthog_resourcenotebook" ADD CONSTRAINT "exactly_one_notebook_related_resource" CHECK ( /* -- existing-table-constraint-ignore */
+                            (group_id IS NOT NULL) /* -- not-null-ignore */
+                        ) NOT VALID;
+                    """,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE "posthog_resourcenotebook" DROP CONSTRAINT IF EXISTS "posthog_resourcenotebook_notebook_id_group_id_88c0a30b_uniq";
+                    """,
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        )
+    ]

--- a/products/notebooks/backend/migrations/0005_resourcenotebook_account_indexes.py
+++ b/products/notebooks/backend/migrations/0005_resourcenotebook_account_indexes.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("notebooks", "0004_resourcenotebook_account"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS "posthog_resourcenotebook_account_id_idx"
+                ON "posthog_resourcenotebook" ("account_id");
+            """,
+            reverse_sql="""
+                DROP INDEX IF EXISTS "posthog_resourcenotebook_account_id_idx";
+            """,
+        ),
+        migrations.RunSQL(
+            sql="""
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique_notebook_account"
+                ON "posthog_resourcenotebook" ("notebook_id", "account_id")
+                WHERE "account_id" IS NOT NULL; -- not-null-ignore
+            """,
+            reverse_sql="""
+                DROP INDEX IF EXISTS "unique_notebook_account";
+            """,
+        ),
+        migrations.RunSQL(
+            sql="""
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "posthog_resourcenotebook_notebook_id_group_id_acc_7a017f67_uniq"
+                ON "posthog_resourcenotebook" (
+                    "notebook_id",
+                    "group_id",
+                    "account_id"
+                );
+            """,
+            reverse_sql="""
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "posthog_resourcenotebook_notebook_id_group_id_88c0a30b_uniq"
+                ON "posthog_resourcenotebook" (
+                    "notebook_id",
+                    "group_id"
+                );
+            """,
+        ),
+    ]

--- a/products/notebooks/backend/migrations/0006_resourcenotebook_account_unique_constraint.py
+++ b/products/notebooks/backend/migrations/0006_resourcenotebook_account_unique_constraint.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("notebooks", "0005_resourcenotebook_account_indexes"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                ALTER TABLE "posthog_resourcenotebook" ADD CONSTRAINT "posthog_resourcenotebook_notebook_id_group_id_acc_7a017f67_uniq"
+                UNIQUE USING INDEX "posthog_resourcenotebook_notebook_id_group_id_acc_7a017f67_uniq"; -- existing-table-constraint-ignore
+            """,
+            reverse_sql="""
+                ALTER TABLE "posthog_resourcenotebook" DROP CONSTRAINT IF EXISTS "posthog_resourcenotebook_notebook_id_group_id_acc_7a017f67_uniq";
+            """,
+        ),
+    ]

--- a/products/notebooks/backend/migrations/max_migration.txt
+++ b/products/notebooks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_add_kernel_timeouts
+0006_resourcenotebook_account_unique_constraint

--- a/products/notebooks/backend/models.py
+++ b/products/notebooks/backend/models.py
@@ -63,7 +63,7 @@ class Notebook(FileSystemSyncMixin, RootTeamMixin, UUIDTModel):
         )
 
 
-RELATED_OBJECTS = ("group",)
+RELATED_OBJECTS = ("group", "account")
 
 
 class ResourceNotebook(UUIDTModel):
@@ -86,6 +86,13 @@ class ResourceNotebook(UUIDTModel):
         null=True,
         blank=True,
         db_column="group_id",
+    )
+    account = models.ForeignKey(
+        "customer_analytics.Account",
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="notebooks",
     )
 
     class Meta:

--- a/products/notebooks/mcp/tools.yaml
+++ b/products/notebooks/mcp/tools.yaml
@@ -9,6 +9,18 @@ feature: notebooks
 url_prefix: /notebooks
 ui_apps: {}
 tools:
+    accounts-notebooks-create:
+        operation: accounts_notebooks_create
+        enabled: false
+    accounts-notebooks-destroy:
+        operation: accounts_notebooks_destroy
+        enabled: false
+    accounts-notebooks-list:
+        operation: accounts_notebooks_list
+        enabled: false
+    accounts-notebooks-retrieve:
+        operation: accounts_notebooks_retrieve
+        enabled: false
     notebooks-activity-retrieve:
         operation: notebooks_activity_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -38,7 +38,7 @@
         "summary": "List accounts",
         "title": "List accounts",
         "required_scopes": ["account:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -86,7 +86,7 @@
         "summary": "List account notebooks",
         "title": "List account notebooks",
         "required_scopes": ["account:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -102,7 +102,7 @@
         "summary": "Get account notebook",
         "title": "Get account notebook",
         "required_scopes": ["account:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -134,7 +134,7 @@
         "summary": "Get account",
         "title": "Get account",
         "required_scopes": ["account:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -47,6 +47,70 @@
         },
         "feature_flag": "customer-analytics-csp"
     },
+    "accounts-notebooks-create": {
+        "description": "Create a notebook attached to a Customer Analytics account. Use for persisting investigations, call notes, and other free-form context. Provide `title` and optional `content` (ProseMirror JSON document structure). The notebook is created with internal visibility so it does not appear in the global notebooks list.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create account notebook",
+        "title": "Create account notebook",
+        "required_scopes": ["account:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-notebooks-destroy": {
+        "description": "Permanently delete an account notebook by its `short_id`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Delete account notebook",
+        "title": "Delete account notebook",
+        "required_scopes": ["account:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-notebooks-list": {
+        "description": "List notebooks attached to a Customer Analytics account, ordered by most recently modified. Each result includes the notebook `short_id`, `title`, `content`, and authorship metadata.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List account notebooks",
+        "title": "List account notebooks",
+        "required_scopes": ["account:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-notebooks-retrieve": {
+        "description": "Fetch a single account notebook by its `short_id`. Returns the full notebook including `content` (ProseMirror JSON document structure) and authorship metadata.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Get account notebook",
+        "title": "Get account notebook",
+        "required_scopes": ["account:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
     "accounts-partial-update": {
         "description": "Update fields on an existing Customer Analytics account. Accepts a subset of fields; unspecified fields are left unchanged. Pass `tags` to replace the full set of tags on the account.",
         "category": "Customer analytics",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -38,7 +38,7 @@
         "summary": "List accounts",
         "title": "List accounts",
         "required_scopes": ["account:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -86,7 +86,7 @@
         "summary": "List account notebooks",
         "title": "List account notebooks",
         "required_scopes": ["account:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -102,7 +102,7 @@
         "summary": "Get account notebook",
         "title": "Get account notebook",
         "required_scopes": ["account:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -134,7 +134,7 @@
         "summary": "Get account",
         "title": "Get account",
         "required_scopes": ["account:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -47,6 +47,70 @@
         },
         "feature_flag": "customer-analytics-csp"
     },
+    "accounts-notebooks-create": {
+        "description": "Create a notebook attached to a Customer Analytics account. Use for persisting investigations, call notes, and other free-form context. Provide `title` and optional `content` (ProseMirror JSON document structure). The notebook is created with internal visibility so it does not appear in the global notebooks list.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create account notebook",
+        "title": "Create account notebook",
+        "required_scopes": ["account:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-notebooks-destroy": {
+        "description": "Permanently delete an account notebook by its `short_id`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Delete account notebook",
+        "title": "Delete account notebook",
+        "required_scopes": ["account:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-notebooks-list": {
+        "description": "List notebooks attached to a Customer Analytics account, ordered by most recently modified. Each result includes the notebook `short_id`, `title`, `content`, and authorship metadata.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List account notebooks",
+        "title": "List account notebooks",
+        "required_scopes": ["account:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-notebooks-retrieve": {
+        "description": "Fetch a single account notebook by its `short_id`. Returns the full notebook including `content` (ProseMirror JSON document structure) and authorship metadata.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Get account notebook",
+        "title": "Get account notebook",
+        "required_scopes": ["account:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
     "accounts-partial-update": {
         "description": "Update fields on an existing Customer Analytics account. Accepts a subset of fields; unspecified fields are left unchanged. Pass `tags` to replace the full set of tags on the account.",
         "category": "Customer analytics",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -89,6 +89,9 @@ export namespace Schemas {
       zendesk_id?: string | null;
     } | null;
 
+    /**
+     * A Customer Analytics account — a logical grouping used to assign customer-success ownership.
+     */
     export interface Account {
       readonly id: string;
       /**
@@ -107,6 +110,8 @@ export namespace Schemas {
          * @nullable
          */
       properties?: AccountProperties;
+      /** Tag names attached to the account. Pass a list to replace existing tags. */
+      tags?: string[];
       /** Short IDs of the internal notebooks linked to this account, used to persist investigations, call notes, and other free-form context. Empty list if no notebooks have been created for the account. */
       readonly notebooks: readonly string[];
       readonly created_at: string;
@@ -1284,6 +1289,20 @@ export namespace Schemas {
       breakpoints: ActiveBreakpoint[];
     }
 
+    /**
+     * * `true` - true
+    * `false` - false
+    * `STALE` - STALE
+     */
+    export type ActiveEnum = typeof ActiveEnum[keyof typeof ActiveEnum];
+
+
+    export const ActiveEnum = {
+      True: 'true',
+      False: 'false',
+      Stale: 'STALE',
+    } as const;
+
     export interface ActivityLog {
       readonly id: string;
       user: UserBasic;
@@ -1479,6 +1498,18 @@ export namespace Schemas {
       Optimized: 'optimized',
     } as const;
 
+    export type ParserMode = typeof ParserMode[keyof typeof ParserMode];
+
+
+    export const ParserMode = {
+      CppOnly: 'cpp_only',
+      CppWithRustShadow: 'cpp_with_rust_shadow',
+      RustWithCppShadow: 'rust_with_cpp_shadow',
+      RustOnly: 'rust_only',
+      RustPyOnly: 'rust_py_only',
+      RustPyWithCppShadow: 'rust_py_with_cpp_shadow',
+    } as const;
+
     export type PersonsArgMaxVersion = typeof PersonsArgMaxVersion[keyof typeof PersonsArgMaxVersion];
 
 
@@ -1549,6 +1580,8 @@ export namespace Schemas {
       materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationMode | null;
       optimizeJoinedFilters?: boolean | null;
       optimizeProjections?: boolean | null;
+      /** HogQL parser backend; absent → `cpp_only`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
+      parserMode?: ParserMode | null;
       personsArgMaxVersion?: PersonsArgMaxVersion | null;
       personsJoinMode?: PersonsJoinMode | null;
       personsOnEventsMode?: PersonsOnEventsMode | null;
@@ -2476,6 +2509,8 @@ export namespace Schemas {
       aggregationPropertyType?: AggregationPropertyType1 | null;
       /** The aggregation type to use for retention */
       aggregationType?: AggregationType | null;
+      /** Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations. */
+      cohortLabelStartIndex?: number | null;
       cumulative?: boolean | null;
       /** For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups. */
       customAggregationTarget?: boolean | null;
@@ -3008,7 +3043,7 @@ export namespace Schemas {
       samplingFactor?: number | null;
       tags?: QueryLogTags | null;
       useSessionsTable?: boolean | null;
-      /** Opt this specific query into the web_overview_query precompute path. Requires the team to be in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` allowlist for the gate to pass. * */
+      /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
       useWebAnalyticsPrecompute?: boolean | null;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -4480,10 +4515,10 @@ export namespace Schemas {
     * `P3` - P3
     * `P4` - P4
      */
-    export type AutostartPriorityEnum = typeof AutostartPriorityEnum[keyof typeof AutostartPriorityEnum];
+    export type AutonomyPriorityEnum = typeof AutonomyPriorityEnum[keyof typeof AutonomyPriorityEnum];
 
 
-    export const AutostartPriorityEnum = {
+    export const AutonomyPriorityEnum = {
       P0: 'P0',
       P1: 'P1',
       P2: 'P2',
@@ -6472,6 +6507,134 @@ export namespace Schemas {
       DeviceId: 'device_id',
     } as const;
 
+    /**
+     * * `fully_rolled_out` - fully_rolled_out
+    * `not_rolled_out` - not_rolled_out
+    * `partial` - partial
+     */
+    export type RolloutStateEnum = typeof RolloutStateEnum[keyof typeof RolloutStateEnum];
+
+
+    export const RolloutStateEnum = {
+      FullyRolledOut: 'fully_rolled_out',
+      NotRolledOut: 'not_rolled_out',
+      Partial: 'partial',
+    } as const;
+
+    export interface BulkDeleteDeletedItem {
+      /** ID of the soft-deleted flag. */
+      id: number;
+      /** The flag key at the time of deletion. */
+      key: string;
+      /** Rollout state captured before deletion.
+
+      * `fully_rolled_out` - fully_rolled_out
+      * `not_rolled_out` - not_rolled_out
+      * `partial` - partial */
+      rollout_state: RolloutStateEnum;
+      /**
+         * Variant key when a multivariate flag was fully rolled out to a single variant; otherwise null.
+         * @nullable
+         */
+      active_variant: string | null;
+    }
+
+    export interface BulkDeleteErrorItem {
+      /** Feature flag ID — integer for valid inputs; the original raw value for invalid inputs. */
+      id: unknown;
+      /** The flag key, when known. */
+      key?: string;
+      /** Human-readable reason the flag could not be deleted. */
+      reason: string;
+    }
+
+    /**
+     * * `boolean` - boolean
+    * `multivariant` - multivariant
+    * `experiment` - experiment
+    * `remote_config` - remote_config
+     */
+    export type BulkDeleteFiltersTypeEnum = typeof BulkDeleteFiltersTypeEnum[keyof typeof BulkDeleteFiltersTypeEnum];
+
+
+    export const BulkDeleteFiltersTypeEnum = {
+      Boolean: 'boolean',
+      Multivariant: 'multivariant',
+      Experiment: 'experiment',
+      RemoteConfig: 'remote_config',
+    } as const;
+
+    /**
+     * * `server` - Server
+    * `client` - Client
+    * `all` - All
+     */
+    export type EvaluationRuntimeEnum = typeof EvaluationRuntimeEnum[keyof typeof EvaluationRuntimeEnum];
+
+
+    export const EvaluationRuntimeEnum = {
+      Server: 'server',
+      Client: 'client',
+      All: 'all',
+    } as const;
+
+    /**
+     * Allowed filter keys for bulk_delete — same shape as the list endpoint's query params.
+     */
+    export interface BulkDeleteFilters {
+      /** Filter by active state.
+
+      * `true` - true
+      * `false` - false
+      * `STALE` - STALE */
+      active?: ActiveEnum;
+      /** Filter to flags created by a specific user ID. */
+      created_by_id?: number;
+      /** Search by feature flag key or name (case-insensitive). */
+      search?: string;
+      /** Filter by flag type.
+
+      * `boolean` - boolean
+      * `multivariant` - multivariant
+      * `experiment` - experiment
+      * `remote_config` - remote_config */
+      type?: BulkDeleteFiltersTypeEnum;
+      /** Filter by evaluation runtime.
+
+      * `server` - Server
+      * `client` - Client
+      * `all` - All */
+      evaluation_runtime?: EvaluationRuntimeEnum;
+      /** JSON-encoded property filter to exclude. Same shape as the list endpoint. */
+      excluded_properties?: string;
+      /** Tag names to filter by. Flags carrying at least one of these tags match. */
+      tags?: string[];
+      /** When true, only matches flags with at least one evaluation context. */
+      has_evaluation_contexts?: boolean;
+    }
+
+    export interface BulkDeleteRequest {
+      /** Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. Use this to bulk-delete by search/active/tags/etc. instead of supplying explicit IDs. */
+      filters?: BulkDeleteFilters;
+      /** Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`. */
+      ids?: number[];
+    }
+
+    /**
+     * Schema-only — referenced from ``@extend_schema(responses=...)`` to describe the wire format.
+    Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
+    declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
+    so accessing ``serializer.errors`` would return this field descriptor instead of validation
+    errors. The handler builds the response dict directly; this class exists only so drf-spectacular
+    can render the response in the OpenAPI spec and downstream generated clients.
+     */
+    export interface BulkDeleteResponse {
+      /** Flags successfully soft-deleted. */
+      deleted: BulkDeleteDeletedItem[];
+      /** Flags that could not be deleted, with reasons. */
+      errors: BulkDeleteErrorItem[];
+    }
+
     export interface BulkIntervieweeContextItem {
       /**
          * Identifier for the interviewee — typically an email address or PostHog distinct ID. Must match a value in the parent topic's interviewee_emails or interviewee_distinct_ids.
@@ -6497,6 +6660,23 @@ export namespace Schemas {
       skipped_count: number;
       /** Identifiers from the request whose rows were skipped because a row for that (topic, interviewee_identifier) already existed. */
       skipped_identifiers: string[];
+    }
+
+    export interface BulkKeysRequest {
+      /** Feature flag IDs to look up keys for. Strings of digits are also accepted; any other value is reported in the response `warning` field and otherwise ignored. */
+      ids?: unknown[];
+    }
+
+    /**
+     * Mapping of feature flag ID (as a string) to flag key, for IDs that exist in this project.
+     */
+    export type BulkKeysResponseKeys = {[key: string]: string};
+
+    export interface BulkKeysResponse {
+      /** Mapping of feature flag ID (as a string) to flag key, for IDs that exist in this project. */
+      keys: BulkKeysResponseKeys;
+      /** Present when some submitted IDs were not numeric and were ignored. */
+      warning?: string;
     }
 
     export interface BulkNotificationIdsRequest {
@@ -8199,6 +8379,86 @@ export namespace Schemas {
     } as const;
 
     /**
+     * Typed configuration for a FileDownload batch-export destination.
+     */
+    export interface FileDownloadDestinationFileConfig {
+      /** File format
+
+      * `Parquet` - Parquet
+      * `JSONLines` - JSONLines */
+      format?: FileFormatEnum;
+      /** Compress the file with a supported compression format
+
+      * `zstd` - zstd
+      * `gzip` - gzip
+      * `brotli` - brotli
+      * `lz4` - lz4
+      * `snappy` - snappy */
+      compression?: CompressionEnum | null;
+      /**
+         * Split download into multiple files of at most this size in MB
+         * @minimum 0
+         * @nullable
+         */
+      max_size_mb?: number | null;
+    }
+
+    export type FileDownloadEventsRequestModel = typeof FileDownloadEventsRequestModel[keyof typeof FileDownloadEventsRequestModel];
+
+
+    export const FileDownloadEventsRequestModel = {
+      Events: 'events',
+    } as const;
+
+    /**
+     * Typed configuration for the events model.
+     */
+    export interface FileDownloadEventsRequest {
+      file: FileDownloadDestinationFileConfig;
+      model: FileDownloadEventsRequestModel;
+      include?: string[];
+      exclude?: string[];
+      data_interval_start: string;
+      data_interval_end: string;
+    }
+
+    export type FileDownloadPersonsRequestModel = typeof FileDownloadPersonsRequestModel[keyof typeof FileDownloadPersonsRequestModel];
+
+
+    export const FileDownloadPersonsRequestModel = {
+      Persons: 'persons',
+    } as const;
+
+    /**
+     * Typed configuration for the persons model.
+     */
+    export interface FileDownloadPersonsRequest {
+      file: FileDownloadDestinationFileConfig;
+      model: FileDownloadPersonsRequestModel;
+      data_interval_start: string;
+      data_interval_end: string;
+    }
+
+    export type FileDownloadSessionsRequestModel = typeof FileDownloadSessionsRequestModel[keyof typeof FileDownloadSessionsRequestModel];
+
+
+    export const FileDownloadSessionsRequestModel = {
+      Sessions: 'sessions',
+    } as const;
+
+    /**
+     * Typed configuration for the sessions model.
+     */
+    export interface FileDownloadSessionsRequest {
+      file: FileDownloadDestinationFileConfig;
+      model: FileDownloadSessionsRequestModel;
+      data_interval_start: string;
+      data_interval_end: string;
+    }
+
+    export type CreateFileDownloadRequest = FileDownloadEventsRequest | FileDownloadPersonsRequest | FileDownloadSessionsRequest;
+
+    /**
      * * `cost` - cost
     * `latency` - latency
     * `eval_pass_rate` - eval_pass_rate
@@ -8281,6 +8541,13 @@ export namespace Schemas {
       company_address: string;
       /** Email the signed PandaDoc envelope is sent to (PandaDoc's Client.Email). */
       representative_email: string;
+    }
+
+    /**
+     * Typed output for view set `create`.
+     */
+    export interface CreateOutput {
+      id: string;
     }
 
     /**
@@ -12968,20 +13235,6 @@ export namespace Schemas {
      */
     export type EarlyAccessFeaturePayload = { [key: string]: unknown };
 
-    /**
-     * * `server` - Server
-    * `client` - Client
-    * `all` - All
-     */
-    export type EvaluationRuntimeEnum = typeof EvaluationRuntimeEnum[keyof typeof EvaluationRuntimeEnum];
-
-
-    export const EvaluationRuntimeEnum = {
-      Server: 'server',
-      Client: 'client',
-      All: 'all',
-    } as const;
-
     export type MinimalFeatureFlagFilters = { [key: string]: unknown };
 
     export interface MinimalFeatureFlag {
@@ -16942,6 +17195,36 @@ export namespace Schemas {
       readonly modified_by: number | null;
     }
 
+    /**
+     * * `events` - events
+     */
+    export type FileDownloadEventsRequestModelEnum = typeof FileDownloadEventsRequestModelEnum[keyof typeof FileDownloadEventsRequestModelEnum];
+
+
+    export const FileDownloadEventsRequestModelEnum = {
+      Events: 'events',
+    } as const;
+
+    /**
+     * * `persons` - persons
+     */
+    export type FileDownloadPersonsRequestModelEnum = typeof FileDownloadPersonsRequestModelEnum[keyof typeof FileDownloadPersonsRequestModelEnum];
+
+
+    export const FileDownloadPersonsRequestModelEnum = {
+      Persons: 'persons',
+    } as const;
+
+    /**
+     * * `sessions` - sessions
+     */
+    export type FileDownloadSessionsRequestModelEnum = typeof FileDownloadSessionsRequestModelEnum[keyof typeof FileDownloadSessionsRequestModelEnum];
+
+
+    export const FileDownloadSessionsRequestModelEnum = {
+      Sessions: 'sessions',
+    } as const;
+
     export interface FileSystem {
       readonly id: string;
       path: string;
@@ -19968,97 +20251,6 @@ export namespace Schemas {
       created_at: string;
     }
 
-    /**
-     * * `gemini-3-flash-preview` - Gemini 3 Flash
-    * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
-     */
-    export type LensModelEnum = typeof LensModelEnum[keyof typeof LensModelEnum];
-
-
-    export const LensModelEnum = {
-      Gemini3FlashPreview: 'gemini-3-flash-preview',
-      Gemini31FlashLitePreview: 'gemini-3.1-flash-lite-preview',
-    } as const;
-
-    /**
-     * * `google` - Google
-     */
-    export type LensProviderEnum = typeof LensProviderEnum[keyof typeof LensProviderEnum];
-
-
-    export const LensProviderEnum = {
-      Google: 'google',
-    } as const;
-
-    /**
-     * Maps the short `event_id` the LLM cites in `model_output.reasoning` to citation metadata: `{uuid, timestamp_ms}`. Only includes hashes the LLM actually cited.
-     */
-    export type LensResultEventIdMapping = { [key: string]: unknown };
-
-    /**
-     * Mirrors `temporal.types.LensResult` for OpenAPI generation.
-     */
-    export interface LensResult {
-      /** Validated lens output. Shape depends on `lens_snapshot.lens_type`; always carries `confidence` and `lens_type`. */
-      model_output: unknown;
-      /**
-         * Number of PostHog Signals emitted from this observation.
-         * @minimum 0
-         */
-      signals_count: number;
-      /** Maps the short `event_id` the LLM cites in `model_output.reasoning` to citation metadata: `{uuid, timestamp_ms}`. Only includes hashes the LLM actually cited. */
-      event_id_mapping: LensResultEventIdMapping;
-    }
-
-    /**
-     * * `monitor` - Monitor
-    * `classifier` - Classifier
-    * `scorer` - Scorer
-    * `summarizer` - Summarizer
-    * `indexer` - Indexer
-     */
-    export type LensTypeEnum = typeof LensTypeEnum[keyof typeof LensTypeEnum];
-
-
-    export const LensTypeEnum = {
-      Monitor: 'monitor',
-      Classifier: 'classifier',
-      Scorer: 'scorer',
-      Summarizer: 'summarizer',
-      Indexer: 'indexer',
-    } as const;
-
-    /**
-     * Mirrors `temporal.types.LensSnapshot` for OpenAPI generation.
-     */
-    export interface LensSnapshot {
-      /** Lens name at run time. */
-      name: string;
-      /** Lens type (monitor, classifier, scorer, summarizer, indexer) at run time.
-
-      * `monitor` - Monitor
-      * `classifier` - Classifier
-      * `scorer` - Scorer
-      * `summarizer` - Summarizer
-      * `indexer` - Indexer */
-      lens_type: LensTypeEnum;
-      /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
-      lens_version: number;
-      /** Concrete model that ran the observation.
-
-      * `gemini-3-flash-preview` - Gemini 3 Flash
-      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
-      model: LensModelEnum;
-      /** Concrete provider that ran the observation.
-
-      * `google` - Google */
-      provider: LensProviderEnum;
-      /** Whether the observation was run with Signal emission enabled. */
-      emits_signals: boolean;
-      /** Lens-type-specific configuration at run time (prompt, tags, scale, etc.). */
-      lens_config: unknown;
-    }
-
     export type LimitContext = typeof LimitContext[keyof typeof LimitContext];
 
 
@@ -20454,7 +20646,7 @@ export namespace Schemas {
       scope_path_pattern?: string | null;
       /** Optional list of predicates over string attributes, e.g. [{"key":"http.route","op":"eq","value":"/api"}]. */
       scope_attribute_filters?: LogsSamplingRuleScopeAttributeFiltersItem[];
-      /** Type-specific JSON. For path_drop: object with optional `filter_group` (PropertyGroupFilter shape — AND/OR tree of property predicates evaluated per record) and/or legacy `patterns` (list of regex strings) + `match_attribute_key` (string). When both are present a record is dropped if EITHER matches. Filter group example: `{"type":"AND","values":[{"type":"AND","values":[{"key":"service.name","operator":"exact","value":"api"}]}]}`. For severity_sampling: object with `actions` per severity level and optional `always_keep`. For rate_limit: object with required `logs_per_second` (integer KB/s, 1–1000000 = 1 GB/s) and optional `burst_logs` (integer KB ≥ logs_per_second, max 10000000) and optional `filter_group` to narrow which logs the cap applies to. */
+      /** Type-specific JSON. For path_drop: object with optional `filter_group` (PropertyGroupFilter shape — AND/OR tree of property predicates evaluated per record) and/or legacy `patterns` (list of regex strings) + `match_attribute_key` (string). When both are present a record is dropped if EITHER matches. Filter group example: `{"type":"AND","values":[{"type":"AND","values":[{"key":"service.name","operator":"exact","value":"api"}]}]}`. For severity_sampling: object with `actions` per severity level and optional `always_keep`. For rate_limit: object with EITHER `logs_per_second` (integer 1–1000000, optional `burst_logs` integer ≥ logs_per_second, max 10000000) OR `kb_per_second` (integer 1–1000000 = 1 GB/s, optional `burst_kb` integer ≥ kb_per_second, max 10000000) — not both. Plus optional `filter_group` to narrow which logs the cap applies to. KB-mode charges each log its own uncompressed byte size, matching how billing measures ingested bytes. */
       config: unknown;
       /** Incremented on each update for worker cache coherency. */
       readonly version: number;
@@ -21448,21 +21640,21 @@ export namespace Schemas {
     } as const;
 
     /**
-     * Body of POST /vision/lenses/{id}/observe/.
+     * Body of POST /vision/scanners/{id}/observe/.
      */
     export interface ObserveRequest {
       /**
-         * ID of the session recording to apply the lens to.
+         * ID of the session recording to apply the scanner to.
          * @maxLength 128
          */
       session_id: string;
     }
 
     /**
-     * Async-accepted response for POST /vision/lenses/{id}/observe/.
+     * Async-accepted response for POST /vision/scanners/{id}/observe/.
      */
     export interface ObserveResponse {
-      /** Temporal workflow id for this lens application. Look up the resulting ReplayObservation via GET /vision/lenses/{id}/observations/?session_id=<session_id>. */
+      /** Temporal workflow id for this scanner application. Look up the resulting ReplayObservation via GET /vision/scanners/{id}/observations/?session_id=<session_id>. */
       workflow_id: string;
     }
 
@@ -23186,70 +23378,102 @@ export namespace Schemas {
       results: QuickFilter[];
     }
 
-    export interface ReplayLens {
-      readonly id: string;
-      /**
-         * Human-readable lens name. Unique within the team.
-         * @maxLength 255
-         */
+    /**
+     * * `monitor` - Monitor
+    * `classifier` - Classifier
+    * `scorer` - Scorer
+    * `summarizer` - Summarizer
+    * `indexer` - Indexer
+     */
+    export type ScannerTypeEnum = typeof ScannerTypeEnum[keyof typeof ScannerTypeEnum];
+
+
+    export const ScannerTypeEnum = {
+      Monitor: 'monitor',
+      Classifier: 'classifier',
+      Scorer: 'scorer',
+      Summarizer: 'summarizer',
+      Indexer: 'indexer',
+    } as const;
+
+    /**
+     * * `gemini-3-flash-preview` - Gemini 3 Flash
+    * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
+     */
+    export type ScannerModelEnum = typeof ScannerModelEnum[keyof typeof ScannerModelEnum];
+
+
+    export const ScannerModelEnum = {
+      Gemini3FlashPreview: 'gemini-3-flash-preview',
+      Gemini31FlashLitePreview: 'gemini-3.1-flash-lite-preview',
+    } as const;
+
+    /**
+     * * `google` - Google
+     */
+    export type ScannerProviderEnum = typeof ScannerProviderEnum[keyof typeof ScannerProviderEnum];
+
+
+    export const ScannerProviderEnum = {
+      Google: 'google',
+    } as const;
+
+    /**
+     * Mirrors `temporal.types.ScannerSnapshot` for OpenAPI generation.
+     */
+    export interface ScannerSnapshot {
+      /** Scanner name at run time. */
       name: string;
-      /** Free-form description shown in the lens management UI. */
-      description?: string;
-      /** What the lens does: monitor, classifier, scorer, summarizer, or indexer.
+      /** Scanner type (monitor, classifier, scorer, summarizer, indexer) at run time.
 
       * `monitor` - Monitor
       * `classifier` - Classifier
       * `scorer` - Scorer
       * `summarizer` - Summarizer
       * `indexer` - Indexer */
-      lens_type: LensTypeEnum;
-      /** Type-specific configuration. Monitor/classifier/scorer/summarizer require `prompt`; classifiers add `tags`, scorers add `scale`. Indexer is fixed-task and rejects `prompt`. */
-      lens_config: unknown;
-      /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
-      query?: unknown;
-      /**
-         * 0..1 random downsample applied after the query matches. Defaults to 1.0 (no downsampling).
-         * @minimum 0
-         * @maximum 1
-         */
-      sampling_rate?: number;
-      /** LLM provider. v1 is Google-only.
-
-      * `google` - Google */
-      provider?: LensProviderEnum;
-      /** Concrete model to use for this lens.
+      scanner_type: ScannerTypeEnum;
+      /** The `ReplayScanner.scanner_version` value at the moment the workflow ran. */
+      scanner_version: number;
+      /** Concrete model that ran the observation.
 
       * `gemini-3-flash-preview` - Gemini 3 Flash
       * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
-      model: LensModelEnum;
-      /** When false, the reconciler removes the lens's Temporal schedule. On-demand triggers still work. */
-      enabled?: boolean;
-      /** When true, the prompt is augmented with the Signal side mission and the lens emits PostHog Signals. */
-      emits_signals?: boolean;
-      /** Increments on every config-changing save. Observations snapshot this value. */
-      readonly lens_version: number;
-      /** Watermark for the lens's last scheduled fire. Mirrors Temporal schedule state for recovery. */
-      readonly last_swept_at: string;
-      readonly created_at: string;
-      /** User who created the lens. */
-      readonly created_by: UserBasic | null;
-      readonly updated_at: string;
+      model: ScannerModelEnum;
+      /** Concrete provider that ran the observation.
+
+      * `google` - Google */
+      provider: ScannerProviderEnum;
+      /** Whether the observation was run with Signal emission enabled. */
+      emits_signals: boolean;
+      /** Scanner-type-specific configuration at run time (prompt, tags, scale, etc.). */
+      scanner_config: unknown;
     }
 
-    export interface PaginatedReplayLensList {
-      count: number;
-      /** @nullable */
-      next?: string | null;
-      /** @nullable */
-      previous?: string | null;
-      results: ReplayLens[];
+    /**
+     * Maps the short `event_id` the LLM cites in `model_output.reasoning` to citation metadata: `{uuid, timestamp_ms}`. Only includes hashes the LLM actually cited.
+     */
+    export type ScannerResultEventIdMapping = { [key: string]: unknown };
+
+    /**
+     * Mirrors `temporal.types.ScannerResult` for OpenAPI generation.
+     */
+    export interface ScannerResult {
+      /** Validated scanner output. Shape depends on `scanner_snapshot.scanner_type`; always carries `confidence` and `scanner_type`. */
+      model_output: unknown;
+      /**
+         * Number of PostHog Signals emitted from this observation.
+         * @minimum 0
+         */
+      signals_count: number;
+      /** Maps the short `event_id` the LLM cites in `model_output.reasoning` to citation metadata: `{uuid, timestamp_ms}`. Only includes hashes the LLM actually cited. */
+      event_id_mapping: ScannerResultEventIdMapping;
     }
 
     export interface ReplayObservation {
       readonly id: string;
-      /** The lens that produced this observation. */
-      readonly lens_id: string;
-      /** Session recording id this lens was applied to. */
+      /** The scanner that produced this observation. */
+      readonly scanner_id: string;
+      /** Session recording id this scanner was applied to. */
       readonly session_id: string;
       /** Observation status (pending, running, succeeded, failed).
 
@@ -23262,10 +23486,10 @@ export namespace Schemas {
       readonly error_reason: string;
       /** Temporal workflow id for progress queries and debugging. Empty until the workflow starts. */
       readonly workflow_id: string;
-      /** Frozen view of the lens at run time; lens edits do not retroactively mutate this observation. */
-      readonly lens_snapshot: LensSnapshot | null;
+      /** Frozen view of the scanner at run time; scanner edits do not retroactively mutate this observation. */
+      readonly scanner_snapshot: ScannerSnapshot | null;
       /** Result data persisted on success; null until the observation succeeds. */
-      readonly lens_result: LensResult | null;
+      readonly scanner_result: ScannerResult | null;
       /** Whether this observation came from the schedule or an on-demand request.
 
       * `schedule` - Schedule
@@ -23287,6 +23511,65 @@ export namespace Schemas {
       /** @nullable */
       previous?: string | null;
       results: ReplayObservation[];
+    }
+
+    export interface ReplayScanner {
+      readonly id: string;
+      /**
+         * Human-readable scanner name. Unique within the team.
+         * @maxLength 255
+         */
+      name: string;
+      /** Free-form description shown in the scanner management UI. */
+      description?: string;
+      /** What the scanner does: monitor, classifier, scorer, summarizer, or indexer.
+
+      * `monitor` - Monitor
+      * `classifier` - Classifier
+      * `scorer` - Scorer
+      * `summarizer` - Summarizer
+      * `indexer` - Indexer */
+      scanner_type: ScannerTypeEnum;
+      /** Type-specific configuration. Monitor/classifier/scorer/summarizer require `prompt`; classifiers add `tags`, scorers add `scale`. Indexer is fixed-task and rejects `prompt`. */
+      scanner_config: unknown;
+      /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
+      query?: unknown;
+      /**
+         * 0..1 random downsample applied after the query matches. Defaults to 1.0 (no downsampling).
+         * @minimum 0
+         * @maximum 1
+         */
+      sampling_rate?: number;
+      /** LLM provider. v1 is Google-only.
+
+      * `google` - Google */
+      provider?: ScannerProviderEnum;
+      /** Concrete model to use for this scanner.
+
+      * `gemini-3-flash-preview` - Gemini 3 Flash
+      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+      model: ScannerModelEnum;
+      /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
+      enabled?: boolean;
+      /** When true, the prompt is augmented with the Signal side mission and the scanner emits PostHog Signals. */
+      emits_signals?: boolean;
+      /** Increments on every config-changing save. Observations snapshot this value. */
+      readonly scanner_version: number;
+      /** Watermark for the scanner's last scheduled fire. Mirrors Temporal schedule state for recovery. */
+      readonly last_swept_at: string;
+      readonly created_at: string;
+      /** User who created the scanner. */
+      readonly created_by: UserBasic | null;
+      readonly updated_at: string;
+    }
+
+    export interface PaginatedReplayScannerList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: ReplayScanner[];
     }
 
     export type RepoBaselineFilePaths = {[key: string]: string};
@@ -25702,6 +25985,9 @@ export namespace Schemas {
       zendesk_id?: string | null;
     } | null;
 
+    /**
+     * A Customer Analytics account — a logical grouping used to assign customer-success ownership.
+     */
     export interface PatchedAccount {
       readonly id?: string;
       /**
@@ -25720,6 +26006,8 @@ export namespace Schemas {
          * @nullable
          */
       properties?: PatchedAccountProperties;
+      /** Tag names attached to the account. Pass a list to replace existing tags. */
+      tags?: string[];
       /** Short IDs of the internal notebooks linked to this account, used to persist investigations, call notes, and other free-form context. Empty list if no notebooks have been created for the account. */
       readonly notebooks?: readonly string[];
       readonly created_at?: string;
@@ -28183,7 +28471,7 @@ export namespace Schemas {
       scope_path_pattern?: string | null;
       /** Optional list of predicates over string attributes, e.g. [{"key":"http.route","op":"eq","value":"/api"}]. */
       scope_attribute_filters?: PatchedLogsSamplingRuleScopeAttributeFiltersItem[];
-      /** Type-specific JSON. For path_drop: object with optional `filter_group` (PropertyGroupFilter shape — AND/OR tree of property predicates evaluated per record) and/or legacy `patterns` (list of regex strings) + `match_attribute_key` (string). When both are present a record is dropped if EITHER matches. Filter group example: `{"type":"AND","values":[{"type":"AND","values":[{"key":"service.name","operator":"exact","value":"api"}]}]}`. For severity_sampling: object with `actions` per severity level and optional `always_keep`. For rate_limit: object with required `logs_per_second` (integer KB/s, 1–1000000 = 1 GB/s) and optional `burst_logs` (integer KB ≥ logs_per_second, max 10000000) and optional `filter_group` to narrow which logs the cap applies to. */
+      /** Type-specific JSON. For path_drop: object with optional `filter_group` (PropertyGroupFilter shape — AND/OR tree of property predicates evaluated per record) and/or legacy `patterns` (list of regex strings) + `match_attribute_key` (string). When both are present a record is dropped if EITHER matches. Filter group example: `{"type":"AND","values":[{"type":"AND","values":[{"key":"service.name","operator":"exact","value":"api"}]}]}`. For severity_sampling: object with `actions` per severity level and optional `always_keep`. For rate_limit: object with EITHER `logs_per_second` (integer 1–1000000, optional `burst_logs` integer ≥ logs_per_second, max 10000000) OR `kb_per_second` (integer 1–1000000 = 1 GB/s, optional `burst_kb` integer ≥ kb_per_second, max 10000000) — not both. Plus optional `filter_group` to narrow which logs the cap applies to. KB-mode charges each log its own uncompressed byte size, matching how billing measures ingested bytes. */
       config?: unknown;
       /** Incremented on each update for worker cache coherency. */
       readonly version?: number;
@@ -29481,25 +29769,25 @@ export namespace Schemas {
       person_id?: string;
     }
 
-    export interface PatchedReplayLens {
+    export interface PatchedReplayScanner {
       readonly id?: string;
       /**
-         * Human-readable lens name. Unique within the team.
+         * Human-readable scanner name. Unique within the team.
          * @maxLength 255
          */
       name?: string;
-      /** Free-form description shown in the lens management UI. */
+      /** Free-form description shown in the scanner management UI. */
       description?: string;
-      /** What the lens does: monitor, classifier, scorer, summarizer, or indexer.
+      /** What the scanner does: monitor, classifier, scorer, summarizer, or indexer.
 
       * `monitor` - Monitor
       * `classifier` - Classifier
       * `scorer` - Scorer
       * `summarizer` - Summarizer
       * `indexer` - Indexer */
-      lens_type?: LensTypeEnum;
+      scanner_type?: ScannerTypeEnum;
       /** Type-specific configuration. Monitor/classifier/scorer/summarizer require `prompt`; classifiers add `tags`, scorers add `scale`. Indexer is fixed-task and rejects `prompt`. */
-      lens_config?: unknown;
+      scanner_config?: unknown;
       /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
       query?: unknown;
       /**
@@ -29511,22 +29799,22 @@ export namespace Schemas {
       /** LLM provider. v1 is Google-only.
 
       * `google` - Google */
-      provider?: LensProviderEnum;
-      /** Concrete model to use for this lens.
+      provider?: ScannerProviderEnum;
+      /** Concrete model to use for this scanner.
 
       * `gemini-3-flash-preview` - Gemini 3 Flash
       * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
-      model?: LensModelEnum;
-      /** When false, the reconciler removes the lens's Temporal schedule. On-demand triggers still work. */
+      model?: ScannerModelEnum;
+      /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
       enabled?: boolean;
-      /** When true, the prompt is augmented with the Signal side mission and the lens emits PostHog Signals. */
+      /** When true, the prompt is augmented with the Signal side mission and the scanner emits PostHog Signals. */
       emits_signals?: boolean;
       /** Increments on every config-changing save. Observations snapshot this value. */
-      readonly lens_version?: number;
-      /** Watermark for the lens's last scheduled fire. Mirrors Temporal schedule state for recovery. */
+      readonly scanner_version?: number;
+      /** Watermark for the scanner's last scheduled fire. Mirrors Temporal schedule state for recovery. */
       readonly last_swept_at?: string;
       readonly created_at?: string;
-      /** User who created the lens. */
+      /** User who created the scanner. */
       readonly created_by?: UserBasic | null;
       readonly updated_at?: string;
     }
@@ -34534,6 +34822,100 @@ export namespace Schemas {
       password: string;
     }
 
+    export type RetrieveBasicOutputStatus = typeof RetrieveBasicOutputStatus[keyof typeof RetrieveBasicOutputStatus];
+
+
+    export const RetrieveBasicOutputStatus = {
+      Starting: 'Starting',
+      Running: 'Running',
+      Cancelled: 'Cancelled',
+    } as const;
+
+    /**
+     * Typed output for view set `retrieve` with any of the statuses without extra output.
+     */
+    export interface RetrieveBasicOutput {
+      status: RetrieveBasicOutputStatus;
+    }
+
+    /**
+     * * `Starting` - Starting
+    * `Running` - Running
+    * `Cancelled` - Cancelled
+     */
+    export type RetrieveBasicOutputStatusEnum = typeof RetrieveBasicOutputStatusEnum[keyof typeof RetrieveBasicOutputStatusEnum];
+
+
+    export const RetrieveBasicOutputStatusEnum = {
+      Starting: 'Starting',
+      Running: 'Running',
+      Cancelled: 'Cancelled',
+    } as const;
+
+    export type RetrieveCompletedOutputStatus = typeof RetrieveCompletedOutputStatus[keyof typeof RetrieveCompletedOutputStatus];
+
+
+    export const RetrieveCompletedOutputStatus = {
+      Completed: 'Completed',
+    } as const;
+
+    /**
+     * Typed output for view set `retrieve` with completed status.
+     */
+    export interface RetrieveCompletedOutput {
+      status: RetrieveCompletedOutputStatus;
+      files: string[];
+    }
+
+    /**
+     * * `Completed` - Completed
+     */
+    export type RetrieveCompletedOutputStatusEnum = typeof RetrieveCompletedOutputStatusEnum[keyof typeof RetrieveCompletedOutputStatusEnum];
+
+
+    export const RetrieveCompletedOutputStatusEnum = {
+      Completed: 'Completed',
+    } as const;
+
+    export type RetrieveFailedOutputStatus = typeof RetrieveFailedOutputStatus[keyof typeof RetrieveFailedOutputStatus];
+
+
+    export const RetrieveFailedOutputStatus = {
+      Failed: 'Failed',
+      FailedRetryable: 'FailedRetryable',
+      FailedBilling: 'FailedBilling',
+      TimedOut: 'TimedOut',
+      Terminated: 'Terminated',
+    } as const;
+
+    /**
+     * Typed output for view set `retrieve` with any of the failed statuses.
+     */
+    export interface RetrieveFailedOutput {
+      status: RetrieveFailedOutputStatus;
+      error: string;
+    }
+
+    /**
+     * * `Failed` - Failed
+    * `FailedRetryable` - FailedRetryable
+    * `FailedBilling` - FailedBilling
+    * `Terminated` - Terminated
+    * `TimedOut` - TimedOut
+     */
+    export type RetrieveFailedOutputStatusEnum = typeof RetrieveFailedOutputStatusEnum[keyof typeof RetrieveFailedOutputStatusEnum];
+
+
+    export const RetrieveFailedOutputStatusEnum = {
+      Failed: 'Failed',
+      FailedRetryable: 'FailedRetryable',
+      FailedBilling: 'FailedBilling',
+      Terminated: 'Terminated',
+      TimedOut: 'TimedOut',
+    } as const;
+
+    export type RetrieveFileDownloadResponse = RetrieveBasicOutput | RetrieveCompletedOutput | RetrieveFailedOutput;
+
     export interface ReviewQueueCreate {
       /**
          * Human-readable queue name.
@@ -34943,7 +35325,26 @@ export namespace Schemas {
     export interface SignalUserAutonomyConfig {
       readonly id: string;
       readonly user: _User;
-      autostart_priority?: AutostartPriorityEnum | BlankEnum | null;
+      autostart_priority?: AutonomyPriorityEnum | BlankEnum | null;
+      /**
+         * ID of the Slack Integration to deliver inbox-item notifications through, or null when notifications are disabled.
+         * @nullable
+         */
+      readonly slack_notification_integration_id: number | null;
+      /**
+         * Slack channel target in the same `channel_id|#channel-name` shape PostHog uses elsewhere (only the channel id is required). Null disables Slack notifications.
+         * @maxLength 255
+         * @nullable
+         */
+      slack_notification_channel?: string | null;
+      /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority (and reports without a priority judgment).
+
+      * `P0` - P0
+      * `P1` - P1
+      * `P2` - P2
+      * `P3` - P3
+      * `P4` - P4 */
+      slack_notification_min_priority?: AutonomyPriorityEnum | BlankEnum | null;
       readonly created_at: string;
       readonly updated_at: string;
     }
@@ -34971,6 +35372,8 @@ export namespace Schemas {
          * @nullable
          */
       lastRefreshedAt?: string | null;
+      /** Whether more channels match the current search beyond this page. */
+      has_more?: boolean;
     }
 
     /**
@@ -35580,6 +35983,14 @@ export namespace Schemas {
       stats: SurveyStatsResponseStats;
       /** Calculated response and dismissal rates. */
       rates: SurveyStatsResponseRates;
+    }
+
+    export interface Synthesize {
+      /**
+         * The text the assistant should speak aloud.
+         * @maxLength 2000
+         */
+      text: string;
     }
 
     export interface TaggerCreate {
@@ -37898,7 +38309,7 @@ export namespace Schemas {
     offset?: number;
     };
 
-    export type EnvironmentsEndpointsOpenapiJsonRetrieveParams = {
+    export type EnvironmentsEndpointsOpenapiSpecRetrieveParams = {
     /**
      * Specific endpoint version to generate the spec for. Defaults to latest.
      */
@@ -38127,6 +38538,38 @@ export namespace Schemas {
     offset?: number;
     /**
      * A search term.
+     */
+    search?: string;
+    };
+
+    export type EnvironmentsFileDownloadBatchExportsLogsRetrieveParams = {
+    /**
+     * Only return entries after this ISO 8601 timestamp.
+     */
+    after?: string;
+    /**
+     * Only return entries before this ISO 8601 timestamp.
+     */
+    before?: string;
+    /**
+     * Filter logs to a specific execution instance.
+     * @minLength 1
+     */
+    instance_id?: string;
+    /**
+     * Comma-separated log levels to include, e.g. 'WARN,ERROR'. Valid levels: DEBUG, LOG, INFO, WARN, ERROR.
+     * @minLength 1
+     */
+    level?: string;
+    /**
+     * Maximum number of log entries to return (1-500, default 50).
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number;
+    /**
+     * Case-insensitive substring search across log messages.
+     * @minLength 1
      */
     search?: string;
     };
@@ -39149,6 +39592,24 @@ export namespace Schemas {
       Vercel: 'vercel',
     } as const;
 
+    export type EnvironmentsIntegrationsChannelsRetrieveParams = {
+    /**
+     * Maximum number of channels to return per request (max 200).
+     * @minimum 1
+     * @maximum 200
+     */
+    limit?: number;
+    /**
+     * Number of channels to skip before returning results.
+     * @minimum 0
+     */
+    offset?: number;
+    /**
+     * Optional case-insensitive channel name or ID search query.
+     */
+    search?: string;
+    };
+
     export type EnvironmentsIntegrationsGithubBranchesRetrieveParams = {
     /**
      * Maximum number of branches to return
@@ -39919,6 +40380,22 @@ export namespace Schemas {
 
     export type AccountsListParams = {
     /**
+     * Filter by account executive. Use 'unassigned' or an integer user id.
+     */
+    account_executive?: string;
+    /**
+     * Filter by account owner. Use 'unassigned' or an integer user id.
+     */
+    account_owner?: string;
+    /**
+     * When true, returns only accounts where CSM, account executive, and account owner are all unset.
+     */
+    all_roles_unassigned?: boolean;
+    /**
+     * Filter by CSM. Use 'unassigned' for accounts with no CSM, or an integer user id.
+     */
+    csm?: string;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -39926,6 +40403,18 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    /**
+     * Sort order. Defaults to '-created_at'.
+     */
+    ordering?: string;
+    /**
+     * Case-insensitive substring search across account name and external ID.
+     */
+    search?: string;
+    /**
+     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags.
+     */
+    tags?: string;
     };
 
     export type AccountsNotebooksListParams = {
@@ -40704,6 +41193,8 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type MaxHandsFreeTokenCreate200 = { [key: string]: unknown };
+
     export type MaxToolsCreateAndQueryInsightCreate200 = { [key: string]: unknown };
 
     export type McpAnalyticsFeedbackListParams = {
@@ -41090,25 +41581,15 @@ export namespace Schemas {
     topic?: string;
     };
 
-    export type VisionLensesListParams = {
+    export type VisionScannersListParams = {
     /**
-     * Filter to lenses that emit Signals.
+     * Filter to scanners that emit Signals.
      */
     emits_signals?: boolean;
     /**
-     * Filter to enabled vs disabled lenses.
+     * Filter to enabled vs disabled scanners.
      */
     enabled?: boolean;
-    /**
-     * Filter by lens type (monitor, classifier, scorer, summarizer, indexer).
-
-    * `monitor` - Monitor
-    * `classifier` - Classifier
-    * `scorer` - Scorer
-    * `summarizer` - Summarizer
-    * `indexer` - Indexer
-     */
-    lens_type?: VisionLensesListLensType;
     /**
      * Number of results to return per page.
      */
@@ -41118,7 +41599,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Sort lenses by name, created_at, updated_at, or lens_type. Prefix with `-` for descending.
+     * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
 
     * `name` - Name
     * `-name` - Name (descending)
@@ -41126,16 +41607,26 @@ export namespace Schemas {
     * `-created_at` - Created at (descending)
     * `updated_at` - Updated at
     * `-updated_at` - Updated at (descending)
-    * `lens_type` - Lens type
-    * `-lens_type` - Lens type (descending)
+    * `scanner_type` - Scanner type
+    * `-scanner_type` - Scanner type (descending)
      */
     order_by?: string[];
+    /**
+     * Filter by scanner type (monitor, classifier, scorer, summarizer, indexer).
+
+    * `monitor` - Monitor
+    * `classifier` - Classifier
+    * `scorer` - Scorer
+    * `summarizer` - Summarizer
+    * `indexer` - Indexer
+     */
+    scanner_type?: VisionScannersListScannerType;
     };
 
-    export type VisionLensesListLensType = typeof VisionLensesListLensType[keyof typeof VisionLensesListLensType];
+    export type VisionScannersListScannerType = typeof VisionScannersListScannerType[keyof typeof VisionScannersListScannerType];
 
 
-    export const VisionLensesListLensType = {
+    export const VisionScannersListScannerType = {
       Classifier: 'classifier',
       Indexer: 'indexer',
       Monitor: 'monitor',
@@ -41143,7 +41634,7 @@ export namespace Schemas {
       Summarizer: 'summarizer',
     } as const;
 
-    export type VisionLensesObservationsListParams = {
+    export type VisionScannersObservationsListParams = {
     /**
      * Number of results to return per page.
      */
@@ -41177,30 +41668,30 @@ export namespace Schemas {
     * `succeeded` - Succeeded
     * `failed` - Failed
      */
-    status?: VisionLensesObservationsListStatus;
+    status?: VisionScannersObservationsListStatus;
     /**
      * Filter by trigger source (schedule or on_demand).
 
     * `schedule` - Schedule
     * `on_demand` - On demand
      */
-    triggered_by?: VisionLensesObservationsListTriggeredBy;
+    triggered_by?: VisionScannersObservationsListTriggeredBy;
     };
 
-    export type VisionLensesObservationsListStatus = typeof VisionLensesObservationsListStatus[keyof typeof VisionLensesObservationsListStatus];
+    export type VisionScannersObservationsListStatus = typeof VisionScannersObservationsListStatus[keyof typeof VisionScannersObservationsListStatus];
 
 
-    export const VisionLensesObservationsListStatus = {
+    export const VisionScannersObservationsListStatus = {
       Failed: 'failed',
       Pending: 'pending',
       Running: 'running',
       Succeeded: 'succeeded',
     } as const;
 
-    export type VisionLensesObservationsListTriggeredBy = typeof VisionLensesObservationsListTriggeredBy[keyof typeof VisionLensesObservationsListTriggeredBy];
+    export type VisionScannersObservationsListTriggeredBy = typeof VisionScannersObservationsListTriggeredBy[keyof typeof VisionScannersObservationsListTriggeredBy];
 
 
-    export const VisionLensesObservationsListTriggeredBy = {
+    export const VisionScannersObservationsListTriggeredBy = {
       OnDemand: 'on_demand',
       Schedule: 'schedule',
     } as const;
@@ -41732,6 +42223,7 @@ export namespace Schemas {
     * `AlertSubscription` - AlertSubscription
     * `ExternalDataSource` - ExternalDataSource
     * `ExternalDataSchema` - ExternalDataSchema
+    * `Evaluation` - Evaluation
     * `LLMTrace` - LLMTrace
     * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
     * `CustomerProfileConfig` - CustomerProfileConfig
@@ -41807,6 +42299,7 @@ export namespace Schemas {
       AlertSubscription: 'AlertSubscription',
       ExternalDataSource: 'ExternalDataSource',
       ExternalDataSchema: 'ExternalDataSchema',
+      Evaluation: 'Evaluation',
       LLMTrace: 'LLMTrace',
       WebAnalyticsFilterPreset: 'WebAnalyticsFilterPreset',
       CustomerProfileConfig: 'CustomerProfileConfig',
@@ -41868,6 +42361,7 @@ export namespace Schemas {
     * `AlertSubscription` - AlertSubscription
     * `ExternalDataSource` - ExternalDataSource
     * `ExternalDataSchema` - ExternalDataSchema
+    * `Evaluation` - Evaluation
     * `LLMTrace` - LLMTrace
     * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
     * `CustomerProfileConfig` - CustomerProfileConfig
@@ -41931,6 +42425,7 @@ export namespace Schemas {
       AlertSubscription: 'AlertSubscription',
       ExternalDataSource: 'ExternalDataSource',
       ExternalDataSchema: 'ExternalDataSchema',
+      Evaluation: 'Evaluation',
       LLMTrace: 'LLMTrace',
       WebAnalyticsFilterPreset: 'WebAnalyticsFilterPreset',
       CustomerProfileConfig: 'CustomerProfileConfig',
@@ -42816,7 +43311,7 @@ export namespace Schemas {
     offset?: number;
     };
 
-    export type EndpointsOpenapiJsonRetrieveParams = {
+    export type EndpointsOpenapiSpecRetrieveParams = {
     /**
      * Specific endpoint version to generate the spec for. Defaults to latest.
      */
@@ -43310,6 +43805,38 @@ export namespace Schemas {
      * Groups for feature flag evaluation (JSON object string)
      */
     groups?: string;
+    };
+
+    export type FileDownloadBatchExportsLogsRetrieveParams = {
+    /**
+     * Only return entries after this ISO 8601 timestamp.
+     */
+    after?: string;
+    /**
+     * Only return entries before this ISO 8601 timestamp.
+     */
+    before?: string;
+    /**
+     * Filter logs to a specific execution instance.
+     * @minLength 1
+     */
+    instance_id?: string;
+    /**
+     * Comma-separated log levels to include, e.g. 'WARN,ERROR'. Valid levels: DEBUG, LOG, INFO, WARN, ERROR.
+     * @minLength 1
+     */
+    level?: string;
+    /**
+     * Maximum number of log entries to return (1-500, default 50).
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number;
+    /**
+     * Case-insensitive substring search across log messages.
+     * @minLength 1
+     */
+    search?: string;
     };
 
     export type FileSystemListParams = {
@@ -44370,6 +44897,24 @@ export namespace Schemas {
       Twilio: 'twilio',
       Vercel: 'vercel',
     } as const;
+
+    export type IntegrationsChannelsRetrieveParams = {
+    /**
+     * Maximum number of channels to return per request (max 200).
+     * @minimum 1
+     * @maximum 200
+     */
+    limit?: number;
+    /**
+     * Number of channels to skip before returning results.
+     * @minimum 0
+     */
+    offset?: number;
+    /**
+     * Optional case-insensitive channel name or ID search query.
+     */
+    search?: string;
+    };
 
     export type IntegrationsGithubBranchesRetrieveParams = {
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -117,6 +117,85 @@ export namespace Schemas {
     }
 
     /**
+     * * `engineering` - Engineering
+    * `data` - Data
+    * `product` - Product Management
+    * `founder` - Founder
+    * `leadership` - Leadership
+    * `marketing` - Marketing
+    * `sales` - Sales / Success
+    * `other` - Other
+     */
+    export type RoleAtOrganizationEnum = typeof RoleAtOrganizationEnum[keyof typeof RoleAtOrganizationEnum];
+
+
+    export const RoleAtOrganizationEnum = {
+      Engineering: 'engineering',
+      Data: 'data',
+      Product: 'product',
+      Founder: 'founder',
+      Leadership: 'leadership',
+      Marketing: 'marketing',
+      Sales: 'sales',
+      Other: 'other',
+    } as const;
+
+    export type BlankEnum = typeof BlankEnum[keyof typeof BlankEnum];
+
+
+    export const BlankEnum = {
+      '': '',
+    } as const;
+
+    /**
+     * @nullable
+     */
+    export type UserBasicHedgehogConfig = { [key: string]: unknown } | null;
+
+    export interface UserBasic {
+      readonly id: number;
+      readonly uuid: string;
+      /**
+         * @maxLength 200
+         * @nullable
+         */
+      distinct_id?: string | null;
+      /** @maxLength 150 */
+      first_name?: string;
+      /** @maxLength 150 */
+      last_name?: string;
+      /** @maxLength 254 */
+      email: string;
+      /** @nullable */
+      is_email_verified?: boolean | null;
+      /** @nullable */
+      readonly hedgehog_config: UserBasicHedgehogConfig;
+      role_at_organization?: RoleAtOrganizationEnum | BlankEnum | null;
+    }
+
+    export interface AccountNotebook {
+      readonly id: string;
+      readonly short_id: string;
+      /**
+         * Human-readable title of the account notebook.
+         * @maxLength 256
+         * @nullable
+         */
+      title?: string | null;
+      /** Notebook content as a ProseMirror JSON document structure. */
+      content?: unknown;
+      /**
+         * Plain text representation of the notebook content for search.
+         * @nullable
+         */
+      text_content?: string | null;
+      readonly created_at: string;
+      readonly created_by: UserBasic;
+      readonly last_modified_at: string;
+      readonly last_modified_by: UserBasic;
+    }
+
+    /**
      * * `event` - event
     * `event_metadata` - event_metadata
     * `feature` - feature
@@ -566,63 +645,6 @@ export namespace Schemas {
       * `regex` - regex
       * `exact` - exact */
       url_matching?: ActionStepMatchingEnum | null;
-    }
-
-    /**
-     * * `engineering` - Engineering
-    * `data` - Data
-    * `product` - Product Management
-    * `founder` - Founder
-    * `leadership` - Leadership
-    * `marketing` - Marketing
-    * `sales` - Sales / Success
-    * `other` - Other
-     */
-    export type RoleAtOrganizationEnum = typeof RoleAtOrganizationEnum[keyof typeof RoleAtOrganizationEnum];
-
-
-    export const RoleAtOrganizationEnum = {
-      Engineering: 'engineering',
-      Data: 'data',
-      Product: 'product',
-      Founder: 'founder',
-      Leadership: 'leadership',
-      Marketing: 'marketing',
-      Sales: 'sales',
-      Other: 'other',
-    } as const;
-
-    export type BlankEnum = typeof BlankEnum[keyof typeof BlankEnum];
-
-
-    export const BlankEnum = {
-      '': '',
-    } as const;
-
-    /**
-     * @nullable
-     */
-    export type UserBasicHedgehogConfig = { [key: string]: unknown } | null;
-
-    export interface UserBasic {
-      readonly id: number;
-      readonly uuid: string;
-      /**
-         * @maxLength 200
-         * @nullable
-         */
-      distinct_id?: string | null;
-      /** @maxLength 150 */
-      first_name?: string;
-      /** @maxLength 150 */
-      last_name?: string;
-      /** @maxLength 254 */
-      email: string;
-      /** @nullable */
-      is_email_verified?: boolean | null;
-      /** @nullable */
-      readonly hedgehog_config: UserBasicHedgehogConfig;
-      role_at_organization?: RoleAtOrganizationEnum | BlankEnum | null;
     }
 
     /**
@@ -21857,6 +21879,15 @@ export namespace Schemas {
       results: Account[];
     }
 
+    export interface PaginatedAccountNotebookList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: AccountNotebook[];
+    }
+
     export interface PaginatedActionList {
       count: number;
       /** @nullable */
@@ -39887,6 +39918,17 @@ export namespace Schemas {
     };
 
     export type AccountsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type AccountsNotebooksListParams = {
     /**
      * Number of results to return per page.
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2935,6 +2935,7 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
+      usedLazyPrecompute?: boolean | null;
       usedPreAggregatedTables?: boolean | null;
     }
 
@@ -2974,6 +2975,8 @@ export namespace Schemas {
       samplingFactor?: number | null;
       tags?: QueryLogTags | null;
       useSessionsTable?: boolean | null;
+      /** Opt this specific query into the web stats table precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
+      useWebAnalyticsPrecompute?: boolean | null;
       /** version of the node, used for schema migrations */
       version?: number | null;
     }
@@ -9276,6 +9279,7 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
+      usedLazyPrecompute?: boolean | null;
       usedPreAggregatedTables?: boolean | null;
     }
 
@@ -20232,6 +20236,15 @@ export namespace Schemas {
       Inactive: 'inactive',
       Never: 'never',
     } as const;
+
+    export interface LatestTestInterview {
+      /** When the test interview was completed. */
+      completed_at: string;
+      /** Full transcript of the test call, if Vapi delivered one. May be empty. */
+      transcript: string;
+      /** AI-generated summary of the test call, if Vapi delivered one. May be empty. */
+      summary: string;
+    }
 
     export interface LegalDocumentCreator {
       first_name: string;
@@ -31768,16 +31781,13 @@ export namespace Schemas {
       date_from: string;
       /** Exclusive UTC end of the spend window resolved from the request. */
       date_to: string;
-      /**
-         * The `ai_product` filter applied to tool / model / trace breakdowns. Null when unfiltered.
-         * @nullable
-         */
-      product: string | null;
+      /** The `ai_product` filter applied to tool / model / trace breakdowns — echoes the request `product`. */
+      product: string;
       /** Total LLM cost in USD across every `ai_product` for the user — independent of the `product` filter. */
       total_cost_usd: number;
       /** Total $ai_generation + $ai_embedding events captured across every product. */
       event_count: number;
-      /** Total cost in USD for the product filter (or all products when unfiltered). Matches the cost summed across `by_tool` / `by_model` for the scoped slice. */
+      /** Total cost in USD for the product filter. Matches the cost summed across `by_tool` / `by_model` for the scoped slice. */
       scoped_cost_usd: number;
       /** Total $ai_generation + $ai_embedding events for the scoped slice. */
       scoped_event_count: number;
@@ -31884,7 +31894,7 @@ export namespace Schemas {
       by_tool: _ToolBreakdown;
       /** Spend grouped by `$ai_model`. Scoped to `product` when set. */
       by_model: _ModelBreakdown;
-      /** Most expensive trace IDs (sessions) in the window. Scoped to `product` when set. */
+      /** Deprecated — always returns `{items: [], truncated: false}`. Trace IDs are opaque strings that aren't actionable in the UI. Kept in the response shape so existing consumers don't crash; remove your rendering of this field and we'll drop it from the response entirely in a follow-up. */
       top_traces: _TopTraces;
     }
 
@@ -33574,6 +33584,7 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
+      usedLazyPrecompute?: boolean | null;
       usedPreAggregatedTables?: boolean | null;
     }
 
@@ -33949,6 +33960,7 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
+      usedLazyPrecompute?: boolean | null;
       usedPreAggregatedTables?: boolean | null;
     }
 
@@ -36020,6 +36032,21 @@ export namespace Schemas {
       deleted?: boolean;
     }
 
+    /**
+     * Request body for the presence beacon and beacon-leave endpoints.
+
+    `device_id` is the UUID of the caller's `UserPushToken` row, which the
+    client received when it registered for push via `/api/users/@me/push_tokens/`.
+    The client is expected to use the same identifier on the beacon and leave
+    calls; if the user has unregistered the underlying push token, the value
+    won't resolve and the call returns 404 — at which point pushes were
+    already not going there anyway.
+     */
+    export interface TaskPresenceBeaconRequest {
+      /** UUID of the caller's UserPushToken (returned by `/api/users/@me/push_tokens/` on register). */
+      device_id: string;
+    }
+
     export interface TaskRepositoriesResponse {
       /** Distinct repositories in use by non-deleted, non-internal tasks for the current team. */
       repositories: string[];
@@ -36859,6 +36886,13 @@ export namespace Schemas {
       results: TestHogTaggerResultItem[];
       /** Optional message, for example when no recent AI events were found. */
       message?: string;
+    }
+
+    export interface TestInterviewLink {
+      /** Public, unauthenticated URL the topic author opens to dogfood the voice interview themselves — does not count against the targeted interviewees. */
+      interview_url: string;
+      /** Most recent test interview completed by the topic author, or null if none yet. */
+      latest_test_interview: LatestTestInterview | null;
     }
 
     export interface TextReprMetadata {
@@ -40412,7 +40446,7 @@ export namespace Schemas {
      */
     search?: string;
     /**
-     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags.
+     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags. Malformed values (not a JSON-encoded list of strings) return a 400.
      */
     tags?: string;
     };
@@ -41760,11 +41794,11 @@ export namespace Schemas {
      */
     limit?: number;
     /**
-     * Optional `ai_product` key to scope the tool / model / trace breakdowns to a single product (e.g. `posthog_code`, `background_agents`). When omitted, those breakdowns aggregate across every product captured for the user.
+     * Required `ai_product` key to scope the tool / model / trace breakdowns to a single product. Only the following products are currently supported: posthog_code.
+     * @minLength 1
      * @maxLength 64
-     * @nullable
      */
-    product?: string | null;
+    product: string;
     /**
      * If true, bypass the result cache and re-run the underlying queries against ClickHouse.
      */
@@ -43400,6 +43434,14 @@ export namespace Schemas {
     } as const;
 
     export type EventDefinitionsListParams = {
+    /**
+     * When true, omit events that have been explicitly hidden by a team admin (Enterprise only).
+     */
+    exclude_hidden?: boolean;
+    /**
+     * When true, omit events whose last ingested occurrence is older than 30 days. Events that have never been seen (`last_seen_at` is null) are kept so newly-defined events remain discoverable. Default false. If a search returns zero results with this filter on, retry with `exclude_stale=false` and tell the user the matches are stale.
+     */
+    exclude_stale?: boolean;
     /**
      * Number of results to return per page.
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -89,9 +89,6 @@ export namespace Schemas {
       zendesk_id?: string | null;
     } | null;
 
-    /**
-     * A Customer Analytics account — a logical grouping used to assign customer-success ownership.
-     */
     export interface Account {
       readonly id: string;
       /**
@@ -110,8 +107,8 @@ export namespace Schemas {
          * @nullable
          */
       properties?: AccountProperties;
-      /** Tag names attached to the account. Pass a list to replace existing tags. */
-      tags?: string[];
+      /** Short IDs of the internal notebooks linked to this account, used to persist investigations, call notes, and other free-form context. Empty list if no notebooks have been created for the account. */
+      readonly notebooks: readonly string[];
       readonly created_at: string;
       /** @nullable */
       readonly created_by: number | null;
@@ -1265,20 +1262,6 @@ export namespace Schemas {
       breakpoints: ActiveBreakpoint[];
     }
 
-    /**
-     * * `true` - true
-    * `false` - false
-    * `STALE` - STALE
-     */
-    export type ActiveEnum = typeof ActiveEnum[keyof typeof ActiveEnum];
-
-
-    export const ActiveEnum = {
-      True: 'true',
-      False: 'false',
-      Stale: 'STALE',
-    } as const;
-
     export interface ActivityLog {
       readonly id: string;
       user: UserBasic;
@@ -1474,18 +1457,6 @@ export namespace Schemas {
       Optimized: 'optimized',
     } as const;
 
-    export type ParserMode = typeof ParserMode[keyof typeof ParserMode];
-
-
-    export const ParserMode = {
-      CppOnly: 'cpp_only',
-      CppWithRustShadow: 'cpp_with_rust_shadow',
-      RustWithCppShadow: 'rust_with_cpp_shadow',
-      RustOnly: 'rust_only',
-      RustPyOnly: 'rust_py_only',
-      RustPyWithCppShadow: 'rust_py_with_cpp_shadow',
-    } as const;
-
     export type PersonsArgMaxVersion = typeof PersonsArgMaxVersion[keyof typeof PersonsArgMaxVersion];
 
 
@@ -1556,8 +1527,6 @@ export namespace Schemas {
       materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationMode | null;
       optimizeJoinedFilters?: boolean | null;
       optimizeProjections?: boolean | null;
-      /** HogQL parser backend; absent → `cpp_only`. `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
-      parserMode?: ParserMode | null;
       personsArgMaxVersion?: PersonsArgMaxVersion | null;
       personsJoinMode?: PersonsJoinMode | null;
       personsOnEventsMode?: PersonsOnEventsMode | null;
@@ -2485,8 +2454,6 @@ export namespace Schemas {
       aggregationPropertyType?: AggregationPropertyType1 | null;
       /** The aggregation type to use for retention */
       aggregationType?: AggregationType | null;
-      /** Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations. */
-      cohortLabelStartIndex?: number | null;
       cumulative?: boolean | null;
       /** For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups. */
       customAggregationTarget?: boolean | null;
@@ -2911,7 +2878,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      usedLazyPrecompute?: boolean | null;
       usedPreAggregatedTables?: boolean | null;
     }
 
@@ -2951,8 +2917,6 @@ export namespace Schemas {
       samplingFactor?: number | null;
       tags?: QueryLogTags | null;
       useSessionsTable?: boolean | null;
-      /** Opt this specific query into the web stats table precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
-      useWebAnalyticsPrecompute?: boolean | null;
       /** version of the node, used for schema migrations */
       version?: number | null;
     }
@@ -3022,7 +2986,7 @@ export namespace Schemas {
       samplingFactor?: number | null;
       tags?: QueryLogTags | null;
       useSessionsTable?: boolean | null;
-      /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
+      /** Opt this specific query into the web_overview_query precompute path. Requires the team to be in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` allowlist for the gate to pass. * */
       useWebAnalyticsPrecompute?: boolean | null;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -4494,10 +4458,10 @@ export namespace Schemas {
     * `P3` - P3
     * `P4` - P4
      */
-    export type AutonomyPriorityEnum = typeof AutonomyPriorityEnum[keyof typeof AutonomyPriorityEnum];
+    export type AutostartPriorityEnum = typeof AutostartPriorityEnum[keyof typeof AutostartPriorityEnum];
 
 
-    export const AutonomyPriorityEnum = {
+    export const AutostartPriorityEnum = {
       P0: 'P0',
       P1: 'P1',
       P2: 'P2',
@@ -6486,134 +6450,6 @@ export namespace Schemas {
       DeviceId: 'device_id',
     } as const;
 
-    /**
-     * * `fully_rolled_out` - fully_rolled_out
-    * `not_rolled_out` - not_rolled_out
-    * `partial` - partial
-     */
-    export type RolloutStateEnum = typeof RolloutStateEnum[keyof typeof RolloutStateEnum];
-
-
-    export const RolloutStateEnum = {
-      FullyRolledOut: 'fully_rolled_out',
-      NotRolledOut: 'not_rolled_out',
-      Partial: 'partial',
-    } as const;
-
-    export interface BulkDeleteDeletedItem {
-      /** ID of the soft-deleted flag. */
-      id: number;
-      /** The flag key at the time of deletion. */
-      key: string;
-      /** Rollout state captured before deletion.
-
-      * `fully_rolled_out` - fully_rolled_out
-      * `not_rolled_out` - not_rolled_out
-      * `partial` - partial */
-      rollout_state: RolloutStateEnum;
-      /**
-         * Variant key when a multivariate flag was fully rolled out to a single variant; otherwise null.
-         * @nullable
-         */
-      active_variant: string | null;
-    }
-
-    export interface BulkDeleteErrorItem {
-      /** Feature flag ID — integer for valid inputs; the original raw value for invalid inputs. */
-      id: unknown;
-      /** The flag key, when known. */
-      key?: string;
-      /** Human-readable reason the flag could not be deleted. */
-      reason: string;
-    }
-
-    /**
-     * * `boolean` - boolean
-    * `multivariant` - multivariant
-    * `experiment` - experiment
-    * `remote_config` - remote_config
-     */
-    export type BulkDeleteFiltersTypeEnum = typeof BulkDeleteFiltersTypeEnum[keyof typeof BulkDeleteFiltersTypeEnum];
-
-
-    export const BulkDeleteFiltersTypeEnum = {
-      Boolean: 'boolean',
-      Multivariant: 'multivariant',
-      Experiment: 'experiment',
-      RemoteConfig: 'remote_config',
-    } as const;
-
-    /**
-     * * `server` - Server
-    * `client` - Client
-    * `all` - All
-     */
-    export type EvaluationRuntimeEnum = typeof EvaluationRuntimeEnum[keyof typeof EvaluationRuntimeEnum];
-
-
-    export const EvaluationRuntimeEnum = {
-      Server: 'server',
-      Client: 'client',
-      All: 'all',
-    } as const;
-
-    /**
-     * Allowed filter keys for bulk_delete — same shape as the list endpoint's query params.
-     */
-    export interface BulkDeleteFilters {
-      /** Filter by active state.
-
-      * `true` - true
-      * `false` - false
-      * `STALE` - STALE */
-      active?: ActiveEnum;
-      /** Filter to flags created by a specific user ID. */
-      created_by_id?: number;
-      /** Search by feature flag key or name (case-insensitive). */
-      search?: string;
-      /** Filter by flag type.
-
-      * `boolean` - boolean
-      * `multivariant` - multivariant
-      * `experiment` - experiment
-      * `remote_config` - remote_config */
-      type?: BulkDeleteFiltersTypeEnum;
-      /** Filter by evaluation runtime.
-
-      * `server` - Server
-      * `client` - Client
-      * `all` - All */
-      evaluation_runtime?: EvaluationRuntimeEnum;
-      /** JSON-encoded property filter to exclude. Same shape as the list endpoint. */
-      excluded_properties?: string;
-      /** Tag names to filter by. Flags carrying at least one of these tags match. */
-      tags?: string[];
-      /** When true, only matches flags with at least one evaluation context. */
-      has_evaluation_contexts?: boolean;
-    }
-
-    export interface BulkDeleteRequest {
-      /** Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. Use this to bulk-delete by search/active/tags/etc. instead of supplying explicit IDs. */
-      filters?: BulkDeleteFilters;
-      /** Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`. */
-      ids?: number[];
-    }
-
-    /**
-     * Schema-only — referenced from ``@extend_schema(responses=...)`` to describe the wire format.
-    Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
-    declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
-    so accessing ``serializer.errors`` would return this field descriptor instead of validation
-    errors. The handler builds the response dict directly; this class exists only so drf-spectacular
-    can render the response in the OpenAPI spec and downstream generated clients.
-     */
-    export interface BulkDeleteResponse {
-      /** Flags successfully soft-deleted. */
-      deleted: BulkDeleteDeletedItem[];
-      /** Flags that could not be deleted, with reasons. */
-      errors: BulkDeleteErrorItem[];
-    }
-
     export interface BulkIntervieweeContextItem {
       /**
          * Identifier for the interviewee — typically an email address or PostHog distinct ID. Must match a value in the parent topic's interviewee_emails or interviewee_distinct_ids.
@@ -6639,23 +6475,6 @@ export namespace Schemas {
       skipped_count: number;
       /** Identifiers from the request whose rows were skipped because a row for that (topic, interviewee_identifier) already existed. */
       skipped_identifiers: string[];
-    }
-
-    export interface BulkKeysRequest {
-      /** Feature flag IDs to look up keys for. Strings of digits are also accepted; any other value is reported in the response `warning` field and otherwise ignored. */
-      ids?: unknown[];
-    }
-
-    /**
-     * Mapping of feature flag ID (as a string) to flag key, for IDs that exist in this project.
-     */
-    export type BulkKeysResponseKeys = {[key: string]: string};
-
-    export interface BulkKeysResponse {
-      /** Mapping of feature flag ID (as a string) to flag key, for IDs that exist in this project. */
-      keys: BulkKeysResponseKeys;
-      /** Present when some submitted IDs were not numeric and were ignored. */
-      warning?: string;
     }
 
     export interface BulkNotificationIdsRequest {
@@ -8358,86 +8177,6 @@ export namespace Schemas {
     } as const;
 
     /**
-     * Typed configuration for a FileDownload batch-export destination.
-     */
-    export interface FileDownloadDestinationFileConfig {
-      /** File format
-
-      * `Parquet` - Parquet
-      * `JSONLines` - JSONLines */
-      format?: FileFormatEnum;
-      /** Compress the file with a supported compression format
-
-      * `zstd` - zstd
-      * `gzip` - gzip
-      * `brotli` - brotli
-      * `lz4` - lz4
-      * `snappy` - snappy */
-      compression?: CompressionEnum | null;
-      /**
-         * Split download into multiple files of at most this size in MB
-         * @minimum 0
-         * @nullable
-         */
-      max_size_mb?: number | null;
-    }
-
-    export type FileDownloadEventsRequestModel = typeof FileDownloadEventsRequestModel[keyof typeof FileDownloadEventsRequestModel];
-
-
-    export const FileDownloadEventsRequestModel = {
-      Events: 'events',
-    } as const;
-
-    /**
-     * Typed configuration for the events model.
-     */
-    export interface FileDownloadEventsRequest {
-      file: FileDownloadDestinationFileConfig;
-      model: FileDownloadEventsRequestModel;
-      include?: string[];
-      exclude?: string[];
-      data_interval_start: string;
-      data_interval_end: string;
-    }
-
-    export type FileDownloadPersonsRequestModel = typeof FileDownloadPersonsRequestModel[keyof typeof FileDownloadPersonsRequestModel];
-
-
-    export const FileDownloadPersonsRequestModel = {
-      Persons: 'persons',
-    } as const;
-
-    /**
-     * Typed configuration for the persons model.
-     */
-    export interface FileDownloadPersonsRequest {
-      file: FileDownloadDestinationFileConfig;
-      model: FileDownloadPersonsRequestModel;
-      data_interval_start: string;
-      data_interval_end: string;
-    }
-
-    export type FileDownloadSessionsRequestModel = typeof FileDownloadSessionsRequestModel[keyof typeof FileDownloadSessionsRequestModel];
-
-
-    export const FileDownloadSessionsRequestModel = {
-      Sessions: 'sessions',
-    } as const;
-
-    /**
-     * Typed configuration for the sessions model.
-     */
-    export interface FileDownloadSessionsRequest {
-      file: FileDownloadDestinationFileConfig;
-      model: FileDownloadSessionsRequestModel;
-      data_interval_start: string;
-      data_interval_end: string;
-    }
-
-    export type CreateFileDownloadRequest = FileDownloadEventsRequest | FileDownloadPersonsRequest | FileDownloadSessionsRequest;
-
-    /**
      * * `cost` - cost
     * `latency` - latency
     * `eval_pass_rate` - eval_pass_rate
@@ -8520,13 +8259,6 @@ export namespace Schemas {
       company_address: string;
       /** Email the signed PandaDoc envelope is sent to (PandaDoc's Client.Email). */
       representative_email: string;
-    }
-
-    /**
-     * Typed output for view set `create`.
-     */
-    export interface CreateOutput {
-      id: string;
     }
 
     /**
@@ -9255,7 +8987,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      usedLazyPrecompute?: boolean | null;
       usedPreAggregatedTables?: boolean | null;
     }
 
@@ -13214,6 +12945,20 @@ export namespace Schemas {
      * Feature flag payload for this early access feature
      */
     export type EarlyAccessFeaturePayload = { [key: string]: unknown };
+
+    /**
+     * * `server` - Server
+    * `client` - Client
+    * `all` - All
+     */
+    export type EvaluationRuntimeEnum = typeof EvaluationRuntimeEnum[keyof typeof EvaluationRuntimeEnum];
+
+
+    export const EvaluationRuntimeEnum = {
+      Server: 'server',
+      Client: 'client',
+      All: 'all',
+    } as const;
 
     export type MinimalFeatureFlagFilters = { [key: string]: unknown };
 
@@ -17175,36 +16920,6 @@ export namespace Schemas {
       readonly modified_by: number | null;
     }
 
-    /**
-     * * `events` - events
-     */
-    export type FileDownloadEventsRequestModelEnum = typeof FileDownloadEventsRequestModelEnum[keyof typeof FileDownloadEventsRequestModelEnum];
-
-
-    export const FileDownloadEventsRequestModelEnum = {
-      Events: 'events',
-    } as const;
-
-    /**
-     * * `persons` - persons
-     */
-    export type FileDownloadPersonsRequestModelEnum = typeof FileDownloadPersonsRequestModelEnum[keyof typeof FileDownloadPersonsRequestModelEnum];
-
-
-    export const FileDownloadPersonsRequestModelEnum = {
-      Persons: 'persons',
-    } as const;
-
-    /**
-     * * `sessions` - sessions
-     */
-    export type FileDownloadSessionsRequestModelEnum = typeof FileDownloadSessionsRequestModelEnum[keyof typeof FileDownloadSessionsRequestModelEnum];
-
-
-    export const FileDownloadSessionsRequestModelEnum = {
-      Sessions: 'sessions',
-    } as const;
-
     export interface FileSystem {
       readonly id: string;
       path: string;
@@ -20213,15 +19928,6 @@ export namespace Schemas {
       Never: 'never',
     } as const;
 
-    export interface LatestTestInterview {
-      /** When the test interview was completed. */
-      completed_at: string;
-      /** Full transcript of the test call, if Vapi delivered one. May be empty. */
-      transcript: string;
-      /** AI-generated summary of the test call, if Vapi delivered one. May be empty. */
-      summary: string;
-    }
-
     export interface LegalDocumentCreator {
       first_name: string;
       email: string;
@@ -20238,6 +19944,97 @@ export namespace Schemas {
       status: string;
       created_by: LegalDocumentCreator | null;
       created_at: string;
+    }
+
+    /**
+     * * `gemini-3-flash-preview` - Gemini 3 Flash
+    * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
+     */
+    export type LensModelEnum = typeof LensModelEnum[keyof typeof LensModelEnum];
+
+
+    export const LensModelEnum = {
+      Gemini3FlashPreview: 'gemini-3-flash-preview',
+      Gemini31FlashLitePreview: 'gemini-3.1-flash-lite-preview',
+    } as const;
+
+    /**
+     * * `google` - Google
+     */
+    export type LensProviderEnum = typeof LensProviderEnum[keyof typeof LensProviderEnum];
+
+
+    export const LensProviderEnum = {
+      Google: 'google',
+    } as const;
+
+    /**
+     * Maps the short `event_id` the LLM cites in `model_output.reasoning` to citation metadata: `{uuid, timestamp_ms}`. Only includes hashes the LLM actually cited.
+     */
+    export type LensResultEventIdMapping = { [key: string]: unknown };
+
+    /**
+     * Mirrors `temporal.types.LensResult` for OpenAPI generation.
+     */
+    export interface LensResult {
+      /** Validated lens output. Shape depends on `lens_snapshot.lens_type`; always carries `confidence` and `lens_type`. */
+      model_output: unknown;
+      /**
+         * Number of PostHog Signals emitted from this observation.
+         * @minimum 0
+         */
+      signals_count: number;
+      /** Maps the short `event_id` the LLM cites in `model_output.reasoning` to citation metadata: `{uuid, timestamp_ms}`. Only includes hashes the LLM actually cited. */
+      event_id_mapping: LensResultEventIdMapping;
+    }
+
+    /**
+     * * `monitor` - Monitor
+    * `classifier` - Classifier
+    * `scorer` - Scorer
+    * `summarizer` - Summarizer
+    * `indexer` - Indexer
+     */
+    export type LensTypeEnum = typeof LensTypeEnum[keyof typeof LensTypeEnum];
+
+
+    export const LensTypeEnum = {
+      Monitor: 'monitor',
+      Classifier: 'classifier',
+      Scorer: 'scorer',
+      Summarizer: 'summarizer',
+      Indexer: 'indexer',
+    } as const;
+
+    /**
+     * Mirrors `temporal.types.LensSnapshot` for OpenAPI generation.
+     */
+    export interface LensSnapshot {
+      /** Lens name at run time. */
+      name: string;
+      /** Lens type (monitor, classifier, scorer, summarizer, indexer) at run time.
+
+      * `monitor` - Monitor
+      * `classifier` - Classifier
+      * `scorer` - Scorer
+      * `summarizer` - Summarizer
+      * `indexer` - Indexer */
+      lens_type: LensTypeEnum;
+      /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
+      lens_version: number;
+      /** Concrete model that ran the observation.
+
+      * `gemini-3-flash-preview` - Gemini 3 Flash
+      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+      model: LensModelEnum;
+      /** Concrete provider that ran the observation.
+
+      * `google` - Google */
+      provider: LensProviderEnum;
+      /** Whether the observation was run with Signal emission enabled. */
+      emits_signals: boolean;
+      /** Lens-type-specific configuration at run time (prompt, tags, scale, etc.). */
+      lens_config: unknown;
     }
 
     export type LimitContext = typeof LimitContext[keyof typeof LimitContext];
@@ -20635,7 +20432,7 @@ export namespace Schemas {
       scope_path_pattern?: string | null;
       /** Optional list of predicates over string attributes, e.g. [{"key":"http.route","op":"eq","value":"/api"}]. */
       scope_attribute_filters?: LogsSamplingRuleScopeAttributeFiltersItem[];
-      /** Type-specific JSON. For path_drop: object with optional `filter_group` (PropertyGroupFilter shape — AND/OR tree of property predicates evaluated per record) and/or legacy `patterns` (list of regex strings) + `match_attribute_key` (string). When both are present a record is dropped if EITHER matches. Filter group example: `{"type":"AND","values":[{"type":"AND","values":[{"key":"service.name","operator":"exact","value":"api"}]}]}`. For severity_sampling: object with `actions` per severity level and optional `always_keep`. For rate_limit: object with EITHER `logs_per_second` (integer 1–1000000, optional `burst_logs` integer ≥ logs_per_second, max 10000000) OR `kb_per_second` (integer 1–1000000 = 1 GB/s, optional `burst_kb` integer ≥ kb_per_second, max 10000000) — not both. Plus optional `filter_group` to narrow which logs the cap applies to. KB-mode charges each log its own uncompressed byte size, matching how billing measures ingested bytes. */
+      /** Type-specific JSON. For path_drop: object with optional `filter_group` (PropertyGroupFilter shape — AND/OR tree of property predicates evaluated per record) and/or legacy `patterns` (list of regex strings) + `match_attribute_key` (string). When both are present a record is dropped if EITHER matches. Filter group example: `{"type":"AND","values":[{"type":"AND","values":[{"key":"service.name","operator":"exact","value":"api"}]}]}`. For severity_sampling: object with `actions` per severity level and optional `always_keep`. For rate_limit: object with required `logs_per_second` (integer KB/s, 1–1000000 = 1 GB/s) and optional `burst_logs` (integer KB ≥ logs_per_second, max 10000000) and optional `filter_group` to narrow which logs the cap applies to. */
       config: unknown;
       /** Incremented on each update for worker cache coherency. */
       readonly version: number;
@@ -21629,21 +21426,21 @@ export namespace Schemas {
     } as const;
 
     /**
-     * Body of POST /vision/scanners/{id}/observe/.
+     * Body of POST /vision/lenses/{id}/observe/.
      */
     export interface ObserveRequest {
       /**
-         * ID of the session recording to apply the scanner to.
+         * ID of the session recording to apply the lens to.
          * @maxLength 128
          */
       session_id: string;
     }
 
     /**
-     * Async-accepted response for POST /vision/scanners/{id}/observe/.
+     * Async-accepted response for POST /vision/lenses/{id}/observe/.
      */
     export interface ObserveResponse {
-      /** Temporal workflow id for this scanner application. Look up the resulting ReplayObservation via GET /vision/scanners/{id}/observations/?session_id=<session_id>. */
+      /** Temporal workflow id for this lens application. Look up the resulting ReplayObservation via GET /vision/lenses/{id}/observations/?session_id=<session_id>. */
       workflow_id: string;
     }
 
@@ -23358,102 +23155,70 @@ export namespace Schemas {
       results: QuickFilter[];
     }
 
-    /**
-     * * `monitor` - Monitor
-    * `classifier` - Classifier
-    * `scorer` - Scorer
-    * `summarizer` - Summarizer
-    * `indexer` - Indexer
-     */
-    export type ScannerTypeEnum = typeof ScannerTypeEnum[keyof typeof ScannerTypeEnum];
-
-
-    export const ScannerTypeEnum = {
-      Monitor: 'monitor',
-      Classifier: 'classifier',
-      Scorer: 'scorer',
-      Summarizer: 'summarizer',
-      Indexer: 'indexer',
-    } as const;
-
-    /**
-     * * `gemini-3-flash-preview` - Gemini 3 Flash
-    * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
-     */
-    export type ScannerModelEnum = typeof ScannerModelEnum[keyof typeof ScannerModelEnum];
-
-
-    export const ScannerModelEnum = {
-      Gemini3FlashPreview: 'gemini-3-flash-preview',
-      Gemini31FlashLitePreview: 'gemini-3.1-flash-lite-preview',
-    } as const;
-
-    /**
-     * * `google` - Google
-     */
-    export type ScannerProviderEnum = typeof ScannerProviderEnum[keyof typeof ScannerProviderEnum];
-
-
-    export const ScannerProviderEnum = {
-      Google: 'google',
-    } as const;
-
-    /**
-     * Mirrors `temporal.types.ScannerSnapshot` for OpenAPI generation.
-     */
-    export interface ScannerSnapshot {
-      /** Scanner name at run time. */
+    export interface ReplayLens {
+      readonly id: string;
+      /**
+         * Human-readable lens name. Unique within the team.
+         * @maxLength 255
+         */
       name: string;
-      /** Scanner type (monitor, classifier, scorer, summarizer, indexer) at run time.
+      /** Free-form description shown in the lens management UI. */
+      description?: string;
+      /** What the lens does: monitor, classifier, scorer, summarizer, or indexer.
 
       * `monitor` - Monitor
       * `classifier` - Classifier
       * `scorer` - Scorer
       * `summarizer` - Summarizer
       * `indexer` - Indexer */
-      scanner_type: ScannerTypeEnum;
-      /** The `ReplayScanner.scanner_version` value at the moment the workflow ran. */
-      scanner_version: number;
-      /** Concrete model that ran the observation.
+      lens_type: LensTypeEnum;
+      /** Type-specific configuration. Monitor/classifier/scorer/summarizer require `prompt`; classifiers add `tags`, scorers add `scale`. Indexer is fixed-task and rejects `prompt`. */
+      lens_config: unknown;
+      /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
+      query?: unknown;
+      /**
+         * 0..1 random downsample applied after the query matches. Defaults to 1.0 (no downsampling).
+         * @minimum 0
+         * @maximum 1
+         */
+      sampling_rate?: number;
+      /** LLM provider. v1 is Google-only.
+
+      * `google` - Google */
+      provider?: LensProviderEnum;
+      /** Concrete model to use for this lens.
 
       * `gemini-3-flash-preview` - Gemini 3 Flash
       * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
-      model: ScannerModelEnum;
-      /** Concrete provider that ran the observation.
-
-      * `google` - Google */
-      provider: ScannerProviderEnum;
-      /** Whether the observation was run with Signal emission enabled. */
-      emits_signals: boolean;
-      /** Scanner-type-specific configuration at run time (prompt, tags, scale, etc.). */
-      scanner_config: unknown;
+      model: LensModelEnum;
+      /** When false, the reconciler removes the lens's Temporal schedule. On-demand triggers still work. */
+      enabled?: boolean;
+      /** When true, the prompt is augmented with the Signal side mission and the lens emits PostHog Signals. */
+      emits_signals?: boolean;
+      /** Increments on every config-changing save. Observations snapshot this value. */
+      readonly lens_version: number;
+      /** Watermark for the lens's last scheduled fire. Mirrors Temporal schedule state for recovery. */
+      readonly last_swept_at: string;
+      readonly created_at: string;
+      /** User who created the lens. */
+      readonly created_by: UserBasic | null;
+      readonly updated_at: string;
     }
 
-    /**
-     * Maps the short `event_id` the LLM cites in `model_output.reasoning` to citation metadata: `{uuid, timestamp_ms}`. Only includes hashes the LLM actually cited.
-     */
-    export type ScannerResultEventIdMapping = { [key: string]: unknown };
-
-    /**
-     * Mirrors `temporal.types.ScannerResult` for OpenAPI generation.
-     */
-    export interface ScannerResult {
-      /** Validated scanner output. Shape depends on `scanner_snapshot.scanner_type`; always carries `confidence` and `scanner_type`. */
-      model_output: unknown;
-      /**
-         * Number of PostHog Signals emitted from this observation.
-         * @minimum 0
-         */
-      signals_count: number;
-      /** Maps the short `event_id` the LLM cites in `model_output.reasoning` to citation metadata: `{uuid, timestamp_ms}`. Only includes hashes the LLM actually cited. */
-      event_id_mapping: ScannerResultEventIdMapping;
+    export interface PaginatedReplayLensList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: ReplayLens[];
     }
 
     export interface ReplayObservation {
       readonly id: string;
-      /** The scanner that produced this observation. */
-      readonly scanner_id: string;
-      /** Session recording id this scanner was applied to. */
+      /** The lens that produced this observation. */
+      readonly lens_id: string;
+      /** Session recording id this lens was applied to. */
       readonly session_id: string;
       /** Observation status (pending, running, succeeded, failed).
 
@@ -23466,10 +23231,10 @@ export namespace Schemas {
       readonly error_reason: string;
       /** Temporal workflow id for progress queries and debugging. Empty until the workflow starts. */
       readonly workflow_id: string;
-      /** Frozen view of the scanner at run time; scanner edits do not retroactively mutate this observation. */
-      readonly scanner_snapshot: ScannerSnapshot | null;
+      /** Frozen view of the lens at run time; lens edits do not retroactively mutate this observation. */
+      readonly lens_snapshot: LensSnapshot | null;
       /** Result data persisted on success; null until the observation succeeds. */
-      readonly scanner_result: ScannerResult | null;
+      readonly lens_result: LensResult | null;
       /** Whether this observation came from the schedule or an on-demand request.
 
       * `schedule` - Schedule
@@ -23491,65 +23256,6 @@ export namespace Schemas {
       /** @nullable */
       previous?: string | null;
       results: ReplayObservation[];
-    }
-
-    export interface ReplayScanner {
-      readonly id: string;
-      /**
-         * Human-readable scanner name. Unique within the team.
-         * @maxLength 255
-         */
-      name: string;
-      /** Free-form description shown in the scanner management UI. */
-      description?: string;
-      /** What the scanner does: monitor, classifier, scorer, summarizer, or indexer.
-
-      * `monitor` - Monitor
-      * `classifier` - Classifier
-      * `scorer` - Scorer
-      * `summarizer` - Summarizer
-      * `indexer` - Indexer */
-      scanner_type: ScannerTypeEnum;
-      /** Type-specific configuration. Monitor/classifier/scorer/summarizer require `prompt`; classifiers add `tags`, scorers add `scale`. Indexer is fixed-task and rejects `prompt`. */
-      scanner_config: unknown;
-      /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
-      query?: unknown;
-      /**
-         * 0..1 random downsample applied after the query matches. Defaults to 1.0 (no downsampling).
-         * @minimum 0
-         * @maximum 1
-         */
-      sampling_rate?: number;
-      /** LLM provider. v1 is Google-only.
-
-      * `google` - Google */
-      provider?: ScannerProviderEnum;
-      /** Concrete model to use for this scanner.
-
-      * `gemini-3-flash-preview` - Gemini 3 Flash
-      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
-      model: ScannerModelEnum;
-      /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
-      enabled?: boolean;
-      /** When true, the prompt is augmented with the Signal side mission and the scanner emits PostHog Signals. */
-      emits_signals?: boolean;
-      /** Increments on every config-changing save. Observations snapshot this value. */
-      readonly scanner_version: number;
-      /** Watermark for the scanner's last scheduled fire. Mirrors Temporal schedule state for recovery. */
-      readonly last_swept_at: string;
-      readonly created_at: string;
-      /** User who created the scanner. */
-      readonly created_by: UserBasic | null;
-      readonly updated_at: string;
-    }
-
-    export interface PaginatedReplayScannerList {
-      count: number;
-      /** @nullable */
-      next?: string | null;
-      /** @nullable */
-      previous?: string | null;
-      results: ReplayScanner[];
     }
 
     export type RepoBaselineFilePaths = {[key: string]: string};
@@ -25965,9 +25671,6 @@ export namespace Schemas {
       zendesk_id?: string | null;
     } | null;
 
-    /**
-     * A Customer Analytics account — a logical grouping used to assign customer-success ownership.
-     */
     export interface PatchedAccount {
       readonly id?: string;
       /**
@@ -25986,8 +25689,8 @@ export namespace Schemas {
          * @nullable
          */
       properties?: PatchedAccountProperties;
-      /** Tag names attached to the account. Pass a list to replace existing tags. */
-      tags?: string[];
+      /** Short IDs of the internal notebooks linked to this account, used to persist investigations, call notes, and other free-form context. Empty list if no notebooks have been created for the account. */
+      readonly notebooks?: readonly string[];
       readonly created_at?: string;
       /** @nullable */
       readonly created_by?: number | null;
@@ -28449,7 +28152,7 @@ export namespace Schemas {
       scope_path_pattern?: string | null;
       /** Optional list of predicates over string attributes, e.g. [{"key":"http.route","op":"eq","value":"/api"}]. */
       scope_attribute_filters?: PatchedLogsSamplingRuleScopeAttributeFiltersItem[];
-      /** Type-specific JSON. For path_drop: object with optional `filter_group` (PropertyGroupFilter shape — AND/OR tree of property predicates evaluated per record) and/or legacy `patterns` (list of regex strings) + `match_attribute_key` (string). When both are present a record is dropped if EITHER matches. Filter group example: `{"type":"AND","values":[{"type":"AND","values":[{"key":"service.name","operator":"exact","value":"api"}]}]}`. For severity_sampling: object with `actions` per severity level and optional `always_keep`. For rate_limit: object with EITHER `logs_per_second` (integer 1–1000000, optional `burst_logs` integer ≥ logs_per_second, max 10000000) OR `kb_per_second` (integer 1–1000000 = 1 GB/s, optional `burst_kb` integer ≥ kb_per_second, max 10000000) — not both. Plus optional `filter_group` to narrow which logs the cap applies to. KB-mode charges each log its own uncompressed byte size, matching how billing measures ingested bytes. */
+      /** Type-specific JSON. For path_drop: object with optional `filter_group` (PropertyGroupFilter shape — AND/OR tree of property predicates evaluated per record) and/or legacy `patterns` (list of regex strings) + `match_attribute_key` (string). When both are present a record is dropped if EITHER matches. Filter group example: `{"type":"AND","values":[{"type":"AND","values":[{"key":"service.name","operator":"exact","value":"api"}]}]}`. For severity_sampling: object with `actions` per severity level and optional `always_keep`. For rate_limit: object with required `logs_per_second` (integer KB/s, 1–1000000 = 1 GB/s) and optional `burst_logs` (integer KB ≥ logs_per_second, max 10000000) and optional `filter_group` to narrow which logs the cap applies to. */
       config?: unknown;
       /** Incremented on each update for worker cache coherency. */
       readonly version?: number;
@@ -29747,25 +29450,25 @@ export namespace Schemas {
       person_id?: string;
     }
 
-    export interface PatchedReplayScanner {
+    export interface PatchedReplayLens {
       readonly id?: string;
       /**
-         * Human-readable scanner name. Unique within the team.
+         * Human-readable lens name. Unique within the team.
          * @maxLength 255
          */
       name?: string;
-      /** Free-form description shown in the scanner management UI. */
+      /** Free-form description shown in the lens management UI. */
       description?: string;
-      /** What the scanner does: monitor, classifier, scorer, summarizer, or indexer.
+      /** What the lens does: monitor, classifier, scorer, summarizer, or indexer.
 
       * `monitor` - Monitor
       * `classifier` - Classifier
       * `scorer` - Scorer
       * `summarizer` - Summarizer
       * `indexer` - Indexer */
-      scanner_type?: ScannerTypeEnum;
+      lens_type?: LensTypeEnum;
       /** Type-specific configuration. Monitor/classifier/scorer/summarizer require `prompt`; classifiers add `tags`, scorers add `scale`. Indexer is fixed-task and rejects `prompt`. */
-      scanner_config?: unknown;
+      lens_config?: unknown;
       /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
       query?: unknown;
       /**
@@ -29777,22 +29480,22 @@ export namespace Schemas {
       /** LLM provider. v1 is Google-only.
 
       * `google` - Google */
-      provider?: ScannerProviderEnum;
-      /** Concrete model to use for this scanner.
+      provider?: LensProviderEnum;
+      /** Concrete model to use for this lens.
 
       * `gemini-3-flash-preview` - Gemini 3 Flash
       * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
-      model?: ScannerModelEnum;
-      /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
+      model?: LensModelEnum;
+      /** When false, the reconciler removes the lens's Temporal schedule. On-demand triggers still work. */
       enabled?: boolean;
-      /** When true, the prompt is augmented with the Signal side mission and the scanner emits PostHog Signals. */
+      /** When true, the prompt is augmented with the Signal side mission and the lens emits PostHog Signals. */
       emits_signals?: boolean;
       /** Increments on every config-changing save. Observations snapshot this value. */
-      readonly scanner_version?: number;
-      /** Watermark for the scanner's last scheduled fire. Mirrors Temporal schedule state for recovery. */
+      readonly lens_version?: number;
+      /** Watermark for the lens's last scheduled fire. Mirrors Temporal schedule state for recovery. */
       readonly last_swept_at?: string;
       readonly created_at?: string;
-      /** User who created the scanner. */
+      /** User who created the lens. */
       readonly created_by?: UserBasic | null;
       readonly updated_at?: string;
     }
@@ -31746,13 +31449,16 @@ export namespace Schemas {
       date_from: string;
       /** Exclusive UTC end of the spend window resolved from the request. */
       date_to: string;
-      /** The `ai_product` filter applied to tool / model / trace breakdowns — echoes the request `product`. */
-      product: string;
+      /**
+         * The `ai_product` filter applied to tool / model / trace breakdowns. Null when unfiltered.
+         * @nullable
+         */
+      product: string | null;
       /** Total LLM cost in USD across every `ai_product` for the user — independent of the `product` filter. */
       total_cost_usd: number;
       /** Total $ai_generation + $ai_embedding events captured across every product. */
       event_count: number;
-      /** Total cost in USD for the product filter. Matches the cost summed across `by_tool` / `by_model` for the scoped slice. */
+      /** Total cost in USD for the product filter (or all products when unfiltered). Matches the cost summed across `by_tool` / `by_model` for the scoped slice. */
       scoped_cost_usd: number;
       /** Total $ai_generation + $ai_embedding events for the scoped slice. */
       scoped_event_count: number;
@@ -31859,7 +31565,7 @@ export namespace Schemas {
       by_tool: _ToolBreakdown;
       /** Spend grouped by `$ai_model`. Scoped to `product` when set. */
       by_model: _ModelBreakdown;
-      /** Deprecated — always returns `{items: [], truncated: false}`. Trace IDs are opaque strings that aren't actionable in the UI. Kept in the response shape so existing consumers don't crash; remove your rendering of this field and we'll drop it from the response entirely in a follow-up. */
+      /** Most expensive trace IDs (sessions) in the window. Scoped to `product` when set. */
       top_traces: _TopTraces;
     }
 
@@ -33549,7 +33255,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      usedLazyPrecompute?: boolean | null;
       usedPreAggregatedTables?: boolean | null;
     }
 
@@ -33925,7 +33630,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      usedLazyPrecompute?: boolean | null;
       usedPreAggregatedTables?: boolean | null;
     }
 
@@ -34799,100 +34503,6 @@ export namespace Schemas {
       password: string;
     }
 
-    export type RetrieveBasicOutputStatus = typeof RetrieveBasicOutputStatus[keyof typeof RetrieveBasicOutputStatus];
-
-
-    export const RetrieveBasicOutputStatus = {
-      Starting: 'Starting',
-      Running: 'Running',
-      Cancelled: 'Cancelled',
-    } as const;
-
-    /**
-     * Typed output for view set `retrieve` with any of the statuses without extra output.
-     */
-    export interface RetrieveBasicOutput {
-      status: RetrieveBasicOutputStatus;
-    }
-
-    /**
-     * * `Starting` - Starting
-    * `Running` - Running
-    * `Cancelled` - Cancelled
-     */
-    export type RetrieveBasicOutputStatusEnum = typeof RetrieveBasicOutputStatusEnum[keyof typeof RetrieveBasicOutputStatusEnum];
-
-
-    export const RetrieveBasicOutputStatusEnum = {
-      Starting: 'Starting',
-      Running: 'Running',
-      Cancelled: 'Cancelled',
-    } as const;
-
-    export type RetrieveCompletedOutputStatus = typeof RetrieveCompletedOutputStatus[keyof typeof RetrieveCompletedOutputStatus];
-
-
-    export const RetrieveCompletedOutputStatus = {
-      Completed: 'Completed',
-    } as const;
-
-    /**
-     * Typed output for view set `retrieve` with completed status.
-     */
-    export interface RetrieveCompletedOutput {
-      status: RetrieveCompletedOutputStatus;
-      files: string[];
-    }
-
-    /**
-     * * `Completed` - Completed
-     */
-    export type RetrieveCompletedOutputStatusEnum = typeof RetrieveCompletedOutputStatusEnum[keyof typeof RetrieveCompletedOutputStatusEnum];
-
-
-    export const RetrieveCompletedOutputStatusEnum = {
-      Completed: 'Completed',
-    } as const;
-
-    export type RetrieveFailedOutputStatus = typeof RetrieveFailedOutputStatus[keyof typeof RetrieveFailedOutputStatus];
-
-
-    export const RetrieveFailedOutputStatus = {
-      Failed: 'Failed',
-      FailedRetryable: 'FailedRetryable',
-      FailedBilling: 'FailedBilling',
-      TimedOut: 'TimedOut',
-      Terminated: 'Terminated',
-    } as const;
-
-    /**
-     * Typed output for view set `retrieve` with any of the failed statuses.
-     */
-    export interface RetrieveFailedOutput {
-      status: RetrieveFailedOutputStatus;
-      error: string;
-    }
-
-    /**
-     * * `Failed` - Failed
-    * `FailedRetryable` - FailedRetryable
-    * `FailedBilling` - FailedBilling
-    * `Terminated` - Terminated
-    * `TimedOut` - TimedOut
-     */
-    export type RetrieveFailedOutputStatusEnum = typeof RetrieveFailedOutputStatusEnum[keyof typeof RetrieveFailedOutputStatusEnum];
-
-
-    export const RetrieveFailedOutputStatusEnum = {
-      Failed: 'Failed',
-      FailedRetryable: 'FailedRetryable',
-      FailedBilling: 'FailedBilling',
-      Terminated: 'Terminated',
-      TimedOut: 'TimedOut',
-    } as const;
-
-    export type RetrieveFileDownloadResponse = RetrieveBasicOutput | RetrieveCompletedOutput | RetrieveFailedOutput;
-
     export interface ReviewQueueCreate {
       /**
          * Human-readable queue name.
@@ -35302,26 +34912,7 @@ export namespace Schemas {
     export interface SignalUserAutonomyConfig {
       readonly id: string;
       readonly user: _User;
-      autostart_priority?: AutonomyPriorityEnum | BlankEnum | null;
-      /**
-         * ID of the Slack Integration to deliver inbox-item notifications through, or null when notifications are disabled.
-         * @nullable
-         */
-      readonly slack_notification_integration_id: number | null;
-      /**
-         * Slack channel target in the same `channel_id|#channel-name` shape PostHog uses elsewhere (only the channel id is required). Null disables Slack notifications.
-         * @maxLength 255
-         * @nullable
-         */
-      slack_notification_channel?: string | null;
-      /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority (and reports without a priority judgment).
-
-      * `P0` - P0
-      * `P1` - P1
-      * `P2` - P2
-      * `P3` - P3
-      * `P4` - P4 */
-      slack_notification_min_priority?: AutonomyPriorityEnum | BlankEnum | null;
+      autostart_priority?: AutostartPriorityEnum | BlankEnum | null;
       readonly created_at: string;
       readonly updated_at: string;
     }
@@ -35349,8 +34940,6 @@ export namespace Schemas {
          * @nullable
          */
       lastRefreshedAt?: string | null;
-      /** Whether more channels match the current search beyond this page. */
-      has_more?: boolean;
     }
 
     /**
@@ -35962,14 +35551,6 @@ export namespace Schemas {
       rates: SurveyStatsResponseRates;
     }
 
-    export interface Synthesize {
-      /**
-         * The text the assistant should speak aloud.
-         * @maxLength 2000
-         */
-      text: string;
-    }
-
     export interface TaggerCreate {
       /** @maxLength 400 */
       name: string;
@@ -35995,21 +35576,6 @@ export namespace Schemas {
       conditions?: TaggerCondition[];
       model_configuration?: TaggerModelConfigurationWrite | null;
       deleted?: boolean;
-    }
-
-    /**
-     * Request body for the presence beacon and beacon-leave endpoints.
-
-    `device_id` is the UUID of the caller's `UserPushToken` row, which the
-    client received when it registered for push via `/api/users/@me/push_tokens/`.
-    The client is expected to use the same identifier on the beacon and leave
-    calls; if the user has unregistered the underlying push token, the value
-    won't resolve and the call returns 404 — at which point pushes were
-    already not going there anyway.
-     */
-    export interface TaskPresenceBeaconRequest {
-      /** UUID of the caller's UserPushToken (returned by `/api/users/@me/push_tokens/` on register). */
-      device_id: string;
     }
 
     export interface TaskRepositoriesResponse {
@@ -36851,13 +36417,6 @@ export namespace Schemas {
       results: TestHogTaggerResultItem[];
       /** Optional message, for example when no recent AI events were found. */
       message?: string;
-    }
-
-    export interface TestInterviewLink {
-      /** Public, unauthenticated URL the topic author opens to dogfood the voice interview themselves — does not count against the targeted interviewees. */
-      interview_url: string;
-      /** Most recent test interview completed by the topic author, or null if none yet. */
-      latest_test_interview: LatestTestInterview | null;
     }
 
     export interface TextReprMetadata {
@@ -38308,7 +37867,7 @@ export namespace Schemas {
     offset?: number;
     };
 
-    export type EnvironmentsEndpointsOpenapiSpecRetrieveParams = {
+    export type EnvironmentsEndpointsOpenapiJsonRetrieveParams = {
     /**
      * Specific endpoint version to generate the spec for. Defaults to latest.
      */
@@ -38537,38 +38096,6 @@ export namespace Schemas {
     offset?: number;
     /**
      * A search term.
-     */
-    search?: string;
-    };
-
-    export type EnvironmentsFileDownloadBatchExportsLogsRetrieveParams = {
-    /**
-     * Only return entries after this ISO 8601 timestamp.
-     */
-    after?: string;
-    /**
-     * Only return entries before this ISO 8601 timestamp.
-     */
-    before?: string;
-    /**
-     * Filter logs to a specific execution instance.
-     * @minLength 1
-     */
-    instance_id?: string;
-    /**
-     * Comma-separated log levels to include, e.g. 'WARN,ERROR'. Valid levels: DEBUG, LOG, INFO, WARN, ERROR.
-     * @minLength 1
-     */
-    level?: string;
-    /**
-     * Maximum number of log entries to return (1-500, default 50).
-     * @minimum 1
-     * @maximum 500
-     */
-    limit?: number;
-    /**
-     * Case-insensitive substring search across log messages.
-     * @minLength 1
      */
     search?: string;
     };
@@ -39591,24 +39118,6 @@ export namespace Schemas {
       Vercel: 'vercel',
     } as const;
 
-    export type EnvironmentsIntegrationsChannelsRetrieveParams = {
-    /**
-     * Maximum number of channels to return per request (max 200).
-     * @minimum 1
-     * @maximum 200
-     */
-    limit?: number;
-    /**
-     * Number of channels to skip before returning results.
-     * @minimum 0
-     */
-    offset?: number;
-    /**
-     * Optional case-insensitive channel name or ID search query.
-     */
-    search?: string;
-    };
-
     export type EnvironmentsIntegrationsGithubBranchesRetrieveParams = {
     /**
      * Maximum number of branches to return
@@ -40379,22 +39888,6 @@ export namespace Schemas {
 
     export type AccountsListParams = {
     /**
-     * Filter by account executive. Use 'unassigned' or an integer user id.
-     */
-    account_executive?: string;
-    /**
-     * Filter by account owner. Use 'unassigned' or an integer user id.
-     */
-    account_owner?: string;
-    /**
-     * When true, returns only accounts where CSM, account executive, and account owner are all unset.
-     */
-    all_roles_unassigned?: boolean;
-    /**
-     * Filter by CSM. Use 'unassigned' for accounts with no CSM, or an integer user id.
-     */
-    csm?: string;
-    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -40402,18 +39895,6 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
-    /**
-     * Sort order. Defaults to '-created_at'.
-     */
-    ordering?: string;
-    /**
-     * Case-insensitive substring search across account name and external ID.
-     */
-    search?: string;
-    /**
-     * JSON-encoded array of tag names to filter by, e.g. `["enterprise","priority"]`. Returns accounts that have any of the listed tags. Malformed values (not a JSON-encoded list of strings) return a 400.
-     */
-    tags?: string;
     };
 
     export type ApprovalPoliciesListParams = {
@@ -41181,8 +40662,6 @@ export namespace Schemas {
     offset?: number;
     };
 
-    export type MaxHandsFreeTokenCreate200 = { [key: string]: unknown };
-
     export type MaxToolsCreateAndQueryInsightCreate200 = { [key: string]: unknown };
 
     export type McpAnalyticsFeedbackListParams = {
@@ -41569,15 +41048,25 @@ export namespace Schemas {
     topic?: string;
     };
 
-    export type VisionScannersListParams = {
+    export type VisionLensesListParams = {
     /**
-     * Filter to scanners that emit Signals.
+     * Filter to lenses that emit Signals.
      */
     emits_signals?: boolean;
     /**
-     * Filter to enabled vs disabled scanners.
+     * Filter to enabled vs disabled lenses.
      */
     enabled?: boolean;
+    /**
+     * Filter by lens type (monitor, classifier, scorer, summarizer, indexer).
+
+    * `monitor` - Monitor
+    * `classifier` - Classifier
+    * `scorer` - Scorer
+    * `summarizer` - Summarizer
+    * `indexer` - Indexer
+     */
+    lens_type?: VisionLensesListLensType;
     /**
      * Number of results to return per page.
      */
@@ -41587,7 +41076,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
+     * Sort lenses by name, created_at, updated_at, or lens_type. Prefix with `-` for descending.
 
     * `name` - Name
     * `-name` - Name (descending)
@@ -41595,26 +41084,16 @@ export namespace Schemas {
     * `-created_at` - Created at (descending)
     * `updated_at` - Updated at
     * `-updated_at` - Updated at (descending)
-    * `scanner_type` - Scanner type
-    * `-scanner_type` - Scanner type (descending)
+    * `lens_type` - Lens type
+    * `-lens_type` - Lens type (descending)
      */
     order_by?: string[];
-    /**
-     * Filter by scanner type (monitor, classifier, scorer, summarizer, indexer).
-
-    * `monitor` - Monitor
-    * `classifier` - Classifier
-    * `scorer` - Scorer
-    * `summarizer` - Summarizer
-    * `indexer` - Indexer
-     */
-    scanner_type?: VisionScannersListScannerType;
     };
 
-    export type VisionScannersListScannerType = typeof VisionScannersListScannerType[keyof typeof VisionScannersListScannerType];
+    export type VisionLensesListLensType = typeof VisionLensesListLensType[keyof typeof VisionLensesListLensType];
 
 
-    export const VisionScannersListScannerType = {
+    export const VisionLensesListLensType = {
       Classifier: 'classifier',
       Indexer: 'indexer',
       Monitor: 'monitor',
@@ -41622,7 +41101,7 @@ export namespace Schemas {
       Summarizer: 'summarizer',
     } as const;
 
-    export type VisionScannersObservationsListParams = {
+    export type VisionLensesObservationsListParams = {
     /**
      * Number of results to return per page.
      */
@@ -41656,30 +41135,30 @@ export namespace Schemas {
     * `succeeded` - Succeeded
     * `failed` - Failed
      */
-    status?: VisionScannersObservationsListStatus;
+    status?: VisionLensesObservationsListStatus;
     /**
      * Filter by trigger source (schedule or on_demand).
 
     * `schedule` - Schedule
     * `on_demand` - On demand
      */
-    triggered_by?: VisionScannersObservationsListTriggeredBy;
+    triggered_by?: VisionLensesObservationsListTriggeredBy;
     };
 
-    export type VisionScannersObservationsListStatus = typeof VisionScannersObservationsListStatus[keyof typeof VisionScannersObservationsListStatus];
+    export type VisionLensesObservationsListStatus = typeof VisionLensesObservationsListStatus[keyof typeof VisionLensesObservationsListStatus];
 
 
-    export const VisionScannersObservationsListStatus = {
+    export const VisionLensesObservationsListStatus = {
       Failed: 'failed',
       Pending: 'pending',
       Running: 'running',
       Succeeded: 'succeeded',
     } as const;
 
-    export type VisionScannersObservationsListTriggeredBy = typeof VisionScannersObservationsListTriggeredBy[keyof typeof VisionScannersObservationsListTriggeredBy];
+    export type VisionLensesObservationsListTriggeredBy = typeof VisionLensesObservationsListTriggeredBy[keyof typeof VisionLensesObservationsListTriggeredBy];
 
 
-    export const VisionScannersObservationsListTriggeredBy = {
+    export const VisionLensesObservationsListTriggeredBy = {
       OnDemand: 'on_demand',
       Schedule: 'schedule',
     } as const;
@@ -41748,11 +41227,11 @@ export namespace Schemas {
      */
     limit?: number;
     /**
-     * Required `ai_product` key to scope the tool / model / trace breakdowns to a single product. Only the following products are currently supported: posthog_code.
-     * @minLength 1
+     * Optional `ai_product` key to scope the tool / model / trace breakdowns to a single product (e.g. `posthog_code`, `background_agents`). When omitted, those breakdowns aggregate across every product captured for the user.
      * @maxLength 64
+     * @nullable
      */
-    product: string;
+    product?: string | null;
     /**
      * If true, bypass the result cache and re-run the underlying queries against ClickHouse.
      */
@@ -42211,7 +41690,6 @@ export namespace Schemas {
     * `AlertSubscription` - AlertSubscription
     * `ExternalDataSource` - ExternalDataSource
     * `ExternalDataSchema` - ExternalDataSchema
-    * `Evaluation` - Evaluation
     * `LLMTrace` - LLMTrace
     * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
     * `CustomerProfileConfig` - CustomerProfileConfig
@@ -42287,7 +41765,6 @@ export namespace Schemas {
       AlertSubscription: 'AlertSubscription',
       ExternalDataSource: 'ExternalDataSource',
       ExternalDataSchema: 'ExternalDataSchema',
-      Evaluation: 'Evaluation',
       LLMTrace: 'LLMTrace',
       WebAnalyticsFilterPreset: 'WebAnalyticsFilterPreset',
       CustomerProfileConfig: 'CustomerProfileConfig',
@@ -42349,7 +41826,6 @@ export namespace Schemas {
     * `AlertSubscription` - AlertSubscription
     * `ExternalDataSource` - ExternalDataSource
     * `ExternalDataSchema` - ExternalDataSchema
-    * `Evaluation` - Evaluation
     * `LLMTrace` - LLMTrace
     * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
     * `CustomerProfileConfig` - CustomerProfileConfig
@@ -42413,7 +41889,6 @@ export namespace Schemas {
       AlertSubscription: 'AlertSubscription',
       ExternalDataSource: 'ExternalDataSource',
       ExternalDataSchema: 'ExternalDataSchema',
-      Evaluation: 'Evaluation',
       LLMTrace: 'LLMTrace',
       WebAnalyticsFilterPreset: 'WebAnalyticsFilterPreset',
       CustomerProfileConfig: 'CustomerProfileConfig',
@@ -43299,7 +42774,7 @@ export namespace Schemas {
     offset?: number;
     };
 
-    export type EndpointsOpenapiSpecRetrieveParams = {
+    export type EndpointsOpenapiJsonRetrieveParams = {
     /**
      * Specific endpoint version to generate the spec for. Defaults to latest.
      */
@@ -43388,14 +42863,6 @@ export namespace Schemas {
     } as const;
 
     export type EventDefinitionsListParams = {
-    /**
-     * When true, omit events that have been explicitly hidden by a team admin (Enterprise only).
-     */
-    exclude_hidden?: boolean;
-    /**
-     * When true, omit events whose last ingested occurrence is older than 30 days. Events that have never been seen (`last_seen_at` is null) are kept so newly-defined events remain discoverable. Default false. If a search returns zero results with this filter on, retry with `exclude_stale=false` and tell the user the matches are stale.
-     */
-    exclude_stale?: boolean;
     /**
      * Number of results to return per page.
      */
@@ -43801,38 +43268,6 @@ export namespace Schemas {
      * Groups for feature flag evaluation (JSON object string)
      */
     groups?: string;
-    };
-
-    export type FileDownloadBatchExportsLogsRetrieveParams = {
-    /**
-     * Only return entries after this ISO 8601 timestamp.
-     */
-    after?: string;
-    /**
-     * Only return entries before this ISO 8601 timestamp.
-     */
-    before?: string;
-    /**
-     * Filter logs to a specific execution instance.
-     * @minLength 1
-     */
-    instance_id?: string;
-    /**
-     * Comma-separated log levels to include, e.g. 'WARN,ERROR'. Valid levels: DEBUG, LOG, INFO, WARN, ERROR.
-     * @minLength 1
-     */
-    level?: string;
-    /**
-     * Maximum number of log entries to return (1-500, default 50).
-     * @minimum 1
-     * @maximum 500
-     */
-    limit?: number;
-    /**
-     * Case-insensitive substring search across log messages.
-     * @minLength 1
-     */
-    search?: string;
     };
 
     export type FileSystemListParams = {
@@ -44893,24 +44328,6 @@ export namespace Schemas {
       Twilio: 'twilio',
       Vercel: 'vercel',
     } as const;
-
-    export type IntegrationsChannelsRetrieveParams = {
-    /**
-     * Maximum number of channels to return per request (max 200).
-     * @minimum 1
-     * @maximum 200
-     */
-    limit?: number;
-    /**
-     * Number of channels to skip before returning results.
-     * @minimum 0
-     */
-    offset?: number;
-    /**
-     * Optional case-insensitive channel name or ID search query.
-     */
-    search?: string;
-    };
 
     export type IntegrationsGithubBranchesRetrieveParams = {
     /**

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 10 enabled ops
+ * PostHog API - MCP 14 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -98,6 +98,61 @@ export const AccountsCreateBody = /* @__PURE__ */ zod
             .describe('Tag names attached to the account. Pass a list to replace existing tags.'),
     })
     .describe('A Customer Analytics account — a logical grouping used to assign customer-success ownership.')
+
+export const AccountsNotebooksListParams = /* @__PURE__ */ zod.object({
+    account_id: zod.string().describe('UUID of the parent account.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const AccountsNotebooksListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+export const AccountsNotebooksCreateParams = /* @__PURE__ */ zod.object({
+    account_id: zod.string().describe('UUID of the parent account.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const accountsNotebooksCreateBodyTitleMax = 256
+
+export const AccountsNotebooksCreateBody = /* @__PURE__ */ zod.object({
+    title: zod
+        .string()
+        .max(accountsNotebooksCreateBodyTitleMax)
+        .nullish()
+        .describe('Human-readable title of the account notebook.'),
+    content: zod.unknown().optional().describe('Notebook content as a ProseMirror JSON document structure.'),
+    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+})
+
+export const AccountsNotebooksRetrieveParams = /* @__PURE__ */ zod.object({
+    account_id: zod.string().describe('UUID of the parent account.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    short_id: zod.string(),
+})
+
+export const AccountsNotebooksDestroyParams = /* @__PURE__ */ zod.object({
+    account_id: zod.string().describe('UUID of the parent account.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    short_id: zod.string(),
+})
 
 export const AccountsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this account.'),

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -88,6 +88,7 @@ const AccountsListSchema = AccountsListQueryParams.extend({
 const accountsList = (): ToolBase<typeof AccountsListSchema, WithPostHogUrl<Schemas.PaginatedAccountList>> => ({
     name: 'accounts-list',
     schema: AccountsListSchema,
+    mcpVersion: 1,
     handler: async (context: Context, params: z.infer<typeof AccountsListSchema>) => {
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.PaginatedAccountList>({
@@ -162,6 +163,7 @@ const accountsNotebooksList = (): ToolBase<
 > => ({
     name: 'accounts-notebooks-list',
     schema: AccountsNotebooksListSchema,
+    mcpVersion: 1,
     handler: async (context: Context, params: z.infer<typeof AccountsNotebooksListSchema>) => {
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.PaginatedAccountNotebookList>({
@@ -181,6 +183,7 @@ const AccountsNotebooksRetrieveSchema = AccountsNotebooksRetrieveParams.omit({ p
 const accountsNotebooksRetrieve = (): ToolBase<typeof AccountsNotebooksRetrieveSchema, Schemas.AccountNotebook> => ({
     name: 'accounts-notebooks-retrieve',
     schema: AccountsNotebooksRetrieveSchema,
+    mcpVersion: 1,
     handler: async (context: Context, params: z.infer<typeof AccountsNotebooksRetrieveSchema>) => {
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.AccountNotebook>({
@@ -234,6 +237,7 @@ const AccountsRetrieveSchema = AccountsRetrieveParams.omit({ project_id: true })
 const accountsRetrieve = (): ToolBase<typeof AccountsRetrieveSchema, Schemas.Account> => ({
     name: 'accounts-retrieve',
     schema: AccountsRetrieveSchema,
+    mcpVersion: 1,
     handler: async (context: Context, params: z.infer<typeof AccountsRetrieveSchema>) => {
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.Account>({

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -6,6 +6,12 @@ import {
     AccountsCreateBody,
     AccountsDestroyParams,
     AccountsListQueryParams,
+    AccountsNotebooksCreateBody,
+    AccountsNotebooksCreateParams,
+    AccountsNotebooksDestroyParams,
+    AccountsNotebooksListParams,
+    AccountsNotebooksListQueryParams,
+    AccountsNotebooksRetrieveParams,
     AccountsPartialUpdateBody,
     AccountsPartialUpdateParams,
     AccountsRetrieveParams,
@@ -100,6 +106,88 @@ const accountsList = (): ToolBase<typeof AccountsListSchema, WithPostHogUrl<Sche
             },
         })
         return await withPostHogUrl(context, result, '/customer-analytics')
+    },
+})
+
+const AccountsNotebooksCreateSchema = AccountsNotebooksCreateParams.omit({ project_id: true }).extend(
+    AccountsNotebooksCreateBody.shape
+)
+
+const accountsNotebooksCreate = (): ToolBase<typeof AccountsNotebooksCreateSchema, Schemas.AccountNotebook> => ({
+    name: 'accounts-notebooks-create',
+    schema: AccountsNotebooksCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountsNotebooksCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.title !== undefined) {
+            body['title'] = params.title
+        }
+        if (params.content !== undefined) {
+            body['content'] = params.content
+        }
+        if (params.text_content !== undefined) {
+            body['text_content'] = params.text_content
+        }
+        const result = await context.api.request<Schemas.AccountNotebook>({
+            method: 'POST',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/accounts/${encodeURIComponent(String(params.account_id))}/notebooks/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AccountsNotebooksDestroySchema = AccountsNotebooksDestroyParams.omit({ project_id: true })
+
+const accountsNotebooksDestroy = (): ToolBase<typeof AccountsNotebooksDestroySchema, unknown> => ({
+    name: 'accounts-notebooks-destroy',
+    schema: AccountsNotebooksDestroySchema,
+    handler: async (context: Context, params: z.infer<typeof AccountsNotebooksDestroySchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'DELETE',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/accounts/${encodeURIComponent(String(params.account_id))}/notebooks/${encodeURIComponent(String(params.short_id))}/`,
+        })
+        return result
+    },
+})
+
+const AccountsNotebooksListSchema = AccountsNotebooksListParams.omit({ project_id: true }).extend(
+    AccountsNotebooksListQueryParams.shape
+)
+
+const accountsNotebooksList = (): ToolBase<
+    typeof AccountsNotebooksListSchema,
+    WithPostHogUrl<Schemas.PaginatedAccountNotebookList>
+> => ({
+    name: 'accounts-notebooks-list',
+    schema: AccountsNotebooksListSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountsNotebooksListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedAccountNotebookList>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/accounts/${encodeURIComponent(String(params.account_id))}/notebooks/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return await withPostHogUrl(context, result, '/customer-analytics')
+    },
+})
+
+const AccountsNotebooksRetrieveSchema = AccountsNotebooksRetrieveParams.omit({ project_id: true })
+
+const accountsNotebooksRetrieve = (): ToolBase<typeof AccountsNotebooksRetrieveSchema, Schemas.AccountNotebook> => ({
+    name: 'accounts-notebooks-retrieve',
+    schema: AccountsNotebooksRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountsNotebooksRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AccountNotebook>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/accounts/${encodeURIComponent(String(params.account_id))}/notebooks/${encodeURIComponent(String(params.short_id))}/`,
+        })
+        return result
     },
 })
 
@@ -324,6 +412,10 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'accounts-create': accountsCreate,
     'accounts-destroy': accountsDestroy,
     'accounts-list': accountsList,
+    'accounts-notebooks-create': accountsNotebooksCreate,
+    'accounts-notebooks-destroy': accountsNotebooksDestroy,
+    'accounts-notebooks-list': accountsNotebooksList,
+    'accounts-notebooks-retrieve': accountsNotebooksRetrieve,
     'accounts-partial-update': accountsPartialUpdate,
     'accounts-retrieve': accountsRetrieve,
     'usage-metrics-create': usageMetricsCreate,

--- a/tach.toml
+++ b/tach.toml
@@ -163,6 +163,7 @@ depends_on = [
     "ee",
     "posthog",
     "products.data_warehouse",
+    "products.notebooks",
 ]
 layer = "modules"
 


### PR DESCRIPTION
## Problem
There is no way to write down notes about an account. Let's make this possible and enable LLMs to also do it via MCP tools.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/57026
## Changes
- Add `accounts` in `ResourceNotebook` model
- Return related account notebooks in the API
- Add MCP tools to create notebooks for accounts

Also added a new column to the accounts list with the count of notes. Will make it interactive later on (click to preview, etc)
<img width="1653" height="576" alt="image" src="https://github.com/user-attachments/assets/f2d1457c-cbfc-4654-9feb-be8e16f20c25" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Unit tests + manually creating account notes via MCP and accessing them also via MCP
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
