### PR TITLE
feat(replay): unify add-to-collection menu into searchable modal

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3662,6 +3662,22 @@ snapshots:
         hash: v1.k794b7964.b0ef436291d127e0454ce74a02c768d1f118f7e32d17271d885ac42c975b46ee.IASwEqjMsp__Bo1Cap9WhhtInKGDq9XISu718YwO9II
     queries-webvitalspathbreakdown--web-vitals-path-breakdown--light:
         hash: v1.k794b7964.fd0ba51aa1e7fbc6df4564bcd53037862f0ac3aee503d2af8f4cca02c170edeb.k1sR9J1GXAgy8FchVJl3jdoRKkrnFuQlHKcP2Ek6mxw
+    replay-components-addtocollectionmodal--no-collections--dark:
+        hash: v1.k794b7964.be350fe6aa74b0b9cdb467708414213566448645662aa3eca28251d3796c5eff.URL0tvmIpsx9nLEXq9MaSZ1B-v68PGI_G99VYirxRvs
+    replay-components-addtocollectionmodal--no-collections--light:
+        hash: v1.k794b7964.c61450bf864b98eb16ff8f5d6765be6c40a86c239e081501003ec17a58e05159.hCE3KBEBwDkIh_037ZwPUdbBm6etpE2HecM0RvG203s
+    replay-components-addtocollectionmodal--no-search-entered--dark:
+        hash: v1.k794b7964.5f19fd40ae16655602e99a0f0053060f1bdc9f51f8f4edd129fcd795b882695e.nkJZMbzynKWiNtEN_qaAqyDCUpcPAjSJOKlNOFXgtn0
+    replay-components-addtocollectionmodal--no-search-entered--light:
+        hash: v1.k794b7964.f4d7bf2be105b65e6b53fbc802c82e12b6c94c8d87d48a8571bc3e97229b78dd.0SyzhSS8dDO433IwKIZPPZ5RILDJJnrtY-OnBlVJDZk
+    replay-components-addtocollectionmodal--search-with-no-results--dark:
+        hash: v1.k794b7964.9889d29aa66b6f9cc3c84cceb02eae55d45c72b331112f8fd926ab146e48346d.JX4kJzbEuFzbfzcGzhj6nMI1punSsxD2p7TXA290D08
+    replay-components-addtocollectionmodal--search-with-no-results--light:
+        hash: v1.k794b7964.dd87bc7b6c2bd55b902a5008f8caa9f131bd7d8602f84ca0ebd994f52413c814.mzmTQgic4NfHeL4TpE6hyJ_aCXRmV9lAVXVDId6PZis
+    replay-components-addtocollectionmodal--search-with-results--dark:
+        hash: v1.k794b7964.7cc4bc6c2e8a05bb54170d166124bc22170a7595c9e72032efe1f072a63414b1.BXYNUohIX2ABzXQ9zhGudMLv7FqEfl0mDLYljl4WKAs
+    replay-components-addtocollectionmodal--search-with-results--light:
+        hash: v1.k794b7964.60b1c221559414716ed423b756e5ef3599e09d25a71e3f814ff323302f077db9.zCZPmWYs4cKjSwtjF2JlSeajtffRCncoa6PLCaZGdrY
     replay-components-comment-modal--default--dark:
         hash: v1.k794b7964.8dc0dd1d81258c518aae25f6dfbd810511af510732eaa156ce7b8b3640ec4db7.NpbN1GlhsLXxUscMwxPvR43xSKA4-Su4iM2tD13JeBc
     replay-components-comment-modal--default--light:
@@ -4719,7 +4735,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
+        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.gaL7vRk-pWoOUkiPi-NGCd1W72x-M5l9jk5Qu-UcjwI
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
@@ -4731,7 +4747,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--superwide--light:
         hash: v1.k794b7964.c95c5a49f7a20b7fcb1041dd26c73ee87c9a906cb229247a44fd4633bbdc9173.StrJ2VBA5acLqvnsiO2CS_o6qadxeaeO6ST8lxf5UdI
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
-        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.URrKOLP9uUjbKWcui2yOA7hm_JsXsbkAlOcWJshoQrI
+        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
     scenes-app-insights-funnels--funnel-time-to-convert--dark:

--- a/frontend/src/scenes/session-recordings/playlist/AddToCollectionModal.stories.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/AddToCollectionModal.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { BindLogic, useActions } from 'kea'
+import { useEffect } from 'react'
+
+import { useStorybookMocks } from '~/mocks/browser'
+import { SavedSessionRecordingPlaylistsResult } from '~/types'
+
+import { recordingPlaylists } from '../__mocks__/recording_playlists'
+import { sessionRecordingsPlaylistLogic } from './sessionRecordingsPlaylistLogic'
+import { AddToCollectionModal } from './SessionRecordingsPlaylistSettings'
+
+const emptyPlaylists: SavedSessionRecordingPlaylistsResult = {
+    count: 0,
+    next: null,
+    previous: null,
+    results: [],
+}
+
+const filterPlaylistsBySearch = (search: string | null): SavedSessionRecordingPlaylistsResult => {
+    if (!search) {
+        return recordingPlaylists
+    }
+    const term = search.toLowerCase()
+    const results = recordingPlaylists.results.filter((p) =>
+        (p.name || p.derived_name || '').toLowerCase().includes(term)
+    )
+    return { ...recordingPlaylists, count: results.length, results }
+}
+
+const StoryWrapper = ({ initialSearch }: { initialSearch?: string }): JSX.Element => {
+    const { setIsAddToCollectionModalOpen, setAddToCollectionSearch, setSelectedRecordingsIds } =
+        useActions(sessionRecordingsPlaylistLogic)
+
+    useEffect(() => {
+        setSelectedRecordingsIds(['rec-1', 'rec-2', 'rec-3'])
+        setIsAddToCollectionModalOpen(true)
+        if (initialSearch) {
+            setAddToCollectionSearch(initialSearch)
+        }
+    }, []) // oxlint-disable-line react-hooks/exhaustive-deps
+
+    return (
+        <div className="p-4 min-h-[600px]">
+            <AddToCollectionModal />
+            <div className="text-secondary text-xs">
+                The modal renders into a portal. Inspect the page to see the dialog.
+            </div>
+        </div>
+    )
+}
+
+const meta: Meta<typeof AddToCollectionModal> = {
+    title: 'Replay/Components/AddToCollectionModal',
+    component: AddToCollectionModal,
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2023-07-04',
+        testOptions: {
+            viewport: { width: 800, height: 720 },
+        },
+    },
+    decorators: [
+        (Story) => (
+            <BindLogic logic={sessionRecordingsPlaylistLogic} props={{ logicKey: 'storybook', onlyPinned: true }}>
+                <Story />
+            </BindLogic>
+        ),
+    ],
+}
+export default meta
+
+type Story = StoryObj<typeof AddToCollectionModal>
+
+export const NoSearchEntered: Story = {
+    render: () => {
+        useStorybookMocks({
+            get: {
+                '/api/projects/:team_id/session_recording_playlists': (req, res, ctx) => {
+                    const search = req.url.searchParams.get('search')
+                    return res(ctx.json(filterPlaylistsBySearch(search)))
+                },
+            },
+        })
+        return <StoryWrapper />
+    },
+}
+
+export const SearchWithResults: Story = {
+    render: () => {
+        useStorybookMocks({
+            get: {
+                '/api/projects/:team_id/session_recording_playlists': (req, res, ctx) => {
+                    const search = req.url.searchParams.get('search')
+                    return res(ctx.json(filterPlaylistsBySearch(search)))
+                },
+            },
+        })
+        return <StoryWrapper initialSearch="nightly" />
+    },
+}
+
+export const SearchWithNoResults: Story = {
+    render: () => {
+        useStorybookMocks({
+            get: {
+                '/api/projects/:team_id/session_recording_playlists': (_req, res, ctx) => res(ctx.json(emptyPlaylists)),
+            },
+        })
+        return <StoryWrapper initialSearch="no-match-for-this-term" />
+    },
+}
+
+export const NoCollections: Story = {
+    render: () => {
+        useStorybookMocks({
+            get: {
+                '/api/projects/:team_id/session_recording_playlists': (_req, res, ctx) => res(ctx.json(emptyPlaylists)),
+            },
+        })
+        return <StoryWrapper />
+    },
+}

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -1,8 +1,9 @@
 import { useActions, useValues } from 'kea'
 
