### PR TITLE
fix(web-analytics): mute precomputed badge color and stop metric tooltip leaking on hover

### DIFF
--- a/frontend/src/lib/components/PreAggregatedBadge/PreAggregatedBadge.tsx
+++ b/frontend/src/lib/components/PreAggregatedBadge/PreAggregatedBadge.tsx
@@ -19,7 +19,7 @@ const VARIANT_CONFIG: Record<
     },
     precomputed: {
         tooltip: 'Loaded from a pre-computed dataset',
-        iconClassName: 'text-success w-4 h-4',
+        iconClassName: 'text-muted w-4 h-4',
         Icon: IconDatabaseBolt,
     },
 }

--- a/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
+++ b/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
@@ -184,59 +184,70 @@ const OverviewItemCell = ({
                 : 'No data'
 
     return (
-        <Tooltip title={tooltip}>
-            <div
-                className={clsx(
-                    compact ? OVERVIEW_ITEM_CELL_CLASSES_COMPACT : OVERVIEW_ITEM_CELL_CLASSES_DEFAULT,
-                    'relative'
-                )}
-            >
-                {usedLazyPrecompute ? (
-                    <PreAggregatedBadge variant="precomputed" />
-                ) : usedPreAggregatedTables ? (
-                    <PreAggregatedBadge variant="preagg" />
-                ) : null}
-                <div className="flex flex-row w-full justify-center items-center gap-1">
-                    <div className={`uppercase py-0.5 ${compact ? 'text-[10px]' : 'text-xs font-bold'}`}>{label}</div>
-                    {item.warning && (
-                        <Tooltip
-                            interactive={!!item.warningLink}
-                            title={
-                                <div>
-                                    {item.warning}
-                                    {item.warningLink && (
-                                        <>
-                                            {' '}
-                                            <Link to={item.warningLink} className="text-link">
-                                                Learn more
-                                            </Link>
-                                        </>
-                                    )}
-                                </div>
-                            }
-                        >
-                            <IconWarning className="text-warning h-3.5 w-3.5 cursor-pointer" />
-                        </Tooltip>
+        <div
+            className={clsx(
+                'flex-1 border bg-surface-primary rounded relative',
+                compact ? 'min-w-[6rem] h-24' : 'min-w-[10rem] h-30'
+            )}
+        >
+            {/* Rendered as a sibling of the Tooltip trigger so hovering the badge
+                does not also surface the cell's metric tooltip. */}
+            {usedLazyPrecompute ? (
+                <PreAggregatedBadge variant="precomputed" />
+            ) : usedPreAggregatedTables ? (
+                <PreAggregatedBadge variant="preagg" />
+            ) : null}
+            <Tooltip title={tooltip}>
+                <div
+                    className={clsx(
+                        'flex flex-col items-center text-center justify-between w-full h-full',
+                        compact ? 'p-1' : 'p-2'
+                    )}
+                >
+                    <div className="flex flex-row w-full justify-center items-center gap-1">
+                        <div className={`uppercase py-0.5 ${compact ? 'text-[10px]' : 'text-xs font-bold'}`}>
+                            {label}
+                        </div>
+                        {item.warning && (
+                            <Tooltip
+                                interactive={!!item.warningLink}
+                                title={
+                                    <div>
+                                        {item.warning}
+                                        {item.warningLink && (
+                                            <>
+                                                {' '}
+                                                <Link to={item.warningLink} className="text-link">
+                                                    Learn more
+                                                </Link>
+                                            </>
+                                        )}
+                                    </div>
+                                }
+                            >
+                                <IconWarning className="text-warning h-3.5 w-3.5 cursor-pointer" />
+                            </Tooltip>
+                        )}
+                    </div>
+                    <div className="w-full flex-1 flex items-center justify-center">
+                        <div className={compact ? 'text-lg' : 'text-2xl'}>
+                            {formatItem(item.value, item.kind, { currency: baseCurrency })}
+                        </div>
+                    </div>
+                    {trend && isNotNil(item.changeFromPreviousPct) ? (
+                        // eslint-disable-next-line react/forbid-dom-props
+                        <div style={{ color: trend.color }}>
+                            <trend.Icon color={trend.color} />
+                            {formatPercentage(item.changeFromPreviousPct)}
+                        </div>
+                    ) : isNotNil(item.changeFromPreviousPct) && Math.abs(item.changeFromPreviousPct) >= 999999 ? (
+                        <div className="text-muted">-</div>
+                    ) : (
+                        <div />
                     )}
                 </div>
-                <div className="w-full flex-1 flex items-center justify-center">
-                    <div className={compact ? 'text-lg' : 'text-2xl'}>
-                        {formatItem(item.value, item.kind, { currency: baseCurrency })}
-                    </div>
-                </div>
-                {trend && isNotNil(item.changeFromPreviousPct) ? (
-                    // eslint-disable-next-line react/forbid-dom-props
-                    <div style={{ color: trend.color }}>
-                        <trend.Icon color={trend.color} />
-                        {formatPercentage(item.changeFromPreviousPct)}
-                    </div>
-                ) : isNotNil(item.changeFromPreviousPct) && Math.abs(item.changeFromPreviousPct) >= 999999 ? (
-                    <div className="text-muted">-</div>
-                ) : (
-                    <div />
-                )}
-            </div>
-        </Tooltip>
+            </Tooltip>
+        </div>
     )
 }
 


### PR DESCRIPTION
## Problem

The pre-computed dataset badge on web analytics overview tiles was rendered in `text-success` green, which read as a status indicator rather than the informational hint it is. It also had a hover bug: because the badge sat inside the same `<Tooltip>` wrapper that drives each cell's metric tooltip, hovering the badge surfaced the metric tooltip (e.g. "Page views: increased by 6%…") instead of the badge's own "Loaded from a pre-computed dataset" tooltip.

## Changes

- `PreAggregatedBadge`: `precomputed` variant now uses `text-muted` instead of `text-success`. The `preagg` (yellow) variant is unchanged.
- `OverviewItemCell`: restructured so the badge is a **sibling** of the `<Tooltip>` trigger, not a descendant. The outer cell keeps the visual styling and `relative` anchor; an inner div picks up the flex layout + padding and is what the metric tooltip wraps. Hovering the badge now only fires the badge tooltip.

| Before | After |
| --- | --- |
| Green badge, hovering badge shows the cell metric tooltip | Muted badge, hovering badge shows its own tooltip |

## How did you test this code?

I am an agent. I ran:

- `pnpm --filter=@posthog/frontend format` (oxlint + oxfmt) — clean for the modified files
- `pnpm --filter=@posthog/frontend exec tsc --noEmit` against the modified files — no errors

No automated tests cover this component; manual verification in the running app is recommended before merge.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) in Claude Code.

- Found the badge in `frontend/src/lib/components/PreAggregatedBadge/PreAggregatedBadge.tsx` and the wrapping `OverviewItemCell` in `frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx`.
- Considered `stopPropagation` on the badge to suppress the outer tooltip — rejected because base-ui's tooltip uses pointer-enter on the trigger element, so the outer tooltip stays open while the cursor sits inside the cell regardless of bubbling.
- Chose to restructure the DOM so the badge is a sibling of the trigger: this gives mouseenter/mouseleave the correct semantics (moving from the inner content to the badge fires mouseleave on the inner trigger because the badge is no longer a descendant) and keeps the visual layout identical (outer holds `border`/`bg`/`min-w`/`h-*`/`relative`, inner picks up `p-*`/flex layout, badge stays `absolute top-2 right-2`).
- Skipped the optional "add a way to disable the badge from the tooltip / context menu" suggestion to keep the diff focused.