### PR TITLE
fix(insights): size hog-charts left margin for empty series y-axis

### DIFF
--- a/frontend/src/lib/hog-charts/core/hooks/useChartMargins.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartMargins.test.ts
@@ -38,6 +38,14 @@ describe('useChartMargins', () => {
         expect(render({ series: [], labels: [] }).left).toBeGreaterThanOrEqual(20)
     })
 
+    it('sizes the left margin for fallback [0, 1] ticks when series is empty', () => {
+        // Empty series still render a y-axis from the [0, 1] fallback domain — the margin
+        // needs to fit those default tick labels ("0.00", "0.20", …, "1.00"), not collapse
+        // to MIN_LEFT_MARGIN, otherwise the labels get clipped on the left.
+        const widthFor4Chars = 4 * 10 + 12 // mocked measureLabelWidth + Y_LABEL_RIGHT_PADDING
+        expect(render({ series: [], labels: [] }).left).toBe(widthFor4Chars)
+    })
+
     it('grows the right margin to at least 48 when multiple y-axes are present', () => {
         const dual: Series[] = [
             { key: 'a', label: 'A', data: [1, 2, 3] },

--- a/frontend/src/lib/hog-charts/core/hooks/useChartMargins.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartMargins.ts
@@ -41,11 +41,11 @@ function widestCategoryLabelWidth(
 
 function widestValueLabelWidth(series: Series[], yTickFormatter: ((value: number) => string) | undefined): number {
     const range = seriesValueRange(series)
-    if (range.count === 0) {
-        return 0
-    }
-    const min = range.min > 0 ? 0 : range.min
-    const max = range.max < 0 ? 0 : range.max
+    // Empty series still render a y-axis from the fallback [0, 1] domain (see createYScale /
+    // buildBarValueScale). Size the margin for those default tick labels so they don't get
+    // clipped against the left edge.
+    const min = range.count === 0 ? 0 : range.min > 0 ? 0 : range.min
+    const max = range.count === 0 ? 1 : range.max < 0 ? 0 : range.max
     const ticks = d3.scaleLinear().domain([min, max]).nice(6).ticks(6)
     if (ticks.length === 0) {
         return 0


### PR DESCRIPTION
## Problem

When a hog-chart is rendered with no series (e.g. the BoxPlot `Empty` Storybook story), the y-axis tick labels were getting clipped against the left edge. `widestValueLabelWidth` returned `0` early when `seriesValueRange` had no values, so the left margin collapsed to `MIN_LEFT_MARGIN` (20px) — but the chart still drew a y-axis from the fallback `[0, 1]` domain in `createYScale` / `buildBarValueScale`, whose default labels (`"0.00"` … `"1.00"`) need more horizontal space than that.

## Changes

- `widestValueLabelWidth` now sizes against the `[0, 1]` fallback domain when the series is empty, matching what the chart actually renders.
- Added a unit test in `useChartMargins.test.ts` covering the empty-series margin.

Before / after of `Components/HogCharts/BoxPlot → Empty` (labels were cut on the left, now fully visible).

## How did you test this code?

I'm an agent (Claude Code). I ran:

- `useChartMargins.test.ts` — all 11 tests pass.
- `frontend/src/lib/hog-charts/charts/BoxPlot/` — all 42 tests pass.
- Visual check via Storybook: the `Empty` BoxPlot story now renders `0.00`–`1.00` on the y-axis without clipping; `SingleSeries` is unchanged.

## Publish to changelog?

<!-- For features only -->

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). The user reported that the new BoxPlot `Empty` Storybook snapshot had its y-axis labels cut off on the left edge. I traced it to the margin hook returning `0` for empty series while the scale still produced default `[0, 1]` ticks, fixed the hook to size against the same fallback domain, added a regression test, and verified the rendered story locally before opening this PR.