### PR TITLE
feat(replay-vision): classify failures into typed FailureKind for user-facing labels

### DIFF
--- a/products/replay_vision/backend/api/observations.py
+++ b/products/replay_vision/backend/api/observations.py
@@ -91,9 +91,10 @@ class ReplayObservationSerializer(serializers.ModelSerializer):
         read_only=True,
         allow_blank=True,
         help_text=(
-            "Populated on terminal non-success statuses. For `failed`, the unwrapped activity error. "
-            "For `ineligible`, formatted as `kind:human-readable message` where kind is one of "
-            "no_recording / too_short / too_inactive / too_long / no_events."
+            "Populated on terminal non-success statuses; formatted as `kind:human-readable message`. "
+            "For `ineligible`, kind is one of no_recording / too_short / too_inactive / too_long / no_events. "
+            "For `failed`, kind is one of provider_transient / provider_rejected / rasterization_failed / "
+            "validation_failed / internal_error."
         ),
     )
     workflow_id = serializers.CharField(

--- a/products/replay_vision/backend/models/replay_observation.py
+++ b/products/replay_vision/backend/models/replay_observation.py
@@ -31,9 +31,10 @@ class ReplayObservation(UUIDModel):
         blank=True,
         default="",
         help_text=(
-            "Populated on terminal non-success statuses. For `failed`, the unwrapped activity error. "
-            "For `ineligible`, formatted as `kind:human-readable message` where kind is one of "
-            "no_recording / too_short / too_inactive / too_long / no_events."
+            "Populated on terminal non-success statuses; formatted as `kind:human-readable message`. "
+            "For `ineligible`, kind is one of no_recording / too_short / too_inactive / too_long / no_events. "
+            "For `failed`, kind is one of provider_transient / provider_rejected / rasterization_failed / "
+            "validation_failed / internal_error."
         ),
     )
     workflow_id = models.CharField(

--- a/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
+++ b/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
@@ -12,12 +12,12 @@ from google.genai import types
 from posthoganalytics.ai.gemini import genai
 from pydantic import BaseModel, ValidationError
 from temporalio import activity
-from temporalio.exceptions import ApplicationError
 
 from posthog.models import Team
 
 from products.replay_vision.backend.models.replay_observation import ReplayObservation
 from products.replay_vision.backend.temporal.constants import replay_vision_distinct_id
+from products.replay_vision.backend.temporal.errors import FailureKind, ScannerFailureError
 from products.replay_vision.backend.temporal.scanners import scanner_from_snapshot
 from products.replay_vision.backend.temporal.scanners.base import BaseScanner
 from products.replay_vision.backend.temporal.state import (
@@ -107,7 +107,9 @@ def _load_snapshot(observation_id: UUID, team_id: int) -> ScannerSnapshot:
         .first()
     )
     if raw is None:
-        raise ApplicationError(f"ReplayObservation {observation_id} not found for team {team_id}", non_retryable=True)
+        raise ScannerFailureError(
+            f"ReplayObservation {observation_id} not found for team {team_id}", kind=FailureKind.INTERNAL_ERROR
+        )
     return ScannerSnapshot.load_for(observation_id, raw)
 
 
@@ -115,7 +117,7 @@ def _load_team_name(team_id: int) -> str:
     try:
         return Team.objects.values_list("name", flat=True).get(pk=team_id)
     except Team.DoesNotExist:
-        raise ApplicationError(f"Team {team_id} not found", non_retryable=True)
+        raise ScannerFailureError(f"Team {team_id} not found", kind=FailureKind.INTERNAL_ERROR)
 
 
 async def _load_llm_inputs(observation_id: UUID) -> ScannerLlmInputs:
@@ -125,8 +127,8 @@ async def _load_llm_inputs(observation_id: UUID) -> ScannerLlmInputs:
     )
     payload = await get_data_class_from_redis(redis_client, redis_key, target_class=ScannerLlmInputs)
     if payload is None:
