### PR TITLE
chore(hog-charts): unwrap hard-wrapped lines in docs

### DIFF
--- a/frontend/src/lib/hog-charts/README.md
+++ b/frontend/src/lib/hog-charts/README.md
@@ -1,8 +1,6 @@
 # hog-charts
 
-PostHog's canvas-based charting library, used for trends, dashboards, and any
-in-app chart that needs to render thousands of points smoothly. D3 powers the
-scales; the canvas does the drawing; React handles overlays.
+PostHog's canvas-based charting library, used for trends, dashboards, and any in-app chart that needs to render thousands of points smoothly. D3 powers the scales; the canvas does the drawing; React handles overlays.
 
 ```tsx
 import { LineChart } from 'lib/hog-charts'
@@ -17,28 +15,17 @@ const THEME: ChartTheme = { colors: ['#1f77b4'], backgroundColor: '#ffffff' }
 
 ## Series
 
-- `series.overlay` (default `false`): marks an auxiliary series derived from
-  primary data — trend lines and moving averages. Excluded from stack
-  computation and from the y-axis baseline calculation, so a trendline
-  projection won't drag the axis below 0 when the underlying data is
-  non-negative. (CI bands are not overlays — they represent real data
-  uncertainty whose range should still influence the axis.)
+- `series.overlay` (default `false`): marks an auxiliary series derived from primary data — trend lines and moving averages. Excluded from stack computation and from the y-axis baseline calculation, so a trendline projection won't drag the axis below 0 when the underlying data is non-negative. (CI bands are not overlays — they represent real data uncertainty whose range should still influence the axis.)
 
 `series.visibility` controls where a series appears:
 
-- `excluded` (default `false`): fully excludes the series — no rendering, no
-  scale contribution, no tooltip row, no hit-testing.
-- `tooltip` (default `true`): when `false`, the series still renders and
-  participates in scales and hit-testing, but is omitted from
-  `TooltipContext.seriesData` so it doesn't appear as a tooltip row.
-- `valueLabel` (default `true`): when `false`, the `ValueLabels` overlay
-  skips this series.
+- `excluded` (default `false`): fully excludes the series — no rendering, no scale contribution, no tooltip row, no hit-testing.
+- `tooltip` (default `true`): when `false`, the series still renders and participates in scales and hit-testing, but is omitted from `TooltipContext.seriesData` so it doesn't appear as a tooltip row.
+- `valueLabel` (default `true`): when `false`, the `ValueLabels` overlay skips this series.
 
 ## Custom tooltip
 
-Pass a render prop to `tooltip`. It receives `TooltipContext` — `seriesData`,
-`label`, `dataIndex`, `position`, etc. Omit to use the built-in
-`DefaultTooltip`.
+Pass a render prop to `tooltip`. It receives `TooltipContext` — `seriesData`, `label`, `dataIndex`, `position`, etc. Omit to use the built-in `DefaultTooltip`.
 
 ```tsx
 <LineChart
@@ -51,14 +38,11 @@ Pass a render prop to `tooltip`. It receives `TooltipContext` — `seriesData`,
 
 ## Custom overlays
 
-Render any React component as a child of the chart and read layout / hover
-state through hooks:
+Render any React component as a child of the chart and read layout / hover state through hooks:
 
-- `useChartLayout()` — scales, dimensions, theme, resolved values. Doesn't
-  re-render on hover.
+- `useChartLayout()` — scales, dimensions, theme, resolved values. Doesn't re-render on hover.
 - `useChartHover()` — hovered data point. Re-renders on every mousemove.
