### PR TITLE
feat(hog-functions): add 'EventProperties' filter for 'logs-alerting' context

### DIFF
--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -141,6 +141,8 @@ export function HogFunctionFiltersInternal(): JSX.Element {
             return [TaxonomicFilterGroupType.Events]
         } else if (contextId === 'activity-log') {
             return [TaxonomicFilterGroupType.ActivityLogProperties]
+        } else if (contextId === 'logs-alerting') {
+            return [TaxonomicFilterGroupType.EventProperties]
         }
         return []
     }, [contextId])


### PR DESCRIPTION
## Problem

The `logs-alerting` context in Hog function filters had no taxonomic filter group associated with it, meaning users couldn't filter by event properties when configuring log-based alerting functions.

## Changes

Adds `TaxonomicFilterGroupType.EventProperties` as the taxonomic filter group for the `logs-alerting` context, enabling event property filtering in that context.

## How did you test this code?

Verified the conditional branch is consistent with the existing pattern used for other context IDs in the same function.

## Publish to changelog?

No