### PR TITLE
chore(capture): move static response headers to v1 middleware

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -149,6 +149,7 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
     capture_v1_max_decompressed_body_bytes: usize,
     overflow_limiter: Option<Arc<OverflowLimiter>>,
     replay_overflow_limiter: Option<Arc<RedisLimiter>>,
+    v1_sink_router: Option<Arc<crate::v1::sinks::Router>>,
 ) -> Router {
     let state = State {
         sink,
@@ -173,7 +174,7 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
         capture_v1_max_decompressed_body_bytes,
         overflow_limiter,
         replay_overflow_limiter,
-        v1_sink_router: None,
+        v1_sink_router,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -93,6 +93,7 @@ pub async fn serve(listener: TcpListener, components: CaptureComponents) {
         app,
         server_handle,
         sink,
+        v1_sink_router,
         http1_header_read_timeout_ms,
     } = components;
 
@@ -227,13 +228,23 @@ pub async fn serve(listener: TcpListener, components: CaptureComponents) {
         graceful.shutdown().await;
         info!("Hyper accept loop (shutdown): graceful shutdown completed");
 
-        // Flush the Kafka producer queue. Events from in-flight handlers may still
-        // be in rdkafka's internal buffer. flush() blocks until the queue drains or
-        // times out (default 30s from rdkafka config).
-        info!("Flushing sink...");
-        if let Err(e) = sink.flush() {
-            error!("Sink flush failed: {e:#}");
-        }
+        // Flush sink producer queues. Events from in-flight handlers may still
+        // be in rdkafka's internal buffers. Flush both concurrently so dual-produce
+        // mode doesn't double shutdown latency.
+        info!("Flushing sinks...");
+        let legacy_flush = async {
+            if let Err(e) = sink.flush() {
+                error!("Sink flush failed: {e:#}");
+            }
+        };
+        let v1_flush = async {
+            if let Some(ref v1_router) = v1_sink_router {
+                if let Err(e) = v1_router.flush().await {
+                    error!("V1 sink router flush failed: {e:#}");
+                }
+            }
+        };
+        tokio::join!(legacy_flush, v1_flush);
         info!("Sink flush complete");
 
         // _scope drops here -> ProcessScopeGuard signals WorkCompleted

--- a/rust/capture/src/setup.rs
+++ b/rust/capture/src/setup.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use axum::Router;
 use common_redis::RedisClient;
 use tracing::{info, warn};
@@ -30,6 +32,7 @@ pub struct LifecycleHandles {
     pub sink: Option<lifecycle::Handle>,
     pub advisory: Option<lifecycle::Handle>,
     pub event_restrictions: Option<lifecycle::Handle>,
+    pub v1_sinks: HashMap<crate::v1::sinks::SinkName, lifecycle::Handle>,
     pub readiness: lifecycle::ReadinessHandler,
     pub liveness: lifecycle::LivenessHandler,
 }
@@ -47,10 +50,13 @@ pub fn register_components(manager: &mut lifecycle::Manager, config: &Config) ->
         (None, None)
     } else if config.s3_fallback_enabled {
         let kafka = manager.register("kafka-sink", sink_opts.clone().is_advisory(true));
-        let s3 = manager.register("s3-sink", sink_opts);
+        let s3 = manager.register("s3-sink", sink_opts.clone());
         (Some(s3), Some(kafka))
     } else {
-        (Some(manager.register("kafka-sink", sink_opts)), None)
+        (
+            Some(manager.register("kafka-sink", sink_opts.clone())),
+            None,
+        )
     };
 
     let event_restrictions =
@@ -58,6 +64,27 @@ pub fn register_components(manager: &mut lifecycle::Manager, config: &Config) ->
             Some(manager.register("event-restrictions", lifecycle::ComponentOptions::new()))
         } else {
             None
+        };
+
+    let v1_sinks: HashMap<crate::v1::sinks::SinkName, lifecycle::Handle> =
+        if !config.capture_v1_sinks.is_empty() {
+            crate::v1::sinks::parse_sink_names(&config.capture_v1_sinks)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "fatal: failed to parse CAPTURE_V1_SINKS='{}': {e:#}",
+                        config.capture_v1_sinks
+                    )
+                })
+                .into_iter()
+                .map(|name| {
+                    (
+                        name,
+                        manager.register(name.lifecycle_tag(), sink_opts.clone()),
+                    )
+                })
+                .collect()
+        } else {
+            HashMap::new()
         };
 
     let readiness = manager.readiness_handler();
@@ -68,6 +95,7 @@ pub fn register_components(manager: &mut lifecycle::Manager, config: &Config) ->
         sink,
         advisory,
         event_restrictions,
+        v1_sinks,
         readiness,
         liveness,
     }
@@ -77,6 +105,7 @@ pub struct CaptureComponents {
     pub app: Router,
     pub server_handle: lifecycle::Handle,
     pub sink: Arc<dyn Event + Send + Sync>,
+    pub v1_sink_router: Option<Arc<crate::v1::sinks::Router>>,
     pub http1_header_read_timeout_ms: Option<u64>,
 }
 
@@ -86,6 +115,7 @@ pub async fn build_components(config: Config, handles: LifecycleHandles) -> Capt
         sink: sink_handle,
         advisory: advisory_handle,
         event_restrictions: event_restrictions_handle,
+        v1_sinks: v1_sink_handles,
         readiness,
         liveness,
     } = handles;
@@ -255,6 +285,15 @@ pub async fn build_components(config: Config, handles: LifecycleHandles) -> Capt
         None
     };
 
+    let v1_sink_router = if !config.capture_v1_sinks.is_empty() {
+        Some(
+            create_v1_sink_router(&config, v1_sink_handles)
+                .unwrap_or_else(|e| panic!("fatal: v1 sink router creation failed: {e:#}")),
+        )
+    } else {
+        None
+    };
+
     let app = router::router(
         crate::time::SystemTime {},
         readiness,
@@ -283,6 +322,7 @@ pub async fn build_components(config: Config, handles: LifecycleHandles) -> Capt
         config.capture_v1_max_decompressed_body_bytes,
         overflow_limiter,
         replay_overflow_limiter,
+        v1_sink_router.clone(),
     );
 
     info!(
@@ -294,8 +334,54 @@ pub async fn build_components(config: Config, handles: LifecycleHandles) -> Capt
         app,
         server_handle: server,
         sink: sink_for_flush,
+        v1_sink_router,
         http1_header_read_timeout_ms: config.http1_header_read_timeout_ms,
     }
