### PR TITLE
fix(billing): run usage report queries as billing user

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -34,6 +34,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.batch_exports.models import BatchExport, BatchExportDestination, BatchExportRun
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import ClickHouseUser
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.cloud_utils import TEST_clear_instance_license_cache
 from posthog.hogql_queries.events_query_runner import EventsQueryRunner
@@ -4380,13 +4381,17 @@ class TestQuerySplitting(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, Test
 
         # First call should use the first half of the time range
         first_call_args = mock_sync_execute.call_args_list[0][0]
+        first_call_kwargs = mock_sync_execute.call_args_list[0].kwargs
         self.assertEqual(first_call_args[1]["begin"], self.begin)
+        self.assertEqual(first_call_kwargs["ch_user"], ClickHouseUser.BILLING)
         mid_point = self.begin + (self.end - self.begin) / 2
         self.assertEqual(first_call_args[1]["end"], mid_point)
 
         # Second call should use the second half of the time range
         second_call_args = mock_sync_execute.call_args_list[1][0]
+        second_call_kwargs = mock_sync_execute.call_args_list[1].kwargs
         self.assertEqual(second_call_args[1]["begin"], mid_point)
+        self.assertEqual(second_call_kwargs["ch_user"], ClickHouseUser.BILLING)
         self.assertEqual(second_call_args[1]["end"], self.end)
 
         # Result should combine both splits (5 + 5 = 10)

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -27,7 +27,7 @@ from posthog.schema import AIEventType
 from posthog import version_requirement
 from posthog.batch_exports.models import BatchExportDestination, BatchExportRun
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.constants import FlagRequestType
@@ -476,6 +476,7 @@ def _execute_split_query(
             split_params,
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
         all_results.append(split_result)
@@ -604,6 +605,7 @@ def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datet
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -745,6 +747,7 @@ def get_teams_with_recording_count_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -781,6 +784,7 @@ def get_teams_with_zero_duration_recording_count_in_period(begin: datetime, end:
             {"previous_begin": previous_begin, "begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -818,6 +822,7 @@ def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, en
             {"previous_begin": previous_begin, "begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -852,6 +857,7 @@ def get_teams_with_api_queries_metrics(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
     result_count: list[tuple[int, int]] = []
     result_read_bytes: list[tuple[int, int]] = []
@@ -900,6 +906,7 @@ def get_teams_with_query_metric(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -932,6 +939,7 @@ def get_teams_with_feature_flag_requests_count_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -973,6 +981,7 @@ def get_teams_with_feature_flag_requests_sdk_breakdown_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1028,6 +1037,7 @@ def get_teams_with_survey_responses_count_in_period(
             params,
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1048,6 +1058,7 @@ def get_teams_with_ai_event_count_in_period(
             {"begin": begin, "end": end, "ai_events": AI_EVENTS},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1224,6 +1235,7 @@ def get_teams_with_ai_credits_used_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
     return results
@@ -1417,6 +1429,7 @@ def get_teams_with_exceptions_captured_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
     library_totals: dict[str, list[list[int]]] = {
@@ -1460,6 +1473,7 @@ def get_teams_with_hog_function_calls_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1480,6 +1494,7 @@ def get_teams_with_hog_function_fetch_calls_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1500,6 +1515,7 @@ def get_teams_with_cdp_billable_invocations_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1546,6 +1562,7 @@ def get_teams_with_recording_bytes_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1594,6 +1611,7 @@ def get_teams_with_workflow_emails_sent_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1614,6 +1632,7 @@ def get_teams_with_workflow_push_sent_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1634,6 +1653,7 @@ def get_teams_with_workflow_sms_sent_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1654,6 +1674,7 @@ def get_teams_with_workflow_billable_invocations_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1674,6 +1695,7 @@ def get_teams_with_logs_bytes_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1694,6 +1716,7 @@ def get_teams_with_logs_records_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
         )
 
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Usage report ClickHouse queries should run under the dedicated billing ClickHouse user so they use the intended resource controls and are not routed through the default/product users.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
  - Pass `ch_user=ClickHouseUser.BILLING` on every `sync_execute` call in `posthog/tasks/usage_report.py`.
  - Add test coverage for the split-query helper to assert split usage-report queries keep using the billing user.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->
- Added unit tests to assert billing user

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->
no
<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
