### PR TITLE
fix(kafka): poll producer while ProduceResult.get() waits

### DIFF
--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -10,6 +10,7 @@ points for producing are in `posthog.kafka_client.routing`:
 
 import os
 import json
+import time
 import asyncio
 import threading
 from collections.abc import Callable
@@ -43,6 +44,12 @@ KAFKA_PRODUCER_MESSAGES_COUNTER = Counter(
 )
 
 
+# Interval (s) `ProduceResult.get` uses when driving the underlying producer's event loop.
+# Short enough that delivery latency stays in the millisecond range, long enough that the
+# CPU cost of polling is negligible relative to network IO.
+_GET_POLL_INTERVAL_S = 0.05
+
+
 @dataclass
 class ProduceResult:
     """
@@ -51,6 +58,11 @@ class ProduceResult:
     """
 
     topic: str
+    # When set, `.get()` drives this callable in a loop while waiting so delivery callbacks
+    # fire. confluent-kafka's `Producer.poll()` is documented as safe to call from any thread.
+    # Without this, `.get()` would block indefinitely whenever the caller is the only thread
+    # driving the producer (no background thread, no nearby `flush()`).
+    _poll: Optional[Callable[[float], None]] = field(default=None, repr=False)
     _event: threading.Event = field(default_factory=threading.Event)
     _message: Optional[Message] = field(default=None)
     _error: Optional[KafkaError] = field(default=None)
