### PR TITLE
feat(session-replay): add surfacing scoring sweep metrics

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -51,6 +51,11 @@ from posthog.temporal.session_replay.delete_recordings.metrics import (
     DELETE_RECORDINGS_LATENCY_HISTOGRAM_METRICS,
     DeleteRecordingsMetricsInterceptor,
 )
+from posthog.temporal.session_replay.surfacing_scoring_sweep.metrics import (
+    SURFACING_SCORING_LATENCY_HISTOGRAM_BUCKETS,
+    SURFACING_SCORING_LATENCY_HISTOGRAM_METRICS,
+    SurfacingScoringMetricsInterceptor,
+)
 
 from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
 from products.experiments.backend.temporal.recalculation_metrics import (
@@ -134,6 +139,7 @@ ALL_INTERCEPTOR_CLASSES = [
     SloInterceptor,
     BatchExportsMetricsInterceptor,
     DeleteRecordingsMetricsInterceptor,
+    SurfacingScoringMetricsInterceptor,
     EvalsMetricsInterceptor,
     SummarizationMetricsInterceptor,
     ClusteringMetricsInterceptor,
@@ -268,6 +274,12 @@ async def create_worker(
             zip(
                 DELETE_RECORDINGS_LATENCY_HISTOGRAM_METRICS,
                 itertools.repeat(DELETE_RECORDINGS_LATENCY_HISTOGRAM_BUCKETS),
+            )
+        )
+        | dict(
+            zip(
+                SURFACING_SCORING_LATENCY_HISTOGRAM_METRICS,
+                itertools.repeat(SURFACING_SCORING_LATENCY_HISTOGRAM_BUCKETS),
             )
         )
         | dict(zip(LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS, itertools.repeat(LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS)))

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/README.md
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/README.md
@@ -280,9 +280,16 @@ Temporal SDK metrics (Prometheus on the worker metrics port):
 
 | Metric                                                     | Type      | When                                   |
 | ---------------------------------------------------------- | --------- | -------------------------------------- |
+| `surfacing_scoring_total_fetched`                          | counter   | end of each tick (`total_fetched > 0`) |
 | `surfacing_scoring_total_scored`                           | counter   | end of each tick (`total_scored > 0`)  |
 | `surfacing_scoring_chunks_failed`                          | counter   | end of each tick (`chunks_failed > 0`) |
 | `surfacing_scoring_score_chunk_activity_execution_latency` | histogram | each `score_chunk_activity` run        |
+
+`total_fetched` is rows the feature SELECT returned from ClickHouse;
+`total_scored` is rows published to Kafka after dropping out-of-contract rows.
+The gap between them is the out-of-contract drop; `total_fetched` near the
+`TARGET_SESSIONS_PER_TICK` cap means the backlog exceeds one tick's budget and
+will drain across several ticks.
 
 Emitted via `SurfacingScoringMetricsInterceptor` on `SURFACING_SCORING_SWEEP_TASK_QUEUE`.
 

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/README.md
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/README.md
@@ -274,6 +274,18 @@ The schedule fires every 5 min with `ScheduleOverlapPolicy.SKIP` — if a tick
 is still running when the next is due, the new one is dropped (the next
 tick's CH `IS NULL` filter naturally picks up whatever the slow tick missed).
 
+## Metrics
+
+Temporal SDK metrics (Prometheus on the worker metrics port):
+
+| Metric                                                     | Type      | When                                   |
+| ---------------------------------------------------------- | --------- | -------------------------------------- |
+| `surfacing_scoring_total_scored`                           | counter   | end of each tick (`total_scored > 0`)  |
+| `surfacing_scoring_chunks_failed`                          | counter   | end of each tick (`chunks_failed > 0`) |
+| `surfacing_scoring_score_chunk_activity_execution_latency` | histogram | each `score_chunk_activity` run        |
+
+Emitted via `SurfacingScoringMetricsInterceptor` on `SURFACING_SCORING_SWEEP_TASK_QUEUE`.
+
 ## Open follow-ups
 
 These are deliberately out of scope for the initial PR:
@@ -294,6 +306,3 @@ These are deliberately out of scope for the initial PR:
   sessions, write a one-off Dagster job that walks
   `cityHash64(session_id) % N` buckets and triggers the same
   `score_chunk_activity` per bucket.
-- **Metrics.** Expose `total_scored`, `chunks_failed`, and the chunk-wall-time
-  histogram to whatever observability stack the `SURFACING_SCORING_SWEEP_TASK_QUEUE`
-  worker pool uses.

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/activities.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/activities.py
@@ -261,8 +261,11 @@ async def score_chunk_activity(spec: ChunkSpec) -> ChunkResult:
     activity.heartbeat({"phase": "fetch", "chunk_id": spec.chunk_id})
     df = await sync_to_async(_fetch_features_dataframe, thread_sensitive=False)(spec)
 
+    # Sessions pulled from ClickHouse for this chunk, before any out-of-contract drop.
+    fetched = len(df)
+
     if df.empty:
-        return ChunkResult(chunk_id=spec.chunk_id, scored=0)
+        return ChunkResult(chunk_id=spec.chunk_id, scored=0, fetched=fetched)
 
     feature_names = await sync_to_async(get_feature_names, thread_sensitive=False)()
 
@@ -296,7 +299,7 @@ async def score_chunk_activity(spec: ChunkSpec) -> ChunkResult:
         )
         df = df.loc[~bad_rows]
         if df.empty:
-            return ChunkResult(chunk_id=spec.chunk_id, scored=0)
+            return ChunkResult(chunk_id=spec.chunk_id, scored=0, fetched=fetched)
 
     activity.heartbeat({"phase": "predict", "chunk_id": spec.chunk_id, "rows": len(df)})
     scores = await sync_to_async(predict, thread_sensitive=False)(df)
@@ -308,6 +311,7 @@ async def score_chunk_activity(spec: ChunkSpec) -> ChunkResult:
         "surfacing_scoring_sweep.chunk_done",
         chunk_id=spec.chunk_id,
         scored=published,
+        fetched=fetched,
         feature_count=len(feature_names),
     )
-    return ChunkResult(chunk_id=spec.chunk_id, scored=published)
+    return ChunkResult(chunk_id=spec.chunk_id, scored=published, fetched=fetched)

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/metrics.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/metrics.py
@@ -1,0 +1,57 @@
+import typing
+
+from django.conf import settings
+
+from temporalio import activity
+from temporalio.worker import ActivityInboundInterceptor, ExecuteActivityInput, Interceptor
+
+from posthog.temporal.ai_observability.metrics import ExecutionTimeRecorder, get_metric_meter
+
+SCORE_CHUNK_ACTIVITY_TYPE = "score_chunk_activity"
+
+SCORE_CHUNK_LATENCY_HISTOGRAM = "surfacing_scoring_score_chunk_activity_execution_latency"
+
+SURFACING_SCORING_LATENCY_HISTOGRAM_METRICS = (SCORE_CHUNK_LATENCY_HISTOGRAM,)
+SURFACING_SCORING_LATENCY_HISTOGRAM_BUCKETS = [
+    1_000.0,  # 1 second
+    5_000.0,  # 5 seconds
+    10_000.0,  # 10 seconds
+    30_000.0,  # 30 seconds
+    60_000.0,  # 1 minute
+    120_000.0,  # 2 minutes
+    240_000.0,  # 4 minutes (SCORE_CHUNK_ACTIVITY_TIMEOUT)
+]
+
+TOTAL_SCORED_COUNTER = "surfacing_scoring_total_scored"
+TOTAL_SCORED_DESCRIPTION = "Sessions scored in a surfacing scoring sweep tick"
+
+CHUNKS_FAILED_COUNTER = "surfacing_scoring_chunks_failed"
+CHUNKS_FAILED_DESCRIPTION = "Hash-partitioned chunks that failed in a surfacing scoring sweep tick"
+
+
+def record_tick_summary(*, total_scored: int, chunks_failed: int) -> None:
+    if total_scored <= 0 and chunks_failed <= 0:
+        return
+    meter = get_metric_meter()
+    if total_scored > 0:
+        meter.create_counter(TOTAL_SCORED_COUNTER, TOTAL_SCORED_DESCRIPTION).add(total_scored)
+    if chunks_failed > 0:
+        meter.create_counter(CHUNKS_FAILED_COUNTER, CHUNKS_FAILED_DESCRIPTION).add(chunks_failed)
+
+
+class SurfacingScoringMetricsInterceptor(Interceptor):
+    task_queue = settings.SURFACING_SCORING_SWEEP_TASK_QUEUE
+
+    def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
+        return _SurfacingScoringActivityInterceptor(super().intercept_activity(next))
+
+
+class _SurfacingScoringActivityInterceptor(ActivityInboundInterceptor):
+    async def execute_activity(self, input: ExecuteActivityInput) -> typing.Any:
+        if activity.info().activity_type != SCORE_CHUNK_ACTIVITY_TYPE:
+            return await super().execute_activity(input)
+        with ExecutionTimeRecorder(
+            SCORE_CHUNK_LATENCY_HISTOGRAM,
+            description="Wall time for score_chunk_activity (fetch, predict, publish)",
+        ):
+            return await super().execute_activity(input)

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/metrics.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/metrics.py
@@ -22,6 +22,9 @@ SURFACING_SCORING_LATENCY_HISTOGRAM_BUCKETS = [
     240_000.0,  # 4 minutes (SCORE_CHUNK_ACTIVITY_TIMEOUT)
 ]
 
+TOTAL_FETCHED_COUNTER = "surfacing_scoring_total_fetched"
+TOTAL_FETCHED_DESCRIPTION = "Sessions fetched from ClickHouse in a surfacing scoring sweep tick"
+
 TOTAL_SCORED_COUNTER = "surfacing_scoring_total_scored"
 TOTAL_SCORED_DESCRIPTION = "Sessions scored in a surfacing scoring sweep tick"
 
@@ -29,10 +32,12 @@ CHUNKS_FAILED_COUNTER = "surfacing_scoring_chunks_failed"
 CHUNKS_FAILED_DESCRIPTION = "Hash-partitioned chunks that failed in a surfacing scoring sweep tick"
 
 
-def record_tick_summary(*, total_scored: int, chunks_failed: int) -> None:
-    if total_scored <= 0 and chunks_failed <= 0:
+def record_tick_summary(*, total_scored: int, total_fetched: int, chunks_failed: int) -> None:
+    if total_scored <= 0 and total_fetched <= 0 and chunks_failed <= 0:
         return
     meter = get_metric_meter()
+    if total_fetched > 0:
+        meter.create_counter(TOTAL_FETCHED_COUNTER, TOTAL_FETCHED_DESCRIPTION).add(total_fetched)
     if total_scored > 0:
         meter.create_counter(TOTAL_SCORED_COUNTER, TOTAL_SCORED_DESCRIPTION).add(total_scored)
     if chunks_failed > 0:

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/types.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/types.py
@@ -46,11 +46,15 @@ class ListChunksResult:
 @dataclass
 class ChunkResult:
     chunk_id: int
+    # Rows published to Kafka (after dropping out-of-contract rows).
     scored: int = 0
+    # Rows the feature SELECT returned from ClickHouse, before any drop.
+    fetched: int = 0
 
 
 @dataclass
 class ScoreSessionsBatchResult:
     total_scored: int = 0
+    total_fetched: int = 0
     chunks_dispatched: int = 0
     chunks_failed: int = 0

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
@@ -45,6 +45,7 @@ with workflow.unsafe.imports_passed_through():
         list_chunks_activity,
         score_chunk_activity,
     )
