### PR TITLE
feat(health-alerts): add wizard and central scene for health-check alerts

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -309,6 +309,7 @@ export const FEATURE_FLAGS = {
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
     GROUP_PROFILE_EXPERIMENT: 'group-profile-experiment', // owner: @arthurdedeus #team-customer-analytics
     HACKATHONS_SUBSCRIPTIONS: 'hackathons_subscriptions', // owner: #team-analytics-platform, gates listing subscription delivery history and AI change summaries
+    HEALTH_ALERTS: 'health-alerts', // owner: #team-growth, gates the central /health/alerts scene and per-page Alerts buttons
     INTER_PROJECT_TRANSFERS: 'inter-project-transfers', // owner: @reecejones #team-platform-features
     JS_SNIPPET_VERSIONING: 'js-snippet-versioning', // owner: #team-client-libraries
     LEGAL_DOCUMENTS: 'legal-documents', // owner: @rafaeelaudibert #team-growth

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -105,6 +105,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.WebScripts]: () => import('./data-pipelines/WebScriptsScene'),
     [Scene.Health]: () => import('./health/HealthScene'),
     [Scene.HealthCategoryDetail]: () => import('./health/categoryDetail/HealthCategoryDetailScene'),
+    [Scene.HealthAlerts]: () => import('./health-alerts/HealthAlertsScene'),
     [Scene.PipelineStatus]: () => import('./health/pipelineStatus/PipelineStatusScene'),
     [Scene.SdkDoctor]: () => import('./onboarding/sdks/SdkDoctorScene'),
     [Scene.Exports]: () => import('./exports/ExportsScene'),

--- a/frontend/src/scenes/health-alerts/HealthAlertsEntryPoint.tsx
+++ b/frontend/src/scenes/health-alerts/HealthAlertsEntryPoint.tsx
@@ -1,0 +1,119 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { AlertWizard } from 'scenes/hog-functions/AlertWizard/AlertWizard'
+import {
+    AlertCreationView,
+    AlertWizardLogicProps,
+    alertWizardLogic,
+} from 'scenes/hog-functions/AlertWizard/alertWizardLogic'
+import { HogFunctionList } from 'scenes/hog-functions/list/HogFunctionsList'
+import { HogFunctionTemplateList } from 'scenes/hog-functions/list/HogFunctionTemplateList'
+import { getFiltersFromSubTemplateId } from 'scenes/hog-functions/list/LinkedHogFunctions'
+
+import { CyclotronJobFiltersType } from '~/types'
+
+import {
+    HEALTH_ALERT_DESTINATIONS,
+    HEALTH_ALERT_SUB_TEMPLATE_IDS,
+    HEALTH_ALERT_TRIGGERS,
+} from './healthAlertsWizardConfig'
+
+const HOG_FUNCTION_FILTER_LIST = HEALTH_ALERT_SUB_TEMPLATE_IDS.map(getFiltersFromSubTemplateId).filter(
+    (f) => !!f
+) as CyclotronJobFiltersType[]
+
+export interface HealthAlertsEntryPointProps {
+    // `logicKey` keeps multiple mounts (e.g. SDK Doctor + central page in the
+    // same session) from sharing wizard state.
+    logicKey?: string
+    // Restricts the resulting HogFunction's filter to a `kind IN (...)` set.
+    // Omit on the central page to leave filters unrestricted (every kind).
+    presetKinds?: string[]
+}
+
+export function HealthAlertsEntryPoint({
+    logicKey = 'health-alerts',
+    presetKinds,
+}: HealthAlertsEntryPointProps = {}): JSX.Element {
+    const wizardProps: AlertWizardLogicProps = {
+        logicKey,
+        subTemplateIds: HEALTH_ALERT_SUB_TEMPLATE_IDS,
+        triggers: HEALTH_ALERT_TRIGGERS,
+        destinations: HEALTH_ALERT_DESTINATIONS,
+        presetTriggerKinds: presetKinds,
+    }
+
+    return (
+        <BindLogic logic={alertWizardLogic} props={wizardProps}>
+            <HealthAlertsEntryPointInner />
+        </BindLogic>
+    )
+}
+
+function HealthAlertsEntryPointInner(): JSX.Element {
+    const { alertCreationView, subTemplateIds } = useValues(alertWizardLogic)
+    const { setAlertCreationView, resetWizard } = useActions(alertWizardLogic)
+
+    if (alertCreationView === AlertCreationView.Wizard) {
+        return (
+            <AlertWizard
+                onCancel={() => {
+                    setAlertCreationView(AlertCreationView.None)
+                    resetWizard()
+                }}
+                onSwitchToTraditional={() => {
+                    posthog.capture('health_alerts_creation_switched_to_traditional', { source: 'wizard' })
+                    setAlertCreationView(AlertCreationView.Traditional)
+                    resetWizard()
+                }}
+            />
+        )
+    }
+
+    if (alertCreationView === AlertCreationView.Traditional) {
+        return (
+            <HogFunctionTemplateList
+                type="destination"
+                subTemplateIds={subTemplateIds}
+                getConfigurationOverrides={(id) => (id ? getFiltersFromSubTemplateId(id) : undefined)}
+                extraControls={
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        onClick={() => setAlertCreationView(AlertCreationView.None)}
+                    >
+                        Cancel
+                    </LemonButton>
+                }
+            />
+        )
+    }
+
+    return (
+        <HogFunctionList
+            forceFilterGroups={HOG_FUNCTION_FILTER_LIST}
+            type="internal_destination"
+            onDeleteHogFunction={(hogFunction) => {
+                posthog.capture('health_alerts_deleted', { hog_function_id: hogFunction.id })
+            }}
+            onEditHogFunction={(hogFunction) => {
+                posthog.capture('health_alerts_edit_clicked', { hog_function_id: hogFunction.id })
+            }}
+            extraControls={
+                <LemonButton
+                    type="primary"
+                    size="small"
+                    onClick={() => {
+                        posthog.capture('health_alerts_creation_started', { source: 'wizard_button' })
+                        setAlertCreationView(AlertCreationView.Wizard)
+                    }}
+                >
+                    New health alert
+                </LemonButton>
+            }
+        />
+    )
+}

