### PR TITLE
feat(organization): default new EU orgs to AI training opt-out

### DIFF
--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -93,6 +93,8 @@ class OrganizationManager(models.Manager):
         # Set default_anonymize_ips based on deployment if not explicitly provided
         if "default_anonymize_ips" not in kwargs:
             kwargs["default_anonymize_ips"] = default_anonymize_ips()
+        if "is_ai_training_opted_in" not in kwargs:
+            kwargs["is_ai_training_opted_in"] = default_is_ai_training_opted_in()
         return create_with_slug(super().create, *args, **kwargs)
 
     def bootstrap(
@@ -109,6 +111,8 @@ class OrganizationManager(models.Manager):
             # Set default_anonymize_ips based on deployment if not explicitly provided
             if "default_anonymize_ips" not in kwargs:
                 kwargs["default_anonymize_ips"] = default_anonymize_ips()
+            if "is_ai_training_opted_in" not in kwargs:
+                kwargs["is_ai_training_opted_in"] = default_is_ai_training_opted_in()
             organization = Organization.objects.create(**kwargs)
             _, team = Project.objects.create_with_team(
                 initiating_user=user, organization=organization, team_fields=team_fields
@@ -132,6 +136,11 @@ class OrganizationManager(models.Manager):
 def default_anonymize_ips():
     """Default to True for EU cloud deployments to comply with stricter privacy requirements"""
     return getattr(settings, "CLOUD_DEPLOYMENT", None) == "EU"
+
+
+def default_is_ai_training_opted_in():
+    """Default to False (opted out) for EU cloud deployments to comply with stricter privacy requirements"""
+    return getattr(settings, "CLOUD_DEPLOYMENT", None) != "EU"
 
 
 class Organization(ModelActivityMixin, UUIDTModel):  # type: ignore[django-manager-missing]

--- a/posthog/models/test/test_organization_model.py
+++ b/posthog/models/test/test_organization_model.py
@@ -99,6 +99,29 @@ class TestOrganization(BaseTest):
             )
             self.assertFalse(explicit_org.default_anonymize_ips)
 
+    def test_default_is_ai_training_opted_in_based_on_deployment(self):
+        # EU deployment should default to opted out (False)
+        with self.settings(CLOUD_DEPLOYMENT="EU"):
+            eu_org, _, _ = Organization.objects.bootstrap(self.user, name="EU Org")
+            self.assertFalse(eu_org.is_ai_training_opted_in)
+
+        # US deployment should default to opted in (True)
+        with self.settings(CLOUD_DEPLOYMENT="US"):
+            us_org, _, _ = Organization.objects.bootstrap(self.user, name="US Org")
+            self.assertTrue(us_org.is_ai_training_opted_in)
+
+        # No deployment setting should default to opted in (True)
+        with self.settings(CLOUD_DEPLOYMENT=None):
+            no_deployment_org, _, _ = Organization.objects.bootstrap(self.user, name="No Deployment Org")
+            self.assertTrue(no_deployment_org.is_ai_training_opted_in)
+
+        # Explicit value should override deployment setting
+        with self.settings(CLOUD_DEPLOYMENT="EU"):
+            explicit_org, _, _ = Organization.objects.bootstrap(
+                self.user, name="Explicit EU Org Opted In", is_ai_training_opted_in=True
+            )
+            self.assertTrue(explicit_org.is_ai_training_opted_in)
+
     def test_update_available_product_features_ignored_if_usage_info_exists(self):
         with self.is_cloud(False):
             new_org, _, _ = Organization.objects.bootstrap(self.user)

--- a/posthog/models/test/test_organization_model.py
+++ b/posthog/models/test/test_organization_model.py
@@ -99,28 +99,21 @@ class TestOrganization(BaseTest):
             )
             self.assertFalse(explicit_org.default_anonymize_ips)
 