-        raise ApplicationError(
-            f"ScannerLlmInputs missing in Redis for observation {observation_id}", non_retryable=True
+        raise ScannerFailureError(
+            f"ScannerLlmInputs missing in Redis for observation {observation_id}", kind=FailureKind.INTERNAL_ERROR
         )
     return payload
 
@@ -185,9 +187,9 @@ async def _call_with_retry(
             ]
 
     # non_retryable so workflow-level retries don't re-burn on schema/semantic failures.
-    raise ApplicationError(
+    raise ScannerFailureError(
         f"Scanner call rejected after {_MAX_LLM_ATTEMPTS} attempts: {last_error}",
-        non_retryable=True,
+        kind=FailureKind.VALIDATION_FAILED,
     )
 
 

--- a/products/replay_vision/backend/temporal/activities/emit_observation_event.py
+++ b/products/replay_vision/backend/temporal/activities/emit_observation_event.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime
 
 import structlog
 from temporalio import activity
-from temporalio.exceptions import ApplicationError
 
 from posthog.api.capture import capture_internal
 from posthog.models.team import Team
@@ -12,6 +11,7 @@ from posthog.sync import database_sync_to_async
 
 from products.replay_vision.backend.models.replay_observation import ObservationTrigger, ReplayObservation
 from products.replay_vision.backend.temporal.constants import replay_vision_distinct_id
+from products.replay_vision.backend.temporal.errors import FailureKind, ScannerFailureError
 from products.replay_vision.backend.temporal.types import EmitObservationEventInputs, ScannerSnapshot
 
 logger = structlog.get_logger(__name__)
@@ -29,12 +29,16 @@ async def emit_observation_event_activity(inputs: EmitObservationEventInputs) ->
 def _emit_event(inputs: EmitObservationEventInputs) -> None:
     observation = ReplayObservation.objects.select_related("team").filter(pk=inputs.observation_id).first()
     if observation is None:
-        raise ApplicationError(f"ReplayObservation {inputs.observation_id} not found", non_retryable=True)
+        raise ScannerFailureError(
+            f"ReplayObservation {inputs.observation_id} not found", kind=FailureKind.INTERNAL_ERROR
+        )
 
     try:
         team: Team = observation.team
     except Team.DoesNotExist:
-        raise ApplicationError(f"Team for observation {inputs.observation_id} not found", non_retryable=True)
+        raise ScannerFailureError(
+            f"Team for observation {inputs.observation_id} not found", kind=FailureKind.INTERNAL_ERROR
+        )
 
     snapshot = ScannerSnapshot.load_for(inputs.observation_id, observation.scanner_snapshot)
     properties: dict = {

--- a/products/replay_vision/backend/temporal/activities/upload_video_to_gemini.py
+++ b/products/replay_vision/backend/temporal/activities/upload_video_to_gemini.py
@@ -19,6 +19,7 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.storage import object_storage
 from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import track_uploaded_file
 
+from products.replay_vision.backend.temporal.errors import FailureKind, ScannerFailureError
 from products.replay_vision.backend.temporal.types import UploadedVideo, UploadVideoToGeminiInputs
 
 logger = structlog.get_logger(__name__)
@@ -32,7 +33,7 @@ async def upload_video_to_gemini_activity(inputs: UploadVideoToGeminiInputs) -> 
     """Read the asset's MP4 bytes, upload to Gemini, poll until ACTIVE, return the file reference."""
     workflow_id = activity.info().workflow_id
     if workflow_id is None:
-        raise RuntimeError("upload_video_to_gemini_activity has no workflow_id")
+        raise ScannerFailureError("upload_video_to_gemini_activity has no workflow_id", kind=FailureKind.INTERNAL_ERROR)
     asset = await ExportedAsset.objects.aget(id=inputs.asset_id)
 
     video_bytes: bytes | None
@@ -41,9 +42,14 @@ async def upload_video_to_gemini_activity(inputs: UploadVideoToGeminiInputs) -> 
     elif asset.content_location:
         video_bytes = await sync_to_async(object_storage.read_bytes, thread_sensitive=False)(asset.content_location)
     else:
-        raise ValueError(f"ExportedAsset {inputs.asset_id} has neither content nor content_location")
+        raise ScannerFailureError(
+            f"ExportedAsset {inputs.asset_id} has neither content nor content_location",
+            kind=FailureKind.INTERNAL_ERROR,
+        )
     if not video_bytes:
-        raise ValueError(f"ExportedAsset {inputs.asset_id} produced empty video bytes")
+        raise ScannerFailureError(
+            f"ExportedAsset {inputs.asset_id} produced empty video bytes", kind=FailureKind.INTERNAL_ERROR
+        )
 
     raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
     # `tmp_file.write` / `flush` are blocking disk I/O; offload the whole tempfile+upload block off the event loop.
@@ -52,7 +58,11 @@ async def upload_video_to_gemini_activity(inputs: UploadVideoToGeminiInputs) -> 
     )
 
     if uploaded_file.name is None:
-        raise RuntimeError("Gemini upload returned a file without a name")
+        raise ScannerFailureError(
+            "Gemini upload returned a file without a name",
+            kind=FailureKind.PROVIDER_TRANSIENT,
+            non_retryable=False,
+        )
     gemini_file_name = uploaded_file.name
 
     # Track BEFORE the ACTIVE-wait so a polling timeout still leaves the file visible to the cleanup sweep.
@@ -70,17 +80,26 @@ async def upload_video_to_gemini_activity(inputs: UploadVideoToGeminiInputs) -> 
     while uploaded_file.state and uploaded_file.state.name == "PROCESSING":
         elapsed = time.time() - wait_start
         if elapsed >= _MAX_PROCESSING_WAIT_SECONDS:
-            raise RuntimeError(
-                f"Gemini file {gemini_file_name} stuck in PROCESSING after {elapsed:.1f}s; left for the cleanup sweep"
+            raise ScannerFailureError(
+                f"Gemini file {gemini_file_name} stuck in PROCESSING after {elapsed:.1f}s; left for the cleanup sweep",
+                kind=FailureKind.PROVIDER_TRANSIENT,
+                non_retryable=False,
             )
         await asyncio.sleep(0.5)
         uploaded_file = await sync_to_async(raw_client.files.get, thread_sensitive=False)(name=gemini_file_name)
 
     final_state = uploaded_file.state.name if uploaded_file.state else None
     if final_state != "ACTIVE":
-        raise RuntimeError(f"Gemini file {gemini_file_name} reached non-ACTIVE state {final_state!r}")
+        raise ScannerFailureError(
+            f"Gemini file {gemini_file_name} reached non-ACTIVE state {final_state!r}",
+            kind=FailureKind.PROVIDER_REJECTED,
+        )
     if not uploaded_file.uri:
-        raise RuntimeError(f"Gemini file {gemini_file_name} reached ACTIVE but has no URI")
+        raise ScannerFailureError(
+            f"Gemini file {gemini_file_name} reached ACTIVE but has no URI",
+            kind=FailureKind.PROVIDER_TRANSIENT,
+            non_retryable=False,
+        )
 
     return UploadedVideo(
         file_uri=uploaded_file.uri,

--- a/products/replay_vision/backend/temporal/errors.py
+++ b/products/replay_vision/backend/temporal/errors.py
@@ -25,3 +25,24 @@ class IneligibleSessionError(ApplicationError):
         # that the workflow can read off `cause.details` after Temporal's ActivityError wrap.
         super().__init__(message, str(kind), type=INELIGIBLE_SESSION_ERROR_TYPE, non_retryable=True)
         self.kind = kind
+
+
+SCANNER_FAILURE_ERROR_TYPE = "ScannerFailure"
+
+
+class FailureKind(StrEnum):
+    """User-facing classification of a failed observation; drives the frontend description + advice."""
+
+    PROVIDER_TRANSIENT = "provider_transient"  # AI provider outage / network — retry usually helps
+    PROVIDER_REJECTED = "provider_rejected"  # AI provider couldn't process the video — won't recover
+    RASTERIZATION_FAILED = "rasterization_failed"  # Rasterizer couldn't render this recording — known issue
+    VALIDATION_FAILED = "validation_failed"  # LLM output didn't match the scanner schema after internal retries
+    INTERNAL_ERROR = "internal_error"  # Unclassified / bug paths — user can't fix
+
+
+class ScannerFailureError(ApplicationError):
+    """A classified workflow failure. Surfaced as ObservationStatus.FAILED with the kind label on the frontend."""
+
+    def __init__(self, message: str, *, kind: FailureKind, non_retryable: bool = True) -> None:
+        super().__init__(message, str(kind), type=SCANNER_FAILURE_ERROR_TYPE, non_retryable=non_retryable)
+        self.kind = kind

--- a/products/replay_vision/backend/temporal/workflow.py
+++ b/products/replay_vision/backend/temporal/workflow.py
@@ -7,12 +7,7 @@ from temporalio import common
 from temporalio.common import SearchAttributePair, TypedSearchAttributes, WorkflowIDReusePolicy
 
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.common.errors import (
-    MAX_ERROR_MESSAGE_CHARS,
-    resolve_exception_class,
-    truncate_for_temporal_payload,
-    unwrap_temporal_cause,
-)
+from posthog.temporal.common.errors import MAX_ERROR_MESSAGE_CHARS, truncate_for_temporal_payload, unwrap_temporal_cause
 from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.session_replay.rasterize_recording.types import RasterizeRecordingInputs
 
@@ -35,7 +30,12 @@ from products.replay_vision.backend.temporal.activities import (
     upload_video_to_gemini_activity,
 )
 from products.replay_vision.backend.temporal.constants import APPLY_SCANNER_WORKFLOW_NAME
-from products.replay_vision.backend.temporal.errors import INELIGIBLE_SESSION_ERROR_TYPE
+from products.replay_vision.backend.temporal.errors import (
+    INELIGIBLE_SESSION_ERROR_TYPE,
+    SCANNER_FAILURE_ERROR_TYPE,
+    FailureKind,
+    ScannerFailureError,
+)
 from products.replay_vision.backend.temporal.scanners.classifier import ClassifierOutput
 from products.replay_vision.backend.temporal.scanners.indexer import IndexerOutput
 from products.replay_vision.backend.temporal.types import (
@@ -111,26 +111,27 @@ _SIDE_EFFECT_RETRY = common.RetryPolicy(
 
 def _extract_ineligible_kind(e: BaseException) -> str | None:
     """If `e` carries an IneligibleSession ApplicationError, return its kind."""
+    return _extract_kind_for_type(e, INELIGIBLE_SESSION_ERROR_TYPE)
+
+
+def _extract_failure_kind(e: BaseException) -> str | None:
+    """If `e` carries a ScannerFailure ApplicationError, return its kind."""
+    return _extract_kind_for_type(e, SCANNER_FAILURE_ERROR_TYPE)
+
+
+def _extract_kind_for_type(e: BaseException, expected_type: str) -> str | None:
     cause = unwrap_temporal_cause(e) or e
-    if getattr(cause, "type", None) != INELIGIBLE_SESSION_ERROR_TYPE:
+    if getattr(cause, "type", None) != expected_type:
         return None
     details = getattr(cause, "details", None)
     return details[0] if details else None
 
 
 def _root_cause_message(e: BaseException) -> str:
-    """Bare message from the root cause — no `TypeName:` prefix, used for ineligible reasons."""
+    """Bare message from the root cause — no `TypeName:` prefix; the kind label takes that role."""
     cause = unwrap_temporal_cause(e) or e
     msg = getattr(cause, "message", None) or str(cause) or type(cause).__name__
     return truncate_for_temporal_payload(msg, MAX_ERROR_MESSAGE_CHARS)
-
-
-def _format_failure(e: BaseException) -> str:
-    """`TypeName: message` from the root cause — replaces the unhelpful outer `ActivityError: Activity task failed`."""
-    cause = unwrap_temporal_cause(e) or e
-    msg = getattr(cause, "message", None) or str(cause) or ""
-    formatted = f"{resolve_exception_class(e)}: {msg}" if msg else resolve_exception_class(e)
-    return truncate_for_temporal_payload(formatted, MAX_ERROR_MESSAGE_CHARS)
 
 
 @wf.defn(name=APPLY_SCANNER_WORKFLOW_NAME)
@@ -212,7 +213,8 @@ class ApplyScannerWorkflow(PostHogWorkflow):
             if ineligible_kind is not None:
                 await self._mark_ineligible(observation_id, ineligible_kind, _root_cause_message(e))
             else:
-                await self._mark_failed(observation_id, _format_failure(e))
+                failure_kind = _extract_failure_kind(e) or FailureKind.INTERNAL_ERROR.value
+                await self._mark_failed(observation_id, failure_kind, _root_cause_message(e))
             raise
         finally:
             if uploaded is not None:
@@ -251,26 +253,31 @@ class ApplyScannerWorkflow(PostHogWorkflow):
 
     async def _run_rasterize_child(self, inputs: ApplyScannerInputs, asset_id: int) -> None:
         # Per-scanner child id so concurrent observations of the same session don't collide on WorkflowAlreadyStartedError.
-        await wf.execute_child_workflow(
-            "rasterize-recording",
-            RasterizeRecordingInputs(exported_asset_id=asset_id),
-            id=f"replay-vision-rasterize-{inputs.team_id}-{inputs.session_id}-{inputs.scanner_id}",
-            task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
-            retry_policy=common.RetryPolicy(maximum_attempts=int(settings.TEMPORAL_WORKFLOW_MAX_ATTEMPTS)),
-            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-            execution_timeout=dt.timedelta(minutes=30),
-            search_attributes=TypedSearchAttributes(
-                search_attributes=[
-                    SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=inputs.team_id),
-                    SearchAttributePair(key=POSTHOG_SESSION_RECORDING_ID_KEY, value=inputs.session_id),
-                ]
-            ),
-        )
+        try:
+            await wf.execute_child_workflow(
+                "rasterize-recording",
+                RasterizeRecordingInputs(exported_asset_id=asset_id),
+                id=f"replay-vision-rasterize-{inputs.team_id}-{inputs.session_id}-{inputs.scanner_id}",
+                task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
+                retry_policy=common.RetryPolicy(maximum_attempts=int(settings.TEMPORAL_WORKFLOW_MAX_ATTEMPTS)),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                execution_timeout=dt.timedelta(minutes=30),
+                search_attributes=TypedSearchAttributes(
+                    search_attributes=[
+                        SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=inputs.team_id),
+                        SearchAttributePair(key=POSTHOG_SESSION_RECORDING_ID_KEY, value=inputs.session_id),
+                    ]
+                ),
+            )
+        except Exception as e:
+            # Re-classify the rasterizer's failure so the user sees a rasterizer label, not a generic "internal error".
+            raise ScannerFailureError(_root_cause_message(e), kind=FailureKind.RASTERIZATION_FAILED) from e
 
-    async def _mark_failed(self, observation_id: UUID, error_reason: str) -> None:
+    async def _mark_failed(self, observation_id: UUID, kind: str, message: str) -> None:
+        # `kind:message` so the frontend can render the kind as a badge and the message as detail.
         await wf.execute_activity(
             mark_observation_failed_activity,
-            MarkObservationFailedInputs(observation_id=observation_id, error_reason=error_reason),
+            MarkObservationFailedInputs(observation_id=observation_id, error_reason=f"{kind}:{message}"),
             start_to_close_timeout=dt.timedelta(seconds=30),
             retry_policy=_STATE_ACTIVITY_RETRY,
         )

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -45,8 +45,10 @@ from products.replay_vision.backend.temporal.activities.observation_state import
 from products.replay_vision.backend.temporal.activities.upload_video_to_gemini import upload_video_to_gemini_activity
 from products.replay_vision.backend.temporal.errors import (
     INELIGIBLE_SESSION_ERROR_TYPE,
+    FailureKind,
     IneligibleSessionError,
     IneligibleSessionKind,
+    ScannerFailureError,
 )
 from products.replay_vision.backend.temporal.scanners.classifier import ClassifierOutput
 from products.replay_vision.backend.temporal.scanners.indexer import IndexerOutput
@@ -77,7 +79,11 @@ from products.replay_vision.backend.temporal.types import (
     SessionMetadata,
     UploadedVideo,
 )
-from products.replay_vision.backend.temporal.workflow import _extract_ineligible_kind, _format_failure
+from products.replay_vision.backend.temporal.workflow import (
+    _extract_failure_kind,
+    _extract_ineligible_kind,
+    _root_cause_message,
+)
 from products.replay_vision.backend.tests.helpers import snapshot_for as _snapshot_for
 
 
@@ -1470,16 +1476,23 @@ class TestWorkflowErrorHelpers:
         err = ApplicationError("something broke", type="RuntimeError", non_retryable=True)
         assert _extract_ineligible_kind(err) is None
 
-    def test_format_failure_uses_application_error_type_over_runtime_class(self) -> None:
-        # Temporal sets `ApplicationError.type` to the original Python exception class name, so we
-        # surface that instead of always reading "ApplicationError" from the runtime class.
-        err = ApplicationError("Gemini file processed=FAILED", type="RuntimeError")
-        assert _format_failure(err) == "RuntimeError: Gemini file processed=FAILED"
+    def test_extract_failure_kind_returns_kind_for_scanner_failure_error(self) -> None:
+        err = ScannerFailureError("gemini rejected", kind=FailureKind.PROVIDER_REJECTED)
+        assert _extract_failure_kind(err) == "provider_rejected"
 
-    def test_format_failure_unwraps_activity_error_wrapper(self) -> None:
-        leaf = ApplicationError("real reason", type="ValueError")
+    def test_extract_failure_kind_unwraps_activity_error_from_worker(self) -> None:
+        leaf = ScannerFailureError("missing asset", kind=FailureKind.INTERNAL_ERROR)
         wrapped = _wrap_in_activity_error(leaf)
-        assert _format_failure(wrapped) == "ValueError: real reason"
+        assert _extract_failure_kind(wrapped) == "internal_error"
 
-    def test_format_failure_falls_back_to_runtime_class_for_bare_python_exceptions(self) -> None:
-        assert _format_failure(ValueError("bad arg")) == "ValueError: bad arg"
+    def test_extract_failure_kind_returns_none_for_unrelated_application_error(self) -> None:
+        err = ApplicationError("something broke", type="RuntimeError", non_retryable=True)
+        assert _extract_failure_kind(err) is None
+
+    def test_root_cause_message_strips_temporal_wrapper(self) -> None:
+        leaf = ApplicationError("Gemini file files/abc reached state FAILED", type="RuntimeError")
+        wrapped = _wrap_in_activity_error(leaf)
+        assert _root_cause_message(wrapped) == "Gemini file files/abc reached state FAILED"
+
+    def test_root_cause_message_falls_back_to_str_for_bare_exceptions(self) -> None:
+        assert _root_cause_message(ValueError("bad arg")) == "bad arg"

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -320,7 +320,7 @@ export interface ReplayObservationApi {
   * `failed` - Failed
   * `ineligible` - Ineligible */
     readonly status: ObservationStatusEnumApi
-    /** Populated on terminal non-success statuses. For `failed`, the unwrapped activity error. For `ineligible`, formatted as `kind:human-readable message` where kind is one of no_recording / too_short / too_inactive / too_long / no_events. */
+    /** Populated on terminal non-success statuses; formatted as `kind:human-readable message`. For `ineligible`, kind is one of no_recording / too_short / too_inactive / too_long / no_events. For `failed`, kind is one of provider_transient / provider_rejected / rasterization_failed / validation_failed / internal_error. */
     readonly error_reason: string
     /** Temporal workflow id for progress queries and debugging. Empty until the workflow starts. */
     readonly workflow_id: string

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -8,7 +8,14 @@ import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { urls } from 'scenes/urls'
 
 import { replayScannerLogic } from '../replayScannerLogic'
-import { ScannerType, ObservationStatus, ReplayObservation, parseIneligibleReason } from '../types'
+import {
+    ScannerType,
+    ObservationStatus,
+    ReplayObservation,
+    failureKindDescription,
+    parseFailureReason,
+    parseIneligibleReason,
+} from '../types'
 
 function StatusTag({ status }: { status: ObservationStatus }): JSX.Element {
     if (status === 'succeeded') {
@@ -48,10 +55,15 @@ function ResultPreview({
         )
     }
     if (observation.status === 'failed') {
+        const parsed = parseFailureReason(observation.error_reason)
+        const label = parsed?.label ?? 'Failed'
+        const description = parsed ? failureKindDescription(parsed.kind) : null
+        const detail = parsed?.message ?? observation.error_reason
+        const tooltip = [description, detail].filter(Boolean).join('\n\n') || 'Unknown error'
         return (
-            <Tooltip title={observation.error_reason || 'Unknown error'}>
+            <Tooltip title={tooltip}>
                 <span className="inline-flex items-center gap-1 text-danger text-sm">
-                    <IconWarning /> {observation.error_reason || 'Failed'}
+                    <IconWarning /> {label}
                 </span>
             </Tooltip>
         )

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -18,25 +18,59 @@ const INELIGIBLE_KIND_LABELS: Record<IneligibleKind, string> = {
     no_events: 'No events',
 }
 
-const _INELIGIBLE_KINDS = new Set<string>(Object.keys(INELIGIBLE_KIND_LABELS))
+export type FailureKind =
+    | 'provider_transient'
+    | 'provider_rejected'
+    | 'rasterization_failed'
+    | 'validation_failed'
+    | 'internal_error'
 
-export type ParsedIneligibleReason = { kind: IneligibleKind; label: string; message: string }
+const FAILURE_KIND_LABELS: Record<FailureKind, string> = {
+    provider_transient: 'AI provider unavailable',
+    provider_rejected: 'AI provider rejected video',
+    rasterization_failed: 'Rasterization failed',
+    validation_failed: 'AI output invalid',
+    internal_error: 'Internal error',
+}
 
-export function parseIneligibleReason(error_reason: string): ParsedIneligibleReason | null {
+const FAILURE_KIND_DESCRIPTIONS: Record<FailureKind, string> = {
+    provider_transient: 'The AI provider was temporarily unreachable. PostHog will retry on the next schedule fire.',
+    provider_rejected: "The AI provider couldn't process this recording. Other recordings should work.",
+    rasterization_failed: "PostHog couldn't render this recording into a video. Other recordings should work.",
+    validation_failed:
+        "The AI's response didn't match the scanner schema after several attempts. Try simplifying the scanner prompt.",
+    internal_error: 'An unexpected PostHog error occurred. Please contact support.',
+}
+
+export type ParsedReason<K extends string> = { kind: K; label: string; message: string }
+
+function parseKindReason<K extends string>(error_reason: string, labels: Record<K, string>): ParsedReason<K> | null {
     // The backend formats `error_reason` as `kind:human message`; fall back to a generic label on drift.
     const idx = error_reason.indexOf(':')
     if (idx <= 0) {
         return null
     }
     const kind = error_reason.slice(0, idx)
-    if (!_INELIGIBLE_KINDS.has(kind)) {
+    if (!(kind in labels)) {
         return null
     }
     return {
-        kind: kind as IneligibleKind,
-        label: INELIGIBLE_KIND_LABELS[kind as IneligibleKind],
+        kind: kind as K,
+        label: labels[kind as K],
         message: error_reason.slice(idx + 1).trim(),
     }
+}
+
+export function parseIneligibleReason(error_reason: string): ParsedReason<IneligibleKind> | null {
+    return parseKindReason(error_reason, INELIGIBLE_KIND_LABELS)
+}
+
+export function parseFailureReason(error_reason: string): ParsedReason<FailureKind> | null {
+    return parseKindReason(error_reason, FAILURE_KIND_LABELS)
+}
+
+export function failureKindDescription(kind: FailureKind): string {
+    return FAILURE_KIND_DESCRIPTIONS[kind]
 }
 
 export const DEFAULT_PROVIDER = 'google'

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -23498,7 +23498,7 @@ export namespace Schemas {
       * `failed` - Failed
       * `ineligible` - Ineligible */
       readonly status: ObservationStatusEnum;
-      /** Populated on terminal non-success statuses. For `failed`, the unwrapped activity error. For `ineligible`, formatted as `kind:human-readable message` where kind is one of no_recording / too_short / too_inactive / too_long / no_events. */
+      /** Populated on terminal non-success statuses; formatted as `kind:human-readable message`. For `ineligible`, kind is one of no_recording / too_short / too_inactive / too_long / no_events. For `failed`, kind is one of provider_transient / provider_rejected / rasterization_failed / validation_failed / internal_error. */
       readonly error_reason: string;
       /** Temporal workflow id for progress queries and debugging. Empty until the workflow starts. */
       readonly workflow_id: string;


### PR DESCRIPTION
## Problem

After #60011, failed observations get a useful `error_reason` like `RuntimeError: Gemini file files/xyz reached state FAILED`. But the user (the customer who set up the scanner) still doesn't know whether to retry, wait, fix something, or report a bug — the raw Python exception class is programmer-facing.

## Changes

Mirrors the `IneligibleSession` pattern from #60011. Each failure raise site now picks a typed `FailureKind`:

| Kind | When | Frontend label |
|---|---|---|
| `provider_transient` | AI provider unreachable / stuck PROCESSING | "AI provider unavailable" |
| `provider_rejected` | AI provider said no to this specific video (state=FAILED) | "AI provider rejected video" |
| `rasterization_failed` | Rasterizer child workflow couldn't render the recording | "Rasterization failed" |
| `validation_failed` | LLM output didn't match the scanner schema after retries | "AI output invalid" |
| `internal_error` | Asset missing content / unclassified bug paths | "Internal error" |

Each gets a human description ("The AI provider was temporarily unreachable. PostHog will retry on the next schedule fire.") shown in a tooltip beside the badge.

Workflow stores `error_reason` as `kind:message` (same shape as ineligible). Unclassified errors fall through to `internal_error`. Rasterizer failures get classified by wrapping the child-workflow call in the parent — the Node.js rasterizer doesn't know about our kinds.

Frontend reuses a generic `parseKindReason` helper across both `parseIneligibleReason` and `parseFailureReason`.

## How did you test this code?

Agent-authored. `hogli test products/replay_vision/backend/tests/test_temporal.py` — 63 passed. New tests: `_extract_failure_kind` (direct + ActivityError-wrapped + unrelated), `_root_cause_message`.

## Publish to changelog?

no

## 🤖 Agent context

Stacked on #60011 (depends on its `kind:message` `error_reason` contract and the `IneligibleSessionError` precedent that this PR mirrors).

`PROVIDER_TRANSIENT` raises get `non_retryable=False` so Temporal's activity retry policy still kicks in for them; the other kinds are non-retryable.
