### PR TITLE
feat(alert-destinations): add display_kind to event specifications and update hog function names

### DIFF
--- a/products/logs/backend/alert_destinations.py
+++ b/products/logs/backend/alert_destinations.py
@@ -13,6 +13,7 @@ EventKind = Literal["firing", "resolved", "broken", "errored"]
 @dataclass(frozen=True)
 class EventKindSpec:
     event_id: str
+    display_kind: str
     header: str
     body: str
     button_url: str
@@ -46,6 +47,7 @@ _BROKEN_ERRORED_BASE_DATA: dict[str, str] = {
 EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
     "firing": EventKindSpec(
         event_id="$logs_alert_firing",
+        display_kind="firing",
         header="🔴 Log alert '{event.properties.alert_name}' is firing",
         body=(
             "*Threshold breached:* {event.properties.result_count} logs in "
@@ -63,6 +65,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
     ),
     "resolved": EventKindSpec(
         event_id="$logs_alert_resolved",
+        display_kind="resolved",
         header="🟢 Log alert '{event.properties.alert_name}' has resolved",
         body=(
             "*Current count:* {event.properties.result_count} logs in "
@@ -80,6 +83,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
     ),
     "broken": EventKindSpec(
         event_id="$logs_alert_auto_disabled",
+        display_kind="auto-disabled",
         header="⚠️ Log alert '{event.properties.alert_name}' was auto-disabled",
         body=(
             "*Reason:* {event.properties.consecutive_failures} consecutive check failures.\n"
@@ -99,6 +103,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
     ),
     "errored": EventKindSpec(
         event_id="$logs_alert_errored",
+        display_kind="errored",
         header="🟡 Log alert '{event.properties.alert_name}' couldn't evaluate",
         body=("*Reason:* {event.properties.error_message}\n*Failure count:* {event.properties.consecutive_failures}"),
         button_url="{project.url}/logs/alerts/{event.properties.alert_id}",
@@ -187,7 +192,8 @@ def build_slack_config(
         "type": "internal_destination",
         "enabled": True,
         "filters": _filter_for(alert, kind),
-        "name": f"{alert.name}: {kind} → Slack #{channel_display}",
+        "name": f"Logs alert — {alert.name} ({spec.display_kind}) → Slack #{channel_display}",
+        "description": f'Sends {spec.display_kind} notifications for logs alert "{alert.name}".',
         "template_id": "template-slack",
         "inputs": {
             "blocks": {"value": _slack_blocks(spec)},
@@ -209,7 +215,8 @@ def build_webhook_config(
         "type": "internal_destination",
         "enabled": True,
         "filters": _filter_for(alert, kind),
-        "name": f"{alert.name}: {kind} → Webhook {webhook_url}",
+        "name": f"Logs alert — {alert.name} ({spec.display_kind}) → Webhook {webhook_url}",
+        "description": f'Sends {spec.display_kind} notifications for logs alert "{alert.name}".',
         "template_id": "template-webhook",
         "inputs": {
             "body": {"value": spec.webhook_body},

--- a/products/logs/backend/alert_destinations.py
+++ b/products/logs/backend/alert_destinations.py
@@ -20,6 +20,9 @@ class EventKindSpec:
     button_label: str
     webhook_body: dict[str, Any]
 
+    def destination_description(self, alert_name: str) -> str:
+        return f'Sends {self.display_kind} notifications for logs alert "{alert_name}".'
+
 
 _FIRE_RESOLVE_DATA: dict[str, str] = {
     "alert_id": "{event.properties.alert_id}",
@@ -193,7 +196,7 @@ def build_slack_config(
         "enabled": True,
         "filters": _filter_for(alert, kind),
         "name": f"Logs alert — {alert.name} ({spec.display_kind}) → Slack #{channel_display}",
-        "description": f'Sends {spec.display_kind} notifications for logs alert "{alert.name}".',
+        "description": spec.destination_description(alert.name),
         "template_id": "template-slack",
         "inputs": {
             "blocks": {"value": _slack_blocks(spec)},
@@ -216,7 +219,7 @@ def build_webhook_config(
         "enabled": True,
         "filters": _filter_for(alert, kind),
         "name": f"Logs alert — {alert.name} ({spec.display_kind}) → Webhook {webhook_url}",
-        "description": f'Sends {spec.display_kind} notifications for logs alert "{alert.name}".',
+        "description": spec.destination_description(alert.name),
         "template_id": "template-webhook",
         "inputs": {
             "body": {"value": spec.webhook_body},


### PR DESCRIPTION
## Problem

Alert destination names and descriptions for logs alerts lacked clarity and consistency. The `name` field used the raw `kind` key (e.g. `firing`, `broken`) which didn't always map to a human-readable label — notably, `broken` alerts display as `auto-disabled` to users. There was also no `description` field to give context about what each destination does.

## Changes

- Added a `display_kind` field to `EventKindSpec` to decouple the human-readable label from the internal `kind` key (e.g. `broken` → `auto-disabled`).
- Updated the `name` format for Slack and Webhook destinations to use a clearer, more consistent pattern:
  - Before: `{alert.name}: {kind} → Slack #{channel}`
  - After: `Logs alert — {alert.name} ({display_kind}) → Slack #{channel}`
- Added a `description` field to both Slack and Webhook destination configs: `Sends {display_kind} notifications for logs alert "{alert.name}".`

## How did you test this code?

Verified by reviewing the config output for each `EventKind` (`firing`, `resolved`, `broken`, `errored`) to confirm `display_kind` values are correct and that the generated `name` and `description` strings render as expected.

## Publish to changelog?

No