### PR TITLE
chore(ci): sync posthog-js reviewer requests

### DIFF
--- a/.github/workflows/pr-posthog-js-reviewer.yml
+++ b/.github/workflows/pr-posthog-js-reviewer.yml
@@ -1,58 +1,130 @@
-name: Request review for posthog-js updates
+name: Sync client libraries review for posthog-js updates
 
 # This workflow uses pull_request_target to get write access for requesting reviewers.
 # SECURITY: We never checkout or execute code from the PR branch.
-# We only use the GitHub API to check the diff and request reviewers.
+# We only use the GitHub API to check the diff and update reviewer requests.
 
 # nosemgrep: semgrep.rules.github-actions-pull-request-target
 on:
     pull_request_target:
-        types: [opened, synchronize]
-        paths:
-            - '**/package.json'
+        # `edited` lets us request review after a stacked PR is retargeted to master.
+        # We intentionally don't use a paths filter: when a package.json change is
+        # rolled back, the PR diff no longer matches `**/package.json`, so a filtered
+        # workflow would never get a chance to remove the stale review request.
+        types: [opened, synchronize, edited]
 
 permissions:
     contents: read
+    issues: read
+    pull-requests: read
 
 jobs:
     check-posthog-js:
-        name: Check for posthog-js updates
+        name: Sync client libraries review request
         runs-on: ubuntu-24.04
         timeout-minutes: 5
 
-        # Skip forks for security - they could manipulate package.json to trigger unwanted reviews
-        if: github.event.pull_request.head.repo.fork == false
+        # Skip forks for security - they could manipulate package.json to trigger unwanted reviews.
+        # Only request reviewers for PRs targeting master. Stacked PR diffs can include package.json
+        # changes from the stack base and leave stale reviewer requests after the PR is retargeted.
+        if: >-
+            github.event.pull_request.head.repo.fork == false &&
+            github.event.pull_request.base.ref == 'master' &&
+            (github.event.action != 'edited' || github.event.changes.base.ref.from != null)
 
         steps:
+            - name: Determine reviewer action
+              id: reviewer-action
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+                  TEAM_REVIEWER_SLUG: client-libraries-approvers
+              run: |
+                  set -euo pipefail
+
+                  echo "Checking PR #${PR_NUMBER} for posthog-js version changes..."
+
+                  MATCHING_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '
+                    [
+                      .[]
+                      | select(.filename | endswith("package.json"))
+                      | select((.patch // "" | split("\n") | any(test("^[+-].*\"posthog-js\"[[:space:]]*:[[:space:]]*\"[^\"]+\""))))
+                      | .filename
+                    ]
+                    | .[]
+                  ')
+
+                  {
+                      echo 'matching_files<<EOF'
+                      echo "$MATCHING_FILES"
+                      echo EOF
+                  } >> "$GITHUB_OUTPUT"
+
+                  if [ -n "$MATCHING_FILES" ]; then
+                      echo "action=add" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+
+                  echo "No posthog-js version changes detected"
+
+                  if gh api "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" --jq '.teams[].slug' | grep -Fxq "$TEAM_REVIEWER_SLUG"; then
+                      # Only remove stale requests that this automation added; don't fight manual review requests.
+                      LATEST_AUTOMATED_REQUEST=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/timeline" --paginate -H 'Accept: application/vnd.github+json' --jq '
+                        [
+                          .[]
+                          | select((.event == "review_requested" or .event == "review_request_removed") and .requested_team.slug == "client-libraries-approvers")
+                          | {event, actor: .actor.login}
+                        ]
+                        | last
+                        | select(.event == "review_requested" and .actor == "assign-reviewers-posthog[bot]")
+                        | .event
+                      ')
+
+                      if [ "$LATEST_AUTOMATED_REQUEST" = "review_requested" ]; then
+                          echo "action=remove" >> "$GITHUB_OUTPUT"
+                          exit 0
+                      fi
+
+                      echo "Existing review request was not most recently added by automation; leaving it in place"
+                  fi
+
+                  echo "action=none" >> "$GITHUB_OUTPUT"
+
             - name: Get app token
               id: app-token
+              if: steps.reviewer-action.outputs.action != 'none'
               uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               with:
                   client-id: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
 
-            - name: Check if posthog-js version changed and request review
+            - name: Update client libraries review request
+              if: steps.reviewer-action.outputs.action != 'none'
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   REPO: ${{ github.repository }}
+                  REVIEWER_ACTION: ${{ steps.reviewer-action.outputs.action }}
+                  MATCHING_FILES: ${{ steps.reviewer-action.outputs.matching_files }}
+                  TEAM_REVIEWER: PostHog/client-libraries-approvers
+                  TEAM_REVIEWER_SLUG: client-libraries-approvers
               run: |
-                  echo "Checking PR #${PR_NUMBER} for posthog-js version changes..."
+                  set -euo pipefail
 
-                  # Get the diff for this PR, filtering to package.json files only
-                  DIFF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[] | select(.filename | endswith("package.json")) | .patch // empty')
-
-                  if [ -z "$DIFF" ]; then
-                      echo "No package.json changes found"
+                  if [ "$REVIEWER_ACTION" = "add" ]; then
+                      echo "posthog-js version change detected in:"
+                      echo "$MATCHING_FILES" | sed 's/^/  - /'
+                      echo "Requesting review from ${TEAM_REVIEWER}"
+                      gh pr edit "${PR_NUMBER}" --repo "${REPO}" --add-reviewer "${TEAM_REVIEWER}"
+                      echo "Review requested successfully"
                       exit 0
                   fi
 
-                  # Check if the diff contains posthog-js version changes
-                  # We look for lines that add or remove posthog-js with a version
-                  if echo "$DIFF" | grep -qE '^\+.*"posthog-js":\s*"[^"]+"|^-.*"posthog-js":\s*"[^"]+"'; then
-                      echo "posthog-js version change detected, requesting review from client-libraries-approvers"
-                      gh pr edit "${PR_NUMBER}" --repo "${REPO}" --add-reviewer "PostHog/client-libraries-approvers"
-                      echo "Review requested successfully"
-                  else
-                      echo "No posthog-js version changes detected"
-                  fi
+                  echo "Removing stale review request from ${TEAM_REVIEWER}"
+                  gh api \
+                      --method DELETE \
+                      "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+                      --field "team_reviewers[]=${TEAM_REVIEWER_SLUG}" \
+                      >/dev/null
+                  echo "Stale review request removed"

--- a/.github/workflows/pr-posthog-js-reviewer.yml
+++ b/.github/workflows/pr-posthog-js-reviewer.yml
@@ -30,7 +30,7 @@ jobs:
         if: >-
             github.event.pull_request.head.repo.fork == false &&
             github.event.pull_request.base.ref == 'master' &&
-            (github.event.action != 'edited' || github.event.changes.base.ref.from != null)
+            (github.event.action != 'edited' || github.event.changes.base.ref.from != '')
 
         steps:
             - name: Determine reviewer action
@@ -70,15 +70,15 @@ jobs:
 
                   if gh api "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" --jq '.teams[].slug' | grep -Fxq "$TEAM_REVIEWER_SLUG"; then
                       # Only remove stale requests that this automation added; don't fight manual review requests.
-                      LATEST_AUTOMATED_REQUEST=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/timeline" --paginate -H 'Accept: application/vnd.github+json' --jq '
+                      LATEST_AUTOMATED_REQUEST=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/timeline" --paginate -H 'Accept: application/vnd.github+json' | jq -s -r '
                         [
-                          .[]
+                          .[][]
                           | select((.event == "review_requested" or .event == "review_request_removed") and .requested_team.slug == "client-libraries-approvers")
                           | {event, actor: .actor.login}
                         ]
                         | last
                         | select(.event == "review_requested" and .actor == "assign-reviewers-posthog[bot]")
-                        | .event
+                        | .event // empty
                       ')
 
                       if [ "$LATEST_AUTOMATED_REQUEST" = "review_requested" ]; then


### PR DESCRIPTION
## Problem

The posthog-js reviewer workflow could leave stale `PostHog/client-libraries-approvers` review requests when a temporary PR diff included a `package.json` posthog-js change and that diff later disappeared, for example after retargeting a stacked PR or rolling back the package change.

## Changes

- Sync the client libraries review request against the current PR diff instead of only adding it.
- Only add the review request for PRs targeting `master` with current `posthog-js` dependency changes in `package.json` files.
- Remove stale review requests when the current diff no longer contains those changes, but only when the latest team request was added by the automation.
- Remove the workflow `paths` filter so rollback commits can trigger stale request cleanup.
- Log the exact files that caused a reviewer request.
- Handle `edited` event guards and paginated timeline checks correctly.

## How did you test this code?

As an agent, I verified:

- Parsed `.github/workflows/pr-posthog-js-reviewer.yml` with PyYAML.
- Ran `git diff --check` for the workflow file.
- Confirmed the current PR #59611 diff has no matching `posthog-js` package changes.
- Confirmed the old stacked diff that caused the request still matches the expected package files.
- Ran the paginated timeline `jq -s` expression against PR #59611 and confirmed it detects the automated reviewer request.
- `lint-staged` ran `bin/hogli format:yaml` during both commits.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

Not needed; CI automation only.

## 🤖 Agent context

Authored with the pi coding agent using shell commands and the GitHub CLI. The workflow now treats the client libraries review request as synced state: add it only when the current `master`-targeting PR diff needs it, and remove it when the automated request becomes stale. The cleanup is guarded by timeline inspection so manual team review requests are left in place. Review feedback led to tightening the GitHub Actions `edited` guard and making timeline inspection aggregate all pages before selecting the latest matching event.