+}
+
+fn create_v1_sink_router(
+    config: &Config,
+    handles: HashMap<crate::v1::sinks::SinkName, lifecycle::Handle>,
+) -> anyhow::Result<Arc<crate::v1::sinks::Router>> {
+    let sinks_cfg = crate::v1::sinks::load_sinks(&config.capture_v1_sinks)
+        .context("failed to parse CAPTURE_V1_SINKS")?;
+    sinks_cfg
+        .validate()
+        .context("v1 sink config validation failed")?;
+
+    let mut sink_map: HashMap<crate::v1::sinks::SinkName, Box<dyn crate::v1::sinks::sink::Sink>> =
+        HashMap::new();
+
+    for (name, cfg) in sinks_cfg.configs {
+        let handle = handles
+            .get(&name)
+            .cloned()
+            .with_context(|| format!("missing lifecycle handle for v1 sink '{name}'"))?;
+
+        let producer = crate::v1::sinks::kafka::producer::KafkaProducer::new(
+            name,
+            &cfg.kafka,
+            handle.clone(),
+            config.capture_mode.as_tag(),
+        )
+        .with_context(|| format!("failed to create v1 kafka producer for sink '{name}'"))?;
+
+        let kafka_sink = crate::v1::sinks::kafka::sink::KafkaSink::new(
+            name,
+            Arc::new(producer),
+            cfg,
+            config.capture_mode,
+            handle,
+        );
+        sink_map.insert(name, Box::new(kafka_sink));
+    }
+
+    let router = crate::v1::sinks::Router::new(sinks_cfg.default, sink_map);
+    info!(
+        sinks = config.capture_v1_sinks.as_str(),
+        "V1 sink router initialized"
+    );
+    Ok(Arc::new(router))
 }
 
 async fn create_sink(
@@ -414,4 +500,51 @@ fn create_event_restriction_service(
     );
 
     Some(service)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn create_v1_sink_router_fails_on_invalid_config() {
+        let cfg_env: HashMap<String, String> = [
+            ("REDIS_URL", "redis://localhost:6379/"),
+            ("CAPTURE_MODE", "events"),
+            ("KAFKA_HOSTS", "localhost:9092"),
+            ("KAFKA_TOPIC", "events_plugin_ingestion"),
+            ("CAPTURE_V1_SINKS", "msk"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+        let config: Config =
+            envconfig::Envconfig::init_from_hashmap(&cfg_env).expect("test config");
+
+        let mut manager = lifecycle::Manager::builder("test")
+            .with_trap_signals(false)
+            .with_prestop_check(false)
+            .build();
+        let handles: HashMap<crate::v1::sinks::SinkName, lifecycle::Handle> =
+            crate::v1::sinks::parse_sink_names(&config.capture_v1_sinks)
+                .unwrap()
+                .into_iter()
+                .map(|name| {
+                    (
+                        name,
+                        manager.register(name.lifecycle_tag(), lifecycle::ComponentOptions::new()),
+                    )
+                })
+                .collect();
+
+        let err = create_v1_sink_router(&config, handles)
+            .err()
+            .expect("should fail with invalid config");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("msk"),
+            "error should name the failing sink: {msg}"
+        );
+    }
 }

--- a/rust/capture/src/v1/analytics/handler.rs
+++ b/rust/capture/src/v1/analytics/handler.rs
@@ -130,3 +130,278 @@ fn raw_header_str<'a>(headers: &'a HeaderMap, name: &str) -> &'a str {
         .and_then(|v| v.to_str().ok())
         .unwrap_or("absent")
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::Router;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use crate::router;
+    use crate::v1::constants::*;
+    use crate::v1::test_utils::{batch_payload, compressed_payload, valid_event, TestStateBuilder};
+
+    fn test_app(state: router::State) -> Router {
+        Router::new()
+            .route(
+                "/i/v1/general/events",
+                axum::routing::post(super::handle_request),
+            )
+            .layer(axum::middleware::from_fn(
+                super::super::router::v1_common_headers,
+            ))
+            .with_state(state)
+    }
+
+    fn valid_request() -> axum::http::request::Builder {
+        Request::builder()
+            .method("POST")
+            .uri("/i/v1/general/events")
+            .header("Authorization", "Bearer phc_test_token")
+            .header("Content-Type", "application/json")
+            .header("X-Forwarded-For", "127.0.0.1")
+            .header(POSTHOG_SDK_INFO, "posthog-rust/1.0.0")
+            .header(POSTHOG_ATTEMPT, "1")
+            .header(POSTHOG_REQUEST_ID, Uuid::new_v4().to_string())
+            .header(POSTHOG_REQUEST_TIMESTAMP, "2026-03-19T14:30:00Z")
+            .header("User-Agent", "test-agent/1.0")
+    }
+
+    async fn response_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn happy_path_single_event() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let event = valid_event();
+        let uuid = event.uuid.clone();
+        let payload = batch_payload(&[event]);
+
+        let resp = app
+            .oneshot(valid_request().body(Body::from(payload)).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_json(resp).await;
+        let results = body["results"].as_object().unwrap();
+        assert_eq!(results[&uuid]["result"], "ok");
+    }
+
+    #[tokio::test]
+    async fn happy_path_batch() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let events = vec![valid_event(), valid_event(), valid_event()];
+        let uuids: Vec<String> = events.iter().map(|e| e.uuid.clone()).collect();
+        let payload = batch_payload(&events);
+
+        let resp = app
+            .oneshot(valid_request().body(Body::from(payload)).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_json(resp).await;
+        let results = body["results"].as_object().unwrap();
+        for uuid in &uuids {
+            assert_eq!(results[uuid]["result"], "ok");
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_authorization() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let payload = batch_payload(&[valid_event()]);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/i/v1/general/events")
+            .header("Content-Type", "application/json")
+            .header("X-Forwarded-For", "127.0.0.1")
+            .header(POSTHOG_SDK_INFO, "posthog-rust/1.0.0")
+            .header(POSTHOG_ATTEMPT, "1")
+            .header(POSTHOG_REQUEST_ID, Uuid::new_v4().to_string())
+            .header(POSTHOG_REQUEST_TIMESTAMP, "2026-03-19T14:30:00Z")
+            .header("User-Agent", "test-agent/1.0")
+            .body(Body::from(payload))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn missing_required_headers() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let payload = batch_payload(&[valid_event()]);
+        // Only Authorization and Content-Type — missing SDK-Info, Attempt, etc.
+        let req = Request::builder()
+            .method("POST")
+            .uri("/i/v1/general/events")
+            .header("Authorization", "Bearer phc_test_token")
+            .header("Content-Type", "application/json")
+            .header("X-Forwarded-For", "127.0.0.1")
+            .header("User-Agent", "test-agent/1.0")
+            .body(Body::from(payload))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn empty_body() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let resp = app
+            .oneshot(valid_request().body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn malformed_json() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let garbage = b"not json at all {{{".to_vec();
+        let resp = app
+            .oneshot(valid_request().body(Body::from(garbage)).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn empty_batch() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let payload = br#"{"created_at":"2026-03-19T14:30:00Z","batch":[]}"#.to_vec();
+        let resp = app
+            .oneshot(valid_request().body(Body::from(payload)).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn gzip_compressed_payload() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let event = valid_event();
+        let uuid = event.uuid.clone();
+        let raw = batch_payload(&[event]);
+        let compressed = compressed_payload(&raw, "gzip");
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/i/v1/general/events")
+            .header("Authorization", "Bearer phc_test_token")
+            .header("Content-Type", "application/json")
+            .header("Content-Encoding", "gzip")
+            .header("X-Forwarded-For", "127.0.0.1")
+            .header(POSTHOG_SDK_INFO, "posthog-rust/1.0.0")
+            .header(POSTHOG_ATTEMPT, "1")
+            .header(POSTHOG_REQUEST_ID, Uuid::new_v4().to_string())
+            .header(POSTHOG_REQUEST_TIMESTAMP, "2026-03-19T14:30:00Z")
+            .header("User-Agent", "test-agent/1.0")
+            .body(Body::from(compressed))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_json(resp).await;
+        assert_eq!(body["results"][&uuid]["result"], "ok");
+    }
+
+    #[tokio::test]
+    async fn zstd_compressed_payload() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let event = valid_event();
+        let uuid = event.uuid.clone();
+        let raw = batch_payload(&[event]);
+        let compressed = compressed_payload(&raw, "zstd");
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/i/v1/general/events")
+            .header("Authorization", "Bearer phc_test_token")
+            .header("Content-Type", "application/json")
+            .header("Content-Encoding", "zstd")
+            .header("X-Forwarded-For", "127.0.0.1")
+            .header(POSTHOG_SDK_INFO, "posthog-rust/1.0.0")
+            .header(POSTHOG_ATTEMPT, "1")
+            .header(POSTHOG_REQUEST_ID, Uuid::new_v4().to_string())
+            .header(POSTHOG_REQUEST_TIMESTAMP, "2026-03-19T14:30:00Z")
+            .header("User-Agent", "test-agent/1.0")
+            .body(Body::from(compressed))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_json(resp).await;
+        assert_eq!(body["results"][&uuid]["result"], "ok");
+    }
+
+    #[tokio::test]
+    async fn unsupported_encoding() {
+        let ts = TestStateBuilder::new().build();
+        let app = test_app(ts.state);
+
+        let payload = batch_payload(&[valid_event()]);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/i/v1/general/events")
+            .header("Authorization", "Bearer phc_test_token")
+            .header("Content-Type", "application/json")
+            .header("Content-Encoding", "lz4")
+            .header("X-Forwarded-For", "127.0.0.1")
+            .header(POSTHOG_SDK_INFO, "posthog-rust/1.0.0")
+            .header(POSTHOG_ATTEMPT, "1")
+            .header(POSTHOG_REQUEST_ID, Uuid::new_v4().to_string())
+            .header(POSTHOG_REQUEST_TIMESTAMP, "2026-03-19T14:30:00Z")
+            .header("User-Agent", "test-agent/1.0")
+            .body(Body::from(payload))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn service_unavailable_no_sink() {
+        let mut ts = TestStateBuilder::new().build();
+        ts.state.v1_sink_router = None;
+        let app = test_app(ts.state);
+
+        let payload = batch_payload(&[valid_event()]);
+        let resp = app
+            .oneshot(valid_request().body(Body::from(payload)).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -139,11 +139,15 @@ pub fn merge_sink_results(events: &mut [WrappedEvent], sink_results: &[Box<dyn S
             }
             Outcome::RetriableError | Outcome::Timeout => {
                 event.result = EventResult::Retry;
-                event.details = Some(result.cause().unwrap_or("not_persisted"));
+                event.details = Some("not_persisted");
             }
             Outcome::FatalError => {
                 event.result = EventResult::Drop;
-                event.details = Some(result.cause().unwrap_or("publish_failed"));
+                let cause = result.cause().unwrap_or("rejected");
+                event.details = Some(match cause {
+                    "serialization_failed" | "event_too_big" => cause,
+                    _ => "rejected",
+                });
             }
         }
     }
@@ -801,6 +805,25 @@ mod tests {
         };
         let err = validate_events(&ctx, batch).unwrap_err();
         assert!(matches!(err, Error::MissingEventUuid));
+    }
+
+    #[test]
+    fn validate_events_uuid_with_whitespace_trimmed_successfully() {
+        let ctx = test_utils::test_context();
+        let inner_uuid = Uuid::new_v4();
+        let padded_uuid = format!("  {}  ", inner_uuid);
+        let batch = Batch {
+            created_at: "2026-03-19T14:30:00.000Z".to_string(),
+            historical_migration: false,
+            capture_internal: None,
+            batch: vec![Event {
+                uuid: padded_uuid,
+                ..valid_event()
+            }],
+        };
+        let events = validate_events(&ctx, batch).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].uuid, inner_uuid);
     }
 
     #[test]
@@ -1906,58 +1929,47 @@ mod tests {
 
     use crate::v1::test_utils::MockSinkResult;
 
-    #[test]
-    fn merge_all_success_leaves_results_intact() {
-        let mut events = vec![
-            wrapped_event("$pageview", "user-1"),
-            wrapped_event("$identify", "user-2"),
-        ];
-        let results: Vec<Box<dyn SinkResult>> = events
-            .iter()
-            .map(|e| MockSinkResult::success(e.uuid))
-            .collect();
-
-        merge_sink_results(&mut events, &results);
-
-        assert_eq!(events[0].result, EventResult::Ok);
-        assert!(events[0].details.is_none());
-        assert_eq!(events[1].result, EventResult::Ok);
-        assert!(events[1].details.is_none());
+    fn mock_result(uuid: Uuid, outcome: &str, cause: &'static str) -> Box<dyn SinkResult> {
+        match outcome {
+            "success" => MockSinkResult::success(uuid),
+            "retriable" => MockSinkResult::retriable(uuid, cause),
+            "timeout" => MockSinkResult::timeout(uuid),
+            "fatal" => MockSinkResult::fatal(uuid, cause),
+            _ => panic!("unknown outcome: {outcome}"),
+        }
     }
 
-    #[test]
-    fn merge_retriable_error_flips_ok_to_retry() {
+    #[rstest::rstest]
+    #[case::success("success", "", EventResult::Ok, None)]
+    #[case::retriable("retriable", "queue_full", EventResult::Retry, Some("not_persisted"))]
+    #[case::timeout("timeout", "", EventResult::Retry, Some("not_persisted"))]
+    #[case::fatal_serialization(
+        "fatal",
+        "serialization_failed",
+        EventResult::Drop,
+        Some("serialization_failed")
+    )]
+    #[case::fatal_event_too_big("fatal", "event_too_big", EventResult::Drop, Some("event_too_big"))]
+    #[case::fatal_generic("fatal", "rdkafka_other", EventResult::Drop, Some("rejected"))]
+    fn merge_single_outcome(
+        #[case] outcome: &str,
+        #[case] cause: &'static str,
+        #[case] expected_result: EventResult,
+        #[case] expected_details: Option<&'static str>,
+    ) {
         let mut events = vec![wrapped_event("$pageview", "user-1")];
-        let results: Vec<Box<dyn SinkResult>> =
-            vec![MockSinkResult::retriable(events[0].uuid, "queue_full")];
+        let results: Vec<Box<dyn SinkResult>> = vec![mock_result(events[0].uuid, outcome, cause)];
 
         merge_sink_results(&mut events, &results);
 
-        assert_eq!(events[0].result, EventResult::Retry);
-        assert_eq!(events[0].details, Some("queue_full"));
-    }
-
-    #[test]
-    fn merge_timeout_flips_ok_to_retry() {
-        let mut events = vec![wrapped_event("$pageview", "user-1")];
-        let results: Vec<Box<dyn SinkResult>> = vec![MockSinkResult::timeout(events[0].uuid)];
-
-        merge_sink_results(&mut events, &results);
-
-        assert_eq!(events[0].result, EventResult::Retry);
-        assert_eq!(events[0].details, Some("timeout"));
-    }
-
-    #[test]
-    fn merge_fatal_error_flips_ok_to_drop() {
-        let mut events = vec![wrapped_event("$pageview", "user-1")];
-        let results: Vec<Box<dyn SinkResult>> =
-            vec![MockSinkResult::fatal(events[0].uuid, "message_too_large")];
-
-        merge_sink_results(&mut events, &results);
-
-        assert_eq!(events[0].result, EventResult::Drop);
-        assert_eq!(events[0].details, Some("message_too_large"));
+        assert_eq!(
+            events[0].result, expected_result,
+            "result for {outcome}:{cause}"
+        );
+        assert_eq!(
+            events[0].details, expected_details,
+            "details for {outcome}:{cause}"
+        );
     }
 
     #[test]
@@ -2015,9 +2027,9 @@ mod tests {
         assert_eq!(events[0].result, EventResult::Ok);
         assert!(events[0].details.is_none());
         assert_eq!(events[1].result, EventResult::Retry);
-        assert_eq!(events[1].details, Some("queue_full"));
+        assert_eq!(events[1].details, Some("not_persisted"));
         assert_eq!(events[2].result, EventResult::Drop);
-        assert_eq!(events[2].details, Some("serialization_error"));
+        assert_eq!(events[2].details, Some("rejected"));
     }
 
     #[test]
@@ -2038,7 +2050,7 @@ mod tests {
         assert_eq!(events[0].result, EventResult::Ok);
         assert!(events[0].details.is_none());
         assert_eq!(events[1].result, EventResult::Retry);
-        assert_eq!(events[1].details, Some("queue_full"));
+        assert_eq!(events[1].details, Some("not_persisted"));
     }
 
     #[test]
@@ -2073,6 +2085,22 @@ mod tests {
 
         assert_eq!(events[0].result, EventResult::Drop);
         assert_eq!(events[0].details, Some("invalid_distinct_id"));
+    }
+
+    #[tokio::test]
+    async fn process_batch_returns_service_unavailable_when_no_sink_router() {
+        let test_state = crate::v1::test_utils::TestStateBuilder::new().build();
+        let mut state = test_state.state;
+        state.v1_sink_router = None;
+
+        let mut ctx = test_utils::test_context();
+        let batch = valid_batch(vec![valid_event()]);
+
+        let err = process_batch(&state, &mut ctx, batch).await.unwrap_err();
+        assert!(
+            matches!(err, Error::ServiceUnavailable(_)),
+            "expected ServiceUnavailable, got: {err:?}"
+        );
     }
 
     // =========================================================================

--- a/rust/capture/src/v1/analytics/router.rs
+++ b/rust/capture/src/v1/analytics/router.rs
@@ -7,7 +7,9 @@ use axum::response::Response;
 use axum::Router;
 use chrono::Utc;
 
-use super::constants::{CAPTURE_V1_PATH, CAPTURE_V1_PATH_TRAILING};
+use super::constants::{
+    ACCEPT_ENCODING_ALL, ACCEPT_JSON, CAPTURE_V1_PATH, CAPTURE_V1_PATH_TRAILING,
+};
 use crate::router::State;
 use crate::v1::constants::{CAPTURE_V1_RESPONSE_TIME, POSTHOG_REQUEST_ID};
 
@@ -38,6 +40,8 @@ pub(super) async fn v1_common_headers(req: Request, next: Next) -> Response {
     if let Some(id) = request_id {
         headers.insert(POSTHOG_REQUEST_ID, id);
     }
+    headers.insert(header::ACCEPT, ACCEPT_JSON);
+    headers.insert(header::ACCEPT_ENCODING, ACCEPT_ENCODING_ALL);
 
     response
 }
@@ -112,6 +116,26 @@ mod tests {
         assert!(
             parsed.is_ok(),
             "Date header is not valid RFC 2822: {date:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn common_headers_sets_accept_and_encoding() {
+        let resp = test_router()
+            .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::ACCEPT).expect("Accept missing"),
+            "application/json"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(header::ACCEPT_ENCODING)
+                .expect("Accept-Encoding missing"),
+            "gzip, deflate, br, zstd"
         );
     }
 

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -1024,6 +1024,19 @@ mod tests {
     }
 
     #[test]
+    fn serialize_into_fails_without_adjusted_timestamp() {
+        let mut ev = pageview_event();
+        ev.adjusted_timestamp = None;
+        let ctx = serialize_ctx();
+        let mut buf = String::new();
+        let err = ev.serialize_into(&ctx, &mut buf).unwrap_err();
+        assert!(
+            err.to_string().contains("adjusted_timestamp"),
+            "error should mention adjusted_timestamp: {err}"
+        );
+    }
+
+    #[test]
     fn serialize_round_trip_basic() {
         let wrapped = pageview_event();
         let ctx = serialize_ctx();

--- a/rust/capture/src/v1/error.rs
+++ b/rust/capture/src/v1/error.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::Level;
 
-use crate::v1::analytics::constants::{ACCEPT_ENCODING_ALL, ACCEPT_JSON, DEFAULT_RETRY_AFTER_SECS};
+use crate::v1::analytics::constants::DEFAULT_RETRY_AFTER_SECS;
 use crate::v1::constants::{CAPTURE_V1_ERROR_METRIC, CAPTURE_V1_UNKNOWN_PATH};
 use crate::v1::context::Context;
 
@@ -268,8 +268,6 @@ impl Error {
 
     pub fn response_headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
-        headers.insert(header::ACCEPT, ACCEPT_JSON);
-        headers.insert(header::ACCEPT_ENCODING, ACCEPT_ENCODING_ALL);
 
         // 402 (BillingLimitExceeded) is intentionally non-retryable per RFC, so no Retry-After.
         if matches!(

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -1152,3 +1152,148 @@ async fn partial_timeout_with_serialization_error() {
     assert_eq!(by_key[&e2.parsed_uuid].outcome(), Outcome::Timeout);
     assert_eq!(by_key[&e2.parsed_uuid].cause(), Some("timeout"));
 }
+
+// ===========================================================================
+// Realistic WrappedEvent — destination routing, property injection, options
+// ===========================================================================
+
+#[tokio::test]
+async fn realistic_exception_routes_to_exception_topic() {
+    let h = TestHarness::new();
+    let wrapped = test_utils::wrapped_event("$exception", "user-1")
+        .with_destination(Destination::ExceptionErrorTracking);
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+    h.producer.with_records(|records| {
+        assert_eq!(records[0].topic, "error_tracking_events");
+    });
+}
+
+#[tokio::test]
+async fn realistic_heatmap_routes_to_heatmap_topic() {
+    let h = TestHarness::new();
+    let wrapped =
+        test_utils::wrapped_event("$$heatmap", "user-1").with_destination(Destination::HeatmapMain);
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+    h.producer.with_records(|records| {
+        assert_eq!(records[0].topic, "heatmaps_ingestion");
+    });
+}
+
+#[tokio::test]
+async fn realistic_session_id_injected_into_properties() {
+    let h = TestHarness::new();
+    let mut wrapped = test_utils::wrapped_event("$pageview", "user-1");
+    wrapped.event.session_id = Some("sess-123".to_string());
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+    h.producer.with_records(|records| {
+        let captured: CapturedEvent =
+            serde_json::from_str(&records[0].payload).expect("must deserialize as CapturedEvent");
+        let data: RawEvent =
+            serde_json::from_str(&captured.data).expect("data must deserialize as RawEvent");
+        assert_eq!(data.properties["$session_id"], "sess-123");
+    });
+}
+
+#[tokio::test]
+async fn realistic_window_id_injected_into_properties() {
+    let h = TestHarness::new();
+    let mut wrapped = test_utils::wrapped_event("$pageview", "user-1");
+    wrapped.event.window_id = Some("win-456".to_string());
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+    h.producer.with_records(|records| {
+        let captured: CapturedEvent =
+            serde_json::from_str(&records[0].payload).expect("must deserialize as CapturedEvent");
+        let data: RawEvent =
+            serde_json::from_str(&captured.data).expect("data must deserialize as RawEvent");
+        assert_eq!(data.properties["$window_id"], "win-456");
+    });
+}
+
+#[tokio::test]
+async fn realistic_cookieless_partition_key() {
+    let h = TestHarness::new();
+    let mut wrapped = test_utils::wrapped_event("$pageview", "user-1");
+    wrapped.event.options.cookieless_mode = Some(true);
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+    let expected_key = format!("{}:{}", h.ctx.api_token, h.ctx.client_ip);
+    h.producer.with_records(|records| {
+        let key = records[0].key.as_deref().expect("key should be present");
+        assert_eq!(key, expected_key);
+    });
+}
+
+#[rstest]
+#[case::main(0, Some("events_main"))]
+#[case::historical(1, Some("events_hist"))]
+#[case::overflow(2, Some("events_overflow"))]
+#[case::dlq(3, Some("events_dlq"))]
+#[case::custom(4, Some("custom_topic"))]
+#[case::drop(5, None)]
+#[tokio::test]
+async fn realistic_spread_destinations_routes_correctly(
+    #[case] idx: usize,
+    #[case] expected_topic: Option<&str>,
+) {
+    let h = TestHarness::new();
+    let all = test_utils::realistic_spread_destinations();
+    let ev = &all[idx];
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![ev];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    match expected_topic {
+        Some(topic) => {
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].outcome(), Outcome::Success);
+            h.producer.with_records(|records| {
+                assert_eq!(records[0].topic, topic);
+            });
+        }
+        None => {
+            assert!(results.is_empty());
+            assert_eq!(h.producer.record_count(), 0);
+        }
+    }
+}
+
+#[tokio::test]
+async fn realistic_force_disable_pp_null_partition_key() {
+    let h = TestHarness::new();
+    let wrapped = test_utils::wrapped_event("$pageview", "user-1")
+        .with_force_disable_person_processing(true)
+        .with_destination(Destination::AnalyticsMain);
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+    h.producer.with_records(|records| {
+        assert!(records[0].key.is_none());
+    });
+}

--- a/rust/capture/src/v1/sinks/mod.rs
+++ b/rust/capture/src/v1/sinks/mod.rs
@@ -42,6 +42,14 @@ impl SinkName {
         }
     }
 
+    pub fn lifecycle_tag(&self) -> &'static str {
+        match self {
+            Self::Msk => "v1-sink-msk",
+            Self::MskAlt => "v1-sink-msk_alt",
+            Self::Ws => "v1-sink-ws",
+        }
+    }
+
     pub fn env_prefix(&self) -> &'static str {
         match self {
             Self::Msk => "CAPTURE_V1_SINK_MSK_",
@@ -134,8 +142,10 @@ pub fn load_sinks(sinks_csv: &str) -> anyhow::Result<Sinks> {
     load_sinks_from(sinks_csv, &env)
 }
 
-/// Testable core: loads sink configs from a provided env snapshot.
-pub fn load_sinks_from(sinks_csv: &str, env: &HashMap<String, String>) -> anyhow::Result<Sinks> {
+/// Parse the comma-separated sink names without loading per-sink configs.
+/// Used by `register_components` to register lifecycle handles before the
+/// full config is available.
+pub fn parse_sink_names(sinks_csv: &str) -> anyhow::Result<Vec<SinkName>> {
     let names: Vec<SinkName> = sinks_csv
         .split(',')
         .filter(|s| !s.trim().is_empty())
@@ -144,6 +154,12 @@ pub fn load_sinks_from(sinks_csv: &str, env: &HashMap<String, String>) -> anyhow
         .map_err(|e| anyhow::anyhow!("bad CAPTURE_V1_SINKS: {e}"))?;
 
     anyhow::ensure!(!names.is_empty(), "CAPTURE_V1_SINKS is empty");
+    Ok(names)
+}
+
+/// Testable core: loads sink configs from a provided env snapshot.
+pub fn load_sinks_from(sinks_csv: &str, env: &HashMap<String, String>) -> anyhow::Result<Sinks> {
+    let names = parse_sink_names(sinks_csv)?;
     let default = names[0];
 
     let mut configs = HashMap::new();

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -589,3 +589,213 @@ impl SinkResultTrait for MockSinkResult {
         self.elapsed
     }
 }
+
+// ---------------------------------------------------------------------------
+// TestStateBuilder — builds a router::State for V1 pipeline integration tests
+// ---------------------------------------------------------------------------
+
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use common_redis::MockRedisClient;
+use limiters::overflow::OverflowLimiter;
+use limiters::redis::{QuotaResource, QUOTA_LIMITER_CACHE_KEY};
+use limiters::token_dropper::TokenDropper;
+
+use crate::config::CaptureMode;
+use crate::event_restrictions::EventRestrictionService;
+use crate::global_rate_limiter::GlobalRateLimiter;
+use crate::quota_limiters::CaptureQuotaLimiter;
+use crate::router::{self, HistoricalConfig};
+use crate::sinks;
+use crate::time::TimeSource;
+use crate::v1::sinks::kafka::mock::MockProducer;
+use crate::v1::sinks::kafka::sink::KafkaSink;
+use crate::v1::sinks::sink::Sink;
+use crate::v1::sinks::{self as v1_sinks, SinkName};
+
+/// Result of building a test state — gives access to both the `router::State`
+/// and the underlying `MockProducer` so tests can inspect sent records.
+pub struct TestState {
+    pub state: router::State,
+    pub mock_producer: Arc<MockProducer>,
+}
+
+/// Builder for `router::State` with configurable mock services.
+pub struct TestStateBuilder {
+    quota_limited: bool,
+    overflow_limiter: Option<(NonZeroU32, NonZeroU32)>,
+    historical_threshold_days: Option<i64>,
+    restriction_service: Option<EventRestrictionService>,
+    global_rate_limiter: Option<Arc<GlobalRateLimiter>>,
+    mock_producer: Option<Arc<MockProducer>>,
+}
+
+impl Default for TestStateBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestStateBuilder {
+    pub fn new() -> Self {
+        Self {
+            quota_limited: false,
+            overflow_limiter: None,
+            historical_threshold_days: None,
+            restriction_service: None,
+            global_rate_limiter: None,
+            mock_producer: None,
+        }
+    }
+
+    /// Configure quota limiter to reject all events for any token.
+    pub fn with_quota_limited(mut self) -> Self {
+        self.quota_limited = true;
+        self
+    }
+
+    /// Add an in-process overflow limiter with the given rate and burst.
+    pub fn with_overflow_limiter(mut self, per_second: u32, burst: u32) -> Self {
+        self.overflow_limiter = Some((
+            NonZeroU32::new(per_second).expect("per_second must be > 0"),
+            NonZeroU32::new(burst).expect("burst must be > 0"),
+        ));
+        self
+    }
+
+    /// Enable historical rerouting with the given threshold in days.
+    pub fn with_historical_rerouting(mut self, threshold_days: i64) -> Self {
+        self.historical_threshold_days = Some(threshold_days);
+        self
+    }
+
+    /// Add a restriction service.
+    pub fn with_restriction_service(mut self, service: EventRestrictionService) -> Self {
+        self.restriction_service = Some(service);
+        self
+    }
+
+    /// Add a global rate limiter.
+    pub fn with_global_rate_limiter(mut self, limiter: Arc<GlobalRateLimiter>) -> Self {
+        self.global_rate_limiter = Some(limiter);
+        self
+    }
+
+    /// Supply a pre-configured MockProducer (e.g. for error injection).
+    pub fn with_mock_producer(mut self, producer: Arc<MockProducer>) -> Self {
+        self.mock_producer = Some(producer);
+        self
+    }
+
+    pub fn build(self) -> TestState {
+        let mut manager = lifecycle::Manager::builder("test_state")
+            .with_trap_signals(false)
+            .with_prestop_check(false)
+            .build();
+        let handle = manager.register("test_state", lifecycle::ComponentOptions::new());
+        handle.report_healthy();
+        let _monitor = manager.monitor_background();
+
+        let redis: Arc<dyn common_redis::Client + Send + Sync> = if self.quota_limited {
+            let mut mock = MockRedisClient::new();
+            for resource in &[
+                QuotaResource::Events,
+                QuotaResource::Recordings,
+                QuotaResource::Exceptions,
+                QuotaResource::Surveys,
+                QuotaResource::LLMEvents,
+            ] {
+                let key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, resource.as_str());
+                // Return a wildcard token so every token is limited
+                mock = mock.zrangebyscore_ret(&key, vec!["*".to_string()]);
+            }
+            Arc::new(mock)
+        } else {
+            Arc::new(MockRedisClient::new())
+        };
+
+        // CaptureQuotaLimiter needs a Config — build a minimal one via envconfig
+        let cfg_env: HashMap<String, String> = [
+            ("REDIS_URL", "redis://localhost:6379/"),
+            ("CAPTURE_MODE", "events"),
+            ("KAFKA_HOSTS", "localhost:9092"),
+            ("KAFKA_TOPIC", "events_plugin_ingestion"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+        let cfg: crate::config::Config =
+            envconfig::Envconfig::init_from_hashmap(&cfg_env).expect("failed to build test Config");
+
+        let quota_limiter = CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60));
+
+        let historical_cfg = match self.historical_threshold_days {
+            Some(days) => HistoricalConfig::new(true, days),
+            None => HistoricalConfig::new(false, 1),
+        };
+
+        let overflow_limiter = self
+            .overflow_limiter
+            .map(|(per_sec, burst)| Arc::new(OverflowLimiter::new(per_sec, burst, None, false)));
+
+        // Build the v1 sink router with a MockProducer-backed KafkaSink
+        let mock_producer = self
+            .mock_producer
+            .unwrap_or_else(|| Arc::new(MockProducer::new(SinkName::Msk, handle.clone())));
+
+        let kafka_config = test_kafka_config();
+        let sink_config = v1_sinks::Config {
+            produce_timeout: Duration::from_secs(30),
+            kafka: kafka_config,
+        };
+
+        let kafka_sink = KafkaSink::new(
+            SinkName::Msk,
+            Arc::clone(&mock_producer),
+            sink_config,
+            CaptureMode::Events,
+            handle.clone(),
+        );
+
+        let boxed_sink: Box<dyn Sink> = Box::new(kafka_sink);
+        let sinks_map: HashMap<SinkName, Box<dyn Sink>> =
+            [(SinkName::Msk, boxed_sink)].into_iter().collect();
+        let v1_router = v1_sinks::Router::new(SinkName::Msk, sinks_map);
+
+        // Legacy sink — no-op since V1 tests go through v1_sink_router
+        let legacy_sink: Arc<dyn sinks::Event + Send + Sync> =
+            Arc::new(crate::sinks::noop::NoOpSink::new());
+
+        let timesource: Arc<dyn TimeSource + Send + Sync> = Arc::new(crate::time::SystemTime {});
+
+        let state = router::State {
+            sink: legacy_sink,
+            timesource,
+            redis,
+            global_rate_limiter_token_distinctid: self.global_rate_limiter,
+            quota_limiter: Arc::new(quota_limiter),
+            token_dropper: Arc::new(TokenDropper::default()),
+            event_restriction_service: self.restriction_service,
+            event_payload_size_limit: 20 * 1024 * 1024,
+            historical_cfg,
+            is_mirror_deploy: false,
+            verbose_sample_percent: 0.0,
+            ai_max_sum_of_parts_bytes: 100 * 1024 * 1024,
+            ai_blob_storage: None,
+            body_chunk_read_timeout: None,
+            body_read_chunk_size_kb: 64,
+            capture_v1_max_compressed_body_bytes: 2 * 1024 * 1024,
+            capture_v1_max_decompressed_body_bytes: 20 * 1024 * 1024,
+            overflow_limiter,
+            replay_overflow_limiter: None,
+            v1_sink_router: Some(Arc::new(v1_router)),
+        };
+
+        TestState {
+            state,
+            mock_producer,
+        }
+    }
+}

--- a/rust/capture/src/v1/util.rs
+++ b/rust/capture/src/v1/util.rs
@@ -456,4 +456,20 @@ mod tests {
         let result = handler_roundtrip(None, original.clone(), 4096, 4096).await;
         assert_eq!(result.unwrap(), original);
     }
+
+    #[tokio::test]
+    async fn extract_body_stream_error_returns_decoding_error() {
+        let error_stream = stream::once(async {
+            Err::<Bytes, std::io::Error>(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "simulated stream error",
+            ))
+        });
+        let body = Body::from_stream(error_stream);
+        let result = extract_body_with_timeout(body, 4096, None, TEST_CHUNK_SIZE_KB, "/test").await;
+        assert!(
+            matches!(result, Err(Error::RequestDecodingError(_))),
+            "stream error should surface as RequestDecodingError, got: {result:?}"
+        );
+    }
 }

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -1109,6 +1109,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
             50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
             None,             // overflow_limiter
             None,             // replay_overflow_limiter
