### PR TITLE
feat(integrations): uninstall GitHub App on disconnect

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -624,6 +624,23 @@ class IntegrationViewSet(
             except Exception as e:
                 capture_exception(e)
 
+        if instance.kind == "github" and instance.integration_id:
+            # Only uninstall the GitHub App when this is the last PostHog team
+            # row referencing the same installation_id — multiple teams in the
+            # same org can share one installation, and uninstalling would break
+            # the others. The GitHub call is best-effort; the local row is
+            # always deleted so the user can re-install cleanly.
+            shared_with_other_teams = (
+                Integration.objects.filter(kind="github", integration_id=instance.integration_id)
+                .exclude(id=instance.id)
+                .exists()
+            )
+            if not shared_with_other_teams:
+                try:
+                    GitHubIntegration(instance).uninstall()
+                except Exception as e:
+                    capture_exception(e)
+
         super().perform_destroy(instance)
 
     @action(methods=["GET"], detail=False)

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -3127,3 +3127,119 @@ class TestAnthropicIntegration:
         body = response.json()
         assert body["vaults"] == [{"id": "vault_1", "display_name": "Customer secrets"}]
         assert body["has_more"] is False
+
+
+class TestGitHubIntegrationDisconnect:
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.organization = Organization.objects.create(name="GH Org")
+        self.team = Team.objects.create(organization=self.organization, name="Team A")
+        self.other_team = Team.objects.create(organization=self.organization, name="Team B")
+        self.user = User.objects.create_and_join(
+            self.organization, "gh@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
+        )
+
+    def _create_github_integration(self, team: Team, installation_id: str = "12345") -> Integration:
+        return Integration.objects.create(
+            team=team,
+            kind="github",
+            integration_id=installation_id,
+            config={"installation_id": installation_id, "account": {"name": "acme"}},
+            sensitive_config={"access_token": "ghs_test"},
+            created_by=self.user,
+        )
+
+    @patch("posthog.api.integration.GitHubIntegration")
+    def test_destroy_calls_uninstall_when_last_team(self, MockGitHubIntegration, client: HttpClient):
+        integration = self._create_github_integration(self.team)
+        mock_instance = MagicMock()
+        MockGitHubIntegration.return_value = mock_instance
+
+        client.force_login(self.user)
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{integration.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        MockGitHubIntegration.assert_called_once_with(integration)
+        mock_instance.uninstall.assert_called_once()
+        assert not Integration.objects.filter(id=integration.id).exists()
+
+    @patch("posthog.api.integration.GitHubIntegration")
+    def test_destroy_skips_uninstall_when_installation_shared(
+        self, MockGitHubIntegration, client: HttpClient
+    ):
+        integration_a = self._create_github_integration(self.team, "12345")
+        integration_b = self._create_github_integration(self.other_team, "12345")
+
+        client.force_login(self.user)
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{integration_a.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        MockGitHubIntegration.assert_not_called()
+        assert not Integration.objects.filter(id=integration_a.id).exists()
+        # Other team's row is untouched so its installation keeps working
+        assert Integration.objects.filter(id=integration_b.id).exists()
+
+    @patch("posthog.api.integration.GitHubIntegration")
+    def test_destroy_still_deletes_when_uninstall_fails(
+        self, MockGitHubIntegration, client: HttpClient
+    ):
+        integration = self._create_github_integration(self.team)
+        mock_instance = MagicMock()
+        mock_instance.uninstall.side_effect = Exception("GitHub API down")
+        MockGitHubIntegration.return_value = mock_instance
+
+        client.force_login(self.user)
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{integration.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_instance.uninstall.assert_called_once()
+        assert not Integration.objects.filter(id=integration.id).exists()
+
+    @patch("posthog.models.integration.GitHubIntegrationBase.client_request")
+    def test_uninstall_treats_404_as_success(self, mock_client_request, client: HttpClient):
+        integration = self._create_github_integration(self.team)
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+        mock_client_request.return_value = mock_response
+
+        GitHubIntegration(integration).uninstall()
+
+        mock_client_request.assert_called_once_with("installations/12345", method="DELETE")
+
+    @patch("posthog.models.integration.GitHubIntegrationBase.client_request")
+    def test_uninstall_treats_204_as_success(self, mock_client_request, client: HttpClient):
+        integration = self._create_github_integration(self.team)
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.text = ""
+        mock_client_request.return_value = mock_response
+
+        GitHubIntegration(integration).uninstall()
+
+        mock_client_request.assert_called_once_with("installations/12345", method="DELETE")
+
+    @patch("posthog.models.integration.GitHubIntegrationBase.client_request")
+    def test_uninstall_swallows_network_exception(self, mock_client_request, client: HttpClient):
+        integration = self._create_github_integration(self.team)
+        mock_client_request.side_effect = Exception("connection reset")
+
+        # Must not raise — perform_destroy depends on uninstall being best-effort
+        GitHubIntegration(integration).uninstall()
+
+    def test_destroy_non_github_does_not_call_uninstall(self, client: HttpClient):
+        integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            config={"authed_user": {"id": "U123"}},
+            sensitive_config={"access_token": "xoxb-test"},
+            created_by=self.user,
+        )
+
+        client.force_login(self.user)
+        with patch("posthog.api.integration.GitHubIntegration") as MockGitHubIntegration:
+            response = client.delete(f"/api/environments/{self.team.pk}/integrations/{integration.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        MockGitHubIntegration.assert_not_called()
+        assert not Integration.objects.filter(id=integration.id).exists()

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2345,6 +2345,36 @@ class GitHubInstallationAccess:
 class GitHubIntegration(GitHubIntegrationBase):
     integration: Integration
 
+    def uninstall(self) -> None:
+        """Uninstall the GitHub App from the user's account on GitHub.
+
+        Calls ``DELETE /app/installations/{installation_id}`` so the installation
+        no longer appears under the user's GitHub apps. Treats 204 and 404 as
+        success (404 = already uninstalled on GitHub's side). Any other failure
+        is logged but not raised — callers are expected to delete the local row
+        regardless so the user is never stuck unable to disconnect.
+        """
+        installation_id = self.integration.integration_id
+        if not installation_id:
+            return
+        try:
+            response = self.client_request(f"installations/{installation_id}", method="DELETE")
+        except Exception:
+            logger.exception(
+                "GitHubIntegration: uninstall request failed",
+                integration_id=self.integration.id,
+                installation_id=installation_id,
+            )
+            return
+        if response.status_code not in (204, 404):
+            logger.warning(
+                "GitHubIntegration: uninstall returned unexpected status",
+                integration_id=self.integration.id,
+                installation_id=installation_id,
+                status_code=response.status_code,
+                body=response.text[:500],
+            )
+
     @classmethod
     def integration_from_installation_id(
         cls, installation_id: str, team_id: int, created_by: User | None = None


### PR DESCRIPTION
## Problem

When a user disconnects their GitHub integration in PostHog today, we only delete the local `Integration` row. The GitHub App installation stays put on GitHub's side, so the next time the user clicks "connect GitHub" they see the existing installation — instead of getting a clean install picker for org/repo scope. From the user's perspective, "disconnect" doesn't really disconnect.

## Changes

On `DELETE /api/environments/{team}/integrations/{id}/` for a `kind="github"` row, call `DELETE /app/installations/{installation_id}` (App JWT auth — the same path the existing token-refresh flow already uses).

Reliability baked in:

- **Best-effort against GitHub.** Network errors, 5xx, anything non-success is logged and reported to Sentry but never blocks the local row deletion. The user always succeeds at disconnecting, even if GitHub is down.
- **404 = success.** If the installation was already uninstalled on GitHub's side, that's the desired end state.
- **Last-team-standing guard.** Multiple PostHog teams in the same org can share one GitHub `installation_id` (via the "link existing" path in `team_services.py`). If another team still references the same installation, the GitHub call is skipped so that team keeps working; only the requesting team's row is removed.

Out of scope for this PR (intentionally — keeping the change minimal and focused on the reported UX issue):

- Handling the inbound `installation.deleted` webhook when uninstall is initiated on github.com. Today the event is silently dropped at `posthog/urls.py`. Worth a follow-up.
- Revoking the per-user OAuth grant (`UserIntegration.user_access_token`) via `DELETE /applications/{client_id}/grant`.
- Modeling `installation.suspended` state.

## How did you test this code?

Agent-authored. No manual testing performed. Added automated tests in `posthog/api/test/test_integration.py::TestGitHubIntegrationDisconnect`:

- `test_destroy_calls_uninstall_when_last_team` — happy path.
- `test_destroy_skips_uninstall_when_installation_shared` — verifies the last-team-standing guard; sibling team's row is untouched and `GitHubIntegration` is not constructed.
- `test_destroy_still_deletes_when_uninstall_fails` — GitHub raises, local row is deleted anyway.
- `test_uninstall_treats_204_as_success` / `test_uninstall_treats_404_as_success` — both terminal statuses accepted.
- `test_uninstall_swallows_network_exception` — bare `Exception` from `client_request` must not propagate (perform_destroy relies on this).
- `test_destroy_non_github_does_not_call_uninstall` — other integration kinds are unaffected.

I ran `ast.parse` against the three changed files to confirm they parse. CI will run the actual test suite — I don't have a working Python env in this sandbox.

## Publish to changelog?

no

## Docs update

No docs changes needed — this is a backend behavior change with no user-facing API change.

## 🤖 Agent context

Authored by Claude (PostHog Code). Tool: Claude Code.

Process: explored the GitHub integration surface twice — first to find the disconnect path, then specifically to validate the plan against GitHub's published guidance and find anything the first pass missed. The deeper exploration surfaced three gaps that I called out separately for the human reviewer (inbound `installation.deleted` webhook is silently dropped today; OAuth user-grant revocation is missing; suspension state isn't modeled). The user explicitly scoped this PR to just the outbound user-initiated disconnect, so the other gaps are deferred.

Key decision: the "last team standing" guard. The first plan I drafted naively called `DELETE /app/installations/{id}` whenever any team disconnected, which would silently break other PostHog teams in the same org that share the installation via `link_existing_team_github_integration`. The codebase patterns make this hazard non-obvious — flagged it and added the guard + dedicated test.

Followed the Stripe pattern for `perform_destroy` (try/except + capture_exception + always call super) so reviewers don't have to reason about a new shape.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*