### PR TITLE
chore(insights): remove calendar heatmap beta banner

### DIFF
--- a/frontend/src/scenes/insights/views/CalendarHeatMap/TrendsCalendarHeatMap.tsx
+++ b/frontend/src/scenes/insights/views/CalendarHeatMap/TrendsCalendarHeatMap.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { timeZoneLabel } from 'lib/utils'
@@ -30,15 +30,6 @@ export function TrendsCalendarHeatMap(_props: ChartParams): JSX.Element {
 
     return (
         <>
-            <LemonBanner
-                type="info"
-                dismissKey="calendar-heatmap-beta-banner"
-                className="mb-2"
-                action={{ children: 'Send feedback', id: 'calendar-heatmap-feedback-button' }}
-            >
-                Calendar heatmap display is in beta. Please let us know what you'd like to see here and/or report any
-                issues directly to us!
-            </LemonBanner>
             <CalendarHeatMap
                 isLoading={false}
                 thresholdFontSize={thresholdFontSize}


### PR DESCRIPTION
## Problem

The calendar heatmap is no longer in beta, so the in-product banner asking for feedback is stale and clutters the insight view.

## Changes

Removed the `LemonBanner` (and its unused `LemonBanner` import) from `TrendsCalendarHeatMap`.

## How did you test this code?

I'm an agent — no manual testing was performed. No automated tests were added since this is a banner removal.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by PostHog Code. User asked to remove the beta banner from the calendar heatmap. Located the string in `frontend/src/scenes/insights/views/CalendarHeatMap/TrendsCalendarHeatMap.tsx`, removed the `LemonBanner` block and pruned the now-unused import.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*