+            None,             // v1_sink_router
         ),
         sink,
     )

--- a/rust/capture/tests/common/mod.rs
+++ b/rust/capture/tests/common/mod.rs
@@ -1,2 +1,36 @@
+#![allow(clippy::duplicate_mod)]
+
 pub mod integration_utils;
 pub mod utils;
+
+/// Compress raw bytes using the given encoding.
+/// Shared across integration tests to avoid duplicating compression logic.
+#[allow(dead_code)]
+pub fn compress(data: &[u8], encoding: &str) -> Vec<u8> {
+    use std::io::Write;
+    match encoding {
+        "gzip" => {
+            let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+            enc.write_all(data).unwrap();
+            enc.finish().unwrap()
+        }
+        "deflate" => {
+            let mut enc =
+                flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::fast());
+            enc.write_all(data).unwrap();
+            enc.finish().unwrap()
+        }
+        "br" => {
+            let mut out = Vec::new();
+            brotli::BrotliCompress(
+                &mut std::io::Cursor::new(data),
+                &mut out,
+                &brotli::enc::BrotliEncoderParams::default(),
+            )
+            .unwrap();
+            out
+        }
+        "zstd" => zstd::encode_all(std::io::Cursor::new(data), 1).unwrap(),
+        other => panic!("unsupported encoding: {other}"),
+    }
+}

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -195,6 +195,7 @@ fn setup_ai_test_router() -> Router {
         50 * 1024 * 1024,                 // capture_v1_max_decompressed_body_bytes
         None,                             // overflow_limiter
         None,                             // replay_overflow_limiter
+        None,                             // v1_sink_router
     )
 }
 
