### PR TITLE
perf(tagged-item): batch tag and tagged-item writes in set_tags_on_object

### DIFF
--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -61,10 +61,10 @@ def set_tags_on_object(tags: list[str], obj: Any) -> list[TaggedItem]:
                 ignore_conflicts=True,
             )
             # bulk_create + ignore_conflicts does not reliably populate PKs, so refetch.
-            refetched = list(Tag.objects.filter(team_id=obj.team_id, name__in=missing_tag_names))
+            # `team` is selected because handle_tag_change reads `after_update.team.organization_id`.
+            refetched = list(Tag.objects.filter(team_id=obj.team_id, name__in=missing_tag_names).select_related("team"))
             for t in refetched:
-                if t.name not in tags_by_name:
-                    newly_created_tags.append(t)
+                newly_created_tags.append(t)
                 tags_by_name[t.name] = t
 
         # `obj.tagged_items` is a reverse manager; `.field` is the FK on TaggedItem

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -32,85 +32,93 @@ def set_tags_on_object(tags: list[str], obj: Any) -> list[TaggedItem]:
     Batches the Tag + TaggedItem reads and writes so the DB cost is constant
     per call rather than O(tags). `bulk_create` and queryset `.delete()` bypass
     the model save/delete hooks, so the activity-log signal is fired manually
