### PR TITLE
fix(mcp): hide org-only tools for project-scoped tokens

### DIFF
--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -137,6 +137,7 @@ export class RequestStateResolver {
         }
 
         const apiKeyScopes = _apiKey?.scopes ?? []
+        const apiKeyScopedTeams = _apiKey?.scoped_teams ?? []
         const aiConsentGiven = await context.stateManager.getAiConsentGiven()
 
         const excludeTools: string[] = []
@@ -154,6 +155,7 @@ export class RequestStateResolver {
             readOnly,
             featureFlags: toolFeatureFlags,
             scopes: apiKeyScopes,
+            scopedTeams: apiKeyScopedTeams,
             aiConsentGiven: aiConsentGiven ?? undefined,
         })
 

--- a/services/mcp/src/tools/toolDefinitions.ts
+++ b/services/mcp/src/tools/toolDefinitions.ts
@@ -94,6 +94,12 @@ export interface ToolFilterOptions {
      * Used to gate tools that declare `feature_flag` in their YAML config.
      */
     featureFlags?: Record<string, boolean> | undefined
+    /**
+     * Project IDs the token is restricted to (`scoped_teams` on the API key).
+     * When set, the backend 403s any org-level endpoint, so we drop tools that
+     * need `organization:*` scopes — they'd fail anyway.
+     */
+    scopedTeams?: number[] | undefined
 }
 
 /**
@@ -116,7 +122,7 @@ function normalizeFeatureName(name: string): string {
 }
 
 export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
-    const { features, tools, version, readOnly, aiConsentGiven, featureFlags } = options || {}
+    const { features, tools, version, readOnly, aiConsentGiven, featureFlags, scopedTeams } = options || {}
     const toolDefinitions = getToolDefinitions(version)
 
     let entries = Object.entries(toolDefinitions)
@@ -184,6 +190,14 @@ export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
             }
             return (definition.feature_flag_behavior ?? 'enable') === 'disable'
         })
+    }
+
+    // Hide tools that need org-level access when the session's token is
+    // project-scoped - the backend would 403 them
+    if (scopedTeams && scopedTeams.length > 0) {
+        entries = entries.filter(
+            ([_, definition]) => !(definition.required_scopes ?? []).some((scope) => scope.startsWith('organization'))
+        )
     }
 
     return entries.map(([toolName, _]) => toolName)

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -521,6 +521,45 @@ describe('Tool Filtering - AI Consent', () => {
     })
 })
 
+describe('Tool Filtering - Scoped Teams', () => {
+    // Tools whose `required_scopes` include an `organization:*` (or
+    // `organization_member:*`, etc.) scope can't be exercised with a
+    // project-scoped key — the backend 403s them. Hide from `tools/list` for
+    // sessions whose token carries `scoped_teams`, surface them otherwise.
+    it('hides tools requiring an org-scoped scope when scopedTeams is non-empty', () => {
+        const tools = getToolsForFeatures({ scopedTeams: [42] })
+        expect(tools).not.toContain('roles-list') // organization:read
+        expect(tools).not.toContain('org-members-list') // organization_member:read
+        expect(tools).not.toContain('organizations-list') // organization:read
+        expect(tools).not.toContain('organization-get') // organization:read
+        expect(tools).not.toContain('projects-get') // organization:read
+    })
+
+    it('keeps project-scoped tools visible when scopedTeams is non-empty', () => {
+        const tools = getToolsForFeatures({ scopedTeams: [42] })
+        expect(tools).toContain('dashboard-get')
+        expect(tools).toContain('feature-flag-get-all')
+    })
+
+    it('keeps org-scope tools visible when scopedTeams is empty (unscoped token)', () => {
+        const tools = getToolsForFeatures({ scopedTeams: [] })
+        expect(tools).toContain('roles-list')
+        expect(tools).toContain('organization-get')
+    })
+
+    it('keeps org-scope tools visible when scopedTeams is undefined', () => {
+        const tools = getToolsForFeatures({ scopedTeams: undefined })
+        expect(tools).toContain('roles-list')
+        expect(tools).toContain('organization-get')
+    })
+
+    it('combines scopedTeams with feature filtering', () => {
+        const tools = getToolsForFeatures({ features: ['workspace'], scopedTeams: [42] })
+        expect(tools).not.toContain('organizations-list')
+        expect(tools).not.toContain('organization-get')
+    })
+})
+
 describe('Tool Filtering - Read-Only Mode', () => {
     it('should only return read-only tools when readOnly is true', () => {
         const tools = getToolsForFeatures({ readOnly: true })


### PR DESCRIPTION
## Problem

Agents that authenticate to PostHog's MCP server with a project-scoped personal API key or OAuth token still see org-level tools in `tools/list` — tools like `roles-list`, `org-members-list`, `organization-get`, `organizations-list`, `projects-get`, and the `proxy-*` family. They call them, the backend 403s the request because `view.team` isn't resolvable for org-nested viewsets, and the agent gets a confusing *"API keys with scoped projects are only supported on project-based endpoints"* error.

In the last 30 days, ~446 such 403s have hit 200+ distinct customer orgs across real clients (claude-code, cursor-vscode, codex-mcp-client, Replit, CodeRabbit, Anthropic/ClaudeAI, etc.). Per-tool error rates: [MCP — Platform Features tools usage](https://us.posthog.com/project/2/dashboard/1627654).

## Changes

- `ToolFilterOptions` gains a `scopedTeams` field — the token's `scoped_teams` array from the API key.
- `request-state-resolver.ts` reads `scoped_teams` off the API key and passes it into `catalog.getFilteredTools` alongside the existing `scopes`
- `getToolsForFeatures()` drops tools whose `required_scopes` include any scope starting with `organization`. Every org-level scope object uses that prefix (`organization`, `organization_integration`, `organization_member`).

**Known gap — three tools still 403, not covered by this filter**

Three tools still 403 on project-scoped tokens but **won't** be hidden by this filter because their `required_scopes` don't include any `organization*` scope:

| Tool | `required_scopes` | Endpoint |
|---|---|---|
| `feature-flags-copy-flags-create` | `feature_flag:write` | `POST /api/organizations/{org_id}/feature_flags/copy_flags/` |
| `project-get` | `project:read` | `GET /api/organizations/{org_id}/projects/{id}/` |
| `project-settings-update` | `project:write` | `PATCH /api/organizations/{org_id}/projects/{id}/settings/` |

For these, the scope describes the *data* being read/written, but the URL is org-nested because the API exposes no project-nested alternative. The right fix is on the backend — add `GET /api/projects/{id}/` for project metadata, similar for settings, and similarly relax `feature-flags-copy-flags-create`. We'll tackle that separately rather than widening the MCP filter to compensate.


## How did you test this code?

Ran the existing unit suite:

```bash
cd services/mcp && npx vitest run tests/unit
```

All 1,300 unit tests pass, including 5 new ones in `tool-filtering.test.ts` covering: non-empty `scopedTeams` hides org-scoped tools, non-empty `scopedTeams` keeps project-scoped tools visible, empty/`undefined` `scopedTeams` keeps everything visible, and the filter composes with the existing feature/tools allowlist.

## Publish to changelog?

no