+    from posthog.temporal.session_replay.surfacing_scoring_sweep.metrics import record_tick_summary
 
 
 @workflow.defn(name=WORKFLOW_NAME)
@@ -115,4 +116,5 @@ def _summarize(chunks: list[ChunkSpec], results: list[ChunkResult | BaseExceptio
         chunks_failed=summary.chunks_failed,
         total_scored=summary.total_scored,
     )
+    record_tick_summary(total_scored=summary.total_scored, chunks_failed=summary.chunks_failed)
     return summary

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
@@ -110,11 +110,17 @@ def _summarize(chunks: list[ChunkSpec], results: list[ChunkResult | BaseExceptio
                 )
             continue
         summary.total_scored += r.scored
+        summary.total_fetched += r.fetched
     workflow.logger.info(
         "surfacing_scoring_sweep.tick_done",
         chunks_dispatched=summary.chunks_dispatched,
         chunks_failed=summary.chunks_failed,
         total_scored=summary.total_scored,
+        total_fetched=summary.total_fetched,
     )
-    record_tick_summary(total_scored=summary.total_scored, chunks_failed=summary.chunks_failed)
+    record_tick_summary(
+        total_scored=summary.total_scored,
+        total_fetched=summary.total_fetched,
+        chunks_failed=summary.chunks_failed,
+    )
     return summary

--- a/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_metrics.py
+++ b/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_metrics.py
@@ -1,0 +1,207 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from django.conf import settings
+
+from parameterized import parameterized
+from temporalio.worker import ExecuteActivityInput
+
+from posthog.temporal.common.worker import ALL_INTERCEPTOR_CLASSES
+from posthog.temporal.session_replay.surfacing_scoring_sweep.activities import (
+    list_chunks_activity,
+    score_chunk_activity,
+)
+from posthog.temporal.session_replay.surfacing_scoring_sweep.constants import SCORE_CHUNK_ACTIVITY_TIMEOUT
+from posthog.temporal.session_replay.surfacing_scoring_sweep.metrics import (
+    CHUNKS_FAILED_COUNTER,
+    CHUNKS_FAILED_DESCRIPTION,
+    SCORE_CHUNK_ACTIVITY_TYPE,
+    SCORE_CHUNK_LATENCY_HISTOGRAM,
+    SURFACING_SCORING_LATENCY_HISTOGRAM_BUCKETS,
+    SURFACING_SCORING_LATENCY_HISTOGRAM_METRICS,
+    TOTAL_SCORED_COUNTER,
+    TOTAL_SCORED_DESCRIPTION,
+    SurfacingScoringMetricsInterceptor,
+    record_tick_summary,
+)
+
+
+class TestHistogramConfig:
+    def test_latency_histogram_metric_names(self) -> None:
+        assert SURFACING_SCORING_LATENCY_HISTOGRAM_METRICS == (SCORE_CHUNK_LATENCY_HISTOGRAM,)
+
+    def test_latency_buckets_include_activity_timeout(self) -> None:
+        timeout_ms = SCORE_CHUNK_ACTIVITY_TIMEOUT.total_seconds() * 1_000
+        assert timeout_ms in SURFACING_SCORING_LATENCY_HISTOGRAM_BUCKETS
+        assert SURFACING_SCORING_LATENCY_HISTOGRAM_BUCKETS == sorted(SURFACING_SCORING_LATENCY_HISTOGRAM_BUCKETS)
+
+    def test_interceptor_registered_on_worker(self) -> None:
+        assert SurfacingScoringMetricsInterceptor in ALL_INTERCEPTOR_CLASSES
+
+
+class TestActivityTypeAlignment:
+    def test_score_chunk_activity_type_matches_defn(self) -> None:
+        assert SCORE_CHUNK_ACTIVITY_TYPE == score_chunk_activity.__name__
+
+    def test_list_chunks_activity_is_not_timed(self) -> None:
+        assert list_chunks_activity.__name__ != SCORE_CHUNK_ACTIVITY_TYPE
+
+
+class TestSurfacingScoringMetricsInterceptor:
+    def test_task_queue_matches_settings(self) -> None:
+        assert SurfacingScoringMetricsInterceptor.task_queue == settings.SURFACING_SCORING_SWEEP_TASK_QUEUE
+
+    def test_creates_activity_interceptor(self) -> None:
+        interceptor = SurfacingScoringMetricsInterceptor()
+        result = interceptor.intercept_activity(MagicMock())
+        assert result is not None
+
+
+class TestRecordTickSummary:
+    @parameterized.expand(
+        [
+            ("scored", 42, 0, TOTAL_SCORED_COUNTER, TOTAL_SCORED_DESCRIPTION, 42),
+            ("failed", 0, 3, CHUNKS_FAILED_COUNTER, CHUNKS_FAILED_DESCRIPTION, 3),
+        ]
+    )
+    def test_emits_counter(
+        self,
+        _name: str,
+        total_scored: int,
+        chunks_failed: int,
+        counter_name: str,
+        counter_description: str,
+        expected_count: int,
+    ) -> None:
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+
+        with patch(
+            "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.get_metric_meter",
+            return_value=mock_meter,
+        ):
+            record_tick_summary(total_scored=total_scored, chunks_failed=chunks_failed)
+
+        mock_meter.create_counter.assert_called_once_with(counter_name, counter_description)
+        mock_counter.add.assert_called_once_with(expected_count)
+
+    def test_emits_both_counters(self) -> None:
+        mock_meter = MagicMock()
+        with patch(
+            "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.get_metric_meter",
+            return_value=mock_meter,
+        ):
+            record_tick_summary(total_scored=10, chunks_failed=2)
+
+        names = [call.args[0] for call in mock_meter.create_counter.call_args_list]
+        assert names == [TOTAL_SCORED_COUNTER, CHUNKS_FAILED_COUNTER]
+
+    @parameterized.expand(
+        [
+            ("both_zero", 0, 0),
+            ("negative_scored", -1, 0),
+            ("negative_failed", 0, -1),
+            ("both_negative", -5, -2),
+        ]
+    )
+    def test_noops_for_non_positive_counts(self, _name: str, total_scored: int, chunks_failed: int) -> None:
+        with patch(
+            "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.get_metric_meter",
+        ) as mock_get_meter:
+            record_tick_summary(total_scored=total_scored, chunks_failed=chunks_failed)
+            mock_get_meter.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("negative_scored_positive_failed", -1, 2, CHUNKS_FAILED_COUNTER, 2),
+            ("positive_scored_negative_failed", 7, -1, TOTAL_SCORED_COUNTER, 7),
+        ]
+    )
+    def test_emits_only_positive_dimension(
+        self,
+        _name: str,
+        total_scored: int,
+        chunks_failed: int,
+        counter_name: str,
+        expected_count: int,
+    ) -> None:
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+
+        with patch(
+            "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.get_metric_meter",
+            return_value=mock_meter,
+        ):
+            record_tick_summary(total_scored=total_scored, chunks_failed=chunks_failed)
+
+        expected_description = (
+            TOTAL_SCORED_DESCRIPTION if counter_name == TOTAL_SCORED_COUNTER else CHUNKS_FAILED_DESCRIPTION
+        )
+        mock_meter.create_counter.assert_called_once_with(counter_name, expected_description)
+        mock_counter.add.assert_called_once_with(expected_count)
+
+
+@pytest.mark.asyncio
+class TestSurfacingScoringActivityInterceptor:
+    async def _run_interceptor(
+        self,
+        *,
+        activity_type: str,
+    ) -> tuple[AsyncMock, MagicMock]:
+        next_interceptor = AsyncMock()
+        next_interceptor.execute_activity.return_value = {"ok": True}
+        interceptor = SurfacingScoringMetricsInterceptor().intercept_activity(next_interceptor)
+        mock_input = MagicMock(spec=ExecuteActivityInput)
+
+        with (
+            patch(
+                "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.activity.info",
+                return_value=MagicMock(activity_type=activity_type),
+            ),
+            patch(
+                "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.ExecutionTimeRecorder",
+            ) as mock_recorder,
+        ):
+            mock_recorder.return_value.__enter__ = MagicMock(return_value=mock_recorder.return_value)
+            mock_recorder.return_value.__exit__ = MagicMock(return_value=False)
+            result = await interceptor.execute_activity(mock_input)
+
+        assert result == {"ok": True}
+        next_interceptor.execute_activity.assert_called_once_with(mock_input)
+        return next_interceptor, mock_recorder
+
+    async def test_records_latency_for_score_chunk_activity(self) -> None:
+        _, mock_recorder = await self._run_interceptor(activity_type=SCORE_CHUNK_ACTIVITY_TYPE)
+        mock_recorder.assert_called_once_with(
+            SCORE_CHUNK_LATENCY_HISTOGRAM,
+            description="Wall time for score_chunk_activity (fetch, predict, publish)",
+        )
+
+    async def test_skips_latency_for_list_chunks_activity(self) -> None:
+        _, mock_recorder = await self._run_interceptor(activity_type=list_chunks_activity.__name__)
+        mock_recorder.assert_not_called()
+
+    async def test_records_latency_even_when_activity_raises(self) -> None:
+        next_interceptor = AsyncMock()
+        next_interceptor.execute_activity.side_effect = RuntimeError("chunk blew up")
+        interceptor = SurfacingScoringMetricsInterceptor().intercept_activity(next_interceptor)
+        mock_input = MagicMock(spec=ExecuteActivityInput)
+
+        with (
+            patch(
+                "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.activity.info",
+                return_value=MagicMock(activity_type=SCORE_CHUNK_ACTIVITY_TYPE),
+            ),
+            patch(
+                "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.ExecutionTimeRecorder",
+            ) as mock_recorder,
+        ):
+            mock_recorder.return_value.__enter__ = MagicMock(return_value=mock_recorder.return_value)
+            mock_recorder.return_value.__exit__ = MagicMock(return_value=False)
+
+            with pytest.raises(RuntimeError, match="chunk blew up"):
+                await interceptor.execute_activity(mock_input)
+
+        mock_recorder.assert_called_once()

