### PR TITLE
feat: Support cancelling file download batch exports

### DIFF
--- a/posthog/batch_exports/api/file_download.py
+++ b/posthog/batch_exports/api/file_download.py
@@ -21,8 +21,9 @@ from posthog.api.log_entries import LogEntryMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.models import BatchExportDestination, BatchExportFileDownload, BatchExportOnDemand, BatchExportRun
+from posthog.temporal.common.client import sync_connect
 
-from products.batch_exports.backend.service import start_file_download_batch_export
+from products.batch_exports.backend.service import cancel_running_batch_export_run, start_file_download_batch_export
 
 SESSION = boto3.Session()
 FILE_DOWNLOAD_MAX_RANGE = dt.timedelta(weeks=1)
@@ -346,6 +347,26 @@ class FileDownloadBatchExportOnDemandViewSet(
         response["Cache-Control"] = "no-store"
 
         return response
+
+    @action(methods=["POST"], detail=True, required_scopes=["batch_export:write"])
+    def cancel(self, request, part=None, *args, **kwargs) -> response.Response:
+        """Cancel an ongoing file-download batch export."""
+        batch_export_run: BatchExportRun = self.get_object()
+
+        if batch_export_run.status not in (BatchExportRun.Status.RUNNING, BatchExportRun.Status.STARTING):
+            raise ValidationError(f"Cannot cancel a run that is in '{batch_export_run.status}' status")
+
+        temporal = sync_connect()
+        try:
+            cancel_running_batch_export_run(temporal, batch_export_run)
+        except Exception as e:
+            # It could be the case that the run is already cancelled but our database hasn't been updated yet. In
+            # this case, we can just ignore the error but log it for visibility (in case there is an actual issue).
+            LOGGER.warning("file_download_batch_export.cancel.failed", exc_info=e)
+
+        batch_export_run.refresh_from_db()
+
+        return response.Response({"status": batch_export_run.status})
 
 
 def _generate_s3_pre_signed_url(

--- a/posthog/batch_exports/api/file_download.py
+++ b/posthog/batch_exports/api/file_download.py
@@ -349,7 +349,7 @@ class FileDownloadBatchExportOnDemandViewSet(
         return response
 
     @action(methods=["POST"], detail=True, required_scopes=["batch_export:write"])
-    def cancel(self, request, part=None, *args, **kwargs) -> response.Response:
+    def cancel(self, request, *args, **kwargs) -> response.Response:
         """Cancel an ongoing file-download batch export."""
         batch_export_run: BatchExportRun = self.get_object()
 

--- a/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_api.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_api.py
@@ -6,6 +6,7 @@ from urllib.parse import urlsplit
 
 import pytest
 import freezegun
+import unittest.mock
 
 from django.conf import settings
 from django.test import AsyncClient, override_settings
@@ -390,9 +391,8 @@ async def test_file_download_end_to_end(
 
 
 @pytest.mark.django_db(transaction=True)
-async def test_file_download_cancel(
+async def test_file_download_cancel_mocked(
     async_client: AsyncClient,
-    temporal_client,
     team,
     user,
     data_interval_start,
@@ -412,9 +412,19 @@ async def test_file_download_cancel(
 
     await async_client.aforce_login(user)
 
-    status_response = await async_client.post(
-        f"/api/projects/{team.pk}/file_download_batch_exports/{run.id}/cancel",
-    )
+    mocked_client = unittest.mock.MagicMock()
+    mocked_handle = unittest.mock.AsyncMock()
+    mocked_client.get_workflow_handle.return_value = mocked_handle
+
+    with unittest.mock.patch("posthog.batch_exports.api.file_download.sync_connect") as mocked_connect:
+        mocked_connect.return_value = mocked_client
+        status_response = await async_client.post(
+            f"/api/projects/{team.pk}/file_download_batch_exports/{run.id}/cancel",
+        )
+
+    mocked_client.get_workflow_handle.assert_called_once_with(workflow_id=run.workflow_id)
+    mocked_handle.cancel.assert_called_once()
+
     data = status_response.json()
     assert data["status"] == "Cancelled", status_response.json()
 

--- a/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_api.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_api.py
@@ -387,3 +387,36 @@ async def test_file_download_end_to_end(
 
     assert len(table) == len(events)
     assert "event" in table.column_names
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_file_download_cancel(
+    async_client: AsyncClient,
+    temporal_client,
+    team,
+    user,
+    data_interval_start,
+    data_interval_end,
+):
+    destination = await BatchExportDestination.objects.acreate(
+        type=BatchExportDestination.Destination.FILE_DOWNLOAD, config={}
+    )
+    with team_scope(team_id=team.pk, canonical=True):
+        batch_export = await BatchExportOnDemand.objects.acreate(team=team, destination=destination, model="events")
+    run = await BatchExportRun.objects.acreate(
+        batch_export_on_demand=batch_export,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        status=BatchExportRun.Status.RUNNING,
+    )
+
+    await async_client.aforce_login(user)
+
+    status_response = await async_client.post(
+        f"/api/projects/{team.pk}/file_download_batch_exports/{run.id}/cancel",
+    )
+    data = status_response.json()
+    assert data["status"] == "Cancelled", status_response.json()
+
+    await run.arefresh_from_db()
+    assert run.status == BatchExportRun.Status.CANCELLED

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -1442,6 +1442,32 @@ export type RetrieveFileDownloadResponseApi =
 
 /**
  * * `events` - events
+ * `persons` - persons
+ * `sessions` - sessions
+ */
+export type FileDownloadBatchExportOnDemandModelEnumApi =
+    (typeof FileDownloadBatchExportOnDemandModelEnumApi)[keyof typeof FileDownloadBatchExportOnDemandModelEnumApi]
+
+export const FileDownloadBatchExportOnDemandModelEnumApi = {
+    Events: 'events',
+    Persons: 'persons',
+    Sessions: 'sessions',
+} as const
+
+/**
+ * Request shape for a FileDownload batch export on demand.
+ */
+export interface FileDownloadBatchExportOnDemandApi {
+    file: FileDownloadDestinationFileConfigApi
+    model: FileDownloadBatchExportOnDemandModelEnumApi
+    include?: string[]
+    exclude?: string[]
+    data_interval_start: string
+    data_interval_end: string
+}
+
+/**
+ * * `events` - events
  */
 export type FileDownloadEventsRequestModelEnumApi =
     (typeof FileDownloadEventsRequestModelEnumApi)[keyof typeof FileDownloadEventsRequestModelEnumApi]

--- a/products/batch_exports/frontend/generated/api.ts
+++ b/products/batch_exports/frontend/generated/api.ts
@@ -20,6 +20,7 @@ import type {
     BatchExportsRunsLogsRetrieveParams,
     CreateFileDownloadRequestApi,
     CreateOutputApi,
+    FileDownloadBatchExportOnDemandApi,
     FileDownloadBatchExportsLogsRetrieveParams,
     PaginatedBatchExportBackfillListApi,
     PaginatedBatchExportListApi,
@@ -543,6 +544,27 @@ export const fileDownloadBatchExportsRetrieve = async (
     return apiMutator<RetrieveFileDownloadResponseApi>(getFileDownloadBatchExportsRetrieveUrl(projectId, id), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getFileDownloadBatchExportsCancelCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/file_download_batch_exports/${id}/cancel/`
+}
+
+/**
+ * Cancel an ongoing file-download batch export.
+ */
+export const fileDownloadBatchExportsCancelCreate = async (
+    projectId: string,
+    id: string,
+    fileDownloadBatchExportOnDemandApi: FileDownloadBatchExportOnDemandApi,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getFileDownloadBatchExportsCancelCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileDownloadBatchExportOnDemandApi),
     })
 }
 

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -1708,3 +1708,48 @@ export const FileDownloadBatchExportsCreateBody = /* @__PURE__ */ zod.union([
         })
         .describe('Typed configuration for the sessions model.'),
 ])
+
+/**
+ * Cancel an ongoing file-download batch export.
+ */
+export const fileDownloadBatchExportsCancelCreateBodyFileFormatDefault = `Parquet`
+export const fileDownloadBatchExportsCancelCreateBodyFileMaxSizeMbMin = 0
+
+export const FileDownloadBatchExportsCancelCreateBody = /* @__PURE__ */ zod
+    .object({
+        file: zod
+            .object({
+                format: zod
+                    .enum(['JSONLines', 'Parquet'])
+                    .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                    .default(fileDownloadBatchExportsCancelCreateBodyFileFormatDefault)
+                    .describe('File format\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'),
+                compression: zod
+                    .union([
+                        zod
+                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                            .describe(
+                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                            ),
+                        zod.null(),
+                    ])
+                    .optional()
+                    .describe(
+                        'Compress the file with a supported compression format\n\n\* `zstd` - zstd\n\* `gzip` - gzip\n\* `brotli` - brotli\n\* `lz4` - lz4\n\* `snappy` - snappy'
+                    ),
+                max_size_mb: zod
+                    .number()
+                    .min(fileDownloadBatchExportsCancelCreateBodyFileMaxSizeMbMin)
+                    .nullish()
+                    .describe('Split download into multiple files of at most this size in MB'),
+            })
+            .describe('Typed configuration for a FileDownload batch-export destination.'),
+        model: zod
+            .enum(['events', 'persons', 'sessions'])
+            .describe('\* `events` - events\n\* `persons` - persons\n\* `sessions` - sessions'),
+        include: zod.array(zod.string()).optional(),
+        exclude: zod.array(zod.string()).optional(),
+        data_interval_start: zod.iso.datetime({ offset: true }),
+        data_interval_end: zod.iso.datetime({ offset: true }),
+    })
+    .describe('Request shape for a FileDownload batch export on demand.')

--- a/products/batch_exports/mcp/tools.yaml
+++ b/products/batch_exports/mcp/tools.yaml
@@ -176,6 +176,9 @@ tools:
     batch-exports-update:
         operation: batch_exports_update
         enabled: false
+    file-download-batch-exports-cancel-create:
+        operation: file_download_batch_exports_cancel_create
+        enabled: false
     file-download-batch-exports-create:
         operation: file_download_batch_exports_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17201,6 +17201,32 @@ export namespace Schemas {
 
     /**
      * * `events` - events
+    * `persons` - persons
+    * `sessions` - sessions
+     */
+    export type FileDownloadBatchExportOnDemandModelEnum = typeof FileDownloadBatchExportOnDemandModelEnum[keyof typeof FileDownloadBatchExportOnDemandModelEnum];
+
+
+    export const FileDownloadBatchExportOnDemandModelEnum = {
+      Events: 'events',
+      Persons: 'persons',
+      Sessions: 'sessions',
+    } as const;
+
+    /**
+     * Request shape for a FileDownload batch export on demand.
+     */
+    export interface FileDownloadBatchExportOnDemand {
+      file: FileDownloadDestinationFileConfig;
+      model: FileDownloadBatchExportOnDemandModelEnum;
+      include?: string[];
+      exclude?: string[];
+      data_interval_start: string;
+      data_interval_end: string;
+    }
+
+    /**
+     * * `events` - events
      */
     export type FileDownloadEventsRequestModelEnum = typeof FileDownloadEventsRequestModelEnum[keyof typeof FileDownloadEventsRequestModelEnum];
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

File download batch exports do not support cancellation.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add support via a cancel endpoint in the file download API, requires write scope.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a unit test.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Yeah.
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

Yeah.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

No agent used, pretty much copied from existing cancel endpoint in the http.py API.
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
