### PR TITLE
feat(experiments): exclude holdouts and excluded variants from the exposure query

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -70,13 +70,18 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         self.group_type_index = self.query.feature_flag.get("filters", {}).get("aggregation_group_type_index")
         self.exposure_criteria = self.query.exposure_criteria
 
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
-        self.variants = [variant.get("key") for variant in multivariate_data.get("variants", [])]
-
-        if self.query.holdout:
-            self.variants.append(f"holdout-{self.query.holdout.id}")
-
         self.experiment = Experiment.objects.get(id=self.query.experiment_id, team=self.team)
+
+        # Holdout is intentionally not appended: holdout users were never exposed to
+        # the experiment, so they don't belong in the exposure chart. self.query.holdout
+        # is still consulted by _calculate_srm for the holdout-adjusted rollout math.
+        excluded_variants = set((self.experiment.parameters or {}).get("excluded_variants") or [])
+        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
+        self.variants = [
+            variant.get("key")
+            for variant in multivariate_data.get("variants", [])
+            if variant.get("key") not in excluded_variants
+        ]
 
         self.date_range = self._get_date_range()
         self.date_range_query = QueryDateRange(
@@ -190,9 +195,13 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             if key:
                 rollout_percentages[key] = pct
 
-        # Holdout takes its percentage from the total, other variants share the remainder
+        # Holdout reduces the share available to the exposed variants. Rescale
+        # the variant rollouts to reflect what's expected AMONG EXPOSED users
+        # (which is what total_exposures measures). The holdout itself is dropped:
+        # it never appears in total_exposures (the exposure query excludes it from
+        # the WHERE IN clause), so including it in the chi-square would compare
+        # observed=0 to expected>0 and falsely trigger SRM.
         if self.query.holdout:
-            holdout_key = f"holdout-{self.query.holdout.id}"
             holdout_filters = self.query.holdout.filters
             holdout_pct = (
                 holdout_filters[0].rollout_percentage
@@ -201,11 +210,13 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             )
 
             if holdout_pct > 0:
-                rollout_percentages[holdout_key] = holdout_pct
-                remaining = 100 - holdout_pct
-                for key in list(rollout_percentages.keys()):
-                    if key != holdout_key:
-                        rollout_percentages[key] = rollout_percentages[key] * (remaining / 100)
+                scale = (100 - holdout_pct) / 100
+                rollout_percentages = {k: v * scale for k, v in rollout_percentages.items()}
+
+        # excluded_variants are not in the exposure chart, so they must not enter
+        # the chi-square. Drop them from rollout_percentages.
+        excluded_variants = set((self.experiment.parameters or {}).get("excluded_variants") or [])
+        rollout_percentages = {k: v for k, v in rollout_percentages.items() if k not in excluded_variants}
 
         # Get all variant keys with non-zero rollout percentage
         # We must iterate over these (not total_exposures) to ensure sum(observed) == sum(expected)
@@ -217,6 +228,12 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             total_exposures.get(key, 0) for key in variants_with_rollout if key != MULTIPLE_VARIANT_KEY
         )
         if total_observed < SRM_MINIMUM_SAMPLE_SIZE:
+            return None
+
+        # After dropping holdout/excluded variants the remaining percentages may not sum to 100.
+        # Normalise so chi-square expected counts sum to total_observed.
+        total_rollout = sum(rollout_percentages[k] for k in variants_with_rollout if k != MULTIPLE_VARIANT_KEY)
+        if total_rollout <= 0:
             return None
 
         observed: list[float] = []
@@ -231,7 +248,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
 
             obs_count = total_exposures.get(variant_key, 0)
             rollout_pct = rollout_percentages[variant_key]
-            exp_count = (rollout_pct / 100) * total_observed
+            exp_count = (rollout_pct / total_rollout) * total_observed
 
             observed.append(float(obs_count))
             expected.append(exp_count)
@@ -344,8 +361,11 @@ class ExperimentExposuresQueryRunner(QueryRunner):
 
     def _fill_date_gaps(self, results):
         """
-        Ensures the exposure data includes all dates within the experiment's date range.
-        For initial dates with no data, adds entries with zero exposures for each variant.
+        Ensures the exposure data includes all dates within the experiment's date range
+        and an entry for every configured variant — even variants that had zero
+        exposures across the whole window. This lets the response carry an empty
+        timeseries for those variants (days filled with the date range, counts all 0)
+        instead of omitting them entirely.
         """
         date_range = self._get_date_range()
 
