### PR TITLE
feat(web-analytics): relax lazy precompute filter gate to any event/session/person filter

### DIFF
--- a/products/web_analytics/PRECOMPUTATION.md
+++ b/products/web_analytics/PRECOMPUTATION.md
@@ -80,10 +80,15 @@ The 24 h pad matches the JS SDK's hard `SESSION_LENGTH_LIMIT` and covers effecti
 - `query.conversionGoal` is set
 - `query.sampling.enabled` is True
 - `query.modifiers.sessionsV2JoinMode == "uuid"` (column type mismatch — temporary; should be re-enabled by re-typing `uniq_sessions_state` to `(uniq, UUID)`)
-- `query.properties` contains more than one filter
-- The single filter is not `EventPropertyFilter(key="$host", operator="exact", value=<non-empty string>)`
+- Any filter in `query.properties` is a `CohortPropertyFilter` (cohort membership changes silently invalidate the cache)
+- Any filter is not one of `EventPropertyFilter` / `SessionPropertyFilter` / `PersonPropertyFilter`
+- Any filter's `value` is a list with more than `MAX_FILTER_VALUE_LIST_LEN` (100) entries (oversized IN-clauses bloat every daily INSERT)
 - Date range exceeds `MAX_PRECOMPUTE_DAYS` (90)
 - Either date_from or date_to is None
+
+Number of filters, operator (`exact`, `is_not`, `icontains`, `regex`, `is_set`, …), and key are unrestricted. Each unique filter combination hashes to its own cache key — combinations not previously seen will miss the cache on first read and fall back to the raw path while the precompute lands; the `WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK{reason="current_not_ready"}` counter surfaces churn-y filter patterns.
+
+The AST that lands in the INSERT's WHERE comes from `property_to_expr(properties, team=...)` — the same helper used for test-account filters. The INSERT source is a HogQL `events` query that auto-joins `session` and `person`, so session/person filters land in the same WHERE clause without template changes.
 
 When the gate returns False the runner silently falls through to v2 / raw. **Today there is no telemetry on gate rejections** — operators tuning the rollout have to read the source to know why a team isn't seeing the lazy path. A `web_overview_lazy_gate_rejected_total{reason}` counter would close that gap (open issue).
 
@@ -166,7 +171,7 @@ The state is `Nullable(Float64)` so the `if(..., NULL)` expression in the INSERT
 
 ### Eligibility gate
 
-`can_use_lazy_precompute(runner)` in `web_stats_paths_lazy_precompute.py`. Shares the common gate (`web_lazy_precompute_common.py`) with web overview — same org flag, same timezone / sampling / UUID-mode / filter rules. Adds PATHS-specific refusals:
+`can_use_lazy_precompute(runner)` in `web_stats_paths_lazy_precompute.py`. Shares the common gate (`web_lazy_precompute_common.py`) with web overview — same org flag, same timezone / sampling / UUID-mode / filter rules (any combination of event/session/person filters with any operator; cohorts and oversized value lists refused). Adds PATHS-specific refusals:
 
 - `query.breakdownBy != WebStatsBreakdown.PAGE`
 - `query.includeBounceRate` is False (the lazy table is purpose-built for bounce-augmented paths)

--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
@@ -185,34 +185,28 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             f"different $host values must produce distinct cache keys, got overlap: {example_jobs & other_jobs}"
         )
 
+    @parameterized.expand(
+        [
+            ("event_pathname", EventPropertyFilter(key="$pathname", value="/a", operator=PropertyOperator.EXACT)),
+            (
+                "event_icontains",
+                EventPropertyFilter(key="$host", value="example", operator=PropertyOperator.ICONTAINS),
+            ),
+            (
+                "session_channel_type",
+                SessionPropertyFilter(key="$channel_type", value="Direct", operator=PropertyOperator.EXACT),
+            ),
+        ]
+    )
     @freeze_time("2024-01-15T12:00:00Z")
-    def test_disqualifying_filter_falls_through(self):
+    def test_relaxed_filter_admitted(self, _name: str, prop) -> None:
+        # Post-relaxation: any event/session/person filter and any operator
+        # flows through `property_to_expr`. Just confirm the gate creates a job.
         self._seed_two_sessions()
-        # $pathname is not in the MVP allowlist → gate returns False → no job created.
         with self._enable_lazy():