-- `useChart()` — both, kept for back-compat. Use the granular hooks above
-  unless you genuinely need both shapes.
+- `useChart()` — both, kept for back-compat. Use the granular hooks above unless you genuinely need both shapes.
 
 ```tsx
 function GoalLine() {
@@ -74,7 +58,5 @@ function GoalLine() {
 
 ## More
 
-- Building a new chart type, library architecture, conventions →
-  [docs/CONTRIBUTING.md](./docs/CONTRIBUTING.md)
-- Writing tests against a chart, or against code that uses one →
-  [docs/TESTING.md](./docs/TESTING.md)
+- Building a new chart type, library architecture, conventions → [docs/CONTRIBUTING.md](./docs/CONTRIBUTING.md)
+- Writing tests against a chart, or against code that uses one → [docs/TESTING.md](./docs/TESTING.md)

--- a/frontend/src/lib/hog-charts/docs/CONTRIBUTING.md
+++ b/frontend/src/lib/hog-charts/docs/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # Contributing to hog-charts
 
-For people working on the library itself — adding a chart type, adjusting the
-draw loop, extending overlays. If you're embedding a chart in product code,
-read the [README](../README.md) instead.
+For people working on the library itself — adding a chart type, adjusting the draw loop, extending overlays. If you're embedding a chart in product code, read the [README](../README.md) instead.
 
 ## Layers
 
@@ -15,29 +13,18 @@ read the [README](../README.md) instead.
 
 Where new code goes:
 
-- Pure geometry (scales, layouts) → `core/scales.ts`, `core/bar-layout.ts`,
-  or a sibling. Test these directly under `core/`.
+- Pure geometry (scales, layouts) → `core/scales.ts`, `core/bar-layout.ts`, or a sibling. Test these directly under `core/`.
 - Drawing primitives → `core/canvas-renderer.ts`. Stateless, no React.
 - Chart-type React → `charts/<name>/<Name>.tsx`.
-- DOM overlays → `overlays/<Name>.tsx`. Read context via `useChartLayout()`
-  / `useChartHover()`.
+- DOM overlays → `overlays/<Name>.tsx`. Read context via `useChartLayout()` / `useChartHover()`.
 
 ## Conventions
 
-- **No kea, no PostHog imports.** Theme, colors, and data are passed in as
-  props. The library has no app dependencies — it's used by trends but
-  shouldn't know about them.
-- **`ChartScales` must not expose d3 types.** Public interface is
-  `x(label) => px`, `y(value) => px`, `yTicks() => number[]`. d3 stays
-  inside the chart-type's `createScales`.
-- **Canvas functions are stateless.** Pure functions in `canvas-renderer.ts`,
-  no React or side effects. State lives in React; drawing reads it.
-- **Overlays use the granular hooks.** `useChartLayout()` doesn't re-render
-  on hover; `useChartHover()` does. Use `useChart()` only when an overlay
-  genuinely needs both — it re-renders on every mousemove.
-- **Pure logic is tested at the `core/` layer.** Chart-level tests assert on
-  the rendered DOM through the `HogChart` accessor — see
-  [TESTING.md](./TESTING.md).
+- **No kea, no PostHog imports.** Theme, colors, and data are passed in as props. The library has no app dependencies — it's used by trends but shouldn't know about them.
+- **`ChartScales` must not expose d3 types.** Public interface is `x(label) => px`, `y(value) => px`, `yTicks() => number[]`. d3 stays inside the chart-type's `createScales`.
+- **Canvas functions are stateless.** Pure functions in `canvas-renderer.ts`, no React or side effects. State lives in React; drawing reads it.
+- **Overlays use the granular hooks.** `useChartLayout()` doesn't re-render on hover; `useChartHover()` does. Use `useChart()` only when an overlay genuinely needs both — it re-renders on every mousemove.
+- **Pure logic is tested at the `core/` layer.** Chart-level tests assert on the rendered DOM through the `HogChart` accessor — see [TESTING.md](./TESTING.md).
 
 ## Adding a new chart type
 

--- a/frontend/src/lib/hog-charts/docs/TESTING.md
+++ b/frontend/src/lib/hog-charts/docs/TESTING.md
@@ -2,22 +2,14 @@
 
 Two audiences:
 
-- **Embedding hog-charts** in your own component or page and writing tests
-  for that surrounding code → [Testing code that uses hog-charts](#testing-code-that-uses-hog-charts).
-- **Working on the library itself** — chart types, overlays, the draw
-  loop → [Testing the library itself](#testing-the-library-itself).
+- **Embedding hog-charts** in your own component or page and writing tests for that surrounding code → [Testing code that uses hog-charts](#testing-code-that-uses-hog-charts).
+- **Working on the library itself** — chart types, overlays, the draw loop → [Testing the library itself](#testing-the-library-itself).
 
-The contract both sections rely on: the `data-attr` selectors and the
-`HogChart` accessor are stable. Renaming a `data-attr` is a breaking
-change — it breaks consumers' tests as much as renaming an exported type.
-JSdom's canvas is a stub, so canvas pixels aren't a viable test surface
-anyway — assertions go through the DOM.
+The contract both sections rely on: the `data-attr` selectors and the `HogChart` accessor are stable. Renaming a `data-attr` is a breaking change — it breaks consumers' tests as much as renaming an exported type. JSdom's canvas is a stub, so canvas pixels aren't a viable test surface anyway — assertions go through the DOM.
 
 ## Testing code that uses hog-charts
 
-You've rendered a tree that contains a chart somewhere — a dashboard, an
-insight scene, a custom panel. Use your own `render` (or RTL wrappers like
-kea-test-utils) and read the chart with `getHogChart(scope)`:
+You've rendered a tree that contains a chart somewhere — a dashboard, an insight scene, a custom panel. Use your own `render` (or RTL wrappers like kea-test-utils) and read the chart with `getHogChart(scope)`:
 
 ```tsx
 import { render } from '@testing-library/react'
