### PR TITLE
chore(hog-functions): thread returnTo through HogFunctionList

### DIFF
--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.test.ts
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.test.ts
@@ -1,0 +1,25 @@
+import { HogFunctionType } from '~/types'
+
+import { urlForHogFunction } from './HogFunctionsList'
+
+const makeFn = (id: string): HogFunctionType => ({ id }) as HogFunctionType
+
+describe('urlForHogFunction', () => {
+    it('returns the bare hog function path when returnTo is undefined', () => {
+        expect(urlForHogFunction(makeFn('abc123'))).toBe('/functions/abc123')
+    })
+
+    it('appends returnTo as a query param for a hog function id', () => {
+        expect(urlForHogFunction(makeFn('abc123'), '/health/sdk-doctor')).toBe(
+            '/functions/abc123?returnTo=%2Fhealth%2Fsdk-doctor'
+        )
+    })
+
+    it('does not append returnTo for plugin- prefix IDs', () => {
+        expect(urlForHogFunction(makeFn('plugin-7'), '/health/sdk-doctor')).toBe('/pipeline/plugins/7')
+    })
+
+    it('does not append returnTo for batch-export- prefix IDs', () => {
+        expect(urlForHogFunction(makeFn('batch-export-9'), '/health/sdk-doctor')).toBe('/pipeline/batch-exports/9')
+    })
+})

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -1,5 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { router } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import { useCallback, useMemo } from 'react'
 
 import { IconBell } from '@posthog/icons'
@@ -90,14 +90,17 @@ function NotificationContextTag({ hogFunction }: { hogFunction: HogFunctionType 
     )
 }
 
-const urlForHogFunction = (hogFunction: HogFunctionType): string => {
+// `returnTo` only applies to the canonical hog-function path; legacy plugin and
+// batch-export scenes don't read it.
+export const urlForHogFunction = (hogFunction: HogFunctionType, returnTo?: string): string => {
     if (hogFunction.id.startsWith('plugin-')) {
         return urls.legacyPlugin(hogFunction.id.replace('plugin-', ''))
     }
     if (hogFunction.id.startsWith('batch-export-')) {
         return urls.batchExport(hogFunction.id.replace('batch-export-', ''))
     }
-    return urls.hogFunction(hogFunction.id)
+    const path = urls.hogFunction(hogFunction.id)
+    return returnTo ? combineUrl(path, { returnTo }).url : path
 }
 
 export function HogFunctionList({
@@ -106,6 +109,7 @@ export function HogFunctionList({
     emptyText,
     onDeleteHogFunction,
     onEditHogFunction,
+    returnTo,
     ...props
 }: HogFunctionListLogicProps & {
     extraControls?: JSX.Element
@@ -113,6 +117,7 @@ export function HogFunctionList({
     emptyText?: string
     onDeleteHogFunction?: (hogFunction: HogFunctionType) => void
     onEditHogFunction?: (hogFunction: HogFunctionType) => void
+    returnTo?: string
 }): JSX.Element {
     const { loading, filteredHogFunctions, filters, hogFunctions, hiddenHogFunctions } = useValues(
         hogFunctionsListLogic(props)
@@ -152,7 +157,7 @@ export function HogFunctionList({
                 render: (_, hogFunction) => {
                     return (
                         <LemonTableLink
-                            to={urlForHogFunction(hogFunction)}
+                            to={urlForHogFunction(hogFunction, returnTo)}
                             onClick={onEditHogFunction ? () => onEditHogFunction(hogFunction) : undefined}
                             title={
                                 <>
@@ -239,7 +244,7 @@ export function HogFunctionList({
                                                   // TRICKY: Hack for now to just link out to the full view
                                                   {
                                                       label: 'View & configure',
-                                                      to: urlForHogFunction(hogFunction),
+                                                      to: urlForHogFunction(hogFunction, returnTo),
                                                   },
                                               ]
                                             : [
@@ -295,6 +300,7 @@ export function HogFunctionList({
         isManualFunction,
         onDeleteHogFunction,
         onEditHogFunction,
+        returnTo,
     ]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     return (


### PR DESCRIPTION
## Problem

When a user opens a HogFunction from a list page (error-tracking alerts, insight alerts, logs alerts, the upcoming health alerts), the back-arrow on the HogFunction configuration scene returns them to the generic destinations list — not to the page that surfaced the alert in the first place. That's a poor breadcrumb experience for any product that surfaces internal-destination HogFunctions via a dedicated wizard.

## Changes

- Export `urlForHogFunction` from `HogFunctionsList` (was previously a module-local helper)
- Add an optional `returnTo: string` parameter; when set, append it as a query param via `combineUrl`
- Thread `returnTo` through `HogFunctionList`'s public props so callers (insights, error-tracking, logs, health) can pass the originating page path
- `returnTo` only applies to the canonical hog-function path — legacy plugin and batch-export scenes ignore it
- New unit-test file `HogFunctionsList.test.ts` covering the four `urlForHogFunction` branches

## How did you test this code?

I'm Claude (Opus 4.7) — automated checks only.

- 4 new unit tests for `urlForHogFunction` (bare path, returnTo encoded, plugin-prefix, batch-export-prefix)
- `ruff` / formatter / `ty check` pass via lint-staged pre-commit
- TypeScript check passes for the touched files (pre-existing repo-wide errors are unrelated)
- Did not exercise the UI manually

## Publish to changelog?

No.

## Docs update

None needed.

## 🤖 Agent context

Authored via Claude Code (Opus 4.7) in collaboration with @rafaeelaudibert. Lifted from the original SDK Doctor alerting PR (#58211) as part of a refactor of that work into an extensible health-alerts stack. Like the IntegrationChoice fallback (#59987), this is reusable polish that benefits every internal-destination wizard, so it ships independently against `master` rather than being entangled with the health-alerts feature stack.

The metric-sparkline links (e.g. `urlForHogFunction(hogFunction) + '?tab=metrics'`) are intentionally not threaded with `returnTo` — the original PR didn't either, and combining `?returnTo=...` with `?tab=metrics` would produce a malformed URL without a deeper refactor.
