### PR TITLE
feat(experiments): exclude holdouts and excluded variants from the metric query runner

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -141,9 +141,14 @@ class ExperimentQueryRunner(QueryRunner):
         self.group_type_index = self.feature_flag.filters.get("aggregation_group_type_index")
         self.entity_key = get_entity_key(self.group_type_index)
 
-        self.variants = [variant["key"] for variant in self.feature_flag.variants]
-        if self.experiment.holdout:
-            self.variants.append(f"holdout-{self.experiment.holdout.id}")
+        # Holdout is intentionally not appended: holdout users were never exposed to
+        # the experiment, so they don't belong in the metric scorecard.
+        # self.experiment.holdout is still readable for code paths that need it
+        # (e.g. the Distribution table on the Variants tab).
+        excluded_variants = set((self.experiment.parameters or {}).get("excluded_variants") or [])
+        self.variants = [
+            variant["key"] for variant in self.feature_flag.variants if variant["key"] not in excluded_variants
+        ]
 
         stats_config = self.experiment.stats_config or {}
         self.baseline_variant_key = stats_config.get("baseline_variant_key", CONTROL_VARIANT_KEY)

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_add_missing_variants.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_add_missing_variants.py
@@ -237,7 +237,6 @@ class TestAddMissingVariants(ExperimentQueryRunnerBaseTest):
 
     @freeze_time("2020-01-01T12:00:00Z")
     def test_with_holdout_variant(self):
