### PR TITLE
fix(insights): sort hog-charts trends tooltip rows by value

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -270,6 +270,7 @@ export function InsightTooltip({
 
     columns.push({
         key: 'datum',
+        className: 'datum-column',
         width: 200,
         title: <span className="whitespace-nowrap">{title}</span>,
         sticky: true,

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
@@ -67,11 +67,15 @@ describe('TrendsLineChart', () => {
         })
 
         it('sorts tooltip rows by descending value regardless of series order', async () => {
+            // At index 2: Pageview=134, Napped=5, Minimal=1, NoActivity=0.
+            // Input order, alphabetic, and value order all differ.
             renderInsight({
                 query: buildTrendsQuery({
                     series: [
                         { kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' },
+                        { kind: NodeKind.EventsNode, event: 'Minimal', name: 'Minimal' },
                         { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
+                        { kind: NodeKind.EventsNode, event: 'NoActivity', name: 'NoActivity' },
                     ],
                 }),
                 featureFlags: HOG_CHARTS_FLAG,
@@ -80,9 +84,14 @@ describe('TrendsLineChart', () => {
             const tooltip = await chart.hoverTooltip(2)
 
             const rows = tooltip.rows()
-            expect(rows).toHaveLength(2)
             expect(rows[0]).toContain('Pageview')
             expect(rows[1]).toContain('Napped')
+            expect(rows[2]).toContain('Minimal')
+            expect(rows[3]).toContain('NoActivity')
+            expect(tooltip.row('Pageview')).toContain('134')
+            expect(tooltip.row('Napped')).toContain('5')
+            expect(tooltip.row('Minimal')).toContain('1')
+            expect(tooltip.row('NoActivity')).toContain('0')
         })
 
         it('shows breakdown values in the tooltip', async () => {

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
@@ -66,6 +66,25 @@ describe('TrendsLineChart', () => {
             expect(glyphs.length).toBe(2)
         })
 
+        it('sorts tooltip rows by descending value regardless of series order', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    series: [
+                        { kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' },
+                        { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
+                    ],
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            const tooltip = await chart.hoverTooltip(2)
+
+            const rows = tooltip.rows()
+            expect(rows).toHaveLength(2)
+            expect(rows[0]).toContain('Pageview')
+            expect(rows[1]).toContain('Napped')
+        })
+
         it('shows breakdown values in the tooltip', async () => {
             renderInsight({
                 query: buildTrendsQuery({

--- a/products/product_analytics/frontend/insights/trends/shared/TrendsTooltip.tsx
+++ b/products/product_analytics/frontend/insights/trends/shared/TrendsTooltip.tsx
@@ -65,27 +65,31 @@ export function TrendsTooltip({
     renderCount: renderCountOverride,
     renderSeriesOverride,
 }: TrendsTooltipProps): React.ReactElement {
-    const seriesData = useMemo<SeriesDatum[]>(
-        () =>
-            context.seriesData.map((entry, idx) => {
-                const meta = entry.series.meta ?? {}
-                return {
-                    id: idx,
-                    dataIndex: context.dataIndex,
-                    datasetIndex: idx,
-                    order: meta.order ?? idx,
-                    label: entry.series.label,
-                    color: entry.color,
-                    count: entry.value,
-                    action: meta.action,
-                    breakdown_value: meta.breakdown_value,
-                    compare_label: meta.compare_label,
-                    date_label: meta.days?.[context.dataIndex],
-                    filter: meta.filter,
-                }
-            }),
-        [context.seriesData, context.dataIndex]
-    )
+    const seriesData = useMemo<SeriesDatum[]>(() => {
+        const data = context.seriesData.map((entry, idx) => {
+            const meta = entry.series.meta ?? {}
+            return {
+                id: idx,
+                dataIndex: context.dataIndex,
+                datasetIndex: idx,
+                order: meta.order ?? idx,
+                label: entry.series.label,
+                color: entry.color,
+                count: entry.value,
+                action: meta.action,
+                breakdown_value: meta.breakdown_value,
+                compare_label: meta.compare_label,
+                date_label: meta.days?.[context.dataIndex],
+                filter: meta.filter,
+            }
+        })
+        data.sort(
+            (a, b) =>
+                b.count - a.count ||
+                (a.label === undefined || b.label === undefined ? -1 : a.label.localeCompare(b.label))
+        )
+        return data.map((s, id) => ({ ...s, id }))
+    }, [context.seriesData, context.dataIndex])
 
     const date = context.seriesData[0]?.series.meta?.days?.[context.dataIndex]
 

--- a/products/product_analytics/frontend/insights/trends/shared/TrendsTooltip.tsx
+++ b/products/product_analytics/frontend/insights/trends/shared/TrendsTooltip.tsx
@@ -86,7 +86,7 @@ export function TrendsTooltip({
         data.sort(
             (a, b) =>
                 b.count - a.count ||
-                (a.label === undefined || b.label === undefined ? -1 : a.label.localeCompare(b.label))
+                (a.label === undefined || b.label === undefined ? 0 : a.label.localeCompare(b.label))
         )
         return data.map((s, id) => ({ ...s, id }))
     }, [context.seriesData, context.dataIndex])


### PR DESCRIPTION
## Problem

In the new hog-charts library, the trends insight tooltip (line, bar, stacked bar, etc.) was rendering series in the order they happened to arrive from the chart, not by descending value. The legacy Chart.js tooltip data builder used to sort by descending count with an alphabetic label fallback, so this was a regression in the hog-charts path.

## Changes

- Sort the rows built by the shared `TrendsTooltip` adapter using the legacy comparator (`count desc`, then `label.localeCompare`), and re-id them after sorting. `datasetIndex` is preserved as the pre-sort context index, so callers that look up the original series (e.g. lifecycle's `onRowClick`) keep working.
- Tag the default `InsightTooltip` first column with `className: 'datum-column'` — the inverted-columns path already did this, so this just makes the two layouts symmetric and lets the existing `tooltip.rows()` test accessor read both.
- Add a `TrendsLineChart` jest test that puts the smaller series first in the query and asserts the larger-count row renders first in the tooltip.

## How did you test this code?

I'm an agent — no manual testing. Ran `pnpm exec jest products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx -t \"sorts tooltip rows\"` and it passes.

## Publish to changelog?