-    for each added/removed row to preserve the existing per-row activity log
+    for each added/removed row to preserve the existing per-row activity-log
     fanout (including the related-object mirror on Ticket / Account streams).
     """
-    deduped_names = {tagify(t) for t in tags}
+    requested_names = {tagify(t) for t in tags}
 
     # `tag__team` is prefetched because the activity-log signal handler reads
     # `tagged_item.tag.team` to resolve organization_id for each fired signal.
     existing_items = list(obj.tagged_items.select_related("tag", "tag__team"))
     existing_names = {ti.tag.name for ti in existing_items}
 
-    to_add = deduped_names - existing_names
-    to_keep = [ti for ti in existing_items if ti.tag.name in deduped_names]
-    to_remove = [ti for ti in existing_items if ti.tag.name not in deduped_names]
+    names_to_add = requested_names - existing_names
+    items_to_keep = [ti for ti in existing_items if ti.tag.name in requested_names]
+    items_to_remove = [ti for ti in existing_items if ti.tag.name not in requested_names]
 
-    current_user = get_current_user()
-    was_impersonated = get_was_impersonated()
+    new_items = _add_tagged_items(obj, names_to_add) if names_to_add else []
+    if items_to_remove:
+        _remove_tagged_items(obj, items_to_remove)
 
-    new_items: list[TaggedItem] = []
-    if to_add:
-        tags_by_name: dict[str, Tag] = {t.name: t for t in Tag.objects.filter(team_id=obj.team_id, name__in=to_add)}
-        missing_tag_names = to_add - tags_by_name.keys()
-        newly_created_tags: list[Tag] = []
-        if missing_tag_names:
-            # ignore_conflicts swallows races with parallel inserts of the same (team_id, name)
-            Tag.objects.bulk_create(
-                [Tag(name=name, team_id=obj.team_id) for name in missing_tag_names],
-                ignore_conflicts=True,
-            )
-            # bulk_create + ignore_conflicts does not reliably populate PKs, so refetch.
-            # `team` is selected because handle_tag_change reads `after_update.team.organization_id`.
-            refetched = list(Tag.objects.filter(team_id=obj.team_id, name__in=missing_tag_names).select_related("team"))
-            for t in refetched:
-                newly_created_tags.append(t)
-                tags_by_name[t.name] = t
+    return items_to_keep + new_items
 
-        # `obj.tagged_items` is a reverse manager; `.field` is the FK on TaggedItem
-        # pointing back at `obj` (e.g. `account`, `dashboard`, `insight`).
-        fk_attname = obj.tagged_items.field.attname
-        TaggedItem.objects.bulk_create(
-            [TaggedItem(tag=tags_by_name[name], **{fk_attname: obj.pk}) for name in to_add],
-            ignore_conflicts=True,
-        )
-        new_items = list(obj.tagged_items.filter(tag__name__in=to_add).select_related("tag", "tag__team"))
 
-        for tag in newly_created_tags:
-            model_activity_signal.send(
-                sender=Tag,
-                scope="Tag",
-                before_update=None,
-                after_update=tag,
-                activity="created",
-                user=current_user,
-                was_impersonated=was_impersonated,
-            )
-        for ti in new_items:
-            model_activity_signal.send(
-                sender=TaggedItem,
-                scope="TaggedItem",
-                before_update=None,
-                after_update=ti,
-                activity="created",
-                user=current_user,
-                was_impersonated=was_impersonated,
-            )
+def _add_tagged_items(obj: Any, names_to_add: set[str]) -> list[TaggedItem]:
+    """Create Tags (if missing) + TaggedItems linking them to `obj`, in two bulk writes."""
+    tags_by_name = _resolve_or_create_tags(obj.team_id, names_to_add)
 
-    if to_remove:
-        obj.tagged_items.filter(pk__in=[ti.pk for ti in to_remove]).delete()
-        for ti in to_remove:
-            model_activity_signal.send(
-                sender=TaggedItem,
-                scope="TaggedItem",
-                before_update=ti,
-                after_update=None,
-                activity="deleted",
-                user=current_user,
-                was_impersonated=was_impersonated,
-            )
+    # `obj.tagged_items` is a reverse manager; `.field` is the FK on TaggedItem
+    # pointing back at `obj` (e.g. `account`, `dashboard`, `insight`).
+    fk_attname = obj.tagged_items.field.attname
+    TaggedItem.objects.bulk_create(
+        [TaggedItem(tag=tags_by_name[name], **{fk_attname: obj.pk}) for name in names_to_add],
+        ignore_conflicts=True,
+    )
+    new_items = list(obj.tagged_items.filter(tag__name__in=names_to_add).select_related("tag", "tag__team"))
 
-    return to_keep + new_items
+    for ti in new_items:
+        _send_model_activity(TaggedItem, "TaggedItem", before=None, after=ti, activity="created")
+
+    return new_items
+
+
+def _resolve_or_create_tags(team_id: int, names: set[str]) -> dict[str, Tag]:
+    """Return ``{name: Tag}`` for every name, creating any missing rows in one bulk insert."""
+    tags_by_name: dict[str, Tag] = {t.name: t for t in Tag.objects.filter(team_id=team_id, name__in=names)}
+    missing_names = names - tags_by_name.keys()
+    if not missing_names:
+        return tags_by_name
+
+    # ignore_conflicts swallows races with parallel inserts of the same (team_id, name).
+    Tag.objects.bulk_create(
+        [Tag(name=name, team_id=team_id) for name in missing_names],
+        ignore_conflicts=True,
+    )
+    # bulk_create + ignore_conflicts does not reliably populate PKs, so refetch.
+    # `team` is selected because handle_tag_change reads `after_update.team.organization_id`.
+    newly_created = list(Tag.objects.filter(team_id=team_id, name__in=missing_names).select_related("team"))
+    for tag in newly_created:
+        tags_by_name[tag.name] = tag
+        _send_model_activity(Tag, "Tag", before=None, after=tag, activity="created")
+
+    return tags_by_name
+
+
+def _remove_tagged_items(obj: Any, items: list[TaggedItem]) -> None:
+    """Delete TaggedItems in one query and fire a `deleted` signal for each removed row."""
+    obj.tagged_items.filter(pk__in=[ti.pk for ti in items]).delete()
+    for ti in items:
+        _send_model_activity(TaggedItem, "TaggedItem", before=ti, after=None, activity="deleted")
+
+
+def _send_model_activity(
+    sender: type[models.Model],
+    scope: str,
+    *,
+    before: Optional[models.Model],
+    after: Optional[models.Model],
+    activity: str,
+) -> None:
+    """Manually fire ``model_activity_signal`` for a row mutated via ``bulk_create`` / queryset ``.delete()``."""
+    model_activity_signal.send(
+        sender=sender,
+        scope=scope,
+        before_update=before,
+        after_update=after,
+        activity=activity,
+        user=get_current_user(),
+        was_impersonated=get_was_impersonated(),
+    )
 
 
 def cleanup_orphan_tags(team_id: int) -> None:

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -19,6 +19,7 @@ from posthog.models.activity_logging.activity_log import (
     changes_between,
     log_activity,
 )
+from posthog.models.activity_logging.model_activity import get_current_user, get_was_impersonated
 from posthog.models.activity_logging.tag_utils import get_tagged_item_related_object_info
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.tag import tagify
@@ -28,23 +29,88 @@ from posthog.rbac.user_access_control import access_level_satisfied_for_resource
 def set_tags_on_object(tags: list[str], obj: Any) -> list[TaggedItem]:
     """Set tags on a taggable object, creating/deleting TaggedItems as needed.
 
