### PR TITLE
feat(slack_app): always proxy app_mention from primary to secondary

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -447,6 +447,9 @@ def resolve_slack_user(
 # The secondary region does the same Integration lookup, but if it doesn't find a match either, it stops processing.
 # We use EU as the primary region, as it's more important to EU customers that their requests don't leave the EU,
 # than to US users that their requests don't leave the US.
+# Exception: app_mention events are always proxied from primary to secondary, regardless of any
+# local coding-agent integration on the primary. The secondary region is the canonical owner of
+# coding-agent execution for Slack mentions.
 SLACK_PRIMARY_REGION_DOMAIN = "eu.posthog.com"
 SLACK_SECONDARY_REGION_DOMAIN = "us.posthog.com"
 
@@ -1319,6 +1322,14 @@ def route_posthog_code_event_to_relevant_region(
         local_match = coding_agent_integration
     else:
         local_match = any_integration
+
+    # app_mention events are unconditionally proxied from the primary region to the secondary,
+    # even when a matching coding-agent integration exists locally. The secondary region owns
+    # all coding-agent execution for mentions; the primary's only role for app_mention is to
+    # forward. On the secondary region itself, fall through to the normal local-handling path.
+    if event_type == "app_mention" and request.get_host() == SLACK_PRIMARY_REGION_DOMAIN:
+        success = proxy_slack_event_to_secondary_region(request)
+        return ROUTE_PROXIED if success else ROUTE_PROXY_FAILED
 
     if local_match and not (settings.DEBUG and request.get_host() == SLACK_PRIMARY_REGION_DOMAIN):
         if event_type == "app_mention":

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -121,7 +121,8 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api.sync_connect")
     @override_settings(DEBUG=False)
     def test_local_match_starts_temporal_workflow(self, mock_sync_connect, mock_asyncio_run, _mock_flag):
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
+        # app_mention is always proxied from the primary, so local handling lives on the secondary region.
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
 
         from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
 
@@ -131,6 +132,29 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         mock_sync_connect.assert_called_once()
         mock_sync_connect.return_value.start_workflow.assert_called_once()
         mock_asyncio_run.assert_called_once()
+
+    @patch("products.slack_app.backend.api.proxy_slack_event_to_secondary_region")
+    @patch("products.slack_app.backend.api.SLACK_PRIMARY_REGION_DOMAIN", "eu.posthog.com")
+    @patch("products.slack_app.backend.api.asyncio.run")
+    @patch("products.slack_app.backend.api.sync_connect")
+    @override_settings(DEBUG=False)
+    def test_app_mention_always_proxies_from_primary_even_with_local_coding_agent(
+        self, mock_sync_connect, mock_asyncio_run, mock_proxy
+    ):
+        # Even when the primary region has a fully configured coding-agent integration,
+        # app_mention must be proxied to the secondary region — the secondary is the canonical
+        # owner of mention execution.
+        mock_proxy.return_value = True
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
+
+        from products.slack_app.backend.api import ROUTE_PROXIED, route_posthog_code_event_to_relevant_region
+
+        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
+
+        assert result == ROUTE_PROXIED
+        mock_proxy.assert_called_once_with(request)
+        mock_sync_connect.assert_not_called()
+        mock_asyncio_run.assert_not_called()
 
     @parameterized.expand(
         [
@@ -180,7 +204,8 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         _mock_flag,
         mock_get_repos,
     ):
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
+        # app_mention local handling now lives on the secondary region — the primary always proxies.
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
         mock_get_repos.return_value = repo_list
         # The route runs _missing_posthog_code_slack_scopes against a real SlackIntegration
         # before the picker / workflow path. Since SlackIntegration is mocked wholesale here,
@@ -250,7 +275,8 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api.sync_connect")
     @override_settings(DEBUG=False)
     def test_local_match_flag_off_skips_workflow(self, mock_sync_connect, mock_asyncio_run, _mock_flag):
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
+        # Flag check runs on the secondary region (where app_mention is handled locally).
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
 
         from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
 
@@ -443,7 +469,8 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
                 message_ts="1234.7777",
             )
 
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
+        # Scope check runs on the secondary region (where app_mention is handled locally).
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
         event = {
             "type": "app_mention",
             "channel": "C001",


### PR DESCRIPTION
## Problem

Restores the behavior previously merged in #59601, which a later refactor (separating `slack` notifications installs from `slack-posthog-code` coding-agent installs) partially undid for workspaces that have a coding-agent integration in the primary region (EU). With the current code, those `app_mention` events get handled locally on EU instead of being proxied to US, where the coding agent actually executes.

## Changes

- For `app_mention` events on the primary region, always proxy to the secondary, bypassing the local coding-agent integration short-circuit.
- Other event types (`link_shared`, etc.) keep the existing local-first routing.
- On the secondary region, `app_mention` still handles locally as before.

## How did you test this code?

Agent-authored. Automated tests only:

- `hogli test products/slack_app/backend/tests/test_posthog_code_event_handler.py` — 24/24 pass
- Added `test_app_mention_always_proxies_from_primary_even_with_local_coding_agent` to lock the behavior.
- Moved existing local-handling assertions for `app_mention` from `eu.posthog.com` to `us.posthog.com` since local handling now only ever happens on the secondary.

No manual testing.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code agent. Same intent as #59601 — keep coding-agent execution on the secondary region. After confirming with the user that #59601 covers the same logic, I'm reinstating the force-proxy path that the later kind-split refactor effectively removed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*