### PR TITLE
feat(rbac): emit object-level HogQL access control as NOT IN subquery

### DIFF
--- a/posthog/hogql/context.py
+++ b/posthog/hogql/context.py
@@ -79,6 +79,11 @@ class HogQLContext:
     # that the current user is denied access to. Populated before type resolution so that
     # FieldType.get_child() can raise QueryError for restricted properties.
     restricted_properties: Optional[set[tuple[str, int]]] = None
+    # Per-query memoization for the `hogql-object-access-control` feature flag check.
+    # `None` = not yet evaluated for this query, True/False = cached result.
+    # Lives on context (not on Database) because the flag gates printer-time behavior
+    # and may be checked once per joined system table during a single query.
+    _object_acl_flag_resolved: Optional[bool] = None
 
     def __post_init__(self):
         if self.team:

--- a/posthog/hogql/database/postgres_table.py
+++ b/posthog/hogql/database/postgres_table.py
@@ -1,3 +1,4 @@
+from functools import cache
 from typing import Optional
 
 from django.conf import settings
@@ -9,6 +10,16 @@ from posthog.hogql.escape_sql import escape_hogql_identifier
 
 from posthog.person_db_router import PERSONS_DB_MODELS
 from posthog.scopes import APIScopeObject
+
+
+@cache
+def _pk_column_for_pg_table(postgres_table_name: str) -> Optional[str]:
+    """Look up the primary key column from the live Postgres schema. Cached per process.
+    Returns None for tables with no single-column primary key (composite PK)."""
+    from django.db import connection
+
+    with connection.cursor() as cursor:
+        return connection.introspection.get_primary_key_column(cursor, postgres_table_name)
 
 
 def build_function_call(postgres_table_name: str, context: Optional[HogQLContext] = None):
@@ -69,6 +80,10 @@ class PostgresTable(FunctionCallTable):
 
     def get_predicates(self) -> list[Expr]:
         return self.predicates
+
+    @property
+    def primary_key(self) -> Optional[str]:
+        return _pk_column_for_pg_table(self.postgres_table_name)
 
     def to_printed_hogql(self):
         return escape_hogql_identifier(self.name)

