### PR TITLE
fix(data-warehouse): allow enabling schemas with no sync method

### DIFF
--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -459,8 +459,12 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
                 validated_data["sync_time_of_day"] = None
                 instance.sync_time_of_day = None
 
+        # Newly-discovered tables (e.g. surfaced by "Pull new schemas") are persisted with no
+        # sync_type, which previously blocked enabling them. Default to a full refresh so the
+        # toggle "just works" — users who want incremental can still configure it explicitly.
         if source.supports_scheduled_sync and should_sync is True and sync_type is None and instance.sync_type is None:
-            raise ValidationError("Sync type must be set up first before enabling schema")
+            sync_type = ExternalDataSchema.SyncType.FULL_REFRESH
+            validated_data["sync_type"] = sync_type
 
         # When re-enabling a webhook schema, force a full refresh to avoid missing data
         if (

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -320,6 +320,39 @@ class TestExternalDataSchema(APIBaseTest):
             assert schema.sync_type_config.get("reset_pipeline") is None
             assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
 
+    def test_enable_schema_without_sync_type_defaults_to_full_refresh(self):
+        # Tables surfaced by "Pull new schemas" are persisted with no sync_type. Enabling such a
+        # schema should default it to a full refresh rather than rejecting the request.
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type=ExternalDataSourceType.STRIPE,
+            job_inputs={"auth_method": {"selection": "api_key", "stripe_secret_key": "123"}},
+        )
+        schema = ExternalDataSchema.objects.create(
+            name="BalanceTransaction",
+            team=self.team,
+            source=source,
+            should_sync=False,
+            sync_type=None,
+        )
+
+        with (
+            mock.patch("products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow"),
+            mock.patch(
+                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                return_value=False,
+            ),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+                data={"should_sync": True},
+            )
+
+        assert response.status_code == 200
+        schema.refresh_from_db()
+        assert schema.should_sync is True
+        assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
+
     @parameterized.expand(
         [ExternalDataSchema.SyncType.APPEND, ExternalDataSchema.SyncType.INCREMENTAL],
     )

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -376,12 +376,14 @@ function ManagedSchemaTable({
                         return (
                             <SourceEditorAction source={source}>
                                 <LemonSwitch
-                                    disabledReason={
-                                        schema.sync_type === null ? 'Set up the sync method first' : undefined
-                                    }
                                     checked={schema.should_sync}
                                     onChange={(active) => {
-                                        if (!active && schema.sync_type === 'cdc') {
+                                        if (active && schema.sync_type === null) {
+                                            // Newly-discovered tables have no sync method yet. Default to a
+                                            // full refresh so enabling "just works"; users who want
+                                            // incremental can still pick it via Configure.
+                                            updateSchema({ ...schema, should_sync: true, sync_type: 'full_refresh' })
+                                        } else if (!active && schema.sync_type === 'cdc') {
                                             LemonDialog.open({
                                                 title: 'Disable CDC table?',
                                                 content: (


### PR DESCRIPTION
## Problem

A data-warehouse table that is surfaced **after** initial setup — e.g. via the **Pull new schemas** button on a scheduled-sync source — is persisted with `sync_type=None` and `should_sync=False`. Such a table shows up in the Schemas list but **cannot be toggled on**:

- The API serializer (`ExternalDataSchemaSerializer.update`) rejects enabling a scheduled-sync schema that has no sync method with **HTTP 400** (`"Sync type must be set up first before enabling schema"`).
- The UI **Enabled** toggle is disabled with the tooltip _"Set up the sync method first"_.

So a discovered table can never be turned on directly — the user first has to open **Configure** and pick a sync method, which is non-obvious. `status=None` confirms the table never attempted a sync; this is purely the no-sync-method gate, not a failed/auto-disabled state.

## Changes

When a user enables a schema that still has no sync method, default it to a **full refresh** so the toggle "just works":

- **API** (`products/data_warehouse/backend/api/external_data_schema.py`): on enable (`should_sync=True`) with `sync_type=None` and no existing sync method, set `sync_type=full_refresh` and persist it instead of raising HTTP 400.
- **UI** (`products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx`): the **Enabled** toggle is no longer disabled when no sync method is set; enabling sends `should_sync=true` together with `sync_type=full_refresh`.

Users who want **Incremental** (or another method) can still set it explicitly via **Configure** — that flow is unchanged.

## How did you test this code?

I'm an agent. Automated tests / checks I actually ran:

- Added a backend test `test_enable_schema_without_sync_type_defaults_to_full_refresh` (in `test_external_data_schema.py`): creates a schema with `sync_type=None, should_sync=False`, PATCHes `{should_sync: true}`, and asserts the response is 200 with `should_sync=True` and `sync_type=full_refresh`.
- `ruff check` and `ruff format --check` pass on both changed Python files.

Not run locally (no flox/DB or installed frontend deps in this environment) — relying on CI:
- Backend test execution (requires the Django test DB).
- Frontend `typescript:check` / `oxfmt`. The TS change is type-safe: `'full_refresh'` is a valid `sync_type` literal and the toggle still passes the existing CDC/webhook disable confirmations.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by an agent (Claude Code). Root cause was traced to the no-sync-method gate that exists on both sides of the enable path; the fix mirrors the existing **Configure** behavior (which PATCHes `sync_type` + `should_sync=true` together) by applying the same default automatically on direct enable. `full_refresh` was chosen as the safe default because it requires no extra configuration (no incremental field / primary key), matching how wizard-selected tables behave. No serializer fields or schema annotations changed, so no OpenAPI regeneration is required. Requires human review — not self-merged.