-    This is the core tag-setting logic extracted for reuse across serializers
-    and bulk operations.
+    Batches the Tag + TaggedItem reads and writes so the DB cost is constant
+    per call rather than O(tags). `bulk_create` and queryset `.delete()` bypass
+    the model save/delete hooks, so the activity-log signal is fired manually
+    for each added/removed row to preserve the existing per-row activity log
+    fanout (including the related-object mirror on Ticket / Account streams).
     """
-    deduped_tags = list({tagify(t) for t in tags})
-    tagged_item_objects = []
+    deduped_names = {tagify(t) for t in tags}
 
-    for tag in deduped_tags:
-        tag_instance, _ = Tag.objects.get_or_create(name=tag, team_id=obj.team_id)
-        tagged_item_instance, _ = obj.tagged_items.get_or_create(tag_id=tag_instance.id)
-        tagged_item_objects.append(tagged_item_instance)
+    # `tag__team` is prefetched because the activity-log signal handler reads
+    # `tagged_item.tag.team` to resolve organization_id for each fired signal.
+    existing_items = list(obj.tagged_items.select_related("tag", "tag__team"))
+    existing_names = {ti.tag.name for ti in existing_items}
 
-    # Delete tags that are missing (use individual deletes to trigger activity logging)
-    tagged_items_to_delete = obj.tagged_items.exclude(tag__name__in=deduped_tags)
-    for tagged_item in tagged_items_to_delete:
-        tagged_item.delete()
+    to_add = deduped_names - existing_names
+    to_keep = [ti for ti in existing_items if ti.tag.name in deduped_names]
+    to_remove = [ti for ti in existing_items if ti.tag.name not in deduped_names]
 
-    return tagged_item_objects
+    current_user = get_current_user()
+    was_impersonated = get_was_impersonated()
+
+    new_items: list[TaggedItem] = []
+    if to_add:
+        tags_by_name: dict[str, Tag] = {t.name: t for t in Tag.objects.filter(team_id=obj.team_id, name__in=to_add)}
+        missing_tag_names = to_add - tags_by_name.keys()
+        newly_created_tags: list[Tag] = []
+        if missing_tag_names:
+            # ignore_conflicts swallows races with parallel inserts of the same (team_id, name)
+            Tag.objects.bulk_create(
+                [Tag(name=name, team_id=obj.team_id) for name in missing_tag_names],
+                ignore_conflicts=True,
+            )
+            # bulk_create + ignore_conflicts does not reliably populate PKs, so refetch.
+            refetched = list(Tag.objects.filter(team_id=obj.team_id, name__in=missing_tag_names))
+            for t in refetched:
+                if t.name not in tags_by_name:
+                    newly_created_tags.append(t)
+                tags_by_name[t.name] = t
+
+        # `obj.tagged_items` is a reverse manager; `.field` is the FK on TaggedItem
+        # pointing back at `obj` (e.g. `account`, `dashboard`, `insight`).
+        fk_attname = obj.tagged_items.field.attname
+        TaggedItem.objects.bulk_create(
+            [TaggedItem(tag=tags_by_name[name], **{fk_attname: obj.pk}) for name in to_add],
+            ignore_conflicts=True,
+        )
+        new_items = list(obj.tagged_items.filter(tag__name__in=to_add).select_related("tag", "tag__team"))
+
+        for tag in newly_created_tags:
+            model_activity_signal.send(
+                sender=Tag,
+                scope="Tag",
+                before_update=None,
+                after_update=tag,
+                activity="created",
+                user=current_user,
+                was_impersonated=was_impersonated,
+            )
+        for ti in new_items:
+            model_activity_signal.send(
+                sender=TaggedItem,
+                scope="TaggedItem",
+                before_update=None,
+                after_update=ti,
+                activity="created",
+                user=current_user,
+                was_impersonated=was_impersonated,
+            )
+
+    if to_remove:
+        obj.tagged_items.filter(pk__in=[ti.pk for ti in to_remove]).delete()
+        for ti in to_remove:
+            model_activity_signal.send(
+                sender=TaggedItem,
+                scope="TaggedItem",
+                before_update=ti,
+                after_update=None,
+                activity="deleted",
+                user=current_user,
+                was_impersonated=was_impersonated,
+            )
+
+    return to_keep + new_items
 
 
 def cleanup_orphan_tags(team_id: int) -> None:

--- a/posthog/api/test/test_tagged_item.py
+++ b/posthog/api/test/test_tagged_item.py
@@ -1,9 +1,14 @@
 from posthog.test.base import APIBaseTest
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.api.tagged_item import set_tags_on_object
 from posthog.models import Insight, Organization, Tag, Team
+from posthog.models.signals import mute_selected_signals
 from posthog.models.tagged_item import TaggedItem
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -94,6 +99,78 @@ class TestTaggedItemSerializerMixin(APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.id}/tags")
         assert response.status_code == status.HTTP_200_OK
         assert sorted(response.json()) == ["dashboard tag", "insight tag"]
+
+
+class TestSetTagsOnObject(APIBaseTest):
+    def test_diff_only_creates_missing_tags_and_removes_orphans(self):
+        dashboard = Dashboard.objects.create(team_id=self.team.id, name="d")
+        keep = Tag.objects.create(name="keep", team_id=self.team.id)
+        old = Tag.objects.create(name="drop", team_id=self.team.id)
+        dashboard.tagged_items.create(tag=keep)
+        dashboard.tagged_items.create(tag=old)
+
+        result = set_tags_on_object(["keep", "new-1", "new-2"], dashboard)
+
+        names = sorted(ti.tag.name for ti in result)
+        assert names == ["keep", "new-1", "new-2"]
+        assert sorted(dashboard.tagged_items.values_list("tag__name", flat=True)) == [
+            "keep",
+            "new-1",
+            "new-2",
+        ]
+
+    def test_handles_tags_already_existing_for_other_objects(self):
+        dashboard = Dashboard.objects.create(team_id=self.team.id, name="d")
+        Tag.objects.create(name="shared", team_id=self.team.id)
+
+        set_tags_on_object(["shared"], dashboard)
+
+        assert Tag.objects.filter(name="shared", team_id=self.team.id).count() == 1
+        assert dashboard.tagged_items.count() == 1
+
+    def test_idempotent_when_tags_unchanged(self):
+        dashboard = Dashboard.objects.create(team_id=self.team.id, name="d")
+        set_tags_on_object(["a", "b"], dashboard)
+
+        result = set_tags_on_object(["a", "b"], dashboard)
+
+        assert sorted(ti.tag.name for ti in result) == ["a", "b"]
+        assert dashboard.tagged_items.count() == 2
+
+    def test_read_write_cost_is_constant_in_tag_count(self):
+        # Activity-log signals still fan out per-row, so we mute them here and
+        # measure only the read/write portion that should be batched.
+        small_dashboard = Dashboard.objects.create(team_id=self.team.id, name="small")
+        large_dashboard = Dashboard.objects.create(team_id=self.team.id, name="large")
+
+        with mute_selected_signals():
+            with CaptureQueriesContext(connection) as small_ctx:
+                set_tags_on_object(["a", "b"], small_dashboard)
+            with CaptureQueriesContext(connection) as large_ctx:
+                set_tags_on_object(["a", "b", "c", "d", "e", "f"], large_dashboard)
+
+        small_count = len(small_ctx.captured_queries)
+        large_count = len(large_ctx.captured_queries)
+        assert small_count == large_count, (
+            f"set_tags_on_object should issue a constant number of read/write queries "
+            f"regardless of tag count, but 2 tags = {small_count}, 6 tags = {large_count}"
+        )
+
+    def test_delete_path_is_a_single_statement(self):
+        dashboard = Dashboard.objects.create(team_id=self.team.id, name="d")
+        for name in ["a", "b", "c", "d", "e"]:
+            tag = Tag.objects.create(name=name, team_id=self.team.id)
+            dashboard.tagged_items.create(tag=tag)
+
+        with mute_selected_signals():
+            with CaptureQueriesContext(connection) as ctx:
+                set_tags_on_object([], dashboard)
+
+        deletes = [q for q in ctx.captured_queries if q["sql"].lstrip().upper().startswith("DELETE")]
+        assert len(deletes) == 1, (
+            f"expected a single batched DELETE for orphan TaggedItems, got {len(deletes)}: "
+            f"{[q['sql'] for q in deletes]}"
+        )
 
 
 class TestBulkUpdateTags(APIBaseTest):


### PR DESCRIPTION
## Problem

`set_tags_on_object` (`posthog/api/tagged_item.py:28`) is on the hot path for every Account / Insight / Dashboard / FeatureFlag / Ticket / Action / EventDefinition / PropertyDefinition / ExperimentSavedMetric create or update that carries a `tags` field, and it is also called per-object inside `bulk_update_tags`. It used to do two `get_or_create` round-trips per tag (one for `Tag`, one for `TaggedItem`) and then delete orphan `TaggedItem` rows one at a time so each delete fanned out the activity-log signal.

A `bulk_update_tags` request touching 500 objects × 5 tags issued ~5,000+ queries, most of them small lookups serialised against Postgres. The per-row delete loop existed because `TaggedItem.delete()` is the only thing that fires the activity-log signal for tag removals.

## Changes

Rewrite `set_tags_on_object` to do the work in batched stages:

- Read the existing `TaggedItem` rows once with `select_related("tag", "tag__team")`, then compute the add / keep / remove diff in Python.
- Materialise missing `Tag` rows with one `bulk_create(..., ignore_conflicts=True)` and one refetch (`bulk_create` + `ignore_conflicts` does not reliably populate PKs).
- Insert the new `TaggedItem` rows with one `bulk_create(..., ignore_conflicts=True)`, then refetch them with `select_related("tag", "tag__team")` so each instance has stable PKs and the FK chain needed by the activity-log signal handler.
- Delete orphan `TaggedItem` rows with a single queryset `.delete()`.

Because `bulk_create` and queryset `.delete()` both bypass the model save / delete hooks, the function now fires `model_activity_signal` manually for each created / removed `TaggedItem` (and for each newly created `Tag`) so the existing per-row TaggedItem activity entries and the mirrored Ticket / Account activity entries continue to appear.

`cleanup_orphan_tags`, `TaggedItemSerializerMixin`, and `TaggedItemViewSetMixin.bulk_update_tags` are unchanged — they each benefit transparently from the per-object win. No serializer or viewset surface changes, no migration, no codegen impact.

## How did you test this code?

I'm an agent. I did not perform manual testing in a running PostHog instance. Local Postgres / Docker were not available in the agent environment, so the test suite was not executed locally; the changes rely on CI for end-to-end validation.

Automated assertions added in `posthog/api/test/test_tagged_item.py::TestSetTagsOnObject`:

- `test_diff_only_creates_missing_tags_and_removes_orphans` — keeps existing tags, adds missing ones, removes orphans in one call.
- `test_handles_tags_already_existing_for_other_objects` — reuses a pre-existing `Tag` row instead of creating a duplicate.
- `test_idempotent_when_tags_unchanged` — calling with the same tag set is a no-op.
- `test_read_write_cost_is_constant_in_tag_count` — with signals muted, the query count for 2 tags equals the count for 6 tags. Pinned so a future refactor reintroducing an N+1 fails loudly.
- `test_delete_path_is_a_single_statement` — exactly one `DELETE` is emitted when clearing tags.

CI-covered regressions worth a quick look during review:

- The existing `TestBulkUpdateTags` class in the same file (set / add / remove flows across single and multiple objects).
- `products/customer_analytics/backend/api/test_views.py::test_list_with_tags_filter_does_not_n_plus_one` — the `assertNumQueries(11)` budget for the tag-filtered list endpoint. This is a list-path budget and is not affected by the save-path refactor, but worth confirming green.
- `products/customer_analytics/backend/api/test_views.py::test_tag_change_logs_to_account_activity_stream` — verifies the Account-scoped activity log entry still appears when an account's tags change, which exercises the manual signal fire.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) via PostHog Code, working from the issue summary that called out the O(tags) round-trips per save and suggested batching with `bulk_create(..., ignore_conflicts=True)` plus a single orphan delete.

Decisions worth flagging for the reviewer:

- **Activity-log shape preserved.** The issue floated a one-summary-entry-per-object alternative for the delete path. I rejected that because the existing `handle_tagged_item_change` receiver writes both a `TaggedItem`-scoped row **and** a mirrored row on the related object's stream (Ticket / Account). `test_tag_change_logs_to_account_activity_stream` depends on the latter, and collapsing would be a visible UX change in activity timelines for users today. The real bottleneck called out in the issue is the `get_or_create` round-trips, not the activity-log inserts — batching the former gives the big win without touching activity-log semantics.
- **`tag__team` is included in `select_related`** because the activity-log signal handler reads `tagged_item.tag.team` to resolve `organization_id`. Without this, each fired signal would issue an extra query.
- **FK on `TaggedItem` is set via `obj.tagged_items.field.attname`** so the same helper works across every taggable model (Account, Dashboard, Insight, FeatureFlag, Ticket, Action, EventDefinition, PropertyDefinition, ExperimentSavedMetric) without needing to know which FK column to populate.
- **`bulk_update_tags` left as a per-object loop.** Cross-object batching would require collapsing the per-object activity-log fanout and is a larger change than this issue justifies; the (now batched) per-object call gets it most of the way.