### PR TITLE
fix(settings): hide AI training UI on hobby installs

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1851,7 +1851,7 @@ snapshots:
     filters-taxonomic-filter-headless--properties--dark:
         hash: v1.k794b7964.4ee695e5751c6f73e9742ab0cfeecf61b5adfe829cf3a0d49ab2877cae8b212f.jPN9l5TDgLRy9NzHenXHCU903UDg8-GdeGpf4PXt7aA
     filters-taxonomic-filter-headless--properties--light:
-        hash: v1.k794b7964.afa422fd784363e602da5668ab488a823260acba8c2b1168dc85bcbf434d3ddf.Wjl32UIE5KhBda_SpJYwXKZ2FGmnlFbtzv4uKDaJRIs
+        hash: v1.k794b7964.7af6b884e5d826df422db99e4a99d2172f3316561a499dbe386ea098b1fc54a9.rti2DMpqC0WEtd_AtG838vQlgQMHfwjBAR4uLN_HnUk
     filters-taxonomic-filter-headless--suggested-filters-with-recents--dark:
         hash: v1.k794b7964.c3a6cd419610bc486261efa753816547f080f00c838bde0b8720cf12067b3b22.nxBtExiDfJ3USkhV9RY1VPU_U2dGyEYCMFbhvtOcuVs
     filters-taxonomic-filter-headless--suggested-filters-with-recents--light:
@@ -4733,7 +4733,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
         hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
-        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
+        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.EIwByuofuT77yP259A9ffqfjSFwW9MrUDOvsZNA_aZM
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
         hash: v1.k794b7964.d64808d2bfc36017f89b57feeaa373e20188738a622801207fa1beb59d02fdd9.cFuKF_Ow887Z3X3BoNhtTvkUWY2vips9HDBe-B02eQE
     scenes-app-insights-funnels--funnel-time-to-convert--light:
@@ -6091,17 +6091,17 @@ snapshots:
     scenes-other-onboarding-product-selection--base--light:
         hash: v1.k794b7964.b06b552dc3c53616de4d809c892e49843271347fcd2445900585a20a925b47b8.S8Ik2YI5dGrmmDbVIIZsLSquFs8o8GpM38j9XBe6vrM
     scenes-other-org-member-invites--current-user-is-admin--dark:
-        hash: v1.k794b7964.0fe1b3acda57647f97cb8b52568497f0f69cd1a4b2cb1afe9401acf7958cce2d.N878AmUnK26__WW2RAQzAgkmh3nMQQTB0IlFrcWNsR8
+        hash: v1.k794b7964.03bd0255de71178d5d2bc1669b728063655453d91497d6de8fa1d22257ecd849.XnQD6Ep1IfWmkm-3ZJW3rfU4Rv2_hnpoIWpY2lDOhpw
     scenes-other-org-member-invites--current-user-is-admin--light:
-        hash: v1.k794b7964.43193e543027c64b994ec7132eba39bd28439f80f448d155c26c0d24811b808c.Rns14SHxaozudQT8Ka_lhMLgADapTlEaJ3WQ4XRLHno
+        hash: v1.k794b7964.31ef5cfec5c63f15fa87231d35eda00edb638a6473c68410ba58d9a1432e2c8c.xPLnE_BjZWC_hAOlXBvrHZ-zlTptrl9SeuSUiLOBpWg
     scenes-other-org-member-invites--current-user-is-member--dark:
-        hash: v1.k794b7964.6a0bffb12a847c8d380c0cb0726aa3e1b3082833daf73081a6e1befbf02266f5.2UP_-c_7VwBD4Wd1qKxgA422IwpczqGMDaR2n9v0jnY
+        hash: v1.k794b7964.f7defa29090742a217b7ade8e1c8fa2064207d9ee9fc44aceee45260a57ad922.rW3BMkZslrpzEz32W0DY2kLOtGFuyXQ17UqNSSQ5JIM
     scenes-other-org-member-invites--current-user-is-member--light:
-        hash: v1.k794b7964.d825d55e987350f6683e26a7ef4e64d98832cf55cebfc51ecf44c9a7fb5238e7.gMRHiJ-y7KnYEeLRE9lxjAFlqGfhKl4jYZHIJS6Ldnc
+        hash: v1.k794b7964.9f88415af74ced3710c2edc3061223cb4f9a7e548cf86726615e8b2a4dede6cc.kYEXe8z8m-NnsOiOZUvk8urVh1fs7JzWLk6ESJdN4Xs
     scenes-other-org-member-invites--current-user-is-owner--dark:
-        hash: v1.k794b7964.67541206c10ee81e86214fba06783930a2b8120ca36e040c68921e4f43c97a03.HW-eQoy69C9TsOSo2fNh_gnzU5Wn7Y5fnc0fQOBIEUE
+        hash: v1.k794b7964.5000575c0a0ffbf7b5cef1829c765cea9cafce05fc480d4889df407a2ed763c4.WKzAFZ9c4XHhBzz8mJFU3Ex-DNPCRaBtVUkWmKCEt2k
     scenes-other-org-member-invites--current-user-is-owner--light:
-        hash: v1.k794b7964.a2b07e52126ec0b0daeb01e77a525cd6abed92c9a340d4b58a2ce89cb929b5f9.F4BGUwsszQvGa4D9LroujXOmE4NBVjXIxvpiurTV_Jo
+        hash: v1.k794b7964.5e6e9a87b9a7e57c526a8bd11be398cd13ced3378a611044b8a335cb4ab8fa62.v6gAd1u4R8gBlo4JlbCWBwfOy9apqrFNz3FjwEs8IhQ
     scenes-other-password-reset--initial--dark:
         hash: v1.k794b7964.9600d0717ba00baf1c900bc5b5a991dacbb4983c57174f96a57f715d02fb0f31.Rigl1rCVxw6-ViWe2s8gKaUBgBRL2b_8CnkaSbt3j-U
     scenes-other-password-reset--initial--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4723,7 +4723,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
-        hash: v1.k794b7964.3be793464915dc6eea38d02a0c85defe2f268c991a2242e99a309a26067672f8.BsH9W6wj5sgSTiKpGHZkGQsykiGx-dlXXqwwvLUiVHs
+        hash: v1.k794b7964.8887db0213a228a0f958496f8de814bd30d4735f99f8dcd886fbc9740a703afd.U7j0SBm9JuPzdVQVGChjxt-Iw1svrkRV06tAv9pg-mM
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--light:
         hash: v1.k794b7964.1dd3425e658b907855610a715527654f68a242ed0c1427803dcf4d2289806fed.xd6ZnWiKWTOAglDDiM771sUAuByJ76icZNkrOre_orA
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--superwide--dark:
@@ -4731,9 +4731,9 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--superwide--light:
         hash: v1.k794b7964.c95c5a49f7a20b7fcb1041dd26c73ee87c9a906cb229247a44fd4633bbdc9173.StrJ2VBA5acLqvnsiO2CS_o6qadxeaeO6ST8lxf5UdI
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
-        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
+        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.URrKOLP9uUjbKWcui2yOA7hm_JsXsbkAlOcWJshoQrI
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
-        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.EIwByuofuT77yP259A9ffqfjSFwW9MrUDOvsZNA_aZM
+        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
         hash: v1.k794b7964.d64808d2bfc36017f89b57feeaa373e20188738a622801207fa1beb59d02fdd9.cFuKF_Ow887Z3X3BoNhtTvkUWY2vips9HDBe-B02eQE
     scenes-app-insights-funnels--funnel-time-to-convert--light:

--- a/frontend/src/lib/components/AllowTrainingCallout/AllowTrainingCallout.tsx
+++ b/frontend/src/lib/components/AllowTrainingCallout/AllowTrainingCallout.tsx
@@ -6,6 +6,7 @@ import { useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 
 export function AllowTrainingCallout({
@@ -17,10 +18,12 @@ export function AllowTrainingCallout({
 }): JSX.Element | null {
     const { currentOrganization, currentOrganizationLoading } = useValues(organizationLogic)
     const { updateOrganization } = useActions(organizationLogic)
+    const { isHobby } = useValues(preflightLogic)
     const isFlagEnabled = useFeatureFlag('AI_TRAINING')
     const restrictionReason = useRestrictedArea({ minimumAccessLevel: OrganizationMembershipLevel.Admin })
 
     if (
+        isHobby ||
         !isFlagEnabled ||
         restrictionReason ||
         currentOrganization?.is_ai_training_opted_in !== false ||

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -1512,6 +1512,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 title: 'Internal AI training',
                 component: <OrganizationAITrainingOptOut />,
                 flag: 'AI_TRAINING',
+                hideOn: [Realm.SelfHostedClickHouse, Realm.SelfHostedPostgres],
                 keywords: ['ai', 'training', 'opt-out', 'opt-in', 'model', 'max'],
                 searchDescription:
                     'Control whether PostHog can use your data to train AI models. Turning this off disables AI features for your organization.',

--- a/frontend/src/scenes/settings/settingsLogic.ts
+++ b/frontend/src/scenes/settings/settingsLogic.ts
@@ -15,8 +15,6 @@ import { organizationIntegrationsLogic } from 'scenes/settings/organization/orga
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { Realm } from '~/types'
-
 import type { settingsLogicType } from './settingsLogicType'
 import { SETTINGS_MAP } from './SettingsMap'
 import { Setting, SettingId, SettingLevelId, SettingSection, SettingSectionId, SettingsLogicProps } from './types'
@@ -320,7 +318,7 @@ export const settingsLogic = kea<settingsLogicType>([
                     if (!doesMatchFlags(setting)) {
                         return false
                     }
-                    if (setting.hideOn?.includes(Realm.Cloud) && preflight?.cloud) {
+                    if (preflight?.realm && setting.hideOn?.includes(preflight.realm)) {
                         return false
                     }
                     if (setting.allowForTeam && !setting.allowForTeam(currentTeam)) {
@@ -462,7 +460,7 @@ export const settingsLogic = kea<settingsLogicType>([
                     if (!doesMatchFlags(x)) {
                         return false
                     }
-                    if (x.hideOn?.includes(Realm.Cloud) && preflight?.cloud) {
+                    if (preflight?.realm && x.hideOn?.includes(preflight.realm)) {
                         return false
                     }
                     if (x.hideWhenNoSection && !effectiveSectionId) {
@@ -535,7 +533,7 @@ export const settingsLogic = kea<settingsLogicType>([
                         if (!doesMatchFlags(setting)) {
                             continue
                         }
-                        if (setting.hideOn?.includes(Realm.Cloud) && preflight?.cloud) {
+                        if (preflight?.realm && setting.hideOn?.includes(preflight.realm)) {
                             continue
                         }
                         if (setting.allowForTeam && !setting.allowForTeam(currentTeam)) {


### PR DESCRIPTION
## Problem

The AI training opt-in setting (`organization-ai-training-opt-out`) and the
`AllowTrainingCallout` banner (rendered in the Inbox sources modal and the
session player summary dock) shipped as cloud-only chrome. They have no
meaningful behavior on self-hosted hobby installs - data never leaves a
hobby deployment to be used for training PostHog AI models in the first
place - so the UI is confusing noise for those operators.

## Changes

- Add `hideOn: [Realm.SelfHostedClickHouse, Realm.SelfHostedPostgres]` to
  the `organization-ai-training-opt-out` setting in `SettingsMap.tsx`, so
  it no longer appears in settings on self-hosted realms.
- Skip rendering `AllowTrainingCallout` when `preflightLogic.isHobby` is
  true. This is the canonical "this is a self-hosted hobby install" check
  already used elsewhere in the codebase.
- Fix a pre-existing bug in `settingsLogic.ts`: `hideOn?: Realm[]` was only
  ever honored when the array included `Realm.Cloud` (three call sites all
  checked `hideOn?.includes(Realm.Cloud) && preflight?.cloud`). Two existing
  settings - PostHog AI memory and changelog - already declared
  `hideOn: [Realm.SelfHostedClickHouse, Realm.SelfHostedPostgres]` but the
  field was effectively a no-op for them. The check now matches the current
  `preflight.realm` against the configured array, which is the implied
  semantics of the field. Removed the now-unused `Realm` import.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual UI verification.
Automated checks I ran:

- TypeScript check via `pnpm --filter=@posthog/frontend typescript:check` -
  no errors introduced by my changes (the run reports environment errors
  in the sandbox because `node_modules` is not installed; none of them
  point at the three files touched here).

Manual verification a reviewer should do: load the settings page and the
Inbox / session replay summary surfaces on both a cloud env and a hobby
self-hosted env, confirm the AI training opt-out setting and the
`AllowTrainingCallout` banner appear on cloud and are absent on hobby.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) at the user's request:
  "hobby installs shouldn't see any of the AI training UI."
- Investigation: located the AI training surfaces (the
  `organization-ai-training-opt-out` setting, the
  `AllowTrainingCallout` banner used in Inbox sources modal and player
  summary dock) and the canonical hobby-detection selector
  (`preflightLogic.isHobby`).
- Considered three approaches:
  1. Add a `useFeatureFlag`-style runtime guard in each consumer.
  2. Add a new `hideSelfHost` boolean to the `Setting` type.
  3. Use the existing `hideOn?: Realm[]` field, which already takes a
     realm array but had a buggy implementation that only handled
     `Realm.Cloud`.
  Chose (3) because the field already existed with the right shape and
  was being used (ineffectively) for the same intent elsewhere. Fixing
  the implementation is a strict improvement and makes two other
  pre-existing settings actually honor their declared `hideOn`.
- The `AllowTrainingCallout` change uses `isHobby` directly rather than a
  setting-level mechanism because it's a standalone React component
  rendered outside the settings page.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*