### PR TITLE
fix(data-warehouse): guard bulk schedule delete in source destroy

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1497,10 +1497,14 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             cancel_external_data_workflow(latest_running_job.workflow_id)
 
         # Delete all schema sync schedules over a single shared Temporal connection — see
-        # the matching comment in `create`.
-        schedule_delete_errors = bulk_delete_external_data_schedules([str(schema.id) for schema in schemas])
-        for schema_id, schedule_delete_error in schedule_delete_errors:
-            capture_exception(schedule_delete_error, {"schema_id": schema_id})
+        # the matching comment in `create`. Guarded so a Temporal-connect failure here
+        # doesn't skip the source/discovery schedule and S3 cleanup below.
+        try:
+            schedule_delete_errors = bulk_delete_external_data_schedules([str(schema.id) for schema in schemas])
+            for schema_id, schedule_delete_error in schedule_delete_errors:
+                capture_exception(schedule_delete_error, {"schema_id": schema_id})
+        except Exception as e:
+            capture_exception(e)
 
         for schema in schemas:
             try:


### PR DESCRIPTION
## Problem

PR #59741 replaces the per-schema `delete_external_data_schedule(...)` loop in `ExternalDataSourceViewSet.destroy` with a single bulk call. The `create` path wraps its bulk call in `try/except`, but the `destroy` path does not — so a failure inside `bulk_delete_external_data_schedules` (most notably an `async_connect()` failure if Temporal is briefly unreachable) propagates out of the handler.

By that point the atomic block above has already committed the soft-deletes for the source, schemas, tables, and `_cdc` companion tables. The unhandled exception then skips the remaining cleanup in the same handler:

- the per-schema `schema.delete_table()` loop (S3 object cleanup)
- the source-level `delete_external_data_schedule(str(instance.id))`
- `delete_discover_schemas_schedule(str(instance.id))`

The pre-#59741 code wrapped every per-schema RPC individually, so this is a regression in error isolation, and the client also sees a 500 even though the DB-level delete succeeded.

This was flagged on #59741 by both the Codex and Greptile review bots; this PR addresses that feedback.

## Changes

Wrap the `bulk_delete_external_data_schedules` call (and the per-schedule `capture_exception` loop on its return value) in a `try/except` that calls `capture_exception(e)` on the outer failure, mirroring the guard already present on the `create` path.

## How did you test this code?

I am an agent (Claude Code). I have not performed manual testing myself.

No automated tests were added — the change is a pure error-isolation wrapper that matches an existing pattern a few lines up in the same file. The fix was validated by reading both call sites and confirming the asymmetry the bots identified.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) at the human author's request after validating the two review bot comments on #59741. The bots independently flagged the same issue (Codex P1, Greptile P1); both were judged correct on inspection of `destroy` vs `create` and `bulk_delete_external_data_schedules` in `products/data_warehouse/backend/data_load/service.py`, where per-item errors are only collected after `async_connect()` returns.