### PR TITLE
fix(insights): anchor percent-stack bar labels to segment top and fix tooltip

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1969,9 +1969,9 @@ snapshots:
     insights-trendsbarchart--compare--light:
         hash: v1.k794b7964.08db5d36c08b26300a7cd09fddd8f02e9ba973ffcf42e556e7f8ae01a27e907b.jN5qaeiDphtPJ90-0-bNC0jmD0MVkSCj6zjO8XzvZkI
     insights-trendsbarchart--percent-stack-breakdown--dark:
-        hash: v1.k794b7964.b7e405e7536059add287822bbcae51772fab8005ac1f864ee3c65495eaeec4a9.0o8Vkv9xYOCBk1d35UNO2_kA2Oy9iajzneJBiTlq6vg
+        hash: v1.k794b7964.138bf85ccb5f3d76d645f84ae186e515469f2d3ab4caefccc1ab29e107f8a0a7.TR6XmF4pRfQW18owW_7TXPt2OIi7nXlcK7_ch84gnKk
     insights-trendsbarchart--percent-stack-breakdown--light:
-        hash: v1.k794b7964.02fcdcf3d83d1d4a1c0e28e097e1affbecb5d89f803d658bfe90ad49da0bd444.Mqj_tHvOG038o4BV0jE89RHVuDXjLZiYAluTs8Hx1pg
+        hash: v1.k794b7964.1e53fb982558041d72d9538f617745c11dae47369056699e5f022155f2314086.1RYMUrMqQxFF57Qn_qNEj-ZT41zxglI1Dcpm69jMbjk
     insights-trendslifecyclechart--stacked--dark:
         hash: v1.k794b7964.f01dae4d665fea93c451e5bb48d6409d586c89856ffb1fff155937c7eb9119d9.coUQ2-TFqEqeP38cPDoiz5RbwkfznST9H3pR5TRbpvg
     insights-trendslifecyclechart--stacked--light:
@@ -4715,11 +4715,11 @@ snapshots:
     scenes-app-insights-funnels--funnel-historical-trends-edit--light:
         hash: v1.k794b7964.fa67675b6f95f0ae9c46eb0e803f9db69702419bb4ccc2d21ea973f9fe49d9cc.Zz4siV83g7nIXf96Nfvy6eN5rRtzwO3CEmv24KSztlA
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--dark:
-        hash: v1.k794b7964.2a18d8ba3f9634f9d7c9ece2ad8ee2f6716706ecbb30595102d003ca8ad27184.y6n_yOa8fbdhe6yHOtjclzfTFAJ9hj0Da0VbQIhaj2M
+        hash: v1.k794b7964.1df97c88a1076b096c08deccb8c4c291c13b6a4a59fb615e2d77254547381c48.gTsDByOCU_bfzNraCRF_0neMgtIfTq796QitehbRNVQ
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
+        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.gaL7vRk-pWoOUkiPi-NGCd1W72x-M5l9jk5Qu-UcjwI
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
@@ -4731,7 +4731,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--superwide--light:
         hash: v1.k794b7964.c95c5a49f7a20b7fcb1041dd26c73ee87c9a906cb229247a44fd4633bbdc9173.StrJ2VBA5acLqvnsiO2CS_o6qadxeaeO6ST8lxf5UdI
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
-        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
+        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.URrKOLP9uUjbKWcui2yOA7hm_JsXsbkAlOcWJshoQrI
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
     scenes-app-insights-funnels--funnel-time-to-convert--dark:

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -32,9 +32,6 @@ interface Candidate {
     width: number
     color: string
     above: boolean
-    /** Anchor the label centered on `(x, y)` instead of offset by `above`. Used for percent-stack
-     *  segments so the topmost label doesn't render above the chart top. */
-    centered: boolean
 }
 
 function defaultLocaleFormatter(v: number): string {
@@ -62,8 +59,7 @@ function pushCandidate(
     text: string,
     categoricalCoord: number,
     valueCoord: number,
-    above: boolean,
-    centered: boolean = false
+    above: boolean
 ): void {
     const textWidth = ctx ? ctx.measureText(text).width : text.length * 6
     const width = textWidth + LABEL_HORIZONTAL_CHROME
@@ -76,7 +72,6 @@ function pushCandidate(
         width,
         color,
         above,
-        centered,
     })
 }
 
@@ -180,31 +175,26 @@ function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
             }
 
             let displayValue = rawValue
-            let positionValue = yValue
-            let above = yValue >= 0
-            let centered = false
+            // In percent layout, anchor *below* the segment's stacked top so the label hangs
+            // inside its own segment (matches chart.js) instead of floating at the seam above.
+            let above = isPercent ? false : yValue >= 0
 
             if (isPercent) {
                 const total = bandTotal(visibleForTotal, dIdx)
                 if (total == null || total === 0) {
                     continue
                 }
-                const fraction = rawValue / total
                 // Pass the fraction (0..1) so consumers can use the same percentage formatter
                 // (`percentage_scaled`, BarChart's default tick formatter, etc.) they already use
                 // for the value axis.
-                displayValue = fraction
-                // `yValue` here is the stacked top in 0..1 space; subtract half the segment's
-                // height to land at the segment center.
-                positionValue = yValue - fraction / 2
-                centered = true
+                displayValue = rawValue / total
             }
 
             // Pass `s.key` so grouped bar charts (compare-against-previous) anchor each
             // label on its own bar rather than the band center between bars. Other chart
             // types ignore the second arg and fall back to the band/point center.
             const categoricalCoord = scales.x(labels[dIdx], s.key)
