### PR TITLE
fix(web-analytics): clearer precomputed badge icon and toggle tooltip

### DIFF
--- a/frontend/src/lib/components/PreAggregatedBadge/PreAggregatedBadge.tsx
+++ b/frontend/src/lib/components/PreAggregatedBadge/PreAggregatedBadge.tsx
@@ -1,4 +1,4 @@
-import { IconBolt, IconSparkles } from '@posthog/icons'
+import { IconBolt, IconDatabaseBolt } from '@posthog/icons'
 
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
@@ -18,9 +18,9 @@ const VARIANT_CONFIG: Record<
         Icon: IconBolt,
     },
     precomputed: {
-        tooltip: 'Served from precomputed cache',
+        tooltip: 'Loaded instantly from a pre-computed result',
         iconClassName: 'text-success w-4 h-4',
-        Icon: IconSparkles,
+        Icon: IconDatabaseBolt,
     },
 }
 

--- a/frontend/src/lib/components/PreAggregatedBadge/PreAggregatedBadge.tsx
+++ b/frontend/src/lib/components/PreAggregatedBadge/PreAggregatedBadge.tsx
@@ -18,7 +18,7 @@ const VARIANT_CONFIG: Record<
         Icon: IconBolt,
     },
     precomputed: {
-        tooltip: 'Loaded instantly from a pre-computed result',
+        tooltip: 'Loaded from a pre-computed dataset',
         iconClassName: 'text-success w-4 h-4',
         Icon: IconDatabaseBolt,
     },

--- a/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
@@ -60,7 +60,7 @@ export const WebAnalyticsMenu = (): JSX.Element => {
                     Filter out internal and test users
                 </ButtonPrimitive>
                 {featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_PRECOMPUTE_TOGGLE] && (
-                    <Tooltip title="Serve eligible web analytics queries (overview, paths) from the precomputed cache. Only takes effect when the web-analytics-precompute-toggle feature flag is on for the team's organization.">
+                    <Tooltip title="When on, eligible web analytics tiles (currently overview and paths) load from a pre-computed result instead of running a live query. Results are faster but may be a few minutes behind the latest events. Other tiles run live as usual.">
                         <ButtonPrimitive
                             menuItem
                             onClick={() => {


### PR DESCRIPTION
## Problem

Two web-analytics UI surfaces communicated the precompute behavior in a confusing way:

1. The badge that appears when a query is served from the precomputed cache used `IconSparkles`, which is the Max AI brand icon — putting it on a non-AI feature created a brand collision and made the result look AI-generated. The tooltip ("Served from precomputed cache") is implementation jargon.
2. The "Allow precompute" toggle in the web analytics scene panel had a tooltip that leaked the internal feature-flag name and didn't explain the user-visible trade-off (speed vs freshness).

## Changes

- `PreAggregatedBadge` `precomputed` variant: `IconSparkles` → `IconDatabaseBolt`, and tooltip → "Loaded instantly from a pre-computed result". `IconDatabaseBolt` stays in the same visual family as the sibling `preagg` variant's `IconBolt` while remaining distinct, and it's not used elsewhere on AI surfaces.
- `WebAnalyticsMenu` toggle tooltip rewritten to explain what the user gets (faster results on overview and paths) and what they give up (a few minutes of freshness), without mentioning the internal feature-flag name. Toggle label is unchanged.

No call sites were touched — both `DataTable` and `OverviewGrid` already consume the badge through the variant config, which is the single source of truth.

## How did you test this code?

I'm an agent. I did not run the app manually. Verified by reading the diff and running the repo's lint-staged hook on commit (oxlint + oxfmt over the two changed files, passed cleanly). The codebase's `tsc --noEmit` job OOM'd in my local environment so I did not get a clean typecheck pass locally — relying on CI for that.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7, 1M context).
- Approach: surveyed both surfaces (`PreAggregatedBadge.tsx`, `WebAnalyticsMenu.tsx`) and the icons currently used by Max AI (`frontend/src/scenes/max/`) to pick a non-colliding icon. `IconDatabaseBolt` was chosen because it reads as "data served fast", parallels the sibling `IconBolt` variant, and is not used on AI surfaces. `IconStack` was considered as a fallback. Toggle-tooltip rewrite drops the feature-flag name (toggle is already conditionally rendered behind that flag, so the user reading the tooltip definitionally has access) and instead surfaces the speed/freshness trade-off and the scoped list of affected tiles.
- Out of scope (kept the diff surgical): renaming the `precomputed` variant, the `useWebAnalyticsPrecompute` action/state, the `preagg` variant's icon/tooltip, and the toggle's label itself.