### PR TITLE
feat(funnels): lighten previous-period series in funnel-trends compare

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -207,9 +207,11 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
 
         merged_results = []
         for row in current_response.results or []:
+            row["compare"] = True
             row["compare_label"] = "current"
             merged_results.append(row)
         for row in previous_response.results or []:
+            row["compare"] = True
             row["compare_label"] = "previous"
             merged_results.append(row)
 

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -3435,10 +3435,12 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
 
         results = FunnelsQueryRunner(query=self._build_query(), team=self.team).calculate().results
 
-        # Frontend-facing shape: one summarized series per period, tagged with compare_label.
-        # This is the same contract STEPS and TIME_TO_CONVERT slices will reuse.
+        # Frontend-facing shape: one summarized series per period, tagged with compare/compare_label.
+        # This is the same contract STEPS and TIME_TO_CONVERT slices will reuse. The `compare: True`
+        # flag activates the shared LineGraph lighter-color path for the previous-period series.
         labels = [row.get("compare_label") for row in results]
         self.assertEqual(labels, ["current", "previous"])
+        self.assertTrue(all(row.get("compare") is True for row in results))
 
         current_series = next(r for r in results if r["compare_label"] == "current")
         previous_series = next(r for r in results if r["compare_label"] == "previous")
@@ -3480,6 +3482,7 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
 
         results = FunnelsQueryRunner(query=self._build_query(compare_to="-30d"), team=self.team).calculate().results
 
+        self.assertTrue(all(row.get("compare") is True for row in results))
         previous_series = next(r for r in results if r["compare_label"] == "previous")
         # Previous window starts 30 days before the current window's start (2021-06-07 - 30d = 2021-05-08).
         self.assertEqual(previous_series["days"][0], "2021-05-08")
@@ -3505,6 +3508,7 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
 
         labels = [row["compare_label"] for row in results]
         self.assertEqual(labels, ["current", "previous"])
+        self.assertTrue(all(row.get("compare") is True for row in results))
 
         previous_series = next(r for r in results if r["compare_label"] == "previous")
         # Skeleton intact: 7 days, no conversions.
@@ -3543,9 +3547,11 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
 
         results = FunnelsQueryRunner(query=self._build_query(), team=self.team).calculate().results
 
-        # Single-period response: one summarized series, no compare_label tagging.
+        # Single-period response: one summarized series, no compare/compare_label tagging.
+        # Mirrors how trends leaves both fields absent when compare is off.
         self.assertEqual(len(results), 1)
         self.assertNotIn("compare_label", results[0])
+        self.assertNotIn("compare", results[0])
 
     @patch("posthoganalytics.feature_enabled", return_value=True)
     def test_compare_with_all_time_date_range(self, _feature_enabled):
@@ -3569,3 +3575,4 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         labels = {row.get("compare_label") for row in results}
         # The orchestrator still emits both tags; the data may be empty / overlapping — that's expected.
         self.assertEqual(labels, {"current", "previous"})
+        self.assertTrue(all(row.get("compare") is True for row in results))


### PR DESCRIPTION
## Problem

PR #59536 added the backend foundation for "compare to previous" on funnel-trends, but the merged rows ship only `compare_label`. The shared `LineGraph` component activates its lighter-color branch when a dataset has **both** `compare: true` AND `compare_label === 'previous'` — so in production both periods were drawn at full opacity. The storybook fixture was hand-crafted with `compare: true`, which is why the visual baseline looked right while real backend traffic didn't match.

## Changes

- `funnels_query_runner._calculate_compare`: set `row["compare"] = True` alongside `row["compare_label"]` for both the current and previous loops. Mirrors what `trends_query_runner` already does.
- `TestFunnelTrendsCompareUDF`: assert `compare is True` on every tagged row in the compare-on cases, and assert that the flag-off case leaves both `compare` and `compare_label` absent (matching trends).

No frontend change needed:
- `LineGraph.tsx` — `isPrevious = !!dataset.compare && dataset.compare_label === 'previous'` already fires for any dataset with both fields.
- `funnelDataLogic.indexedSteps` spreads each row, so the new `compare` field is preserved.
- `FunnelLineGraph` passes `indexedSteps` straight to `<LineGraph>`.
- The hog-charts funnel adapter (`funnelChartTransforms`) is exported but not yet wired into the funnel UI — out of scope for this slice.

## How did you test this code?

I'm an agent (Claude). I extended the existing `TestFunnelTrendsCompareUDF` assertions to cover the new `compare` field. I did **not** run the test suite locally — this environment doesn't have a working Python/ClickHouse stack, so the ClickHouse-backed funnels tests can't execute here. CI will run them.

I did not perform manual verification in storybook or against a live dev instance.

## Publish to changelog?

no

## Docs update

No docs change needed; this is an internal data-shape alignment.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) following a written plan from a prior session. The plan was the minimum-viable fix:

- Mirror the trends compare path which sets both `compare` and `compare_label` on each merged row.
- Out of scope: the hog-charts funnel adapter (`buildFunnelLineSeries`) has no callers yet and was intentionally left alone; STEPS / TIME_TO_CONVERT viz splitter belongs to a later slice; visual-review baseline regeneration deferred unless CI flags a diff.

Stacked on `posthog-code/slice-1-funnels-trends-compare`; review the diff against that base.