--- a/frontend/src/scenes/health-alerts/HealthAlertsScene.tsx
+++ b/frontend/src/scenes/health-alerts/HealthAlertsScene.tsx
@@ -1,0 +1,25 @@
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { HealthAlertsEntryPoint } from './HealthAlertsEntryPoint'
+
+export const scene: SceneExport = {
+    component: HealthAlertsScene,
+}
+
+export function HealthAlertsScene(): JSX.Element {
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name="Health alerts"
+                description="Get notified when a PostHog health check fires or recovers. Pick a destination (Slack, Discord, Teams, email, or webhook) and the kinds of checks you care about."
+                resourceType={{ type: 'health' }}
+            />
+            <HealthAlertsEntryPoint />
+        </SceneContent>
+    )
+}
+
+export default HealthAlertsScene

--- a/frontend/src/scenes/health-alerts/healthAlertsWizardConfig.ts
+++ b/frontend/src/scenes/health-alerts/healthAlertsWizardConfig.ts
@@ -1,0 +1,59 @@
+import { WizardDestination, WizardTrigger } from 'scenes/hog-functions/AlertWizard/alertWizardLogic'
+
+import { HogFunctionSubTemplateIdType } from '~/types'
+
+export const HEALTH_ALERT_SUB_TEMPLATE_IDS: HogFunctionSubTemplateIdType[] = [
+    'health-check-firing',
+    'health-check-resolved',
+]
+
+export const HEALTH_ALERT_TRIGGERS: WizardTrigger[] = [
+    {
+        key: 'health-check-firing',
+        name: 'Health check fired',
+        description: 'Get notified when a health issue is newly detected',
+    },
+    {
+        key: 'health-check-resolved',
+        name: 'Health check resolved',
+        description: 'Get notified when a previously active health issue clears',
+    },
+]
+
+export const HEALTH_ALERT_DESTINATIONS: WizardDestination[] = [
+    {
+        key: 'slack',
+        name: 'Slack',
+        description: 'Send a message to a channel',
+        icon: '/static/services/slack.png',
+        templateId: 'template-slack',
+    },
+    {
+        key: 'discord',
+        name: 'Discord',
+        description: 'Post a notification via webhook',
+        icon: '/static/services/discord.png',
+        templateId: 'template-discord',
+    },
+    {
+        key: 'microsoft-teams',
+        name: 'Teams',
+        description: 'Send a message to a channel',
+        icon: '/static/services/microsoft-teams.png',
+        templateId: 'template-microsoft-teams',
+    },
+    {
+        key: 'email',
+        name: 'Email',
+        description: 'Send an email notification',
+        icon: '/static/posthog-icon.svg',
+        templateId: 'template-email',
+    },
+    {
+        key: 'webhook',
+        name: 'Webhook',
+        description: 'Send an HTTP request to any URL',
+        icon: '/static/services/webhook.svg',
+        templateId: 'template-webhook',
+    },
+]

