### PR TITLE
feat(personhog): route methods to different grpc channels

### DIFF
--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -105,6 +105,11 @@ pub fn is_light_method(method: &str) -> bool {
     LIGHT_METHODS.binary_search(&method).is_ok()
 }
 
+/// RPCs that bypass the replica channel pools entirely (routed to leader via
+/// typed proxy in proxy.rs). Excluded from the retry_call! coverage check.
+#[cfg(test)]
+const LEADER_ONLY_METHODS: &[&str] = &["UpdatePersonProperties"];
+
 fn build_endpoint(config: &ReplicaBackendConfig) -> Endpoint {
     let mut endpoint = Channel::from_shared(config.url.clone())
         .unwrap_or_else(|e| panic!("invalid replica URL '{}': {e}", config.url))
@@ -183,26 +188,24 @@ impl ReplicaBackend {
     }
 
     fn next_heavy_client(&self) -> PersonHogReplicaClient<Channel> {
-        let idx =
-            self.heavy_next_idx.fetch_add(1, Ordering::Relaxed) % self.heavy_clients.len();
+        let idx = self.heavy_next_idx.fetch_add(1, Ordering::Relaxed) % self.heavy_clients.len();
         self.heavy_clients[idx].clone()
     }
 
     fn next_light_client(&self) -> PersonHogReplicaClient<Channel> {
-        let idx =
-            self.light_next_idx.fetch_add(1, Ordering::Relaxed) % self.light_clients.len();
+        let idx = self.light_next_idx.fetch_add(1, Ordering::Relaxed) % self.light_clients.len();
         self.light_clients[idx].clone()
     }
 
     /// Get the next raw channel for byte-level proxying, routed by method weight.
     pub fn next_raw_channel_for(&self, method: &str) -> Channel {
         if is_light_method(method) {
-            let idx = self.light_next_idx.fetch_add(1, Ordering::Relaxed)
-                % self.light_raw_channels.len();
+            let idx =
+                self.light_next_idx.fetch_add(1, Ordering::Relaxed) % self.light_raw_channels.len();
             self.light_raw_channels[idx].clone()
         } else {
-            let idx = self.heavy_next_idx.fetch_add(1, Ordering::Relaxed)
-                % self.heavy_raw_channels.len();
+            let idx =
+                self.heavy_next_idx.fetch_add(1, Ordering::Relaxed) % self.heavy_raw_channels.len();
             self.heavy_raw_channels[idx].clone()
         }
     }
@@ -274,14 +277,24 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: GetPersonsByDistinctIdsInTeamRequest,
     ) -> Result<PersonsByDistinctIdsInTeamResponse, Status> {
-        retry_call!(self, next_heavy_client, get_persons_by_distinct_ids_in_team, request)
+        retry_call!(
+            self,
+            next_heavy_client,
+            get_persons_by_distinct_ids_in_team,
+            request
+        )
     }
 
     async fn get_persons_by_distinct_ids(
         &self,
         request: GetPersonsByDistinctIdsRequest,
     ) -> Result<PersonsByDistinctIdsResponse, Status> {
-        retry_call!(self, next_heavy_client, get_persons_by_distinct_ids, request)
+        retry_call!(
+            self,
+            next_heavy_client,
+            get_persons_by_distinct_ids,
+            request
+        )
     }
 
     // ── Light: Distinct ID for single person (bounded string list) ───
@@ -290,7 +303,12 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: GetDistinctIdsForPersonRequest,
     ) -> Result<GetDistinctIdsForPersonResponse, Status> {
-        retry_call!(self, next_light_client, get_distinct_ids_for_person, request)
+        retry_call!(
+            self,
+            next_light_client,
+            get_distinct_ids_for_person,
+            request
+        )
     }
 
     // ── Heavy: Distinct IDs for multiple persons (p99: 540 rows EU) ──
@@ -299,7 +317,12 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: GetDistinctIdsForPersonsRequest,
     ) -> Result<GetDistinctIdsForPersonsResponse, Status> {
-        retry_call!(self, next_heavy_client, get_distinct_ids_for_persons, request)
+        retry_call!(
+            self,
+            next_heavy_client,
+            get_distinct_ids_for_persons,
+            request
+        )
     }
 
     // ── Light: Feature flag hash key overrides (small structs/scalars) ─
@@ -308,7 +331,12 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: GetHashKeyOverrideContextRequest,
     ) -> Result<GetHashKeyOverrideContextResponse, Status> {
-        retry_call!(self, next_light_client, get_hash_key_override_context, request)
+        retry_call!(
+            self,
+            next_light_client,
+            get_hash_key_override_context,
+            request
+        )
     }
 
     async fn upsert_hash_key_overrides(
@@ -322,7 +350,12 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: DeleteHashKeyOverridesByTeamsRequest,
     ) -> Result<DeleteHashKeyOverridesByTeamsResponse, Status> {
-        retry_call!(self, next_light_client, delete_hash_key_overrides_by_teams, request)
+        retry_call!(
+            self,
+            next_light_client,
+            delete_hash_key_overrides_by_teams,
+            request
+        )
     }
 
     // ── Light: Person deletes (scalar responses) ─────────────────────
@@ -338,7 +371,12 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: DeletePersonsBatchForTeamRequest,
     ) -> Result<DeletePersonsBatchForTeamResponse, Status> {
-        retry_call!(self, next_light_client, delete_persons_batch_for_team, request)
+        retry_call!(
+            self,
+            next_light_client,
+            delete_persons_batch_for_team,
+            request
+        )
     }
 
     // ── Light: Cohort membership (small/scalar responses) ────────────