-        """Should handle holdout variants correctly."""
         from products.experiments.backend.models.experiment import ExperimentHoldout
 
         holdout = ExperimentHoldout.objects.create(
@@ -259,8 +258,8 @@ class TestAddMissingVariants(ExperimentQueryRunnerBaseTest):
 
         result = runner._add_missing_variants(cast(list[tuple[tuple[str, ...] | None, ExperimentStatsBase]], variants))
 
-        assert len(result) == 3  # control + test + holdout
+        assert len(result) == 2
         keys = [v[1].key for v in result]
         assert "control" in keys
         assert "test" in keys
-        assert f"holdout-{holdout.id}" in keys
+        assert f"holdout-{holdout.id}" not in keys

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_excluded_variants.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_excluded_variants.py
@@ -1,0 +1,193 @@
+from freezegun import freeze_time
+
+from django.test import override_settings
+
+from posthog.schema import EventsNode, ExperimentMeanMetric, ExperimentMetricMathType, ExperimentQuery
+
+from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
+from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
+from posthog.hogql_queries.experiments.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
+
+from products.experiments.backend.models.experiment import ExperimentHoldout
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestExcludedVariants(ExperimentQueryRunnerBaseTest):
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_excluded_variant_dropped_from_runner_variants(self):
+        # Set up a feature flag with 3 variants: control, test, test-2
+        feature_flag = self.create_feature_flag(key="multi-variant-exclusion-test")
+        feature_flag.filters["multivariate"]["variants"].append(
+            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
+        )
+        feature_flag.save()
+
+        experiment = self.create_experiment(feature_flag=feature_flag)
+
+        # Exclude 'test-2'
+        experiment.parameters = {"excluded_variants": ["test-2"]}
+        experiment.save()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
+        )
+        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+
+        assert "test-2" not in runner.variants
+        assert "control" in runner.variants
+        assert "test" in runner.variants
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_no_exclusions_leaves_variants_unchanged(self):
+        feature_flag = self.create_feature_flag(key="no-exclusion-test")
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        # parameters without excluded_variants
+        experiment.parameters = {}
+        experiment.save()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
+        )
+        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+
+        assert set(runner.variants) == {"control", "test"}
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_none_parameters_leaves_variants_unchanged(self):
+        feature_flag = self.create_feature_flag(key="null-parameters-test")
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.parameters = None
+        experiment.save()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
+        )
+        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+
+        assert set(runner.variants) == {"control", "test"}
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_empty_excluded_variants_list_leaves_variants_unchanged(self):
+        feature_flag = self.create_feature_flag(key="empty-exclusion-test")
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        # Explicitly set excluded_variants to an empty list
+        experiment.parameters = {"excluded_variants": []}
+        experiment.save()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
+        )
+        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+
+        assert set(runner.variants) == {"control", "test"}
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_holdout_not_in_runner_variants_even_with_excluded_variants(self):
+        feature_flag = self.create_feature_flag(key="holdout-exclusion-test")
+        feature_flag.filters["multivariate"]["variants"].append(
+            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
+        )
+        feature_flag.save()
+
+        holdout = ExperimentHoldout.objects.create(
+            team=self.team, name="Test Holdout", filters=[{"properties": [], "rollout_percentage": 20}]
+        )
+
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.holdout = holdout
+        experiment.parameters = {"excluded_variants": ["test-2"]}
+        experiment.save()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
+        )
+        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+
+        assert set(runner.variants) == {"control", "test"}
+        assert f"holdout-{holdout.id}" not in runner.variants
+        assert "test-2" not in runner.variants
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_holdout_attached_does_not_appear_in_runner_variants(self):
+        feature_flag = self.create_feature_flag(key="holdout-only-metric-test")
+        holdout = ExperimentHoldout.objects.create(
+            team=self.team,
+            name="Holdout A",
+            filters=[{"properties": [], "rollout_percentage": 20}],
+        )
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.holdout = holdout
+        experiment.save()
+        metric = ExperimentMeanMetric(source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL))
+        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+
+        assert f"holdout-{holdout.id}" not in runner.variants
+        assert set(runner.variants) == {"control", "test"}
+        # Holdout is still readable on the experiment for UI/etc.
+        assert runner.experiment.holdout is not None
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_holdout_and_excluded_variants_both_filtered(self):
+        feature_flag = self.create_feature_flag(key="both-filters-metric-test")
+        feature_flag.filters["multivariate"]["variants"].append(
+            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
+        )
+        feature_flag.save()
+        holdout = ExperimentHoldout.objects.create(
+            team=self.team,
+            name="Holdout B",
+            filters=[{"properties": [], "rollout_percentage": 10}],
+        )
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.holdout = holdout
+        experiment.parameters = {"excluded_variants": ["test-2"]}
+        experiment.save()
+        metric = ExperimentMeanMetric(source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL))
+        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+
+        assert set(runner.variants) == {"control", "test"}
+        assert f"holdout-{holdout.id}" not in runner.variants
+        assert "test-2" not in runner.variants
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_excluded_variants_containing_holdout_key_is_idempotent(self):
+        feature_flag = self.create_feature_flag(key="exclude-names-holdout-metric-test")
+        holdout = ExperimentHoldout.objects.create(
+            team=self.team,
+            name="Holdout C",
+            filters=[{"properties": [], "rollout_percentage": 15}],
+        )
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.holdout = holdout
+        experiment.parameters = {"excluded_variants": [f"holdout-{holdout.id}"]}
+        experiment.save()
+        metric = ExperimentMeanMetric(source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL))
+        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+
+        assert set(runner.variants) == {"control", "test"}
+
+
+def test_fingerprint_changes_when_excluded_variants_change():
+    metric = {"kind": "ExperimentMeanMetric", "source": {"kind": "EventsNode", "event": "$pageview"}}
+    start = "2026-01-01T00:00:00+00:00"
+
+    fp_none = compute_metric_fingerprint(metric, start, excluded_variants=None)
+    fp_empty = compute_metric_fingerprint(metric, start, excluded_variants=[])
+    fp_one = compute_metric_fingerprint(metric, start, excluded_variants=["test-2"])
+    fp_two = compute_metric_fingerprint(metric, start, excluded_variants=["test-2", "test-3"])
+    fp_two_reversed = compute_metric_fingerprint(metric, start, excluded_variants=["test-3", "test-2"])
+    fp_one_other = compute_metric_fingerprint(metric, start, excluded_variants=["test-3"])
+
+    assert fp_none == fp_empty
+    assert fp_one != fp_empty
+    assert fp_two != fp_one
+    assert fp_two_reversed == fp_two, "Order of excluded keys must not affect fingerprint"
+    assert fp_one != fp_one_other

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_excluded_variants.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_excluded_variants.py
@@ -2,6 +2,8 @@ from freezegun import freeze_time
 
 from django.test import override_settings
 
