### PR TITLE
feat(llma): accept generic llm.* OTEL spans (e.g. Plano)

### DIFF
--- a/rust/capture/src/otel/providers.rs
+++ b/rust/capture/src/otel/providers.rs
@@ -74,6 +74,24 @@ const PYDANTIC_AI: SupportedProvider = SupportedProvider {
     classify: |_| "$ai_span",
 };
 
+/// Generic OpenLLMetry-style `llm.*` spans that carry no SDK-specific namespace
+/// or operation key — e.g. proxies/gateways like Plano, which emit `llm.model`,
+/// `llm.usage.*`, etc. (plus their own enrichments such as `signals.*`). There
+/// is no standard operation key here, so we infer: a model name or token usage
+/// marks an LLM call (`$ai_generation`); anything else is a generic `$ai_span`.
+/// Must be matched LAST so the more specific providers above (notably Traceloop,
+/// which keys on `llm.request.type`) win first.
+const LLM_GENERIC: SupportedProvider = SupportedProvider {
+    prefixes: &["llm."],
+    classify: |attrs| {
+        if attrs.keys().any(|k| k.starts_with("llm.usage.")) || attrs.contains_key("llm.model") {
+            "$ai_generation"
+        } else {
+            "$ai_span"
+        }
+    },
+};
+
 /// Providers are matched in order — first prefix match wins. More specific
 /// matchers must come before less specific ones to avoid shadowing. For example,
 /// Vercel AI spans carry both `ai.*` and `gen_ai.*` attributes; if GEN_AI were
@@ -87,6 +105,9 @@ const SUPPORTED_PROVIDERS: &[SupportedProvider] = &[
     TRACELOOP,
     // 3. Generic catch-all — standard OpenTelemetry semantic conventions (gen_ai.*)
     GEN_AI,
+    // 4. Broadest catch-all — bare `llm.*` spans (e.g. Plano). Must stay last so
+    //    `llm.request.type` still routes to Traceloop above.
+    LLM_GENERIC,
 ];
 
 /// Returns the matching provider for raw protobuf attributes, based on prefix
@@ -236,6 +257,37 @@ mod tests {
             get_event_name(&attrs_with("llm.request.type", "chat")),
             Some("$ai_generation")
         );
