### PR TITLE
fix(insights): tighten percent-stack value labels

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1969,9 +1969,9 @@ snapshots:
     insights-trendsbarchart--compare--light:
         hash: v1.k794b7964.08db5d36c08b26300a7cd09fddd8f02e9ba973ffcf42e556e7f8ae01a27e907b.jN5qaeiDphtPJ90-0-bNC0jmD0MVkSCj6zjO8XzvZkI
     insights-trendsbarchart--percent-stack-breakdown--dark:
-        hash: v1.k794b7964.138bf85ccb5f3d76d645f84ae186e515469f2d3ab4caefccc1ab29e107f8a0a7.TR6XmF4pRfQW18owW_7TXPt2OIi7nXlcK7_ch84gnKk
+        hash: v1.k794b7964.90b4877789670adc2780ca9dab0945b5350766fb7187bd93f01cb1a1dfcc377b.xYM0L_6dVhqxzW_EficHvSiV99A-LIrnYBkMAe_udjc
     insights-trendsbarchart--percent-stack-breakdown--light:
-        hash: v1.k794b7964.1e53fb982558041d72d9538f617745c11dae47369056699e5f022155f2314086.1RYMUrMqQxFF57Qn_qNEj-ZT41zxglI1Dcpm69jMbjk
+        hash: v1.k794b7964.94dcced10754de4cf816cd83eb27f803082aee84fcf1b081bc98b8f4be366edd.KYJWPI86CCOx9TZf83eCCWbHwAlIqRJ8jcPZAK7-zyM
     insights-trendslifecyclechart--stacked--dark:
         hash: v1.k794b7964.f01dae4d665fea93c451e5bb48d6409d586c89856ffb1fff155937c7eb9119d9.coUQ2-TFqEqeP38cPDoiz5RbwkfznST9H3pR5TRbpvg
     insights-trendslifecyclechart--stacked--light:
@@ -4719,7 +4719,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.gaL7vRk-pWoOUkiPi-NGCd1W72x-M5l9jk5Qu-UcjwI
+        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
@@ -4731,7 +4731,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--superwide--light:
         hash: v1.k794b7964.c95c5a49f7a20b7fcb1041dd26c73ee87c9a906cb229247a44fd4633bbdc9173.StrJ2VBA5acLqvnsiO2CS_o6qadxeaeO6ST8lxf5UdI
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
-        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.URrKOLP9uUjbKWcui2yOA7hm_JsXsbkAlOcWJshoQrI
+        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
     scenes-app-insights-funnels--funnel-time-to-convert--dark:

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -32,6 +32,8 @@ interface Candidate {
     width: number
     color: string
     above: boolean
+    /** Center the label across the value-axis coord instead of anchoring its leading edge there. */
+    centerAnchor: boolean
 }
 
 function defaultLocaleFormatter(v: number): string {
@@ -59,7 +61,8 @@ function pushCandidate(
     text: string,
     categoricalCoord: number,
     valueCoord: number,
-    above: boolean
+    above: boolean,
+    centerAnchor: boolean = false
 ): void {
     const textWidth = ctx ? ctx.measureText(text).width : text.length * 6
     const width = textWidth + LABEL_HORIZONTAL_CHROME
@@ -72,6 +75,7 @@ function pushCandidate(
         width,
         color,
         above,
+        centerAnchor,
     })
 }
 
@@ -175,8 +179,8 @@ function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
             }
 
             let displayValue = rawValue
-            // In percent layout, anchor *below* the segment's stacked top so the label hangs
-            // inside its own segment (matches chart.js) instead of floating at the seam above.
+            // In percent layout we center the label across the segment's stacked top (see
+            // `centerAnchor` below), so `above` is unused — keep it false to be explicit.
             let above = isPercent ? false : yValue >= 0
 
             if (isPercent) {
@@ -208,7 +212,8 @@ function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
                 valueFormatter(displayValue, sIdx, dIdx),
                 categoricalCoord,
                 valueCoord,
-                above
+                above,
+                isPercent
             )
         }
     }
@@ -225,11 +230,21 @@ interface Rect {
 function labelRect(c: Candidate, isHorizontal: boolean): Rect {
     if (isHorizontal) {
         const halfH = LABEL_HEIGHT / 2
-        const left = c.above ? c.x : c.x - c.width
+        let left: number
+        if (c.centerAnchor) {
+            left = c.x - c.width / 2
+        } else {
+            left = c.above ? c.x : c.x - c.width
+        }
         return { left, right: left + c.width, top: c.y - halfH, bottom: c.y + halfH }
     }
     const halfW = c.width / 2
-    const top = c.above ? c.y - LABEL_HEIGHT : c.y
+    let top: number
+    if (c.centerAnchor) {
+        top = c.y - LABEL_HEIGHT / 2
+    } else {
+        top = c.above ? c.y - LABEL_HEIGHT : c.y
+    }
     return { left: c.x - halfW, right: c.x + halfW, top, bottom: top + LABEL_HEIGHT }
 }
 
@@ -303,6 +318,9 @@ const LABEL_STYLE_BASE: React.CSSProperties = {
 }
 
 function transformFor(c: Candidate, isHorizontal: boolean): string {
+    if (c.centerAnchor) {
+        return 'translate(-50%, -50%)'
+    }
     if (isHorizontal) {
         return c.above ? 'translateY(-50%)' : 'translate(-100%, -50%)'
     }

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -134,7 +134,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
             // In percent layout the chart computes each segment's share of its band and passes
             // a 0..1 fraction here, so we render it directly as a percentage.
             if (isPercentStackView) {
-                return percentage(value)
+                return percentage(value, 1)
             }
             return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
         },

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -109,7 +109,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             // In percent layout the chart computes each segment's share of its band and passes
             // a 0..1 fraction here, so we render it directly as a percentage.
             if (isPercentStackView) {
-                return percentage(value)
+                return percentage(value, 1)
             }
             return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
         },


### PR DESCRIPTION
## Summary

- Round percent-stack value labels to 1 decimal place (was 2) so they read as `84.4%` instead of `84.39%`.
- Center each label across the segment's top edge (vertical center on the segment top) instead of anchoring its top edge there, so the label straddles the seam.

Applies to TrendsBarChart and TrendsLineChart in percent stack view, plus the underlying \`ValueLabels\` overlay in \`lib/hog-charts\` (new \`centerAnchor\` candidate flag, set when \`isPercent\`).

## How did you test this code?

- [x] \`pnpm exec jest src/lib/hog-charts\` — 962 tests pass, including the existing \`in percent layout\` cases.

## 🤖 Agent context

Authored by Claude (Opus 4.7) at @sam@posthog.com's request after the percent-stack screenshot showed two-decimal labels top-aligned to each segment top. The decimal change is in the two callers (\`TrendsBarChart.tsx\`, \`TrendsLineChart.tsx\`) since they own the \`percentage(value)\` call; the positioning change is in \`ValueLabels.tsx\` and only applies when the chart is in percent mode (\`isPercent === true\`).