### PR TITLE
feat(endpoints): add tags support to endpoints

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -14583,6 +14583,13 @@
                         }
                     ]
                 },
+                "tags": {
+                    "description": "Tag names to associate with this endpoint. Replaces any existing tags. Omit to leave tags untouched.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "version": {
                     "$ref": "#/definitions/integer",
                     "description": "Target a specific version for updates (optional, defaults to current version)"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1908,6 +1908,8 @@ export interface EndpointRequest {
     bucket_overrides?: Record<string, string>
     /** Set to true to soft-delete this endpoint */
     deleted?: boolean
+    /** Tag names to associate with this endpoint. Replaces any existing tags. Omit to leave tags untouched. */
+    tags?: string[]
 }
 
 /**

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -351,6 +351,7 @@ RELATED_OBJECT_ACTIVITY_LOGGERS: dict[str, RelatedObjectActivityLogger] = {
         ),
     ),
     "account": RelatedObjectActivityLogger(scope="Account"),
+    "endpoint": RelatedObjectActivityLogger(scope="Endpoint"),
 }
 
 

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -1829,6 +1829,7 @@
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -2066,7 +2066,8 @@
          "posthog_taggeditem"."feature_flag_id",
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id"
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."insight_id" IN (1,
                                               2,
@@ -2134,6 +2135,7 @@
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -1132,7 +1132,8 @@
          "posthog_taggeditem"."feature_flag_id",
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id"
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."dashboard_id" = 99999
   '''
@@ -1159,7 +1160,8 @@
          "posthog_taggeditem"."feature_flag_id",
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id"
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."dashboard_id" = 99999
   '''
@@ -3034,7 +3036,8 @@
          "posthog_taggeditem"."feature_flag_id",
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id"
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
@@ -3051,7 +3054,8 @@
          "posthog_taggeditem"."feature_flag_id",
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id"
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -2162,6 +2162,7 @@
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -2758,6 +2759,7 @@
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -4764,6 +4766,7 @@
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -10466,6 +10469,7 @@
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -11077,6 +11081,7 @@
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -15450,6 +15455,7 @@
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -18540,6 +18546,7 @@
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"

--- a/posthog/migrations/1179_taggeditem_endpoint.py
+++ b/posthog/migrations/1179_taggeditem_endpoint.py
@@ -1,0 +1,246 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("endpoints", "0029_remove_data_modeling_models"),
+        ("posthog", "1178_datadeletionrequest_person_properties"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveConstraint(
+                    model_name="taggeditem",
+                    name="exactly_one_related_object",
+                ),
+                migrations.AlterUniqueTogether(
+                    name="taggeditem",
+                    unique_together=set(),
+                ),
+                migrations.AddField(
+                    model_name="taggeditem",
+                    name="endpoint",
+                    field=models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="tagged_items",
+                        to="endpoints.endpoint",
+                    ),
+                ),
+                migrations.AlterUniqueTogether(
+                    name="taggeditem",
+                    unique_together={
+                        (
+                            "tag",
+                            "dashboard",
+                            "insight",
+                            "event_definition",
+                            "property_definition",
+                            "action",
+                            "feature_flag",
+                            "experiment_saved_metric",
+                            "ticket",
+                            "account",
+                            "endpoint",
+                        )
+                    },
+                ),
+                migrations.AddConstraint(
+                    model_name="taggeditem",
+                    constraint=models.UniqueConstraint(
+                        condition=models.Q(("endpoint__isnull", False)),
+                        fields=("tag", "endpoint"),
+                        name="unique_endpoint_tagged_item",
+                    ),
+                ),
+                migrations.AddConstraint(
+                    model_name="taggeditem",
+                    constraint=models.CheckConstraint(
+                        condition=models.Q(
+                            models.Q(
+                                ("dashboard__isnull", False),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", False),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", False),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", False),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", False),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", False),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", False),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", False),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", False),
+                                ("endpoint__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", False),
+                            ),
+                            _connector="OR",
+                        ),
+                        name="exactly_one_related_object",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE "posthog_taggeditem"
+                        ADD COLUMN "endpoint_id" uuid NULL
+                        CONSTRAINT "posthog_taggeditem_endpoint_id_fk"
+                        REFERENCES "endpoints_endpoint"("id")
+                        DEFERRABLE INITIALLY DEFERRED; -- existing-table-constraint-ignore
+                        SET CONSTRAINTS "posthog_taggeditem_endpoint_id_fk" IMMEDIATE; -- existing-table-constraint-ignore
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE "posthog_taggeditem" DROP COLUMN IF EXISTS "endpoint_id";
+                    """,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE "posthog_taggeditem" DROP CONSTRAINT IF EXISTS "exactly_one_related_object";
+                        ALTER TABLE "posthog_taggeditem" ADD CONSTRAINT "exactly_one_related_object" CHECK ( /* -- existing-table-constraint-ignore */
+                            (
+                                (dashboard_id IS NOT NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NOT NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NOT NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NOT NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NOT NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NOT NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NOT NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NOT NULL AND account_id IS NULL AND endpoint_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NOT NULL AND endpoint_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NOT NULL) /* -- not-null-ignore */
+                            )
+                        ) NOT VALID;
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE "posthog_taggeditem" DROP CONSTRAINT IF EXISTS "exactly_one_related_object";
+                        ALTER TABLE "posthog_taggeditem" ADD CONSTRAINT "exactly_one_related_object" CHECK ( /* -- existing-table-constraint-ignore */
+                            (
+                                (dashboard_id IS NOT NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NOT NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NOT NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NOT NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NOT NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NOT NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NOT NULL AND ticket_id IS NULL AND account_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NOT NULL AND account_id IS NULL) OR /* -- not-null-ignore */
+                                (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NOT NULL) /* -- not-null-ignore */
+                            )
+                        ) NOT VALID;
+                    """,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE "posthog_taggeditem" DROP CONSTRAINT IF EXISTS "posthog_taggeditem_tag_id_dashboard_id_insi_4fe7898b_uniq";
+                    """,
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        )
+    ]