-            self._run(
-                self._build_query(
-                    properties=[
-                        EventPropertyFilter(key="$pathname", value="/a", operator=PropertyOperator.EXACT),
-                    ]
-                )
-            )
+            self._run(self._build_query(properties=[prop]))
 
-        assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
-
-    @freeze_time("2024-01-15T12:00:00Z")
-    def test_session_property_falls_through(self):
-        # Session-level filters never qualify for MVP — only EventPropertyFilter on $host.
-        with self._enable_lazy():
-            self._run(
-                self._build_query(
-                    properties=[
-                        SessionPropertyFilter(key="$channel_type", value="Direct", operator=PropertyOperator.EXACT),
-                    ]
-                )
-            )
-
-        assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
+        assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() > 0
 
     @freeze_time("2024-01-15T12:00:00Z")
     def test_sampling_falls_through(self):
@@ -395,14 +389,53 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
     # --- Group B: gate strictness -------------------------------------------
 
     @freeze_time("2024-01-15T12:00:00Z")
-    def test_multiple_host_filters_fall_through(self):
-        # Gate accepts at most one user-supplied property — multi-host inputs
-        # collide on a single-filter cache key and must be rejected.
+    def test_multiple_filters_admitted_and_distinct_cache_entry(self):
+        # Post-relaxation: any number of filters is admitted. A multi-filter
+        # combo hashes to a cache key distinct from each subset.
         self._seed_two_sessions()
-        host_a = EventPropertyFilter(key="$host", value="example.com", operator=PropertyOperator.EXACT)
-        host_b = EventPropertyFilter(key="$host", value="other.com", operator=PropertyOperator.EXACT)
+        host_filter = EventPropertyFilter(key="$host", value="example.com", operator=PropertyOperator.EXACT)
+        device_filter = EventPropertyFilter(key="$device_type", value="Desktop", operator=PropertyOperator.EXACT)
+
         with self._enable_lazy():
-            self._run(self._build_query(properties=[host_a, host_b]))
+            self._run(self._build_query(properties=[host_filter]))
+            host_only = {str(j.query_hash) for j in PreaggregationJob.objects.filter(team_id=self.team.pk)}
+            PreaggregationJob.objects.filter(team_id=self.team.pk).delete()
+
+            self._run(self._build_query(properties=[host_filter, device_filter]))
+            combo = {str(j.query_hash) for j in PreaggregationJob.objects.filter(team_id=self.team.pk)}
+
+        assert host_only and combo
+        assert host_only.isdisjoint(combo), "multi-filter combos must hash to distinct cache keys"
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_cohort_filter_falls_through(self):
+        from posthog.schema import CohortPropertyFilter
+
+        from posthog.models.cohort import Cohort
+
+        self._seed_two_sessions()
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="lazy gate cohort",
+            groups=[{"properties": [{"key": "name", "value": "p1", "type": "person"}]}],
+        )
+        with self._enable_lazy():
+            self._run(self._build_query(properties=[CohortPropertyFilter(value=cohort.pk)]))
+
+        # Cohort membership changes silently invalidate the cache — gate refuses.
+        assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_oversized_value_list_falls_through(self):
+        # IN-clause with >MAX_FILTER_VALUE_LIST_LEN items bloats every daily INSERT.
+        from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute import MAX_FILTER_VALUE_LIST_LEN
+
+        self._seed_two_sessions()
+        oversized = [f"host{i}.com" for i in range(MAX_FILTER_VALUE_LIST_LEN + 1)]
+        prop = EventPropertyFilter(key="$host", value=oversized, operator=PropertyOperator.EXACT)
+
+        with self._enable_lazy():
+            self._run(self._build_query(properties=[prop]))
 
         assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
 
@@ -415,22 +448,6 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         query.modifiers = HogQLQueryModifiers(sessionsV2JoinMode=SessionsV2JoinMode.UUID)
         with self._enable_lazy():
             self._run(query)
-
-        assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
-
-    @parameterized.expand(
-        [
-            ("none_value", None),
-            ("list_value", ["example.com", "other.com"]),
-            ("empty_string", ""),
-        ]
-    )
-    @freeze_time("2024-01-15T12:00:00Z")
-    def test_non_string_host_value_falls_through(self, _name: str, host_value) -> None:
-        self._seed_two_sessions()
-        prop = EventPropertyFilter(key="$host", value=host_value, operator=PropertyOperator.EXACT)
-        with self._enable_lazy():
-            self._run(self._build_query(properties=[prop]))
 
         assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
 

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
@@ -238,29 +238,44 @@ class TestWebStatsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             f"includeHost on/off must produce distinct cache keys, got overlap: {no_host_hashes & with_host_hashes}"
         )
 
