### PR TITLE
fix(ci): cap frontend build heap to avoid OOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,9 @@ RUN --mount=type=cache,id=pnpm,target=/tmp/pnpm-store-v24 \
     CI=1 pnpm --filter=@posthog/frontend... install --frozen-lockfile --store-dir /tmp/pnpm-store-v24
 
 COPY frontend/ frontend/
-RUN bin/turbo --filter=@posthog/frontend build
+# Cap the V8 heap: the esbuild build also runs Tailwind/PostCSS in-process, and an
+# uncapped heap lets it grow until the Depot builder OOM-kills the build under load.
+RUN NODE_OPTIONS="--max-old-space-size=16384" bin/turbo --filter=@posthog/frontend build
 
 
 #


### PR DESCRIPTION
## Problem

The `posthog` image build on Depot has an elevated, climbing failure rate (~0–5% earlier in May rising to ~18% by 05-26), concentrated in high-build-volume hours. Failures surface in CI as `keepalive ping failed to receive ACK within timeout`, which is the symptom of the remote BuildKit builder being OOM-killed mid-build — not a network flake. The `frontend-build` stage runs `bin/turbo --filter=@posthog/frontend build` with an **uncapped V8 heap**, and since the esbuild build now also runs Tailwind/PostCSS in-process, peak memory has grown enough to exhaust the builder under load. Other Depot projects in the org were unaffected in the same windows, confirming this is specific to our build, not a platform outage.

## Changes

Set `NODE_OPTIONS="--max-old-space-size=16384"` on the `frontend-build` `RUN` in `Dockerfile`, bounding the V8 heap so the build can't grow until the builder OOMs. 16 GB matches the repo's existing convention for heavy frontend operations (`typescript:check`, `jest` in CI) and leaves headroom on the 32 GB builder for esbuild's allocations. Mirrors the cap already present on the `node-scripts-build` stage.

## How did you test this code?

I'm an agent. This is a one-line Dockerfile change; I have **not** run the container build or manually verified the OOM no longer occurs — the fix should be validated by watching the Container Images CI failure rate after merge, ideally during a high-volume window. No automated tests apply.

## Publish to changelog?

No.

## 🤖 Agent context

Authored with Claude Code.