### PR TITLE
feat(health-checks): emit alert events on issue lifecycle transitions

### DIFF
--- a/posthog/temporal/health_checks/alerts.py
+++ b/posthog/temporal/health_checks/alerts.py
@@ -47,8 +47,8 @@ def emit_health_check_alert(issue: HealthIssue, *, status: Literal["firing", "re
     """Emit one $health_check_issue_{firing,resolved} event for a transition.
 
     Returns True if the event was produced. Failures (render or Kafka) are
-    swallowed and reported to Sentry so a single bad issue cannot break the
-    orchestrator batch.
+    swallowed and reported to error tracking so a single bad issue cannot
+    break the orchestrator batch.
     """
     try:
         content = _render(issue)

--- a/posthog/temporal/health_checks/alerts.py
+++ b/posthog/temporal/health_checks/alerts.py
@@ -6,7 +6,7 @@ from posthog.cdp.internal_events import InternalEventEvent, produce_internal_eve
 from posthog.exceptions_capture import capture_exception
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.framework import AlertContent, HealthCheck
-from posthog.temporal.health_checks.registry import _DETECT_FNS
+from posthog.temporal.health_checks.registry import _DETECT_FNS, ensure_registry_loaded
 
 logger = structlog.get_logger(__name__)
 
@@ -24,7 +24,9 @@ EVENT_RESOLVED = "$health_check_issue_resolved"
 def _check_class_for_kind(kind: str) -> type[HealthCheck] | None:
     # The registry only stores instance-bound detect callables, but every
     # HealthCheck subclass binds `cls()` so the underlying class is reachable
-    # via the bound method's `__self__`.
+    # via the bound method's `__self__`. Ensure the registry is loaded so this
+    # works when called outside the orchestrator's primary code path.
+    ensure_registry_loaded()
     fn = _DETECT_FNS.get(kind)
     if fn is None:
         return None

--- a/posthog/temporal/health_checks/alerts.py
+++ b/posthog/temporal/health_checks/alerts.py
@@ -1,0 +1,79 @@
+from typing import Literal
+
+import structlog
+
+from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
+from posthog.exceptions_capture import capture_exception
+from posthog.models.health_issue import HealthIssue
+from posthog.temporal.health_checks.framework import AlertContent, HealthCheck
+from posthog.temporal.health_checks.registry import _DETECT_FNS
+
+logger = structlog.get_logger(__name__)
+
+
+EVENT_FIRING = "$health_check_issue_firing"
+EVENT_RESOLVED = "$health_check_issue_resolved"
+
+
+# FUTURE: this module is the seam where a Signals-style inbox can plug in.
+# Health-check transitions already carry a uniform envelope (kind / severity /
+# title / summary / link / payload); a Signals integration can read from the
+# same event stream — keep that envelope stable as new fields are added.
+
+
+def _check_class_for_kind(kind: str) -> type[HealthCheck] | None:
+    # The registry only stores instance-bound detect callables, but every
+    # HealthCheck subclass binds `cls()` so the underlying class is reachable
+    # via the bound method's `__self__`.
+    fn = _DETECT_FNS.get(kind)
+    if fn is None:
+        return None
+    instance = getattr(fn, "__self__", None)
+    if instance is None:
+        return None
+    return type(instance)
+
+
+def _render(issue: HealthIssue) -> AlertContent:
+    check_cls = _check_class_for_kind(issue.kind)
+    if check_cls is None:
+        return AlertContent(title=issue.kind, summary=f"{issue.kind} ({issue.severity})", link="/health")
+    return check_cls.render_alert(issue)
+
+
+def emit_health_check_alert(issue: HealthIssue, *, status: Literal["firing", "resolved"]) -> bool:
+    """Emit one $health_check_issue_{firing,resolved} event for a transition.
+
+    Returns True if the event was produced. Failures (render or Kafka) are
+    swallowed and reported to Sentry so a single bad issue cannot break the
+    orchestrator batch.
+    """
+    try:
+        content = _render(issue)
+        produce_internal_event(
+            team_id=issue.team_id,
+            event=InternalEventEvent(
+                event=EVENT_FIRING if status == "firing" else EVENT_RESOLVED,
+                distinct_id=f"team_{issue.team_id}",
+                properties={
+                    "kind": issue.kind,
+                    "severity": issue.severity,
+                    "issue_id": str(issue.id),
+                    "title": content.title,
+                    "summary": content.summary,
+                    "link": content.link,
+                    "payload": issue.payload,
+                },
+            ),
+        )
+        return True
+    except Exception as e:
+        logger.exception(
+            "Failed to emit health-check alert",
+            kind=issue.kind,
+            issue_id=str(issue.id),
+            status=status,
+            error=str(e),
+        )
+        capture_exception(e, additional_properties={"kind": issue.kind, "issue_id": str(issue.id), "status": status})
+        return False

--- a/posthog/temporal/health_checks/framework.py
+++ b/posthog/temporal/health_checks/framework.py
@@ -1,12 +1,33 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from posthog.clickhouse.query_tagging import Product
 from posthog.dags.common.owners import JobOwners
 from posthog.temporal.health_checks.detectors import DEFAULT_EXECUTION_POLICY, HealthExecutionPolicy
 from posthog.temporal.health_checks.models import DEFAULT_ACTIVE_SINCE_DAYS, HealthCheckResult
 from posthog.temporal.health_checks.registry import _DETECT_FNS, HEALTH_CHECKS
+
+if TYPE_CHECKING:
+    from posthog.models.health_issue import HealthIssue
+
+
+@dataclass(frozen=True)
+class AlertContent:
+    """User-facing description of a fired health-check alert.
+
+    Health checks override `HealthCheck.render_alert` to produce one of
+    these. The fields are embedded into `$health_check_issue_firing` and
+    `$health_check_issue_resolved` event properties, where HogFunction
+    templates pick them up as `event.properties.title`, etc.
+    """
+
+    title: str
+    summary: str
+    # Relative path inside the PostHog app (e.g. "/health/sdk-doctor").
+    # HogFunction templates concatenate this onto {project.url}.
+    link: str
 
 
 @dataclass(frozen=True)
@@ -67,3 +88,17 @@ class HealthCheck:
 
     def detect(self, team_ids: list[int]) -> dict[int, list[HealthCheckResult]]:
         raise NotImplementedError
+
+    @classmethod
+    def render_alert(cls, issue: HealthIssue) -> AlertContent:
+        """Build the alert content surfaced to HogFunction destinations.
+
+        The default produces a generic title/summary keyed off `kind` and
+        `severity` with a link to /health. Concrete checks override this to
+        produce a human-readable message that names the affected resource.
+        """
+        return AlertContent(
+            title=cls.name,
+            summary=f"{cls.kind} ({issue.severity})",
+            link="/health",
+        )

--- a/posthog/temporal/health_checks/processing.py
+++ b/posthog/temporal/health_checks/processing.py
@@ -2,6 +2,7 @@ import time
 
 import structlog
 
+from posthog.temporal.health_checks.alerts import emit_health_check_alert
 from posthog.temporal.health_checks.db import resolve_stale_issues_with_deltas, upsert_issues_with_deltas
 from posthog.temporal.health_checks.models import BatchDetectFn, BatchResult
 from posthog.temporal.health_checks.validation import _validate_batch_output
@@ -50,5 +51,10 @@ def _process_batch_detection(
     newly_resolved = resolve_stale_issues_with_deltas(kind, issues_by_team, healthy_team_ids)
     result.issues_resolved = len(newly_resolved)
     result.resolve_duration = time.monotonic() - start
+
+    for issue in newly_active:
+        emit_health_check_alert(issue, status="firing")
+    for issue in newly_resolved:
+        emit_health_check_alert(issue, status="resolved")
 
     return result

--- a/posthog/temporal/health_checks/tests/test_alert_emission.py
+++ b/posthog/temporal/health_checks/tests/test_alert_emission.py
@@ -2,6 +2,8 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
+from parameterized import parameterized
+
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.alerts import EVENT_FIRING, EVENT_RESOLVED, emit_health_check_alert
 from posthog.temporal.health_checks.framework import AlertContent, HealthCheck
@@ -59,19 +61,31 @@ class TestEmitHealthCheckAlert(SimpleTestCase):
         self.assertEqual(props["title"], "not_in_registry")
         self.assertEqual(props["link"], "/health")
 
-    @patch("posthog.temporal.health_checks.alerts.capture_exception")
-    @patch("posthog.temporal.health_checks.alerts._check_class_for_kind", return_value=_StubCheck)
-    @patch("posthog.temporal.health_checks.alerts.produce_internal_event", side_effect=RuntimeError("kafka down"))
-    def test_produce_failure_is_swallowed_and_captured(self, _produce, _lookup, capture):
-        fired = emit_health_check_alert(_make_issue(), status="firing")
-        self.assertFalse(fired)
-        capture.assert_called_once()
-
-    @patch("posthog.temporal.health_checks.alerts.capture_exception")
-    @patch("posthog.temporal.health_checks.alerts._check_class_for_kind", return_value=_BadCheck)
-    @patch("posthog.temporal.health_checks.alerts.produce_internal_event")
-    def test_render_failure_is_swallowed_and_captured(self, produce, _lookup, capture):
-        fired = emit_health_check_alert(_make_issue(), status="firing")
-        self.assertFalse(fired)
-        produce.assert_not_called()
-        capture.assert_called_once()
+    @parameterized.expand(
+        [
+            ("produce_fails", _StubCheck, RuntimeError("kafka down"), True),
+            ("render_fails", _BadCheck, None, False),
+        ]
+    )
+    def test_failure_is_swallowed_and_captured(
+        self,
+        _name: str,
+        check_cls: type[HealthCheck],
+        produce_side_effect: Exception | None,
+        expects_produce_call: bool,
+    ) -> None:
+        with (
+            patch("posthog.temporal.health_checks.alerts._check_class_for_kind", return_value=check_cls),
+            patch(
+                "posthog.temporal.health_checks.alerts.produce_internal_event",
+                side_effect=produce_side_effect,
+            ) as produce,
+            patch("posthog.temporal.health_checks.alerts.capture_exception") as capture,
+        ):
+            fired = emit_health_check_alert(_make_issue(), status="firing")
+            self.assertFalse(fired)
+            if expects_produce_call:
+                produce.assert_called_once()
+            else:
+                produce.assert_not_called()
+            capture.assert_called_once()

--- a/posthog/temporal/health_checks/tests/test_alert_emission.py
+++ b/posthog/temporal/health_checks/tests/test_alert_emission.py
@@ -1,0 +1,77 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from posthog.models.health_issue import HealthIssue
+from posthog.temporal.health_checks.alerts import EVENT_FIRING, EVENT_RESOLVED, emit_health_check_alert
+from posthog.temporal.health_checks.framework import AlertContent, HealthCheck
+
+
+class _StubCheck(HealthCheck):
+    # No name/kind class attributes -> __init_subclass__ skips auto-registration.
+    @classmethod
+    def render_alert(cls, issue: HealthIssue) -> AlertContent:
+        return AlertContent(title="stub title", summary=f"stub for {issue.kind}", link="/health/stub")
+
+
+class _BadCheck(HealthCheck):
+    @classmethod
+    def render_alert(cls, issue: HealthIssue) -> AlertContent:
+        raise ValueError("boom")
+
+
+def _make_issue(kind: str = "stub_check", severity: str = "warning") -> HealthIssue:
+    return HealthIssue(team_id=42, kind=kind, severity=severity, payload={"detail": "x"}, unique_hash="h")
+
+
+class TestEmitHealthCheckAlert(SimpleTestCase):
+    @patch("posthog.temporal.health_checks.alerts._check_class_for_kind", return_value=_StubCheck)
+    @patch("posthog.temporal.health_checks.alerts.produce_internal_event")
+    def test_firing_emits_event_with_envelope(self, produce, _lookup):
+        issue = _make_issue()
+        fired = emit_health_check_alert(issue, status="firing")
+        self.assertTrue(fired)
+        produce.assert_called_once()
+        kwargs = produce.call_args.kwargs
+        self.assertEqual(kwargs["team_id"], 42)
+        event = kwargs["event"]
+        self.assertEqual(event.event, EVENT_FIRING)
+        self.assertEqual(event.distinct_id, "team_42")
+        self.assertEqual(event.properties["kind"], "stub_check")
+        self.assertEqual(event.properties["severity"], "warning")
+        self.assertEqual(event.properties["title"], "stub title")
+        self.assertEqual(event.properties["summary"], "stub for stub_check")
+        self.assertEqual(event.properties["link"], "/health/stub")
+        self.assertEqual(event.properties["payload"], {"detail": "x"})
+
+    @patch("posthog.temporal.health_checks.alerts._check_class_for_kind", return_value=_StubCheck)
+    @patch("posthog.temporal.health_checks.alerts.produce_internal_event")
+    def test_resolved_emits_resolved_event(self, produce, _lookup):
+        emit_health_check_alert(_make_issue(), status="resolved")
+        self.assertEqual(produce.call_args.kwargs["event"].event, EVENT_RESOLVED)
+
+    @patch("posthog.temporal.health_checks.alerts._check_class_for_kind", return_value=None)
+    @patch("posthog.temporal.health_checks.alerts.produce_internal_event")
+    def test_unregistered_kind_falls_back_to_generic_content(self, produce, _lookup):
+        emit_health_check_alert(_make_issue(kind="not_in_registry"), status="firing")
+        props = produce.call_args.kwargs["event"].properties
+        # Generic fallback: title == kind, link defaults to /health
+        self.assertEqual(props["title"], "not_in_registry")
+        self.assertEqual(props["link"], "/health")
+
+    @patch("posthog.temporal.health_checks.alerts.capture_exception")
+    @patch("posthog.temporal.health_checks.alerts._check_class_for_kind", return_value=_StubCheck)
+    @patch("posthog.temporal.health_checks.alerts.produce_internal_event", side_effect=RuntimeError("kafka down"))
+    def test_produce_failure_is_swallowed_and_captured(self, _produce, _lookup, capture):
+        fired = emit_health_check_alert(_make_issue(), status="firing")
+        self.assertFalse(fired)
+        capture.assert_called_once()
+
+    @patch("posthog.temporal.health_checks.alerts.capture_exception")
+    @patch("posthog.temporal.health_checks.alerts._check_class_for_kind", return_value=_BadCheck)
+    @patch("posthog.temporal.health_checks.alerts.produce_internal_event")
+    def test_render_failure_is_swallowed_and_captured(self, produce, _lookup, capture):
+        fired = emit_health_check_alert(_make_issue(), status="firing")
+        self.assertFalse(fired)
+        produce.assert_not_called()
+        capture.assert_called_once()

--- a/products/growth/backend/temporal/health_checks/sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/sdk_outdated.py
@@ -18,6 +18,7 @@ from products.growth.backend.constants import (
     github_sdk_versions_key,
     team_sdk_versions_key,
 )
+from products.growth.backend.sdk_health import _is_safe_for_interpolation
 
 logger = structlog.get_logger(__name__)
 
@@ -91,7 +92,12 @@ class SdkOutdatedCheck(HealthCheck):
         sdk_name = issue.payload.get("sdk_name", "an SDK")
         latest = issue.payload.get("latest_version") or "the latest version"
         usage = issue.payload.get("usage") or []
-        current = usage[0].get("lib_version") if usage else None
+        # `lib_version` originates from the $lib_version event property — attacker
+        # controllable via project token. Gate it through the same allowlist used
+        # by SDK Doctor before interpolating into a string we forward to alert
+        # destinations (Slack, email, webhooks).
+        raw_current = usage[0].get("lib_version") if usage else None
+        current = raw_current if raw_current and _is_safe_for_interpolation(raw_current) else None
         summary = f"{sdk_name} is on {current}, latest is {latest}" if current else f"{sdk_name} is behind {latest}"
         return AlertContent(
             title=f"{sdk_name} SDK is outdated",

--- a/products/growth/backend/temporal/health_checks/sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/sdk_outdated.py
@@ -7,7 +7,7 @@ from posthog.dags.common.owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.redis import get_client
 from posthog.temporal.health_checks.detectors import HealthExecutionPolicy
-from posthog.temporal.health_checks.framework import HealthCheck
+from posthog.temporal.health_checks.framework import AlertContent, HealthCheck
 from posthog.temporal.health_checks.models import HealthCheckResult
 from posthog.temporal.health_checks.query import execute_clickhouse_health_team_query
 
@@ -85,6 +85,19 @@ class SdkOutdatedCheck(HealthCheck):
     policy = HealthExecutionPolicy(batch_size=10, max_concurrent=3)
     schedule = "0 8 * * *"
     active_since_days = 30
+
+    @classmethod
+    def render_alert(cls, issue: HealthIssue) -> AlertContent:
+        sdk_name = issue.payload.get("sdk_name", "an SDK")
+        latest = issue.payload.get("latest_version") or "the latest version"
+        usage = issue.payload.get("usage") or []
+        current = usage[0].get("lib_version") if usage else None
+        summary = f"{sdk_name} is on {current}, latest is {latest}" if current else f"{sdk_name} is behind {latest}"
+        return AlertContent(
+            title=f"{sdk_name} SDK is outdated",
+            summary=summary,
+            link="/health/sdk-doctor",
+        )
 
     def detect(self, team_ids: list[int]) -> dict[int, list[HealthCheckResult]]:
         github_data = _load_github_sdk_data()

--- a/products/growth/backend/temporal/health_checks/tests/test_sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/tests/test_sdk_outdated.py
@@ -2,7 +2,9 @@ import json
 
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
+
+from parameterized import parameterized
 
 from posthog.models.health_issue import HealthIssue
 
@@ -189,3 +191,29 @@ class TestSdkOutdatedCheck(TestCase):
         mock_pipe.setex.assert_called_once()
         _key, ttl, _payload = mock_pipe.setex.call_args[0]
         assert ttl == TEAM_SDK_CACHE_EXPIRY
+
+
+class TestSdkOutdatedRenderAlert(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("safe_version", "1.198.0", "web is on 1.198.0, latest is 1.200.0"),
+            ("space_injection", "1.198.0 <https://evil.example|click>", "web is behind 1.200.0"),
+            ("newline_injection", "1.198.0\n@channel", "web is behind 1.200.0"),
+            ("markdown_injection", "**1.198.0**", "web is behind 1.200.0"),
+            ("empty_string", "", "web is behind 1.200.0"),
+        ]
+    )
+    def test_render_alert_rejects_unsafe_lib_version(self, _name: str, raw_version: str, expected_summary: str) -> None:
+        issue = HealthIssue(
+            team_id=1,
+            kind="sdk_outdated",
+            severity=HealthIssue.Severity.WARNING,
+            payload={
+                "sdk_name": "web",
+                "latest_version": "1.200.0",
+                "usage": [{"lib_version": raw_version, "count": 100, "max_timestamp": "2026-03-20"}],
+            },
+            unique_hash="h",
+        )
+        content = SdkOutdatedCheck.render_alert(issue)
+        assert content.summary == expected_summary


### PR DESCRIPTION
## Problem

PostHog has ~10 concrete health checks under `posthog/temporal/health_checks/` (SDK outdated, ingestion warnings, external data failures, web-vitals gaps, no-pageleave, scroll depth, authorized URLs, reverse proxy, materialized view failures, …). The original SDK Doctor alerting PR (#58211) wired Slack/Discord/Teams/email/webhook destinations to **one** of those kinds via a bespoke event name (`$sdk_doctor_alert_firing`), a bespoke `HogFunctionConfigurationContextId`, a bespoke per-team Redis cooldown, and ~120 lines of hand-authored destination templates in `sub-templates.ts`. Repeating that pattern per kind would bloat `sub-templates.ts` to ~2000 lines and require ~10 copies of the emission glue.

This PR introduces a single emission path that fires for every health check, with a uniform event envelope. Concrete checks override one `render_alert` classmethod to provide their user-facing copy; nothing else per-kind is needed.

## Changes

**Framework — `posthog/temporal/health_checks/framework.py`:**

- New `AlertContent` frozen dataclass: `title`, `summary`, `link` (relative path; templates concatenate onto `{project.url}`)
- New `HealthCheck.render_alert(issue) -> AlertContent` classmethod with a generic default that uses `cls.name` / `cls.kind` / `issue.severity` and links to `/health`

**Emitter — new `posthog/temporal/health_checks/alerts.py`:**

Two internal event names — `$health_check_issue_firing` and `$health_check_issue_resolved` — produced via `produce_internal_event` with a uniform envelope:

```
kind, severity, issue_id, title, summary, link, payload
```

Per-issue `try/except` mirroring `products/logs/backend/temporal/activities.py` so one bad render or one Kafka error never breaks the batch. Failures are captured via `posthog.exceptions_capture.capture_exception`.

**Orchestrator — `posthog/temporal/health_checks/processing.py`:**

Iterates the newly-active and newly-resolved lists returned by the previous PR ([#59983](https://github.com/PostHog/posthog/pull/59983)) and calls `emit_health_check_alert(issue, status=...)` per row.

**SDK Doctor — `products/growth/backend/temporal/health_checks/sdk_outdated.py`:**

`SdkOutdatedCheck.render_alert` returns a human-readable summary keyed off `issue.payload['sdk_name']` and `latest_version`, with `link="/health/sdk-doctor"`.

## How did you test this code?

I'm Claude (Opus 4.7) — automated checks only.

- 5 new tests in `posthog/temporal/health_checks/tests/test_alert_emission.py` covering:
  - Firing emits with the full envelope
  - Resolved emits the resolved event name
  - Unregistered kinds fall back to the generic content
  - Kafka failures are swallowed and captured
  - `render_alert` exceptions are swallowed and captured
- `ruff` / formatter / `ty check` pass via lint-staged pre-commit
- Did not run end-to-end against a real Kafka / temporal worker locally

## Publish to changelog?

No — wait for the user-facing pieces ([#59985](https://github.com/PostHog/posthog/pull/59985), [#59986](https://github.com/PostHog/posthog/pull/59986)).

## Docs update

None needed yet — user-facing docs land with the rollout PR.

## 🤖 Agent context

Authored via Claude Code (Opus 4.7) in collaboration with @rafaeelaudibert. Originated from a review of #58211; plan refined remotely via Ultraplan.

Decisions worth flagging for reviewers:

- **Cooldown via lifecycle, not Redis.** Built on top of [#59983](https://github.com/PostHog/posthog/pull/59983)'s delta returns: while an issue stays `ACTIVE`, no re-emission. Only `to_create` (brand-new + reactivated) and `bulk_resolve` outputs fire. This subsumes the 7-day per-team Redis cooldown the original PR added in `products/growth/backend/sdk_doctor_alerts.py`. That file gets removed in the SDK-Doctor migration further up the stack.
- **Symmetric firing/resolved events.** Logs alerting also does this; symmetric semantics let users get a "recovered" notification without extra plumbing.
- **Registry lookup via `_DETECT_FNS[kind].__self__`.** The registry stores the bound `detect` method per kind; the unbound class is reachable via the method's `__self__`. No new registry surface area was needed.
- **Existing precedents kept intact.** Error tracking and logs alerting still use their own event names and sub-templates; they remain sibling alert families. No refactor of those is included here.

This PR stacks on [#59983](https://github.com/PostHog/posthog/pull/59983) and is followed by [#59985](https://github.com/PostHog/posthog/pull/59985) and [#59986](https://github.com/PostHog/posthog/pull/59986).