-import { IconEllipsis, IconSort, IconTrash } from '@posthog/icons'
+import { IconEllipsis, IconPlus, IconSort, IconTrash } from '@posthog/icons'
 import { LemonBadge, LemonButton, LemonCheckbox, LemonInput, LemonModal, Spinner } from '@posthog/lemon-ui'
 
+import { dayjs } from 'lib/dayjs'
 import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { sessionRecordingCollectionsLogic } from 'scenes/session-recordings/collections/sessionRecordingCollectionsLogic'
@@ -190,50 +191,145 @@ function ConfirmDeleteRecordings({ shortId }: { shortId?: string }): JSX.Element
     )
 }
 
-function NewCollectionModal(): JSX.Element {
-    const { isNewCollectionDialogOpen, selectedRecordingsIds, newCollectionName } =
-        useValues(sessionRecordingsPlaylistLogic)
-    const { setIsNewCollectionDialogOpen, setNewCollectionName, handleCreateNewCollectionBulkAdd } =
-        useActions(sessionRecordingsPlaylistLogic)
+function AddToCollectionModal({ shortId }: { shortId?: string }): JSX.Element {
+    const {
+        isAddToCollectionModalOpen,
+        selectedRecordingsIds,
+        addToCollectionSearch,
+        collectionsForBulkAdd,
+        collectionsForBulkAddLoading,
+        isCreatingNewCollectionInModal,
+        newCollectionName,
+    } = useValues(sessionRecordingsPlaylistLogic)
+    const {
+        setIsAddToCollectionModalOpen,
+        setAddToCollectionSearch,
+        setIsCreatingNewCollectionInModal,
+        setNewCollectionName,
+        handleBulkAddToPlaylist,
+        handleCreateNewCollectionBulkAdd,
+    } = useActions(sessionRecordingsPlaylistLogic)
     const { loadPlaylists } = useActions(sessionRecordingCollectionsLogic)
 
+    const accessControlDisabledReason = getAccessControlDisabledReason(
+        AccessControlResourceType.SessionRecording,
+        AccessControlLevel.Editor
+    )
+
     const handleClose = (): void => {
-        setIsNewCollectionDialogOpen(false)
-        setNewCollectionName('')
+        setIsAddToCollectionModalOpen(false)
     }
 
+    const recordingCountSuffix = `${selectedRecordingsIds.length} recording${
+        selectedRecordingsIds.length > 1 ? 's' : ''
+    }`
+
+    const collections = (collectionsForBulkAdd?.results ?? []).filter((p) => (shortId ? p.short_id !== shortId : true))
+
     return (
-        <LemonModal isOpen={isNewCollectionDialogOpen} onClose={handleClose} title="Create collection" maxWidth="500px">
-            <div className="space-y-4">
-                <p>
-                    Collections help you organize and save recordings for later analysis. This will create a new
-                    collection with the {selectedRecordingsIds.length} selected recording
-                    {selectedRecordingsIds.length > 1 ? 's' : ''}.
-                </p>
-                <div className="space-y-2">
-                    <label className="text-sm font-medium">Collection name</label>
+        <LemonModal
+            isOpen={isAddToCollectionModalOpen}
+            onClose={handleClose}
+            title={isCreatingNewCollectionInModal ? 'Create collection' : 'Add to collection'}
+            maxWidth="500px"
+        >
+            {!isCreatingNewCollectionInModal ? (
+                <div className="space-y-3">
+                    <p className="mb-0 text-secondary">Add {recordingCountSuffix} to an existing collection.</p>
                     <LemonInput
-                        value={newCollectionName}
-                        onChange={setNewCollectionName}
-                        placeholder="e.g., Bug reports, User onboarding, Feature usage"
-                        className="w-full"
+                        type="search"
+                        placeholder="Search collections"
+                        value={addToCollectionSearch}
+                        onChange={setAddToCollectionSearch}
+                        fullWidth
                         autoFocus
                     />
+                    <div className="border border-primary rounded overflow-hidden">
+                        <div className="max-h-80 overflow-y-auto">
+                            {collectionsForBulkAddLoading ? (
+                                <div className="p-4 text-center">
+                                    <Spinner textColored />
+                                </div>
+                            ) : collections.length === 0 ? (
+                                <div className="p-4 text-center text-secondary">
+                                    {addToCollectionSearch ? 'No collections match your search' : 'No collections yet'}
+                                </div>
+                            ) : (
+                                <ul className="m-0 p-0 list-none">
+                                    {collections.map((playlist) => (
+                                        <li key={playlist.short_id}>
+                                            <LemonButton
+                                                fullWidth
+                                                size="small"
+                                                disabledReason={accessControlDisabledReason}
+                                                onClick={() => {
+                                                    handleBulkAddToPlaylist(playlist.short_id)
+                                                    handleClose()
+                                                }}
+                                                data-attr="add-to-existing-collection-item"
+                                            >
+                                                <div className="flex flex-col items-start w-full">
+                                                    <span className="truncate w-full">
+                                                        {playlist.name || playlist.derived_name || 'Unnamed'}
+                                                    </span>
+                                                    {playlist.last_modified_at ? (
+                                                        <span className="text-xs text-secondary">
+                                                            Updated {dayjs(playlist.last_modified_at).fromNow()}
+                                                        </span>
+                                                    ) : null}
+                                                </div>
+                                            </LemonButton>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+                    </div>
+                    <div className="flex justify-between items-center gap-2 mt-2">
+                        <LemonButton
+                            type="secondary"
+                            icon={<IconPlus />}
+                            onClick={() => setIsCreatingNewCollectionInModal(true)}
+                            disabledReason={accessControlDisabledReason}
+                            data-attr="add-to-new-collection"
+                        >
+                            New collection
+                        </LemonButton>
+                        <LemonButton type="secondary" onClick={handleClose}>
+                            Cancel
+                        </LemonButton>
+                    </div>
                 </div>
-            </div>
-
-            <div className="flex justify-end gap-2 mt-8">
-                <LemonButton type="secondary" onClick={handleClose}>
-                    Cancel
-                </LemonButton>
-                <LemonButton
-                    type="primary"
-                    disabledReason={newCollectionName.length === 0 ? 'Collection name is required' : undefined}
-                    onClick={() => handleCreateNewCollectionBulkAdd(loadPlaylists)}
-                >
-                    Create collection
-                </LemonButton>
-            </div>
+            ) : (
+                <div className="space-y-4">
+                    <p>
+                        Collections help you organize and save recordings for later analysis. This will create a new
+                        collection with the {recordingCountSuffix}.
+                    </p>
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Collection name</label>
+                        <LemonInput
+                            value={newCollectionName}
+                            onChange={setNewCollectionName}
+                            placeholder="e.g., Bug reports, User onboarding, Feature usage"
+                            className="w-full"
+                            autoFocus
+                        />
+                    </div>
+                    <div className="flex justify-end gap-2 mt-8">
+                        <LemonButton type="secondary" onClick={() => setIsCreatingNewCollectionInModal(false)}>
+                            Back
+                        </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            disabledReason={newCollectionName.length === 0 ? 'Collection name is required' : undefined}
+                            onClick={() => handleCreateNewCollectionBulkAdd(loadPlaylists)}
+                        >
+                            Create collection
+                        </LemonButton>
+                    </div>
+                </div>
+            )}
         </LemonModal>
     )
 }
@@ -251,18 +347,16 @@ export function SessionRecordingsPlaylistTopSettings({
 }): JSX.Element {
     const { autoplayDirection } = useValues(playerSettingsLogic)
     const { setAutoplayDirection } = useActions(playerSettingsLogic)
-    const { playlists, playlistsLoading } = useValues(sessionRecordingCollectionsLogic)
     const {
         selectedRecordingsIds,
         otherRecordings,
         visiblePinnedRecordings: pinnedRecordings,
     } = useValues(sessionRecordingsPlaylistLogic)
     const {
-        handleBulkAddToPlaylist,
         handleBulkDeleteFromPlaylist,
         handleSelectUnselectAll,
         setIsDeleteSelectedRecordingsDialogOpen,
-        setIsNewCollectionDialogOpen,
+        setIsAddToCollectionModalOpen,
         handleBulkMarkAsViewed,
         handleBulkMarkAsNotViewed,
     } = useActions(sessionRecordingsPlaylistLogic)
@@ -278,34 +372,12 @@ export function SessionRecordingsPlaylistTopSettings({
     const getActionsMenuItems = (): LemonMenuItem[] => {
         const menuItems: LemonMenuItem[] = [
             {
-                label: 'Add to new collection...',
-                onClick: () => setIsNewCollectionDialogOpen(true),
-                'data-attr': 'add-to-new-collection',
+                label: 'Add to collection...',
+                onClick: () => setIsAddToCollectionModalOpen(true),
+                'data-attr': 'add-to-collection',
                 disabledReason: accessControlDisabledReason,
             },
         ]
-
-        const collections =
-            type === 'collection' && shortId
-                ? playlists.results.filter((playlist) => playlist.short_id !== shortId)
-                : playlists.results
-
-        menuItems.push({
-            label: 'Add to collection',
-            items: playlistsLoading
-                ? [
-                      {
-                          label: <Spinner textColored={true} />,
-                          onClick: () => {},
-                      },
-                  ]
-                : collections.map((playlist) => ({
-                      label: <span className="truncate">{playlist.name || playlist.derived_name || 'Unnamed'}</span>,
-                      onClick: () => handleBulkAddToPlaylist(playlist.short_id),
-                  })),
-            disabledReason: collections.length === 0 ? 'There are no collections' : accessControlDisabledReason,
-            'data-attr': 'add-to-collection',
-        })
 
         if (type === 'collection' && shortId) {
             menuItems.push({
@@ -405,7 +477,7 @@ export function SessionRecordingsPlaylistTopSettings({
                 />
             </div>
             <ConfirmDeleteRecordings shortId={shortId} />
-            <NewCollectionModal />
+            <AddToCollectionModal shortId={shortId} />
         </SettingsBar>
     )
 }

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -191,7 +191,7 @@ function ConfirmDeleteRecordings({ shortId }: { shortId?: string }): JSX.Element
     )
 }
 
-function AddToCollectionModal({ shortId }: { shortId?: string }): JSX.Element {
+export function AddToCollectionModal({ shortId }: { shortId?: string }): JSX.Element {
     const {
         isAddToCollectionModalOpen,
         selectedRecordingsIds,

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -25,7 +25,7 @@ import {
 } from 'lib/components/UniversalFilters/utils'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { isString, objectClean, objectsEqual } from 'lib/utils'
+import { isString, objectClean, objectsEqual, toParams } from 'lib/utils'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { createPlaylist } from 'scenes/session-recordings/playlist/playlistUtils'
 import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
@@ -51,6 +51,7 @@ import {
     PropertyOperator,
     RecordingDurationFilter,
     RecordingUniversalFilters,
+    SavedSessionRecordingPlaylistsResult,
     SessionRecordingId,
     SessionRecordingType,
     UniversalFilterValue,
@@ -607,7 +608,11 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         }),
         setDeleteConfirmationText: (deleteConfirmationText: string) => ({ deleteConfirmationText }),
         handleDeleteSelectedRecordings: (shortId?: string) => ({ shortId }),
-        setIsNewCollectionDialogOpen: (isNewCollectionDialogOpen: boolean) => ({ isNewCollectionDialogOpen }),
+        setIsAddToCollectionModalOpen: (isAddToCollectionModalOpen: boolean) => ({ isAddToCollectionModalOpen }),
+        setAddToCollectionSearch: (addToCollectionSearch: string) => ({ addToCollectionSearch }),
+        setIsCreatingNewCollectionInModal: (isCreatingNewCollectionInModal: boolean) => ({
+            isCreatingNewCollectionInModal,
+        }),
         setNewCollectionName: (newCollectionName: string) => ({ newCollectionName }),
         handleCreateNewCollectionBulkAdd: (onSuccess: () => void) => ({ onSuccess }),
         handleBulkMarkAsViewed: (shortId?: string) => ({ shortId }),
@@ -716,6 +721,24 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                         order: params.order,
                         order_direction: params.order_direction,
                     }
+                },
+            },
+        ],
+        collectionsForBulkAdd: [
+            { results: [], count: 0 } as SavedSessionRecordingPlaylistsResult,
+            {
+                loadCollectionsForBulkAdd: async (_, breakpoint) => {
+                    await breakpoint(300)
+                    const response = await api.recordings.listPlaylists(
+                        toParams({
+                            limit: 30,
+                            order: '-last_modified_at',
+                            type: 'collection',
+                            search: values.addToCollectionSearch || undefined,
+                        })
+                    )
+                    breakpoint()
+                    return response
                 },
             },
         ],
@@ -885,16 +908,34 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                 setDeleteConfirmationText: (_, { deleteConfirmationText }) => deleteConfirmationText,
             },
         ],
-        isNewCollectionDialogOpen: [
+        isAddToCollectionModalOpen: [
             false,
             {
-                setIsNewCollectionDialogOpen: (_, { isNewCollectionDialogOpen }) => isNewCollectionDialogOpen,
+                setIsAddToCollectionModalOpen: (_, { isAddToCollectionModalOpen }) => isAddToCollectionModalOpen,
+            },
+        ],
+        addToCollectionSearch: [
+            '',
+            {
+                setAddToCollectionSearch: (_, { addToCollectionSearch }) => addToCollectionSearch,
+                setIsAddToCollectionModalOpen: () => '',
+            },
+        ],
+        isCreatingNewCollectionInModal: [
+            false,
+            {
+                setIsCreatingNewCollectionInModal: (_, { isCreatingNewCollectionInModal }) =>
+                    isCreatingNewCollectionInModal,
+                setIsAddToCollectionModalOpen: () => false,
             },
         ],
         newCollectionName: [
             '',
             {
                 setNewCollectionName: (_, { newCollectionName }) => newCollectionName,
+                setIsAddToCollectionModalOpen: () => '',
+                setIsCreatingNewCollectionInModal: (state, { isCreatingNewCollectionInModal }) =>
+                    isCreatingNewCollectionInModal ? state : '',
             },
         ],
     })),
@@ -1233,10 +1274,17 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
 
             if (newPlaylist) {
                 actions.handleBulkAddToPlaylist(newPlaylist.short_id)
-                actions.setIsNewCollectionDialogOpen(false)
-                actions.setNewCollectionName('')
+                actions.setIsAddToCollectionModalOpen(false)
                 onSuccess()
             }
+        },
+        setIsAddToCollectionModalOpen: ({ isAddToCollectionModalOpen }) => {
+            if (isAddToCollectionModalOpen) {
+                actions.loadCollectionsForBulkAdd(null)
+            }
+        },
+        setAddToCollectionSearch: () => {
+            actions.loadCollectionsForBulkAdd(null)
         },
         handleBulkMarkAsViewed: async ({ shortId }: { shortId?: string }) => {
             await lemonToast.promise(

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -728,7 +728,6 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             { results: [], count: 0 } as SavedSessionRecordingPlaylistsResult,
             {
                 loadCollectionsForBulkAdd: async (_, breakpoint) => {
-                    await breakpoint(300)
                     const response = await api.recordings.listPlaylists(
                         toParams({
                             limit: 30,
@@ -1283,7 +1282,8 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                 actions.loadCollectionsForBulkAdd(null)
             }
         },
-        setAddToCollectionSearch: () => {
+        setAddToCollectionSearch: async (_, breakpoint) => {
+            await breakpoint(200)
             actions.loadCollectionsForBulkAdd(null)
         },
         handleBulkMarkAsViewed: async ({ shortId }: { shortId?: string }) => {


### PR DESCRIPTION
see papercuts https://posthog.slack.com/archives/C0ACRAMJUAG/p1779804160629989

## Problem

When users multi-select session recordings, the bulk action menu offers two related items: "Add to new collection..." (opens a modal) and "Add to collection" (a submenu listing every collection by name). The submenu has no search, no ordering hint, and renders only the first 30 results — users with many collections cannot find what they want, and the split between "new" and "existing" forces a decision before they know what's already there.

## Changes

Replaced both menu items with a single "Add to collection..." action that opens one modal:

- search input that queries the API server-side, so collections beyond the first page are reachable
- list ordered by most recently modified, with an "Updated N ago" sublabel for context
- inline "New collection" button that swaps the modal into the existing create-collection form (with a Back button)

90-day autocapture for the bulk menu (filtered by `data-attr` to exclude the unrelated single-recording pin button) shows the existing-collection submenu trigger gets ~3× the clicks of the new-collection item (2,012 vs 695 clicks; 838 vs 534 unique users), so the modal keeps both flows but defaults to the dominant one and adds the search/ordering signals users were asking for.

The modal's "New collection" button retains the `add-to-new-collection` data-attr so the prior click signal stays comparable; the menu entry that opens the modal carries `add-to-collection`.

## How did you test this code?

I'm a Claude Code agent — no manual UI testing.

Automated checks I actually ran:

- `pnpm --filter=@posthog/frontend run typegen:write` — kea types regenerate cleanly with the new actions/reducers/loader
- `tsc --noEmit` — no new TypeScript errors in either touched file (pre-existing `@posthog/quill` errors are unrelated)
- `oxlint` — clean on both files
- `oxfmt` — applied to both files

Jest could not run in this environment due to the same pre-existing missing `@posthog/quill` module, so the playlist logic test file wasn't exercised here.

## Publish to changelog?

no

## Docs update

n/a — internal UX change with no docs surface.

## 🤖 Agent context

Tools used: Claude Code with PostHog MCP (`execute-sql` against `events` for the autocapture frequency check) and the signed-commit tool.

Key decisions:

- **Did the data justify the change?** Yes. Filtering `\$autocapture` by the precise `data-attr` strings in `elements_chain` (rather than `\$el_text`, which collides with the single-recording pin button) isolated bulk-menu clicks to the SettingsMenu portal. Existing-collection submenu opens beat new-collection clicks ~3:1, so collapsing the two into one search-first modal preserves both flows without removing functionality.
- **Server-side search, isolated state.** Considered piggy-backing on `sessionRecordingCollectionsLogic.setSavedPlaylistsFilters({ search })` — rejected because that mutates the Playlists tab's filters and URL. Added a dedicated loader (`collectionsForBulkAdd`) on `sessionRecordingsPlaylistLogic` with its own debounced search so the modal doesn't bleed into other scenes.
- **Repurposed existing reducer/actions** (`isNewCollectionDialogOpen` → `isAddToCollectionModalOpen`, kept `newCollectionName` / `handleCreateNewCollectionBulkAdd`) so the create-collection path stays untouched at the API/listener level. New `isCreatingNewCollectionInModal` reducer toggles between the two views inside the modal, and all related state resets whenever the modal closes.
- **Did not adjust the single-recording `PlayerMetaLinks` "Add to collection" button** — out of scope; the data showed the multi-select menu was the friction point.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*