@@ -357,7 +377,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         end_date = datetime.fromisoformat(date_range.date_to).date() if date_range.date_to else datetime.now().date()
 
         result_dict = {}
-        variants = set()
+        variants = set(self.variants)
         for date, variant, count in results:
             result_dict[(date, variant)] = count
             variants.add(variant)

--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -75,12 +75,12 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # Holdout is intentionally not appended: holdout users were never exposed to
         # the experiment, so they don't belong in the exposure chart. self.query.holdout
         # is still consulted by _calculate_srm for the holdout-adjusted rollout math.
-        excluded_variants = set((self.experiment.parameters or {}).get("excluded_variants") or [])
+        self.excluded_variants = set((self.experiment.parameters or {}).get("excluded_variants") or [])
         multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
         self.variants = [
             variant.get("key")
             for variant in multivariate_data.get("variants", [])
-            if variant.get("key") not in excluded_variants
+            if variant.get("key") not in self.excluded_variants
         ]
 
         self.date_range = self._get_date_range()
@@ -215,8 +215,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
 
         # excluded_variants are not in the exposure chart, so they must not enter
         # the chi-square. Drop them from rollout_percentages.
-        excluded_variants = set((self.experiment.parameters or {}).get("excluded_variants") or [])
-        rollout_percentages = {k: v for k, v in rollout_percentages.items() if k not in excluded_variants}
+        rollout_percentages = {k: v for k, v in rollout_percentages.items() if k not in self.excluded_variants}
 
         # Get all variant keys with non-zero rollout percentage
         # We must iterate over these (not total_exposures) to ensure sum(observed) == sum(expected)

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -1698,10 +1698,11 @@ class TestExposureRunnerVariantFiltering(ExperimentQueryRunnerBaseTest):
         if parameters != "unset":
             resolved = parameters
             if isinstance(parameters, dict):
+                holdout_key = f"holdout-{holdout.id}" if holdout is not None else self._HOLDOUT_KEY
                 resolved = {
                     **parameters,
                     "excluded_variants": [
-                        f"holdout-{holdout.id}" if key == self._HOLDOUT_KEY else key
+                        holdout_key if key == self._HOLDOUT_KEY else key
                         for key in parameters.get("excluded_variants", [])
                     ],
                 }

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -19,6 +19,7 @@ from posthog.test.test_journeys import journeys_for
 
 from products.actions.backend.models.action import Action
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
+from products.experiments.backend.models.experiment import ExperimentHoldout
 
 
 @override_settings(IN_UNIT_TESTING=True)
@@ -1322,7 +1323,6 @@ class TestExperimentExposuresQueryRunner(ExperimentQueryRunnerBaseTest):
         self.assertIsNone(response.sample_ratio_mismatch)
 
     def test_srm_calculation_adjusts_for_holdout(self):
