### PR TITLE
feat(health-checks): return lifecycle deltas from bulk_upsert/bulk_resolve

### DIFF
--- a/posthog/models/health_issue.py
+++ b/posthog/models/health_issue.py
@@ -2,7 +2,7 @@ import json
 import hashlib
 from typing import Any, Optional
 
-from django.db import models, transaction
+from django.db import connection, models, transaction
 from django.utils import timezone
 
 from posthog.models.utils import UUIDModel
@@ -119,7 +119,19 @@ class HealthIssue(UUIDModel):
             key = (issue["team_id"], issue["unique_hash"])
             incoming[key] = issue
 
+        # Serialize concurrent upserts for the same (kind, team_id) — SELECT
+        # FOR UPDATE can't lock a row that doesn't exist yet, and READ
+        # COMMITTED doesn't lock gaps, so two callers would otherwise both
+        # decide a hash is new and race into a duplicate bulk_create. Locks
+        # acquired in sorted order to avoid deadlocks across overlapping
+        # team_id sets.
+        kind_lock_key = int.from_bytes(hashlib.sha256(kind.encode()).digest()[:4], "big", signed=True)
+
         with transaction.atomic():
+            with connection.cursor() as cursor:
+                for team_id in sorted({tid for tid, _ in incoming}):
+                    cursor.execute("SELECT pg_advisory_xact_lock(%s, %s)", [kind_lock_key, team_id])
+
             existing_issues = {
                 (issue.team_id, issue.unique_hash): issue
                 for issue in cls.objects.filter(
@@ -195,7 +207,7 @@ class HealthIssue(UUIDModel):
                     status=cls.Status.ACTIVE,
                     team_id__in=team_ids,
                 )
-                resolved_rows = list(qs)
+                resolved_rows = list(qs.select_for_update())
                 qs.update(status=cls.Status.RESOLVED, resolved_at=now, updated_at=now)
                 _mark_resolved(resolved_rows)
                 return resolved_rows
@@ -209,7 +221,7 @@ class HealthIssue(UUIDModel):
                     status=cls.Status.ACTIVE,
                     team_id__in=team_ids_without_keep_hashes,
                 )
-                batch = list(qs)
+                batch = list(qs.select_for_update())
                 qs.update(status=cls.Status.RESOLVED, resolved_at=now, updated_at=now)
                 resolved_rows.extend(batch)
 
@@ -221,7 +233,7 @@ class HealthIssue(UUIDModel):
                 )
                 if hashes:
                     team_qs = team_qs.exclude(unique_hash__in=hashes)
-                batch = list(team_qs)
+                batch = list(team_qs.select_for_update())
                 team_qs.update(status=cls.Status.RESOLVED, resolved_at=now, updated_at=now)
                 resolved_rows.extend(batch)
 

--- a/posthog/models/health_issue.py
+++ b/posthog/models/health_issue.py
@@ -98,9 +98,19 @@ class HealthIssue(UUIDModel):
         cls,
         kind: str,
         issues: list[dict[str, Any]],
-    ) -> int:
+    ) -> list["HealthIssue"]:
+        """Upsert health issues; returns the rows that became active in this call.
+
+        A row is "newly active" when it had no matching ACTIVE row before — this
+        covers both brand-new issues and ones transitioning RESOLVED → ACTIVE
+        (the partial unique constraint only covers ACTIVE rows, so a resolved
+        row with the same hash does not block creation of a new active one).
+        Rows that were already ACTIVE and just got their severity/payload
+        refreshed are *not* returned — alert emission should fire on lifecycle
+        transitions, not on every detection tick.
+        """
         if not issues:
-            return 0
+            return []
 
         now = timezone.now()
 
@@ -150,7 +160,7 @@ class HealthIssue(UUIDModel):
             if to_update:
                 HealthIssue.objects.bulk_update(to_update, fields=["severity", "payload", "updated_at"])
 
-        return len(to_create) + len(to_update)
+        return to_create
 
     @classmethod
     def bulk_resolve(
@@ -158,43 +168,65 @@ class HealthIssue(UUIDModel):
         kind: str,
         team_ids: set[int],
         keep_hashes: dict[int, set[str]] | None = None,
-    ) -> int:
+    ) -> list["HealthIssue"]:
+        """Resolve stale active issues; returns the rows that transitioned ACTIVE -> RESOLVED.
+
+        Each row is fetched before the update so callers can fire side effects
+        (e.g. alert emission) on the exact set of transitioned rows. The
+        in-memory copies are mutated to reflect post-update state.
+        """
         if not team_ids:
-            return 0
+            return []
 
         now = timezone.now()
 
+        def _mark_resolved(rows: list[HealthIssue]) -> None:
+            for row in rows:
+                row.status = cls.Status.RESOLVED
+                row.resolved_at = now
+                row.updated_at = now
+
+        resolved_rows: list[HealthIssue] = []
+
         with transaction.atomic():
             if not keep_hashes:
-                return cls.objects.filter(
+                qs = HealthIssue.objects.filter(
                     kind=kind,
                     status=cls.Status.ACTIVE,
                     team_id__in=team_ids,
-                ).update(status=cls.Status.RESOLVED, resolved_at=now, updated_at=now)
+                )
+                resolved_rows = list(qs)
+                qs.update(status=cls.Status.RESOLVED, resolved_at=now, updated_at=now)
+                _mark_resolved(resolved_rows)
+                return resolved_rows
 
             keep_hashes_by_team = {team_id: hashes for team_id, hashes in keep_hashes.items() if team_id in team_ids}
             team_ids_without_keep_hashes = team_ids - set(keep_hashes_by_team.keys())
 
-            resolved = 0
-
             if team_ids_without_keep_hashes:
-                resolved += cls.objects.filter(
+                qs = HealthIssue.objects.filter(
                     kind=kind,
                     status=cls.Status.ACTIVE,
                     team_id__in=team_ids_without_keep_hashes,
-                ).update(status=cls.Status.RESOLVED, resolved_at=now, updated_at=now)
+                )
+                batch = list(qs)
+                qs.update(status=cls.Status.RESOLVED, resolved_at=now, updated_at=now)
+                resolved_rows.extend(batch)
 
             for team_id, hashes in keep_hashes_by_team.items():