+from parameterized import parameterized
+
 from posthog.schema import EventsNode, ExperimentMeanMetric, ExperimentMetricMathType, ExperimentQuery
 
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
@@ -13,166 +15,72 @@ from products.experiments.backend.models.experiment import ExperimentHoldout
 
 @override_settings(IN_UNIT_TESTING=True)
 class TestExcludedVariants(ExperimentQueryRunnerBaseTest):
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_excluded_variant_dropped_from_runner_variants(self):
-        # Set up a feature flag with 3 variants: control, test, test-2
-        feature_flag = self.create_feature_flag(key="multi-variant-exclusion-test")
-        feature_flag.filters["multivariate"]["variants"].append(
-            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
-        )
-        feature_flag.save()
+    # Sentinel used in `excluded_variants` specs to mean "the attached holdout's pseudo-key",
+    # resolved to `holdout-{id}` once the holdout row exists.
+    _HOLDOUT_KEY = "<holdout>"
 
-        experiment = self.create_experiment(feature_flag=feature_flag)
-
-        # Exclude 'test-2'
-        experiment.parameters = {"excluded_variants": ["test-2"]}
-        experiment.save()
-
-        metric = ExperimentMeanMetric(
-            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
-        )
-        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
-        runner = ExperimentQueryRunner(query=query, team=self.team)
-
-        assert "test-2" not in runner.variants
-        assert "control" in runner.variants
-        assert "test" in runner.variants
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_no_exclusions_leaves_variants_unchanged(self):
-        feature_flag = self.create_feature_flag(key="no-exclusion-test")
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        # parameters without excluded_variants
-        experiment.parameters = {}
-        experiment.save()
-
-        metric = ExperimentMeanMetric(
-            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
-        )
-        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
-        runner = ExperimentQueryRunner(query=query, team=self.team)
-
-        assert set(runner.variants) == {"control", "test"}
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_none_parameters_leaves_variants_unchanged(self):
-        feature_flag = self.create_feature_flag(key="null-parameters-test")
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.parameters = None
-        experiment.save()
-
-        metric = ExperimentMeanMetric(
-            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
-        )
-        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
-        runner = ExperimentQueryRunner(query=query, team=self.team)
-
-        assert set(runner.variants) == {"control", "test"}
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_empty_excluded_variants_list_leaves_variants_unchanged(self):
-        feature_flag = self.create_feature_flag(key="empty-exclusion-test")
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        # Explicitly set excluded_variants to an empty list
-        experiment.parameters = {"excluded_variants": []}
-        experiment.save()
-
-        metric = ExperimentMeanMetric(
-            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
-        )
-        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
-        runner = ExperimentQueryRunner(query=query, team=self.team)
-
-        assert set(runner.variants) == {"control", "test"}
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_holdout_not_in_runner_variants_even_with_excluded_variants(self):
-        feature_flag = self.create_feature_flag(key="holdout-exclusion-test")
-        feature_flag.filters["multivariate"]["variants"].append(
-            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
-        )
-        feature_flag.save()
-
-        holdout = ExperimentHoldout.objects.create(
-            team=self.team, name="Test Holdout", filters=[{"properties": [], "rollout_percentage": 20}]
-        )
-
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.holdout = holdout
-        experiment.parameters = {"excluded_variants": ["test-2"]}
-        experiment.save()
-
-        metric = ExperimentMeanMetric(
-            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
-        )
-        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
-        runner = ExperimentQueryRunner(query=query, team=self.team)
-
-        assert set(runner.variants) == {"control", "test"}
-        assert f"holdout-{holdout.id}" not in runner.variants
-        assert "test-2" not in runner.variants
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_holdout_attached_does_not_appear_in_runner_variants(self):
-        feature_flag = self.create_feature_flag(key="holdout-only-metric-test")
-        holdout = ExperimentHoldout.objects.create(
-            team=self.team,
-            name="Holdout A",
-            filters=[{"properties": [], "rollout_percentage": 20}],
-        )
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.holdout = holdout
-        experiment.save()
+    def _make_runner(self, experiment):
         metric = ExperimentMeanMetric(source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL))
         query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
-        runner = ExperimentQueryRunner(query=query, team=self.team)
+        return ExperimentQueryRunner(query=query, team=self.team)
 
