### PR TITLE
fix(trends): strip outer user alias from math=hogql expression

### DIFF
--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -74,11 +74,19 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
 
     def select_aggregation(self) -> ast.Expr:
         if self.series.math == "hogql" and self.series.math_hogql is not None:
+            parsed = parse_expr(self.series.math_hogql)
+            # An outer alias on the user expression (`avg(x) as foo`) is shadowed by the
+            # `AS total` wrap added downstream. If we leave it in place, ClickHouse's
+            # new analyzer expands `ORDER BY total` into a copy of the SELECT expression
+            # with the inner alias stripped, producing two AST-different `AS total`
+            # projections and a MULTIPLE_EXPRESSIONS_FOR_ALIAS rejection.
+            if isinstance(parsed, ast.Alias):
+                parsed = parsed.expr
             # Wrap in ifNull to handle empty result sets - formulas can't handle NULL values
             return ast.Call(
                 name="ifNull",
                 args=[
-                    ast.Call(name="toFloat", args=[parse_expr(self.series.math_hogql)]),
+                    ast.Call(name="toFloat", args=[parsed]),
                     ast.Constant(value=0),
                 ],
             )

--- a/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
@@ -117,6 +117,38 @@ def test_requiring_query_orchestration(
     assert res == result
 
 
+@pytest.mark.parametrize(
+    "math_hogql",
+    [
+        "avg((properties.duration_seconds)/60) as avg_duration_mins",
+        "avg((properties.duration_seconds)/60) AS avg_duration_mins",
+        "sum(properties.amount) as total_amount",
+    ],
+)
+@pytest.mark.django_db
+def test_hogql_math_strips_outer_user_alias(math_hogql: str):
+    """The user's outer alias on a `math=hogql` expression is shadowed by the downstream
+    `AS total` wrap. Leaving it in place causes ClickHouse's new analyzer to reject the
+    query with MULTIPLE_EXPRESSIONS_FOR_ALIAS (code 179) because `ORDER BY total` expands
+    into a copy of the SELECT expression with the inner alias stripped, producing two
+    AST-different `AS total` projections.
+    """
+    team = Team()
+    series = EventsNode(event="$pageview", math="hogql", math_hogql=math_hogql)
+    query_date_range = QueryDateRange(date_range=None, interval=None, now=datetime.now(), team=team)
+
+    agg_ops = AggregationOperations(team, series, ChartDisplayType.ACTIONS_LINE_GRAPH, query_date_range, False)
+    result = agg_ops.select_aggregation()
+
+    assert isinstance(result, ast.Call)
+    assert result.name == "ifNull"
+    to_float = result.args[0]
+    assert isinstance(to_float, ast.Call)
+    assert to_float.name == "toFloat"
+    # The expression inside toFloat must NOT be an Alias; the user's `as foo` is stripped.
+    assert not isinstance(to_float.args[0], ast.Alias)
+
+
 @pytest.mark.django_db
 def test_math_multiplier_with_sum():
     team = Team()


### PR DESCRIPTION
## Problem

ClickHouse's new analyzer (`allow_experimental_analyzer=1`) has a bug resolving `ORDER BY <position>` when the SELECT projection contains a nested alias. It rebuilds the projection tree to resolve the position, and the rebuild drops the inner alias — so the analyzer ends up with two AST-different expressions bound to the same outer alias and fires `MULTIPLE_EXPRESSIONS_FOR_ALIAS` (code 179). Confirmed against prod CH 25.12 with a minimal `events`-only repro: `ORDER BY 1` fails, `ORDER BY total` (same query, alias by name) succeeds, removing the inner alias also makes `ORDER BY 1` succeed.

Trends insights with a user-aliased HogQL math expression (e.g. `avg((properties.duration_seconds)/60) as avg_duration_mins`) hit this because the HogQL printer emits `ORDER BY 1` and the user's `as avg_duration_mins` becomes the inner alias the analyzer mishandles.

## Changes

- `aggregation_operations.py`: in `select_aggregation()` for `math == "hogql"`, strip the outer `ast.Alias` from the parsed user expression before wrapping with `ifNull(toFloat(...), 0)`. The outer alias was already shadowed downstream by `AS total` (in `trends_query_builder.py:411`), so removing it is a no-op for the old analyzer and unblocks the new one.
- `test_aggregation_operations.py`: new parametrized regression test asserting the expression handed to `toFloat` is not an `Alias`, covering both `as` and `AS` and a second formula shape.

## How did you test this code?

I'm an agent (Claude). I ran:

- `posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py` — 90/90 pass (including the 3 new cases).
- `posthog/hogql_queries/insights/trends/test/test_formula.py -k hogql` — 37/37 pass, 31 snapshots intact.
- `posthog/hogql_queries/insights/trends/test/test_trends.py -k 'hogql_math or math_hogql'` — 1/1 pass.
- Bisected the failing prod query against CH 25.12 via Metabase to isolate the exact trigger (table above).
- The fixed SQL was confirmed working in prod by Sam.

## Publish to changelog?

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7, 1M context).
- Investigation started from a single failing `query_id`. Confirmed via `system.query_log` that the same query shape from the same team was succeeding before the prod analyzer setting flipped (`allow_experimental_analyzer` 0 → 1 between May 21 and May 24) and failing after.
- Two earlier hypotheses were investigated and rejected: (a) a rust-py parser default flip — turned out the PR was open, not merged; (b) one of the May-22 trends-builder commits — none touched the affected code path.
- The root cause was nailed down by bisecting the failing query in prod: minimal repro is just `SELECT ... AS foo, ...) AS total FROM events ... ORDER BY 1` against the real `events` table with `allow_experimental_analyzer=1`. Removing the inner `AS foo` OR switching `ORDER BY 1` to `ORDER BY total` makes it succeed.
- This fix is the cheapest surgical change. A complementary defensive change worth considering separately: have the trends builder emit `ORDER BY total` by name instead of `ORDER BY 1` by position, which would sidestep the entire class of analyzer bug. A CH upstream issue with the minimal repro is also worth filing.