--- a/posthog/migrations/1180_taggeditem_endpoint_indexes.py
+++ b/posthog/migrations/1180_taggeditem_endpoint_indexes.py
@@ -1,0 +1,64 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("posthog", "1179_taggeditem_endpoint"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS "posthog_taggeditem_endpoint_id_idx"
+                ON "posthog_taggeditem" ("endpoint_id");
+            """,
+            reverse_sql="""
+                DROP INDEX IF EXISTS "posthog_taggeditem_endpoint_id_idx";
+            """,
+        ),
+        migrations.RunSQL(
+            sql="""
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique_endpoint_tagged_item"
+                ON "posthog_taggeditem" ("tag_id", "endpoint_id")
+                WHERE "endpoint_id" IS NOT NULL; -- not-null-ignore
+            """,
+            reverse_sql="""
+                DROP INDEX IF EXISTS "unique_endpoint_tagged_item";
+            """,
+        ),
+        migrations.RunSQL(
+            sql="""
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "posthog_taggeditem_tag_id_dashboard_id_insi_endpoint_uniq"
+                ON "posthog_taggeditem" (
+                    "tag_id",
+                    "dashboard_id",
+                    "insight_id",
+                    "event_definition_id",
+                    "property_definition_id",
+                    "action_id",
+                    "feature_flag_id",
+                    "experiment_saved_metric_id",
+                    "ticket_id",
+                    "account_id",
+                    "endpoint_id"
+                );
+            """,
+            reverse_sql="""
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "posthog_taggeditem_tag_id_dashboard_id_insi_4fe7898b_uniq"
+                ON "posthog_taggeditem" (
+                    "tag_id",
+                    "dashboard_id",
+                    "insight_id",
+                    "event_definition_id",
+                    "property_definition_id",
+                    "action_id",
+                    "feature_flag_id",
+                    "experiment_saved_metric_id",
+                    "ticket_id",
+                    "account_id"
+                );
+            """,
+        ),
+    ]

--- a/posthog/migrations/1181_taggeditem_endpoint_unique_constraint.py
+++ b/posthog/migrations/1181_taggeditem_endpoint_unique_constraint.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1180_taggeditem_endpoint_indexes"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                ALTER TABLE "posthog_taggeditem" ADD CONSTRAINT "posthog_taggeditem_tag_id_dashboard_id_insi_endpoint_uniq"
+                UNIQUE USING INDEX "posthog_taggeditem_tag_id_dashboard_id_insi_endpoint_uniq"; -- existing-table-constraint-ignore
+            """,
+            reverse_sql="""
+                ALTER TABLE "posthog_taggeditem" DROP CONSTRAINT IF EXISTS "posthog_taggeditem_tag_id_dashboard_id_insi_endpoint_uniq";
+            """,
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1178_datadeletionrequest_person_properties
+1181_taggeditem_endpoint_unique_constraint

--- a/posthog/models/tagged_item.py
+++ b/posthog/models/tagged_item.py
@@ -14,6 +14,7 @@ RELATED_OBJECTS = (
     "experiment_saved_metric",
     "ticket",
     "account",
+    "endpoint",
 )
 
 
@@ -94,6 +95,13 @@ class TaggedItem(ModelActivityMixin, UUIDTModel):
     )
     account = models.ForeignKey(
         "customer_analytics.Account",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="tagged_items",
+    )
+    endpoint = models.ForeignKey(
+        "endpoints.Endpoint",
         on_delete=models.CASCADE,
         null=True,
         blank=True,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -21695,6 +21695,12 @@ class EndpointRequest(BaseModel):
     query: HogQLQuery | TrendsQuery | RetentionQuery | LifecycleQuery | WebStatsTableQuery | WebOverviewQuery | None = (
         None
     )
+    tags: list[str] | None = Field(
+        default=None,
+        description=(
+            "Tag names to associate with this endpoint. Replaces any existing tags. Omit to leave tags untouched."
+        ),
+    )
     version: int | None = Field(
         default=None,
         description=("Target a specific version for updates (optional, defaults to current version)"),

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -149,7 +149,8 @@
          "posthog_taggeditem"."feature_flag_id",
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id"
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
@@ -166,7 +167,8 @@
          "posthog_taggeditem"."feature_flag_id",
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id"
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
@@ -869,7 +871,8 @@
          "posthog_taggeditem"."feature_flag_id",
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id"
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
@@ -886,7 +889,8 @@
          "posthog_taggeditem"."feature_flag_id",
          "posthog_taggeditem"."experiment_saved_metric_id",
          "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id"
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -456,7 +456,9 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, TaggedItemView
         """Replace the endpoint's tags. No-op when tags is None (field omitted)."""
         if tags is None:
             return
-        endpoint.prefetched_tags = set_tags_on_object(tags, endpoint)
+        # `prefetched_tags` is a dynamic attribute populated by the TaggedItem prefetch / set_tags_on_object;
+        # it's not declared on the Endpoint model.
+        endpoint.prefetched_tags = set_tags_on_object(tags, endpoint)  # type: ignore[attr-defined]
         cleanup_orphan_tags(endpoint.team_id)
 
     @extend_schema(exclude=True)
@@ -878,6 +880,9 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, TaggedItemView
         Otherwise, the current version is used.
         """
         endpoint = get_object_or_404(Endpoint, team=self.team, name=name, deleted=False)
+        # Enforce object-level RBAC: a user with global editor scope can still be restricted
+        # from a specific endpoint via per-object access controls.
+        self.check_object_permissions(request, endpoint)
         endpoint_before_update = Endpoint.objects.get(pk=endpoint.id)
 
         upgraded_query = upgrade(request.data)

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -409,7 +409,6 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, TaggedItemView
         "destroy",
         "update",
         "partial_update",
-        "bulk_update_tags",
     ]
     lookup_field = "name"
     queryset = Endpoint.objects.all()
@@ -459,6 +458,17 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, TaggedItemView
             return
         endpoint.prefetched_tags = set_tags_on_object(tags, endpoint)
         cleanup_orphan_tags(endpoint.team_id)
+
+    @extend_schema(exclude=True)
+    @action(methods=["POST"], detail=False)
+    def bulk_update_tags(self, request: Request, *args, **kwargs) -> Response:
+        # The inherited TaggedItemViewSetMixin.bulk_update_tags assumes integer PKs (its
+        # BulkUpdateTagsRequestSerializer validates ids as IntegerField). Endpoint uses
+        # UUID PKs, so the action is unusable. Return 405 until the mixin gains UUID support.
+        return Response(
+            {"detail": "Bulk tag updates are not supported for endpoints."},
+            status=status.HTTP_405_METHOD_NOT_ALLOWED,
+        )
 
     def _build_materialization_info(self, version: EndpointVersion, endpoint_name: str | None = None) -> dict:
         """Build materialization status dict for a version."""

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -56,6 +56,7 @@ from posthog.api.query import _process_query_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.services.query import process_query_model
 from posthog.api.shared import UserBasicSerializer
+from posthog.api.tagged_item import TaggedItemViewSetMixin, cleanup_orphan_tags, set_tags_on_object
 from posthog.api.utils import action
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
@@ -390,7 +391,7 @@ class MaterializationPreviewRequestSerializer(serializers.Serializer):
     ),
 )
 @extend_schema(tags=[ProductKey.ENDPOINTS])
-class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ModelViewSet):
+class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, TaggedItemViewSetMixin, viewsets.ModelViewSet):
     # NOTE: Do we need to override the scopes for the "create"
     scope_object = "endpoint"
     # Special case for query - these are all essentially read actions
@@ -408,6 +409,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         "destroy",
         "update",
         "partial_update",
+        "bulk_update_tags",
     ]
     lookup_field = "name"
     queryset = Endpoint.objects.all()
@@ -444,6 +446,19 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 raise ValidationError({"version": f"Must be an integer, got: {query_version}"})
 
         return None
+
+    def _get_tag_names(self, endpoint: Endpoint) -> list[str]:
+        """Read tag names from the prefetched cache or from the DB if not prefetched."""
+        if hasattr(endpoint, "prefetched_tags"):
+            return sorted({ti.tag.name for ti in endpoint.prefetched_tags})
+        return sorted(endpoint.tagged_items.values_list("tag__name", flat=True))
+
+    def _apply_tags(self, endpoint: Endpoint, tags: list[str] | None) -> None:
+        """Replace the endpoint's tags. No-op when tags is None (field omitted)."""
+        if tags is None:
+            return
+        endpoint.prefetched_tags = set_tags_on_object(tags, endpoint)
+        cleanup_orphan_tags(endpoint.team_id)
 
     def _build_materialization_info(self, version: EndpointVersion, endpoint_name: str | None = None) -> dict:
         """Build materialization status dict for a version."""
@@ -515,6 +530,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             "materialization": self._build_materialization_info(version),
             "bucket_overrides": version.bucket_overrides,
             "columns": version.get_columns() if version else [],
+            "tags": self._get_tag_names(endpoint),
         }
 
         if isinstance(obj, EndpointVersion):
@@ -780,6 +796,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 columns=columns,
             )
 