@@ -1656,6 +1657,7 @@ fn setup_ai_test_router_with_capturing_sink() -> (Router, CapturingSink) {
         50 * 1024 * 1024,                 // capture_v1_max_decompressed_body_bytes
         None,                             // overflow_limiter
         None,                             // replay_overflow_limiter
+        None,                             // v1_sink_router
     );
 
     (router, sink_clone)
@@ -2569,6 +2571,7 @@ fn setup_ai_test_router_with_token_dropper(token_dropper: TokenDropper) -> (Rout
         50 * 1024 * 1024,                 // capture_v1_max_decompressed_body_bytes
         None,                             // overflow_limiter
         None,                             // replay_overflow_limiter
+        None,                             // v1_sink_router
     );
 
     (router, sink_clone)
@@ -2777,6 +2780,7 @@ fn setup_ai_test_router_with_llm_quota_limited(token: &str) -> (Router, Capturin
         50 * 1024 * 1024,                 // capture_v1_max_decompressed_body_bytes
         None,                             // overflow_limiter
         None,                             // replay_overflow_limiter
+        None,                             // v1_sink_router
     );
 
     (router, sink_clone)
@@ -2930,6 +2934,7 @@ fn setup_ai_test_router_with_overflow_limiter(
         50 * 1024 * 1024,       // capture_v1_max_decompressed_body_bytes
         Some(overflow_limiter), // overflow_limiter
         None,                   // replay_overflow_limiter
+        None,                   // v1_sink_router
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/integration_ai_restrictions.rs
+++ b/rust/capture/tests/integration_ai_restrictions.rs
@@ -193,6 +193,7 @@ async fn setup_ai_router_with_restriction(
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     (router, sink_clone)
@@ -510,6 +511,7 @@ async fn setup_ai_router_with_redirect_to_topic(
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     (router, sink_clone)
@@ -584,6 +586,7 @@ async fn setup_ai_router_with_force_overflow_and_limiter(
         50 * 1024 * 1024,       // capture_v1_max_decompressed_body_bytes
         Some(overflow_limiter), // overflow_limiter
         None,                   // replay_overflow_limiter
+        None,                   // v1_sink_router
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/integration_analytics_restrictions.rs
+++ b/rust/capture/tests/integration_analytics_restrictions.rs
@@ -127,6 +127,7 @@ async fn setup_analytics_router_with_restriction(
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     (router, sink_clone)
@@ -469,6 +470,7 @@ async fn setup_analytics_router_with_redirect_to_topic(
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/integration_otel_endpoint.rs
+++ b/rust/capture/tests/integration_otel_endpoint.rs
@@ -185,6 +185,7 @@ fn make_test_client_with_options(sink: &CapturingSink, options: TestClientOption
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         options.overflow_limiter, // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     TestClient::new(app)

--- a/rust/capture/tests/integration_replay_restrictions.rs
+++ b/rust/capture/tests/integration_replay_restrictions.rs
@@ -129,6 +129,7 @@ async fn setup_recordings_router_with_restriction(
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     (router, sink_clone)
@@ -497,6 +498,7 @@ async fn setup_recordings_router_with_redirect_to_topic(
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/quota_limiters.rs
+++ b/rust/capture/tests/quota_limiters.rs
@@ -151,6 +151,7 @@ async fn setup_router_with_limits(
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     (app, sink)
@@ -1201,6 +1202,7 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     let client = TestClient::new(app);
@@ -1289,6 +1291,7 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     let client = TestClient::new(app);
@@ -1381,6 +1384,7 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     let client = TestClient::new(app);
@@ -1810,6 +1814,7 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
         50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         None,             // overflow_limiter
         None,             // replay_overflow_limiter
+        None,             // v1_sink_router
     );
 
     let client = TestClient::new(app);

--- a/rust/capture/tests/v1_pipeline.rs
+++ b/rust/capture/tests/v1_pipeline.rs
@@ -1,0 +1,304 @@
+mod common;
+
+use std::sync::Arc;
+
+use rdkafka::error::RDKafkaErrorCode;
+use rstest::rstest;
+use uuid::Uuid;
+
+use capture::v1::analytics::process::process_batch;
+use capture::v1::analytics::response::BatchResponse;
+use capture::v1::analytics::types::{Batch, EventResult};
+use capture::v1::sinks::kafka::mock::MockProducer;
+use capture::v1::sinks::kafka::producer::ProduceError;
+use capture::v1::sinks::SinkName;
+use capture::v1::test_utils::{self, batch_payload, valid_event, TestStateBuilder};
+use capture::v1::Error;
+
+fn event_with_name(name: &str) -> capture::v1::analytics::types::Event {
+    let mut e = valid_event();
+    e.event = name.to_string();
+    e.uuid = Uuid::new_v4().to_string();
+    e
+}
+
+async fn run_batch(payload: &[u8], builder: TestStateBuilder) -> Result<BatchResponse, Error> {
+    run_batch_with_state(payload, builder).await.0
+}
+
+async fn run_batch_with_state(
+    payload: &[u8],
+    builder: TestStateBuilder,
+) -> (Result<BatchResponse, Error>, test_utils::TestState) {
+    let batch: Batch = serde_json::from_slice(payload).expect("payload must parse as Batch");
+    let ts = builder.build();
+    let mut ctx = test_utils::test_context();
+    let result = process_batch(&ts.state, &mut ctx, batch).await;
+    (result, ts)
+}
+
+// -------------------------------------------------------------------------
+// Table 1: Event Type → Destination Routing
+// -------------------------------------------------------------------------
+
+#[rstest]
+#[case::pageview("$pageview", "events_main")]
+#[case::exception("$exception", "error_tracking_events")]
+#[case::heatmap("$$heatmap", "heatmaps_ingestion")]
+#[case::client_warning("$$client_ingestion_warning", "events_plugin_ingestion")]
+#[case::custom("signup_complete", "events_main")]
+#[tokio::test]
+async fn event_type_routes_to_destination(#[case] event_name: &str, #[case] expected_topic: &str) {
+    let events = vec![event_with_name(event_name)];
+    let payload = batch_payload(&events);
+
+    let (result, ts) = run_batch_with_state(&payload, TestStateBuilder::new()).await;
+
+    let resp = result.expect("batch should succeed");
+    assert_eq!(resp.entries().len(), 1);
+    assert_eq!(resp.entries()[0].1.result, EventResult::Ok);
+
+    ts.mock_producer.with_records(|records| {
+        assert_eq!(records.len(), 1, "expected exactly 1 Kafka record");
+        assert_eq!(records[0].topic, expected_topic);
+    });
+}
+
+// -------------------------------------------------------------------------
+// Table 2: Processing Outcomes (Mixed Batches)
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mixed_batch_all_ok() {
+    let events = vec![
+        event_with_name("$pageview"),
+        event_with_name("$identify"),
+        event_with_name("custom_event"),
+    ];
+    let payload = batch_payload(&events);
+
+    let resp = run_batch(&payload, TestStateBuilder::new())
+        .await
+        .expect("batch should succeed");
+
+    assert_eq!(resp.entries().len(), 3);
+    assert!(!resp.has_retry);
+    for (_, status) in resp.entries() {
+        assert_eq!(status.result, EventResult::Ok);
+    }
+}
+
+#[tokio::test]
+async fn sink_ack_error_causes_retry() {
+    let mut manager = lifecycle::Manager::builder("test_ack_err")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .build();
+    let handle = manager.register("test_ack_err", lifecycle::ComponentOptions::new());
+    handle.report_healthy();
+    let _monitor = manager.monitor_background();
+
+    let producer =
+        Arc::new(
+            MockProducer::new(SinkName::Msk, handle).with_ack_error(|| ProduceError::Kafka {
+                code: RDKafkaErrorCode::BrokerNotAvailable,
+            }),
+        );
+
+    let events = vec![event_with_name("$pageview"), event_with_name("$identify")];
+    let payload = batch_payload(&events);
+
+    let resp = run_batch(
+        &payload,
+        TestStateBuilder::new().with_mock_producer(producer),
+    )
+    .await
+    .expect("batch should succeed");
+
+    assert_eq!(resp.entries().len(), 2);
+    assert!(resp.has_retry);
+    for (_, status) in resp.entries() {
+        assert_eq!(status.result, EventResult::Retry);
+    }
+}
+
+#[tokio::test]
+async fn all_events_quota_dropped() {
+    let events = vec![
+        event_with_name("$pageview"),
+        event_with_name("custom_event"),
+    ];
+    let payload = batch_payload(&events);
+
+    let ts = TestStateBuilder::new().with_quota_limited().build();
+
+    // with_quota_limited() loads a wildcard "*" token into the limiter's
+    // DashMap — use "*" as the api_token so `is_limited("*")` matches.
+    // Poll until the background task populates the cache (avoids flaky fixed sleep).
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let batch: Batch = serde_json::from_slice(&payload).expect("payload must parse as Batch");
+        let mut ctx = test_utils::test_context();
+        ctx.api_token = "*".to_string();
+        let result = process_batch(&ts.state, &mut ctx, batch).await;
+        if result.is_err() {
+            let err = result.unwrap_err();
+            assert!(
+                matches!(err, Error::BillingLimitExceeded),
+                "expected BillingLimitExceeded, got: {err:?}"
+            );
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "quota limiter cache was not populated within 2s"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+}
+
+#[tokio::test]
+async fn historical_rerouting() {
+    let old_ts = chrono::Utc::now() - chrono::Duration::days(60);
+    let mut event = valid_event();
+    event.timestamp = old_ts.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    event.uuid = Uuid::new_v4().to_string();
+
+    let events = vec![event];
+    let payload = batch_payload(&events);
+
+    let (result, ts) = run_batch_with_state(
+        &payload,
+        TestStateBuilder::new().with_historical_rerouting(30),
+    )
+    .await;
+
+    let resp = result.expect("batch should succeed");
+    assert_eq!(resp.entries().len(), 1);
+    assert_eq!(resp.entries()[0].1.result, EventResult::Ok);
+
+    ts.mock_producer.with_records(|records| {
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].topic, "events_hist",
+            "old event should route to historical topic"
+        );
+    });
+}
+
+// -------------------------------------------------------------------------
+// Table 3: Compression Round-Trip
+// -------------------------------------------------------------------------
+
+#[rstest]
+#[case::identity(None)]
+#[case::gzip(Some("gzip"))]
+#[case::zstd(Some("zstd"))]
+#[case::deflate(Some("deflate"))]
+#[case::brotli(Some("br"))]
+#[tokio::test]
+async fn compression_round_trip(#[case] encoding: Option<&str>) {
+    let events = vec![
+        event_with_name("$pageview"),
+        event_with_name("$exception"),
+        event_with_name("custom"),
+    ];
+    let raw = batch_payload(&events);
+
+    let payload = match encoding {
+        Some(enc) => common::compress(&raw, enc),
+        None => raw,
+    };
+
+    let batch: Batch = match encoding {
+        Some(enc) => {
+            let decompressed = capture::v1::util::decompress_payload(
+                Some(enc),
+                bytes::Bytes::from(payload),
+                20 * 1024 * 1024,
+                64,
+            )
+            .await
+            .expect("decompression should succeed");
+            serde_json::from_slice(&decompressed).expect("decompressed payload must parse")
+        }
+        None => serde_json::from_slice(&payload).expect("raw payload must parse"),
+    };
+
+    let ts = TestStateBuilder::new().build();
+    let mut ctx = test_utils::test_context();
+    if encoding.is_some() {
+        ctx.content_encoding = encoding.map(String::from);
+    }
+
+    let resp = process_batch(&ts.state, &mut ctx, batch)
+        .await
+        .expect("batch should succeed");
+
+    assert_eq!(resp.entries().len(), 3);
+    assert!(!resp.has_retry);
+    for (_, status) in resp.entries() {
+        assert_eq!(status.result, EventResult::Ok);
+    }
+}
+
+// -------------------------------------------------------------------------
+// Table 4: Validation Errors
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn empty_batch_error() {
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "created_at": "2026-03-19T14:30:00.000Z",
+        "batch": []
+    }))
+    .unwrap();
+
+    let err = run_batch(&payload, TestStateBuilder::new())
+        .await
+        .expect_err("empty batch should fail");
+
+    assert!(
+        matches!(err, Error::EmptyBatch),
+        "expected EmptyBatch, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_uuid_error() {
+    let shared_uuid = Uuid::new_v4().to_string();
+    let mut e1 = valid_event();
+    e1.uuid = shared_uuid.clone();
+    let mut e2 = valid_event();
+    e2.event = "$identify".to_string();
+    e2.uuid = shared_uuid;
+
+    let payload = batch_payload(&[e1, e2]);
+
+    let err = run_batch(&payload, TestStateBuilder::new())
+        .await
+        .expect_err("duplicate uuid should fail");
+
+    assert!(
+        matches!(err, Error::DuplicateEventUuid(_)),
+        "expected DuplicateEventUuid, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn missing_event_name_drops_event() {
+    let mut bad = valid_event();
+    bad.event = String::new();
+    let good = event_with_name("$pageview");
+
+    let payload = batch_payload(&[bad, good]);
+
+    let resp = run_batch(&payload, TestStateBuilder::new())
+        .await
+        .expect("batch with mix of valid and invalid events should succeed");
+
+    assert_eq!(resp.entries().len(), 2);
+    assert_eq!(resp.entries()[0].1.result, EventResult::Drop);
+    assert_eq!(resp.entries()[0].1.details, Some("missing_event_name"));
+    assert_eq!(resp.entries()[1].1.result, EventResult::Ok);
+}

--- a/rust/capture/tests/v1_sink_integration.rs
+++ b/rust/capture/tests/v1_sink_integration.rs
@@ -255,3 +255,194 @@ async fn v1_dropped_event_not_published() -> Result<()> {
     topic.assert_empty();
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Exception event routes to exception topic
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_exception_event_round_trip() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let ctx = v1_test_context();
+
+    let uuid = uuid::Uuid::new_v4();
+    let mut wrapped = test_utils::realistic_pageview("integ-user-exception");
+    wrapped.event.event = "$exception".to_string();
+    wrapped.uuid = uuid;
+    wrapped.event.uuid = uuid.to_string();
+    wrapped.destination = capture::v1::sinks::Destination::ExceptionErrorTracking;
+
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let results = sink.publish_batch(&ctx, &events).await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+
+    let event_json = topic.next_event()?;
+    let captured: CapturedEvent = serde_json::from_value(event_json)?;
+    assert_eq!(captured.event, "$exception");
+    assert_eq!(captured.uuid, uuid);
+    assert_eq!(captured.distinct_id, "integ-user-exception");
+
+    topic.assert_empty();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Cookieless mode affects partition key
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_cookieless_mode_partition_key() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let mut ctx = v1_test_context();
+    ctx.client_ip = "198.51.100.7".parse().unwrap();
+
+    let uuid = uuid::Uuid::new_v4();
+    let mut wrapped = test_utils::realistic_pageview("integ-user-cookieless");
+    wrapped.uuid = uuid;
+    wrapped.event.uuid = uuid.to_string();
+    wrapped.event.options.cookieless_mode = Some(true);
+
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let results = sink.publish_batch(&ctx, &events).await;
+    assert_eq!(results[0].outcome(), Outcome::Success);
+
+    let key = topic.next_message_key()?;
+    assert_eq!(
+        key.as_deref(),
+        Some("phc_integration_test_token:198.51.100.7"),
+        "cookieless mode should use token:IP as partition key"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Event with all options fields set — property injection round-trip
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_all_options_property_injection() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let ctx = v1_test_context();
+
+    let uuid = uuid::Uuid::new_v4();
+    let mut wrapped = test_utils::realistic_pageview("integ-user-all-opts");
+    wrapped.uuid = uuid;
+    wrapped.event.uuid = uuid.to_string();
+    wrapped.event.options = capture::v1::analytics::types::Options {
+        cookieless_mode: Some(true),
+        disable_skew_correction: Some(true),
+        product_tour_id: Some("tour_abc123".to_string()),
+        process_person_profile: Some(false),
+    };
+    wrapped.event.session_id = Some("sess-opt-test".to_string());
+    wrapped.event.window_id = Some("win-opt-test".to_string());
+
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let results = sink.publish_batch(&ctx, &events).await;
+    assert_eq!(results[0].outcome(), Outcome::Success);
+
+    let event_json = topic.next_event()?;
+    let captured: CapturedEvent = serde_json::from_value(event_json)?;
+    let data: RawEvent = serde_json::from_str(&captured.data)?;
+
+    assert_eq!(data.properties["$session_id"], "sess-opt-test");
+    assert_eq!(data.properties["$window_id"], "win-opt-test");
+    assert_eq!(data.properties["$cookieless_mode"], true);
+    assert_eq!(data.properties["$ignore_sent_at"], true);
+    assert_eq!(data.properties["$product_tour_id"], "tour_abc123");
+    assert_eq!(data.properties["$process_person_profile"], false);
+
+    topic.assert_empty();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Event with empty options — no extra properties injected from options
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_empty_options_no_injection() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let ctx = v1_test_context();
+
+    let uuid = uuid::Uuid::new_v4();
+    let mut wrapped = test_utils::realistic_pageview("integ-user-no-opts");
+    wrapped.uuid = uuid;
+    wrapped.event.uuid = uuid.to_string();
+    wrapped.event.options = capture::v1::analytics::types::Options {
+        cookieless_mode: None,
+        disable_skew_correction: None,
+        product_tour_id: None,
+        process_person_profile: None,
+    };
+    wrapped.event.session_id = None;
+    wrapped.event.window_id = None;
+
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let results = sink.publish_batch(&ctx, &events).await;
+    assert_eq!(results[0].outcome(), Outcome::Success);
+
+    let event_json = topic.next_event()?;
+    let captured: CapturedEvent = serde_json::from_value(event_json)?;
+    let data: RawEvent = serde_json::from_str(&captured.data)?;
+
+    assert!(!data.properties.contains_key("$session_id"));
+    assert!(!data.properties.contains_key("$window_id"));
+    assert!(!data.properties.contains_key("$cookieless_mode"));
+    assert!(!data.properties.contains_key("$ignore_sent_at"));
+    assert!(!data.properties.contains_key("$product_tour_id"));
+    assert!(!data.properties.contains_key("$process_person_profile"));
+
+    topic.assert_empty();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Multi-destination batch — events route correctly
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_multi_destination_batch() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let ctx = v1_test_context();
+
+    let main_ev = test_utils::realistic_pageview("integ-dest-main");
+    let hist_ev = test_utils::realistic_pageview("integ-dest-hist")
+        .with_destination(capture::v1::sinks::Destination::AnalyticsHistorical);
+    let overflow_ev = test_utils::realistic_pageview("integ-dest-overflow")
+        .with_destination(capture::v1::sinks::Destination::Overflow);
+
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&main_ev, &hist_ev, &overflow_ev];
+    let results = sink.publish_batch(&ctx, &events).await;
+    assert_eq!(results.len(), 3);
+    for r in &results {
+        assert_eq!(r.outcome(), Outcome::Success);
+    }
+
+    let mut distinct_ids = Vec::new();
+    for _ in 0..3 {
+        let json = topic.next_event()?;
+        let captured: CapturedEvent = serde_json::from_value(json)?;
+        distinct_ids.push(captured.distinct_id.clone());
+    }
+    distinct_ids.sort();
+    assert_eq!(
+        distinct_ids,
+        vec!["integ-dest-hist", "integ-dest-main", "integ-dest-overflow"]
+    );
+
+    topic.assert_empty();
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Move headers applied to every response type into middleware.

## Changes
Small change to DRY up response header generation

## How did you test this code?
Locally and in CI; existing tests validate

Stacked on #59757.

## Publish to changelog?
N/A

## 🤖 Agent context
N/A