-        assert f"holdout-{holdout.id}" not in runner.variants
-        assert set(runner.variants) == {"control", "test"}
-        # Holdout is still readable on the experiment for UI/etc.
-        assert runner.experiment.holdout is not None
-
+    @parameterized.expand(
+        [
+            # name, extra_variants, attach_holdout, parameters
+            ("excluded_variant_dropped", ["test-2"], False, {"excluded_variants": ["test-2"]}),
+            ("no_exclusions_unchanged", [], False, {}),
+            ("none_parameters_unchanged", [], False, None),
+            ("empty_excluded_variants_unchanged", [], False, {"excluded_variants": []}),
+            ("holdout_and_excluded_both_filtered", ["test-2"], True, {"excluded_variants": ["test-2"]}),
+            ("holdout_attached", [], True, "unset"),
+            ("excluded_variants_naming_holdout_is_idempotent", [], True, {"excluded_variants": [_HOLDOUT_KEY]}),
+        ]
+    )
     @freeze_time("2020-01-01T12:00:00Z")
-    def test_holdout_and_excluded_variants_both_filtered(self):
-        feature_flag = self.create_feature_flag(key="both-filters-metric-test")
-        feature_flag.filters["multivariate"]["variants"].append(
-            {"key": "test-2", "name": "Test 2", "rollout_percentage": 33}
-        )
-        feature_flag.save()
-        holdout = ExperimentHoldout.objects.create(
-            team=self.team,
-            name="Holdout B",
-            filters=[{"properties": [], "rollout_percentage": 10}],
-        )
+    def test_runner_variant_filtering(self, name, extra_variants, attach_holdout, parameters):
+        feature_flag = self.create_feature_flag(key=f"{name.replace('_', '-')}-test")
+        for index, variant_key in enumerate(extra_variants):
+            feature_flag.filters["multivariate"]["variants"].append(
+                {"key": variant_key, "name": f"Test {index + 2}", "rollout_percentage": 33}
+            )
+        if extra_variants:
+            feature_flag.save()
+
         experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.holdout = holdout
-        experiment.parameters = {"excluded_variants": ["test-2"]}
+
+        holdout = None
+        if attach_holdout:
+            holdout = ExperimentHoldout.objects.create(
+                team=self.team,
+                name=f"Holdout {name}",
+                filters=[{"properties": [], "rollout_percentage": 20}],
+            )
+            experiment.holdout = holdout
+
+        if parameters != "unset":
+            resolved = parameters
+            if isinstance(parameters, dict):
+                holdout_key = f"holdout-{holdout.id}" if holdout is not None else self._HOLDOUT_KEY
+                resolved = {
+                    **parameters,
+                    "excluded_variants": [
+                        holdout_key if key == self._HOLDOUT_KEY else key
+                        for key in parameters.get("excluded_variants", [])
+                    ],
+                }
+            experiment.parameters = resolved
         experiment.save()
-        metric = ExperimentMeanMetric(source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL))
-        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
-        runner = ExperimentQueryRunner(query=query, team=self.team)
 
+        runner = self._make_runner(experiment)
+
+        # The runner always reports exactly the analyzable variants — holdout pseudo-variants
+        # and excluded variants are filtered out regardless of how they were specified.
         assert set(runner.variants) == {"control", "test"}
-        assert f"holdout-{holdout.id}" not in runner.variants
-        assert "test-2" not in runner.variants
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_excluded_variants_containing_holdout_key_is_idempotent(self):
-        feature_flag = self.create_feature_flag(key="exclude-names-holdout-metric-test")
-        holdout = ExperimentHoldout.objects.create(
-            team=self.team,
-            name="Holdout C",
-            filters=[{"properties": [], "rollout_percentage": 15}],
-        )
-        experiment = self.create_experiment(feature_flag=feature_flag)
-        experiment.holdout = holdout
-        experiment.parameters = {"excluded_variants": [f"holdout-{holdout.id}"]}
-        experiment.save()
-        metric = ExperimentMeanMetric(source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL))
-        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
-        runner = ExperimentQueryRunner(query=query, team=self.team)
-
-        assert set(runner.variants) == {"control", "test"}
+        for excluded in extra_variants:
+            assert excluded not in runner.variants
+        if holdout is not None:
+            assert f"holdout-{holdout.id}" not in runner.variants
+            assert runner.experiment.holdout is not None  # still readable for UI/etc.
 
 
 def test_fingerprint_changes_when_excluded_variants_change():

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1015,7 +1015,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1031,7 +1031,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,