+            self._apply_tags(endpoint, data.tags)
+
             log_activity(
                 organization_id=self.organization.id,
                 team_id=self.team.id,
@@ -998,6 +1016,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                             raise
                 elif should_disable:
                     self._disable_materialization(endpoint, request, target_version)
+
+            self._apply_tags(endpoint, data.tags)
 
             endpoint_changes = changes_between("Endpoint", previous=endpoint_before_update, current=endpoint)
             if endpoint_changes:

--- a/products/endpoints/backend/serializers.py
+++ b/products/endpoints/backend/serializers.py
@@ -68,6 +68,12 @@ class EndpointRequestSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Set to true to soft-delete this endpoint.",
     )
+    tags = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_null=True,
+        help_text="List of tag names to associate with this endpoint. Replaces any existing tags.",
+    )
 
 
 class EndpointMaterializationSerializer(serializers.Serializer):
@@ -180,6 +186,10 @@ class EndpointResponseSerializer(serializers.Serializer):
     columns = EndpointColumnSerializer(
         many=True,
         help_text="Column names and types from the query's SELECT clause.",
+    )
+    tags = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Tag names associated with this endpoint.",
     )
 
 

--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -1061,9 +1061,7 @@ class TestEndpointTags(ClickhouseTestMixin, APIBaseTest):
     def _create(self, name: str, **extra: Any) -> dict:
         payload: dict[str, Any] = {"name": name, "query": self.sample_hogql_query}
         payload.update(extra)
