### PR TITLE
chore(ci): make E2E Playwright tests work again

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -511,6 +511,13 @@ jobs:
                   sqlx database create -D "$PERSONS_DATABASE_URL"
                   sqlx migrate run -D "$PERSONS_DATABASE_URL" --source rust/persons_migrations/
 
+                  # Cyclotron node DB — the plugins container runs the CDP rerun worker
+                  # (default capabilities), which requires CYCLOTRON_NODE_DATABASE_URL to point
+                  # at a real, migrated database or it throws on startup and the server exits.
+                  CYCLOTRON_NODE_DATABASE_URL="postgres://posthog:posthog@localhost:5432/cyclotron_node"
+                  sqlx database create -D "$CYCLOTRON_NODE_DATABASE_URL"
+                  sqlx migrate run -D "$CYCLOTRON_NODE_DATABASE_URL" --source rust/cyclotron-node-migrations/
+
                   python manage.py migrate_clickhouse 2>&1
                   python manage.py setup_dev
 

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -431,9 +431,10 @@ jobs:
 
             - name: Collect static files
               run: |
-                  # KLUDGE: to get the image-bitmap-data-url-worker-*.js.map files into the dist folder
-                  # KLUDGE: rrweb thinks they're alongside and the django's collectstatic fails
-                  cp frontend/node_modules/@posthog/rrweb/dist/image-bitmap-data-url-worker-*.js.map frontend/dist/ && python manage.py collectstatic --noinput
+                  # KLUDGE: posthog-js now bundles rrweb and ships image-bitmap-data-url-worker-*.js.map
+                  # KLUDGE: under its own dist; the worker references the map alongside, so copy it into
+                  # KLUDGE: dist/ or django's collectstatic fails on the missing source map
+                  cp frontend/node_modules/posthog-js/dist/image-bitmap-data-url-worker-*.js.map frontend/dist/ && python manage.py collectstatic --noinput
             - name: Create test database
               shell: bash
               run: |

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -154,6 +154,10 @@ services:
         environment:
             DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_DB_NAME:-posthog}
             PERSONS_DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_PERSONS_DB_NAME:-posthog}
+            # The plugins container runs the CDP rerun worker (default capabilities), which
+            # requires this. bin/start exports it for local dev; the value below is the default
+            # for callers (like the E2E CI job) that launch this service without bin/start.
+            CYCLOTRON_NODE_DATABASE_URL: ${CYCLOTRON_NODE_DATABASE_URL:-postgres://posthog:posthog@db:5432/cyclotron_node}
             CLICKHOUSE_DATABASE: ${CLICKHOUSE_DATABASE:-posthog}
             # CDP Redis defaults to 127.0.0.1 — must point to the Docker service
             CDP_REDIS_HOST: redis7


### PR DESCRIPTION
## Problem

The `E2E CI Playwright` workflow has been failing run-wide on every recent push to `master` (example failing master run: [run 26456128643, "Collect static files" step](https://github.com/PostHog/posthog/actions/runs/26456128643/job/77891105075)). There are two independent breakages, the second hidden behind the first:

1. **`Collect static files` dies immediately.** The step copies rrweb's `image-bitmap-data-url-worker-*.js.map` from `@posthog/rrweb/dist/`, but `posthog-js` no longer pulls a separate `@posthog/rrweb` package (it bundles rrweb), so the glob matches nothing, `cp` exits 1, and the job stops before any test runs.

2. **`Wait for node services to be ready` then times out.** With step 1 fixed, the job progresses to starting the node containers, where the `plugins` container (CDP, default capabilities) crashes on startup:
   ```
   Error: CYCLOTRON_NODE_DATABASE_URL is required for the rerun worker
   [MAIN] 💥 Exception while starting server, shutting down!
   ```
   That var is only auto-defaulted under test/dev env (`nodejs/src/cdp/config.ts`); the E2E containers run as production and neither the workflow nor docker-compose set it, so the server throws, shuts down, and never goes healthy. (The `Cannot use a pool after calling end on the pool` line in the logs is just the messy-shutdown symptom, not the cause.)

## Changes

Make the E2E job runnable again by clearing both blockers:

1. Point the `collectstatic` source-map copy at `frontend/node_modules/posthog-js/dist/`, where the map now lives.
2. Create and migrate a `cyclotron_node` database in the E2E migration step (it was never created there), and set `CYCLOTRON_NODE_DATABASE_URL` on the `plugins` service so the rerun worker has a real DB to connect to. Only `plugins` runs the rerun worker (the other node services logged zero cyclotron errors), so they are left unchanged.

## How did you test this code?

I am an agent (Claude Code), so CI is the real test bed here:

- The first push of this PR validated fix #1: the E2E run got ~12 steps past where master dies (collectstatic passed, frontend built, migrations ran, PostHog web came up), then surfaced fix #2's crash. I confirmed the `plugins` failure from the captured `docker-plugins.log` artifact.
- Diagnosis is grounded in the repo: `bin/start` exports the same `CYCLOTRON_NODE_DATABASE_URL` for local dev, the cyclotron-node migrations live in `rust/cyclotron-node-migrations/`, and `plugins` starts after the migration step (workflow comment: "Start the Node.js containers now that the database exists and migrations have run").
- I cannot run the full E2E stack locally. The E2E run triggered by this PR (it touches the workflow, which is in the workflow's own `mustRun` path filter) is the validation. Fixing these two may reveal further blockers, since E2E has not run end-to-end on master in a while.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code (Claude Opus 4.7), agent-driven. Requires human review; do not self-merge.

Found while investigating why a dependency-bump PR (#60023) had a red `Playwright E2E tests` check. That turned out to be unrelated to the deps: the workflow has been failing master-wide. Both breakages are pre-existing master bugs surfaced by removing the first one. The second is in the CDP plugin-server domain; at the maintainer's direction I fixed forward here rather than handing it off, but it touches CI/setup only (workflow + docker-compose), not plugin-server code. The deliberate `throw` in `CdpRerunWorkerConsumer` (added to stop it silently falling back to the default DB) is preserved; this PR satisfies the requirement by provisioning the DB and wiring the URL in E2E, the same way local dev does via `bin/start`.