--- a/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_metrics.py
+++ b/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_metrics.py
@@ -19,6 +19,8 @@ from posthog.temporal.session_replay.surfacing_scoring_sweep.metrics import (
     SCORE_CHUNK_LATENCY_HISTOGRAM,
     SURFACING_SCORING_LATENCY_HISTOGRAM_BUCKETS,
     SURFACING_SCORING_LATENCY_HISTOGRAM_METRICS,
+    TOTAL_FETCHED_COUNTER,
+    TOTAL_FETCHED_DESCRIPTION,
     TOTAL_SCORED_COUNTER,
     TOTAL_SCORED_DESCRIPTION,
     SurfacingScoringMetricsInterceptor,
@@ -60,14 +62,16 @@ class TestSurfacingScoringMetricsInterceptor:
 class TestRecordTickSummary:
     @parameterized.expand(
         [
-            ("scored", 42, 0, TOTAL_SCORED_COUNTER, TOTAL_SCORED_DESCRIPTION, 42),
-            ("failed", 0, 3, CHUNKS_FAILED_COUNTER, CHUNKS_FAILED_DESCRIPTION, 3),
+            ("fetched", 0, 99, 0, TOTAL_FETCHED_COUNTER, TOTAL_FETCHED_DESCRIPTION, 99),
+            ("scored", 42, 0, 0, TOTAL_SCORED_COUNTER, TOTAL_SCORED_DESCRIPTION, 42),
+            ("failed", 0, 0, 3, CHUNKS_FAILED_COUNTER, CHUNKS_FAILED_DESCRIPTION, 3),
         ]
     )
     def test_emits_counter(
         self,
         _name: str,
         total_scored: int,
+        total_fetched: int,
         chunks_failed: int,
         counter_name: str,
         counter_description: str,
@@ -81,49 +85,55 @@ class TestRecordTickSummary:
             "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.get_metric_meter",
             return_value=mock_meter,
         ):
-            record_tick_summary(total_scored=total_scored, chunks_failed=chunks_failed)
+            record_tick_summary(total_scored=total_scored, total_fetched=total_fetched, chunks_failed=chunks_failed)
 
         mock_meter.create_counter.assert_called_once_with(counter_name, counter_description)
         mock_counter.add.assert_called_once_with(expected_count)
 
-    def test_emits_both_counters(self) -> None:
+    def test_emits_all_counters(self) -> None:
         mock_meter = MagicMock()
         with patch(
             "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.get_metric_meter",
             return_value=mock_meter,
         ):
-            record_tick_summary(total_scored=10, chunks_failed=2)
+            record_tick_summary(total_scored=10, total_fetched=100, chunks_failed=2)
 
         names = [call.args[0] for call in mock_meter.create_counter.call_args_list]
-        assert names == [TOTAL_SCORED_COUNTER, CHUNKS_FAILED_COUNTER]
+        assert names == [TOTAL_FETCHED_COUNTER, TOTAL_SCORED_COUNTER, CHUNKS_FAILED_COUNTER]
 
     @parameterized.expand(
         [
-            ("both_zero", 0, 0),
-            ("negative_scored", -1, 0),
-            ("negative_failed", 0, -1),
-            ("both_negative", -5, -2),
+            ("all_zero", 0, 0, 0),
+            ("negative_scored", -1, 0, 0),
+            ("negative_fetched", 0, -1, 0),
+            ("negative_failed", 0, 0, -1),
+            ("all_negative", -5, -3, -2),
         ]
     )
-    def test_noops_for_non_positive_counts(self, _name: str, total_scored: int, chunks_failed: int) -> None:
+    def test_noops_for_non_positive_counts(
+        self, _name: str, total_scored: int, total_fetched: int, chunks_failed: int
+    ) -> None:
         with patch(
             "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.get_metric_meter",
         ) as mock_get_meter:
-            record_tick_summary(total_scored=total_scored, chunks_failed=chunks_failed)
+            record_tick_summary(total_scored=total_scored, total_fetched=total_fetched, chunks_failed=chunks_failed)
             mock_get_meter.assert_not_called()
 
     @parameterized.expand(
         [
-            ("negative_scored_positive_failed", -1, 2, CHUNKS_FAILED_COUNTER, 2),
-            ("positive_scored_negative_failed", 7, -1, TOTAL_SCORED_COUNTER, 7),
+            ("only_fetched", -1, 5, 0, TOTAL_FETCHED_COUNTER, TOTAL_FETCHED_DESCRIPTION, 5),
+            ("only_failed", 0, -1, 2, CHUNKS_FAILED_COUNTER, CHUNKS_FAILED_DESCRIPTION, 2),
+            ("only_scored", 7, -1, 0, TOTAL_SCORED_COUNTER, TOTAL_SCORED_DESCRIPTION, 7),
         ]
     )
     def test_emits_only_positive_dimension(
         self,
         _name: str,
         total_scored: int,
+        total_fetched: int,
         chunks_failed: int,
         counter_name: str,
+        counter_description: str,
         expected_count: int,
     ) -> None:
         mock_meter = MagicMock()
@@ -134,12 +144,9 @@ class TestRecordTickSummary:
             "posthog.temporal.session_replay.surfacing_scoring_sweep.metrics.get_metric_meter",
             return_value=mock_meter,
         ):