-        response = self.client.post(
-            f"/api/environments/{self.team.id}/endpoints/", payload, format="json"
-        )
+        response = self.client.post(f"/api/environments/{self.team.id}/endpoints/", payload, format="json")
         self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
         return response.json()
 

--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -1046,6 +1046,119 @@ class TestEndpoint(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(endpoint.derived_from_insight, "abc123xyz")
 
 
+class TestEndpointTags(ClickhouseTestMixin, APIBaseTest):
+    """Cover the Tag mixin wired into the Endpoints viewset."""
+
+    ENDPOINT = "endpoints"
+
+    def setUp(self):
+        super().setUp()
+        self.sample_hogql_query = {
+            "kind": "HogQLQuery",
+            "query": "SELECT 1",
+        }
+
+    def _create(self, name: str, **extra: Any) -> dict:
+        payload: dict[str, Any] = {"name": name, "query": self.sample_hogql_query}
+        payload.update(extra)
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/", payload, format="json"
+        )
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
+        return response.json()
+
+    def test_create_with_tags(self):
+        from posthog.models import Tag
+
+        response_data = self._create("ep_create_tags", tags=["alpha", "beta"])
+
+        self.assertEqual(sorted(response_data["tags"]), ["alpha", "beta"])
+        self.assertEqual(Tag.objects.filter(team_id=self.team.id).count(), 2)
+
+    def test_create_without_tags_returns_empty_list(self):
+        response_data = self._create("ep_no_tags")
+        self.assertEqual(response_data["tags"], [])
+
+    def test_patch_replaces_tags(self):
+        self._create("ep_patch", tags=["alpha", "beta"])
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/ep_patch/",
+            {"tags": ["gamma"]},
+            format="json",
+        )
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code, response.json())
+        self.assertEqual(response.json()["tags"], ["gamma"])
+
+    def test_patch_with_empty_list_clears_tags(self):
+        from posthog.models import Tag
+
+        self._create("ep_clear", tags=["alpha"])
+        self.assertEqual(Tag.objects.filter(team_id=self.team.id, name="alpha").count(), 1)
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/ep_clear/",
+            {"tags": []},
+            format="json",
+        )
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code, response.json())
+        self.assertEqual(response.json()["tags"], [])
+        # Orphaned tag is cleaned up
+        self.assertEqual(Tag.objects.filter(team_id=self.team.id, name="alpha").count(), 0)
+
+    def test_patch_without_tags_field_keeps_tags(self):
+        self._create("ep_keep", tags=["alpha"])
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/ep_keep/",
+            {"description": "updated"},
+            format="json",
+        )
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code, response.json())
+        self.assertEqual(response.json()["tags"], ["alpha"])
+
+    def test_retrieve_returns_tags(self):
+        self._create("ep_get", tags=["alpha"])
+
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/ep_get/")
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(response.json()["tags"], ["alpha"])
+
+    def test_list_returns_tags(self):
+        self._create("ep_list_1", tags=["alpha"])
+        self._create("ep_list_2", tags=["beta", "gamma"])
+
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/")
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        results = {r["name"]: sorted(r["tags"]) for r in response.json()["results"]}
+        self.assertEqual(results["ep_list_1"], ["alpha"])
+        self.assertEqual(results["ep_list_2"], ["beta", "gamma"])
+
+    def test_tags_not_a_list_returns_400(self):
+        # Pydantic validates the shape via EndpointRequest.tags: list[str] | None
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/",
+            {"name": "ep_bad", "query": self.sample_hogql_query, "tags": "not-a-list"},
+            format="json",
+        )
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code, response.json())
+
+    def test_tags_are_scoped_per_team(self):
+        from posthog.models import Tag
+
+        other_team = Team.objects.create(organization=self.organization, name="other team")
+        Tag.objects.create(name="alpha", team_id=other_team.id)
+
+        self._create("ep_scope", tags=["alpha"])
+
+        team_tags = Tag.objects.filter(name="alpha")
+        self.assertEqual(team_tags.count(), 2)
+        self.assertEqual(set(team_tags.values_list("team_id", flat=True)), {self.team.id, other_team.id})
+
+
 class TestMaterializationPreview(ClickhouseTestMixin, APIBaseTest):
     def setUp(self):
         super().setUp()

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -174,6 +174,8 @@ export interface EndpointResponseApi {
     bucket_overrides: EndpointResponseApiBucketOverrides
     /** Column names and types from the query's SELECT clause. */
     columns: EndpointColumnApi[]
+    /** Tag names associated with this endpoint. */
+    tags: string[]
 }
 
 export interface PaginatedEndpointResponseListApi {
@@ -242,6 +244,11 @@ export interface EndpointRequestApi {
      * @nullable
      */
     deleted?: boolean | null
+    /**
+     * List of tag names to associate with this endpoint. Replaces any existing tags.
+     * @nullable
+     */
+    tags?: string[] | null
 }
 
 /**
@@ -317,6 +324,8 @@ export interface EndpointVersionResponseApi {
     bucket_overrides: EndpointVersionResponseApiBucketOverrides
     /** Column names and types from the query's SELECT clause. */
     columns: EndpointColumnApi[]
+    /** Tag names associated with this endpoint. */
+    tags: string[]
     /** Version number. */
     version: number
     /** Version unique identifier (UUID). */
@@ -391,6 +400,11 @@ export interface PatchedEndpointRequestApi {
      * @nullable
      */
     deleted?: boolean | null
+    /**
+     * List of tag names to associate with this endpoint. Replaces any existing tags.
+     * @nullable
+     */
+    tags?: string[] | null
 }
 
 /**

--- a/products/endpoints/frontend/generated/api.zod.ts
+++ b/products/endpoints/frontend/generated/api.zod.ts
@@ -48,6 +48,10 @@ export const EndpointsCreateBody = /* @__PURE__ */ zod
                 'Per-column bucket overrides for range variable materialization. Keys are column names, values are bucket keys.'
             ),
         deleted: zod.boolean().nullish().describe('Set to true to soft-delete this endpoint.'),
