### PR TITLE
feat(hogql): add admin-only system tables and register system.access_controls

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -584,19 +584,26 @@ class Database(BaseModel):
         if not system_node or not hasattr(system_node, "children"):
             return
 
+        is_project_admin = self.user_access_control.check_access_level_for_object(
+            team, required_level="admin", explicit=True
+        )
+
         denied: set[str] = set()
         for table_node in list(system_node.children.values()):
             table = table_node.table
-            if not isinstance(table, PostgresTable) or table.access_scope is None:
-                continue  # Not access-controlled, keep it
+            if not isinstance(table, PostgresTable):
+                continue
 
-            access_level = self.user_access_control.access_level_for_resource(table.access_scope)
-            if access_level and access_level != NO_ACCESS_LEVEL:
-                continue  # User has access, keep it
+            should_remove = False
+            if table.requires_project_admin:
+                should_remove = not is_project_admin
+            elif table.access_scope is not None:
+                level = self.user_access_control.access_level_for_resource(table.access_scope)
+                should_remove = level is None or level == NO_ACCESS_LEVEL
 
-            # No access - remove from schema
-            del system_node.children[table_node.name]
-            denied.add(f"system.{table_node.name}")
+            if should_remove:
+                del system_node.children[table_node.name]
+                denied.add(f"system.{table_node.name}")
 
         self._denied_tables = denied
 
@@ -609,7 +616,9 @@ class Database(BaseModel):
         denied: set[str] = set()
         for table_node in list(system_node.children.values()):
             table = table_node.table
-            if not isinstance(table, PostgresTable) or table.access_scope is None:
+            if not isinstance(table, PostgresTable) or (
+                table.access_scope is None and not table.requires_project_admin
+            ):
                 continue  # Not access-controlled, keep it
 
             del system_node.children[table_node.name]

--- a/posthog/hogql/database/postgres_table.py
+++ b/posthog/hogql/database/postgres_table.py
@@ -65,6 +65,7 @@ class PostgresTable(FunctionCallTable):
     requires_args: bool = False
     postgres_table_name: str
     access_scope: Optional[APIScopeObject] = None
+    requires_project_admin: bool = False
     predicates: list[Expr] = []
 
     def get_predicates(self) -> list[Expr]:

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -1010,6 +1010,25 @@ early_access_features: PostgresTable = PostgresTable(
     },
 )
 