--- a/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.test.ts
@@ -1,0 +1,70 @@
+import { CyclotronJobFiltersType, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { applyKindFilter } from './alertWizardLogic'
+
+describe('applyKindFilter', () => {
+    const baseFilters: CyclotronJobFiltersType = {
+        events: [{ id: '$health_check_issue_firing', type: 'events' }],
+    }
+
+    it('returns filters unchanged when selectedKinds is null', () => {
+        expect(applyKindFilter(baseFilters, null)).toBe(baseFilters)
+    })
+
+    it('returns filters unchanged when selectedKinds is empty', () => {
+        expect(applyKindFilter(baseFilters, [])).toBe(baseFilters)
+    })
+
+    it('returns undefined when base filters are undefined', () => {
+        expect(applyKindFilter(undefined, ['sdk_outdated'])).toBeUndefined()
+    })
+
+    it('adds a kind IN (...) property filter on the first event', () => {
+        const result = applyKindFilter(baseFilters, ['sdk_outdated', 'ingestion_warning'])
+        expect(result?.events?.[0]).toEqual({
+            id: '$health_check_issue_firing',
+            type: 'events',
+            properties: [
+                {
+                    key: 'kind',
+                    value: ['sdk_outdated', 'ingestion_warning'],
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.Event,
+                },
+            ],
+        })
+    })
+
+    it('replaces any existing properties on the first event', () => {
+        const withProps: CyclotronJobFiltersType = {
+            events: [
+                {
+                    id: '$health_check_issue_firing',
+                    type: 'events',
+                    properties: [
+                        {
+                            key: 'some_other',
+                            value: 'x',
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                },
+            ],
+        }
+        const result = applyKindFilter(withProps, ['sdk_outdated'])
+        expect(result?.events?.[0].properties).toHaveLength(1)
+        expect(result?.events?.[0].properties?.[0].key).toBe('kind')
+    })
+
+    it('does not touch additional events past the first', () => {
+        const twoEvents: CyclotronJobFiltersType = {
+            events: [
+                { id: '$health_check_issue_firing', type: 'events' },
+                { id: '$other_event', type: 'events' },
+            ],
+        }
+        const result = applyKindFilter(twoEvents, ['sdk_outdated'])
+        expect(result?.events?.[1]).toEqual({ id: '$other_event', type: 'events' })
+    })
+})

--- a/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.test.ts
@@ -7,12 +7,11 @@ describe('applyKindFilter', () => {
         events: [{ id: '$health_check_issue_firing', type: 'events' }],
     }
 
-    it('returns filters unchanged when selectedKinds is null', () => {
-        expect(applyKindFilter(baseFilters, null)).toBe(baseFilters)
-    })
-
-    it('returns filters unchanged when selectedKinds is empty', () => {
-        expect(applyKindFilter(baseFilters, [])).toBe(baseFilters)
+    it.each([
+        ['null', null],
+        ['an empty array', [] as string[]],
+    ])('returns filters unchanged when selectedKinds is %s', (_, kinds) => {
+        expect(applyKindFilter(baseFilters, kinds)).toBe(baseFilters)
     })
 
     it('returns undefined when base filters are undefined', () => {

--- a/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts
+++ b/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts
@@ -133,7 +133,6 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
         setStep: (step: WizardStep) => ({ step }),
         setDestinationKey: (destinationKey: string) => ({ destinationKey }),
         setTriggerKey: (triggerKey: HogFunctionSubTemplateIdType) => ({ triggerKey }),
-        setKinds: (kinds: string[]) => ({ kinds }),
         setInputValue: (key: string, value: CyclotronJobInputType) => ({ key, value }),
         restoreWizardState: (state: {
             step: WizardStep
@@ -189,7 +188,6 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
         selectedKinds: [
             (logicProps.presetTriggerKinds ?? null) as string[] | null,
             {
-                setKinds: (_, { kinds }) => kinds,
                 resetWizard: () => (logicProps.presetTriggerKinds ?? null) as string[] | null,
             },
         ],

--- a/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts
+++ b/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts
@@ -11,7 +11,15 @@ import {
     HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES,
 } from 'scenes/hog-functions/sub-templates/sub-templates'
 
-import { CyclotronJobInputType, HogFunctionSubTemplateIdType, HogFunctionTemplateType, HogFunctionType } from '~/types'
+import {
+    CyclotronJobFiltersType,
+    CyclotronJobInputType,
+    HogFunctionSubTemplateIdType,
+    HogFunctionTemplateType,
+    HogFunctionType,
+    PropertyFilterType,
+    PropertyOperator,
+} from '~/types'
 
 import type { alertWizardLogicType } from './alertWizardLogicType'
 
@@ -48,6 +56,12 @@ export interface AlertWizardLogicProps {
     destinations: WizardDestination[]
     disableUrlSync?: boolean
     presetTriggerKey?: HogFunctionSubTemplateIdType
+    // When set, the wizard pre-applies a `kind IN (...)` property filter on the
+    // first event of the created HogFunction. Used by the health-alerts family
+    // so a per-page entry point (e.g. the SDK Doctor scene) can scope the alert
+    // to one or more health-check kinds. Pass an empty array to mean "all kinds"
+    // explicitly; omit the prop to leave filters untouched.
+    presetTriggerKinds?: string[]
     onAlertCreated?: () => void
 }
 
@@ -59,6 +73,41 @@ function hasSubTemplateForDestination(
 ): boolean {
     const subTemplates = HOG_FUNCTION_SUB_TEMPLATES[triggerKey]
     return subTemplates?.some((t) => t.template_id === destination.templateId) ?? false
+}
+
+// Pre-applies `kind IN (selectedKinds)` to the first event of the sub-template's
+// filter group. A null or empty `selectedKinds` leaves filters untouched (matches
+// every kind). Used by the health-alerts family so a per-page entry point can
+// scope the resulting HogFunction to specific kinds.
+export function applyKindFilter(
+    baseFilters: CyclotronJobFiltersType | null | undefined,
+    selectedKinds: string[] | null
+): CyclotronJobFiltersType | null | undefined {
+    if (!baseFilters || !selectedKinds || selectedKinds.length === 0) {
+        return baseFilters
+    }
+    const events = baseFilters.events ?? []
+    const firstEvent = events[0]
+    if (!firstEvent) {
+        return baseFilters
+    }
+    return {
+        ...baseFilters,
+        events: [
+            {
+                ...firstEvent,
+                properties: [
+                    {
+                        key: 'kind',
+                        value: selectedKinds,
+                        operator: PropertyOperator.Exact,
+                        type: PropertyFilterType.Event,
+                    },
+                ],
+            },
+            ...events.slice(1),
+        ],
+    }
 }
 
 function extractDestinationKeyFromAlert(alert: HogFunctionType, allDestinations: WizardDestination[]): string | null {
@@ -84,6 +133,7 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
         setStep: (step: WizardStep) => ({ step }),
         setDestinationKey: (destinationKey: string) => ({ destinationKey }),
         setTriggerKey: (triggerKey: HogFunctionSubTemplateIdType) => ({ triggerKey }),
+        setKinds: (kinds: string[]) => ({ kinds }),
         setInputValue: (key: string, value: CyclotronJobInputType) => ({ key, value }),
         restoreWizardState: (state: {
             step: WizardStep
@@ -134,6 +184,13 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
                 setTriggerKey: (_, { triggerKey }) => triggerKey,
                 restoreWizardState: (_, { state }) => state.triggerKey,
                 resetWizard: () => (logicProps.presetTriggerKey ?? null) as HogFunctionSubTemplateIdType | null,
+            },
+        ],
+        selectedKinds: [
+            (logicProps.presetTriggerKinds ?? null) as string[] | null,
+            {
+                setKinds: (_, { kinds }) => kinds,
+                resetWizard: () => (logicProps.presetTriggerKinds ?? null) as string[] | null,
             },
         ],
         alertCreated: [
@@ -430,12 +487,14 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
                     mergedInputs[key] = val
                 }
 
+                const filters = applyKindFilter(subTemplate.filters, values.selectedKinds)
+
                 const configuration: Record<string, any> = {
                     type: 'internal_destination',
                     template_id: destination.templateId,
                     name: subTemplate.name,
                     description: subTemplate.description,
-                    filters: subTemplate.filters,
+                    filters,
                     enabled: true,
                     masking: null,
                     inputs: mergedInputs,

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -871,24 +871,42 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                                                 description: 'This is the issue description',
                                             },
                                         }
-                                      : contextId === 'activity-log'
+                                      : contextId === 'health-alerts'
                                         ? {
-                                              event: '$activity_log_entry_created',
+                                              event:
+                                                  configuration?.filters?.events?.[0].id ||
+                                                  '$health_check_issue_firing',
                                               properties: {
-                                                  activity: 'created',
-                                                  scope: 'Insight',
-                                                  item_id: 'abcdef',
+                                                  kind: 'sdk_outdated',
+                                                  severity: 'warning',
+                                                  issue_id: '00000000-0000-0000-0000-000000000000',
+                                                  title: 'posthog-python SDK is outdated',
+                                                  summary: 'posthog-python is on 7.0.0, latest is 7.14.0',
+                                                  link: '/health/sdk-doctor',
+                                                  payload: {
+                                                      sdk_name: 'posthog-python',
+                                                      latest_version: '7.14.0',
+                                                  },
                                               },
                                           }
-                                        : {
-                                              event: '$pageview',
-                                              properties: {
-                                                  $current_url: currentUrl,
-                                                  $browser: 'Chrome',
-                                                  $ip: '89.160.20.129',
-                                                  this_is_an_example_event: true,
-                                              },
-                                          }),
+                                        : contextId === 'activity-log'
+                                          ? {
+                                                event: '$activity_log_entry_created',
+                                                properties: {
+                                                    activity: 'created',
+                                                    scope: 'Insight',
+                                                    item_id: 'abcdef',
+                                                },
+                                            }
+                                          : {
+                                                event: '$pageview',
+                                                properties: {
+                                                    $current_url: currentUrl,
+                                                    $browser: 'Chrome',
+                                                    $ip: '89.160.20.129',
+                                                    this_is_an_example_event: true,
+                                                },
+                                            }),
                               },
                               person:
                                   contextId !== 'error-tracking'

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -51,6 +51,10 @@ const INTERNAL_DESTINATION_CONTEXT: Partial<
     },
     'insight-alerts': { label: 'Insight alerts' },
     'experiment-alerts': { label: 'Experiment alerts' },
+    'health-alerts': {
+        label: 'Health alerts',
+        url: urls.healthAlerts(),
+    },
 }
 
 function NotificationContextTag({ hogFunction }: { hogFunction: HogFunctionType }): JSX.Element | null {

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -129,6 +129,20 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
         filters: { events: [{ id: '$logs_alert_errored', type: 'events' }] },
         flag: FEATURE_FLAGS.LOGS_ALERTING,
     },
+    'health-check-firing': {
+        sub_template_id: 'health-check-firing',
+        type: 'internal_destination',
+        context_id: 'health-alerts',
+        filters: { events: [{ id: '$health_check_issue_firing', type: 'events' }] },
+        flag: FEATURE_FLAGS.HEALTH_ALERTS,
+    },
+    'health-check-resolved': {
+        sub_template_id: 'health-check-resolved',
+        type: 'internal_destination',
+        context_id: 'health-alerts',
+        filters: { events: [{ id: '$health_check_issue_resolved', type: 'events' }] },
+        flag: FEATURE_FLAGS.HEALTH_ALERTS,
+    },
 }
 
 const FLAG_ACTOR_NAME = "{event.properties.user.first_name ? event.properties.user.first_name : 'PostHog'}"
@@ -161,6 +175,121 @@ function buildFlagChangeVerbPhrase(): string {
 }
 
 const FLAG_CHANGE_VERB_PHRASE = buildFlagChangeVerbPhrase()
+
+interface HealthAlertTemplateCopy {
+    slackHeader: string
+    slackBody: string
+    webhookSummary: string
+    emailSubject: string
+    emailHtml: string
+    emailText: string
+    discordContent: string
+    teamsText: string
+    actionButtonText: string
+    namePrefix: string
+    descriptionVerb: string
+}
+
+// Builds the 5 destination variants for a health-alert sub-template. The body
+// strings reference only the event envelope (title/summary/link/severity/kind),
+// so adding a new health-check kind requires no changes here.
+function buildHealthAlertSubTemplates(
+    subTemplateId: 'health-check-firing' | 'health-check-resolved',
+    copy: HealthAlertTemplateCopy
+): HogFunctionSubTemplateType[] {
+    const common = HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES[subTemplateId]
+    return [
+        {
+            ...common,
+            template_id: 'template-webhook',
+            name: `HTTP webhook when a ${copy.namePrefix}`,
+            description: `Send a webhook when a health check ${copy.descriptionVerb}`,
+            inputs: {
+                body: {
+                    value: {
+                        summary: copy.webhookSummary,
+                        title: '{event.properties.title}',
+                        message: '{event.properties.summary}',
+                        kind: '{event.properties.kind}',
+                        severity: '{event.properties.severity}',
+                        link: '{project.url}{event.properties.link}',
+                        payload: '{event.properties.payload}',
+                    },
+                },
+            },
+        },
+        {
+            ...common,
+            template_id: 'template-slack',
+            name: `Post to Slack when a ${copy.namePrefix}`,
+            description: `Post to a Slack channel when a health check ${copy.descriptionVerb}`,
+            inputs: {
+                blocks: {
+                    value: [
+                        { type: 'header', text: { type: 'plain_text', text: copy.slackHeader } },
+                        { type: 'section', text: { type: 'mrkdwn', text: copy.slackBody } },
+                        {
+                            type: 'context',
+                            elements: [
+                                {
+                                    type: 'mrkdwn',
+                                    text: 'Severity: {event.properties.severity} · Project: <{project.url}|{project.name}>',
+                                },
+                            ],
+                        },
+                        { type: 'divider' },
+                        {
+                            type: 'actions',
+                            elements: [
+                                {
+                                    url: '{project.url}{event.properties.link}',
+                                    text: { text: copy.actionButtonText, type: 'plain_text' },
+                                    type: 'button',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                text: { value: copy.webhookSummary },
+            },
+        },
+        {
+            ...common,
+            template_id: 'template-discord',
+            name: `Post to Discord when a ${copy.namePrefix}`,
+            description: `Post to a Discord channel when a health check ${copy.descriptionVerb}`,
+            inputs: { content: { value: copy.discordContent } },
+        },
+        {
+            ...common,
+            template_id: 'template-microsoft-teams',
+            name: `Post to Microsoft Teams when a ${copy.namePrefix}`,
+            description: `Post to a Microsoft Teams channel when a health check ${copy.descriptionVerb}`,
+            inputs: { text: { value: copy.teamsText } },
+        },
+        {
+            ...common,
+            template_id: 'template-email',
+            name: `Email when a ${copy.namePrefix}`,
+            description: `Send an email when a health check ${copy.descriptionVerb}`,
+            inputs: {
+                email: {
+                    value: {
+                        to: { email: '', name: '' },
+                        from: { email: '', name: 'PostHog' },
+                        replyTo: '',
+                        cc: '',
+                        bcc: '',
+                        subject: copy.emailSubject,
+                        preheader: '{event.properties.summary}',
+                        text: copy.emailText,
+                        html: copy.emailHtml,
+                    },
+                },
+            },
+        },
+    ]
+}
 
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
     'survey-response': [
@@ -1021,6 +1150,41 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             },
         },
     ],
+    'health-check-firing': buildHealthAlertSubTemplates('health-check-firing', {
+        // Verbs/copy chosen so the same template body works for any health-check kind.
+        slackHeader: '{event.properties.title}',
+        slackBody: '{event.properties.summary}',
+        webhookSummary: '{event.properties.title}: {event.properties.summary}',
+        emailSubject: 'PostHog health check: {event.properties.title}',
+        emailHtml:
+            '<p><strong>{event.properties.title}</strong></p><p>{event.properties.summary}</p><p>Severity: {event.properties.severity}</p><p><a href="{project.url}{event.properties.link}">View in PostHog</a></p>',
+        emailText:
+            '{event.properties.title}\n\n{event.properties.summary}\n\nSeverity: {event.properties.severity}\n\n{project.url}{event.properties.link}',
+        discordContent:
+            '**🩺 PostHog health check**\n\n*{event.properties.title}*\n{event.properties.summary}\n\n[View in PostHog]({project.url}{event.properties.link})',
+        teamsText:
+            '**🩺 PostHog health check:** *{event.properties.title}* — {event.properties.summary} (View in [PostHog]({project.url}{event.properties.link}))',
+        actionButtonText: 'View in PostHog',
+        namePrefix: 'health check fires',
+        descriptionVerb: 'fires',
+    }),
+    'health-check-resolved': buildHealthAlertSubTemplates('health-check-resolved', {
+        slackHeader: 'Resolved: {event.properties.title}',
+        slackBody: '{event.properties.summary}',
+        webhookSummary: 'Resolved: {event.properties.title} — {event.properties.summary}',
+        emailSubject: 'PostHog health check resolved: {event.properties.title}',
+        emailHtml:
+            '<p><strong>Resolved: {event.properties.title}</strong></p><p>{event.properties.summary}</p><p><a href="{project.url}{event.properties.link}">View in PostHog</a></p>',
+        emailText:
+            'Resolved: {event.properties.title}\n\n{event.properties.summary}\n\n{project.url}{event.properties.link}',
+        discordContent:
+            '**✅ PostHog health check resolved**\n\n*{event.properties.title}*\n{event.properties.summary}\n\n[View in PostHog]({project.url}{event.properties.link})',
+        teamsText:
+            '**✅ Resolved:** *{event.properties.title}* — {event.properties.summary} (View in [PostHog]({project.url}{event.properties.link}))',
+        actionButtonText: 'View in PostHog',
+        namePrefix: 'health check resolves',
+        descriptionVerb: 'resolves',
+    }),
     'logs-alert-errored': [
         {
             ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['logs-alert-errored'],
@@ -1101,6 +1265,9 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
         case '$logs_alert_auto_disabled':
         case '$logs_alert_errored':
             return 'logs-alerting'
+        case '$health_check_issue_firing':
+        case '$health_check_issue_resolved':
+            return 'health-alerts'
         default:
             return 'standard'
     }

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -144,6 +144,7 @@ export enum Scene {
     SavedInsights = 'SavedInsights',
     Health = 'Health',
     HealthCategoryDetail = 'HealthCategoryDetail',
+    HealthAlerts = 'HealthAlerts',
     SdkDoctor = 'SdkDoctor',
     SessionAttributionExplorer = 'SessionAttributionExplorer',
     SessionGroupSummariesTable = 'SessionGroupSummariesTable',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -488,6 +488,12 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         name: 'Health detail',
         iconType: 'health',
     },
+    [Scene.HealthAlerts]: {
+        projectBased: true,
+        name: 'Health alerts',
+        description: 'Subscribe to alerts when health checks fire.',
+        iconType: 'health',
+    },
     [Scene.PipelineStatus]: {
         projectBased: true,
         name: 'Pipeline status',
@@ -918,6 +924,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.inbox(':reportId')]: [Scene.Inbox, 'inbox'],
     [urls.pipelineStatus()]: [Scene.PipelineStatus, 'pipelineStatus'],
     [urls.sdkDoctor()]: [Scene.SdkDoctor, 'sdkDoctor'],
+    [urls.healthAlerts()]: [Scene.HealthAlerts, 'healthAlerts'],
     // Parameterized route must come after static /health/* routes
     [urls.healthCategory(':category')]: [Scene.HealthCategoryDetail, 'healthCategoryDetail'],
     [urls.exports()]: [Scene.Exports, 'exports'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -288,6 +288,7 @@ export const urls = {
     approval: (id: string): string => `/approvals/${id}`,
     health: (): string => '/health',
     healthCategory: (category: string): string => `/health/${category}`,
+    healthAlerts: (): string => '/health/alerts',
     inbox: (reportId?: string): string => `/inbox${reportId ? `/${reportId}` : ''}`,
     webAnalyticsBotAnalytics: (): string => '/web/bots',
     webAnalyticsHealth: (): string => '/web/health',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6650,6 +6650,7 @@ export type HogFunctionConfigurationContextId =
     | 'insight-alerts'
     | 'experiment-alerts'
     | 'logs-alerting'
+    | 'health-alerts'
 
 export type HogFunctionSubTemplateIdType =
     | 'early-access-feature-enrollment'
@@ -6666,6 +6667,8 @@ export type HogFunctionSubTemplateIdType =
     | 'logs-alert-resolved'
     | 'logs-alert-auto-disabled'
     | 'logs-alert-errored'
+    | 'health-check-firing'
+    | 'health-check-resolved'
 
 export type HogFunctionConfigurationType = Omit<
     HogFunctionType,


### PR DESCRIPTION
## Problem

With backend `$health_check_issue_firing` / `$health_check_issue_resolved` events flowing from [#59984](https://github.com/PostHog/posthog/pull/59984), users need a UI to subscribe a HogFunction destination to them. This mirrors the existing error-tracking and logs-alerting wizards, but with one twist — health-check alerts are cross-cutting by `kind`, so the wizard needs a way to scope each created alert to a subset of kinds (or all of them).

## Changes

**Types — `frontend/src/types.ts`:**

- `'health-alerts'` added to `HogFunctionConfigurationContextId`
- `'health-check-firing'` and `'health-check-resolved'` added to `HogFunctionSubTemplateIdType`

**Sub-templates — `frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts`:**

- Two entries in `HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES` for firing / resolved, both gated by `FEATURE_FLAGS.HEALTH_ALERTS`
- New `buildHealthAlertSubTemplates()` helper that produces the five destination variants (Slack / Discord / Microsoft Teams / email / webhook). Templates reference **only** the envelope properties — `event.properties.title`, `summary`, `link`, `severity`, `kind` — so adding a new health check kind requires zero frontend changes.
- New `eventToHogFunctionContextId` cases for both event names

**Wizard logic — `frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts`:**

- New `presetTriggerKinds?: string[]` prop (sibling to `presetTriggerKey`, which selects firing vs resolved). When set, the wizard pre-applies a `kind IN (...)` property filter on the first event of the created HogFunction's filter group.
- New `selectedKinds` reducer + `setKinds` action
- Exported `applyKindFilter()` helper, plus five unit tests covering: null/empty selection, undefined base, the kind IN filter shape, replacing existing properties, leaving second-event filters untouched

**Central scene — new `frontend/src/scenes/health-alerts/`:**

- `healthAlertsWizardConfig.ts` — `HEALTH_ALERT_SUB_TEMPLATE_IDS`, `HEALTH_ALERT_TRIGGERS`, `HEALTH_ALERT_DESTINATIONS`
- `HealthAlertsEntryPoint.tsx` — the shared component used both by the central scene and by per-page mounts in the next PR ([#59986](https://github.com/PostHog/posthog/pull/59986))
- `HealthAlertsScene.tsx` — full-page scene at `/health/alerts`
- Registered in `urls.ts`, `appScenes.ts`, `scenes.ts`, `sceneTypes.ts`. Route is inserted **before** the parameterised `/health/:category` so it isn't shadowed.

**Other:**

- `HEALTH_ALERTS: 'health-alerts'` feature flag in `lib/constants.tsx`, gating both the scene and the per-page buttons
- `'health-alerts'` entry in `INTERNAL_DESTINATION_CONTEXT` so an existing HogFunction surfaces with a "Health alerts" tag and link
- Test-panel sample event for the `'health-alerts'` context in `hogFunctionConfigurationLogic.tsx`

## How did you test this code?

I'm Claude (Opus 4.7) — automated checks only.

- 5 new unit tests for `applyKindFilter`
- `kea-typegen write` regenerated the logic type file (gitignored)
- TypeScript check passes for the touched files (the pre-existing `posthog-js/rrweb-types` errors are unrelated)
- `ruff` / formatter / `ty check` pass via lint-staged pre-commit
- Did not exercise the wizard or central scene manually in a running app

## Publish to changelog?

Yes — staggered rollout via `HEALTH_ALERTS` feature flag. Notes will follow when the rollout PR lands.

## Docs update

The Health docs / SDK Doctor docs should mention the new alert subscription flow once the rollout PR ([#59986](https://github.com/PostHog/posthog/pull/59986)) lands. Inkeep should pick this up.

## 🤖 Agent context

Authored via Claude Code (Opus 4.7) in collaboration with @rafaeelaudibert. Plan refined remotely via Ultraplan.

Decisions worth flagging for reviewers:

- **One generic destination family, not N per-kind families.** The original PR shipped ~120 lines of SDK-Doctor-specific Slack/Discord/Teams/email/webhook templates. Repeating that pattern for 10 kinds was the main scaling concern. By referencing only the envelope props, one helper produces the templates for both firing/resolved.
- **`presetTriggerKinds` (plural) is separate from `presetTriggerKey` (singular).** The existing `presetTriggerKey` selects firing-vs-resolved on existing wizards (error-tracking, logs); the new `presetTriggerKinds` is independent and only applies to the health-alerts family. Adding a wizard step UI for in-wizard multi-select kind selection was intentionally deferred — per-page mounts pre-select via the prop, and the central scene leaves kinds unrestricted ("all kinds").
- **No changes to error-tracking / logs-alerting wizards.** Those continue using their own sub-templates and event names; this PR adds a sibling family.

This PR stacks on [#59984](https://github.com/PostHog/posthog/pull/59984) and is followed by [#59986](https://github.com/PostHog/posthog/pull/59986).
