### PR TITLE
fix(web-analytics): drop redundant web_stats_preaggregated Distributed from AUX

### DIFF
--- a/posthog/clickhouse/migrations/0262_drop_web_stats_preaggregated_distributed_from_aux.py
+++ b/posthog/clickhouse/migrations/0262_drop_web_stats_preaggregated_distributed_from_aux.py
@@ -1,0 +1,26 @@
+"""Drop the redundant `web_stats_preaggregated` Distributed table from AUX.
+
+Migration 0259 created the Distributed routing table on both DATA and AUX. The
+AUX-side definition was added for ad-hoc operator debugging convenience, but
+nothing in production reads or writes through it — the lazy precompute path
+issues all queries via the DATA-side Distributed (which already forwards to
+the AUX-resident sharded table).
+
+The other two web preagg tables (0256_web_overview_preaggregated and
+0260_web_stats_paths_preaggregated) follow the original convention: sharded on
+AUX, Distributed on DATA only. This migration aligns `web_stats_preaggregated`
+with that convention so all three web preagg tables have an identical layout.
+
+Distributed engines hold no data — dropping the AUX-side table only removes
+the routing metadata. The sharded table on AUX is untouched.
+"""
+
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = [
+    run_sql_with_exceptions(
+        "DROP TABLE IF EXISTS web_stats_preaggregated SYNC SETTINGS max_table_size_to_drop = 0",
+        node_roles=[NodeRole.AUX],
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0261_conversion_goal_attributed_preaggregated
+0262_drop_web_stats_preaggregated_distributed_from_aux


### PR DESCRIPTION
## Summary

Aligns `web_stats_preaggregated` with the two sibling web preagg tables so all three follow the convention Rory established in PR #59075: **sharded data on AUX, Distributed routing on DATA only**.

| Migration | Sharded (data) | Distributed (routing) |
|---|---|---|
| 0256 `web_overview_preaggregated` | AUX | DATA |
| 0259 `web_stats_preaggregated` (today) | AUX | **DATA + AUX** ← outlier |
| 0260 `web_stats_paths_preaggregated` | AUX | DATA |

This PR adds migration 0262 that drops `web_stats_preaggregated` from AUX. Distributed engines hold no data — only routing metadata is removed; the AUX-resident sharded table is untouched.

## Background

The AUX-side Distributed was added in #59076 as an ad-hoc debugging affordance ("lets operators `SELECT … FROM web_stats_preaggregated` directly from an AUX node instead of bouncing through DATA"). Nothing in production reads or writes through it — `cache_warming`, the lazy precompute query path, and the eager precompute path all issue queries from app servers (which connect to DATA cluster).

## Test plan

- [ ] CI passes (no functional change to query paths)
- [ ] Verify in staging: `clusterAllReplicas(aux, system, tables) WHERE name = 'web_stats_preaggregated'` returns 0 rows post-migration
- [ ] Verify in staging: lazy precompute writes/reads against `web_stats_preaggregated` continue to work (existing tests cover this — no app-server-side path uses the AUX route)

## Out of scope / flagged for follow-up

Migration 0261 (`conversion_goal_attributed_preaggregated`, from #55005) has the same dual-cluster pattern with `node_roles=[NodeRole.AUX, NodeRole.DATA]`. It's a marketing-analytics table, not web analytics, and the original PR author may have a different rationale. Not changed here — cc @marketing-analytics team if you want to align.