@@ -66,8 +78,20 @@ class ProduceResult:
         Wait for the produce to complete and return the result.
         Raises KafkaException if the produce failed.
         """
-        if not self._event.wait(timeout=timeout):
-            raise TimeoutError("Timeout waiting for produce result")
+        if self._poll is None:
+            # No producer attached (e.g. test path that pre-sets the result) — just wait on the event.
+            if not self._event.wait(timeout=timeout):
+                raise TimeoutError("Timeout waiting for produce result")
+        else:
+            deadline = time.monotonic() + timeout if timeout is not None else None
+            while not self._event.is_set():
+                if deadline is None:
+                    self._poll(_GET_POLL_INTERVAL_S)
+                else:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError("Timeout waiting for produce result")
+                    self._poll(min(_GET_POLL_INTERVAL_S, remaining))
         if self._error is not None:
             raise KafkaException(self._error)
         return self._message
@@ -304,12 +328,14 @@ class _KafkaProducer:
             else None
         )
 
-        result = ProduceResult(topic=topic)
-
         if self._test:
+            result = ProduceResult(topic=topic)
             self.producer.produce(topic, value=b, key=key, headers=encoded_headers)
             result.set_result(None, None)
         else:
+            # Attach a poll hook so callers blocking on `.get()` keep the producer's
+            # event loop alive — otherwise the delivery callback never fires.
+            result = ProduceResult(topic=topic, _poll=self.producer.poll)
             self.producer.produce(
                 topic,
                 value=b,
@@ -317,7 +343,7 @@ class _KafkaProducer:
                 headers=encoded_headers,
                 on_delivery=lambda err, msg: self._on_delivery(topic, result, err, msg),
             )
-            # Poll to trigger any pending delivery callbacks (non-blocking)
+            # Drain any already-ready callbacks (non-blocking).
             self.producer.poll(0)
 
         return result

--- a/posthog/kafka_client/test/test_client.py
+++ b/posthog/kafka_client/test/test_client.py
@@ -1,11 +1,15 @@
 import os
 import json
+import time
 import uuid
+from typing import Any
 
 import pytest
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from confluent_kafka import Producer as ConfluentProducer
 
 from posthog.kafka_client.client import _KafkaProducer
 from posthog.settings.kafka import KafkaProfileSettings
@@ -214,6 +218,78 @@ class KafkaClientTestCase(TestCase):
         # Producer settings still flow through — this is what the old helper dropped.
         self.assertEqual(config["linger.ms"], 250)
         self.assertEqual(config["batch.size"], 1_000_000)
+
+
+@override_settings(TEST=False)
+class ProduceResultTestCase(SimpleTestCase):
+    """Behavioural tests for `_KafkaProducer.produce()` -> `ProduceResult.get()`.
+
+    Regression for: the wrapper used to call `producer.poll(0)` once and return,
+    so a synchronous caller blocking on `ProduceResult.get(timeout=10)` would
+    time out because nothing was driving the producer's event loop to fire the
+    delivery callback. Fix is `get()` polls the producer while waiting.
+    """
+
+    def _make_producer_with_deferred_delivery(self) -> tuple[_KafkaProducer, MagicMock]:
+        """A `_KafkaProducer` whose underlying confluent producer only fires delivery
+        callbacks when `.poll()` is invoked with a non-zero timeout (mirroring real librdkafka)."""
+
+        pending: list[tuple[Any, Any]] = []  # (on_delivery callback, args to pass it)
+
+        def fake_produce(topic, value=None, key=None, headers=None, on_delivery=None):
+            # Stash the callback; do NOT fire it. Real librdkafka batches the produce
+            # and only invokes callbacks when poll() runs after the broker acks.
+            pending.append((on_delivery, (None, MagicMock(topic=lambda: topic))))
+
+        def fake_poll(timeout):
+            # The first poll(0) (drain) shouldn't fire anything if the broker hasn't acked.
+            # We model a real ack arriving after at least one >0-timeout poll by firing
+            # whatever is pending whenever poll is called with a non-zero timeout.
+            if timeout and pending:
+                cb, args = pending.pop(0)
+                if cb is not None:
+                    cb(*args)
+
+        mock_producer = MagicMock(spec=ConfluentProducer)
+        mock_producer.produce.side_effect = fake_produce
+        mock_producer.poll.side_effect = fake_poll
+
+        with patch("posthog.kafka_client.client.ConfluentProducer", return_value=mock_producer):
+            producer = _KafkaProducer(test=False)
+        return producer, mock_producer
+
+    def test_get_returns_when_caller_is_the_only_thread_driving_the_producer(self):
+        """Regression: a sync caller blocking on `.get()` must keep the producer
+        polling, otherwise the delivery callback never fires."""
+        producer, _ = self._make_producer_with_deferred_delivery()
+        result = producer.produce(topic="t", data={"k": "v"})
+        # No background thread polling the producer; if `.get()` doesn't drive
+        # `poll()` itself, the delivery callback above never fires and this times out.
+        msg = result.get(timeout=2.0)
+        self.assertIsNotNone(msg)
+
+    def test_get_raises_timeout_error_when_delivery_never_fires(self):
+        """If the broker never acks, `.get(timeout=...)` should raise TimeoutError
+        after roughly the requested timeout (not hang forever)."""
+        pending_dropped: list[None] = []
+
+        def fake_produce(topic, value=None, key=None, headers=None, on_delivery=None):
+            pending_dropped.append(None)  # callback intentionally never invoked
+
+        mock_producer = MagicMock(spec=ConfluentProducer)
+        mock_producer.produce.side_effect = fake_produce
+        mock_producer.poll.return_value = None  # poll is a no-op
+        with patch("posthog.kafka_client.client.ConfluentProducer", return_value=mock_producer):
+            producer = _KafkaProducer(test=False)
+
+        start = time.monotonic()
+        result = producer.produce(topic="t", data={"k": "v"})
+        with self.assertRaises(TimeoutError):
+            result.get(timeout=0.3)
+        elapsed = time.monotonic() - start
+        # Loosely bounded — we just want to confirm the timeout fires near the requested deadline
+        # rather than hanging the test runner.
+        self.assertLess(elapsed, 2.0)
 
 
 # Real-broker round-trip tests. Disabled by default because they require a reachable


### PR DESCRIPTION
## Problem

`_KafkaProducer.produce()` returns a `ProduceResult` whose `.get(timeout=...)` is documented as a Future-like "wait for the produce to complete". In practice it blocks forever (until timeout) whenever the caller is the only thread driving the producer — confluent-kafka requires `Producer.poll()` to be called periodically for delivery callbacks to fire, and the wrapper only called `poll(0)` once right after `produce()`. That drains anything already ready and returns; real broker acks land milliseconds later but never trigger the callback because nobody polls again.

Production paths get away with it today because they either (a) call `flush()` afterwards in batch contexts (which polls until empty), (b) use the async `AIOProducer` (its own event loop), or (c) never `.get()`. The bug surfaces the moment a sync caller awaits `.get()`.

Hit in prod by the Replay Vision side-effect activities from #59388 — `embed_indexer_observation_activity` and `emit_classifier_tags_activity` both consistently time out at `ProduceResult.get(timeout=10)` even though the broker acks within milliseconds (confirmed by attaching `confluent_kafka.Producer` directly with `poll(1.0)` — delivery fires within 1s, same broker, same payload).

## Changes

- `ProduceResult` gains an optional `_poll` field — a callable bound to the underlying producer's `.poll`. When set, `.get()` drives it in a loop while waiting on the delivery event so callbacks actually fire.
- `_KafkaProducer.produce()` wires `self.producer.poll` into the result on the real-producer path.
- Test path (`KafkaProducerForTests`) leaves `_poll=None` and continues pre-setting the result, so the loop is skipped entirely.
- Two regression tests: one proves a sync caller's `.get()` resolves when nobody else polls; one proves `.get(timeout=...)` raises `TimeoutError` near the requested deadline rather than hanging.

`Producer.poll()` is thread-safe in librdkafka, so concurrent `.get()` calls from multiple threads are fine. Polling interval is 50 ms — short enough that delivery latency stays in the millisecond range, long enough that the CPU cost is negligible.

## How did you test this code?

I'm an agent. Automated:

- `hogli test posthog/kafka_client/test/test_client.py::ProduceResultTestCase` — both new tests pass; they fail without the fix.
- `ruff check` + `ruff format` — clean.
- Reproduced the original hang against the deployed worker pod with the unmodified wrapper, then re-verified with a hand-driven poll loop that the broker ack arrives within ~0.4 s.

Did not exercise the fix against a real broker in CI yet — `KafkaClientRoundtripTestCase` is gated behind `KAFKA_ROUNDTRIP_TESTS=1`. The fix path will get covered organically once the side-effect activities (which were the trigger) run against a deployed branch.

## Publish to changelog?

no

## 🤖 Agent context

Tool: Claude Code. Diagnosis flow: workflow failed at `emit_classifier_tags_activity` / `embed_indexer_observation_activity` with `TimeoutError: Timeout waiting for produce result`. Worked through TCP reachability → librdkafka debug logs → manual `confluent_kafka.Producer` probe (delivery in 0.4 s) → wrapper bug. Considered three fixes — background poll thread, `flush()` after every produce, polling inside `.get()` — went with the third because it adds no thread lifecycle, only does work when somebody actually waits, and leaves all other call sites unaffected.