@@ -414,35 +452,60 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: GetGroupTypeMappingsByTeamIdRequest,
     ) -> Result<GroupTypeMappingsResponse, Status> {
-        retry_call!(self, next_light_client, get_group_type_mappings_by_team_id, request)
+        retry_call!(
+            self,
+            next_light_client,
+            get_group_type_mappings_by_team_id,
+            request
+        )
     }
 
     async fn get_group_type_mappings_by_team_ids(
         &self,
         request: GetGroupTypeMappingsByTeamIdsRequest,
     ) -> Result<GroupTypeMappingsBatchResponse, Status> {
-        retry_call!(self, next_light_client, get_group_type_mappings_by_team_ids, request)
+        retry_call!(
+            self,
+            next_light_client,
+            get_group_type_mappings_by_team_ids,
+            request
+        )
     }
 
     async fn get_group_type_mappings_by_project_id(
         &self,
         request: GetGroupTypeMappingsByProjectIdRequest,
     ) -> Result<GroupTypeMappingsResponse, Status> {
-        retry_call!(self, next_light_client, get_group_type_mappings_by_project_id, request)
+        retry_call!(
+            self,
+            next_light_client,
+            get_group_type_mappings_by_project_id,
+            request
+        )
     }
 
     async fn get_group_type_mappings_by_project_ids(
         &self,
         request: GetGroupTypeMappingsByProjectIdsRequest,
     ) -> Result<GroupTypeMappingsBatchResponse, Status> {
-        retry_call!(self, next_light_client, get_group_type_mappings_by_project_ids, request)
+        retry_call!(
+            self,
+            next_light_client,
+            get_group_type_mappings_by_project_ids,
+            request
+        )
     }
 
     async fn get_group_type_mapping_by_dashboard_id(
         &self,
         request: GetGroupTypeMappingByDashboardIdRequest,
     ) -> Result<GetGroupTypeMappingByDashboardIdResponse, Status> {
-        retry_call!(self, next_light_client, get_group_type_mapping_by_dashboard_id, request)
+        retry_call!(
+            self,
+            next_light_client,
+            get_group_type_mapping_by_dashboard_id,
+            request
+        )
     }
 
     // ── Heavy: Group writes (return Group objects with properties) ────
@@ -467,7 +530,12 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: DeleteGroupsBatchForTeamRequest,
     ) -> Result<DeleteGroupsBatchForTeamResponse, Status> {
-        retry_call!(self, next_light_client, delete_groups_batch_for_team, request)
+        retry_call!(
+            self,
+            next_light_client,
+            delete_groups_batch_for_team,
+            request
+        )
     }
 
     // ── Light: Group type mapping writes (small struct/scalar) ───────
@@ -490,7 +558,12 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: DeleteGroupTypeMappingsBatchForTeamRequest,
     ) -> Result<DeleteGroupTypeMappingsBatchForTeamResponse, Status> {
-        retry_call!(self, next_light_client, delete_group_type_mappings_batch_for_team, request)
+        retry_call!(
+            self,
+            next_light_client,
+            delete_group_type_mappings_batch_for_team,
+            request
+        )
     }
 }
 