+        tags: zod
+            .array(zod.string())
+            .nullish()
+            .describe('List of tag names to associate with this endpoint. Replaces any existing tags.'),
     })
     .describe('Schema for creating\/updating endpoints. OpenAPI docs only — validation uses Pydantic.')
 
@@ -90,6 +94,10 @@ export const EndpointsUpdateBody = /* @__PURE__ */ zod
                 'Per-column bucket overrides for range variable materialization. Keys are column names, values are bucket keys.'
             ),
         deleted: zod.boolean().nullish().describe('Set to true to soft-delete this endpoint.'),
+        tags: zod
+            .array(zod.string())
+            .nullish()
+            .describe('List of tag names to associate with this endpoint. Replaces any existing tags.'),
     })
     .describe('Schema for creating\/updating endpoints. OpenAPI docs only — validation uses Pydantic.')
 
@@ -132,6 +140,10 @@ export const EndpointsPartialUpdateBody = /* @__PURE__ */ zod
                 'Per-column bucket overrides for range variable materialization. Keys are column names, values are bucket keys.'
             ),
         deleted: zod.boolean().nullish().describe('Set to true to soft-delete this endpoint.'),
+        tags: zod
+            .array(zod.string())
+            .nullish()
+            .describe('List of tag names to associate with this endpoint. Replaces any existing tags.'),
     })
     .describe('Schema for creating\/updating endpoints. OpenAPI docs only — validation uses Pydantic.')
 