-            record_tick_summary(total_scored=total_scored, chunks_failed=chunks_failed)
+            record_tick_summary(total_scored=total_scored, total_fetched=total_fetched, chunks_failed=chunks_failed)
 
-        expected_description = (
-            TOTAL_SCORED_DESCRIPTION if counter_name == TOTAL_SCORED_COUNTER else CHUNKS_FAILED_DESCRIPTION
-        )
-        mock_meter.create_counter.assert_called_once_with(counter_name, expected_description)
+        mock_meter.create_counter.assert_called_once_with(counter_name, counter_description)
         mock_counter.add.assert_called_once_with(expected_count)
 
 

--- a/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
@@ -39,9 +39,9 @@ class TestSummarize:
     def test_aggregates_scored_and_failed_chunks(self) -> None:
         chunks = [_chunk(0), _chunk(1), _chunk(2)]
         results: list[ChunkResult | BaseException] = [
-            ChunkResult(chunk_id=0, scored=3),
+            ChunkResult(chunk_id=0, scored=3, fetched=4),
             RuntimeError("ch timeout"),
-            ChunkResult(chunk_id=2, scored=7),
+            ChunkResult(chunk_id=2, scored=7, fetched=9),
         ]
         with (
             mock.patch("posthog.temporal.session_replay.surfacing_scoring_sweep.workflow.workflow.logger"),
@@ -50,14 +50,16 @@ class TestSummarize:
             ) as mock_record_tick_summary,
         ):
             summary = _summarize(chunks, results)