+        assert_eq!(
+            get_event_name(&attrs_with("llm.request.type", "embedding")),
+            Some("$ai_embedding")
+        );
+    }
+
+    #[test]
+    fn test_generic_llm_namespace_classifies_plano_style_spans() {
+        // Plano (and other OpenLLMetry-style emitters) use the bare `llm.*`
+        // namespace with no gen_ai.*/ai.* key and no `llm.request.type`. A model
+        // name or token usage marks an LLM call; anything else is a generic span.
+        assert_eq!(
+            get_event_name(&attrs_with("llm.model", "openai/gpt-5.1-codex-mini")),
+            Some("$ai_generation")
+        );
+        assert_eq!(
+            get_event_name(&attrs_with("llm.usage.prompt_tokens", "1243")),
+            Some("$ai_generation")
+        );
+        // No model/usage signal — accepted but classified as a plain span.
+        assert_eq!(
+            get_event_name(&attrs_with("llm.tools", "search_for_images")),
+            Some("$ai_span")
+        );
+    }
+
+    #[test]
+    fn test_traceloop_takes_precedence_over_generic_llm() {
+        // A Traceloop span keyed on `llm.request.type` must classify via
+        // Traceloop, not fall through to the broader LLM_GENERIC provider
+        // (which, lacking model/usage here, would mislabel it as `$ai_span`).
         assert_eq!(
             get_event_name(&attrs_with("llm.request.type", "embedding")),
             Some("$ai_embedding")

--- a/rust/capture/src/otel/providers.rs
+++ b/rust/capture/src/otel/providers.rs
@@ -74,22 +74,20 @@ const PYDANTIC_AI: SupportedProvider = SupportedProvider {
     classify: |_| "$ai_span",
 };
 
-/// Generic OpenLLMetry-style `llm.*` spans that carry no SDK-specific namespace
-/// or operation key — e.g. proxies/gateways like Plano, which emit `llm.model`,
-/// `llm.usage.*`, etc. (plus their own enrichments such as `signals.*`). There
-/// is no standard operation key here, so we infer: a model name or token usage
-/// marks an LLM call (`$ai_generation`); anything else is a generic `$ai_span`.
-/// Must be matched LAST so the more specific providers above (notably Traceloop,
-/// which keys on `llm.request.type`) win first.
+/// Generic OpenLLMetry-style `llm.*` spans from proxies/gateways like Plano,
+/// which emit `llm.model` / `llm.usage.*` (plus their own enrichments such as
+/// `signals.*`).
+///
+/// Deliberately narrow: we accept only `llm.*` spans that carry a model name or
+/// token usage — i.e. spans that are clearly LLM calls — rather than the whole
+/// `llm.*` namespace. The broad `llm.` prefix is avoided on purpose because lots
+/// of unrelated instrumentation tags spans with some `llm.*` attribute, and
+/// accepting all of them over-captures non-AI traffic. Bare `llm.*` has no
+/// standard operation key, so accepted spans are treated as `$ai_generation`.
+/// Matched LAST so Traceloop (`llm.request.type`) still wins.
 const LLM_GENERIC: SupportedProvider = SupportedProvider {
-    prefixes: &["llm."],
-    classify: |attrs| {
-        if attrs.keys().any(|k| k.starts_with("llm.usage.")) || attrs.contains_key("llm.model") {
-            "$ai_generation"
-        } else {
-            "$ai_span"
-        }
-    },
+    prefixes: &["llm.model", "llm.usage."],
+    classify: |_| "$ai_generation",
 };
 
 /// Providers are matched in order — first prefix match wins. More specific
@@ -264,10 +262,10 @@ mod tests {
     }
 
     #[test]
-    fn test_generic_llm_namespace_classifies_plano_style_spans() {
+    fn test_generic_llm_namespace_accepts_only_model_or_usage_spans() {
         // Plano (and other OpenLLMetry-style emitters) use the bare `llm.*`
         // namespace with no gen_ai.*/ai.* key and no `llm.request.type`. A model
-        // name or token usage marks an LLM call; anything else is a generic span.
+        // name or token usage marks an LLM call -> accepted as a generation.
         assert_eq!(
             get_event_name(&attrs_with("llm.model", "openai/gpt-5.1-codex-mini")),
             Some("$ai_generation")
@@ -276,22 +274,31 @@ mod tests {
             get_event_name(&attrs_with("llm.usage.prompt_tokens", "1243")),
             Some("$ai_generation")
         );
-        // No model/usage signal — accepted but classified as a plain span.
+        // Narrow on purpose: a bare `llm.*` span with no model/usage is NOT
+        // captured, so we don't over-ingest arbitrary `llm.`-tagged spans.
         assert_eq!(
             get_event_name(&attrs_with("llm.tools", "search_for_images")),
-            Some("$ai_span")
+            None
         );
+        assert_eq!(get_event_name(&attrs_with("llm.is_streaming", "true")), None);
     }
 
     #[test]
     fn test_traceloop_takes_precedence_over_generic_llm() {
-        // A Traceloop span keyed on `llm.request.type` must classify via
-        // Traceloop, not fall through to the broader LLM_GENERIC provider
-        // (which, lacking model/usage here, would mislabel it as `$ai_span`).
-        assert_eq!(
-            get_event_name(&attrs_with("llm.request.type", "embedding")),
-            Some("$ai_embedding")
+        // A Traceloop span carries `llm.request.type` and often `llm.usage.*`, so
+        // it matches both TRACELOOP and LLM_GENERIC. TRACELOOP must win (it's
+        // earlier) and classify via `llm.request.type` rather than LLM_GENERIC
+        // forcing `$ai_generation`.
+        let mut attrs = serde_json::Map::new();
+        attrs.insert(
+            "llm.request.type".to_string(),
+            Value::String("embedding".to_string()),
         );
+        attrs.insert(
+            "llm.usage.prompt_tokens".to_string(),
+            Value::String("10".to_string()),
+        );
+        assert_eq!(get_event_name(&attrs), Some("$ai_embedding"));
     }
 
     #[test]


### PR DESCRIPTION
> **Draft / discussion** — motivating a small OTEL-ingestion change with a concrete dogfooding example, and flagging a scope decision for the LLM analytics / capture owners before this is ready to merge.

## Motivation

While dogfooding [Plano](https://github.com/katanemo/plano) (an AI-native proxy that computes "Signals" and exports them over OTEL), its spans were silently dropped by our OTEL ingestion despite capture returning `200`.

Root cause: `rust/capture/src/otel/providers.rs` only accepts spans whose attributes match `gen_ai.*`, `ai.*`, `traceloop.*`/`llm.request.type`, or `pydantic_ai.*`. Plano (like other OpenLLMetry-style emitters) uses the bare **`llm.*`** convention (`llm.model`, `llm.usage.*`, …), which matches none of them, so `get_provider_raw()` returns `None` and the span is dropped at `fan_out.rs` before any event is built.

But our [AI observability OTEL docs](https://posthog.com/docs/ai-observability/installation/opentelemetry) explicitly list `llm.*` as a supported namespace — so this is a **doc/code gap**.

## Why this is narrow (and not just "accept `llm.*`")

The ingestion was deliberately scoped to specific SDK namespaces because **broad acceptance previously over-captured non-AI traffic**. A bare `llm.` prefix would risk exactly that — lots of unrelated instrumentation tags spans with *some* `llm.*` attribute.

So instead of accepting the whole namespace, the new `LLM_GENERIC` provider accepts `llm.*` spans **only when they carry a model name (`llm.model`) or token usage (`llm.usage.*`)** — i.e. spans that are clearly LLM calls. It's matched **last** so Traceloop's `llm.request.type` still wins; accepted spans classify as `$ai_generation`. Non-namespace attrs (e.g. Plano's `signals.*`) then pass through as custom properties — no provider-specific code.

Tests: `llm.model` / `llm.usage.*` → `$ai_generation`; a **bare `llm.*` span (no model/usage) is NOT captured**; and a precedence guard that a span matching both Traceloop and `LLM_GENERIC` still classifies via Traceloop. `cargo test -p capture --lib otel::providers` → 11 passed.

## Question for the team (why it's a draft)

Even gated on model/usage, this widens what we ingest. Two paths:

1. **This PR** — narrowly accept `llm.model` / `llm.usage.*` spans. Makes Plano (and OpenLLMetry-style emitters) work, and matches what the docs already promise, while staying clear of the old over-capture behaviour.
2. **Keep ingestion as-is and fix the docs** to drop the `llm.*` claim (separate `posthog.com` PR), leaving clients to map `llm.*` → `gen_ai.*` themselves.

Given the over-capture history, I'd like the owners' call on whether the gated `llm.model`/`llm.usage.*` acceptance is comfortable, or whether you'd rather go the docs route.

## Context

Dogfood writeup + the client-side workaround this would obviate (an OTEL-collector transform mapping `llm.*`→`gen_ai.*`): andrewm4894/emoji-hero#2.