+access_controls: PostgresTable = PostgresTable(
+    name="access_controls",
+    postgres_table_name="ee_accesscontrol",
+    access_scope="access_control",
+    requires_project_admin=True,
+    fields={
+        "id": StringDatabaseField(name="id"),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "access_level": StringDatabaseField(name="access_level"),
+        "resource": StringDatabaseField(name="resource"),
+        "resource_id": StringDatabaseField(name="resource_id", nullable=True),
+        "organization_member_id": StringDatabaseField(name="organization_member_id", nullable=True),
+        "role_id": StringDatabaseField(name="role_id", nullable=True),
+        "created_by_id": IntegerDatabaseField(name="created_by_id", nullable=True),
+        "created_at": DateTimeDatabaseField(name="created_at"),
+        "updated_at": DateTimeDatabaseField(name="updated_at"),
+    },
+)
+
 usage_metrics: PostgresTable = PostgresTable(
     name="usage_metrics",
     postgres_table_name="posthog_groupusagemetric",
@@ -1121,6 +1140,7 @@ sandbox_environments: PostgresTable = PostgresTable(
 class SystemTables(TableNode):
     name: str = "system"
     children: dict[str, TableNode] = {
+        "access_controls": TableNode(name="access_controls", table=access_controls),
         "accounts": TableNode(name="accounts", table=accounts),
         "activity_logs": TableNode(name="activity_logs", table=activity_logs),
         "actions": TableNode(name="actions", table=actions),

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -1,4 +1,6 @@
+import pytest
 from posthog.test.base import BaseTest, NonAtomicBaseTest
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -515,7 +517,19 @@ def _create_usage_metric(team: Team, label: str) -> GroupUsageMetric:
     )
 
 
+def _create_access_control_row(team: Team, label: str):
+    from ee.models.rbac.access_control import AccessControl
+
+    return AccessControl.objects.create(
+        team=team,
+        resource="dashboard",
+        resource_id=label,
+        access_level="editor",
+    )
+
+
 SYSTEM_TABLE_FACTORIES = [
+    ("access_controls", _create_access_control_row),
     ("accounts", _create_account),
     ("activity_logs", _create_activity_log),
     ("actions", _create_action),
@@ -687,3 +701,131 @@ class TestSystemTablesTaskInternalExclusionIsolation(NonAtomicBaseTest):
 
         assert str(regular_task.pk) in ids
         assert str(internal_task.pk) not in ids
+
+
+class TestSystemTablesAdminOnly(BaseTest):
+    """Tables with `requires_project_admin=True` are hidden from non-admin members.
+
+    Currently `system.access_controls` is the only such table; it exposes raw RBAC rows
+    that could be used to enumerate org structure. Org admins and explicit project admins
+    keep access; everyone else gets the table filtered out of their HogQL schema.
+    """
+
+    def _make_org_admin(self):
+        from posthog.models import OrganizationMembership
+
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.ADMIN
+        membership.save()
+
+    def _enable_access_control_feature(self):
+        from posthog.constants import AvailableFeature
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+        ]
+        self.organization.save()
+
+    def _make_project_admin(self):
+        from posthog.models import OrganizationMembership
+
+        from ee.models.rbac.access_control import AccessControl
+
+        self._enable_access_control_feature()
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.MEMBER
+        membership.save()
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            access_level="admin",
+            organization_member=membership,
+        )
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_member_cannot_see_access_controls_table(self, _mock_ff):
+        from posthog.models import OrganizationMembership
+
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.MEMBER
+        membership.save()
+
+        db = Database.create_for(team=self.team, user=self.user)
+        system_node = db.tables.children.get("system")
+        assert system_node is not None
+        assert "access_controls" not in system_node.children
+        assert "system.access_controls" in db._denied_tables
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_project_admin_can_see_access_controls_table(self, _mock_ff):
+        self._make_project_admin()
+
+        db = Database.create_for(team=self.team, user=self.user)
+        system_node = db.tables.children.get("system")
+        assert system_node is not None
+        assert "access_controls" in system_node.children
+        assert "system.access_controls" not in db._denied_tables
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_org_admin_can_see_access_controls_table(self, _mock_ff):
+        self._make_org_admin()
+
+        db = Database.create_for(team=self.team, user=self.user)
+        system_node = db.tables.children.get("system")
+        assert system_node is not None
+        assert "access_controls" in system_node.children
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_no_user_hides_access_controls_table(self, _mock_ff):
+        db = Database.create_for(team=self.team, user=None)
+        system_node = db.tables.children.get("system")
+        assert system_node is not None
+        assert "access_controls" not in system_node.children
+        assert "system.access_controls" in db._denied_tables
+
+    @patch("posthoganalytics.feature_enabled", return_value=False)
+    def test_feature_flag_off_keeps_access_controls_table(self, _mock_ff):
+        # When the resource-level/admin-only filter is gated off, the registration
+        # is still present in the unfiltered schema — admins and non-admins alike
+        # fall back to the pre-PR behavior (everyone can query it via HogQL).
+        from posthog.models import OrganizationMembership
+
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.MEMBER
+        membership.save()
+
+        db = Database.create_for(team=self.team, user=self.user)
+        system_node = db.tables.children.get("system")
+        assert system_node is not None
+        assert "access_controls" in system_node.children
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_denied_table_error_message(self, _mock_ff):
+        from posthog.hogql.errors import QueryError
+
+        from posthog.models import OrganizationMembership
+
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.MEMBER
+        membership.save()
+
+        db = Database.create_for(team=self.team, user=self.user)
+        with pytest.raises(QueryError, match="don't have access"):
+            db.get_table("system.access_controls")
+
+    def test_generated_sql_for_admin_uses_ee_accesscontrol(self):
+        # Admin compiles a query against system.access_controls — verify the printer
+        # emits the correct postgresql() function call and team_id scoping.
+        # The DSN/table name go through `add_sensitive_value`, so they appear in
+        # `context.values` rather than as literals in the printed SQL.
+        self._make_org_admin()
+
+        db = Database.create_for(team=self.team, user=self.user)
+        context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=db)
+        query, _ = prepare_and_print_ast(
+            parse_select("SELECT id FROM system.access_controls"), context, dialect="clickhouse"
+        )
+        assert "postgresql(" in query
+        assert f"equals(system__access_controls.team_id, {self.team.pk})" in query
+        assert "ee_accesscontrol" in context.values.values()


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
