### PR TITLE
feat(capture): add dry run mode to GlobalRateLimiter wrapper

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -56,6 +56,11 @@ pub struct Config {
     #[envconfig(default = "false")]
     pub global_rate_limit_enabled: bool,
 
+    /// When true, the global rate limiter evaluates and emits metrics/logs
+    /// but does not enforce (events pass through as if not limited).
+    #[envconfig(default = "false")]
+    pub global_rate_limit_dry_run: bool,
+
     /// Sliding window interval to apply global rate limiting threshold to
     #[envconfig(default = "60")]
     pub global_rate_limit_window_interval_secs: u64,

--- a/rust/capture/src/global_rate_limiter.rs
+++ b/rust/capture/src/global_rate_limiter.rs
@@ -10,7 +10,8 @@ use limiters::global_rate_limiter::{
     EvalResult, GlobalRateLimitResponse, GlobalRateLimiter as CommonGlobalRateLimiter,
     GlobalRateLimiterConfig, GlobalRateLimiterImpl as CommonGlobalRateLimiterImpl,
 };
-use tracing::{error, info};
+use metrics::counter;
+use tracing::{error, info, warn};
 
 #[cfg(test)]
 use chrono::DateTime;
@@ -43,6 +44,7 @@ impl<'a> GlobalRateLimitKey<'a> {
 
 pub struct GlobalRateLimiter {
     limiter: Box<dyn CommonGlobalRateLimiter>,
+    dry_run: bool,
 }
 
 impl GlobalRateLimiter {
@@ -122,6 +124,8 @@ impl GlobalRateLimiter {
             ..Default::default()
         };
 
+        let dry_run = config.global_rate_limit_dry_run;
+
         let limiter = match CommonGlobalRateLimiterImpl::new(grl_config, redis_instances) {
             Ok(l) => l,
             Err(e) => {
@@ -130,19 +134,48 @@ impl GlobalRateLimiter {
             }
         };
 
+        if dry_run {
+            info!("GlobalRateLimiter initialized in dry-run mode (evaluating but not enforcing)");
+        }
+
         Ok(Self {
             limiter: Box::new(limiter),
+            dry_run,
         })
     }
 
     /// Check if a key is rate limited. Routes to custom or global check based on
     /// whether the key is registered in the custom_keys map. Exactly one check
     /// fires per call — no double-enqueue to the Redis batch channel.
+    ///
+    /// In dry-run mode the underlying limiter is still evaluated (counts are
+    /// tracked, Redis is synced) but the result is suppressed: metrics and a
+    /// warn log are emitted, then `None` is returned so callers never enforce.
     pub async fn is_limited(&self, key: &str, count: u64) -> Option<GlobalRateLimitResponse> {
-        if self.limiter.is_custom_key(key) {
+        let result = if self.limiter.is_custom_key(key) {
             self.is_custom_key_limited(key, count).await
         } else {
             self.is_global_key_limited(key, count).await
+        };
+
+        match (result, self.dry_run) {
+            (Some(response), true) => {
+                counter!(
+                    "capture_global_rate_limiter_dry_run",
+                    "key_type" => if response.is_custom_limited { "custom" } else { "global" },
+                )
+                .increment(1);
+                warn!(
+                    key = key,
+                    current_count = response.current_count,
+                    threshold = response.threshold,
+                    is_custom_limited = response.is_custom_limited,
+                    dry_run = true,
+                    "global rate limiter would have limited (dry run)"
+                );
+                None
+            }
+            (result, _) => result,
         }
     }
 
@@ -231,6 +264,15 @@ impl GlobalRateLimiter {
     pub(crate) fn new_with(limiter: impl CommonGlobalRateLimiter + 'static) -> Self {
         Self {
             limiter: Box::new(limiter),
+            dry_run: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_dry_run(limiter: impl CommonGlobalRateLimiter + 'static) -> Self {
+        Self {
+            limiter: Box::new(limiter),
+            dry_run: true,
         }
     }
 
@@ -556,5 +598,85 @@ mod tests {
         let key2 = GlobalRateLimitKey::TokenDistinctId("t", &distinct_id_129);
         let result2 = key2.to_cache_key();
         assert_eq!(&*result2, &format!("t:{prefix_129}"));
+    }
+
+    // --- dry-run mode tests ---
+
+    #[tokio::test]
+    async fn test_dry_run_global_limited_returns_none() {
+        let (mock, calls) = MockLimiter::new(
+            HashSet::new(),
+            make_limited_response(false),
+            EvalResult::NotApplicable,
+        );
+        let wrapper = GlobalRateLimiter::new_with_dry_run(mock);
+
+        let result = wrapper.is_limited("some_key", 1).await;
+
+        assert!(
+            result.is_none(),
+            "dry-run should suppress Limited → None, got {result:?}"
+        );
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec!["is_custom_key", "check_limit"],
+            "underlying limiter must still be called in dry-run mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_custom_limited_returns_none() {
+        let (mock, calls) = MockLimiter::new(
+            HashSet::from(["custom_key".to_string()]),
+            EvalResult::Allowed,
+            make_limited_response(true),
+        );
+        let wrapper = GlobalRateLimiter::new_with_dry_run(mock);
+
+        let result = wrapper.is_limited("custom_key", 1).await;
+
+        assert!(
+            result.is_none(),
+            "dry-run should suppress custom Limited → None, got {result:?}"
+        );
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec!["is_custom_key", "check_custom_limit"],
+            "underlying limiter must still be called in dry-run mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_allowed_stays_none() {
+        let (mock, _calls) = MockLimiter::new(
+            HashSet::new(),
+            EvalResult::Allowed,
+            EvalResult::NotApplicable,
+        );
+        let wrapper = GlobalRateLimiter::new_with_dry_run(mock);
+
+        let result = wrapper.is_limited("some_key", 1).await;
+
+        assert!(
+            result.is_none(),
+            "allowed result should remain None in dry-run mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_dry_run_limited_still_returns_some() {
+        let (mock, _calls) = MockLimiter::new(
+            HashSet::new(),
+            make_limited_response(false),
+            EvalResult::NotApplicable,
+        );
+        let wrapper = GlobalRateLimiter::new_with(mock);
+
+        let result = wrapper.is_limited("some_key", 1).await;
+
+        assert!(
+            result.is_some(),
+            "non-dry-run should return Some(response) when limited"
+        );
     }
 }

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -116,6 +116,7 @@ mod tests {
             redis_response_timeout_ms: 100,
             redis_connection_timeout_ms: 5000,
             global_rate_limit_enabled: false,
+            global_rate_limit_dry_run: false,
             global_rate_limit_window_interval_secs: 60,
             global_rate_limit_sync_interval_secs: 15,
             global_rate_limit_tick_interval_ms: 1000,

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -39,6 +39,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     redis_response_timeout_ms: 100,
     redis_connection_timeout_ms: 5000,
     global_rate_limit_enabled: false,
+    global_rate_limit_dry_run: false,
     global_rate_limit_window_interval_secs: 60,
     global_rate_limit_sync_interval_secs: 15,
     global_rate_limit_tick_interval_ms: 1000,


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
We will want visibility into the behavior of the new RFC-decided `token:distinct_id` rate limit before we ship it in capture.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
*Add dry run mode (controlled with cfg env var for prod deploys, default disabled)
* Related wrapper/test updates
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (new unit tests too)
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
Eli planned, Claude typed
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
