### PR TITLE
feat(experiments): exclude variant from experiment.

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -292,6 +292,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_FUNNEL_DWH_SUPPORT: 'experiment-funnel-dwh-support', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
+    EXPERIMENTS_EXCLUDED_VARIANTS: 'experiments-excluded-variants', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_LLM_PROMPTS: 'experiments-llm-prompts', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SYNC_QUERIES: 'experiments-sync-queries', // owner: @andehen #team-experiments

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -18319,7 +18319,7 @@
                     "type": "array"
                 },
                 "id": {
-                    "type": ["number", "null"]
+                    "type": "integer"
                 },
                 "name": {
                     "type": "string"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -18699,6 +18699,13 @@
         "ExperimentParameters": {
             "additionalProperties": false,
             "properties": {
+                "excluded_variants": {
+                    "description": "Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "feature_flag_variants": {
                     "description": "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20.",
                     "items": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3636,6 +3636,8 @@ export interface ExperimentParameters {
     minimum_detectable_effect?: number
     /** Overall rollout percentage (0-100). Controls what fraction of all users enter the experiment. Users outside the rollout never see any variant and are excluded from analysis. Default: 100. */
     rollout_percentage?: number
+    /** Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis. */
+    excluded_variants?: string[]
 }
 
 /** Slim exposure config for experiment API payloads. */

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -1,29 +1,31 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { IconFlag } from '@posthog/icons'
+import { IconFlag, IconLock } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
     LemonDialog,
     LemonModal,
+    LemonSwitch,
     LemonTable,
     LemonTableColumns,
+    LemonTag,
     Link,
 } from '@posthog/lemon-ui'
 
-import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
-import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
-import { IconOpenInApp } from 'lib/lemon-ui/icons'
-
-import { MultivariateFlagVariant } from '~/types'
-
+import { AuthorizedUrlList } from '~/lib/components/AuthorizedUrlList/AuthorizedUrlList'
+import { AuthorizedUrlListType } from '~/lib/components/AuthorizedUrlList/authorizedUrlListLogic'
+import { useFeatureFlag } from '~/lib/hooks/useFeatureFlag'
+import { IconOpenInApp } from '~/lib/lemon-ui/icons'
 import {
     useVariantDistributionValidation,
     VariantDistributionEditor,
-} from '../ExperimentForm/VariantDistributionEditor'
-import { experimentLogic } from '../experimentLogic'
-import { modalsLogic } from '../modalsLogic'
+} from '~/scenes/experiments/ExperimentForm/VariantDistributionEditor'
+import { experimentLogic } from '~/scenes/experiments/experimentLogic'
+import { modalsLogic } from '~/scenes/experiments/modalsLogic'
+import { MultivariateFlagVariant } from '~/types'
+
 import { HoldoutSelector } from './HoldoutSelector'
 import { VariantScreenshot } from './VariantScreenshot'
 import { VariantTag } from './VariantTag'
@@ -106,8 +108,25 @@ export function DistributionModal(): JSX.Element {
 
 export function DistributionTable(): JSX.Element {
     const { openDistributionModal } = useActions(modalsLogic)
-    const { experiment } = useValues(experimentLogic)
-    const { reportExperimentReleaseConditionsViewed } = useActions(experimentLogic)
+    const { experiment, excludedVariants, experimentUpdateLoading } = useValues(experimentLogic)
+    const { reportExperimentReleaseConditionsViewed, setVariantExcluded } = useActions(experimentLogic)
+
+    const excludedVariantsEnabled = useFeatureFlag('EXPERIMENTS_EXCLUDED_VARIANTS')
+
+    /**
+     * This is future-proofing to match the experiment query runner backend, that uses
+     * the baseline variant key to determine the baseline variant.
+     */
+    const baselineKey = experiment.stats_config?.baseline_variant_key || 'control'
+    const variants = experiment.feature_flag?.filters.multivariate?.variants || []
+
+    /**
+     * We use this check to disable the toggle if there's only one test variant left.
+     * - not the baseline variant
+     * - not excluded
+     */
+    const hasOnlyOneTestVariant =
+        variants.filter(({ key }) => key !== baselineKey && !excludedVariants.includes(key)).length <= 1
 
     const onSelectElement = (variant: string): void => {
         LemonDialog.open({
@@ -146,6 +165,55 @@ export function DistributionTable(): JSX.Element {
                 return <div>{`${item.rollout_percentage}%`}</div>
             },
         },
+        ...(excludedVariantsEnabled
+            ? [
+                  {
+                      className,
+                      key: 'analysis',
+                      title: 'Analysis',
+                      render: function Analysis(_, { key }): JSX.Element {
+                          /**
+                           * bail early for holdouts
+                           */
+                          if (key === `holdout-${experiment.holdout?.id}`) {
+                              return <span className="text-muted">-</span>
+                          }
+                          /**
+                           * bail early for baseline variant
+                           */
+                          if (key === baselineKey) {
+                              return (
+                                  <LemonTag type="muted" icon={<IconLock />}>
+                                      Baseline
+                                  </LemonTag>
+                              )
+                          }
+                          const excluded = excludedVariants.includes(key)
+                          /**
+                           * we disable the toggle if:
+                           * - the variant is not excluded: we have to allow re-including it
+                           * - there's only one variant left when we remove the baseline
+                           */
+                          const disableToggle = !excluded && hasOnlyOneTestVariant
+                          return (
+                              <div className="flex items-center gap-2">
+                                  <LemonSwitch
+                                      checked={!excluded}
+                                      onChange={(checked) => setVariantExcluded(key, !checked)}
+                                      disabledReason={
+                                          disableToggle
+                                              ? 'At least one test variant must remain in analysis'
+                                              : undefined
+                                      }
+                                      loading={experimentUpdateLoading}
+                                  />
+                                  {excluded && <LemonTag type="warning">Excluded</LemonTag>}
+                              </div>
+                          )
+                      },
+                  } as LemonTableColumns<MultivariateFlagVariant>[number],
+              ]
+            : []),
         {
             className: className,
             key: 'variant_screenshot',
@@ -235,13 +303,24 @@ export function DistributionTable(): JSX.Element {
                     variants are modified to show their relative rollout percentage.
                 </LemonBanner>
             )}
+            {excludedVariants.length > 0 && hasOnlyOneTestVariant && (
+                <LemonBanner type="warning" className="mb-4">
+                    At least one test variant must remain in analysis. Re-include a variant to exclude others.
+                </LemonBanner>
+            )}
             <LemonTable
                 loading={false}
                 columns={columns}
                 dataSource={tableData}
-                rowClassName={(item) =>
-                    item.key === `holdout-${experiment.holdout?.id}` ? 'dark:bg-fill-primary bg-mid' : ''
-                }
+                rowClassName={(item) => {
+                    if (item.key === `holdout-${experiment.holdout?.id}`) {
+                        return 'dark:bg-fill-primary bg-mid'
+                    }
+                    if (excludedVariants.includes(item.key)) {
+                        return 'bg-fill-tertiary'
+                    }
+                    return ''
+                }}
             />
         </div>
     )

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -2,12 +2,12 @@ import { useActions, useValues } from 'kea'
 import { useCallback, useState } from 'react'
 
 import { IconCheckCircle, IconCorrelationAnalysis, IconInfo, IconPencil, IconWarning } from '@posthog/icons'
-import { LemonButton, LemonCollapse, LemonTable, Spinner, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonCollapse, LemonTable, LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { getSeriesBackgroundColor, getSeriesColor } from 'lib/colors'
 import { dayjs } from 'lib/dayjs'
 import { useChart } from 'lib/hooks/useChart'
-import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
+import { humanFriendlyLargeNumber, humanFriendlyNumber, pluralize } from 'lib/utils'
 
 import {
     ExperimentExposureCriteria,
@@ -230,7 +230,8 @@ function getExposureCriteriaLabel(exposureCriteria: ExperimentExposureCriteria |
 }
 
 export function Exposures(): JSX.Element {
-    const { exposures, exposuresLoading, exposureCriteria, isExperimentDraft } = useValues(experimentLogic)
+    const { exposures, exposuresLoading, exposureCriteria, isExperimentDraft, experiment, excludedVariants } =
+        useValues(experimentLogic)
     const { openExposureCriteriaModal } = useActions(exposureCriteriaModalLogic)
     const colors = useChartColors()
 
@@ -319,6 +320,26 @@ export function Exposures(): JSX.Element {
                                         <IconWarning className="text-warning text-lg" />
                                     </Tooltip>
                                 )}
+                                {excludedVariants.length > 0 && (
+                                    <Tooltip
+                                        title={`Excluded from analysis: ${excludedVariants.join(', ')}. Manage on the Variants tab.`}
+                                    >
+                                        <span className="text-secondary text-xs">
+                                            {pluralize(
+                                                excludedVariants.length,
+                                                'variant excluded',
+                                                'variants excluded'
+                                            )}
+                                        </span>
+                                    </Tooltip>
+                                )}
+                                {experiment.holdout && (
+                                    <Tooltip title="Users held out of this experiment and not included in analysis.">
+                                        <LemonTag type="option" className="ml-2">
+                                            {experiment.holdout.name}
+                                        </LemonTag>
+                                    </Tooltip>
+                                )}
                             </>
                         )}
                     </div>
@@ -386,9 +407,24 @@ export function Exposures(): JSX.Element {
                                 <div>
                                     <h3 className="card-secondary">Total exposures</h3>
                                     <LemonTable
+                                        rowClassName={(series) =>
+                                            series.isExcluded || series.isHoldout ? 'opacity-60' : ''
+                                        }
                                         dataSource={[
                                             //This includes EXPERIMENT_VARIANT_MULTIPLE
                                             ...(exposures?.timeseries || []),
+                                            ...excludedVariants.map((variant) => ({
+                                                variant,
+                                                isExcluded: true,
+                                            })),
+                                            ...(experiment.holdout
+                                                ? [
+                                                      {
+                                                          variant: `holdout-${experiment.holdout_id}`,
+                                                          isHoldout: true,
+                                                      },
+                                                  ]
+                                                : []),
                                             { variant: '__total__', isTotal: true },
                                         ]}
                                         columns={[
@@ -425,27 +461,48 @@ export function Exposures(): JSX.Element {
                                             {
                                                 title: 'Exposures',
                                                 key: 'exposures',
-                                                render: function Exposures(_, series) {
-                                                    if (series.isTotal) {
+                                                render: function Exposures(
+                                                    _,
+                                                    { variant, isTotal, isExcluded, isHoldout }
+                                                ) {
+                                                    if (isTotal) {
                                                         return (
                                                             <span className="font-semibold">
                                                                 {humanFriendlyNumber(totalExposures)}
                                                             </span>
                                                         )
                                                     }
-                                                    return humanFriendlyNumber(
-                                                        exposures?.total_exposures[series.variant]
-                                                    )
+                                                    if (isExcluded || isHoldout) {
+                                                        return <span className="text-secondary">—</span>
+                                                    }
+                                                    return humanFriendlyNumber(exposures?.total_exposures[variant])
                                                 },
                                             },
                                             {
                                                 title: '%',
                                                 key: 'percentage',
-                                                render: function Percentage(_, series) {
-                                                    if (series.isTotal) {
+                                                render: function Percentage(
+                                                    _,
+                                                    { variant, isTotal, isExcluded, isHoldout }
+                                                ) {
+                                                    if (isTotal) {
                                                         return (
                                                             <span className="font-semibold">
                                                                 {totalExposures > 0 ? '100.0%' : '-%'}
+                                                            </span>
+                                                        )
+                                                    }
+                                                    if (isExcluded) {
+                                                        return (
+                                                            <span className="text-secondary italic">
+                                                                Excluded from analysis
+                                                            </span>
+                                                        )
+                                                    }
+                                                    if (isHoldout) {
+                                                        return (
+                                                            <span className="text-secondary italic">
+                                                                Reserved (holdout)
                                                             </span>
                                                         )
                                                     }
@@ -462,8 +519,7 @@ export function Exposures(): JSX.Element {
                                                             {total ? (
                                                                 <>
                                                                     {(
-                                                                        (exposures?.total_exposures[series.variant] /
-                                                                            total) *
+                                                                        (exposures?.total_exposures[variant] / total) *
                                                                         100
                                                                     ).toFixed(1)}
                                                                     %

--- a/frontend/src/scenes/experiments/ExperimentView/VariantTag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/VariantTag.tsx
@@ -3,9 +3,9 @@ import { useValues } from 'kea'
 
 import { LemonTag, Tooltip } from '@posthog/lemon-ui'
 
-import { EXPERIMENT_VARIANT_MULTIPLE } from '../constants'
-import { experimentLogic } from '../experimentLogic'
-import { getVariantColor } from '../utils'
+import { EXPERIMENT_VARIANT_MULTIPLE } from '~/scenes/experiments/constants'
+import { experimentLogic } from '~/scenes/experiments/experimentLogic'
+import { getVariantColor } from '~/scenes/experiments/utils'
 
 export function VariantTag({
     variantKey,
@@ -29,23 +29,6 @@ export function VariantTag({
     const variantColor = experiment.feature_flag?.filters.multivariate?.variants
         ? getVariantColor(variantKey, experiment.feature_flag?.filters.multivariate?.variants)
         : 'var(--text-muted)'
-
-    if (experiment.holdout && variantKey === `holdout-${experiment.holdout_id}`) {
-        return (
-            <span className={clsx('flex items-center min-w-0', className)}>
-                <div
-                    className="w-2 h-2 rounded-full shrink-0"
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{
-                        backgroundColor: variantColor,
-                    }}
-                />
-                <LemonTag type="option" className="ml-2">
-                    {experiment.holdout.name}
-                </LemonTag>
-            </span>
-        )
-    }
 
     return (
         <span className={clsx('flex items-center min-w-0', className)}>

--- a/frontend/src/scenes/experiments/ExperimentView/VariantTag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/VariantTag.tsx
@@ -30,6 +30,19 @@ export function VariantTag({
         ? getVariantColor(variantKey, experiment.feature_flag?.filters.multivariate?.variants)
         : 'var(--text-muted)'
 
+    /**
+     * this is only used on the distribution table, to display the holdout name
+     */
+    if (experiment.holdout && variantKey === `holdout-${experiment.holdout_id}`) {
+        return (
+            <span className={clsx('flex items-center min-w-0', className)}>
+                <LemonTag type="option" className="ml-2">
+                    {experiment.holdout.name}
+                </LemonTag>
+            </span>
+        )
+    }
+
     return (
         <span className={clsx('flex items-center min-w-0', className)}>
             <div

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -20,15 +20,13 @@ import {
     NewExperimentQueryResponse,
 } from '~/queries/schema/schema-general'
 import { NodeKind } from '~/queries/schema/schema-general'
-import { Experiment, InsightType } from '~/types'
-
-import { experimentLogic } from '../../experimentLogic'
-import { isLaunched } from '../../experimentsLogic'
-import { useColumnWidthSync } from '../hooks/useColumnWidthSync'
-import { ChartEmptyState } from '../shared/ChartEmptyState'
-import { ChartLoadingState } from '../shared/ChartLoadingState'
-import { useChartColors } from '../shared/colors'
-import { MetricHeader } from '../shared/MetricHeader'
+import { experimentLogic } from '~/scenes/experiments/experimentLogic'
+import { isLaunched } from '~/scenes/experiments/experimentsLogic'
+import { useColumnWidthSync } from '~/scenes/experiments/MetricsView/hooks/useColumnWidthSync'
+import { ChartEmptyState } from '~/scenes/experiments/MetricsView/shared/ChartEmptyState'
+import { ChartLoadingState } from '~/scenes/experiments/MetricsView/shared/ChartLoadingState'
+import { useChartColors } from '~/scenes/experiments/MetricsView/shared/colors'
+import { MetricHeader } from '~/scenes/experiments/MetricsView/shared/MetricHeader'
 import {
     type ExperimentVariantResult,
     formatChanceToWinForGoal,
@@ -42,7 +40,9 @@ import {
     isDeltaPositive,
     isSignificant,
     isWinning,
-} from '../shared/utils'
+} from '~/scenes/experiments/MetricsView/shared/utils'
+import { Experiment, InsightType } from '~/types'
+
 import { ChartCell } from './ChartCell'
 import {
     CELL_HEIGHT,
@@ -744,8 +744,7 @@ export function MetricRowGroup({
     // At this point, we know result is defined, so we can safely access its properties
     const baselineResult = result.baseline
     const variantResults = result.variant_results || []
-    const totalRows = 1 + variantResults.length
-    const totalRowsHeightStyle = getScaledHeightStyle(totalRows)
+    const totalRowsHeightStyle = getScaledHeightStyle(variantResults.length + 1)
 
     const ratioMetricLabel = (variant: ExperimentStatsBaseValidated, metric: ExperimentMetric): JSX.Element => {
         return (
@@ -802,7 +801,7 @@ export function MetricRowGroup({
                 {/* Metric column - with rowspan */}
                 <td
                     className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${!isLastMetric ? 'border-b' : ''} ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                    rowSpan={totalRows}
+                    rowSpan={variantResults.length + 1}
                     style={totalRowsHeightStyle}
                 >
                     <MetricHeader
@@ -865,7 +864,7 @@ export function MetricRowGroup({
                     className={`w-20 pt-3 align-top relative overflow-hidden ${
                         !isLastMetric ? 'border-b' : ''
                     } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                    rowSpan={totalRows}
+                    rowSpan={variantResults.length + 1}
                     style={totalRowsHeightStyle}
                 >
                     {showDetailsModal && (

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -1595,4 +1595,74 @@ describe('experimentLogic', () => {
             expect(extractErrorDetailString(circular)).toBeNull()
         })
     })
+
+    describe('excluded variants', () => {
+        it('excludedVariants selector returns parameters.excluded_variants', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setExperiment({
+                    ...experiment,
+                    parameters: {
+                        ...experiment.parameters,
+                        excluded_variants: ['test-2'],
+                    },
+                })
+            }).toMatchValues({
+                excludedVariants: ['test-2'],
+            })
+        })
+
+        it('excludedVariants defaults to [] when missing', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setExperiment({
+                    ...experiment,
+                    parameters: { ...experiment.parameters },
+                })
+            }).toMatchValues({
+                excludedVariants: [],
+            })
+        })
+
+        it('setVariantExcluded sends a PATCH with the merged exclusion list', async () => {
+            jest.spyOn(api, 'update')
+            api.update.mockClear()
+            const existingExperiment = {
+                ...experiment,
+                parameters: {
+                    ...experiment.parameters,
+                    excluded_variants: ['test-1'],
+                },
+            } as Experiment
+            api.update.mockResolvedValue(existingExperiment)
+
+            logic.actions.setExperiment(existingExperiment)
+
+            await expectLogic(logic, () => {
+                logic.actions.setVariantExcluded('test-2', true)
+            })
+                .toDispatchActions(['setVariantExcluded'])
+                .toFinishAllListeners()
+
+            const sentParams = (api.update.mock.calls[0][1] as Record<string, any>).parameters
+            expect(sentParams.excluded_variants).toEqual(expect.arrayContaining(['test-1', 'test-2']))
+            expect(sentParams.excluded_variants).toHaveLength(2)
+        })
+
+        it('setVariantExcluded(key, false) removes the key from the exclusion list', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setExperiment({
+                    ...experiment,
+                    parameters: {
+                        ...experiment.parameters,
+                        excluded_variants: ['test-1', 'test-2'],
+                    },
+                })
+            }).toMatchValues({
+                excludedVariants: ['test-1', 'test-2'],
+            })
+
+            // Re-include test-2 — the new list (computed in the listener) must drop it.
+            const next = logic.values.excludedVariants.filter((k) => k !== 'test-2')
+            expect(next).toEqual(['test-1'])
+        })
+    })
 })

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -801,6 +801,7 @@ export const experimentLogic = kea<experimentLogicType>([
         setShowNotificationOffer: (show: boolean) => ({ show }),
         setNotifyWhenResultsReady: (notify: boolean) => ({ notify }),
         toggleDebugPanel: true,
+        setVariantExcluded: (variantKey: string, excluded: boolean) => ({ variantKey, excluded }),
     }),
     reducers({
         showDebugPanel: [
@@ -2215,6 +2216,36 @@ export const experimentLogic = kea<experimentLogicType>([
                 actions.loadSecondaryMetricsResults(true)
             }
         },
+        setVariantExcluded: async ({ variantKey, excluded }, _breakpoint) => {
+            const current = values.excludedVariants
+            const next = excluded
+                ? Array.from(new Set([...current, variantKey]))
+                : current.filter((k: string) => k !== variantKey)
+
+            try {
+                await asyncActions.updateExperiment({
+                    parameters: { ...values.experiment.parameters, excluded_variants: next },
+                })
+                lemonToast.success(
+                    excluded
+                        ? `Variant ${variantKey} excluded from analysis`
+                        : `Variant ${variantKey} re-included in analysis`,
+                    {
+                        button: {
+                            label: 'Undo',
+                            action: () => actions.setVariantExcluded(variantKey, !excluded),
+                        },
+                    }
+                )
+                // Re-fetch metric and exposure results since the variant set changed.
+                actions.loadPrimaryMetricsResults(true)
+                actions.loadSecondaryMetricsResults(true)
+                actions.loadExposures(true)
+            } catch (error) {
+                lemonToast.error('Could not update variant exclusion. Please try again.')
+                throw error
+            }
+        },
         setAutoRefresh: ({ enabled, interval }) => {
             // Track when user toggles auto-refresh settings
             actions.reportExperimentAutoRefreshToggled(values.experiment, enabled, interval)
@@ -2418,6 +2449,10 @@ export const experimentLogic = kea<experimentLogicType>([
             (experiment): MultivariateFlagVariant[] => {
                 return experiment?.parameters?.feature_flag_variants || []
             },
+        ],
+        excludedVariants: [
+            (s) => [s.experiment],
+            (experiment: Experiment): string[] => experiment?.parameters?.excluded_variants ?? [],
         ],
         experimentMathAggregationForTrends: [
             (s) => [s.experiment],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4567,6 +4567,7 @@ export enum ExperimentConclusion {
 }
 
 export interface ExperimentHoldoutType {
+    /** @asType integer */
     id: number | null
     name: string
     description: string | null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4615,6 +4615,7 @@ export interface Experiment {
         aggregation_group_type_index?: integer
         variant_screenshot_media_ids?: Record<string, string[]>
         rollout_percentage?: number
+        excluded_variants?: string[]
         /** Present when the experiment was created from an LLM prompt via /create_from_prompt/. */
         prompt_metadata?: {
             name: string
@@ -4635,6 +4636,7 @@ export interface Experiment {
     stats_config?: {
         version?: number
         method?: ExperimentStatsMethod
+        baseline_variant_key?: string
         bayesian?: {
             ci_level?: number
         }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -22360,7 +22360,7 @@ class ExperimentHoldoutType(BaseModel):
     created_by: UserBasicType | None = None
     description: str | None = None
     filters: list[FeatureFlagGroupType]
-    id: float | None = None
+    id: int
     name: str
     updated_at: str | None = None
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7123,6 +7123,13 @@ class ExperimentParameters(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    excluded_variants: list[str] | None = Field(
+        default=None,
+        description=(
+            "Variant keys to exclude from metric result calculations. Excluded variants"
+            " are still served to users but omitted from statistical analysis."
+        ),
+    )
     feature_flag_variants: list[ExperimentVariant] | None = Field(
         default=None,
         description=(

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -179,6 +179,8 @@ export interface ExperimentVariantApi {
 }
 
 export interface ExperimentParametersApi {
+    /** Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis. */
+    excluded_variants?: string[] | null
     /** Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20. */
     feature_flag_variants?: ExperimentVariantApi[] | null
     /** Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16253,6 +16253,8 @@ export namespace Schemas {
     }
 
     export interface ExperimentParameters {
+      /** Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis. */
+      excluded_variants?: string[] | null;
       /** Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20. */
       feature_flag_variants?: ExperimentVariant[] | null;
       /** Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments. */
@@ -16500,7 +16502,7 @@ export namespace Schemas {
       created_by?: UserBasicType | null;
       description?: string | null;
       filters: FeatureFlagGroupType[];
-      id?: number | null;
+      id: number;
       name: string;
       updated_at?: string | null;
     }

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -159,6 +159,7 @@ export const experimentsCreateBodyNameMax = 400
 
 export const experimentsCreateBodyDescriptionMax = 3000
 
+export const experimentsCreateBodyParametersOneExcludedVariantsDefault = null
 export const experimentsCreateBodyParametersOneFeatureFlagVariantsOneItemNameDefault = null
 export const experimentsCreateBodyParametersOneFeatureFlagVariantsOneItemRolloutPercentageDefault = null
 export const experimentsCreateBodyParametersOneFeatureFlagVariantsOneItemSplitPercentDefault = null
@@ -415,6 +416,12 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
         parameters: zod
             .union([
                 zod.object({
+                    excluded_variants: zod
+                        .union([zod.array(zod.string()), zod.null()])
+                        .default(experimentsCreateBodyParametersOneExcludedVariantsDefault)
+                        .describe(
+                            'Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis.'
+                        ),
                     feature_flag_variants: zod
                         .union([
                             zod.array(
@@ -2846,6 +2853,7 @@ export const experimentsPartialUpdateBodyNameMax = 400
 
 export const experimentsPartialUpdateBodyDescriptionMax = 3000
 
+export const experimentsPartialUpdateBodyParametersOneExcludedVariantsDefault = null
 export const experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsOneItemNameDefault = null
 export const experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsOneItemRolloutPercentageDefault = null
 export const experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsOneItemSplitPercentDefault = null
@@ -3104,6 +3112,12 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
         parameters: zod
             .union([
                 zod.object({
+                    excluded_variants: zod
+                        .union([zod.array(zod.string()), zod.null()])
+                        .default(experimentsPartialUpdateBodyParametersOneExcludedVariantsDefault)
+                        .describe(
+                            'Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis.'
+                        ),
                     feature_flag_variants: zod
                         .union([
                             zod.array(
@@ -5616,6 +5630,7 @@ export const experimentsDuplicateCreateBodyNameMax = 400
 
 export const experimentsDuplicateCreateBodyDescriptionMax = 3000
 
+export const experimentsDuplicateCreateBodyParametersOneExcludedVariantsDefault = null
 export const experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsOneItemNameDefault = null
 export const experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsOneItemRolloutPercentageDefault = null
 export const experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsOneItemSplitPercentDefault = null
@@ -5876,6 +5891,12 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
         parameters: zod
             .union([
                 zod.object({
+                    excluded_variants: zod
+                        .union([zod.array(zod.string()), zod.null()])
+                        .default(experimentsDuplicateCreateBodyParametersOneExcludedVariantsDefault)
+                        .describe(
+                            'Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis.'
+                        ),
                     feature_flag_variants: zod
                         .union([
                             zod.array(

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-create.json
@@ -199,6 +199,21 @@
             "anyOf": [
                 {
                     "properties": {
+                        "excluded_variants": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "default": null,
+                            "description": "Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis."
+                        },
                         "feature_flag_variants": {
                             "anyOf": [
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-duplicate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-duplicate.json
@@ -3692,6 +3692,21 @@
             "anyOf": [
                 {
                     "properties": {
+                        "excluded_variants": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "default": null,
+                            "description": "Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis."
+                        },
                         "feature_flag_variants": {
                             "anyOf": [
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-update.json
@@ -3503,6 +3503,21 @@
             "anyOf": [
                 {
                     "properties": {
+                        "excluded_variants": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "default": null,
+                            "description": "Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis."
+                        },
                         "feature_flag_variants": {
                             "anyOf": [
                                 {


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Holdouts have very limited functionality, so users instead use Feature Flags release conditions to create holdout metrics. That means that some variants need to be excluded from the experiment and its statistical calculations.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR adds all the frontend support needed to manage excluded metrics and visualize results correctly.

### Feature Gated

This code is controlled by a release feature flag, so we can safely merge and test these changes. This is enforced on the `DistributionTable` component.

- `frontend/src/lib/constants.tsx`
- `frontend/src/scenes/experiments/DistributionTable.tsx`

### Experiment type updates

The list of excluded variants is saved on the `Experiment.parameters` JSON field as `excluded_variants`. For backend compatibility, we are also adding `baseline_variant_key` to the `Experiment.stats_config` object. At this moment, we are not allowing changing the baseline ket from `control`, but the backend uses the field, so we are future-proofing this change.

- `frontend/src/types.ts`
- `posthog/schema.py` (generated)
- `frontend/src/queries/schema.json` (generated)
- `frontend/src/queries/schema/schema-general.ts` (generated)

### Manage exclusions on the _variants_ tab

Added an _analysis_ column with a toggle component to allow the user to exclude variants from the experiment. _Baseline_ and holdouts can't be edited (holdouts are excluded by default), and we validate that there is at least one other metric.

Adding or removing exclusions will trigger a refresh of the exposure and all metrics.

| distribution panel on the variants tab |
| - |
| <img width="1454" height="662" alt="image" src="https://github.com/user-attachments/assets/fa63a0c8-d5fa-42ac-b750-ea124289ec8b" /> |

- `frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx`
- `frontend/src/scenes/experiments/ExperimentView/VariantTag.tsx`
- `frontend/src/scenes/experiments/experimentLogic.tsx`

### Exposures

The exposures now include the excluded variants and the configured holdout on its collapsed and expanded views.

| collapsed exposures panel |
| - |
| <img width="1456" height="79" alt="image" src="https://github.com/user-attachments/assets/b5ee0abd-037d-4fd4-9a56-9cce156235b9" /> |

| expanded exposures panel |
| - |
| <img width="1445" height="667" alt="image" src="https://github.com/user-attachments/assets/7eca4553-3506-4151-bb12-135e66b52837" /> |

- `frontend/src/scenes/experiments/ExperimentView/Exposures.tsx`
- `frontend/src/scenes/experiments/ExperimentView/VariantTag.tsx`

### Metrics

There are no necessary changes to the metric results components, since the backend dictates which branches are shown on the results.

### Side effects

There's a minor refactor in `MetricRowGroup` that's a leftover from the original version of this feature.

Also, we fixed a Pydantic problem where the holdout ID was being coerced as a `float`. This had the side effect of hiding cohorts on the exposure view

- `frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test frontend/src/scenes/experiments/experimentLogic.test.ts
```

![cat-type-small](https://github.com/user-attachments/assets/0e9eea19-ff8f-4559-8bef-754f4e3e2083)

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

yes

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

yes

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Model: Opus 4.7
Manually refactored: **yes**
Skills used:
- /brainstorming (superpowers)
- /writing-plans (superpowers)
- /executing-plans (superpowers)
- /subagent-driven-development (superpowers)
- /test-driven-development (superpowers)
- /writing-kea-logics (local)
- /improving-drf-endpoints (local)
- /adopting-generated-api-types (local)

Relevant decisions:
- Storage on `Experiment.parameters.excluded_variants: string[]`, keyed by variant `key` rather than ID, so the schema travels through the planned deprecation of `feature_flag_variants`.
- The query runner filters `self.variants` at a single chokepoint so SQL, missing-variant backfill, and stats inherit the exclusion automatically.
- Cache fingerprint includes `excluded_variants` (sorted, for determinism); changing the list invalidates `ExperimentMetricResult` rows.
- The collapsed exposures header is the single visual indicator: pluralized "N variants excluded" chip plus the holdout LemonTag. Excluded variants and holdout also appear as dimmed rows inside the expanded TOTAL EXPOSURES table.
- Exposure timeseries returns zero-exposure variants with a full date range of zeros (instead of omitting them), so the chart and table render them consistently.
- Toggling exclusion reloads both metric and exposure results so the UI never displays stale fingerprinted data.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