### PR DESCRIPTION
## Problem

The metric query runner needs to consume the `excluded_variants` contract introduced in the parent PR, and the holdout-removal-from-analysis decision from the exposure runner needs to land here too. Without these changes:

- A variant in `experiment.parameters.excluded_variants` would still appear in the metric scorecard. The frontend exposes the toggle but the SQL keeps returning the row.
- Holdout users were rendered as a third comparison variant in metric results, with `chance_to_win`, `p_value`, and credible intervals computed against `control`. That's statistically misleading: a holdout user wasn't exposed to the experiment, so comparing their metric to control isn't measuring this experiment.
- The fingerprint that backs `ExperimentMetricResult` caching didn't include `excluded_variants`, so toggling the exclusion list would serve stale results from cache.

## Changes

This PR makes `ExperimentQueryRunner` honour `excluded_variants` and removes holdouts from the metric analysis entirely, with cache fingerprinting that picks up the change.

### Variant list filtering

The runner builds `self.variants` from the feature flag's variants minus anything in `experiment.parameters.excluded_variants`. The holdout pseudo-variant is no longer appended. `self.variants` drives the SQL `WHERE variant IN (...)`, `_add_missing_variants` backfill, and `split_baseline_and_test_variants` stats split, so this single chokepoint propagates the exclusion through the whole pipeline. `self.experiment.holdout` stays readable for code paths that still need it (UI Distribution table, activity log, etc.).

- `posthog/hogql_queries/experiments/experiment_query_runner.py`

### Cache invalidation

`compute_metric_fingerprint` accepts a new `excluded_variants` kwarg and includes the sorted list in the hash inputs. Sorting makes the fingerprint order-insensitive (`['a', 'b']` and `['b', 'a']` hash identically). When the exclusion list changes, the fingerprint changes, and stale `ExperimentMetricResult` rows naturally fall out of cache on the next recompute.

- `posthog/hogql_queries/experiments/experiment_metric_fingerprint.py`

### Tests

`_add_missing_variants` is updated to assert the holdout is NOT backfilled into the missing-variants list (was previously asserting the opposite). A new `TestExcludedVariants` test file covers the exclusion matrix: holdout-attached variants are not in `runner.variants`, both filters at once, null `parameters`, empty exclusion list, exclusion list naming a holdout key (idempotent). It also includes a unit-level fingerprint test that exercises order-independence and confirms None == [].

- `posthog/hogql_queries/experiments/test/experiment_query_runner/test_add_missing_variants.py`
- `posthog/hogql_queries/experiments/test/experiment_query_runner/test_excluded_variants.py`

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
hogli test posthog/hogql_queries/experiments/test/experiment_query_runner/test_excluded_variants.py -v
```

![cat-type-small](https://github.com/user-attachments/assets/8c7fd578-6210-4f9d-b47f-57d06bd947b1)

## Publish to changelog?

no

## 🤖 Agent context

Model: Opus 4.7
Manually refactored: **yes**
Skills used:
- /brainstorming (superpowers)
- /writing-plans (superpowers)
- /subagent-driven-development (superpowers)
- /test-driven-development (superpowers)

Relevant decisions:
- Holdouts are removed from `self.variants` entirely rather than rendered as a third variant in the metric scorecard. A holdout user was never exposed to the experiment, so comparing them to control measures cumulative experiment impact, not this experiment - that belongs on a separate surface.
- Fingerprint hashes `sorted(excluded_variants)` so the cache key is order-independent. Without sorting, `['a', 'b']` and `['b', 'a']` would produce different fingerprints despite being the same logical exclusion.
- No frontend changes required. The `Distribution` table and `VariantTag` synthesize the holdout row from `experiment.holdout` directly, not from `variant_results`, so removing the holdout key from the response is graceful.