--- a/posthog/hogql/printer/access_control.py
+++ b/posthog/hogql/printer/access_control.py
@@ -1,0 +1,300 @@
+"""HogQL object-level access control guard.
+
+Emits a `NOT IN (SELECT resource_id FROM ee_accesscontrol WHERE ... GROUP BY ... HAVING ...)`
+subquery against the live Postgres `ee_accesscontrol` table for every system table query
+made by a non-admin user.
+
+Why a subquery and not a literal `NOT IN (id1, id2, ...)` list?
+- C1: a literal list is unbounded (CH 1 MB query cap hits at ~25k IDs). The subquery
+  approach is bounded by per-team `ee_accesscontrol` row count.
+- C2: literal IDs leak into `system.query_log` server-side. The subquery only embeds
+  the calling user's own membership UUID and role UUIDs as parameters.
+
+Why a private (unregistered) `PostgresTable` instance?
+- The `ee_accesscontrol` table content leaks org structure (who is locked out of what).
+  Keeping it off the public HogQL schema prevents accidental exposure through
+  autocomplete, MCP, OAuth scopes, and the SQL editor. Only this printer references it.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+import posthoganalytics
+from opentelemetry import trace
+from prometheus_client import Counter
+
+from posthog.hogql import ast
+from posthog.hogql.database.models import IntegerDatabaseField, StringDatabaseField
+from posthog.hogql.database.postgres_table import PostgresTable
+
+if TYPE_CHECKING:
+    from posthog.hogql.context import HogQLContext
+
+
+HOGQL_OBJECT_ACCESS_CONTROL_FLAG = "hogql-object-access-control"
+
+tracer = trace.get_tracer(__name__)
+
+ACL_SUBQUERY_EMITTED_COUNTER = Counter(
+    "posthog_hogql_acl_subquery_emitted_total",
+    "Count of HogQL queries where an object-level access control subquery was emitted",
+    labelnames=["resource"],
+)
+
+
+# Private. Never registered on the HogQL Database. Only this module instantiates AST nodes
+# pointing at it; the printer renders it via `to_printed_clickhouse(context)` which emits a
+# `postgresql(...)` function call with credentials masked through `add_sensitive_value`.
+_access_controls_table = PostgresTable(
+    name="access_controls",
+    postgres_table_name="ee_accesscontrol",
+    fields={
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "resource": StringDatabaseField(name="resource"),
+        "resource_id": StringDatabaseField(name="resource_id", nullable=True),
+        "organization_member_id": StringDatabaseField(name="organization_member_id", nullable=True),
+        "role_id": StringDatabaseField(name="role_id", nullable=True),
+        "access_level": StringDatabaseField(name="access_level"),
+    },
+)
+
+
+def _is_object_acl_enabled(context: "HogQLContext") -> bool:
+    """Evaluate the feature flag once per query and cache on the context."""
+    if context._object_acl_flag_resolved is not None:
+        return context._object_acl_flag_resolved
+
+    team = context.team
+    if team is None:
+        context._object_acl_flag_resolved = False
+        return False
+
+    enabled = bool(
+        posthoganalytics.feature_enabled(
+            HOGQL_OBJECT_ACCESS_CONTROL_FLAG,
+            str(team.uuid),
+            groups={"organization": str(team.organization_id), "project": str(team.id)},
+            group_properties={
+                "organization": {"id": str(team.organization_id)},
+                "project": {"id": str(team.id)},
+            },
+            send_feature_flag_events=False,
+        )
+    )
+    context._object_acl_flag_resolved = enabled
+    return enabled
+
+
+def _build_access_controls_subquery(
+    resource: str,
+    team_id: int,
+    member_id: str,
+    role_ids: list[str],
+) -> ast.SelectQuery:
+    """Construct the typed AST for:
+
+    SELECT resource_id FROM ee_accesscontrol
+    WHERE team_id = $team_id
+      AND resource = $resource
+      AND isNotNull(resource_id)
+      AND (
+        (isNull(organization_member_id) AND isNull(role_id))
+        OR organization_member_id = $member_id
+        [OR role_id IN ($role_ids)]   -- only if role_ids non-empty
+      )
+    GROUP BY resource_id
+    HAVING
+      if(
+        max(toUInt8(isNotNull(organization_member_id) OR isNotNull(role_id))),
+        -- explicit rows exist: blocked iff every explicit row is 'none'
+        max(if(isNotNull(organization_member_id) OR isNotNull(role_id), access_level != 'none', 0)) = 0,
+        -- only default rows present: blocked iff every default row is 'none'
+        max(access_level != 'none') = 0
+      )
+    """
+    # The printer only emits `AS <alias>` when the JoinExpr's type is a TableAliasType — see
+    # `BasePrinter.visit_join_expr` around the `isinstance(node.type, (ast.TableAliasType, ...))`
+    # branch. Without an alias, field qualifiers (`access_controls.team_id`) would not bind to
+    # anything in CH because the FROM resolves to `postgresql(...)`, not to a named table.
+    base_type = ast.TableType(table=_access_controls_table)
+    ac_alias = "access_controls"
+    ac_type = ast.TableAliasType(alias=ac_alias, table_type=base_type)
+
+    def ac_field(name: str) -> ast.Field:
+        # The chain doesn't drive SQL output (visit_field delegates to node.type for that). We
+        # match the pattern in `team_id_guard_for_table` — single-segment chain, fully-typed.
+        return ast.Field(chain=[name], type=ast.FieldType(name=name, table_type=ac_type))
+
+    is_explicit = ast.Or(
+        exprs=[
+            ast.Call(name="isNotNull", args=[ac_field("organization_member_id")]),
+            ast.Call(name="isNotNull", args=[ac_field("role_id")]),
+        ]
+    )
+
+    is_default = ast.And(
+        exprs=[
+            ast.Call(name="isNull", args=[ac_field("organization_member_id")]),
+            ast.Call(name="isNull", args=[ac_field("role_id")]),
+        ]
+    )
+
+    member_match = ast.CompareOperation(
+        op=ast.CompareOperationOp.Eq,
+        left=ac_field("organization_member_id"),
+        right=ast.Constant(value=member_id),
+    )
+
+    applies_to_user_exprs: list[ast.Expr] = [is_default, member_match]
+    if role_ids:
+        applies_to_user_exprs.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.In,
+                left=ac_field("role_id"),
+                right=ast.Tuple(exprs=[ast.Constant(value=rid) for rid in role_ids]),
+            )
+        )
+    applies_to_user = ast.Or(exprs=applies_to_user_exprs)
+
+    where = ast.And(
+        exprs=[
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ac_field("team_id"),
+                right=ast.Constant(value=team_id),
+            ),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ac_field("resource"),
+                right=ast.Constant(value=resource),
+            ),
+            ast.Call(name="isNotNull", args=[ac_field("resource_id")]),
+            applies_to_user,
+        ]
+    )
+
+    access_level_not_none = ast.CompareOperation(
+        op=ast.CompareOperationOp.NotEq,
+        left=ac_field("access_level"),
+        right=ast.Constant(value="none"),
+    )
+
+    # Branch 1 (explicit rows exist): blocked iff every explicit row is 'none'.
+    # Use `if(is_explicit, access_level != 'none', 0)` so default rows contribute 0 (don't
+    # mask the explicit-tier decision).
+    branch_explicit = ast.CompareOperation(
+        op=ast.CompareOperationOp.Eq,
+        left=ast.Call(
+            name="max",
+            args=[
+                ast.Call(
+                    name="if",
+                    args=[is_explicit, access_level_not_none, ast.Constant(value=0)],
+                )
+            ],
+        ),
+        right=ast.Constant(value=0),
+    )
+
+    # Branch 2 (no explicit rows): only default rows survived the WHERE filter; blocked iff every
+    # default row is 'none'.
+    branch_default = ast.CompareOperation(
+        op=ast.CompareOperationOp.Eq,
+        left=ast.Call(name="max", args=[access_level_not_none]),
+        right=ast.Constant(value=0),
+    )
+
+    # `if(has_any_explicit_row, branch_explicit, branch_default)` — explicit rows override defaults.
+    having = ast.Call(
+        name="if",
+        args=[
+            ast.Call(name="max", args=[ast.Call(name="toUInt8", args=[is_explicit])]),
+            branch_explicit,
+            branch_default,
+        ],
+    )
+
+    return ast.SelectQuery(
+        select=[ac_field("resource_id")],
+        select_from=ast.JoinExpr(
+            table=ast.Field(chain=[ac_alias]),
+            alias=ac_alias,
+            type=ac_type,
+        ),
+        where=where,
+        group_by=[ac_field("resource_id")],
+        having=having,
+    )
+
+
+def build_access_control_guard(
+    table: PostgresTable,
+    table_type: ast.TableOrSelectType,
+    context: "HogQLContext",
+) -> Optional[ast.Expr]:
+    """Build the `notIn(toString(pk), <subquery>)` guard for a system PostgresTable.
+
+    Returns None when the guard is not applicable (bypassed).
+    Returns `Constant(value=False)` when we fail closed (user context expected but missing membership).
+    """
+    from posthog.models import OrganizationMembership
+
+    resource = table.access_scope
+    if not resource:
+        return None  # Table is not RBAC-controlled (e.g. system.numbers).
+
+    pk = table.primary_key
+    if pk is None:
+        return None  # Composite PK or introspection failure — can't safely build the guard.
+
+    if not context.team or not context.team_id:
+        return None  # System queries / exports with no team context — handled by other gates.
+
+    if context.database is None or context.database.user_access_control is None:
+        return None  # No user on the context — existing resource-level filter is fail-closed already.
+
+    uac = context.database.user_access_control
+
+    if not uac.access_controls_supported:
+        return None  # EE not installed / org doesn't have the ACCESS_CONTROL feature.
+
+    org_membership = uac._organization_membership
+    if org_membership is None:
+        # Should be impossible: the resource-level filter already ran and would have hidden the
+        # table for a user who isn't a member of this team's org. Fail closed defensively.
+        return ast.Constant(value=False)
+
+    # Bypass: org admins see everything.
+    if org_membership.level >= OrganizationMembership.Level.ADMIN:
+        return None
+
+    # Bypass: project admins see everything (same as REST behavior).
+    if uac.check_access_level_for_object(context.team, required_level="admin", explicit=True):
+        return None
+
+    if not _is_object_acl_enabled(context):
+        return None  # Kill-switch.
+
+    role_ids = [str(rid) for rid in uac._user_role_ids]
+    member_id = str(org_membership.id)
+
+    with tracer.start_as_current_span("rbac.acl_subquery") as span:
+        span.set_attribute("rbac.resource", resource)
+        span.set_attribute("rbac.acl_subquery.emitted", True)
+        ACL_SUBQUERY_EMITTED_COUNTER.labels(resource=resource).inc()
+
+        subquery = _build_access_controls_subquery(
+            resource=resource,
+            team_id=context.team_id,
+            member_id=member_id,
+            role_ids=role_ids,
+        )
+
+        return ast.CompareOperation(
+            op=ast.CompareOperationOp.NotIn,
+            left=ast.Call(
+                name="toString",
+                args=[ast.Field(chain=[pk], type=ast.FieldType(name=pk, table_type=table_type))],
+            ),
+            right=subquery,
+            type=ast.BooleanType(),
+        )

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -520,6 +520,19 @@ class BasePrinter(Visitor[str]):
         scope = ast.SelectQueryType(tables={"t": node_type})
         return [resolve_types(clone_expr(pred), self.context, self.DIALECT_NAME, [scope]) for pred in predicates]
 
+    def _ensure_access_control_where_clause(
+        self,
+        table_type: ast.TableType | ast.LazyTableType,
+        node_type: ast.TableOrSelectType | None,
+    ) -> ast.Expr | None:
+        """Inject an object-level access control predicate per joined table.
+
+        Fail-fast by default — every dialect must opt in (no-op or real logic). ``HogQLPrinter``
+        returns None (HogQL never executes against a real DB); ``ClickHousePrinter`` injects the
+        subquery guard; ``PostgresPrinter`` is a no-op for now.
+        """
+        raise NotImplementedError("BasePrinter._ensure_access_control_where_clause not overridden")
+
     def _print_table_ref(self, table_type: ast.TableType | ast.LazyTableType, node: ast.JoinExpr) -> str:
         """Print a table reference. Fail-fast by default: each dialect must override.
 