-        """SRM calculation should adjust expected percentages when holdout is present"""
         holdout_dict = {
             "id": 123,
             "name": "Test Holdout",
@@ -1342,22 +1342,25 @@ class TestExperimentExposuresQueryRunner(ExperimentQueryRunnerBaseTest):
 
         runner = ExperimentExposuresQueryRunner(team=self.team, query=query)
 
-        # Note: holdout.id is a float in schema, so key becomes "holdout-123.0"
-        assert query.holdout is not None
-        holdout_key = f"holdout-{query.holdout.id}"
-
-        # Directly test _calculate_srm with holdout-adjusted data
-        # 20% holdout means control/test share remaining 80% → 40% each
-        total_exposures = {holdout_key: 20, "control": 40, "test": 40}
+        # With 20% holdout, control/test share remaining 80% → 40% each.
+        # The holdout itself is no longer in total_exposures (WHERE IN drops it).
+        # 100 total exposed users at 50:50 = perfectly balanced for the adjusted rollouts.
+        total_exposures = {"control": 50, "test": 50}
 
         result = runner._calculate_srm(total_exposures)
 
         assert result is not None
-        # With 20% holdout, expected is: holdout=20, control=40, test=40 of 100
-        self.assertEqual(result.expected[holdout_key], 20.0)
-        self.assertEqual(result.expected["control"], 40.0)
-        self.assertEqual(result.expected["test"], 40.0)
-        # Perfectly balanced should have p-value = 1.0
+        # Holdout is dropped from rollout_percentages → not in result.expected
+        assert "control" in result.expected
+        assert "test" in result.expected
+        assert query.holdout is not None
+        assert f"holdout-{query.holdout.id}" not in result.expected
+        # After dropping holdout, control and test each have 40% raw rollout (50% × 80%).
+        # The chi-square normalises those equal shares against total_observed=100, so
+        # expected["control"] = expected["test"] = (40/80) * 100 = 50.0.
+        self.assertAlmostEqual(result.expected["control"], 50.0)
+        self.assertAlmostEqual(result.expected["test"], 50.0)
+        # 50:50 of 100 total = 50:50, matches adjusted rollouts exactly → p_value=1.0
         self.assertEqual(result.p_value, 1.0)
 
     def test_srm_excludes_variant_with_zero_rollout_percentage(self):
@@ -1629,3 +1632,141 @@ class TestExperimentExposuresQueryRunner(ExperimentQueryRunnerBaseTest):
         risk = running_runner._evaluate_bias_risk(total_exposures)
         assert risk is not None
         self.assertGreater(risk.multiple_variant_percentage, 0)
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestExposureRunnerVariantFiltering(ExperimentQueryRunnerBaseTest):
+    @staticmethod
+    def _holdout_to_dict(holdout):
+        # model_to_dict includes team/created_at as Python objects, which fail pydantic
+        # validation. Build a minimal dict that matches ExperimentHoldoutType instead.
+        return {
+            "id": holdout.id,
+            "name": holdout.name,
+            "filters": holdout.filters,
+        }
+
+    def _make_query(self, experiment):
+        return ExperimentExposureQuery(
+            kind="ExperimentExposureQuery",
+            experiment_id=experiment.id,
+            experiment_name=experiment.name,
+            feature_flag=model_to_dict(experiment.feature_flag),
+            holdout=self._holdout_to_dict(experiment.holdout) if experiment.holdout else None,
+            start_date=experiment.start_date.isoformat() if experiment.start_date else None,
+            end_date=experiment.end_date.isoformat() if experiment.end_date else None,
+            exposure_criteria=experiment.exposure_criteria,
+        )
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_no_holdout_no_exclusions_keeps_feature_flag_variants(self):
+        feature_flag = self.create_feature_flag(key="neither-exclusion-test")
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
+        assert set(runner.variants) == {"control", "test"}
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_holdout_attached_does_not_appear_in_runner_variants(self):
+        feature_flag = self.create_feature_flag(key="holdout-only-exclusion-test")
+        holdout = ExperimentHoldout.objects.create(
+            team=self.team,
+            name="Holdout A",
+            filters=[{"properties": [], "rollout_percentage": 20}],
+        )
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.holdout = holdout
+        experiment.save()
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
+        assert f"holdout-{holdout.id}" not in runner.variants
+        assert set(runner.variants) == {"control", "test"}
+        assert runner.query.holdout is not None  # still available for SRM
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_excluded_variants_dropped_from_runner_variants(self):
+        feature_flag = self.create_feature_flag(key="excluded-only-exclusion-test")
+        feature_flag.filters["multivariate"]["variants"].append(
+            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
+        )
+        feature_flag.save()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.parameters = {"excluded_variants": ["test-2"]}
+        experiment.save()
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
+        assert "test-2" not in runner.variants
+        assert set(runner.variants) == {"control", "test"}
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_holdout_and_excluded_variants_both_filtered(self):
+        feature_flag = self.create_feature_flag(key="both-exclusion-test")
+        feature_flag.filters["multivariate"]["variants"].append(
+            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
+        )
+        feature_flag.save()
+        holdout = ExperimentHoldout.objects.create(
+            team=self.team,
+            name="Holdout B",
+            filters=[{"properties": [], "rollout_percentage": 10}],
+        )
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.holdout = holdout
+        experiment.parameters = {"excluded_variants": ["test-2"]}
+        experiment.save()
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
+        assert set(runner.variants) == {"control", "test"}
+        assert f"holdout-{holdout.id}" not in runner.variants
+        assert "test-2" not in runner.variants
+        assert runner.query.holdout is not None
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_null_parameters_does_not_raise(self):
+        feature_flag = self.create_feature_flag(key="null-params-exclusion-test")
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.parameters = None
+        experiment.save()
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
+        assert set(runner.variants) == {"control", "test"}
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_empty_excluded_variants_list_is_noop(self):
+        feature_flag = self.create_feature_flag(key="empty-exclusion-list-test")
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.parameters = {"excluded_variants": []}
+        experiment.save()
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
+        assert set(runner.variants) == {"control", "test"}
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_excluded_variants_containing_holdout_key_is_idempotent(self):
+        feature_flag = self.create_feature_flag(key="exclude-names-holdout-test")
+        holdout = ExperimentHoldout.objects.create(
+            team=self.team,
+            name="Holdout C",
+            filters=[{"properties": [], "rollout_percentage": 15}],
+        )
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.holdout = holdout
+        experiment.parameters = {"excluded_variants": [f"holdout-{holdout.id}"]}
+        experiment.save()
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
+        assert set(runner.variants) == {"control", "test"}
+
+    def test_srm_no_false_alarm_when_holdout_present_but_balanced(self):
+        feature_flag = self.create_feature_flag(key="srm-balanced-with-holdout-test")
+        holdout = ExperimentHoldout.objects.create(
+            team=self.team,
+            name="Holdout SRM",
+            filters=[{"properties": [], "rollout_percentage": 20}],
+        )
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.holdout = holdout
+        experiment.save()
+        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
+
+        # 100 exposed users at 50/50 split. Holdout key absent (matches new reality).
+        # total_observed = 50+50 = 100, meeting SRM_MINIMUM_SAMPLE_SIZE.
+        total_exposures = {"control": 50, "test": 50}
+        result = runner._calculate_srm(total_exposures)
+        assert result is not None
+        # Expected percentages should be the holdout-adjusted 40/40 = 50/50 of exposed
+        # (we drop holdout from rollout_percentages). p_value should be 1.0 for perfect balance.
+        assert result.p_value == 1.0

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -18,8 +18,8 @@ from posthog.hogql_queries.experiments.test.experiment_query_runner.utils import
 from posthog.test.test_journeys import journeys_for
 
 from products.actions.backend.models.action import Action
-from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.experiments.backend.models.experiment import ExperimentHoldout
+from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 
 @override_settings(IN_UNIT_TESTING=True)

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -1658,97 +1658,64 @@ class TestExposureRunnerVariantFiltering(ExperimentQueryRunnerBaseTest):
             exposure_criteria=experiment.exposure_criteria,
         )
 
