### PR TITLE
chore(property-vals): replace tautological aggregator proptest with pinned values

### DIFF
--- a/rust/property-vals-rs/src/aggregator.rs
+++ b/rust/property-vals-rs/src/aggregator.rs
@@ -40,7 +40,6 @@ impl Default for Aggregator {
 mod tests {
     use super::*;
     use crate::types::PropertyType;
-    use proptest::prelude::*;
 
     fn tuple(team: i64, key: &str, value: &str) -> TupleKey {
         TupleKey {
@@ -51,40 +50,17 @@ mod tests {
         }
     }
 
-    fn arb_property_type() -> impl Strategy<Value = PropertyType> {
-        prop_oneof![
-            Just(PropertyType::Event),
-            Just(PropertyType::Person),
-            (0u8..=10).prop_map(PropertyType::Group),
-        ]
-    }
+    #[test]
+    fn add_accumulates_counts_for_same_tuple() {
+        let mut agg = Aggregator::new();
+        agg.add(tuple(2, "$lib", "web"), 3);
+        agg.add(tuple(2, "$lib", "web"), 5);
+        agg.add(tuple(2, "$os", "mac"), 2);
 
-    prop_compose! {
-        fn arb_tuple()(
-            team_id in -5i64..=5,
-            property_type in arb_property_type(),
-            property_key in "[a-c]{1,3}",
-            property_value in "[x-z]{1,3}",
-        ) -> TupleKey {
-            TupleKey { team_id, property_type, property_key, property_value }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn drained_counts_equal_per_tuple_sum(
-            ops in prop::collection::vec((arb_tuple(), 1u64..1_000), 0..200),
-        ) {
-            let mut agg = Aggregator::new();
-            let mut expected: HashMap<TupleKey, u64> = HashMap::new();
-
-            for (t, n) in &ops {
-                agg.add(t.clone(), *n);
-                *expected.entry(t.clone()).or_insert(0) += *n;
-            }
-
-            prop_assert_eq!(agg.drain(), expected);
-        }
+        let drained = agg.drain();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[&tuple(2, "$lib", "web")], 8);
+        assert_eq!(drained[&tuple(2, "$os", "mac")], 2);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

\`drained_counts_equal_per_tuple_sum\` was a proptest that maintained a parallel \`expected: HashMap<TupleKey, u64>\` and incremented it with \`*expected.entry(t).or_insert(0) += *n\` — verbatim the same logic that \`Aggregator::add\` uses internally. The test was asserting that a HashMap with \`+=\` accumulation matched another HashMap with \`+=\` accumulation. A regression in \`Aggregator::add\` would only fail this if the regression did something *different* from the test reimplementation, which itself is the simplest possible accumulator. The test wasn't anchored to any external truth.

## Changes

Replace the proptest with a pinned-input unit test that asserts specific arithmetic: add 3, then 5 to the same tuple, drain, expect 8. A regression like "overwrite instead of accumulate" fails because 5 ≠ 8 — that's a fact the test states explicitly, not one derived from the production code.

\`drain_clears_state\` is unchanged.

## How did you test this code?

\`cargo test -p property-vals-rs --lib aggregator::\` — both tests pass.

## Publish to changelog?

no

## 🤖 Agent context

Came up while auditing the property-vals-rs tests for "is this actually testing our code?" The aggregator proptest was the only clearly tautological one in the crate. Two near-duplicate tests in fan_out.rs ship as a follow-up PR; the rest of the test suite genuinely exercises production code paths.