@@ -650,24 +723,56 @@ mod tests {
         let mut typed_light: Vec<String> = Vec::new();
         let mut typed_heavy: Vec<String> = Vec::new();
 
+        // Collect retry_call! invocations spanning multiple lines by accumulating
+        // text between `retry_call!(` and the closing `)`.
+        let mut in_macro = false;
+        let mut macro_buf = String::new();
+
         for line in source.lines() {
             let trimmed = line.trim();
-            if let Some(rest) = trimmed.strip_prefix("retry_call!(self, ") {
-                let parts: Vec<&str> = rest.splitn(3, ", ").collect();
-                if parts.len() >= 2 {
-                    let client_fn = parts[0];
-                    let method = snake_to_pascal(parts[1].trim_end_matches(|c| c == ',' || c == ')'));
-                    match client_fn {
-                        "next_light_client" => typed_light.push(method),
-                        "next_heavy_client" => typed_heavy.push(method),
-                        other => panic!("unexpected client function in retry_call!: {other}"),
+            if !in_macro {
+                if let Some(rest) = trimmed.strip_prefix("retry_call!(") {
+                    if rest.ends_with(')') {
+                        macro_buf = rest.trim_end_matches(')').to_string();
+                    } else {
+                        macro_buf = rest.to_string();
+                        in_macro = true;
+                        continue;
                     }
+                } else {
+                    continue;
+                }
+            } else {
+                if trimmed == ")" {
+                    in_macro = false;
+                } else {
+                    macro_buf.push(' ');
+                    macro_buf.push_str(trimmed);
+                    continue;
                 }
             }
+
+            let args: Vec<&str> = macro_buf.split(',').collect();
+            if args.len() >= 3 {
+                let client_fn = args[1].trim();
+                let method_snake = args[2].trim();
+                let method = snake_to_pascal(method_snake);
+                match client_fn {
+                    "next_light_client" => typed_light.push(method),
+                    "next_heavy_client" => typed_heavy.push(method),
+                    _ => {}
+                }
+            }
+            macro_buf.clear();
         }
 
         typed_light.sort();
         typed_heavy.sort();
+
+        assert!(
+            !typed_light.is_empty() && !typed_heavy.is_empty(),
+            "parser found no retry_call! invocations — source formatting may have changed"
+        );
 
         for method in &typed_light {
             assert!(
@@ -691,8 +796,7 @@ mod tests {
         all_typed.sort();
 
         let mut all_known: Vec<&str> = KNOWN_METHODS.to_vec();
-        // UpdatePersonProperties goes through the leader path, not retry_call!
-        all_known.retain(|m| *m != "UpdatePersonProperties");
+        all_known.retain(|m| !LEADER_ONLY_METHODS.contains(m));
         all_known.sort();
 
         assert_eq!(

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -39,15 +39,23 @@ use super::PersonHogBackend;
 use crate::config::RetryConfig;
 
 /// Backend implementation that forwards requests to a personhog-replica service
-/// using multiple gRPC channels with round-robin selection.
+/// using separate heavy/light gRPC channel pools with round-robin selection.
+///
+/// Heavy channels carry RPCs that return Person/Group objects with large JSON
+/// property blobs. Light channels carry everything else (group type mappings,
+/// cohort checks, scalar responses). This isolation prevents TCP head-of-line
+/// blocking from large responses stalling small ones on shared HTTP/2 connections.
 ///
 /// Connection lifecycle is managed server-side via `max_connection_age` on the
 /// replica's gRPC server, which sends GOAWAY to trigger transparent client
 /// reconnects — no client-side recycling needed.
 pub struct ReplicaBackend {
-    clients: Vec<PersonHogReplicaClient<Channel>>,
-    raw_channels: Vec<Channel>,
-    next_idx: AtomicUsize,
+    heavy_clients: Vec<PersonHogReplicaClient<Channel>>,
+    heavy_raw_channels: Vec<Channel>,
+    heavy_next_idx: AtomicUsize,
+    light_clients: Vec<PersonHogReplicaClient<Channel>>,
+    light_raw_channels: Vec<Channel>,
+    light_next_idx: AtomicUsize,
     retry_config: RetryConfig,
 }
 
@@ -62,6 +70,39 @@ pub struct ReplicaBackendConfig {
     pub max_send_message_size: usize,
     pub max_recv_message_size: usize,
     pub num_channels: usize,
+    pub num_light_channels: usize,
+}
+
+/// RPCs whose responses contain only small/scalar data (no Person/Group objects
+/// with JSON property blobs). These are routed to dedicated light channels to
+/// isolate them from TCP head-of-line blocking caused by large responses.
+///
+/// Must be sorted — used with binary_search.
+const LIGHT_METHODS: &[&str] = &[
+    "CheckCohortMembership",
+    "CountCohortMembers",
+    "DeleteCohortMember",
+    "DeleteCohortMembersBulk",
+    "DeleteGroupTypeMapping",
+    "DeleteGroupTypeMappingsBatchForTeam",
+    "DeleteGroupsBatchForTeam",
+    "DeleteHashKeyOverridesByTeams",
+    "DeletePersons",
+    "DeletePersonsBatchForTeam",
+    "GetDistinctIdsForPerson",
+    "GetGroupTypeMappingByDashboardId",
+    "GetGroupTypeMappingsByProjectId",
+    "GetGroupTypeMappingsByProjectIds",
+    "GetGroupTypeMappingsByTeamId",
+    "GetGroupTypeMappingsByTeamIds",
+    "GetHashKeyOverrideContext",
+    "InsertCohortMembers",
+    "UpdateGroupTypeMapping",
+    "UpsertHashKeyOverrides",
+];
+
+pub fn is_light_method(method: &str) -> bool {
+    LIGHT_METHODS.binary_search(&method).is_ok()
 }
 
 fn build_endpoint(config: &ReplicaBackendConfig) -> Endpoint {
@@ -105,37 +146,65 @@ fn wrap_clients(
 impl ReplicaBackend {
     pub fn new(config: ReplicaBackendConfig) -> Self {
         let retry_config = config.retry_config;
-        let num_channels = config.num_channels.max(1);
-        let config = ReplicaBackendConfig {
-            num_channels,
+        let num_heavy = config.num_channels.max(1);
+        let num_light = config.num_light_channels.max(1);
+
+        let heavy_config = ReplicaBackendConfig {
+            num_channels: num_heavy,
+            ..config.clone()
+        };
+        let light_config = ReplicaBackendConfig {
+            num_channels: num_light,
             ..config
         };
 
-        let raw_channels = create_channels(&config);
-        let clients = wrap_clients(&raw_channels, &config);
+        let heavy_raw_channels = create_channels(&heavy_config);
+        let heavy_clients = wrap_clients(&heavy_raw_channels, &heavy_config);
+
+        let light_raw_channels = create_channels(&light_config);
+        let light_clients = wrap_clients(&light_raw_channels, &light_config);
+
         info!(
-            num_channels,
-            url = config.url,
+            num_heavy,
+            num_light,
+            url = heavy_config.url,
             "created replica backend channels"
         );
 
         Self {
-            clients,
-            raw_channels,
-            next_idx: AtomicUsize::new(0),
+            heavy_clients,
+            heavy_raw_channels,
+            heavy_next_idx: AtomicUsize::new(0),
+            light_clients,
+            light_raw_channels,
+            light_next_idx: AtomicUsize::new(0),
             retry_config,
         }
     }
 
-    fn next_client(&self) -> PersonHogReplicaClient<Channel> {
-        let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % self.clients.len();
-        self.clients[idx].clone()
+    fn next_heavy_client(&self) -> PersonHogReplicaClient<Channel> {
+        let idx =
+            self.heavy_next_idx.fetch_add(1, Ordering::Relaxed) % self.heavy_clients.len();
+        self.heavy_clients[idx].clone()
     }
 
-    /// Get the next raw channel for byte-level proxying.
-    pub fn next_raw_channel(&self) -> Channel {
-        let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % self.raw_channels.len();
-        self.raw_channels[idx].clone()
+    fn next_light_client(&self) -> PersonHogReplicaClient<Channel> {
+        let idx =
+            self.light_next_idx.fetch_add(1, Ordering::Relaxed) % self.light_clients.len();
+        self.light_clients[idx].clone()
+    }
+
+    /// Get the next raw channel for byte-level proxying, routed by method weight.
+    pub fn next_raw_channel_for(&self, method: &str) -> Channel {
+        if is_light_method(method) {
+            let idx = self.light_next_idx.fetch_add(1, Ordering::Relaxed)
+                % self.light_raw_channels.len();
+            self.light_raw_channels[idx].clone()
+        } else {
+            let idx = self.heavy_next_idx.fetch_add(1, Ordering::Relaxed)
+                % self.heavy_raw_channels.len();
+            self.heavy_raw_channels[idx].clone()
+        }
     }
 
     pub fn retry_config(&self) -> &RetryConfig {
@@ -146,10 +215,14 @@ impl ReplicaBackend {
 /// Wraps a gRPC call with retry logic. Clones the request for each attempt.
 /// Forwards the `x-client-name` header so the downstream service can
 /// attribute metrics to the originating client.
+///
+/// The `$client_fn` parameter selects the channel pool: `next_heavy_client`
+/// for RPCs returning large Person/Group payloads, `next_light_client` for
+/// small/scalar responses.
 macro_rules! retry_call {
-    ($self:expr, $method:ident, $request:expr) => {{
+    ($self:expr, $client_fn:ident, $method:ident, $request:expr) => {{
         with_retry(&$self.retry_config, stringify!($method), || {
-            let mut client = $self.next_client();
+            let mut client = $self.$client_fn();
             let req = $request.clone();
             let client_name = current_client_name();
             async move {
@@ -166,262 +239,267 @@ macro_rules! retry_call {
 
 #[async_trait]
 impl PersonHogBackend for ReplicaBackend {
-    // Person lookups by ID
+    // ── Heavy: Person lookups (return Person objects with properties) ───
 
     async fn get_person(&self, request: GetPersonRequest) -> Result<GetPersonResponse, Status> {
-        retry_call!(self, get_person, request)
+        retry_call!(self, next_heavy_client, get_person, request)
     }
 
     async fn get_persons(&self, request: GetPersonsRequest) -> Result<PersonsResponse, Status> {
-        retry_call!(self, get_persons, request)
+        retry_call!(self, next_heavy_client, get_persons, request)
     }
 
     async fn get_person_by_uuid(
         &self,
         request: GetPersonByUuidRequest,
     ) -> Result<GetPersonResponse, Status> {
-        retry_call!(self, get_person_by_uuid, request)
+        retry_call!(self, next_heavy_client, get_person_by_uuid, request)
     }
 
     async fn get_persons_by_uuids(
         &self,
         request: GetPersonsByUuidsRequest,
     ) -> Result<PersonsResponse, Status> {
-        retry_call!(self, get_persons_by_uuids, request)
+        retry_call!(self, next_heavy_client, get_persons_by_uuids, request)
     }
-
-    // Person lookups by distinct ID
 
     async fn get_person_by_distinct_id(
         &self,
         request: GetPersonByDistinctIdRequest,
     ) -> Result<GetPersonResponse, Status> {
-        retry_call!(self, get_person_by_distinct_id, request)
+        retry_call!(self, next_heavy_client, get_person_by_distinct_id, request)
     }
 
     async fn get_persons_by_distinct_ids_in_team(
         &self,
         request: GetPersonsByDistinctIdsInTeamRequest,
     ) -> Result<PersonsByDistinctIdsInTeamResponse, Status> {
-        retry_call!(self, get_persons_by_distinct_ids_in_team, request)
+        retry_call!(self, next_heavy_client, get_persons_by_distinct_ids_in_team, request)
     }
 
     async fn get_persons_by_distinct_ids(
         &self,
         request: GetPersonsByDistinctIdsRequest,
     ) -> Result<PersonsByDistinctIdsResponse, Status> {
-        retry_call!(self, get_persons_by_distinct_ids, request)
+        retry_call!(self, next_heavy_client, get_persons_by_distinct_ids, request)
     }
 
-    // Distinct ID operations
+    // ── Light: Distinct ID for single person (bounded string list) ───
 
     async fn get_distinct_ids_for_person(
         &self,
         request: GetDistinctIdsForPersonRequest,
     ) -> Result<GetDistinctIdsForPersonResponse, Status> {
-        retry_call!(self, get_distinct_ids_for_person, request)
+        retry_call!(self, next_light_client, get_distinct_ids_for_person, request)
     }
+
+    // ── Heavy: Distinct IDs for multiple persons (p99: 540 rows EU) ──
 
     async fn get_distinct_ids_for_persons(
         &self,
         request: GetDistinctIdsForPersonsRequest,
     ) -> Result<GetDistinctIdsForPersonsResponse, Status> {
-        retry_call!(self, get_distinct_ids_for_persons, request)
+        retry_call!(self, next_heavy_client, get_distinct_ids_for_persons, request)
     }
 
-    // Feature flag hash key override support
+    // ── Light: Feature flag hash key overrides (small structs/scalars) ─
 
     async fn get_hash_key_override_context(
         &self,
         request: GetHashKeyOverrideContextRequest,
     ) -> Result<GetHashKeyOverrideContextResponse, Status> {
-        retry_call!(self, get_hash_key_override_context, request)
+        retry_call!(self, next_light_client, get_hash_key_override_context, request)
     }
 
     async fn upsert_hash_key_overrides(
         &self,
         request: UpsertHashKeyOverridesRequest,
     ) -> Result<UpsertHashKeyOverridesResponse, Status> {
-        retry_call!(self, upsert_hash_key_overrides, request)
+        retry_call!(self, next_light_client, upsert_hash_key_overrides, request)
     }
 
     async fn delete_hash_key_overrides_by_teams(
         &self,
         request: DeleteHashKeyOverridesByTeamsRequest,
     ) -> Result<DeleteHashKeyOverridesByTeamsResponse, Status> {
-        retry_call!(self, delete_hash_key_overrides_by_teams, request)
+        retry_call!(self, next_light_client, delete_hash_key_overrides_by_teams, request)
     }
 
-    // Person deletes
+    // ── Light: Person deletes (scalar responses) ─────────────────────
 
     async fn delete_persons(
         &self,
         request: DeletePersonsRequest,
     ) -> Result<DeletePersonsResponse, Status> {
-        retry_call!(self, delete_persons, request)
+        retry_call!(self, next_light_client, delete_persons, request)
     }
 
     async fn delete_persons_batch_for_team(
         &self,
         request: DeletePersonsBatchForTeamRequest,
     ) -> Result<DeletePersonsBatchForTeamResponse, Status> {
-        retry_call!(self, delete_persons_batch_for_team, request)
+        retry_call!(self, next_light_client, delete_persons_batch_for_team, request)
     }
 
-    // Cohort membership
+    // ── Light: Cohort membership (small/scalar responses) ────────────
 
     async fn check_cohort_membership(
         &self,
         request: CheckCohortMembershipRequest,
     ) -> Result<CohortMembershipResponse, Status> {
-        retry_call!(self, check_cohort_membership, request)
+        retry_call!(self, next_light_client, check_cohort_membership, request)
     }
 
     async fn count_cohort_members(
         &self,
         request: CountCohortMembersRequest,
     ) -> Result<CountCohortMembersResponse, Status> {
-        retry_call!(self, count_cohort_members, request)
+        retry_call!(self, next_light_client, count_cohort_members, request)
     }
 
     async fn delete_cohort_member(
         &self,
         request: DeleteCohortMemberRequest,
     ) -> Result<DeleteCohortMemberResponse, Status> {
-        retry_call!(self, delete_cohort_member, request)
+        retry_call!(self, next_light_client, delete_cohort_member, request)
     }
 
     async fn delete_cohort_members_bulk(
         &self,
         request: DeleteCohortMembersBulkRequest,
     ) -> Result<DeleteCohortMembersBulkResponse, Status> {
-        retry_call!(self, delete_cohort_members_bulk, request)
+        retry_call!(self, next_light_client, delete_cohort_members_bulk, request)
     }
 
     async fn insert_cohort_members(
         &self,
         request: InsertCohortMembersRequest,
     ) -> Result<InsertCohortMembersResponse, Status> {
-        retry_call!(self, insert_cohort_members, request)
+        retry_call!(self, next_light_client, insert_cohort_members, request)
     }
+
+    // ── Heavy: ListCohortMemberIds (unbounded repeated int64) ────────
 
     async fn list_cohort_member_ids(
         &self,
         request: ListCohortMemberIdsRequest,
     ) -> Result<ListCohortMemberIdsResponse, Status> {
-        retry_call!(self, list_cohort_member_ids, request)
+        retry_call!(self, next_heavy_client, list_cohort_member_ids, request)
     }
 
-    // Groups
+    // ── Heavy: Group reads (return Group objects with properties) ─────
 
     async fn get_group(&self, request: GetGroupRequest) -> Result<GetGroupResponse, Status> {
-        retry_call!(self, get_group, request)
+        retry_call!(self, next_heavy_client, get_group, request)
     }
 
     async fn get_groups(&self, request: GetGroupsRequest) -> Result<GroupsResponse, Status> {
-        retry_call!(self, get_groups, request)
+        retry_call!(self, next_heavy_client, get_groups, request)
     }
 
     async fn get_groups_batch(
         &self,
         request: GetGroupsBatchRequest,
     ) -> Result<GetGroupsBatchResponse, Status> {
-        retry_call!(self, get_groups_batch, request)
+        retry_call!(self, next_heavy_client, get_groups_batch, request)
     }
 
     async fn list_groups(&self, request: ListGroupsRequest) -> Result<ListGroupsResponse, Status> {
-        retry_call!(self, list_groups, request)
+        retry_call!(self, next_heavy_client, list_groups, request)
     }
 
-    // Group type mappings
+    // ── Light: Group type mappings (small struct rows, no JSON blobs) ─
 
     async fn get_group_type_mappings_by_team_id(
         &self,
         request: GetGroupTypeMappingsByTeamIdRequest,
     ) -> Result<GroupTypeMappingsResponse, Status> {
-        retry_call!(self, get_group_type_mappings_by_team_id, request)
+        retry_call!(self, next_light_client, get_group_type_mappings_by_team_id, request)
     }
 
     async fn get_group_type_mappings_by_team_ids(
         &self,
         request: GetGroupTypeMappingsByTeamIdsRequest,
     ) -> Result<GroupTypeMappingsBatchResponse, Status> {
-        retry_call!(self, get_group_type_mappings_by_team_ids, request)
+        retry_call!(self, next_light_client, get_group_type_mappings_by_team_ids, request)
     }
 
     async fn get_group_type_mappings_by_project_id(
         &self,
         request: GetGroupTypeMappingsByProjectIdRequest,
     ) -> Result<GroupTypeMappingsResponse, Status> {
-        retry_call!(self, get_group_type_mappings_by_project_id, request)
+        retry_call!(self, next_light_client, get_group_type_mappings_by_project_id, request)
     }
 
     async fn get_group_type_mappings_by_project_ids(
         &self,
         request: GetGroupTypeMappingsByProjectIdsRequest,
     ) -> Result<GroupTypeMappingsBatchResponse, Status> {
-        retry_call!(self, get_group_type_mappings_by_project_ids, request)
+        retry_call!(self, next_light_client, get_group_type_mappings_by_project_ids, request)
     }
 
     async fn get_group_type_mapping_by_dashboard_id(
         &self,
         request: GetGroupTypeMappingByDashboardIdRequest,
     ) -> Result<GetGroupTypeMappingByDashboardIdResponse, Status> {
-        retry_call!(self, get_group_type_mapping_by_dashboard_id, request)
+        retry_call!(self, next_light_client, get_group_type_mapping_by_dashboard_id, request)
     }
 
-    // Group writes
+    // ── Heavy: Group writes (return Group objects with properties) ────
 
     async fn create_group(
         &self,
         request: CreateGroupRequest,
     ) -> Result<CreateGroupResponse, Status> {
-        retry_call!(self, create_group, request)
+        retry_call!(self, next_heavy_client, create_group, request)
     }
 
     async fn update_group(
         &self,
         request: UpdateGroupRequest,
     ) -> Result<UpdateGroupResponse, Status> {
-        retry_call!(self, update_group, request)
+        retry_call!(self, next_heavy_client, update_group, request)
     }
+
+    // ── Light: Group batch delete (scalar response) ──────────────────
 
     async fn delete_groups_batch_for_team(
         &self,
         request: DeleteGroupsBatchForTeamRequest,
     ) -> Result<DeleteGroupsBatchForTeamResponse, Status> {
-        retry_call!(self, delete_groups_batch_for_team, request)
+        retry_call!(self, next_light_client, delete_groups_batch_for_team, request)
     }
 
-    // Group type mapping writes
+    // ── Light: Group type mapping writes (small struct/scalar) ───────
 
     async fn update_group_type_mapping(
         &self,
         request: UpdateGroupTypeMappingRequest,
     ) -> Result<UpdateGroupTypeMappingResponse, Status> {
-        retry_call!(self, update_group_type_mapping, request)
+        retry_call!(self, next_light_client, update_group_type_mapping, request)
     }
 
     async fn delete_group_type_mapping(
         &self,
         request: DeleteGroupTypeMappingRequest,
     ) -> Result<DeleteGroupTypeMappingResponse, Status> {
-        retry_call!(self, delete_group_type_mapping, request)
+        retry_call!(self, next_light_client, delete_group_type_mapping, request)
     }
 
     async fn delete_group_type_mappings_batch_for_team(
         &self,
         request: DeleteGroupTypeMappingsBatchForTeamRequest,
     ) -> Result<DeleteGroupTypeMappingsBatchForTeamResponse, Status> {
-        retry_call!(self, delete_group_type_mappings_batch_for_team, request)
+        retry_call!(self, next_light_client, delete_group_type_mappings_batch_for_team, request)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proxy::KNOWN_METHODS;
 
-    fn make_backend(num_channels: usize) -> ReplicaBackend {
+    fn make_backend(num_heavy: usize, num_light: usize) -> ReplicaBackend {
         ReplicaBackend::new(ReplicaBackendConfig {
             url: "http://localhost:50051".to_string(),
             timeout: Duration::from_secs(1),
@@ -434,37 +512,217 @@ mod tests {
             keepalive_timeout: None,
             max_send_message_size: 4 * 1024 * 1024,
             max_recv_message_size: 4 * 1024 * 1024,
-            num_channels,
+            num_channels: num_heavy,
+            num_light_channels: num_light,
         })
     }
 
     #[tokio::test]
-    async fn next_client_round_robins_across_channels() {
-        let backend = make_backend(4);
+    async fn heavy_client_round_robins_across_channels() {
+        let backend = make_backend(4, 2);
         for round in 0..3u64 {
             for ch in 0..4u64 {
-                backend.next_client();
+                backend.next_heavy_client();
                 let expected = round * 4 + ch + 1;
-                assert_eq!(backend.next_idx.load(Ordering::Relaxed), expected as usize);
+                assert_eq!(
+                    backend.heavy_next_idx.load(Ordering::Relaxed),
+                    expected as usize
+                );
             }
         }
     }
 
     #[tokio::test]
-    async fn next_client_wraps_around() {
-        let backend = make_backend(3);
-        for _ in 0..3 {
-            backend.next_client();
+    async fn light_client_round_robins_across_channels() {
+        let backend = make_backend(4, 2);
+        for round in 0..3u64 {
+            for ch in 0..2u64 {
+                backend.next_light_client();
+                let expected = round * 2 + ch + 1;
+                assert_eq!(
+                    backend.light_next_idx.load(Ordering::Relaxed),
+                    expected as usize
+                );
+            }
         }
-        // 4th call uses counter=3, so index = 3 % 3 = 0 (wraps back to first channel)
-        let idx_before = backend.next_idx.load(Ordering::Relaxed);
-        backend.next_client();
-        assert_eq!(idx_before % backend.clients.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn heavy_and_light_pools_are_independent() {
+        let backend = make_backend(4, 2);
+        for _ in 0..5 {
+            backend.next_heavy_client();
+        }
+        assert_eq!(backend.heavy_next_idx.load(Ordering::Relaxed), 5);
+        assert_eq!(backend.light_next_idx.load(Ordering::Relaxed), 0);
+
+        for _ in 0..3 {
+            backend.next_light_client();
+        }
+        assert_eq!(backend.heavy_next_idx.load(Ordering::Relaxed), 5);
+        assert_eq!(backend.light_next_idx.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn heavy_client_wraps_around() {
+        let backend = make_backend(3, 2);
+        for _ in 0..3 {
+            backend.next_heavy_client();
+        }
+        let idx_before = backend.heavy_next_idx.load(Ordering::Relaxed);
+        backend.next_heavy_client();
+        assert_eq!(idx_before % backend.heavy_clients.len(), 0);
     }
 
     #[tokio::test]
     async fn num_channels_floors_to_one() {
-        let backend = make_backend(0);
-        assert_eq!(backend.clients.len(), 1);
+        let backend = make_backend(0, 0);
+        assert_eq!(backend.heavy_clients.len(), 1);
+        assert_eq!(backend.light_clients.len(), 1);
+    }
+
+    #[test]
+    fn light_methods_is_sorted() {
+        for window in LIGHT_METHODS.windows(2) {
+            assert!(
+                window[0] < window[1],
+                "LIGHT_METHODS is not sorted: {:?} should come after {:?}",
+                window[0],
+                window[1],
+            );
+        }
+    }
+
+    #[test]
+    fn light_methods_are_all_known() {
+        for method in LIGHT_METHODS {
+            assert!(
+                KNOWN_METHODS.contains(method),
+                "LIGHT_METHODS contains unknown method: {method}"
+            );
+        }
+    }
+
+    #[test]
+    fn classification_correctness() {
+        // Light methods
+        assert!(is_light_method("GetGroupTypeMappingsByProjectIds"));
+        assert!(is_light_method("GetGroupTypeMappingsByTeamIds"));
+        assert!(is_light_method("CheckCohortMembership"));
+        assert!(is_light_method("GetHashKeyOverrideContext"));
+        assert!(is_light_method("DeletePersons"));
+        assert!(is_light_method("GetDistinctIdsForPerson"));
+
+        // Heavy methods
+        assert!(!is_light_method("GetPerson"));
+        assert!(!is_light_method("GetPersonsByDistinctIds"));
+        assert!(!is_light_method("GetGroupsBatch"));
+        assert!(!is_light_method("GetGroups"));
+        assert!(!is_light_method("GetDistinctIdsForPersons"));
+        assert!(!is_light_method("ListCohortMemberIds"));
+        assert!(!is_light_method("CreateGroup"));
+
+        // Unknown methods default to heavy
+        assert!(!is_light_method("FakeMethod"));
+        assert!(!is_light_method(""));
+    }
+
+    fn snake_to_pascal(s: &str) -> String {
+        s.split('_')
+            .map(|part| {
+                let mut chars = part.chars();
+                match chars.next() {
+                    Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+                    None => String::new(),
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn typed_proxy_annotations_match_light_methods() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/backend/replica.rs"
+        ))
+        .expect("failed to read replica.rs");
+
+        let mut typed_light: Vec<String> = Vec::new();
+        let mut typed_heavy: Vec<String> = Vec::new();
+
+        for line in source.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("retry_call!(self, ") {
+                let parts: Vec<&str> = rest.splitn(3, ", ").collect();
+                if parts.len() >= 2 {
+                    let client_fn = parts[0];
+                    let method = snake_to_pascal(parts[1].trim_end_matches(|c| c == ',' || c == ')'));
+                    match client_fn {
+                        "next_light_client" => typed_light.push(method),
+                        "next_heavy_client" => typed_heavy.push(method),
+                        other => panic!("unexpected client function in retry_call!: {other}"),
+                    }
+                }
+            }
+        }
+
+        typed_light.sort();
+        typed_heavy.sort();
+
+        for method in &typed_light {
+            assert!(
+                is_light_method(method),
+                "retry_call! uses next_light_client for '{method}' but it's not in LIGHT_METHODS"
+            );
+        }
+
+        for method in &typed_heavy {
+            assert!(
+                !is_light_method(method),
+                "retry_call! uses next_heavy_client for '{method}' but it IS in LIGHT_METHODS"
+            );
+        }
+
+        let mut all_typed: Vec<&str> = typed_light
+            .iter()
+            .chain(typed_heavy.iter())
+            .map(|s| s.as_str())
+            .collect();
+        all_typed.sort();
+
+        let mut all_known: Vec<&str> = KNOWN_METHODS.to_vec();
+        // UpdatePersonProperties goes through the leader path, not retry_call!
+        all_known.retain(|m| *m != "UpdatePersonProperties");
+        all_known.sort();
+
+        assert_eq!(
+            all_typed, all_known,
+            "retry_call! annotations don't cover all known methods (minus leader-only ones)"
+        );
+
+        assert_eq!(
+            typed_light.len(),
+            LIGHT_METHODS.len(),
+            "number of next_light_client annotations ({}) doesn't match LIGHT_METHODS ({})",
+            typed_light.len(),
+            LIGHT_METHODS.len(),
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_channel_routes_by_method() {
+        let backend = make_backend(4, 2);
+
+        backend.next_raw_channel_for("GetGroupTypeMappingsByProjectIds");
+        assert_eq!(backend.light_next_idx.load(Ordering::Relaxed), 1);
+        assert_eq!(backend.heavy_next_idx.load(Ordering::Relaxed), 0);
+
+        backend.next_raw_channel_for("GetGroupsBatch");
+        assert_eq!(backend.light_next_idx.load(Ordering::Relaxed), 1);
+        assert_eq!(backend.heavy_next_idx.load(Ordering::Relaxed), 1);
+
+        backend.next_raw_channel_for("UnknownMethod");
+        assert_eq!(backend.light_next_idx.load(Ordering::Relaxed), 1);
+        assert_eq!(backend.heavy_next_idx.load(Ordering::Relaxed), 2);
     }
 }

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -742,14 +742,12 @@ mod tests {
                 } else {
                     continue;
                 }
+            } else if trimmed == ")" {
+                in_macro = false;
             } else {
-                if trimmed == ")" {
-                    in_macro = false;
-                } else {
-                    macro_buf.push(' ');
-                    macro_buf.push_str(trimmed);
-                    continue;
-                }
+                macro_buf.push(' ');
+                macro_buf.push_str(trimmed);
+                continue;
             }
 
             let args: Vec<&str> = macro_buf.split(',').collect();

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -88,10 +88,18 @@ pub struct Config {
     #[envconfig(default = "http://127.0.0.1:50051")]
     pub replica_url: String,
 
-    /// Number of gRPC channels (HTTP/2 connections) to open to the replica backend.
+    /// Number of gRPC channels (HTTP/2 connections) to open to the replica backend
+    /// for heavy RPCs (Person/Group lookups with large JSON property blobs).
     /// Multiple channels distribute requests across K8s service endpoints.
     #[envconfig(default = "4")]
     pub replica_channels: usize,
+
+    /// Number of dedicated gRPC channels for light RPCs (group type mappings,
+    /// cohort checks, scalar responses). Isolates small responses from TCP
+    /// head-of-line blocking caused by large Person/Group payloads on the
+    /// heavy channels.
+    #[envconfig(default = "2")]
+    pub replica_light_channels: usize,
 
     /// Timeout for backend requests in milliseconds
     #[envconfig(default = "5000")]

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -59,7 +59,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Proxy mode: {}", config.proxy_mode);
     tracing::info!("gRPC address: {}", config.grpc_address);
     tracing::info!("Replica URL: {}", config.replica_url);
-    tracing::info!("Replica channels: {}", config.replica_channels);
+    tracing::info!(
+        "Replica channels: {} heavy, {} light",
+        config.replica_channels,
+        config.replica_light_channels
+    );
     tracing::info!("Backend timeout: {}ms", config.backend_timeout_ms);
     tracing::info!("Metrics port: {}", config.metrics_port);
     tracing::info!(
@@ -152,6 +156,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_send_message_size: config.grpc_max_send_message_size,
         max_recv_message_size: config.grpc_max_recv_message_size,
         num_channels: config.replica_channels,
+        num_light_channels: config.replica_light_channels,
     }));
 
     // In leader mode, wire up etcd coordination and the leader backend

--- a/rust/personhog-router/src/proxy.rs
+++ b/rust/personhog-router/src/proxy.rs
@@ -23,7 +23,7 @@ use crate::config::RetryConfig;
 const SERVICE_PREFIX: &str = "/personhog.service.v1.PersonHogService/";
 const REPLICA_PREFIX: &str = "/personhog.replica.v1.PersonHogReplica/";
 
-const KNOWN_METHODS: &[&str] = &[
+pub const KNOWN_METHODS: &[&str] = &[
     "CheckCohortMembership",
     "CountCohortMembers",
     "CreateGroup",
@@ -222,7 +222,7 @@ impl RawProxyInner {
         let mut delay_ms = self.retry_config.initial_backoff_ms;
 
         for attempt in 0..=self.retry_config.max_retries {
-            let channel = self.replica.next_raw_channel();
+            let channel = self.replica.next_raw_channel_for(method);
 
             let body = BoxBody::new(Full::new(body_bytes.clone()).map_err(|never| match never {}));
 

--- a/rust/personhog-router/tests/common/mod.rs
+++ b/rust/personhog-router/tests/common/mod.rs
@@ -479,6 +479,7 @@ pub async fn start_test_router(replica_addr: SocketAddr) -> SocketAddr {
         max_send_message_size: 4 * 1024 * 1024,
         max_recv_message_size: 4 * 1024 * 1024,
         num_channels: 1,
+        num_light_channels: 1,
     });
     let router = PersonHogRouter::new(Arc::new(backend));
     let service = PersonHogRouterService::new(Arc::new(router));
@@ -670,6 +671,7 @@ pub async fn start_test_router_with_leader(
         max_send_message_size: 4 * 1024 * 1024,
         max_recv_message_size: 4 * 1024 * 1024,
         num_channels: 1,
+        num_light_channels: 1,
     });
 
     // Leader backend: all partitions → "leader-0", resolver → leader_addr
@@ -729,6 +731,7 @@ fn make_replica_backend(replica_addr: SocketAddr) -> Arc<ReplicaBackend> {
         max_send_message_size: 4 * 1024 * 1024,
         max_recv_message_size: 4 * 1024 * 1024,
         num_channels: 1,
+        num_light_channels: 1,
     }))
 }
 


### PR DESCRIPTION
## Problem

Lightweight queries in personhog are showing some fat tail latencies. The problem is possibly due to TCP-level head-of-line blocking: there are 4 HTTP/2 connections from each router pod to the replicas, and each connection carries all the RPCs. Larger `GetGroupsBatch` responses cause TCP congestion that stalls small responses sharing the same connections.

## Changes

Split the router's single gRPC channel pool into two isolated pools, so small responses never share a TCP connection with large ones.
	- Heavy pool: carries RPCs that return Person/Group objects with large JSON property blobs
	- Light pool: carries everything else

Classifciation of channels uses allow list for the light methods.

We'll have metrics that report how much data goes over the wire for each method, which will help ensure we allocate the right methods to the correct pools.

## How did you test this code?

- Adds tests to cover the channel routing logic
