### PR TITLE
feat(tasks): link Slack "View agent logs" to PostHog Code deeplink

### DIFF
--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -133,7 +133,7 @@ class SlackThreadHandler:
     def post_or_update_progress(
         self,
         stage: str,
-        logs_url: str | None = None,
+        task_url: str | None = None,
     ) -> None:
         """Post a new progress message or update the existing one."""
         text = f"*{PROGRESS_MESSAGE_MARKER}* :hourglass_flowing_sand:\nStage: {stage}"
@@ -141,7 +141,7 @@ class SlackThreadHandler:
             {"type": "section", "text": {"type": "mrkdwn", "text": text}},
         ]
 
-        if logs_url:
+        if task_url:
             blocks.append(
                 {
                     "type": "actions",
@@ -153,7 +153,7 @@ class SlackThreadHandler:
                                 "text": "View agent logs",
                                 "emoji": True,
                             },
-                            "url": logs_url,
+                            "url": task_url,
                         }
                     ],
                 }

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -133,7 +133,7 @@ class SlackThreadHandler:
     def post_or_update_progress(
         self,
         stage: str,
-        task_url: str | None = None,
+        logs_url: str | None = None,
     ) -> None:
         """Post a new progress message or update the existing one."""
         text = f"*{PROGRESS_MESSAGE_MARKER}* :hourglass_flowing_sand:\nStage: {stage}"
@@ -141,7 +141,7 @@ class SlackThreadHandler:
             {"type": "section", "text": {"type": "mrkdwn", "text": text}},
         ]
 
-        if task_url:
+        if logs_url:
             blocks.append(
                 {
                     "type": "actions",
@@ -153,7 +153,7 @@ class SlackThreadHandler:
                                 "text": "View agent logs",
                                 "emoji": True,
                             },
-                            "url": task_url,
+                            "url": logs_url,
                         }
                     ],
                 }

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -42,7 +42,7 @@ class TestSlackThreadHandler(TestCase):
         )
         handler = SlackThreadHandler(context)
 
-        handler.post_or_update_progress("In progress...", task_url="https://example.com/task")
+        handler.post_or_update_progress("In progress...", logs_url="posthog-code://task/abc/run/xyz")
 
         mock_client.chat_postMessage.assert_called_once()
         blocks = mock_client.chat_postMessage.call_args.kwargs["blocks"]

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -42,7 +42,7 @@ class TestSlackThreadHandler(TestCase):
         )
         handler = SlackThreadHandler(context)
 
-        handler.post_or_update_progress("In progress...", logs_url="posthog-code://task/abc/run/xyz")
+        handler.post_or_update_progress("In progress...", task_url="posthog-code://task/abc/run/xyz")
 
         mock_client.chat_postMessage.assert_called_once()
         blocks = mock_client.chat_postMessage.call_args.kwargs["blocks"]

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -33,6 +33,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
         context = SlackThreadContext.from_dict(input.slack_thread_context)
         handler = SlackThreadHandler(context)
         task_url = f"{settings.SITE_URL}/project/{task_run.task.team_id}/tasks/{task_run.task_id}?runId={task_run.id}"
+        logs_deeplink = f"posthog-code://task/{task_run.task_id}/run/{task_run.id}"
         pr_url = (task_run.output or {}).get("pr_url")
 
         if input.sandbox_cleaned:
@@ -73,7 +74,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
                 handler.delete_progress()
                 return
             stage = _get_stage_from_status(task_run.status, task_run.stage)
-            handler.post_or_update_progress(stage, task_url)
+            handler.post_or_update_progress(stage, logs_deeplink)
     except Exception:
         logger.exception("post_slack_update_failed", run_id=input.run_id)
 


### PR DESCRIPTION
## Problem

The "View agent logs" button on the Slack progress message for a task run currently opens the run in the PostHog web app. For users who run cloud tasks from Slack and live in the PostHog Code desktop app, jumping back through the web app is an unnecessary hop — the desktop app already supports a deeplink for opening a specific task run.

## Changes

- `post_slack_update` activity now builds a `posthog-code://task/<task_id>/run/<run_id>` deeplink alongside the existing web `task_url` and passes the deeplink to the in-progress Slack message.
- `SlackThreadHandler.post_or_update_progress` parameter renamed `task_url` → `logs_url` for clarity (it only powers the "View agent logs" button).
- Other Slack buttons ("Open in PostHog", "See details in PostHog", "View PR") are unchanged and still point to the web app or GitHub.

## How did you test this code?

Agent-authored. No manual Slack delivery test was performed. Automated tests run:

- `products/slack_app/backend/tests/test_slack_thread.py::TestSlackThreadHandler::test_progress_message_has_no_terminate_button` (updated to assert the new kwarg name)
- `products/slack_app/backend/tests/test_post_slack_update.py` (full file — 12 tests)

All 13 tests pass.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code. The user asked to swap only the "view logs" button on the cloud/task-run Slack message to use the `posthog-code://` deeplink — other action buttons in the same handler intentionally remain on the web URL. Considered (and rejected) replacing the web URL for every button: out of scope and would degrade the experience for users without the desktop app installed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*