### PR TITLE
fix(billing): revert usage report billing user

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -34,7 +34,6 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.batch_exports.models import BatchExport, BatchExportDestination, BatchExportRun
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.client.connection import ClickHouseUser
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.cloud_utils import TEST_clear_instance_license_cache
 from posthog.hogql_queries.events_query_runner import EventsQueryRunner
@@ -4381,17 +4380,13 @@ class TestQuerySplitting(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, Test
 
         # First call should use the first half of the time range
         first_call_args = mock_sync_execute.call_args_list[0][0]
-        first_call_kwargs = mock_sync_execute.call_args_list[0].kwargs
         self.assertEqual(first_call_args[1]["begin"], self.begin)
-        self.assertEqual(first_call_kwargs["ch_user"], ClickHouseUser.BILLING)
         mid_point = self.begin + (self.end - self.begin) / 2
         self.assertEqual(first_call_args[1]["end"], mid_point)
 
         # Second call should use the second half of the time range
         second_call_args = mock_sync_execute.call_args_list[1][0]
-        second_call_kwargs = mock_sync_execute.call_args_list[1].kwargs
         self.assertEqual(second_call_args[1]["begin"], mid_point)
-        self.assertEqual(second_call_kwargs["ch_user"], ClickHouseUser.BILLING)
         self.assertEqual(second_call_args[1]["end"], self.end)
 
         # Result should combine both splits (5 + 5 = 10)

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -27,7 +27,7 @@ from posthog.schema import AIEventType
 from posthog import version_requirement
 from posthog.batch_exports.models import BatchExportDestination, BatchExportRun
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.client.connection import ClickHouseUser, Workload
+from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.constants import FlagRequestType
@@ -476,7 +476,6 @@ def _execute_split_query(
             split_params,
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
         all_results.append(split_result)
@@ -605,7 +604,6 @@ def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datet
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -747,7 +745,6 @@ def get_teams_with_recording_count_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -784,7 +781,6 @@ def get_teams_with_zero_duration_recording_count_in_period(begin: datetime, end:
             {"previous_begin": previous_begin, "begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -822,7 +818,6 @@ def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, en
             {"previous_begin": previous_begin, "begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -857,7 +852,6 @@ def get_teams_with_api_queries_metrics(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
     result_count: list[tuple[int, int]] = []
     result_read_bytes: list[tuple[int, int]] = []
@@ -906,7 +900,6 @@ def get_teams_with_query_metric(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -939,7 +932,6 @@ def get_teams_with_feature_flag_requests_count_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -981,7 +973,6 @@ def get_teams_with_feature_flag_requests_sdk_breakdown_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1037,7 +1028,6 @@ def get_teams_with_survey_responses_count_in_period(
             params,
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1058,7 +1048,6 @@ def get_teams_with_ai_event_count_in_period(
             {"begin": begin, "end": end, "ai_events": AI_EVENTS},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1235,7 +1224,6 @@ def get_teams_with_ai_credits_used_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
     return results
@@ -1429,7 +1417,6 @@ def get_teams_with_exceptions_captured_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
     library_totals: dict[str, list[list[int]]] = {
@@ -1473,7 +1460,6 @@ def get_teams_with_hog_function_calls_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1494,7 +1480,6 @@ def get_teams_with_hog_function_fetch_calls_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1515,7 +1500,6 @@ def get_teams_with_cdp_billable_invocations_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1562,7 +1546,6 @@ def get_teams_with_recording_bytes_in_period(
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1611,7 +1594,6 @@ def get_teams_with_workflow_emails_sent_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1632,7 +1614,6 @@ def get_teams_with_workflow_push_sent_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1653,7 +1634,6 @@ def get_teams_with_workflow_sms_sent_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1674,7 +1654,6 @@ def get_teams_with_workflow_billable_invocations_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1695,7 +1674,6 @@ def get_teams_with_logs_bytes_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 
@@ -1716,7 +1694,6 @@ def get_teams_with_logs_records_in_period(
             {"begin": begin, "end": end},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
-            ch_user=ClickHouseUser.BILLING,
         )
 
 


### PR DESCRIPTION
This reverts commit 19bbb90e6306db8b522d6b2edd82bffcd6ee3f24 of https://github.com/PostHog/posthog/pull/60019

Ran into trouble sending the `max_query_size` default in the `usage_report.py`:
```
Traceback (most recent call last):
  File "/code/posthog/clickhouse/client/execute.py", line 444, in sync_execute
    result = client.execute(
             ^^^^^^^^^^^^^^^
  File "/python-runtime/lib/python3.12/site-packages/clickhouse_driver/client.py", line 382, in execute
    rv = self.process_ordinary_query(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python-runtime/lib/python3.12/site-packages/clickhouse_driver/client.py", line 580, in process_ordinary_query
    return self.receive_result(with_column_types=with_column_types,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python-runtime/lib/python3.12/site-packages/clickhouse_driver/client.py", line 212, in receive_result
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/python-runtime/lib/python3.12/site-packages/clickhouse_driver/result.py", line 50, in get_result
    for packet in self.packet_generator:
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/python-runtime/lib/python3.12/site-packages/clickhouse_driver/client.py", line 228, in packet_generator
    packet = self.receive_packet()
             ^^^^^^^^^^^^^^^^^^^^^
  File "/python-runtime/lib/python3.12/site-packages/clickhouse_driver/client.py", line 245, in receive_packet
    raise packet.exception
clickhouse_driver.errors.ServerException: Code: 164.
DB::Exception: Cannot modify 'max_query_size' setting in readonly mode.
```

