### PR TITLE
fix(web-analytics): thread uniqueKey through all dashboard tile renderers

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeCollectionLogic.test.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeCollectionLogic.test.ts
@@ -1,0 +1,95 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
+import { initKeaTests } from '~/test/init'
+
+describe('dataNodeCollectionLogic', () => {
+    let logic: ReturnType<typeof dataNodeCollectionLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = dataNodeCollectionLogic({ key: 'test-collection' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('reloadAll fires loadData on every mounted data node with force_async', () => {
+        const loadDataA = jest.fn()
+        const loadDataB = jest.fn()
+        const loadDataC = jest.fn()
+        const cancelQuery = jest.fn()
+
+        logic.actions.mountDataNode('tile-a', { id: 'tile-a', loadData: loadDataA, cancelQuery })
+        logic.actions.mountDataNode('tile-b', { id: 'tile-b', loadData: loadDataB, cancelQuery })
+        logic.actions.mountDataNode('tile-c', { id: 'tile-c', loadData: loadDataC, cancelQuery })
+
+        logic.actions.reloadAll()
+
+        expect(loadDataA).toHaveBeenCalledTimes(1)
+        expect(loadDataA).toHaveBeenCalledWith('force_async')
+        expect(loadDataB).toHaveBeenCalledTimes(1)
+        expect(loadDataB).toHaveBeenCalledWith('force_async')
+        expect(loadDataC).toHaveBeenCalledTimes(1)
+        expect(loadDataC).toHaveBeenCalledWith('force_async')
+    })
+
+    it('mountDataNode dedupes by id, replacing the prior loadData reference', () => {
+        const stale = jest.fn()
+        const fresh = jest.fn()
+        const cancelQuery = jest.fn()
+
+        logic.actions.mountDataNode('tile-a', { id: 'tile-a', loadData: stale, cancelQuery })
+        logic.actions.mountDataNode('tile-a', { id: 'tile-a', loadData: fresh, cancelQuery })
+
+        logic.actions.reloadAll()
+
+        expect(stale).not.toHaveBeenCalled()
+        expect(fresh).toHaveBeenCalledWith('force_async')
+    })
+
+    it('unmountDataNode removes the node so reloadAll skips it', () => {
+        const loadDataA = jest.fn()
+        const loadDataB = jest.fn()
+        const cancelQuery = jest.fn()
+
+        logic.actions.mountDataNode('tile-a', { id: 'tile-a', loadData: loadDataA, cancelQuery })
+        logic.actions.mountDataNode('tile-b', { id: 'tile-b', loadData: loadDataB, cancelQuery })
+        logic.actions.unmountDataNode('tile-a')
+
+        logic.actions.reloadAll()
+
+        expect(loadDataA).not.toHaveBeenCalled()
+        expect(loadDataB).toHaveBeenCalledWith('force_async')
+    })
+
+    it('areAnyLoading reflects per-node load state', async () => {
+        const cancelQuery = jest.fn()
+        logic.actions.mountDataNode('tile-a', { id: 'tile-a', loadData: jest.fn(), cancelQuery })
+        logic.actions.mountDataNode('tile-b', { id: 'tile-b', loadData: jest.fn(), cancelQuery })
+
+        await expectLogic(logic).toMatchValues({ areAnyLoading: false })
+
+        logic.actions.collectionNodeLoadData('tile-a')
+        await expectLogic(logic).toMatchValues({ areAnyLoading: true })
+
+        logic.actions.collectionNodeLoadDataSuccess('tile-a')
+        await expectLogic(logic).toMatchValues({ areAnyLoading: false })
+    })
+
+    it('cancelAllLoading only cancels nodes whose status is loading', () => {
+        const cancelA = jest.fn()
+        const cancelB = jest.fn()
+        logic.actions.mountDataNode('tile-a', { id: 'tile-a', loadData: jest.fn(), cancelQuery: cancelA })
+        logic.actions.mountDataNode('tile-b', { id: 'tile-b', loadData: jest.fn(), cancelQuery: cancelB })
+
+        logic.actions.collectionNodeLoadData('tile-a')
+        // tile-b never started loading
+        logic.actions.cancelAllLoading()
+
+        expect(cancelA).toHaveBeenCalledTimes(1)
+        expect(cancelB).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -650,9 +650,11 @@ export const WebStatsTrendTile = ({
     insightProps,
     attachTo,
     headerSlot,
+    uniqueKey,
 }: QueryWithInsightProps<InsightVizNode> & {
     showIntervalTile?: boolean
     headerSlot?: React.ReactNode
+    uniqueKey: string
 }): JSX.Element => {
     const { togglePropertyFilter, setDateInterval, zoomIntoPeriod, resetZoom } = useActions(webAnalyticsLogic)
     const {
@@ -808,7 +810,7 @@ export const WebStatsTrendTile = ({
                     )
                 }
             >
-                <Query attachTo={attachTo} query={query} readOnly={true} context={context} />
+                <Query uniqueKey={uniqueKey} attachTo={attachTo} query={query} readOnly={true} context={context} />
             </WebAnalyticsTileSkeletonGate>
         </div>
     )
@@ -818,7 +820,8 @@ export const AveragePageViewVisualizationTile = ({
     query,
     insightProps,
     attachTo,
-}: QueryWithInsightProps<DataVisualizationNode>): JSX.Element => {
+    uniqueKey,
+}: QueryWithInsightProps<DataVisualizationNode> & { uniqueKey: string }): JSX.Element => {
     const { setDateInterval } = useActions(webAnalyticsLogic)
     const {
         dateFilter: { interval },
@@ -833,6 +836,7 @@ export const AveragePageViewVisualizationTile = ({
                 </div>
             </div>
             <Query
+                uniqueKey={uniqueKey}
                 attachTo={attachTo}
                 query={query}
                 readOnly={true}
@@ -847,7 +851,8 @@ export const MarketingAnalyticsTrendTile = ({
     showIntervalTile,
     insightProps,
     attachTo,
-}: QueryWithInsightProps<InsightVizNode> & { showIntervalTile?: boolean }): JSX.Element => {
+    uniqueKey,
+}: QueryWithInsightProps<InsightVizNode> & { showIntervalTile?: boolean; uniqueKey: string }): JSX.Element => {
     const { setDateInterval, setChartDisplayType, setTileColumnSelection } = useActions(marketingAnalyticsLogic)
     const { dateFilter, chartDisplayType, tileColumnSelection } = useValues(marketingAnalyticsLogic)
 
@@ -891,6 +896,7 @@ export const MarketingAnalyticsTrendTile = ({
                 </div>
             )}
             <Query
+                uniqueKey={uniqueKey}
                 attachTo={attachTo}
                 query={query}
                 readOnly={true}
@@ -1152,7 +1158,11 @@ export const WebGoalsTile = ({
     insightProps,
     attachTo,
     headerSlot,
-}: QueryWithInsightProps<DataTableNode> & { headerSlot?: React.ReactNode }): JSX.Element | null => {
+    uniqueKey,
+}: QueryWithInsightProps<DataTableNode> & {
+    headerSlot?: React.ReactNode
+    uniqueKey: string
+}): JSX.Element | null => {
     const { actions, actionsLoading } = useValues(actionsModel)
     const { updateHasSeenProductIntroFor } = useActions(userLogic)
 
@@ -1176,7 +1186,15 @@ export const WebGoalsTile = ({
         )
     }
 
-    return <WebGoalsTileContent query={query} insightProps={insightProps} attachTo={attachTo} headerSlot={headerSlot} />
+    return (
+        <WebGoalsTileContent
+            query={query}
+            insightProps={insightProps}
+            attachTo={attachTo}
+            headerSlot={headerSlot}
+            uniqueKey={uniqueKey}
+        />
+    )
 }
 
 const WebGoalsTileContent = ({
@@ -1184,13 +1202,17 @@ const WebGoalsTileContent = ({
     insightProps,
     attachTo,
     headerSlot,
-}: QueryWithInsightProps<DataTableNode> & { headerSlot?: React.ReactNode }): JSX.Element => {
+    uniqueKey,
+}: QueryWithInsightProps<DataTableNode> & {
+    headerSlot?: React.ReactNode
+    uniqueKey: string
+}): JSX.Element => {
     const { addProductIntentForCrossSell } = useActions(teamLogic)
 
     const context = useMemo((): QueryContext => {
         return { ...webAnalyticsDataTableQueryContext, insightProps }
     }, [insightProps])
-    const dataNodeLogicProps = buildDataTableTileDataNodeLogicProps({ query, insightProps, context })
+    const dataNodeLogicProps = buildDataTableTileDataNodeLogicProps({ query, insightProps, context, uniqueKey })
 
     return (
         <div className="border rounded bg-surface-primary flex-1">
@@ -1217,7 +1239,7 @@ const WebGoalsTileContent = ({
                 dataNodeLogicProps={dataNodeLogicProps}
                 skeleton={<TableTileSkeleton numericColumns={4} />}
             >
-                <Query attachTo={attachTo} query={query} readOnly={true} context={context} />
+                <Query uniqueKey={uniqueKey} attachTo={attachTo} query={query} readOnly={true} context={context} />
             </WebAnalyticsTileSkeletonGate>
         </div>
     )
@@ -1228,7 +1250,11 @@ export const WebExternalClicksTile = ({
     insightProps,
     attachTo,
     headerSlot,
-}: QueryWithInsightProps<DataTableNode> & { headerSlot?: React.ReactNode }): JSX.Element | null => {
+    uniqueKey,
+}: QueryWithInsightProps<DataTableNode> & {
+    headerSlot?: React.ReactNode
+    uniqueKey: string
+}): JSX.Element | null => {
     const { productTab, shouldStripQueryParams } = useValues(webAnalyticsLogic)
     const { setShouldStripQueryParams } = useActions(webAnalyticsLogic)
 
@@ -1237,7 +1263,7 @@ export const WebExternalClicksTile = ({
     const context = useMemo((): QueryContext => {
         return { ...webAnalyticsDataTableQueryContext, insightProps }
     }, [insightProps])
-    const dataNodeLogicProps = buildDataTableTileDataNodeLogicProps({ query, insightProps, context })
+    const dataNodeLogicProps = buildDataTableTileDataNodeLogicProps({ query, insightProps, context, uniqueKey })
 
     return (
         <div className="border rounded bg-surface-primary flex-1 flex flex-col">
@@ -1258,7 +1284,7 @@ export const WebExternalClicksTile = ({
                 dataNodeLogicProps={dataNodeLogicProps}
                 skeleton={<TableTileSkeleton numericColumns={2} />}
             >
-                <Query attachTo={attachTo} query={query} readOnly={true} context={context} />
+                <Query uniqueKey={uniqueKey} attachTo={attachTo} query={query} readOnly={true} context={context} />
             </WebAnalyticsTileSkeletonGate>
         </div>
     )
@@ -1268,7 +1294,8 @@ export const WebVitalsPathBreakdownTile = ({
     query,
     insightProps,
     attachTo,
-}: QueryWithInsightProps<WebVitalsPathBreakdownQuery>): JSX.Element => {
+    uniqueKey,
+}: QueryWithInsightProps<WebVitalsPathBreakdownQuery> & { uniqueKey: string }): JSX.Element => {
     const { isPathCleaningEnabled } = useValues(webAnalyticsLogic)
     const { setIsPathCleaningEnabled } = useActions(webAnalyticsLogic)
 
@@ -1291,6 +1318,7 @@ export const WebVitalsPathBreakdownTile = ({
                 )}
             </div>
             <Query
+                uniqueKey={uniqueKey}
                 attachTo={attachTo}
                 query={query}
                 readOnly
@@ -1456,6 +1484,7 @@ export const WebQuery = ({
                 query={adjustedQuery}
                 insightProps={insightProps}
                 headerSlot={headerSlot}
+                uniqueKey={uniqueKey}
             />
         )
     }
@@ -1467,6 +1496,7 @@ export const WebQuery = ({
                 query={query}
                 showIntervalTile={showIntervalSelect}
                 insightProps={insightProps}
+                uniqueKey={uniqueKey}
             />
         )
     } else if (query.kind === NodeKind.InsightVizNode) {
@@ -1477,12 +1507,21 @@ export const WebQuery = ({
                 showIntervalTile={showIntervalSelect}
                 insightProps={insightProps}
                 headerSlot={headerSlot}
+                uniqueKey={uniqueKey}
             />
         )
     }
 
     if (query.kind === NodeKind.DataTableNode && query.source.kind === NodeKind.WebGoalsQuery) {
-        return <WebGoalsTile attachTo={attachTo} query={query} insightProps={insightProps} headerSlot={headerSlot} />
+        return (
+            <WebGoalsTile
+                attachTo={attachTo}
+                query={query}
+                insightProps={insightProps}
+                headerSlot={headerSlot}
+                uniqueKey={uniqueKey}
+            />
+        )
     }
 
     if (query.kind === NodeKind.DataTableNode && query.source.kind === NodeKind.MarketingAnalyticsTableQuery) {
@@ -1502,11 +1541,25 @@ export const WebQuery = ({
     }
 
     if (query.kind === NodeKind.WebVitalsPathBreakdownQuery) {
-        return <WebVitalsPathBreakdownTile attachTo={attachTo} query={query} insightProps={insightProps} />
+        return (
+            <WebVitalsPathBreakdownTile
+                attachTo={attachTo}
+                query={query}
+                insightProps={insightProps}
+                uniqueKey={uniqueKey}
+            />
+        )
     }
 
     if (query.kind === NodeKind.DataVisualizationNode) {
-        return <AveragePageViewVisualizationTile attachTo={attachTo} query={query} insightProps={insightProps} />
+        return (
+            <AveragePageViewVisualizationTile
+                attachTo={attachTo}
+                query={query}
+                insightProps={insightProps}
+                uniqueKey={uniqueKey}
+            />
+        )
     }
 
     if (query.kind === NodeKind.DataTableNode && query.source.kind === NodeKind.HogQLQuery) {


### PR DESCRIPTION
## Problem

User reported that clicking **Reload** in Web Analytics only refreshes the Web Overview tile — other tiles (Trends, tables, etc.) appear not to reload. Could not reproduce locally without the dev stack, and a full static audit of the data-node collection flow shows every tile factory correctly sets `dataNodeCollectionId: 'web-analytics'`. This PR doesn't claim to be the silver bullet — it closes a real consistency gap (a follow-up on #59670 / #59672) so the React `uniqueKey` is explicit across every dashboard tile renderer, eliminating one layer of "auto-derived" plumbing as a possible source of weird state-sharing between tiles.

## Changes

- `WebQuery` now passes its `uniqueKey` prop to every tile renderer it dispatches to. Previously only `WebStatsTableTile` (after #59670) and `HogQLTableTile` received it. Added to: `WebStatsTrendTile`, `WebGoalsTile`, `WebExternalClicksTile`, `MarketingAnalyticsTrendTile`, `WebVitalsPathBreakdownTile`, `AveragePageViewVisualizationTile`.
- Each of those tile components now accepts `uniqueKey: string`, forwards it to the inner `<Query>`, and (for `DataTable`-based tiles) passes it to `buildDataTableTileDataNodeLogicProps`.
- New `dataNodeCollectionLogic.test.ts` regression test covering `mountDataNode`/`unmountDataNode` dedup, `reloadAll` firing `loadData('force_async')` on every registered node, and `areAnyLoading`/`cancelAllLoading` semantics. Five tests, all passing.

No change to data-node logic keying — the key is still derived from `insightProps.dashboardItemId` in every path. This change just makes the React-level `uniqueKey` explicit instead of relying on `Query.tsx` to auto-derive it from `context.insightProps`.

## How did you test this code?

I'm an agent — only automated checks below, no manual UI verification:

- New `dataNodeCollectionLogic.test.ts` — 5 tests, all pass locally.
- Existing TypeScript compiles with no new errors from these files (verified by comparing `tsc` output against master).
- `oxlint` clean on both files.
- Existing `skeletons.test.tsx` has a pre-existing module-resolution failure on master (`@posthog/quill` missing) that this PR doesn't touch.

I could not start the PostHog dev stack in this environment, so the reported Web Analytics symptom hasn't been re-verified in a browser. **Reviewer please** open the dashboard with `#kea` appended to the URL, dispatch a Reload, and confirm `dataNodeCollectionLogic[key="web-analytics"].mountedDataNodes` lists every visible tile and that each receives `collectionNodeLoadData` on click.

## Publish to changelog?

no

## Docs update

No docs impact.

## 🤖 Agent context

Authored by Claude (agent) in collaboration with the reporter. The reporter described the bug ("only Web Overview reloads on click"), I traced the reload pipeline through `Reload.tsx` → `dataNodeCollectionLogic.reloadAll` → each tile's `dataNodeLogic` mount, audited every tile renderer in `WebAnalyticsTile.tsx`, and could not locate a definitive cause from static analysis: in master every tile factory already sets `dataNodeCollectionId: 'web-analytics'` via `createInsightProps` (`webAnalyticsLogic.tsx:1033`) and both the DataTable and InsightViz paths thread it correctly to `dataNodeLogic`.

Two paths were considered: (A) ask the reporter for a Kea-devtools snapshot of `mountedDataNodes` after clicking Reload, or (B) submit a defensive consistency PR while waiting for runtime confirmation. The reporter chose B. The change here is exactly the same pattern as the recently merged #59670 ("scope WebStatsTableTile dataNode key per tile"), extended to the rest of the tile family — making `uniqueKey` explicit on every dispatch out of `WebQuery` instead of leaving it to `Query.tsx`'s `props.uniqueKey ?? insightVizDataNodeKey(insightProps)` fallback. I deliberately did NOT touch `MarketingAnalyticsTable` (different scene, different collection key — `MARKETING_ANALYTICS_DATA_COLLECTION_NODE_ID`).

The regression test (`dataNodeCollectionLogic.test.ts`) is the part I'm most confident in: it locks down the contract that the Reload-all button depends on (every mounted node receives `loadData('force_async')`), so if anything in the registration layer regresses in the future, this test will catch it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*