-        assert summary == ScoreSessionsBatchResult(total_scored=10, chunks_dispatched=3, chunks_failed=1)
-        mock_record_tick_summary.assert_called_once_with(total_scored=10, chunks_failed=1)
+        assert summary == ScoreSessionsBatchResult(
+            total_scored=10, total_fetched=13, chunks_dispatched=3, chunks_failed=1
+        )
+        mock_record_tick_summary.assert_called_once_with(total_scored=10, total_fetched=13, chunks_failed=1)
 
     def test_record_tick_summary_noops_when_tick_has_no_positive_counts(self) -> None:
         chunks = [_chunk(0), _chunk(1)]
         results: list[ChunkResult | BaseException] = [
-            ChunkResult(chunk_id=0, scored=0),
-            ChunkResult(chunk_id=1, scored=0),
+            ChunkResult(chunk_id=0, scored=0, fetched=0),
+            ChunkResult(chunk_id=1, scored=0, fetched=0),
         ]
         with (
             mock.patch("posthog.temporal.session_replay.surfacing_scoring_sweep.workflow.workflow.logger"),
@@ -66,8 +68,10 @@ class TestSummarize:
             ) as mock_record_tick_summary,
         ):
             summary = _summarize(chunks, results)
-        assert summary == ScoreSessionsBatchResult(total_scored=0, chunks_dispatched=2, chunks_failed=0)
-        mock_record_tick_summary.assert_called_once_with(total_scored=0, chunks_failed=0)
+        assert summary == ScoreSessionsBatchResult(
+            total_scored=0, total_fetched=0, chunks_dispatched=2, chunks_failed=0
+        )
+        mock_record_tick_summary.assert_called_once_with(total_scored=0, total_fetched=0, chunks_failed=0)
 
 
 @pytest.mark.asyncio