@@ -568,14 +581,22 @@ class BasePrinter(Visitor[str]):
 
             self._collect_table_top_level_settings(table_type.table)
 
-            # :IMPORTANT: Ensures team_id filtering on every table. For LEFT JOINs, we add it to the
-            # ON clause (not WHERE) to preserve LEFT JOIN semantics - otherwise NULL rows get filtered out.
+            # :IMPORTANT: Ensures team_id and object-level access-control guards are present on
+            # every joined table. For LEFT JOINs, guards go in ON (not WHERE) to preserve NULL rows.
             team_id_expr = self._ensure_team_id_where_clause(table_type, node.type)
-            is_left_join = node.join_type is not None and "LEFT" in node.join_type
-            if is_left_join and team_id_expr is not None and node.constraint is not None:
-                team_id_for_on_clause = team_id_expr
+            access_control_expr = self._ensure_access_control_where_clause(table_type, node.type)
+
+            combined_guard: ast.Expr | None
+            if team_id_expr is not None and access_control_expr is not None:
+                combined_guard = ast.And(exprs=[team_id_expr, access_control_expr], type=ast.BooleanType())
             else:
-                extra_where = team_id_expr
+                combined_guard = team_id_expr or access_control_expr
+
+            is_left_join = node.join_type is not None and "LEFT" in node.join_type
+            if is_left_join and combined_guard is not None and node.constraint is not None:
+                team_id_for_on_clause = combined_guard
+            else:
+                extra_where = combined_guard
 
             # Apply table-level predicates (e.g., date filters on PostgresTable).
             predicate_exprs = self._get_table_predicates(table_type, node.type)

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -1432,6 +1432,38 @@ class ClickHousePrinter(BasePrinter):
         ):
             return team_id_guard_for_table(node_type, self.context)
 