+    @parameterized.expand(
+        [
+            ("event_pathname", EventPropertyFilter(key="$pathname", value="/a", operator=PropertyOperator.EXACT)),
+            (
+                "event_icontains",
+                EventPropertyFilter(key="$host", value="example", operator=PropertyOperator.ICONTAINS),
+            ),
+            (
+                "session_channel_type",
+                SessionPropertyFilter(key="$channel_type", value="Direct", operator=PropertyOperator.EXACT),
+            ),
+        ]
+    )
     @freeze_time("2024-01-15T12:00:00Z")
-    def test_session_property_filter_falls_through(self):
+    def test_relaxed_filter_admitted(self, _name: str, prop) -> None:
+        # Post-relaxation: any event/session/person filter and any operator
+        # flows through `property_to_expr`. Just confirm the gate creates a job.
+        self._seed_two_sessions()
         with self._enable_lazy():
-            self._run(
-                self._build_query(
-                    properties=[
-                        SessionPropertyFilter(key="$channel_type", value="Direct", operator=PropertyOperator.EXACT),
-                    ]
-                )
-            )
-        assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
+            self._run(self._build_query(properties=[prop]))
+
+        assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() > 0
 
     @freeze_time("2024-01-15T12:00:00Z")
-    def test_disqualifying_filter_falls_through(self):
-        # $pathname filter is outside the MVP allowlist.
+    def test_cohort_filter_falls_through(self):
+        from posthog.schema import CohortPropertyFilter
+
+        from posthog.models.cohort import Cohort
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="lazy gate cohort",
+            groups=[{"properties": [{"key": "name", "value": "p1", "type": "person"}]}],
+        )
         with self._enable_lazy():
-            self._run(
-                self._build_query(
-                    properties=[
-                        EventPropertyFilter(key="$pathname", value="/a", operator=PropertyOperator.EXACT),
-                    ]
-                )
-            )
+            self._run(self._build_query(properties=[CohortPropertyFilter(value=cohort.pk)]))
+
+        # Cohort membership changes silently invalidate the cache — gate refuses.
         assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
 
     @freeze_time("2024-01-15T12:00:00Z")
@@ -359,18 +374,17 @@ class TestWebStatsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             self._run(self._build_query(date_from="2023-01-01", date_to="2024-01-07"))
         assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
 
-    @parameterized.expand(
-        [
-            ("none_value", None),
-            ("list_value", ["example.com", "other.com"]),
-            ("empty_string", ""),
-        ]
-    )
     @freeze_time("2024-01-15T12:00:00Z")
-    def test_non_string_host_value_falls_through(self, _name: str, host_value) -> None:
-        prop = EventPropertyFilter(key="$host", value=host_value, operator=PropertyOperator.EXACT)
+    def test_oversized_value_list_falls_through(self):
+        # IN-clause with >MAX_FILTER_VALUE_LIST_LEN items bloats every daily INSERT.
+        from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import MAX_FILTER_VALUE_LIST_LEN
+
+        oversized = [f"host{i}.com" for i in range(MAX_FILTER_VALUE_LIST_LEN + 1)]
+        prop = EventPropertyFilter(key="$host", value=oversized, operator=PropertyOperator.EXACT)
+
         with self._enable_lazy():
             self._run(self._build_query(properties=[prop]))
