### PR TITLE
fix(llma): guard mcp sessions detail loader against stale responses

### DIFF
--- a/products/mcp_analytics/frontend/sessions/mcpSessionsLogic.ts
+++ b/products/mcp_analytics/frontend/sessions/mcpSessionsLogic.ts
@@ -75,11 +75,12 @@ export const mcpSessionsLogic = kea<mcpSessionsLogicType>([
         toolCalls: [
             [] as MCPToolCallApi[],
             {
-                loadToolCalls: async (sessionId: string) => {
+                loadToolCalls: async (sessionId: string, breakpoint) => {
                     if (!values.currentProjectId || !sessionId) {
                         return []
                     }
                     const response = await mcpAnalyticsSessionsToolCalls(String(values.currentProjectId), sessionId)
+                    breakpoint()
                     return [...(response.results ?? [])]
                 },
             },


### PR DESCRIPTION
## Problem

On `/project/:id/mcp-analytics/sessions`, clicking session rows in quick
succession can leave the detail panel displaying tool calls for a previously
clicked row. Row selection updates synchronously via a reducer, but the
`loadToolCalls` loader fires a network request per click with no staleness
guard — when responses arrive out of order, the late-arriving (stale)
response overwrites the freshest one in the store, so the highlighted row
and the tool calls shown for it disagree.

## Changes

`products/mcp_analytics/frontend/sessions/mcpSessionsLogic.ts` — add the
kea-loaders `breakpoint` parameter to `loadToolCalls` and call
`breakpoint()` immediately after the awaited fetch. When a newer
`loadToolCalls` invocation starts, older in-flight invocations throw
`BreakPointException` at the `breakpoint()` call and their results are
discarded by kea-loaders instead of being committed.

The sibling `loadSessions` loader already uses `breakpoint` for search
debouncing; this brings `loadToolCalls` to parity.

```ts
loadToolCalls: async (sessionId: string, breakpoint) => {
    if (!values.currentProjectId || !sessionId) {
        return []
    }
    const response = await mcpAnalyticsSessionsToolCalls(String(values.currentProjectId), sessionId)
    breakpoint()
    return [...(response.results ?? [])]
},
```

No call sites or action signatures change — kea-loaders injects
`breakpoint` automatically.

## How did you test this code?

I'm an agent — I did not manually exercise the UI. No automated tests were
run; this logic does not currently have a dedicated unit test. A reviewer
can verify by:

1. Opening the sessions page with DevTools Network throttling set to a slow
   profile so requests overlap.
2. Clicking session row A, then B, then C in quick succession.
3. Confirming the detail panel settles on row C's tool calls. Before this
   change, it can settle on A's or B's depending on response order.

## Publish to changelog?

do not publish to changelog

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) at the user's request.

- Repro reported by the user: clicking different items in the MCP sessions
  list sometimes shows the previously clicked session's content when
  responses return out of order. User suggested the loader was "missing a
  key or a breakpoint".
- Exploration with an Explore subagent identified
  `products/mcp_analytics/frontend/sessions/mcpSessionsLogic.ts` and
  pinpointed `loadToolCalls` (no `breakpoint` arg, no AbortController, no
  request-ID tracking) as the only loader without a staleness guard. The
  sibling `loadSessions` already uses `breakpoint` for search debouncing.
- Considered alternatives: AbortController on the fetch call, request-ID
  tracking on the action. Chose `breakpoint` because it's the kea-native
  pattern already used in the same file, requires no new state, and is the
  minimum change consistent with the user's diagnosis.
- Decided against also adding a post-await `breakpoint()` to `loadSessions`
  — it already has a search debounce, and `setFilters`/`setSorting` aren't
  spammed the way row clicks are. Kept this PR minimal and focused.