+    def _ensure_access_control_where_clause(
+        self,
+        table_type: ast.TableType | ast.LazyTableType,
+        node_type: ast.TableOrSelectType | None,
+    ) -> ast.Expr | None:
+        """Inject the object-level AC guard for `system.*` PostgresTable references.
+
+        Skipped for: non-PostgresTable, tables not in the `system` schema (e.g. the printer's
+        own private `_access_controls_table` which references `ee_accesscontrol` directly),
+        tables without a primary key (composite PK), and contexts without a `Database` or user.
+        Further bypass logic (org admin, project admin, flag off, EE disabled) lives in
+        `build_access_control_guard`.
+        """
+        from posthog.hogql.database.postgres_table import PostgresTable
+        from posthog.hogql.printer.access_control import build_access_control_guard
+
+        if node_type is None:
+            return None
+        if not isinstance(table_type.table, PostgresTable):
+            return None
+        if self.context.database is None or self.context.database.user_access_control is None:
+            return None
+
+        system_node = self.context.database.tables.children.get("system")
+        if system_node is None or table_type.table.name not in system_node.children:
+            return None  # Includes the printer's private `_access_controls_table` — recursion stops here.
+
+        if table_type.table.primary_key is None:
+            return None
+
+        return build_access_control_guard(table_type.table, node_type, self.context)
+
     def _print_table_ref(self, table_type: ast.TableType | ast.LazyTableType, node: ast.JoinExpr) -> str:
         sql = table_type.table.to_printed_clickhouse(self.context)
 

