### PR TITLE
chore(personhog): response size bucket sizes

### DIFF
--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ];
         const RESPONSE_SIZE_BUCKETS: &[f64] = &[
             256.0, 1024.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0, 4194304.0, 16777216.0,
-            52428800.0,
+            67108864.0,
         ];
         let recorder_handle = PrometheusBuilder::new()
             .add_global_label("service", "personhog-router")

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -115,7 +115,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             1.0, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0,
         ];
         const RESPONSE_SIZE_BUCKETS: &[f64] = &[
-            64.0, 256.0, 1024.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0,
+            256.0, 1024.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0, 4194304.0, 16777216.0,
+            52428800.0,
         ];
         let recorder_handle = PrometheusBuilder::new()
             .add_global_label("service", "personhog-router")


### PR DESCRIPTION


## Problem

Response size buckets were the wrong size

## Changes

Adds more bucket sizes to the response size metric in personhog

## How did you test this code?

Simpel bucket addition. no tests needed