@@ -108,7 +112,7 @@ async def test_workflow_fans_out_chunks_and_aggregates_scores() -> None:
 
     @activity.defn(name="score_chunk_activity")
     async def score_chunk_mocked(spec: ChunkSpec) -> ChunkResult:
-        return ChunkResult(chunk_id=spec.chunk_id, scored=spec.chunk_id + 1)
+        return ChunkResult(chunk_id=spec.chunk_id, scored=spec.chunk_id + 1, fetched=(spec.chunk_id + 1) * 2)
 
     task_queue = str(uuid.uuid4())
     async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -130,6 +134,7 @@ async def test_workflow_fans_out_chunks_and_aggregates_scores() -> None:
     assert parsed.chunks_dispatched == 4
     assert parsed.chunks_failed == 0
     assert parsed.total_scored == 1 + 2 + 3 + 4
+    assert parsed.total_fetched == (1 + 2 + 3 + 4) * 2
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
@@ -43,9 +43,31 @@ class TestSummarize:
             RuntimeError("ch timeout"),
             ChunkResult(chunk_id=2, scored=7),
         ]
-        with mock.patch("posthog.temporal.session_replay.surfacing_scoring_sweep.workflow.workflow.logger"):
+        with (
+            mock.patch("posthog.temporal.session_replay.surfacing_scoring_sweep.workflow.workflow.logger"),
+            mock.patch(
+                "posthog.temporal.session_replay.surfacing_scoring_sweep.workflow.record_tick_summary",
+            ) as mock_record_tick_summary,
+        ):
             summary = _summarize(chunks, results)
         assert summary == ScoreSessionsBatchResult(total_scored=10, chunks_dispatched=3, chunks_failed=1)
