### PR TITLE
fix(data-warehouse): use org id as distinct_id for dwh-postgres-cdc flag

### DIFF
--- a/products/data_warehouse/backend/data_load/service.py
+++ b/products/data_warehouse/backend/data_load/service.py
@@ -274,7 +274,7 @@ def is_cdc_enabled_for_team(team: Team) -> bool:
 
     return posthoganalytics.feature_enabled(
         "dwh-postgres-cdc",
-        str(team.uuid),
+        str(team.organization_id),
         groups={"organization": str(team.organization_id)},
         group_properties={"organization": {"id": str(team.organization_id)}},
     )


### PR DESCRIPTION
## Problem

The `dwh-postgres-cdc` feature flag is evaluated server-side in [`is_cdc_enabled_for_team`](products/data_warehouse/backend/data_load/service.py) and on the frontend (via `posthog-js` with the org auto-bound as a group in `userLogic.ts`). The flag's intent is org-level rollout, but the backend passed `team.uuid` as the `distinct_id` while supplying the organization in `groups` / `group_properties`. That works, but it's inconsistent with how the rest of the codebase evaluates org-aggregated flags (e.g. `warehouse-api` in [`products/data_warehouse/backend/api/table.py`](products/data_warehouse/backend/api/table.py)) and makes the evaluation semantics ambiguous before we widen the rollout.

## Changes

- Pass `str(team.organization_id)` as the `distinct_id` in `is_cdc_enabled_for_team`, matching the existing convention used by other org-aggregated flag checks in the repo.
- No frontend changes — `userLogic.ts` already calls `posthog.group('organization', user.organization.id, …)`, so org-aggregated evaluation works as-is for the `featureFlags[FEATURE_FLAGS.DWH_POSTGRES_CDC]` read in `SourceForm.tsx`.

## How did you test this code?

I'm an agent. No automated or manual tests were run for this one-line distinct_id swap; the change is type-preserving and the call site contract is unchanged. Pre-commit `ruff` / `ty` checks passed via lint-staged.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Decisions:
  - Considered leaving `team.uuid` as the `distinct_id`; rejected because the flag will be flipped to org-aggregated with a kill-list condition for safe 100% rollout, and inconsistent identifiers across call sites make the kill switch behavior harder to reason about.
  - Considered moving the frontend read to an explicit `posthog.isFeatureEnabled` call with manually-provided groups; rejected because `posthog-js` already has the org bound and the existing kea selector pattern is the standard.