-    @freeze_time("2024-01-01T12:00:00Z")
-    def test_no_holdout_no_exclusions_keeps_feature_flag_variants(self):
-        feature_flag = self.create_feature_flag(key="neither-exclusion-test")
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
-        assert set(runner.variants) == {"control", "test"}
+    # Sentinel used in `excluded_variants` specs to mean "the attached holdout's pseudo-key",
+    # resolved to `holdout-{id}` once the holdout row exists.
+    _HOLDOUT_KEY = "<holdout>"
 
+    @parameterized.expand(
+        [
+            # name, extra_variants, attach_holdout, parameters
+            ("no_holdout_no_exclusions", [], False, "unset"),
+            ("holdout_attached", [], True, "unset"),
+            ("excluded_variant_dropped", ["test-2"], False, {"excluded_variants": ["test-2"]}),
+            ("holdout_and_excluded_both_filtered", ["test-2"], True, {"excluded_variants": ["test-2"]}),
+            ("null_parameters_does_not_raise", [], False, None),
+            ("empty_excluded_variants_is_noop", [], False, {"excluded_variants": []}),
+            ("excluded_variants_naming_holdout_is_idempotent", [], True, {"excluded_variants": [_HOLDOUT_KEY]}),
+        ]
+    )
     @freeze_time("2024-01-01T12:00:00Z")
