### PR TITLE
fix(docs): use projectId in Nuxt sourcemaps config

### DIFF
--- a/docs/onboarding/error-tracking/nuxt.tsx
+++ b/docs/onboarding/error-tracking/nuxt.tsx
@@ -75,7 +75,7 @@ export const getNuxt37Steps = (ctx: OnboardingComponentsContext): StepDefinition
                                       },
                                       sourcemaps: {
                                         enabled: true,
-                                        project: '<ph_project_id>', // Your project ID from PostHog settings https://app.posthog.com/settings/environment#variables
+                                        projectId: '<ph_project_id>', // Your project ID, found in your environment settings: https://app.posthog.com/settings/environment#variables
                                         personalApiKey: '<ph_personal_api_key>', // Your personal API key from PostHog settings https://app.posthog.com/settings/user-api-keys (requires organization:read and error_tracking:write scopes)
                                         releaseName: 'my-application', // Optional: defaults to git repository name
                                         releaseVersion: '1.0.0', // Optional: defaults to current git commit

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
@@ -36,7 +36,7 @@ export function NuxtSourceMapsInstructions(): JSX.Element {
                 {nuxtModuleConfig(
                     currentTeam?.api_token ?? '<ph_project_token>',
                     host,
-                    currentTeam?.id?.toString() ?? '<team_id>'
+                    currentTeam?.id?.toString() ?? '<ph_project_id>'
                 )}
             </CodeSnippet>
 
@@ -51,12 +51,12 @@ export function NuxtSourceMapsInstructions(): JSX.Element {
     )
 }
 
-const nuxtModuleConfig = (apiKey: string, host: string, teamId: string): string => `export default defineNuxtConfig({
+const nuxtModuleConfig = (apiKey: string, host: string, projectId: string): string => `export default defineNuxtConfig({
   modules: ['@posthog/nuxt'],
 
   // Enable source maps generation in both vue and nitro
-  sourcemap: { 
-    client: 'hidden' 
+  sourcemap: {
+    client: 'hidden'
   },
   nitro: {
     rollupConfig: {
@@ -77,10 +77,10 @@ const nuxtModuleConfig = (apiKey: string, host: string, teamId: string): string 
     },
     sourcemaps: {
       enabled: true,
-      envId: '${teamId}', // Your environment ID (project ID)
+      projectId: '${projectId}', // Your project ID from PostHog settings
       personalApiKey: '<ph_personal_api_key>', // Your personal API key from PostHog settings
-      project: 'my-application', // Optional: Project name, defaults to git repository name
-      version: '1.0.0', // Optional: Release version, defaults to current git commit
+      releaseName: 'my-application', // Optional: Release name, defaults to git repository name
+      releaseVersion: '1.0.0', // Optional: Release version, defaults to current git commit
     },
   },
 })`


### PR DESCRIPTION
## Problem

Fixes #57371. Re-do of #59931 with the Copilot/Greptile review feedback applied in the initial commit.

The Nuxt error tracking docs and onboarding still referenced the deprecated `project` / `envId` keys for the PostHog project ID. In the current `@posthog/nuxt` sourcemaps config, the project ID field is `projectId` (`project` is now a deprecated alias for the release name).

## Changes

- Update the Nuxt error tracking docs to use `sourcemaps.projectId`
- Update the Nuxt onboarding source maps snippet to use the current `projectId`, `releaseName`, and `releaseVersion` keys
- Rename the `teamId` template parameter to `projectId` so the variable name matches the config key (Copilot review)
- Align the inline comment with the sibling docs file: "Your project ID from PostHog settings" (Greptile review)
- Tighten the docs wording so it matches the linked settings page ("found in your environment settings") (Copilot review)

## Validation

- `git diff --check`
- Snippets visually inspected against `@posthog/nuxt` sourcemaps config keys

Credit to @Sambhram1 for the original PR (#59931).