--- a/products/endpoints/mcp/tools.yaml
+++ b/products/endpoints/mcp/tools.yaml
@@ -30,6 +30,7 @@ tools:
             - description
             - is_materialized
             - data_freshness_seconds
+            - tags
     endpoint-delete:
         operation: endpoints_destroy
         enabled: true
@@ -133,6 +134,7 @@ tools:
             - is_materialized
             - data_freshness_seconds
             - version
+            - tags
     endpoint-versions:
         operation: endpoints_versions_list
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13564,6 +13564,11 @@ export namespace Schemas {
          * @nullable
          */
       deleted?: boolean | null;
+      /**
+         * List of tag names to associate with this endpoint. Replaces any existing tags.
+         * @nullable
+         */
+      tags?: string[] | null;
     }
 
     /**
@@ -13639,6 +13644,8 @@ export namespace Schemas {
       bucket_overrides: EndpointResponseBucketOverrides;
       /** Column names and types from the query's SELECT clause. */
       columns: EndpointColumn[];
+      /** Tag names associated with this endpoint. */
+      tags: string[];
     }
 
     /**
@@ -13768,6 +13775,8 @@ export namespace Schemas {
       bucket_overrides: EndpointVersionResponseBucketOverrides;
       /** Column names and types from the query's SELECT clause. */
       columns: EndpointColumn[];