+        mock_record_tick_summary.assert_called_once_with(total_scored=10, chunks_failed=1)
+
+    def test_record_tick_summary_noops_when_tick_has_no_positive_counts(self) -> None:
+        chunks = [_chunk(0), _chunk(1)]
+        results: list[ChunkResult | BaseException] = [
+            ChunkResult(chunk_id=0, scored=0),
+            ChunkResult(chunk_id=1, scored=0),
+        ]
+        with (
+            mock.patch("posthog.temporal.session_replay.surfacing_scoring_sweep.workflow.workflow.logger"),
+            mock.patch(
+                "posthog.temporal.session_replay.surfacing_scoring_sweep.workflow.record_tick_summary",
+            ) as mock_record_tick_summary,
+        ):
+            summary = _summarize(chunks, results)
+        assert summary == ScoreSessionsBatchResult(total_scored=0, chunks_dispatched=2, chunks_failed=0)
+        mock_record_tick_summary.assert_called_once_with(total_scored=0, chunks_failed=0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The surfacing scoring sweep workflow had no metrics on its dedicated worker pool, so we could not observe throughput, chunk failures, or per-chunk latency in production.

## Changes

Add a `SurfacingScoringMetricsInterceptor` on `SURFACING_SCORING_SWEEP_TASK_QUEUE` (which aliases the session-replay queue) that emits Temporal SDK metrics (Prometheus on the worker metrics port):

| Metric | Type | When |
| --- | --- | --- |
| `surfacing_scoring_total_scored` | counter | end of each tick (`total_scored > 0`) |
| `surfacing_scoring_chunks_failed` | counter | end of each tick (`chunks_failed > 0`) |
| `surfacing_scoring_score_chunk_activity_execution_latency` | histogram | each `score_chunk_activity` run |

`surfacing_scoring_chunks_failed` is the counter failure alerts fire on. New file `metrics.py` holds the interceptor + `record_tick_summary`; `worker.py` registers it and its histogram buckets; `workflow.py` records the tick counters from `_summarize`; README documents the metrics.

## How did you test this code?

I'm an agent (Claude Code). Automated tests run locally:

- `test_metrics.py` (19 tests) covers the counters, the no-positive-counts no-op, and the activity-latency interceptor.
- `test_workflow.py` (extended `TestSummarize`) asserts `_summarize` records the tick counters; full file passes (25 tests with `test_metrics.py`).
- `ruff` (0.15.16) clean on all changed files; `worker.py` imports with the interceptor registered.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @arnohillen.

This branch was a Graphite stack on top of the core surfacing PR (#60084). Once #60084 merged to master, the branch was ~1565 commits behind with stale copies of the now-merged core, so it showed as conflicting with a 4.5k-line diff. Rebuilt cleanly on fresh master: brought the two genuinely-new files (`metrics.py`, `test_metrics.py`) verbatim and re-applied the small `worker.py` / `workflow.py` / `README.md` hunks, dropping the merged core and the unrelated master-sync commit. The PR now contains only the metrics delta (6 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `surfacing_scoring_total_fetched` counter to track rows returned from ClickHouse before the out-of-contract drop, complementing the existing `total_scored` counter. Also adds a `fetched` field to `ChunkResult` and `ScoreSessionsBatchResult` types, threads it through the activity and workflow, and updates tests and documentation accordingly.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a1564c09b31a9031b82731ca95846f2de3863a1c.</sup>
<!-- /MENDRAL_SUMMARY -->