-                team_qs = cls.objects.filter(
+                team_qs = HealthIssue.objects.filter(
                     kind=kind,
                     status=cls.Status.ACTIVE,
                     team_id=team_id,
                 )
                 if hashes:
                     team_qs = team_qs.exclude(unique_hash__in=hashes)
-                resolved += team_qs.update(status=cls.Status.RESOLVED, resolved_at=now, updated_at=now)
+                batch = list(team_qs)
+                team_qs.update(status=cls.Status.RESOLVED, resolved_at=now, updated_at=now)
+                resolved_rows.extend(batch)
 
-        return resolved
+            _mark_resolved(resolved_rows)
+            return resolved_rows
 
     def resolve(self) -> None:
         if self.status != self.Status.ACTIVE:

--- a/posthog/models/test/test_health_issue.py
+++ b/posthog/models/test/test_health_issue.py
@@ -142,3 +142,60 @@ class TestHealthIssue(BaseTest):
         issue.resolve()
         issue.refresh_from_db()
         self.assertIsNotNone(issue.resolved_at)
+
+    def _bulk_payload(self, unique_hash: str, severity: str = "warning") -> dict:
+        return {
+            "team_id": self.team.id,
+            "severity": severity,
+            "payload": {"detail": unique_hash},
+            "unique_hash": unique_hash,
+        }
+
+    def test_bulk_upsert_returns_newly_created_issues(self):
+        created = HealthIssue.bulk_upsert("test_kind", [self._bulk_payload("a"), self._bulk_payload("b")])
+        self.assertEqual({i.unique_hash for i in created}, {"a", "b"})
+        self.assertTrue(all(i.status == HealthIssue.Status.ACTIVE for i in created))
+
+    def test_bulk_upsert_does_not_return_already_active_issues(self):
+        HealthIssue.bulk_upsert("test_kind", [self._bulk_payload("a", severity="warning")])
+        second_pass = HealthIssue.bulk_upsert("test_kind", [self._bulk_payload("a", severity="critical")])
+        self.assertEqual(second_pass, [])
+
+        existing = HealthIssue.objects.get(team=self.team, kind="test_kind", unique_hash="a")
+        self.assertEqual(existing.severity, "critical")
+
+    def test_bulk_upsert_returns_reactivated_issue(self):
+        first = HealthIssue.bulk_upsert("test_kind", [self._bulk_payload("a")])
+        self.assertEqual(len(first), 1)
+        first[0].resolve()
+
+        reactivated = HealthIssue.bulk_upsert("test_kind", [self._bulk_payload("a")])
+        self.assertEqual(len(reactivated), 1)
+        self.assertEqual(reactivated[0].unique_hash, "a")
+        self.assertEqual(reactivated[0].status, HealthIssue.Status.ACTIVE)
+        self.assertNotEqual(reactivated[0].id, first[0].id)
+
+    def test_bulk_upsert_empty_input_returns_empty_list(self):
+        self.assertEqual(HealthIssue.bulk_upsert("test_kind", []), [])
+
+    def test_bulk_resolve_returns_transitioned_rows(self):
+        created = HealthIssue.bulk_upsert("test_kind", [self._bulk_payload("a"), self._bulk_payload("b")])
+        self.assertEqual(len(created), 2)
+
+        resolved = HealthIssue.bulk_resolve("test_kind", {self.team.id})
+        self.assertEqual({i.unique_hash for i in resolved}, {"a", "b"})
+        self.assertTrue(all(i.status == HealthIssue.Status.RESOLVED for i in resolved))
+        self.assertTrue(all(i.resolved_at is not None for i in resolved))
+
+    def test_bulk_resolve_with_keep_hashes_skips_active(self):
+        HealthIssue.bulk_upsert("test_kind", [self._bulk_payload("a"), self._bulk_payload("b")])
+        resolved = HealthIssue.bulk_resolve("test_kind", {self.team.id}, keep_hashes={self.team.id: {"a"}})
+        self.assertEqual({i.unique_hash for i in resolved}, {"b"})
+        self.assertTrue(HealthIssue.objects.filter(unique_hash="a", status=HealthIssue.Status.ACTIVE).exists())
+
+    def test_bulk_resolve_empty_team_ids_returns_empty_list(self):
+        self.assertEqual(HealthIssue.bulk_resolve("test_kind", set()), [])
+
+    def test_bulk_resolve_no_active_issues_returns_empty_list(self):
+        resolved = HealthIssue.bulk_resolve("test_kind", {self.team.id})
+        self.assertEqual(resolved, [])

--- a/posthog/temporal/health_checks/db.py
+++ b/posthog/temporal/health_checks/db.py
@@ -2,10 +2,16 @@ from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.models import HealthCheckResult
 
 
-def _upsert_issues(
+def upsert_issues_with_deltas(
     kind: str,
     issues_by_team: dict[int, list[HealthCheckResult]],
-) -> int:
+) -> list[HealthIssue]:
+    """Upsert health issues from a batch detection result.
+
+    Returns the rows that became active in this call (newly created or
+    transitioned from RESOLVED). These are the rows that should trigger
+    a `firing` alert.
+    """
     issues = [
         {
             "team_id": team_id,
@@ -19,11 +25,16 @@ def _upsert_issues(
     return HealthIssue.bulk_upsert(kind, issues)
 
 
-def _resolve_stale_issues(
+def resolve_stale_issues_with_deltas(
     kind: str,
     issues_by_team: dict[int, list[HealthCheckResult]],
     healthy_team_ids: set[int],
-) -> int:
+) -> list[HealthIssue]:
+    """Resolve issues for teams that no longer trip the check.
+
+    Returns the rows that transitioned ACTIVE -> RESOLVED in this call.
+    These are the rows that should trigger a `resolved` alert.
+    """
     all_team_ids = healthy_team_ids | set(issues_by_team.keys())
 
     keep_hashes: dict[int, set[str]] = {}

--- a/posthog/temporal/health_checks/processing.py
+++ b/posthog/temporal/health_checks/processing.py
@@ -2,7 +2,7 @@ import time
 
 import structlog
 
-from posthog.temporal.health_checks.db import _resolve_stale_issues, _upsert_issues
+from posthog.temporal.health_checks.db import resolve_stale_issues_with_deltas, upsert_issues_with_deltas
 from posthog.temporal.health_checks.models import BatchDetectFn, BatchResult
 from posthog.temporal.health_checks.validation import _validate_batch_output
 
@@ -40,13 +40,15 @@ def _process_batch_detection(
         return result
 
     start = time.monotonic()
-    result.issues_upserted = _upsert_issues(kind, issues_by_team)
+    newly_active = upsert_issues_with_deltas(kind, issues_by_team)
+    result.issues_upserted = len(newly_active)
     result.db_write_duration = time.monotonic() - start
 
     healthy_team_ids = set(team_ids) - set(issues_by_team.keys())
 
     start = time.monotonic()
-    result.issues_resolved = _resolve_stale_issues(kind, issues_by_team, healthy_team_ids)
+    newly_resolved = resolve_stale_issues_with_deltas(kind, issues_by_team, healthy_team_ids)
+    result.issues_resolved = len(newly_resolved)
     result.resolve_duration = time.monotonic() - start
 
     return result


### PR DESCRIPTION
## Problem

The Temporal health-check orchestrator wants to fire alert events on `HealthIssue` lifecycle transitions — once when a row becomes ACTIVE, once when it transitions ACTIVE → RESOLVED. Today `bulk_upsert` and `bulk_resolve` return only `int` counts, so the per-row delta isn't exposed to the orchestrator.

This PR adds the plumbing. No alerts are emitted yet — that's the next PR in the stack ([#59984](https://github.com/PostHog/posthog/pull/59984)).

## Changes

**Model — `posthog/models/health_issue.py`:**

- `bulk_upsert` now returns `list[HealthIssue]` of rows that became active in this call. The existing query already filters by `status=ACTIVE`, so reactivation from `RESOLVED` naturally lands in `to_create` (the partial unique constraint only covers `ACTIVE` rows). Updates to already-active rows aren't returned — alert emission should fire on lifecycle transitions, not every detection tick.
- `bulk_resolve` now returns `list[HealthIssue]` of rows that transitioned `ACTIVE` → `RESOLVED`. Each batch is materialised before the `.update()` so callers see the exact set of transitioned rows; in-memory copies are mutated to reflect the post-update state.

**Temporal-side wrappers — new `posthog/temporal/health_checks/db.py`:**

`upsert_issues_with_deltas` and `resolve_stale_issues_with_deltas` mirror the existing Dagster helpers in `posthog/dags/common/health/db.py` but forward the lists out. The Dagster path is intentionally untouched: its `_upsert_issues` / `_resolve_stale_issues` keep their `-> int` contract via a `len(...)` wrapper, so no behaviour changes for Dagster.

**Orchestrator — `posthog/temporal/health_checks/processing.py`:**

Switches to the new wrappers and captures the delta lists into local variables. `result.issues_upserted` / `result.issues_resolved` still report ints via `len(...)`. The lists are stored for the next PR to consume.

## How did you test this code?

I'm Claude (Opus 4.7) — automated checks only.

- 8 new tests in `posthog/models/test/test_health_issue.py` covering:
  - `bulk_upsert` returns newly-created rows
  - `bulk_upsert` returns nothing for already-active rows that just got refreshed
  - `bulk_upsert` returns reactivated-from-resolved rows
  - `bulk_resolve` returns the rows it transitioned (with mutated status / resolved_at)
  - `bulk_resolve` with `keep_hashes` skips matching active rows
  - Empty-input and no-active-issues edge cases
- `ruff` / formatter / `ty check` pass via lint-staged pre-commit
- Did not run the tests against a real ClickHouse/Postgres locally (no local stack); pytest collects all 19 tests cleanly

## Publish to changelog?

No.

## Docs update

None needed.

## 🤖 Agent context

Authored via Claude Code (Opus 4.7) in collaboration with @rafaeelaudibert. Originated from a review of PR #58211 (SDK Doctor alerting), where the per-product `_emit_alerts_for_outdated_teams` pattern was found to not scale to the ~10 health checks already in the registry. Plan refined remotely via Ultraplan.

Key design choice: keep the partial-unique-constraint semantics doing the dedup work. A row in `to_create` is exactly "newly active" — there is no separate Redis cooldown needed. This subsumes the per-team 7-day cooldown the original PR added in `products/growth/backend/sdk_doctor_alerts.py`; that file gets deleted later in the stack.

This is the base of a 4-PR stack:

- this PR (model deltas)
- [#59984](https://github.com/PostHog/posthog/pull/59984) — emit alert events from the deltas
- [#59985](https://github.com/PostHog/posthog/pull/59985) — wizard + central scene
- [#59986](https://github.com/PostHog/posthog/pull/59986) — mount entry points + per-check `render_alert`