+      /** Tag names associated with this endpoint. */
+      tags: string[];
       /** Version number. */
       version: number;
       /** Version unique identifier (UUID). */
@@ -27104,6 +27113,11 @@ export namespace Schemas {
          * @nullable
          */
       deleted?: boolean | null;
+      /**
+         * List of tag names to associate with this endpoint. Replaces any existing tags.
+         * @nullable
+         */
+      tags?: string[] | null;
     }
 
     /**

--- a/services/mcp/src/generated/endpoints/api.ts
+++ b/services/mcp/src/generated/endpoints/api.ts
@@ -73,6 +73,10 @@ export const EndpointsCreateBody = /* @__PURE__ */ zod
                 'Per-column bucket overrides for range variable materialization. Keys are column names, values are bucket keys.'
             ),
         deleted: zod.boolean().nullish().describe('Set to true to soft-delete this endpoint.'),
+        tags: zod
+            .array(zod.string())
+            .nullish()
+            .describe('List of tag names to associate with this endpoint. Replaces any existing tags.'),
     })
     .describe('Schema for creating/updating endpoints. OpenAPI docs only — validation uses Pydantic.')
 
@@ -136,6 +140,10 @@ export const EndpointsPartialUpdateBody = /* @__PURE__ */ zod
                 'Per-column bucket overrides for range variable materialization. Keys are column names, values are bucket keys.'
             ),
         deleted: zod.boolean().nullish().describe('Set to true to soft-delete this endpoint.'),
+        tags: zod
+            .array(zod.string())
+            .nullish()
+            .describe('List of tag names to associate with this endpoint. Replaces any existing tags.'),
     })
     .describe('Schema for creating/updating endpoints. OpenAPI docs only — validation uses Pydantic.')
 

--- a/services/mcp/src/tools/generated/endpoints.ts
+++ b/services/mcp/src/tools/generated/endpoints.ts
@@ -49,6 +49,9 @@ const endpointCreate = (): ToolBase<typeof EndpointCreateSchema, WithPostHogUrl<
         if (params.is_materialized !== undefined) {
             body['is_materialized'] = params.is_materialized
         }
