### PR TITLE
fix(hogvm): handle BigInt values in jsonStringify

### DIFF
--- a/common/hogvm/typescript/src/__tests__/execute.test.ts
+++ b/common/hogvm/typescript/src/__tests__/execute.test.ts
@@ -1883,6 +1883,31 @@ describe('hogvm execute', () => {
         )
     })
 
+    test('jsonStringify handles BigInt values', () => {
+        // BigInt values from external data (e.g. event properties) should be
+        // converted to strings instead of throwing
+        // "TypeError: Do not know how to serialize a BigInt"
+        // Test the STL function directly since BigInt can't be expressed as bytecode opcodes
+        const { STL } = require('../stl/stl')
+        const stringify = STL.jsonStringify.fn
+
+        // BigInt primitive
+        expect(stringify([9007199254740993n])).toEqual('"9007199254740993"')
+
+        // BigInt inside an object
+        expect(stringify([{ id: 9007199254740993n, name: 'test' }])).toEqual(
+            '{"id":"9007199254740993","name":"test"}'
+        )
+
+        // BigInt inside an array
+        expect(stringify([[123n, 456n]])).toEqual('["123","456"]')
+
+        // Mixed object with BigInt and normal values
+        expect(stringify([{ count: 5n, label: 'hello', active: true }])).toEqual(
+            '{"count":"5","label":"hello","active":true}'
+        )
+    })
+
     test('can not modify globals', () => {
         const globals = { globalEvent: { event: '$pageview', properties: { $browser: 'Chrome' } } }
         expect(

--- a/common/hogvm/typescript/src/stl/stl.ts
+++ b/common/hogvm/typescript/src/stl/stl.ts
@@ -755,6 +755,9 @@ export const STL: Record<string, STLFunction> = {
                 if (!marked) {
                     marked = new Set()
                 }
+                if (typeof x === 'bigint') {
+                    return x.toString()
+                }
                 if (typeof x === 'object' && x !== null) {
                     if (marked.has(x)) {
                         return null


### PR DESCRIPTION
## Summary

Fixes #19367

`jsonStringify` in the HogVM STL threw `TypeError: Do not know how to serialize a BigInt` when event properties contained BigInt values.

**Root cause:** The `convert` function in `jsonStringify` handled Maps, Arrays, and objects but fell through to `return x` for `bigint` primitives. When `JSON.stringify` was then called with a BigInt still in the data, it threw.

**Fix:** Added a `typeof x === 'bigint'` check at the top of the `convert` function that converts BigInt to string before serialization. This matches how other parts of the codebase handle BigInt (e.g., `normalizeTraceProperties`, `KeaDevTools`).

BigInt values can originate from:
- External events ingested with large integer IDs (beyond `Number.MAX_SAFE_INTEGER`)
- UUID `valueOf()` which returns a 128-bit BigInt
- OTel/AI event trace properties

## Changes

- `common/hogvm/typescript/src/stl/stl.ts` - Added BigInt to string conversion in `jsonStringify`'s `convert` function
- `common/hogvm/typescript/src/__tests__/execute.test.ts` - Added test coverage for BigInt in objects and arrays

## Test plan

- [x] Added unit test: `jsonStringify handles BigInt values` covers BigInt in objects and arrays
- [ ] Verify existing `jsonStringify` tests still pass (`pnpm test` in `common/hogvm/typescript`)
- [ ] Manual: create a Hog function that processes an event with BigInt properties and call `jsonStringify()` on it

## Agent context

AI assistance (Claude Code) was used to explore the codebase and draft the fix. I reviewed and understand the change — the fix adds a `typeof === 'bigint'` guard in the `convert` function that converts BigInt primitives to strings before `JSON.stringify` is called, matching existing patterns elsewhere in the codebase. Tests were written but not run locally due to missing dependencies.