### PR TITLE
fix(mcp): discard stale tool-call results when switching sessions

### DIFF
--- a/products/mcp_analytics/frontend/sessions/mcpSessionsLogic.ts
+++ b/products/mcp_analytics/frontend/sessions/mcpSessionsLogic.ts
@@ -108,11 +108,14 @@ export const mcpSessionsLogic = kea<mcpSessionsLogicType>([
         toolCalls: [
             [] as MCPToolCallApi[],
             {
-                loadToolCalls: async (sessionId: string) => {
+                loadToolCalls: async (sessionId: string, breakpoint) => {
                     if (!values.currentProjectId || !sessionId) {
                         return []
                     }
                     const response = await mcpAnalyticsSessionsToolCalls(String(values.currentProjectId), sessionId)
+                    // Discard stale results when the user clicks through sessions quickly —
+                    // only the most recently selected session's tool calls should win.
+                    breakpoint()
                     return [...(response.results ?? [])]
                 },
             },


### PR DESCRIPTION
## Problem

Clicking through MCP sessions quickly fires multiple `loadToolCalls` requests. kea-loaders applied whichever resolved last, so a slow earlier request could overwrite the tool calls of the session you actually selected last.

## Changes

Call `breakpoint()` after the await in the `loadToolCalls` loader so superseded invocations are discarded — only the latest selection wins.

## How did you test this code?

Agent-authored. No automated tests added; verified manually by simulating variable backend latency and switching sessions rapidly.

## Docs update

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Chose kea's `breakpoint()` over an `AbortController` since the result-discard fixes the visible glitch with one line; true network cancellation wasn't worth the extra state for a small per-session payload.