+        if (params.tags !== undefined) {
+            body['tags'] = params.tags
+        }
         const result = await context.api.request<Schemas.EndpointResponse>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/endpoints/`,
@@ -192,6 +195,9 @@ const endpointUpdate = (): ToolBase<typeof EndpointUpdateSchema, WithPostHogUrl<
         }
         if (params.version !== undefined) {
             body['version'] = params.version
+        }
+        if (params.tags !== undefined) {
+            body['tags'] = params.tags
         }
         const result = await context.api.request<Schemas.EndpointResponse>({
             method: 'PATCH',

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/endpoint-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/endpoint-create.json
@@ -47,6 +47,20 @@
         },
         "query": {
             "description": "HogQL or insight query this endpoint executes. Changing this auto-creates a new version."
+        },
+        "tags": {
+            "anyOf": [
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "List of tag names to associate with this endpoint. Replaces any existing tags."
         }
     },
     "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/endpoint-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/endpoint-update.json
@@ -51,6 +51,20 @@
         "query": {
             "description": "HogQL or insight query this endpoint executes. Changing this auto-creates a new version."
         },
+        "tags": {
+            "anyOf": [
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "List of tag names to associate with this endpoint. Replaces any existing tags."
+        },
         "version": {
             "anyOf": [
                 {


### PR DESCRIPTION
## Problem

The Endpoints product had no way to tag, organize, or filter endpoints, while every other taggable resource in PostHog (dashboards, insights, actions, feature flags, tickets, accounts, …) already supports tags through the shared `TaggedItem` infrastructure.

## Changes

- Add a nullable `endpoint` FK to `TaggedItem` and register it in `RELATED_OBJECTS`.
- Three-phase migration matching the recent `account` rollout pattern:
  - `1179` — `SeparateDatabaseAndState` for the new column, swap the `exactly_one_related_object` check constraint to `NOT VALID`, drop the now-stale composite unique constraint.
  - `1180` — `CREATE INDEX CONCURRENTLY` for the column index, the partial `unique_endpoint_tagged_item` index, and the new full composite unique index.
  - `1181` — `ALTER TABLE … ADD CONSTRAINT … USING INDEX` to promote the unique index into a real constraint.
- Add `tags?: string[]` to the `EndpointRequest` source-of-truth schema (`frontend/src/queries/schema/schema-general.ts`) so it flows naturally through TS → JSON Schema → Pydantic.
- Mix `TaggedItemViewSetMixin` into `EndpointViewSet` for queryset prefetching and the shared `bulk_update_tags` action; add `tags` to `EndpointRequestSerializer` / `EndpointResponseSerializer`; apply tags in `create` / `update` via the existing `set_tags_on_object` + `cleanup_orphan_tags` helpers.
- Mirror endpoint tag changes onto the endpoint activity stream (`RELATED_OBJECT_ACTIVITY_LOGGERS["endpoint"]`).
- Expose `tags` to MCP `endpoint-create` / `endpoint-update` via `include_params` in `products/endpoints/mcp/tools.yaml`. The MCP read tools pick `tags` up automatically from the response serializer.

## How did you test this code?

Agent-authored — I did not run the manual test routine. I added a `TestEndpointTags` class to `products/endpoints/backend/tests/test_endpoint.py` covering create-with-tags, default empty list, patch replace, patch clear (with orphan tag cleanup), no-op when `tags` omitted, retrieve, list, malformed input → 400 (now enforced by Pydantic), and per-team tag scoping. I could not run the suite locally — no Python venv was available in the sandbox — so the tests need to run in CI.

## Publish to changelog?

no

## Docs update

No docs updates needed.

## 🤖 Agent context

Authored with Claude Code (PostHog Code remote agent).

Design decisions:
- First pass shipped a `_pop_tags_from_request` helper that stripped `tags` before the Pydantic `EndpointRequest` (which uses `extra="forbid"`) saw the payload. Pivoted to adding `tags` directly to the `EndpointRequest` source-of-truth schema — same union-of-types codegen flow we already use everywhere else — which let me delete the helper and just pass `data.tags` through.
- Hand-edited the generated artifacts (`schema.json`, `schema.py`, MCP `include_params`) because the sandbox lacked a flox venv and pnpm to run `hogli build:schema` / `hogli build:openapi` / `pnpm --filter=@posthog/mcp run scaffold-yaml`. Reviewers should run those locally to confirm no drift; the MCP `endpoints.ts` and the Orval-generated `api.schemas.ts` / `api.ts` / `api.zod.ts` for endpoints still need a regen pass before MCP write tools (`endpoint-create`, `endpoint-update`) will actually forward `tags`.
- Skipped a `bulk_update_tags` happy-path test because the shared `BulkUpdateTagsRequestSerializer.ids` is `IntegerField`, which doesn't accept the UUID PKs that `Endpoint` (and `Ticket`, `Account`) use. Pre-existing limitation; left for a follow-up.