-            const valueCoord = yScale(positionValue)
+            const valueCoord = yScale(yValue)
             if (categoricalCoord == null || !isFinite(categoricalCoord) || !isFinite(valueCoord)) {
                 continue
             }
@@ -218,8 +208,7 @@ function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
                 valueFormatter(displayValue, sIdx, dIdx),
                 categoricalCoord,
                 valueCoord,
-                above,
-                centered
+                above
             )
         }
     }
@@ -236,12 +225,11 @@ interface Rect {
 function labelRect(c: Candidate, isHorizontal: boolean): Rect {
     if (isHorizontal) {
         const halfH = LABEL_HEIGHT / 2
-        const halfW = c.width / 2
-        const left = c.centered ? c.x - halfW : c.above ? c.x : c.x - c.width
+        const left = c.above ? c.x : c.x - c.width
         return { left, right: left + c.width, top: c.y - halfH, bottom: c.y + halfH }
     }
     const halfW = c.width / 2
-    const top = c.centered ? c.y - LABEL_HEIGHT / 2 : c.above ? c.y - LABEL_HEIGHT : c.y
+    const top = c.above ? c.y - LABEL_HEIGHT : c.y
     return { left: c.x - halfW, right: c.x + halfW, top, bottom: top + LABEL_HEIGHT }
 }
 
@@ -315,9 +303,6 @@ const LABEL_STYLE_BASE: React.CSSProperties = {
 }
 
 function transformFor(c: Candidate, isHorizontal: boolean): string {
-    if (c.centered) {
-        return 'translate(-50%, -50%)'
-    }
     if (isHorizontal) {
         return c.above ? 'translateY(-50%)' : 'translate(-100%, -50%)'
     }

--- a/products/product_analytics/frontend/insights/trends/shared/TrendsTooltip.tsx
+++ b/products/product_analytics/frontend/insights/trends/shared/TrendsTooltip.tsx
@@ -2,7 +2,8 @@ import { useCallback, useMemo } from 'react'
 
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import type { TooltipContext } from 'lib/hog-charts'
-import { formatAggregationAxisValue, formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { percentage } from 'lib/utils'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { getDatumTitle, SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
@@ -100,7 +101,9 @@ export function TrendsTooltip({
             if (!isPercentStackView) {
                 return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
             }
-            return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency)
+            // hog-charts passes each segment as a 0..1 fraction (segment_height = top − bottom
+            // in expanded-stack space), so format it directly as a percentage.
+            return percentage(value)
         },
         [renderCountOverride, showPercentView, isPercentStackView, trendsFilter, baseCurrency]
     )


### PR DESCRIPTION
## Problem

After #59932 landed, two issues remained in the hog-charts percent-stack bar chart:

1. **Per-segment value labels were vertically centered on their segment**, which made them visually drift toward the middle of the bar instead of clearly belonging to a single colored band. chart.js anchors each label at the top of its segment — that's what the design follows.
2. **The tooltip rendered percentages 100× too small** (`10.26%` showed as `0.10%`). `TrendsTooltip` was sending the segment's 0..1 fraction through `formatPercentStackAxisValue`, which divides by 100 again under the old chart.js 0..100 contract.

## Changes

- **`ValueLabels.tsx`**: in percent layout, render each label inside its segment hanging down from the segment's stacked top (`above: false`) instead of centering it. Removed the now-dead `centered` Candidate flag and its rect/transform special-cases.
- **`TrendsTooltip.tsx`**: when `isPercentStackView` is on, format the value with `percentage(value)` directly. chart.js's `LineGraph` still calls `formatPercentStackAxisValue` with its 0..100 contract, so the helper is left as-is.

### Before / after

| Before | After |
| --- | --- |
| Labels floated centered on each segment; tooltip showed `0.24%` / `0.28%` summing to ~1% per band | Labels hang inside each segment from its top edge; tooltip shows real percentages summing to ~100% |

## How did you test this code?

I'm an agent. I ran the affected jest suites locally:

- `frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx`
- `frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx`
- `frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.test.tsx`
- `products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts`
- `products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat.test.ts`

I also rendered the `Insights/TrendsBarChart` → `PercentStackBreakdown` story locally via Storybook and confirmed the labels now sit inside the top of each colored segment. The user verified the tooltip bug from a real dashboard screenshot; I did not re-verify the tooltip end-to-end in the dev app.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code. Followup to #59932 after the user pointed out the centered-on-segment layout didn't match chart.js's anchored-top design, and the tooltip values were off by 100× on the live dashboard.

Decisions:

- Considered keeping the `centered` Candidate flag for future use; removed it since the only caller was the percent-stack branch and dead optional plumbing tends to mislead readers.
- Considered changing `formatPercentStackAxisValue` to accept 0..1 input; rejected because four chart.js `LineGraph` call sites still rely on its 0..100 contract and there's no value-add in unifying them as part of this fix.