### PR TITLE
chore(ff): extend test coverage of regex flag validation

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -7205,7 +7205,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["detail"], "groups[0].properties[0].value: invalid regex pattern")
 
-    def test_patch_flag_with_unchanged_python_incompatible_regex(self):
+    def test_patch_non_filter_field_skips_regex_validation(self):
         flag = FeatureFlag.objects.create(
             team=self.team,
             created_by=self.user,
@@ -7232,33 +7232,33 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.client.patch(
-            f"/api/projects/{self.team.id}/feature_flags/{flag.id}",
-            {
-                "filters": {
-                    "groups": [
-                        {
-                            "rollout_percentage": 50,
-                            "properties": [
-                                {
-                                    "key": "email",
-                                    "type": "person",
-                                    "value": "(?<!a{2,5})b",
-                                    "operator": "regex",
-                                }
-                            ],
-                        }
-                    ]
-                }
-            },
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test_patch_flag_rejects_new_invalid_regex(self):
+    @parameterized.expand(
+        [
+            (
+                "unchanged_invalid_regex_accepted",
+                "(?<!a{2,5})b",
+                "(?<!a{2,5})b",
+                status.HTTP_200_OK,
+            ),
+            (
+                "valid_to_invalid_regex_rejected",
+                "^valid$",
+                "[unclosed",
+                status.HTTP_400_BAD_REQUEST,
+            ),
+            (
+                "different_invalid_regex_rejected",
+                "[unclosed",
+                "(unbalanced",
+                status.HTTP_400_BAD_REQUEST,
+            ),
+        ]
+    )
+    def test_patch_flag_regex_validation(self, _name, existing_pattern, new_pattern, expected_status):
         flag = FeatureFlag.objects.create(
             team=self.team,
             created_by=self.user,
-            key="flag-valid-regex",
+            key="flag-regex-test",
             filters={
                 "groups": [
                     {
@@ -7267,7 +7267,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                             {
                                 "key": "email",
                                 "type": "person",
-                                "value": "^valid$",
+                                "value": existing_pattern,
                                 "operator": "regex",
                             }
                         ],
@@ -7286,7 +7286,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                                 {
                                     "key": "email",
                                     "type": "person",
-                                    "value": "[unclosed",
+                                    "value": new_pattern,
                                     "operator": "regex",
                                 }
                             ],
@@ -7295,8 +7295,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 }
             },
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.json()["detail"], "groups[0].properties[0].value: invalid regex pattern")
+        self.assertEqual(response.status_code, expected_status)
+        if expected_status == status.HTTP_400_BAD_REQUEST:
+            self.assertEqual(response.json()["detail"], "groups[0].properties[0].value: invalid regex pattern")
 
     def test_cant_create_flag_with_non_string_regex_value(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem

The feature flag regex validation on PATCH has a value-equality escape hatch at `posthog/api/feature_flag.py:1057` that allows unchanged Python-incompatible patterns through. Two of the three key behaviors were covered by tests, but the third, patching an existing invalid regex with a different invalid regex, was not. Without that case, a refactor could accidentally turn `existing_patterns` into a blanket "skip regex validation if any existing pattern was invalid" bypass and still pass tests.

## Changes

- Added a parameterized test (`test_patch_flag_regex_validation`) that covers all three PATCH regex scenarios in one place:
  - Unchanged invalid regex → accepted (200)
  - Valid existing → new invalid → rejected (400)
  - Invalid existing → different invalid → rejected (400)
- Extracted the non-filter PATCH sub-test (`active=False`) into its own focused test (`test_patch_non_filter_field_skips_regex_validation`) since it tests a different concern.


## How did you test this code?

It is a test addition