-    def test_default_is_ai_training_opted_in_based_on_deployment(self):
-        # EU deployment should default to opted out (False)
-        with self.settings(CLOUD_DEPLOYMENT="EU"):
-            eu_org, _, _ = Organization.objects.bootstrap(self.user, name="EU Org")
-            self.assertFalse(eu_org.is_ai_training_opted_in)
-
-        # US deployment should default to opted in (True)
-        with self.settings(CLOUD_DEPLOYMENT="US"):
-            us_org, _, _ = Organization.objects.bootstrap(self.user, name="US Org")
-            self.assertTrue(us_org.is_ai_training_opted_in)
-
-        # No deployment setting should default to opted in (True)
-        with self.settings(CLOUD_DEPLOYMENT=None):
-            no_deployment_org, _, _ = Organization.objects.bootstrap(self.user, name="No Deployment Org")
-            self.assertTrue(no_deployment_org.is_ai_training_opted_in)
-
-        # Explicit value should override deployment setting
-        with self.settings(CLOUD_DEPLOYMENT="EU"):
-            explicit_org, _, _ = Organization.objects.bootstrap(
-                self.user, name="Explicit EU Org Opted In", is_ai_training_opted_in=True
-            )
-            self.assertTrue(explicit_org.is_ai_training_opted_in)
+    @parameterized.expand(
+        [
+            ("eu_defaults_to_opted_out", "EU", None, False),
+            ("us_defaults_to_opted_in", "US", None, True),
+            ("unset_deployment_defaults_to_opted_in", None, None, True),
+            ("explicit_value_overrides_eu_default", "EU", True, True),
+        ]
+    )
+    def test_default_is_ai_training_opted_in_based_on_deployment(
+        self, _name, cloud_deployment, explicit_value, expected
+    ):
+        with self.settings(CLOUD_DEPLOYMENT=cloud_deployment):
+            extra_kwargs = {} if explicit_value is None else {"is_ai_training_opted_in": explicit_value}
+            org, _, _ = Organization.objects.bootstrap(self.user, name=_name, **extra_kwargs)
+            self.assertEqual(org.is_ai_training_opted_in, expected)
 
     def test_update_available_product_features_ignored_if_usage_info_exists(self):
         with self.is_cloud(False):


### PR DESCRIPTION
## Problem

EU cloud orgs default to being opted in to AI training when created. This is at odds with EU privacy expectations: any EU org created since the last manual opt-out sweep has to be cleaned up retroactively. Setting the correct default at creation time avoids that drift.

## Changes

- Add `default_is_ai_training_opted_in()` helper that returns `False` when `CLOUD_DEPLOYMENT == "EU"`, otherwise `True`.
- Apply it in `OrganizationManager.create()` and `OrganizationManager.bootstrap()` (mirroring the existing `default_anonymize_ips` EU-default pattern), so new EU orgs are opted out of AI training unless the caller explicitly passes a value.

Self-hosted and US cloud behavior is unchanged. The `is_ai_training_locked` flag is not touched here — locking is BAA-driven and handled separately.

## How did you test this code?

I'm an agent. Local test environment wasn't set up, so I did not run the suite; CI will. I added a unit test (`test_default_is_ai_training_opted_in_based_on_deployment`) that mirrors the existing `test_default_anonymize_ips_based_on_deployment` and exercises EU / US / unset / explicit-override cases.

## Publish to changelog?

no

## Docs update

No docs changes needed — this is a creation-time default, not a user-facing API change.

## 🤖 Agent context

Authored by PostHog Code on behalf of @pauldambra after a manual sweep to opt out existing EU orgs from AI training. Goal: prevent the same drift for orgs created from now on.

- Considered changing the field's Django `default=` to a callable but rejected it: the field can be `null=True`, the existing privacy pattern (`default_anonymize_ips`) lives in the manager, and that pattern already covers both creation paths.
- Considered also setting `is_ai_training_locked=True` for EU but rejected it: in the prior manual sweep, locking applied to BAA orgs (in both regions), not EU specifically.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*