+
         assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
 
     @parameterized.expand(

--- a/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
@@ -16,7 +16,14 @@ import structlog
 import posthoganalytics
 from prometheus_client import Counter
 
-from posthog.schema import EventPropertyFilter, PropertyOperator, WebOverviewQuery, WebStatsTableQuery
+from posthog.schema import (
+    CohortPropertyFilter,
+    EventPropertyFilter,
+    PersonPropertyFilter,
+    SessionPropertyFilter,
+    WebOverviewQuery,
+    WebStatsTableQuery,
+)
 
 from posthog.hogql import ast
 from posthog.hogql.property import property_to_expr
@@ -64,10 +71,24 @@ LAZY_TTL_SECONDS: dict[str, int] = {
     "default": 7 * 24 * 60 * 60,
 }
 
-# Today the gate accepts: empty user filters, or a single EventPropertyFilter
-# on `$host` with operator `exact`. Test-account filters are always allowed
+# The gate accepts any combination of `EventPropertyFilter`,
+# `SessionPropertyFilter`, and `PersonPropertyFilter` regardless of operator
+# — we delegate AST construction to `property_to_expr`, which already handles
+# every operator HogQL supports and produces the right join shape per filter
+# type. `CohortPropertyFilter` is rejected because cohort membership changes
+# silently invalidate the cache. Test-account filters are always allowed
 # (their content is hashed into the cache key).
-SUPPORTED_USER_FILTER_KEYS: set[str] = {"$host"}
+SUPPORTED_USER_FILTER_TYPES: tuple[type, ...] = (
+    EventPropertyFilter,
+    SessionPropertyFilter,
+    PersonPropertyFilter,
+)
+
+# Multi-value operators (`exact` with a list, `in`, …) embed the value list
+# inside the INSERT. Past this cap the IN-clause bloats the per-day INSERT
+# without a corresponding cardinality win; the 7d prod-us distribution of
+# filter cardinalities sits well under this threshold for every team.
+MAX_FILTER_VALUE_LIST_LEN = 100
 
 # Upper bound on the precompute span. Above this, the framework would create
 # enough daily jobs that the first request burns INSERT slots for minutes.
@@ -144,28 +165,20 @@ class SessionsV2UuidMode(LazyPrecomputeIneligible):
     pass
 
 
-class TooManyFilters(LazyPrecomputeIneligible):
+class CohortFilterUnsupported(LazyPrecomputeIneligible):
     pass
 
 
-class NonEventPropertyFilter(LazyPrecomputeIneligible):
-    pass
+class UnsupportedFilterType(LazyPrecomputeIneligible):
+    def __init__(self, filter_type: str):
+        self.filter_type = filter_type
+        super().__init__(f"filter_type={filter_type!r}")
 
 
-class UnsupportedFilterKey(LazyPrecomputeIneligible):
-    def __init__(self, key: str):
-        self.key = key
-        super().__init__(f"key={key!r}")
-
-
-class UnsupportedFilterOperator(LazyPrecomputeIneligible):
-    def __init__(self, operator: object):
-        self.operator = operator
-        super().__init__(f"operator={operator!r}")
-
-
-class NonStringOrEmptyFilterValue(LazyPrecomputeIneligible):
-    pass
+class FilterValueListTooLong(LazyPrecomputeIneligible):
+    def __init__(self, length: int):
+        self.length = length
+        super().__init__(f"length={length} max={MAX_FILTER_VALUE_LIST_LEN}")
 
 
 class MissingDateRange(LazyPrecomputeIneligible):
@@ -267,18 +280,18 @@ def check_common_eligible(runner: LazyPrecomputeRunner) -> None:
     if query.modifiers and query.modifiers.sessionsV2JoinMode == "uuid":
         raise SessionsV2UuidMode()
 
-    properties = query.properties or []
-    if len(properties) > 1:
-        raise TooManyFilters()
-    for prop in properties:
-        if not isinstance(prop, EventPropertyFilter):
-            raise NonEventPropertyFilter()
-        if prop.key not in SUPPORTED_USER_FILTER_KEYS:
-            raise UnsupportedFilterKey(prop.key)
-        if prop.operator != PropertyOperator.EXACT:
-            raise UnsupportedFilterOperator(prop.operator)
-        if not isinstance(prop.value, str) or not prop.value:
-            raise NonStringOrEmptyFilterValue()
+    # Filter combinations: any number, any operator, any key. Cardinality is
+    # bounded by reality (97% of WA queries in prod-us use ≤2 filters), the
+    # daily-fan-out keeps each precompute INSERT bounded, and any churn-y
+    # combos surface in `WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK{reason=
+    # "current_not_ready"}` rather than producing wrong results.
+    for prop in query.properties or []:
+        if isinstance(prop, CohortPropertyFilter):
+            raise CohortFilterUnsupported()
+        if not isinstance(prop, SUPPORTED_USER_FILTER_TYPES):
+            raise UnsupportedFilterType(type(prop).__name__)
+        if isinstance(prop.value, list) and len(prop.value) > MAX_FILTER_VALUE_LIST_LEN:
+            raise FilterValueListTooLong(len(prop.value))
 
     date_from = runner.query_date_range.date_from()  # type: ignore[attr-defined]
     date_to = runner.query_date_range.date_to()  # type: ignore[attr-defined]
@@ -295,20 +308,16 @@ def user_filter_expr(runner: LazyPrecomputeRunner) -> ast.Expr:
 
     The substituted AST is what `ensure_precomputed` hashes into the cache key —
     different filter values therefore become different precomputed jobs.
+
+    `property_to_expr` handles every event/session/person filter type and every
+    operator HogQL knows about (exact, is_not, icontains, regex, is_set, …) and
+    produces the right join shape per filter type. The INSERT source is an
+    `events` query that HogQL already auto-joins to `session` and `person`, so
+    session/person filters land in the same WHERE clause without template changes.
     """
     if not runner.query.properties:
         return ast.Constant(value=True)
-
-    # Gate already enforces single EventPropertyFilter with $host exact + string value.
-    host_filter = runner.query.properties[0]
-    assert isinstance(host_filter, EventPropertyFilter)
-    return ast.Call(
-        name="equals",
-        args=[
-            ast.Field(chain=["events", "properties", host_filter.key]),
-            ast.Constant(value=host_filter.value),
-        ],
-    )
+    return property_to_expr(runner.query.properties, team=runner.team)
 
 
 def test_account_filter_expr(runner: LazyPrecomputeRunner) -> ast.Expr:

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -15,7 +15,13 @@ from typing import Any, Optional
 import structlog
 import posthoganalytics
 
-from posthog.schema import EventPropertyFilter, PropertyOperator, SessionsV2JoinMode
+from posthog.schema import (
+    CohortPropertyFilter,
+    EventPropertyFilter,
+    PersonPropertyFilter,
+    SessionPropertyFilter,
+    SessionsV2JoinMode,
+)
 
 from posthog.hogql import ast
 from posthog.hogql.property import property_to_expr
@@ -34,10 +40,23 @@ LAZY_TTL_SECONDS: dict[str, int] = {
     "default": 7 * 24 * 60 * 60,
 }
 
-# MVP user-filter allowlist: only an EventPropertyFilter on `$host` with
-# operator `exact` is admitted. Test-account filters are always allowed
+# The gate accepts any combination of `EventPropertyFilter`,
+# `SessionPropertyFilter`, and `PersonPropertyFilter` regardless of operator —
+# we delegate AST construction to `property_to_expr`, which already handles
+# every operator HogQL supports and produces the right join shape per filter
+# type. `CohortPropertyFilter` is rejected because cohort membership changes
+# silently invalidate the cache. Test-account filters are always allowed
 # (their content is hashed into the cache key).
-SUPPORTED_USER_FILTER_KEYS: set[str] = {"$host"}
+SUPPORTED_USER_FILTER_TYPES: tuple[type, ...] = (
+    EventPropertyFilter,
+    SessionPropertyFilter,
+    PersonPropertyFilter,
+)
+
+# Multi-value operators (`exact` with a list, `in`, …) embed the value list
+# inside the INSERT. Past this cap the IN-clause bloats the per-day INSERT
+# without a corresponding cardinality win.
+MAX_FILTER_VALUE_LIST_LEN = 100
 
 # Upper bound on the precompute span. Above this, the framework would create
 # enough daily jobs that the first request burns INSERT slots for minutes.
@@ -85,28 +104,20 @@ class SessionsV2UuidMode(LazyPrecomputeIneligible):
     pass
 
 
-class TooManyFilters(LazyPrecomputeIneligible):
+class CohortFilterUnsupported(LazyPrecomputeIneligible):
     pass
 
 
-class NonEventPropertyFilter(LazyPrecomputeIneligible):
-    pass
+class UnsupportedFilterType(LazyPrecomputeIneligible):
+    def __init__(self, filter_type: str):
+        self.filter_type = filter_type
+        super().__init__(f"filter_type={filter_type!r}")
 
 
-class UnsupportedFilterKey(LazyPrecomputeIneligible):
-    def __init__(self, key: str):
-        self.key = key
-        super().__init__(f"key={key!r}")
-
-
-class UnsupportedFilterOperator(LazyPrecomputeIneligible):
-    def __init__(self, operator: object):
-        self.operator = operator
-        super().__init__(f"operator={operator!r}")
-
-
-class NonStringOrEmptyFilterValue(LazyPrecomputeIneligible):
-    pass
+class FilterValueListTooLong(LazyPrecomputeIneligible):
+    def __init__(self, length: int):
+        self.length = length
+        super().__init__(f"length={length} max={MAX_FILTER_VALUE_LIST_LEN}")
 
 
 class MissingDateRange(LazyPrecomputeIneligible):
@@ -177,17 +188,17 @@ def check_common_eligibility(
     if modifiers and getattr(modifiers, "sessionsV2JoinMode", None) == SessionsV2JoinMode.UUID:
         raise SessionsV2UuidMode()
 
-    if len(properties) > 1:
-        raise TooManyFilters()
+    # Filter combinations: any number, any operator, any key. Cardinality is
+    # bounded by reality (97% of WA queries in prod-us use ≤2 filters), the
+    # daily-fan-out keeps each precompute INSERT bounded, and any churn-y
+    # combos surface in the fallback metric rather than producing wrong results.
     for prop in properties:
-        if not isinstance(prop, EventPropertyFilter):
-            raise NonEventPropertyFilter()
-        if prop.key not in SUPPORTED_USER_FILTER_KEYS:
-            raise UnsupportedFilterKey(prop.key)
-        if prop.operator != PropertyOperator.EXACT:
-            raise UnsupportedFilterOperator(prop.operator)
-        if not isinstance(prop.value, str) or not prop.value:
-            raise NonStringOrEmptyFilterValue()
+        if isinstance(prop, CohortPropertyFilter):
+            raise CohortFilterUnsupported()
+        if not isinstance(prop, SUPPORTED_USER_FILTER_TYPES):
+            raise UnsupportedFilterType(type(prop).__name__)
+        if isinstance(prop.value, list) and len(prop.value) > MAX_FILTER_VALUE_LIST_LEN:
+            raise FilterValueListTooLong(len(prop.value))
 
     date_from, date_to = resolve_date_range()
     if date_from is None or date_to is None:
@@ -212,23 +223,22 @@ def log_eligibility_outcome(*, log_prefix: str, team_id: int, error: Optional[La
         logger.info(f"{log_prefix}_eligible", team_id=team_id)
 
 
-def host_filter_expr(properties: list) -> ast.Expr:
-    """Translate the (gated-down-to-≤1) user filter list to an AST expression.
+def user_filter_expr(properties: list, *, team: Team) -> ast.Expr:
+    """Translate the gated user filter list to an AST expression.
 
     The returned AST is what `ensure_precomputed` hashes into the cache key —
-    different filter values therefore become different precomputed jobs.
+    different filter combinations therefore become different precomputed jobs.
+
+    `property_to_expr` handles every event/session/person filter type and
+    every operator HogQL knows about (exact, is_not, icontains, regex, is_set,
+    …) and produces the right join shape per filter type. The INSERT source is
+    an `events` query that HogQL already auto-joins to `session` and `person`,
+    so session/person filters land in the same WHERE clause without template
+    changes.
     """
     if not properties:
         return ast.Constant(value=True)
-    host_filter = properties[0]
-    assert isinstance(host_filter, EventPropertyFilter)
-    return ast.Call(
-        name="equals",
-        args=[
-            ast.Field(chain=["events", "properties", host_filter.key]),
-            ast.Constant(value=host_filter.value),
-        ],
-    )
+    return property_to_expr(properties, team=team)
 
 
 def test_account_filter_expr(*, test_account_filters: list, team: Team) -> ast.Expr:

--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -37,9 +37,9 @@ from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common imp
     ceil_utc_day,
     check_common_eligibility,
     floor_utc_day,
-    host_filter_expr,
     log_eligibility_outcome,
     test_account_filter_expr,
+    user_filter_expr,
 )
 
 if TYPE_CHECKING:
@@ -283,7 +283,7 @@ def ensure_web_stats_paths_precomputed(
         "breakdown_value_expr": _breakdown_value_expr(runner),
         "entry_breakdown_value_expr": _entry_breakdown_value_expr(runner),
         "event_type_filter": runner.event_type_expr,
-        "user_filter": host_filter_expr(runner.query.properties or []),
+        "user_filter": user_filter_expr(runner.query.properties or [], team=runner.team),
         "test_account_filter": test_account_filter_expr(
             test_account_filters=runner._test_account_filters, team=runner.team
         ),


### PR DESCRIPTION
## Problem

The web analytics lazy-precompute gate (`web_analytics_lazy_precompute.py` and `web_lazy_precompute_common.py`) used to accept only `EventPropertyFilter(key="$host", operator=EXACT, value=<non-empty string>)` — single filter, single key, single operator. This MVP shape blocked the majority of filtered web-analytics traffic from ever hitting the precompute path, even though the underlying INSERT template can express richer WHERE clauses natively.

A 7d prod-us scan of `system.query_log` showed:

- 84% of WA queries have 0 or 1 filters; only ~1% have 4+. Reality bounds filter cardinality regardless of any cap.
- Event-typed `$pathname` (35K / 7d) is the second most common EXACT filter and was rejected by the previous allowlist.
- Session-typed filters (`session:$channel_type`, `session:$entry_referring_domain`, …) account for ~25K / 7d and were rejected by `isinstance(prop, EventPropertyFilter)` — but the lazy INSERT already auto-joins `session` and `person` for unrelated reasons, so they slot into the same WHERE clause without any template change.

## Changes

- Relax `check_common_eligible` / `check_common_eligibility` to accept any number of `EventPropertyFilter` / `SessionPropertyFilter` / `PersonPropertyFilter` with any operator.
- Reject `CohortPropertyFilter` (cohort membership changes silently invalidate the cache).
- Reject multi-value filter lists with more than `MAX_FILTER_VALUE_LIST_LEN=100` entries (oversized IN-clauses bloat every daily INSERT).
- Replace the hand-built `equals(events.properties.$host, value)` AST with `property_to_expr(properties, team=team)` — the same helper already used for the adjacent test-account filter AST.
- New rejection-reason exception classes (`CohortFilterUnsupported`, `UnsupportedFilterType`, `FilterValueListTooLong`) drive the `WEB_ANALYTICS_LAZY_PRECOMPUTE_REJECTED{reason=...}` Prometheus label so we can keep attributing fall-throughs.
- Update `PRECOMPUTATION.md` to reflect the relaxed gate.
- Test files: drop the no-longer-applicable rejection assertions, add positive coverage for multi-filter cache-key separation, cohort rejection, and oversized-list rejection.

The org-level `web-analytics-precompute-toggle` PostHog feature flag still gates rollout per team — the blast radius of this change is bounded by that flag.

## How did you test this code?

Agent-authored PR. Automated tests run locally against the dev ClickHouse:

- `hogli test products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py` — 21 pass / 6 pre-existing CI-flake skips.
- `hogli test products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py` — 25 pass / 9 pre-existing CI-flake skips.
- `hogli test products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py products/web_analytics/backend/hogql_queries/test/test_web_vitals_path_breakdown.py` — 54 pass (regression check).
- `hogli test products/web_analytics/backend/hogql_queries/test/test_web_analytics_metrics.py` — 48 pass (verifies the rejection-reason Prometheus label space).

No manual UI testing performed.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Investigation flow:

1. Used the `evaluating-web-analytics-performance` skill to extract the 7d filter distribution and per-key counts from `system.query_log` via Metabase. The headline data point (~97% of WA queries use ≤2 filters) is what motivated removing the count cap entirely instead of bumping it to 3 or 5.
2. Considered a phased relaxation (expand key allowlist to `BASE_SUPPORTED_PROPERTIES`, keep `EventPropertyFilter` narrow check, keep `EXACT`-only). Rejected after recognizing that the INSERT template already auto-joins `session` and `person` (it references `session.$start_timestamp` etc.), so `SessionPropertyFilter` / `PersonPropertyFilter` land in the same WHERE clause via `property_to_expr` with no template change. The narrow `isinstance` check was conservatism, not correctness.
3. Two parallel common modules (`web_analytics_lazy_precompute.py` for web overview + simple breakdowns, `web_lazy_precompute_common.py` for PATHS + vitals paths) currently duplicate the gate. Both updated in lockstep. Consolidation is an open follow-up — not blocking this change but worth flagging.
4. The `CohortPropertyFilter` test originally crashed at the raw-runner stage because `property_to_expr` resolves cohort IDs at AST-build time and the runner builds the raw query before deciding whether to take the lazy path. Fixed by creating a real `Cohort` fixture in the test.

Reviewer focus areas:

- `property_to_expr` behavior with the relaxed filter types — confirm there is no surprise AST shape that breaks the daily INSERT.
- `MAX_FILTER_VALUE_LIST_LEN=100` as a sane upper bound; the prod distribution doesn't show anything close to that.
- The two-common-modules duplication — happy to file a follow-up issue if it's worth converging now.