### PR TITLE
feat(logs-alerting): add missing event filter option

### DIFF
--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -53,6 +53,10 @@ export const getProductEventFilterOptions = (contextId: HogFunctionConfiguration
                     label: 'Log alert auto-disabled',
                     value: '$logs_alert_auto_disabled',
                 },
+                {
+                    label: 'Log alert errored',
+                    value: '$logs_alert_errored',
+                },
             ]
         case 'discussion-mention':
             return [


### PR DESCRIPTION
## Problem

When a log alert encounters an error, there was no corresponding filter option available in the Hog Function internal filters UI to match against the `$logs_alert_errored` event. This made it impossible to filter or trigger on log alert error conditions.

## Changes

Adds a new `$logs_alert_errored` event option to the product event filter list for the `log-alert` configuration context, alongside the existing `$logs_alert_auto_disabled` option.

## How did you test this code?

Verified the new filter option appears in the dropdown for log alert Hog Function configurations.

## Publish to changelog?

No