-    def test_holdout_attached_does_not_appear_in_runner_variants(self):
-        feature_flag = self.create_feature_flag(key="holdout-only-exclusion-test")
-        holdout = ExperimentHoldout.objects.create(
-            team=self.team,
-            name="Holdout A",
-            filters=[{"properties": [], "rollout_percentage": 20}],
-        )
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.holdout = holdout
-        experiment.save()
-        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
-        assert f"holdout-{holdout.id}" not in runner.variants
-        assert set(runner.variants) == {"control", "test"}
-        assert runner.query.holdout is not None  # still available for SRM
+    def test_runner_variant_filtering(self, name, extra_variants, attach_holdout, parameters):
+        feature_flag = self.create_feature_flag(key=f"{name.replace('_', '-')}-test")
+        for index, variant_key in enumerate(extra_variants):
+            feature_flag.filters["multivariate"]["variants"].append(
+                {"key": variant_key, "name": f"Test {index + 2}", "rollout_percentage": 33}
+            )
+        if extra_variants:
+            feature_flag.save()
 
-    @freeze_time("2024-01-01T12:00:00Z")
-    def test_excluded_variants_dropped_from_runner_variants(self):
-        feature_flag = self.create_feature_flag(key="excluded-only-exclusion-test")
-        feature_flag.filters["multivariate"]["variants"].append(
-            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
-        )
-        feature_flag.save()
         experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.parameters = {"excluded_variants": ["test-2"]}
-        experiment.save()
-        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
-        assert "test-2" not in runner.variants
-        assert set(runner.variants) == {"control", "test"}
 
-    @freeze_time("2024-01-01T12:00:00Z")
-    def test_holdout_and_excluded_variants_both_filtered(self):
-        feature_flag = self.create_feature_flag(key="both-exclusion-test")
-        feature_flag.filters["multivariate"]["variants"].append(
-            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
-        )
-        feature_flag.save()
-        holdout = ExperimentHoldout.objects.create(
-            team=self.team,
-            name="Holdout B",
-            filters=[{"properties": [], "rollout_percentage": 10}],
-        )
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.holdout = holdout
-        experiment.parameters = {"excluded_variants": ["test-2"]}
-        experiment.save()
-        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
-        assert set(runner.variants) == {"control", "test"}
-        assert f"holdout-{holdout.id}" not in runner.variants
-        assert "test-2" not in runner.variants
-        assert runner.query.holdout is not None
+        holdout = None
+        if attach_holdout:
+            holdout = ExperimentHoldout.objects.create(
+                team=self.team,
+                name=f"Holdout {name}",
+                filters=[{"properties": [], "rollout_percentage": 20}],
+            )
+            experiment.holdout = holdout
 
-    @freeze_time("2024-01-01T12:00:00Z")
-    def test_null_parameters_does_not_raise(self):
-        feature_flag = self.create_feature_flag(key="null-params-exclusion-test")
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.parameters = None
+        if parameters != "unset":
+            resolved = parameters
+            if isinstance(parameters, dict):
+                resolved = {
+                    **parameters,
+                    "excluded_variants": [
+                        f"holdout-{holdout.id}" if key == self._HOLDOUT_KEY else key
+                        for key in parameters.get("excluded_variants", [])
+                    ],
+                }
+            experiment.parameters = resolved
         experiment.save()
-        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
-        assert set(runner.variants) == {"control", "test"}
 
-    @freeze_time("2024-01-01T12:00:00Z")
-    def test_empty_excluded_variants_list_is_noop(self):
-        feature_flag = self.create_feature_flag(key="empty-exclusion-list-test")
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.parameters = {"excluded_variants": []}
-        experiment.save()
         runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
-        assert set(runner.variants) == {"control", "test"}
 
-    @freeze_time("2024-01-01T12:00:00Z")
-    def test_excluded_variants_containing_holdout_key_is_idempotent(self):
-        feature_flag = self.create_feature_flag(key="exclude-names-holdout-test")
-        holdout = ExperimentHoldout.objects.create(
-            team=self.team,
-            name="Holdout C",
-            filters=[{"properties": [], "rollout_percentage": 15}],
-        )
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.holdout = holdout
-        experiment.parameters = {"excluded_variants": [f"holdout-{holdout.id}"]}
-        experiment.save()
-        runner = ExperimentExposuresQueryRunner(team=self.team, query=self._make_query(experiment))
+        # The runner always reports exactly the analyzable variants — holdout pseudo-variants
+        # and excluded variants are filtered out regardless of how they were specified.
         assert set(runner.variants) == {"control", "test"}
