### PR TITLE
feat(welcome): add nullable PostHog human + Slack channel card

### DIFF
--- a/frontend/src/scenes/welcome/WelcomeDialog.tsx
+++ b/frontend/src/scenes/welcome/WelcomeDialog.tsx
@@ -10,6 +10,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { AskMaxCard } from './cards/AskMaxCard'
 import { PopularDashboardsCard } from './cards/PopularDashboardsCard'
+import { PostHogHumanCard } from './cards/PostHogHumanCard'
 import { ProductsInUseCard } from './cards/ProductsInUseCard'
 import { RecentActivityCard } from './cards/RecentActivityCard'
 import { SuggestedNextStepsCard } from './cards/SuggestedNextStepsCard'
@@ -123,6 +124,9 @@ export function WelcomeDialog(): JSX.Element | null {
                     <RecentActivityCard />
                     <PopularDashboardsCard />
                     <TeamMembersCard />
+                    {/* Small concierge note — only renders when there's a contact name and/or
+                     * a shared Slack channel URL on the payload; otherwise this is a no-op. */}
+                    <PostHogHumanCard />
                 </div>
             )}
         </LemonModal>

--- a/frontend/src/scenes/welcome/cards/PostHogHumanCard.test.tsx
+++ b/frontend/src/scenes/welcome/cards/PostHogHumanCard.test.tsx
@@ -1,6 +1,6 @@
-import '@testing-library/jest-dom'
-
 import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+
+import '@testing-library/jest-dom'
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 

