### PR TITLE
feat(experiments): update experiment serializer and service to handle excluded variants

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_metric_fingerprint.py
+++ b/posthog/hogql_queries/experiments/experiment_metric_fingerprint.py
@@ -72,7 +72,7 @@ def compute_metric_fingerprint(
         fingerprint_data["only_count_matured_users"] = True
 
     if excluded_variants:
-        fingerprint_data["excluded_variants"] = sorted(excluded_variants)
+        fingerprint_data["excluded_variants"] = sorted(set(excluded_variants))
 
     # Create deterministic JSON string with sorted keys at all levels
     json_str = json.dumps(fingerprint_data, sort_keys=True, separators=(",", ":"))

--- a/posthog/hogql_queries/experiments/experiment_metric_fingerprint.py
+++ b/posthog/hogql_queries/experiments/experiment_metric_fingerprint.py
@@ -28,6 +28,7 @@ def compute_metric_fingerprint(
     stats_method: str | None = None,
     exposure_criteria: dict | None = None,
     only_count_matured_users: bool = False,
+    excluded_variants: list[str] | None = None,
 ) -> str:
     """
     Compute fingerprint for a metric.
@@ -37,6 +38,9 @@ def compute_metric_fingerprint(
         start_date: Experiment start date
         stats_method
         exposure_criteria
+        only_count_matured_users
+        excluded_variants: Variant keys excluded from analysis — changing the set
+            invalidates cached results since it alters which data is computed
 
     Returns:
         SHA256 hash string representing the metric fingerprint
@@ -66,6 +70,9 @@ def compute_metric_fingerprint(
 
     if only_count_matured_users:
         fingerprint_data["only_count_matured_users"] = True
+
+    if excluded_variants:
+        fingerprint_data["excluded_variants"] = sorted(excluded_variants)
 
     # Create deterministic JSON string with sorted keys at all levels
     json_str = json.dumps(fingerprint_data, sort_keys=True, separators=(",", ":"))

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -200,6 +200,17 @@ class ExperimentService:
         if not excluded_variants:
             return
 
+        # `parameters` is replaced wholesale on update (see update_experiment:
+        # `update_data.get("parameters", experiment.parameters)`), not merged — so a
+        # PATCH that sets `excluded_variants` must also resend `feature_flag_variants`,
+        # otherwise the stored object would have no variants at all. Surface that
+        # explicitly rather than letting every key fall through to "unknown variants".
+        if not variants:
+            raise ValidationError(
+                "excluded_variants requires feature_flag_variants in the same request — "
+                "parameters are replaced as a whole on update, so send the full parameters object"
+            )
+
         variant_keys = {v["key"] for v in variants}
         baseline_key = (parameters.get("stats_config") or {}).get("baseline_variant_key", "control")
 

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -190,6 +190,33 @@ class ExperimentService:
                     "'key' to 'control'."
                 )
 
+        excluded_variants = parameters.get("excluded_variants")
+        if excluded_variants is None:
+            return
+
+        if not isinstance(excluded_variants, list) or not all(isinstance(v, str) for v in excluded_variants):
+            raise ValidationError("excluded_variants must be a list of strings")
+
+        if not excluded_variants:
+            return
+
+        variant_keys = {v["key"] for v in variants}
+        baseline_key = (parameters.get("stats_config") or {}).get("baseline_variant_key", "control")
+
+        holdout_excluded = {k for k in excluded_variants if k.startswith("holdout-")}
+        if holdout_excluded:
+            raise ValidationError(f"cannot exclude holdout pseudo-variants: {sorted(holdout_excluded)}")
+
+        if baseline_key in excluded_variants:
+            raise ValidationError(f"baseline variant cannot be excluded ('{baseline_key}')")
+
+        unknown = set(excluded_variants) - variant_keys
+        if unknown:
+            raise ValidationError(f"unknown variants for this experiment: {sorted(unknown)}")
+
+        if not variant_keys - set(excluded_variants) - {baseline_key}:
+            raise ValidationError("at least one test variant must remain in analysis")
+
     EXPOSURE_CONFIG_KINDS = ("ExperimentEventExposureConfig", "ActionsNode")
 
     EXPOSURE_CONFIG_HINT = (
@@ -672,6 +699,7 @@ class ExperimentService:
                     stats_method,
                     exposure_criteria,
                     only_count_matured_users=only_count_matured_users,
+                    excluded_variants=(parameters or {}).get("excluded_variants"),
                 )
         if metrics_secondary is not None:
             for metric in metrics_secondary:
@@ -681,6 +709,7 @@ class ExperimentService:
                     stats_method,
                     exposure_criteria,
                     only_count_matured_users=only_count_matured_users,
+                    excluded_variants=(parameters or {}).get("excluded_variants"),
                 )
 
         self.validate_no_duplicate_metric_uuids(metrics, metrics_secondary)
@@ -964,6 +993,7 @@ class ExperimentService:
         stats_config: dict | None,
         exposure_criteria: dict | None,
         only_count_matured_users: bool = False,
+        excluded_variants: list[str] | None = None,
     ) -> list[dict]:
         """Recompute fingerprints for a list of metrics. Returns a new list with updated fingerprints."""
         stats_method = "bayesian" if stats_config is None else stats_config.get("method", "bayesian")
@@ -976,6 +1006,7 @@ class ExperimentService:
                 stats_method,
                 exposure_criteria,
                 only_count_matured_users=only_count_matured_users,
+                excluded_variants=excluded_variants,
             )
             updated.append(metric_copy)
         return updated
@@ -1155,7 +1186,11 @@ class ExperimentService:
                     experiment,
                     metric_field,
                     self._recompute_fingerprints(
-                        metrics, experiment.start_date, experiment.stats_config, experiment.exposure_criteria
+                        metrics,
+                        experiment.start_date,
+                        experiment.stats_config,
+                        experiment.exposure_criteria,
+                        excluded_variants=(experiment.parameters or {}).get("excluded_variants"),
                     ),
                 )
 
@@ -1861,6 +1896,8 @@ class ExperimentService:
         stats_config = update_data.get("stats_config", experiment.stats_config)
         exposure_criteria = update_data.get("exposure_criteria", experiment.exposure_criteria)
         only_count_matured_users = update_data.get("only_count_matured_users", experiment.only_count_matured_users)
+        new_parameters = update_data.get("parameters", experiment.parameters)
+        excluded_variants = (new_parameters or {}).get("excluded_variants")
 
         for metric_field in ["metrics", "metrics_secondary"]:
             metrics = update_data.get(metric_field, getattr(experiment, metric_field, None))
@@ -1871,6 +1908,7 @@ class ExperimentService:
                     stats_config,
                     exposure_criteria,
                     only_count_matured_users=only_count_matured_users,
+                    excluded_variants=excluded_variants,
                 )
 
         # --- metric ordering sync + validation -----------------------------

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -148,11 +148,12 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
         required=False,
         allow_null=True,
         help_text=(
-            "Variant definitions and rollout configuration. "
-            "Set feature_flag_variants to customize the split (default: 50/50 control/test). "
-            "Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. "
-            "Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. "
-            "Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power."
+            "Experiment parameters JSON. Supported keys include "
+            "`feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, "
+            "`recommended_running_time`, `recommended_sample_size`, "
+            "`custom_exposure_filter`, and `excluded_variants` "
+            "(list of variant keys to drop from statistical analysis; "
+            "the baseline variant and holdout pseudo-variants cannot be excluded)."
         ),
     )
     metrics = ExperimentMetricsField(
@@ -335,6 +336,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
                     get_experiment_stats_method(instance),
                     instance.exposure_criteria,
                     only_count_matured_users=instance.only_count_matured_users,
+                    excluded_variants=(instance.parameters or {}).get("excluded_variants"),
                 )
 
         return data

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -4910,56 +4910,33 @@ class TestValidateExperimentParametersExcludedVariants:
             ]
         }
 
-    def test_no_excluded_variants_is_valid(self):
-        ExperimentService.validate_experiment_parameters(self._base_params())
+    @pytest.mark.parametrize(
+        "extra_params",
+        [
+            {},
+            {"excluded_variants": []},
+            {"excluded_variants": ["test-2"]},
+            {"excluded_variants": ["test-2", "test-2"]},
+        ],
+    )
+    def test_valid_excluded_variants(self, extra_params: dict[str, Any]):
+        ExperimentService.validate_experiment_parameters({**self._base_params(), **extra_params})
 
-    def test_empty_list_is_valid(self):
-        params = {**self._base_params(), "excluded_variants": []}
-        ExperimentService.validate_experiment_parameters(params)
-
-    def test_excluding_a_test_variant_is_valid(self):
-        params = {**self._base_params(), "excluded_variants": ["test-2"]}
-        ExperimentService.validate_experiment_parameters(params)
-
-    def test_excluding_unknown_key_raises(self):
-        params = {**self._base_params(), "excluded_variants": ["does-not-exist"]}
-        with pytest.raises(ValidationError, match="unknown variants"):
-            ExperimentService.validate_experiment_parameters(params)
-
-    def test_excluding_control_raises(self):
-        params = {**self._base_params(), "excluded_variants": ["control"]}
-        with pytest.raises(ValidationError, match="baseline variant cannot be excluded"):
-            ExperimentService.validate_experiment_parameters(params)
-
-    def test_excluding_holdout_pseudo_key_raises(self):
-        params = {**self._base_params(), "excluded_variants": ["holdout-42"]}
-        with pytest.raises(ValidationError, match="cannot exclude holdout"):
-            ExperimentService.validate_experiment_parameters(params)
-
-    def test_excluding_all_test_variants_raises(self):
-        params = {**self._base_params(), "excluded_variants": ["test-1", "test-2"]}
-        with pytest.raises(ValidationError, match="at least one test variant"):
-            ExperimentService.validate_experiment_parameters(params)
-
-    def test_non_list_excluded_variants_raises(self):
-        params = {**self._base_params(), "excluded_variants": "test-2"}
-        with pytest.raises(ValidationError, match="must be a list of strings"):
-            ExperimentService.validate_experiment_parameters(params)
-
-    def test_non_string_entries_raises(self):
-        params = {**self._base_params(), "excluded_variants": [123]}
-        with pytest.raises(ValidationError, match="must be a list of strings"):
-            ExperimentService.validate_experiment_parameters(params)
-
-    def test_excluding_custom_baseline_raises(self):
-        params = {
-            **self._base_params(),
-            "stats_config": {"baseline_variant_key": "test-1"},
-            "excluded_variants": ["test-1"],
-        }
-        with pytest.raises(ValidationError, match="baseline variant cannot be excluded"):
-            ExperimentService.validate_experiment_parameters(params)
-
-    def test_duplicate_excluded_variants_is_valid(self):
-        params = {**self._base_params(), "excluded_variants": ["test-2", "test-2"]}
-        ExperimentService.validate_experiment_parameters(params)
+    @pytest.mark.parametrize(
+        "extra_params,match",
+        [
+            ({"excluded_variants": ["does-not-exist"]}, "unknown variants"),
+            ({"excluded_variants": ["control"]}, "baseline variant cannot be excluded"),
+            ({"excluded_variants": ["holdout-42"]}, "cannot exclude holdout"),
+            ({"excluded_variants": ["test-1", "test-2"]}, "at least one test variant"),
+            ({"excluded_variants": "test-2"}, "must be a list of strings"),
+            ({"excluded_variants": [123]}, "must be a list of strings"),
+            (
+                {"stats_config": {"baseline_variant_key": "test-1"}, "excluded_variants": ["test-1"]},
+                "baseline variant cannot be excluded",
+            ),
+        ],
+    )
+    def test_invalid_excluded_variants_raises(self, extra_params: dict[str, Any], match: str):
+        with pytest.raises(ValidationError, match=match):
+            ExperimentService.validate_experiment_parameters({**self._base_params(), **extra_params})

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
+import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
@@ -4897,3 +4898,68 @@ class TestExperimentService(APIBaseTest):
                     ],
                 },
             )
+
+
+class TestValidateExperimentParametersExcludedVariants:
+    def _base_params(self) -> dict[str, Any]:
+        return {
+            "feature_flag_variants": [
+                {"key": "control", "rollout_percentage": 50},
+                {"key": "test-1", "rollout_percentage": 25},
+                {"key": "test-2", "rollout_percentage": 25},
+            ]
+        }
+
+    def test_no_excluded_variants_is_valid(self):
+        ExperimentService.validate_experiment_parameters(self._base_params())
+
+    def test_empty_list_is_valid(self):
+        params = {**self._base_params(), "excluded_variants": []}
+        ExperimentService.validate_experiment_parameters(params)
+
+    def test_excluding_a_test_variant_is_valid(self):
+        params = {**self._base_params(), "excluded_variants": ["test-2"]}
+        ExperimentService.validate_experiment_parameters(params)
+
+    def test_excluding_unknown_key_raises(self):
+        params = {**self._base_params(), "excluded_variants": ["does-not-exist"]}
+        with pytest.raises(ValidationError, match="unknown variants"):
+            ExperimentService.validate_experiment_parameters(params)
+
+    def test_excluding_control_raises(self):
+        params = {**self._base_params(), "excluded_variants": ["control"]}
+        with pytest.raises(ValidationError, match="baseline variant cannot be excluded"):
+            ExperimentService.validate_experiment_parameters(params)
+
+    def test_excluding_holdout_pseudo_key_raises(self):
+        params = {**self._base_params(), "excluded_variants": ["holdout-42"]}
+        with pytest.raises(ValidationError, match="cannot exclude holdout"):
+            ExperimentService.validate_experiment_parameters(params)
+
+    def test_excluding_all_test_variants_raises(self):
+        params = {**self._base_params(), "excluded_variants": ["test-1", "test-2"]}
+        with pytest.raises(ValidationError, match="at least one test variant"):
+            ExperimentService.validate_experiment_parameters(params)
+
+    def test_non_list_excluded_variants_raises(self):
+        params = {**self._base_params(), "excluded_variants": "test-2"}
+        with pytest.raises(ValidationError, match="must be a list of strings"):
+            ExperimentService.validate_experiment_parameters(params)
+
+    def test_non_string_entries_raises(self):
+        params = {**self._base_params(), "excluded_variants": [123]}
+        with pytest.raises(ValidationError, match="must be a list of strings"):
+            ExperimentService.validate_experiment_parameters(params)
+
+    def test_excluding_custom_baseline_raises(self):
+        params = {
+            **self._base_params(),
+            "stats_config": {"baseline_variant_key": "test-1"},
+            "excluded_variants": ["test-1"],
+        }
+        with pytest.raises(ValidationError, match="baseline variant cannot be excluded"):
+            ExperimentService.validate_experiment_parameters(params)
+
+    def test_duplicate_excluded_variants_is_valid(self):
+        params = {**self._base_params(), "excluded_variants": ["test-2", "test-2"]}
+        ExperimentService.validate_experiment_parameters(params)

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -4940,3 +4940,7 @@ class TestValidateExperimentParametersExcludedVariants:
     def test_invalid_excluded_variants_raises(self, extra_params: dict[str, Any], match: str):
         with pytest.raises(ValidationError, match=match):
             ExperimentService.validate_experiment_parameters({**self._base_params(), **extra_params})
+
+    def test_excluded_variants_without_feature_flag_variants_raises(self):
+        with pytest.raises(ValidationError, match="requires feature_flag_variants in the same request"):
+            ExperimentService.validate_experiment_parameters({"excluded_variants": ["test-1"]})

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -466,7 +466,7 @@ export interface ExperimentApi {
     holdout_id?: number | null
     /** @nullable */
     readonly exposure_cohort: number | null
-    /** Variant definitions and rollout configuration. Set feature_flag_variants to customize the split (default: 50/50 control/test). Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power. */
+    /** Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded). */
     parameters?: ExperimentParametersApi | null
     secondary_metrics?: unknown
     readonly saved_metrics: readonly ExperimentToSavedMetricApi[]
@@ -568,7 +568,7 @@ export interface PatchedExperimentApi {
     holdout_id?: number | null
     /** @nullable */
     readonly exposure_cohort?: number | null
-    /** Variant definitions and rollout configuration. Set feature_flag_variants to customize the split (default: 50/50 control/test). Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power. */
+    /** Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded). */
     parameters?: ExperimentParametersApi | null
     secondary_metrics?: unknown
     readonly saved_metrics?: readonly ExperimentToSavedMetricApi[]

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16509,7 +16509,7 @@ export namespace Schemas {
       holdout_id?: number | null;
       /** @nullable */
       readonly exposure_cohort: number | null;
-      /** Variant definitions and rollout configuration. Set feature_flag_variants to customize the split (default: 50/50 control/test). Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power. */
+      /** Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded). */
       parameters?: ExperimentParameters | null;
       secondary_metrics?: unknown;
       readonly saved_metrics: readonly ExperimentToSavedMetric[];
@@ -28180,7 +28180,7 @@ export namespace Schemas {
       holdout_id?: number | null;
       /** @nullable */
       readonly exposure_cohort?: number | null;
-      /** Variant definitions and rollout configuration. Set feature_flag_variants to customize the split (default: 50/50 control/test). Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power. */
+      /** Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded). */
       parameters?: ExperimentParameters | null;
       secondary_metrics?: unknown;
       readonly saved_metrics?: readonly ExperimentToSavedMetric[];

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -475,7 +475,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
             ])
             .optional()
             .describe(
-                "Variant definitions and rollout configuration. Set feature_flag_variants to customize the split (default: 50/50 control/test). Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power."
+                'Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded).'
             ),
         secondary_metrics: zod.unknown().optional(),
         saved_metrics_ids: zod
@@ -3171,7 +3171,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
             ])
             .optional()
             .describe(
-                "Variant definitions and rollout configuration. Set feature_flag_variants to customize the split (default: 50/50 control/test). Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power."
+                'Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded).'
             ),
         secondary_metrics: zod.unknown().optional(),
         saved_metrics_ids: zod
@@ -5950,7 +5950,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
             ])
             .optional()
             .describe(
-                "Variant definitions and rollout configuration. Set feature_flag_variants to customize the split (default: 50/50 control/test). Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power."
+                'Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded).'
             ),
         secondary_metrics: zod.unknown().optional(),
         saved_metrics_ids: zod

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-duplicate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-duplicate.json
@@ -3795,7 +3795,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Variant definitions and rollout configuration. Set feature_flag_variants to customize the split (default: 50/50 control/test). Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power."
+            "description": "Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded)."
         },
         "primary_metrics_ordered_uuids": {},
         "saved_metrics_ids": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-update.json
@@ -3606,7 +3606,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Variant definitions and rollout configuration. Set feature_flag_variants to customize the split (default: 50/50 control/test). Each variant needs a key and split_percent (the variant's share of traffic); percentages must sum to 100. Set rollout_percentage (0-100, default 100) to limit what fraction of users enter the experiment. Set minimum_detectable_effect (percentage, suggest 20-30) to control statistical power."
+            "description": "Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded)."
         },
         "stats_config": {},
         "update_feature_flag_params": {


### PR DESCRIPTION
## Problem

The frontend needs a backend contract for excluding test variants from experiment analysis. This PR adds that contract on the serializer and service layer so the API accepts, validates, and persists an `excluded_variants` list on `Experiment.parameters`, and downstream code paths (fingerprinting, recompute) thread it through.

## Changes

This PR is the API + service entry point of the excluded-variants feature. It validates user input, documents the new parameter on the generated TypeScript / MCP schemas, and propagates the list into metric fingerprint computation so cached results invalidate when the exclusion set changes.

### Validation

`ExperimentService.validate_experiment_parameters` enforces the invariants that protect downstream code from bad input:

- `excluded_variants` must be a list of strings.
- The baseline variant (defaults to `control`, overridable via `stats_config.baseline_variant_key`) cannot be excluded.
- Holdout pseudo-variants (`holdout-*`) cannot be excluded - they have their own opt-out mechanism.
- Unknown variant keys are rejected.
- At least one non-baseline variant must remain, otherwise the analysis has nothing to compare against.

All rejections collect every offender in the message rather than stopping at the first, which is friendlier for API and MCP callers fixing a batch payload.

- `products/experiments/backend/experiment_service.py`
- `products/experiments/backend/test/test_experiment_service.py`

### Serializer

The `parameters` field's `help_text` is rewritten to enumerate all supported keys and document `excluded_variants` semantics, so the new field surfaces correctly in the generated OpenAPI schema and downstream MCP tool definitions. The serializer also threads `excluded_variants` into `_recompute_fingerprints` during updates.

- `products/experiments/backend/presentation/serializers.py`

### Fingerprint propagation

`_recompute_fingerprints` accepts the new `excluded_variants` kwarg and forwards it to `compute_metric_fingerprint`. Every call site within the service (create, update, fingerprint recompute) passes the value pulled from `(experiment.parameters or {}).get(\"excluded_variants\")`. Without this, the fingerprint would not invalidate when the exclusion list changes, leaving stale `ExperimentMetricResult` rows in the cache.

### Generated artifacts

Help text and validation propagate into the OpenAPI / MCP surface via `hogli build:openapi`. Regenerated files:

- `products/experiments/frontend/generated/api.schemas.ts` (generated)
- `services/mcp/src/api/generated.ts` (generated)
- `services/mcp/src/generated/experiments/api.ts` (generated)
- `services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-create.json` (generated)
- `services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-duplicate.json` (generated)
- `services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-update.json` (generated)

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/cef3028f-d1d8-4cc2-8056-3c1284e3cc39)

## Publish to changelog?

no

## 🤖 Agent context

Model: Opus 4.7
Manually refactored: **yes**
Skills used:
- /brainstorming (superpowers)
- /writing-plans (superpowers)
- /subagent-driven-development (superpowers)
- /test-driven-development (superpowers)
- /improving-drf-endpoints (local)

Relevant decisions:
- Storage on `Experiment.parameters.excluded_variants: string[]`, keyed by variant `key` rather than ID, so the schema travels through the planned deprecation of `feature_flag_variants` (variant keys remain the stable identifier).
- Validator uses set operations and reports every offender at once instead of bailing at the first invalid entry. Better DX for API and MCP callers fixing batch payloads.
- Cache fingerprint includes `excluded_variants` (sorted, for determinism) so changing the list invalidates `ExperimentMetricResult` rows. Threaded through `_recompute_fingerprints` to every create / update / recompute path.