### PR TITLE
chore(modeling): relax retries and timeouts for v2 workflows

### DIFF
--- a/posthog/temporal/data_modeling/workflows/execute_dag.py
+++ b/posthog/temporal/data_modeling/workflows/execute_dag.py
@@ -204,7 +204,7 @@ class ExecuteDAGWorkflow(PostHogWorkflow):
             ),
             start_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=temporalio.common.RetryPolicy(
-                maximum_attempts=2,
+                maximum_attempts=3,
             ),
         )
         try:
@@ -227,7 +227,7 @@ class ExecuteDAGWorkflow(PostHogWorkflow):
             ),
             start_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=temporalio.common.RetryPolicy(
-                maximum_attempts=2,
+                maximum_attempts=3,
             ),
         )
         executable_nodes = dag_structure.executable_nodes

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -2,13 +2,9 @@ import json
 import datetime as dt
 import dataclasses
 
-from django.conf import settings
-
 import temporalio.common
 import temporalio.workflow
 import temporalio.exceptions
-from temporalio.exceptions import WorkflowAlreadyStartedError
-from temporalio.workflow import ParentClosePolicy
 
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.base import PostHogWorkflow
@@ -42,7 +38,6 @@ from posthog.temporal.data_modeling.metrics import (
     get_node_storage_delta_mib_metric,
     get_node_total_storage_mib_metric,
 )
-from posthog.temporal.ducklake.types import DataModelingDuckLakeCopyInputs, DuckLakeCopyModelInput
 
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJobEngine
 
@@ -132,9 +127,9 @@ class MaterializeViewWorkflow(PostHogWorkflow):
         duckgres_enabled = await temporalio.workflow.execute_activity(
             check_duckgres_shadow_enabled_activity,
             inputs.team_id,
-            start_to_close_timeout=dt.timedelta(minutes=1),
+            start_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=temporalio.common.RetryPolicy(
-                maximum_attempts=1,
+                maximum_attempts=3,
             ),
         )
 
@@ -149,9 +144,9 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                     engine=DataModelingJobEngine.DUCKGRES,
                     parent_workflow_id=parent_workflow_id,
                 ),
-                start_to_close_timeout=dt.timedelta(minutes=1),
+                start_to_close_timeout=dt.timedelta(minutes=5),
                 retry_policy=temporalio.common.RetryPolicy(
-                    maximum_attempts=1,
+                    maximum_attempts=3,
                 ),
             )
             # fire-and-forget: start duckgres shadow materialization in parallel
@@ -164,7 +159,7 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                     job_id=duckgres_job_id,
                     dangerously_execute_raw_sql=inputs.dangerously_execute_raw_sql,
                 ),
-                start_to_close_timeout=dt.timedelta(minutes=15),
+                start_to_close_timeout=dt.timedelta(minutes=20),
                 retry_policy=temporalio.common.RetryPolicy(
                     maximum_attempts=3 if inputs.duckgres_only else 1,
                     initial_interval=dt.timedelta(seconds=10),
@@ -181,9 +176,9 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                     dag_id=inputs.dag_id,
                     parent_workflow_id=parent_workflow_id,
                 ),
-                start_to_close_timeout=dt.timedelta(minutes=1),
+                start_to_close_timeout=dt.timedelta(minutes=5),
                 retry_policy=temporalio.common.RetryPolicy(
-                    maximum_attempts=1,
+                    maximum_attempts=3,
                 ),
             )
             try:
@@ -196,7 +191,7 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                         job_id=job_id,
                     ),
                     # clickhouse timeout is 10mins so start to close is that plus a bit of margin
-                    start_to_close_timeout=dt.timedelta(minutes=15),
+                    start_to_close_timeout=dt.timedelta(minutes=20),
                     heartbeat_timeout=dt.timedelta(minutes=2),
                     retry_policy=temporalio.common.RetryPolicy(
                         maximum_attempts=3,
@@ -223,37 +218,6 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                         maximum_attempts=3,
                     ),
                 )
-                try:
-                    model = DuckLakeCopyModelInput(
-                        model_label=materialize_result.node_name,
-                        saved_query_id=materialize_result.saved_query_id,
-                        table_uri=materialize_result.table_uri,
-                    )
-                    ducklake_inputs = DataModelingDuckLakeCopyInputs(
-                        team_id=inputs.team_id, job_id=job_id, models=[model]
-                    )
-                    await temporalio.workflow.start_child_workflow(
-                        workflow="ducklake-copy.data-modeling",
-                        arg=dataclasses.asdict(ducklake_inputs),
-                        id=f"ducklake-copy-data-modeling-{inputs.team_id}-{materialize_result.saved_query_id}",
-                        task_queue=settings.DUCKLAKE_TASK_QUEUE,
-                        parent_close_policy=ParentClosePolicy.ABANDON,
-                        retry_policy=temporalio.common.RetryPolicy(
-                            maximum_attempts=1,
-                            non_retryable_error_types=["NondeterminismError"],
-                        ),
-                    )
-                except WorkflowAlreadyStartedError:
-                    temporalio.workflow.logger.warning(
-                        "DuckLake copy already running, skipping",
-                        saved_query_id=materialize_result.saved_query_id,
-                    )
-                except Exception as ducklake_err:
-                    temporalio.workflow.logger.warning(
-                        f"DuckLake copy workflow failed: {str(ducklake_err)}",
-                        extra=inputs.properties_to_log,
-                    )
-                    capture_exception(ducklake_err)
                 # handle success
                 end_time = temporalio.workflow.now()
                 duration_seconds = (end_time - start_time).total_seconds()


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

start to close timeouts in v2

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

give them slightly more time and more retries

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

didn't. minor change

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->

<!-- gg:stack-start -->
## gg stack

- **#59991 `andrew/v2-tweaks` 👈 this PR**
<!-- gg:stack-end -->