+        if holdout is not None:
+            assert f"holdout-{holdout.id}" not in runner.variants
+            assert runner.query.holdout is not None  # still available for SRM
 
     def test_srm_no_false_alarm_when_holdout_present_but_balanced(self):
         feature_flag = self.create_feature_flag(key="srm-balanced-with-holdout-test")


### PR DESCRIPTION
## Problem

The exposure query runner was inflating the "exposures" surface with users who didn't actually experience the experiment. Two related issues:

- Holdout users were appearing as a third variant in the exposure timeseries, total exposures, and the SRM chi-square. By definition, a holdout user was never exposed to the experiment, so they don't belong in the "who participated" view. Including them conflated "users assigned to a variant" with "users withheld from the experiment".
- `experiment.parameters.excluded_variants` (introduced in the parent PR) was honored by the metric runner but ignored by the exposure runner. The exposure chart would still show variants the user had explicitly removed from analysis.

Fixing the first issue surfaced a latent SRM bug: once the holdout is filtered out of the SQL `WHERE IN`, `total_exposures` no longer contains a holdout key, but the existing `_calculate_srm` still added the holdout to `rollout_percentages` and computed `expected > 0` for it. That produced a false sample-ratio-mismatch alarm on every holdout experiment.

A separate adjacent gap also surfaced during testing: variants with zero exposures were being omitted from the response entirely (rather than returning an empty timeseries), which broke the chart's x-axis assumption that all series share the same days array.

## Changes

This PR makes the exposure runner consistent with the metric runner: holdouts and excluded variants flow out of analysis, the SRM math handles their absence correctly, and the response always carries every configured variant.

### Variant list filtering

The constructor no longer appends the `holdout-{id}` pseudo-variant to `self.variants` and filters out `excluded_variants` from `experiment.parameters`. The Django `Experiment` is loaded first so `parameters` is available before building the list. `self.query.holdout` stays readable for code paths that still need it (SRM rescale, frontend).

- `posthog/hogql_queries/experiments/experiment_exposures_query_runner.py`

### SRM math

`_calculate_srm` no longer adds the holdout key to `rollout_percentages`. The holdout's rollout percentage is still used to rescale the included variants (so the expected control:test ratio reflects "among exposed users"), but the holdout itself is dropped because it has no observed exposures. `excluded_variants` are also dropped from `rollout_percentages` for the same reason.

After dropping entries, the remaining percentages no longer sum to 100, so the chi-square expected counts are now normalised by `sum(rollout_percentages)` instead of dividing by a hardcoded 100. Without this, scipy's `chisquare` would raise because `sum(expected) != sum(observed)`.

### Zero-exposure variants

`_fill_date_gaps` now seeds its variants set from `self.variants` rather than building it only from rows the SQL returned. A variant with zero events across the whole window is now emitted with a full date range of zeros (`days = [d1, d2, ...]`, `exposure_counts = [0, 0, ...]`) instead of being omitted from the response. This unblocks the chart and the totals table, which both assume every configured variant appears in `timeseries`.

- `posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py`

A new `TestExposureRunnerVariantFiltering` test class covers the matrix: no-filter baseline, holdout-only, excluded-only, both filters at once, null `parameters`, empty exclusion list, exclusion list that names the holdout key (idempotent), and an SRM no-false-alarm regression test.

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
hogli test posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py -v
```

![cat-type-small](https://github.com/user-attachments/assets/bf689f29-6990-45fb-ad2f-05be8fb52989)

## Publish to changelog?

no

## 🤖 Agent context

Model: Opus 4.7
Manually refactored: **yes**
Skills used:
- /brainstorming (superpowers)
- /writing-plans (superpowers)
- /subagent-driven-development (superpowers)
- /test-driven-development (superpowers)

Relevant decisions:
- Holdouts are dropped from the exposure analysis entirely rather than rendered as a third comparison variant. A holdout user is by definition not exposed, so comparing their metric to control isn't measuring this experiment - it's measuring cumulative impact of all experiments, which belongs on a separate surface.
- SRM rescale normalisation switched from `pct / 100` to `pct / sum(rollout_percentages)`. Required because dropping holdout/excluded entries leaves the surviving percentages not summing to 100, which scipy's `chisquare` rejects.
- Zero-exposure variants are returned with explicit zero counts (full date range of zeros) rather than omitted. The frontend chart uses `timeseries[0].days` as the x-axis source, so the response must guarantee every configured variant appears in `timeseries`.