@@ -38,9 +30,7 @@ it('renders the goal line on the dashboard chart', async () => {
 })
 ```
 
-`ensureJsdom()` installs the jsdom mocks (`ResizeObserver`,
-`getBoundingClientRect`) and a synchronous `requestAnimationFrame` shim.
-It's idempotent — call it once at the top of a file and forget about it.
+`ensureJsdom()` installs the jsdom mocks (`ResizeObserver`, `getBoundingClientRect`) and a synchronous `requestAnimationFrame` shim. It's idempotent — call it once at the top of a file and forget about it.
 
 The accessor surface (full list in `testing/accessor.ts`):
 
@@ -60,22 +50,14 @@ chart.annotationBadges() // HTMLElement[]
 For interactions, use the module-level helpers:
 
 - `hoverAtIndex(wrapper, i, totalLabels)` — `mouseMove` over labels[i].
-- `clickAtIndex(wrapper, i, totalLabels)` — hover-then-click. Resolves
-  after the click handler runs.
-- `waitForHogChartTooltip()` — resolves with the rendered tooltip element
-  once it mounts in the `FloatingPortal`.
+- `clickAtIndex(wrapper, i, totalLabels)` — hover-then-click. Resolves after the click handler runs.
+- `waitForHogChartTooltip()` — resolves with the rendered tooltip element once it mounts in the `FloatingPortal`.
 
-`chart.hoverAtIndex(i)` and `chart.waitForTooltip()` (returning a
-structured `TooltipSnapshot` with `seriesData`, `isPinned`, etc.) need
-`renderHogChart` — they read label count and the captured `TooltipContext`
-that only the library's own render wrapper sets up. For most consumer
-tests, DOM assertions through the accessor are enough.
+`chart.hoverAtIndex(i)` and `chart.waitForTooltip()` (returning a structured `TooltipSnapshot` with `seriesData`, `isPinned`, etc.) need `renderHogChart` — they read label count and the captured `TooltipContext` that only the library's own render wrapper sets up. For most consumer tests, DOM assertions through the accessor are enough.
 
 ## Testing the library itself
 
-Chart-level tests live under `charts/<name>/<Name>.test.tsx` and overlay
-tests under `overlays/<Name>.test.tsx`. They render the chart at the top
-level via `renderHogChart` and assert through the `chart` accessor.
+Chart-level tests live under `charts/<name>/<Name>.test.tsx` and overlay tests under `overlays/<Name>.test.tsx`. They render the chart at the top level via `renderHogChart` and assert through the `chart` accessor.
 
 ```tsx
 import type { ChartTheme, Series } from '../core/types'
@@ -96,10 +78,7 @@ describe('LineChart', () => {
 })
 ```
 
-`renderHogChart` is `render` plus three things consumers don't need:
-auto-`ensureJsdom`, tooltip-context capture (so `chart.waitForTooltip()`
-returns the structured `TooltipContext`), and a cached `labels.length`
-(so `chart.hoverAtIndex(i)` doesn't take a `totalLabels` argument).
+`renderHogChart` is `render` plus three things consumers don't need: auto-`ensureJsdom`, tooltip-context capture (so `chart.waitForTooltip()` returns the structured `TooltipContext`), and a cached `labels.length` (so `chart.hoverAtIndex(i)` doesn't take a `totalLabels` argument).
 
 ### Interactions and tooltip context
 
@@ -115,8 +94,7 @@ tooltip.element // rendered portal element
 tooltip.isPinned // true once the user has pinned via click
 ```
 