--- a/frontend/src/scenes/welcome/cards/PostHogHumanCard.test.tsx
+++ b/frontend/src/scenes/welcome/cards/PostHogHumanCard.test.tsx
@@ -1,0 +1,99 @@
+import '@testing-library/jest-dom'
+
+import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { userLogic } from 'scenes/userLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { UserType } from '~/types'
+
+import { WelcomePayload, welcomeDialogLogic } from '../welcomeDialogLogic'
+import { PostHogHumanCard } from './PostHogHumanCard'
+
+const INVITED_USER: UserType = {
+    ...MOCK_DEFAULT_USER,
+    is_organization_first_user: false,
+}
+
+const BASE_PAYLOAD: WelcomePayload = {
+    organization_name: 'Acme Inc',
+    inviter: null,
+    team_members: [],
+    recent_activity: [],
+    popular_dashboards: [],
+    products_in_use: [],
+    suggested_next_steps: [],
+    is_organization_first_user: false,
+    posthog_contact: null,
+    shared_slack_channel_url: null,
+}
+
+describe('PostHogHumanCard', () => {
+    let logic: ReturnType<typeof welcomeDialogLogic.build>
+
+    beforeEach(() => {
+        window.localStorage.clear()
+        window.sessionStorage.clear()
+        useMocks({
+            get: {
+                '/api/organizations/@current/welcome/current/': BASE_PAYLOAD,
+            },
+        })
+        initKeaTests()
+        userLogic.mount()
+        userLogic.actions.loadUserSuccess(INVITED_USER)
+        logic = welcomeDialogLogic()
+        logic.mount()
+    }) // useMocks is the project's mock helper, not a React hook — its `use` prefix only collides naming-wise.
+
+    function seed(overrides: Partial<WelcomePayload>): void {
+        // Bypass the loader's async path so tests don't need to await network mocks just to assert
+        // rendering against a deterministic payload.
+        logic.actions.loadWelcomeDataSuccess({ ...BASE_PAYLOAD, ...overrides })
+    }
+
+    afterEach(() => {
+        // Project jest config doesn't enable RTL auto-cleanup, so without this the previous
+        // test's DOM leaks into the next and getByText fails with "multiple elements".
+        cleanup()
+    })
+
+    it('renders nothing when no contact and no Slack channel is set', () => {
+        seed({ posthog_contact: null, shared_slack_channel_url: null })
+        const { container } = render(<PostHogHumanCard />)
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('renders the contact name when a contact is set', () => {
+        seed({ posthog_contact: { name: 'Fernando' }, shared_slack_channel_url: null })
+        render(<PostHogHumanCard />)
+        expect(screen.getByText('Your PostHog human')).toBeInTheDocument()
+        expect(screen.getByText('Fernando can help if you get stuck.')).toBeInTheDocument()
+        expect(screen.queryByText('Join your shared Slack channel')).not.toBeInTheDocument()
+    })
+
+    it('renders the Slack CTA with no name when only a Slack channel is set', () => {
+        seed({ posthog_contact: null, shared_slack_channel_url: 'https://posthog.slack.com/c/acme' })
+        render(<PostHogHumanCard />)
+        expect(screen.getByText('Your PostHog human')).toBeInTheDocument()
+        const slackLink = screen.getByText('Join your shared Slack channel').closest('a')
+        expect(slackLink).toHaveAttribute('href', 'https://posthog.slack.com/c/acme')
+        expect(slackLink).toHaveAttribute('target', '_blank')
+        // No body line when there's no name to attach it to.
+        expect(screen.queryByText(/can help if you get stuck\./)).not.toBeInTheDocument()
+    })
+
+    it('tracks Slack CTA clicks via the existing welcome analytics pattern', () => {
+        seed({
+            posthog_contact: { name: 'Fernando' },
+            shared_slack_channel_url: 'https://posthog.slack.com/c/acme',
+        })
+        const trackSpy = jest.spyOn(logic.actions, 'trackCardClick')
+        render(<PostHogHumanCard />)
+        fireEvent.click(screen.getByText('Join your shared Slack channel'))
+        expect(trackSpy).toHaveBeenCalledWith('contact', 'https://posthog.slack.com/c/acme')
+    })
+})

--- a/frontend/src/scenes/welcome/cards/PostHogHumanCard.tsx
+++ b/frontend/src/scenes/welcome/cards/PostHogHumanCard.tsx
@@ -1,0 +1,47 @@
+import { useActions, useValues } from 'kea'
+
+import { IconArrowRight, IconHeadset } from '@posthog/icons'
+
+import { LemonCard } from 'lib/lemon-ui/LemonCard'
+import { Link } from 'lib/lemon-ui/Link'
+
+import { welcomeDialogLogic } from '../welcomeDialogLogic'
+
+export function PostHogHumanCard(): JSX.Element | null {
+    const { posthogContact, sharedSlackChannelUrl } = useValues(welcomeDialogLogic)
+    const { trackCardClick } = useActions(welcomeDialogLogic)
+
+    if (!posthogContact && !sharedSlackChannelUrl) {
+        return null
+    }
+
+    const subtitle = posthogContact ? `${posthogContact.name} can help if you get stuck.` : null
+
+    return (
+        <LemonCard hoverEffect={false} className="p-4" data-attr="welcome-posthog-human-card">
+            <div className="flex items-center gap-3">
+                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-[var(--color-brand-yellow)]/15 flex items-center justify-center text-[var(--color-brand-yellow)]">
+                    <IconHeadset className="text-xl" />
+                </div>
+                <div className="flex-1 min-w-0">
+                    <div className="text-sm font-semibold">Your PostHog human</div>
+                    {subtitle ? <div className="text-xs text-muted">{subtitle}</div> : null}
+                </div>
+                {sharedSlackChannelUrl ? (
+                    <Link
+                        to={sharedSlackChannelUrl}
+                        target="_blank"
+                        targetBlankIcon={false}
+                        subtle
+                        onClick={() => trackCardClick('contact', sharedSlackChannelUrl)}
+                        data-attr="welcome-posthog-human-slack-cta"
+                        className="inline-flex items-center gap-1 text-xs text-muted flex-shrink-0"
+                    >
+                        <span>Join your shared Slack channel</span>
+                        <IconArrowRight />
+                    </Link>
+                ) : null}
+            </div>
+        </LemonCard>
+    )
+}

--- a/frontend/src/scenes/welcome/welcomeDialogLogic.test.ts
+++ b/frontend/src/scenes/welcome/welcomeDialogLogic.test.ts
@@ -47,6 +47,8 @@ const mockPayload = {
         { label: 'See active feature flags', href: '/feature_flags', reason: 'Your team uses Feature flags' },
     ],
     is_organization_first_user: false,
+    posthog_contact: null,
+    shared_slack_channel_url: null,
 }
 
 describe('welcomeDialogLogic', () => {

--- a/frontend/src/scenes/welcome/welcomeDialogLogic.ts
+++ b/frontend/src/scenes/welcome/welcomeDialogLogic.ts
@@ -47,6 +47,10 @@ export interface WelcomeSuggestedStep {
     product_key?: string
 }
 
+export interface WelcomePostHogContact {
+    name: string
+}
+
 export interface WelcomePayload {
     organization_name: string
     inviter: WelcomeInviter | null
@@ -56,6 +60,8 @@ export interface WelcomePayload {
     products_in_use: string[]
     suggested_next_steps: WelcomeSuggestedStep[]
     is_organization_first_user: boolean
+    posthog_contact: WelcomePostHogContact | null
+    shared_slack_channel_url: string | null
 }
 
 const EMPTY_PAYLOAD: WelcomePayload = {
@@ -67,9 +73,11 @@ const EMPTY_PAYLOAD: WelcomePayload = {
     products_in_use: [],
     suggested_next_steps: [],
     is_organization_first_user: false,
+    posthog_contact: null,
+    shared_slack_channel_url: null,
 }
 
-export type WelcomeCardKind = 'members' | 'activity' | 'dashboards' | 'products' | 'next_steps'
+export type WelcomeCardKind = 'members' | 'activity' | 'dashboards' | 'products' | 'next_steps' | 'contact'
 
 // LocalStorage key used to suppress the dialog on subsequent visits after the user has dismissed it.
 // Scoped per user AND organization so a contractor/agency who works across multiple orgs gets
@@ -234,6 +242,8 @@ export const welcomeDialogLogic = kea<welcomeDialogLogicType>([
         popularDashboards: [(s) => [s.welcomeData], (data): WelcomePopularDashboard[] => data.popular_dashboards],
         productsInUse: [(s) => [s.welcomeData], (data): string[] => data.products_in_use],
         suggestedNextSteps: [(s) => [s.welcomeData], (data): WelcomeSuggestedStep[] => data.suggested_next_steps],
+        posthogContact: [(s) => [s.welcomeData], (data): WelcomePostHogContact | null => data.posthog_contact],
+        sharedSlackChannelUrl: [(s) => [s.welcomeData], (data): string | null => data.shared_slack_channel_url],
         organizationName: [
             (s) => [s.welcomeData, s.user],
             (data, user): string => data.organization_name || user?.organization?.name || '',

--- a/posthog/api/test/test_welcome.py
+++ b/posthog/api/test/test_welcome.py
@@ -187,3 +187,18 @@ class TestWelcomeEndpoint(APIBaseTest):
         self.client.logout()
         response = self.client.get("/api/organizations/@current/welcome/current/")
         self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))
+
+    def test_payload_exposes_posthog_contact_and_slack_channel_keys(self):
+        """Contract test: the response always carries the two contact-section keys, even when null.
+
+        Frontend renders the concierge card off these fields; the keys must be present so the
+        TypeScript types and the kea selectors don't go undefined when the data source is unhooked.
+        """
+        response = self.client.get("/api/organizations/@current/welcome/current/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("posthog_contact", data)
+        self.assertIn("shared_slack_channel_url", data)
+        # No internal source of truth wired up yet — both must be null until one is added.
+        self.assertIsNone(data["posthog_contact"])
+        self.assertIsNone(data["shared_slack_channel_url"])

--- a/posthog/api/welcome.py
+++ b/posthog/api/welcome.py
@@ -68,6 +68,10 @@ class _WelcomeInviterSerializer(serializers.Serializer):
     email = serializers.EmailField()
 
 
+class _WelcomePostHogContactSerializer(serializers.Serializer):
+    name = serializers.CharField(help_text="Display name of the PostHog contact (TAM/CSM) assigned to this org.")
+
+
 class _WelcomeTeamMemberSerializer(serializers.Serializer):
     name = serializers.CharField()
     email = serializers.EmailField()
@@ -109,6 +113,14 @@ class WelcomeResponseSerializer(serializers.Serializer):
     products_in_use = serializers.ListField(child=serializers.CharField())
     suggested_next_steps = _WelcomeSuggestedStepSerializer(many=True)
     is_organization_first_user = serializers.BooleanField()
+    posthog_contact = _WelcomePostHogContactSerializer(
+        allow_null=True,
+        help_text="PostHog 'human' (TAM/CSM) assigned to this org, if known. May be null.",
+    )
+    shared_slack_channel_url = serializers.URLField(
+        allow_null=True,
+        help_text="URL of the shared Slack channel with PostHog for this org, if any.",
+    )
 
 
 # ------------- Viewset --------------------------------------------------------------------------------
@@ -176,6 +188,8 @@ def _get_welcome_payload(organization: Organization, user: User) -> dict[str, An
             "recent_activity": _get_recent_activity(accessible_team_ids, since),
             "popular_dashboards": _get_popular_dashboards(accessible_team_ids, access_control),
             "products_in_use": _get_products_in_use(organization),
+            "posthog_contact": _get_posthog_contact(organization),
+            "shared_slack_channel_url": _get_shared_slack_channel_url(organization),
         }
         cache.set(cache_key, cacheable, _CACHE_TTL_SECONDS)
 
@@ -323,6 +337,31 @@ def _get_inviter(user: User, organization: Organization) -> dict[str, str] | Non
         "name": inviter.first_name or (inviter.email.split("@", 1)[0] if inviter.email else "A teammate"),
         "email": inviter.email,
     }
+
+
+def _get_posthog_contact(organization: Organization) -> dict[str, str] | None:
+    """Return the PostHog "human" (TAM/CSM/account owner) for this org, or None.
+
+    No internal source of truth currently links a PostHog Organization to its assigned
+    PostHog employee: Salesforce ownership is one-way outbound (see
+    ee/billing/salesforce_enrichment), Vitally only lands in the customer-facing data
+    warehouse, and the customer_analytics Account model carries CSM/AE/owner fields for
+    *PostHog customers' own customers* — not for PostHog's own TAM mapping. When a real
+    source is wired up (Organization admin field, Salesforce ingestion, etc.), return
+    {"name": "..."} here; the cache key already rotates on member count and onboarding
+    signals only, so changes here will be visible at most _CACHE_TTL_SECONDS later.
+    """
+    return None
+
+
+def _get_shared_slack_channel_url(organization: Organization) -> str | None:
+    """Return the shared-with-PostHog Slack channel URL for this org, or None.
+
+    No internal source of truth currently exists. See _get_posthog_contact for the
+    broader context — when wired up (e.g. an Organization admin field synced from
+    Slack Connect metadata), return the channel URL here.
+    """
+    return None
 
 
 def _get_team_members(organization: Organization) -> list[dict[str, Any]]:

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -553,6 +553,11 @@ export interface _WelcomeSuggestedStepApi {
     product_key?: string
 }
 
+export interface _WelcomePostHogContactApi {
+    /** Display name of the PostHog contact (TAM/CSM) assigned to this org. */
+    name: string
+}
+
 export interface WelcomeResponseApi {
     organization_name: string
     inviter: _WelcomeInviterApi | null
@@ -562,6 +567,13 @@ export interface WelcomeResponseApi {
     products_in_use: string[]
     suggested_next_steps: _WelcomeSuggestedStepApi[]
     is_organization_first_user: boolean
+    /** PostHog 'human' (TAM/CSM) assigned to this org, if known. May be null. */
+    posthog_contact: _WelcomePostHogContactApi | null
+    /**
+     * URL of the shared Slack channel with PostHog for this org, if any.
+     * @nullable
+     */
+    shared_slack_channel_url: string | null
 }
 
 export interface ActivityLogApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37245,6 +37245,11 @@ export namespace Schemas {
       product_key?: string;
     }
 
+    export interface _WelcomePostHogContact {
+      /** Display name of the PostHog contact (TAM/CSM) assigned to this org. */
+      name: string;
+    }
+
     export interface WelcomeResponse {
       organization_name: string;
       inviter: _WelcomeInviter | null;
@@ -37254,6 +37259,13 @@ export namespace Schemas {
       products_in_use: string[];
       suggested_next_steps: _WelcomeSuggestedStep[];
       is_organization_first_user: boolean;
+      /** PostHog 'human' (TAM/CSM) assigned to this org, if known. May be null. */
+      posthog_contact: _WelcomePostHogContact | null;
+      /**
+         * URL of the shared Slack channel with PostHog for this org, if any.
+         * @nullable
+         */
+      shared_slack_channel_url: string | null;
     }
 
     export interface _CompareFilter {


### PR DESCRIPTION
## Problem

Invited users land in the welcome modal with no obvious thread back to the PostHog team helping them roll out. There's no concierge moment to point them at their assigned contact or the shared Slack channel — context other tools surface up-front during onboarding.

## Changes

- Backend `posthog/api/welcome.py`: two new nullable fields on the welcome payload, `posthog_contact` (`{ name }`) and `shared_slack_channel_url`. Helpers `_get_posthog_contact` and `_get_shared_slack_channel_url` currently return `None` with a clear comment explaining that **no internal source of truth exists yet** — Salesforce ownership is one-way outbound, Vitally only reaches the data warehouse, and the `customer_analytics.Account` model carries CSM/AE/owner fields for *PostHog customers' own customers*, not for PostHog's TAM mapping. Wiring up a real source (Organization admin field, Salesforce ingestion, etc.) only needs to flip those two helpers.
- Frontend `frontend/src/scenes/welcome/`: new `PostHogHumanCard.tsx` rendered after the team-context cards. It hides itself when both fields are null, renders the human's name as the body line when present, and shows a Slack CTA (opens in new tab) whenever a URL exists. Adds `posthog_contact`, `shared_slack_channel_url` to the `WelcomePayload` interface and `EMPTY_PAYLOAD`, plus selectors and a new `'contact'` value on `WelcomeCardKind` so Slack clicks reuse the existing `trackCardClick` analytics path (`welcome_screen_card_clicked` with `card: 'contact'`).
- Copy matches the original request: title "Your PostHog human", body "<name> can help if you get stuck.", CTA "Join your shared Slack channel".

What is *not* changed:
- No new database fields, no new sync from Salesforce/Vitally/HubSpot, no admin tooling. Until a backend source is wired in, the card is dormant in production.

## How did you test this code?

I'm an agent. I ran the narrow automated tests:
- Frontend: `pnpm --filter=@posthog/frontend exec jest frontend/src/scenes/welcome/` — 10 tests across 2 suites pass (4 new card tests + 6 existing dialog-logic tests with updated mock payload).
- Backend: full `pytest` requires Postgres/ClickHouse which isn't available in this sandbox, so I ran a Django-bootstrapped smoke check that the serializer exposes the two new fields, both are nullable, and round-trips a `None` payload cleanly. The new `test_payload_exposes_posthog_contact_and_slack_channel_keys` test will run on CI to assert the contract.
- Lint: `ruff check` + `ruff format --check` clean on the Python files; `oxlint` clean on the welcome dir.
- No manual UI testing was performed.

## Publish to changelog?

no

## Docs update

No docs change needed — the card is dormant until a backend source for the two new fields is wired up.

## 🤖 Agent context

- Tools: Claude Code (Opus 4.7); used the Explore agent to inventory existing data sources for TAM/CSM/account-owner and shared Slack channels across the monorepo.
- Decisions:
  - Considered hooking up to `products/customer_analytics.Account.properties.csm/.account_executive/.account_owner`. Rejected: that model is customer-facing CRM data — PostHog *customers* tracking *their* accounts — not PostHog's TAM mapping. Using it would be semantically wrong and risk leaking unrelated assignments.
  - Considered the outbound Salesforce enrichment pipeline (`ee/billing/salesforce_enrichment`). Rejected as a data source: it pushes from PostHog → Salesforce; nothing flows back into Django models.
  - Considered Vitally. Rejected: warehouse-only.
  - Chose to ship the API contract + frontend card now with the helpers returning `None`, per the explicit ask to "stop before inventing a fake data source." The shape is committed so a future PR that adds an internal source touches only the two helper bodies.
  - Placed the card at the bottom of the modal next to `TeamMembersCard` so the concierge note sits alongside "your team" context, rather than competing with the orientation cards at the top.
  - Card hides entirely when both fields are null (LemonCard not rendered, no empty container).
- Slack thread context referenced an internal ask from the growth team; nothing customer-specific is encoded in the change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
