### PR TITLE
fix(cohorts): Treat null properties as unset

### DIFF
--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -1774,7 +1774,8 @@ def test_prop_filter_json_extract_materialized(
 
     query, params = prop_filter_json_extract(property, 0, allow_denormalized_props=True)
 
-    assert "JSONExtract" not in query
+    if property.operator not in ("is_set", "is_not_set"):
+        assert "JSONExtract" not in query
 
     uuids = sorted(
         [
@@ -1818,6 +1819,55 @@ def test_prop_filter_json_extract_nullable_materialized_is_set_uses_json(
         expected = sorted([test_events[index] for index in expected_event_indexes])
 
         assert uuids == expected
+
+
+@pytest.mark.parametrize(
+    "property,expected_query",
+    [
+        (
+            Property(key="email", operator="is_set", value="is_set"),
+            "(JSONHas(properties, %(k_0)s) AND JSONExtractRaw(properties, %(k_0)s) != 'null')",
+        ),
+        (
+            Property(key="email", operator="is_not_set", value="is_not_set"),
+            "(isNull(replaceRegexpAll(JSONExtractRaw(properties, %(k_0)s), '^\"|\"$', '')) OR JSONExtractRaw(properties, %(k_0)s) = 'null' OR NOT JSONHas(properties, %(k_0)s))",
+        ),
+    ],
+)
+def test_prop_filter_json_extract_set_operators_handle_json_null_values(property, expected_query):
+    query, params = prop_filter_json_extract(property, 0, allow_denormalized_props=False)
+
+    assert expected_query in query
+    assert params == {"k_0": "email", "v_0": property.value}
+
+
+@pytest.mark.parametrize(
+    "property,expected_query,unexpected_query",
+    [
+        (
+            Property(key="email", operator="is_set", value="is_set"),
+            "JSONExtractRaw(properties, %(k_0)s) != 'null'",
+            "materialized_email != 'null'",
+        ),
+        (
+            Property(key="email", operator="is_not_set", value="is_not_set"),
+            "JSONExtractRaw(properties, %(k_0)s) = 'null'",
+            "materialized_email = 'null'",
+        ),
+    ],
+)
+def test_prop_filter_json_extract_set_operators_use_raw_json_when_materialized(
+    monkeypatch, property, expected_query, unexpected_query
+):
+    monkeypatch.setattr(
+        "posthog.models.property.util.get_property_string_expr",
+        lambda *args, **kwargs: ("materialized_email", True),
+    )
+
+    query, _ = prop_filter_json_extract(property, 0, allow_denormalized_props=True)
+
+    assert expected_query in query
+    assert unexpected_query not in query
 
 
 @pytest.mark.parametrize("property,expected_event_indexes", TEST_PROPERTIES)

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -443,7 +443,14 @@ def property_to_Q_test_factory(filter_persons: Callable, person_factory):
                     properties={"is_first_user": True},
                 ).uuid
             )
-            p2_uuid = str(person_factory(team_id=self.team.pk, distinct_ids=["p2"]).uuid)
+            p2_uuid = str(
+                person_factory(
+                    team_id=self.team.pk,
+                    distinct_ids=["p2"],
+                    properties={"is_first_user": None},
+                ).uuid
+            )
+            p3_uuid = str(person_factory(team_id=self.team.pk, distinct_ids=["p3"]).uuid)
 
             filter = Filter(
                 data={
@@ -473,7 +480,7 @@ def property_to_Q_test_factory(filter_persons: Callable, person_factory):
                 }
             )
             results = filter_persons(filter, self.team)
-            self.assertEqual(results, [p2_uuid])
+            self.assertCountEqual(results, [p2_uuid, p3_uuid])
 
         def test_is_not_true_false_persons(self):
             person_factory(

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -493,13 +493,8 @@ def prop_filter_json_extract(
             "k{}_{}".format(prepend, idx): prop.key,
             "v{}_{}".format(prepend, idx): prop.value,
         }
-        if is_denormalized:
-            return (
-                " {property_operator} {left} != ''".format(left=property_expr, property_operator=property_operator),
-                params,
-            )
         return (
-            " {property_operator} JSONHas({prop_var}, %(k{prepend}_{idx})s)".format(
+            " {property_operator} (JSONHas({prop_var}, %(k{prepend}_{idx})s) AND JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s) != 'null')".format(
                 idx=idx,
                 prepend=prepend,
                 prop_var=prop_var,
@@ -512,13 +507,8 @@ def prop_filter_json_extract(
             "k{}_{}".format(prepend, idx): prop.key,
             "v{}_{}".format(prepend, idx): prop.value,
         }
-        if is_denormalized:
-            return (
-                " {property_operator} {left} = ''".format(left=property_expr, property_operator=property_operator),
-                params,
-            )
         return (
-            " {property_operator} (isNull({left}) OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s))".format(
+            " {property_operator} (isNull({left}) OR JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s) = 'null' OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s))".format(
                 idx=idx,
                 prepend=prepend,
                 prop_var=prop_var,

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -81,7 +81,7 @@ def handle_compare(filter, func: Callable, team: Team, **kwargs) -> list:
 
 def match_property(property: Property, override_property_values: dict[str, Any]) -> bool:
     # only looks for matches where key exists in override_property_values
-    # doesn't support operator is_not_set
+    # supports is_not_set when the key is present with a None value
 
     if property.key not in override_property_values:
         raise ValidationError("can't match properties without an override value")
@@ -110,12 +110,10 @@ def match_property(property: Property, override_property_values: dict[str, Any])
             return not compute_exact_match(value, override_value)
 
     if operator == "is_set":
-        return key in override_property_values
+        return override_value is not None
 
     if operator == "is_not_set":
-        if key in override_property_values:
-            return False
-        raise ValidationError("can't match properties with operator is_not_set")
+        return override_value is None
 
     if operator == "icontains":
         return str(value).lower() in str(override_value).lower()
@@ -413,10 +411,10 @@ def property_to_Q(
 
     if property.operator == "is_set":
         # nosemgrep: orm-field-injection -- key prefixed by JSONField column; __ is JSON key traversal, not FK
-        return Q(**{f"{column}__{property.key}__isnull": False})
+        return Q(**{f"{column}__{property.key}__isnull": False}) & ~Q(**{f"{column}__{property.key}": None})
     if property.operator == "is_not_set":
         # nosemgrep: orm-field-injection -- key prefixed by JSONField column; __ is JSON key traversal, not FK
-        return Q(**{f"{column}__{property.key}__isnull": True})
+        return Q(**{f"{column}__{property.key}__isnull": True}) | Q(**{f"{column}__{property.key}": None})
     if property.operator in ("regex", "not_regex") and not is_valid_regex(str(value)):
         # Return no data for invalid regexes
         return Q(pk=-1)

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from dateutil import parser, tz
 from rest_framework.exceptions import ValidationError
@@ -41,7 +41,7 @@ class TestBase(APIBaseTest):
         )
 
 
-class TestMatchProperties(TestCase):
+class TestMatchProperties(SimpleTestCase):
     def test_match_properties_exact(self):
         property_a = Property(key="key", value="value")
 
@@ -96,7 +96,12 @@ class TestMatchProperties(TestCase):
         self.assertTrue(match_property(property_a, {"key": "value"}))
         self.assertTrue(match_property(property_a, {"key": "value2"}))
         self.assertTrue(match_property(property_a, {"key": ""}))
-        self.assertTrue(match_property(property_a, {"key": None}))
+        self.assertFalse(match_property(property_a, {"key": None}))
+
+        property_b = Property(key="key", operator="is_not_set")
+        self.assertTrue(match_property(property_b, {"key": None}))
+        self.assertFalse(match_property(property_b, {"key": ""}))
+        self.assertFalse(match_property(property_b, {"key": "value"}))
 
         with self.assertRaises(ValidationError):
             match_property(property_a, {"key2": "value"})

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -72,16 +72,20 @@ pub fn match_property(
 
     // first match operators that don't require a value
     match operator {
-        OperatorType::IsSet => return Ok(matching_property_values.contains_key(key)),
+        OperatorType::IsSet => {
+            return Ok(matches!(match_value, Some(value) if !value.is_null()));
+        }
         OperatorType::IsNotSet => {
             return if partial_props {
-                if matching_property_values.contains_key(key) {
-                    Ok(false)
-                } else {
-                    Err(FlagMatchingError::InconclusiveOperatorMatch)
+                match match_value {
+                    Some(value) => Ok(value.is_null()),
+                    None => Err(FlagMatchingError::InconclusiveOperatorMatch),
                 }
             } else {
-                Ok(!matching_property_values.contains_key(key))
+                Ok(match match_value {
+                    Some(value) => value.is_null(),
+                    None => true,
+                })
             }
         }
         _ => {}
@@ -740,7 +744,7 @@ mod test_match_properties {
         )
         .expect("expected match to exist"));
 
-        assert!(match_property(
+        assert!(!match_property(
             &property_a,
             &HashMap::from([("key".to_string(), json!(null))]),
             true
@@ -862,7 +866,7 @@ mod test_match_properties {
         )
         .expect("expected match to exist"));
 
-        assert!(match_property(
+        assert!(!match_property(
             &property_a,
             &HashMap::from([("key".to_string(), json!(null))]),
             true
@@ -1412,7 +1416,7 @@ mod test_match_properties {
             compiled_regex: None,
         };
 
-        assert!(match_property(
+        assert!(!match_property(
             &property_b,
             &HashMap::from([("key".to_string(), json!(null))]),
             true
@@ -1565,6 +1569,12 @@ mod test_match_properties {
             false
         )
         .expect("Expected no errors with full props mode"));
+        assert!(match_property(
+            &property_is_not_set,
+            &HashMap::from([("key".to_string(), json!(null))]),
+            false
+        )
+        .expect("Expected no errors with full props mode"));
         assert!(!match_property(
             &property_is_not_set,
             &HashMap::from([("key".to_string(), json!("value"))]),
@@ -1576,6 +1586,12 @@ mod test_match_properties {
         assert!(!match_property(
             &property_is_not_set,
             &HashMap::from([("key".to_string(), json!("value"))]),
+            true
+        )
+        .expect("Expected no errors with full props mode"));
+        assert!(match_property(
+            &property_is_not_set,
+            &HashMap::from([("key".to_string(), json!(null))]),
             true
         )
         .expect("Expected no errors with full props mode"));


### PR DESCRIPTION
Treat explicit JSON/null property values as unset for cohort and person-property matching.

Previously, `set` filters could match properties whose key existed but whose value was JSON null. This makes `set` require a non-null value and makes `not set` include missing or null values across ClickHouse SQL, Django query construction, override matching, and the Rust cohort/feature-flag matcher.

ClickHouse materialized-property filters now check the raw JSON value for null semantics, keeping the literal string `"null"` distinct from JSON null.

Verified with focused Python property-filter tests and targeted Rust matcher tests.

Fixes #29916