-Prefer the structured fields. Reach for `tooltip.element.textContent` only
-when the test specifically asserts what the user sees rendered.
+Prefer the structured fields. Reach for `tooltip.element.textContent` only when the test specifically asserts what the user sees rendered.
 
 ### Recipes
 
@@ -165,10 +143,7 @@ it('renders a right axis when a series opts in', () => {
 
 #### Catch a render error
 
-Each chart wraps its inner tree in `ChartErrorBoundary`, which surfaces
-render errors through `onError` instead of unmounting the parent. The
-simplest forcing function is a `tooltip` render prop that throws, since
-the boundary covers tooltip rendering during hover.
+Each chart wraps its inner tree in `ChartErrorBoundary`, which surfaces render errors through `onError` instead of unmounting the parent. The simplest forcing function is a `tooltip` render prop that throws, since the boundary covers tooltip rendering during hover.
 
 ```tsx
 it('reports render errors through onError', () => {
@@ -187,26 +162,14 @@ it('reports render errors through onError', () => {
 
 ### Anti-patterns
 
-**Don't mock `core/canvas-renderer`.** Reaching into draw-function call
-lists tests an internal contract through a side channel. The geometry
-that produced those calls lives in `core/bar-layout.ts` — test it
-directly in `core/bar-layout.test.ts` against `computeSeriesBars`.
+**Don't mock `core/canvas-renderer`.** Reaching into draw-function call lists tests an internal contract through a side channel. The geometry that produced those calls lives in `core/bar-layout.ts` — test it directly in `core/bar-layout.test.ts` against `computeSeriesBars`.
 
-**Don't read `scales._private`.** It's an opaque chart-type-private slot.
-Anything reachable through it is reachable more cleanly at the chart
-type's pure-scale layer.
+**Don't read `scales._private`.** It's an opaque chart-type-private slot. Anything reachable through it is reachable more cleanly at the chart type's pure-scale layer.
 
-**Don't inspect canvas pixels.** No `getContext('2d')` spies, no pixel
-snapshots — JSdom's canvas is a stub anyway.
+**Don't inspect canvas pixels.** No `getContext('2d')` spies, no pixel snapshots — JSdom's canvas is a stub anyway.
 
-**Don't fall back to `container.querySelector('canvas')` for canvas
-presence.** `renderHogChart` already throws when the canvas is missing.
+**Don't fall back to `container.querySelector('canvas')` for canvas presence.** `renderHogChart` already throws when the canvas is missing.
 
-**Don't write `it.each` matrices that only assert "a canvas rendered".**
-Each row should read at least one observable property of that
-permutation — `chart.yTicks().some(t => t.endsWith('%'))` for percent
-layout, `chart.hasRightAxis` for a multi-axis case.
+**Don't write `it.each` matrices that only assert "a canvas rendered".** Each row should read at least one observable property of that permutation — `chart.yTicks().some(t => t.endsWith('%'))` for percent layout, `chart.hasRightAxis` for a multi-axis case.
 
-**Don't reach into React internals.** `useRef` values, internal effects,
-and d3 scale objects are not test surface. The accessor and tooltip
-helpers are the entire surface.
+**Don't reach into React internals.** `useRef` values, internal effects, and d3 scale objects are not test surface. The accessor and tooltip helpers are the entire surface.


### PR DESCRIPTION
## Problem

The hog-charts docs (`README.md`, `docs/CONTRIBUTING.md`, `docs/TESTING.md`) were hard-wrapped mid-sentence at ~80 columns. GitHub renders markdown with flow layout, so the manual breaks produced ragged paragraphs that didn't reflow with the viewport.

## Changes

- Unwrapped prose paragraphs and bullet continuations across the three docs so they wrap naturally.
- Left code blocks, the Layers table, and list structure untouched.

## How did you test this code?

I'm an agent. No manual or automated testing was run — these are markdown-only changes with no code behavior to verify. Diff inspection only.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) at the user's request to remove "random line breaks" from the hog-charts docs. Approach: read each file, rewrite each prose block as a single line per paragraph/bullet while preserving fenced code blocks and the markdown table verbatim. No structural or wording changes.