--- a/posthog/hogql/printer/hogql.py
+++ b/posthog/hogql/printer/hogql.py
@@ -25,6 +25,13 @@ class HogQLPrinter(BasePrinter):
     ):
         return
 
+    def _ensure_access_control_where_clause(
+        self,
+        table_type: ast.TableType | ast.LazyTableType,
+        node_type: ast.TableOrSelectType | None,
+    ) -> ast.Expr | None:
+        return None
+
     def _print_table_ref(self, table_type: ast.TableType | ast.LazyTableType, node: ast.JoinExpr) -> str:
         return table_type.table.to_printed_hogql()
 

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -386,6 +386,14 @@ class PostgresPrinter(BasePrinter):
         # Team ID filtering is not required for Postgres queries
         pass
 
+    def _ensure_access_control_where_clause(
+        self,
+        table_type: ast.TableType | ast.LazyTableType,
+        node_type: ast.TableOrSelectType | None,
+    ) -> ast.Expr | None:
+        # Object-level access control is currently only wired into the ClickHouse dialect.
+        return None
+
     def _print_identifier(self, name: str) -> str:
         if len(name) > 63 and "__" in name:
             name = self._truncate_identifier(name)


### PR DESCRIPTION
## Problem

HogQL's object-level access control on `system.*` tables (PR #49264) emits`notIn(toString(id), tuple($v0, $v1, ...))` against the user's blocked-ID set. It has two issues:

- **Unbounded** **`NOT IN`** **list (C1).** The set is materialized in Python and inlined as a tuple of literals. Hard-fails at ~25k IDs (ClickHouse 1 MB query cap), with no telemetry and no graceful degradation.
- **Resource ID leakage (C2).** `/query` masks the literal IDs with `%(hogql_val_N)s` placeholders, but the values still land in `system.query_log` server-side and can echo through error paths.

## Changes

Replace the literal list with an inner subquery that reads `ee_accesscontrol`directly via the `postgresql(...)` table function and computes the deny set in SQL:

```sql
WHERE notIn(toString(d.id), (
  SELECT ac.resource_id
  FROM postgresql(..., 'ee_accesscontrol', ...) AS ac
  WHERE ac.team_id = ? AND ac.resource = ? AND isNotNull(ac.resource_id)
    AND ( (isNull(member_id) AND isNull(role_id))
          OR ac.organization_member_id = ?
          OR ac.role_id IN (...) )
  GROUP BY ac.resource_id
  HAVING <precedence: explicit overrides default; deny iff all-in-tier are 'none'>
))
```

Why this fixes both concerns:

- **C1**: set size scales with per-team `ee_accesscontrol` rows (low double digits in practice), not with the user's visible row count. No 25k-IDs cliff.
- **C2**: emitted CH SQL only embeds the calling user's own membership UUID and role UUIDs as parameters. Resource IDs never leave Postgres.

Other notable bits:

- **`ee_accesscontrol`** **is referenced via a private** **`PostgresTable`** **instance inside** **`posthog/hogql/printer/access_control.py`** **and is never registered on the HogQL schema.** Keeps access-control row data invisible to autocomplete, MCP, OAuth scopes, and the SQL editor — only this printer module references it. The DSN/credentials flow through the existing `add_sensitive_value `plumbing in `build_function_call`, same as every other Postgres-backed system table.
- **Anti-join semantics via** **`NOT IN (SELECT ...)`** **rather than literal** **`LEFT ANTI JOIN`** — same physical plan in CH (both compile to hash-anti-join), but `NOT IN` is a one-line WHERE injection vs restructuring the FROM clause mid-traversal.
- **Bypass matrix**: org admin, project admin, no user/team on context, table without `access_scope`, EE not installed / org without `ACCESS_CONTROL`feature, and a kill-switch via the new `hogql-object-access-control `feature flag. The flag is evaluated once per query and cached on `HogQLContext`.
- **Telemetry**: `rbac.acl_subquery` span attribute plus a Prometheus counter `posthog_hogql_acl_subquery_emitted_total{resource}`.
- **HogQL stays strictly more restrictive than the REST queryset** — no Mode B (resource_access=none + explicit allow grants), no creator bypass. The resource-level filter from #47130 already hides the whole table when the user has no resource-level access, which is the only precondition for Mode B, so the net effect is "user sees nothing" instead of "user sees curated allow-list" — strictly safer, not over-permissive.

## How did you test this code?

Tests will land in a follow-up

## Publish to changelog?

no

## 🤖 Agent context

- **Private** **`PostgresTable`** **vs registering** **`system.access_controls`.** An earlier iteration in a prior chat registered the table on the schema (gated to project/org admins via a new `requires_project_admin` flag). That branch was abandoned in favor of this approach — the only thing schema registration bought us was admins being able to query the table via HogQL, which is a minor convenience that doesn't justify the additional disclosure surface. The printer references the table by Python instance directly; the resolver
never sees it.
- **The auto-injected** **`team_id`** **guard fires on the subquery too**, so the emitted SQL contains a redundant `equals(access_controls.team_id, ?)` in addition to the one we put in our explicit WHERE. CH optimizes it out; suppressing it would require exposing a bypass mechanism in the type system that isn't worth one line of generated SQL.