### PR TITLE
chore(retention): make first-time anchor entity-polymorphic

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -4,9 +4,11 @@ from abc import ABC, abstractmethod
 from functools import cached_property
 from typing import TYPE_CHECKING, Optional, cast
 
+from posthog.schema import EntityType
+
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
-from posthog.hogql.property import entity_to_expr
+from posthog.hogql.property import entity_to_expr, property_to_expr
 
 from posthog.hogql_queries.insights.retention.utils import breakdown_extract_expr
 
@@ -48,12 +50,33 @@ class RetentionBaseQueryBuilder(ABC):
     def start_entity_expr(self) -> ast.Expr:
         return self.runner.start_entity_expr
 
+    def entity_expr_no_props(self, entity: RetentionEntity) -> ast.Expr:
+        # Entity matcher with property filters stripped — used to anchor "first ever" against the unfiltered stream.
+        # For a data warehouse entity, "presence in the table" is the unfiltered stream, so the predicate is a truthy constant.
+        if entity.type == EntityType.DATA_WAREHOUSE:
+            return ast.Constant(value=True)
+        clean_entity = entity.model_copy(deep=True)
+        clean_entity.properties = []
+        return entity_to_expr(clean_entity, self.team)
+
+    def entity_expr_with_props(self, entity: RetentionEntity) -> ast.Expr:
+        # For data warehouse entities the table itself IS the type matcher, so the "with properties" predicate is
+        # just the property filter (or a truthy constant when no properties are configured).
+        if entity.type == EntityType.DATA_WAREHOUSE:
+            if entity.properties:
+                return property_to_expr(entity.properties, self.team)
+            return ast.Constant(value=True)
+        return entity_to_expr(entity, self.team)
+
+    def entity_timestamp_field(self, entity: RetentionEntity) -> ast.Expr:
+        if entity.type == EntityType.DATA_WAREHOUSE:
+            assert entity.table_name and entity.timestamp_field
+            return ast.Field(chain=[entity.table_name, entity.timestamp_field])
+        return ast.Field(chain=["events", "timestamp"])
+
     @cached_property
     def start_entity_expr_no_props(self) -> ast.Expr:
-        # Start-event matcher with property filters stripped — used to anchor "first ever" against the unfiltered stream.
-        clean_start_event = self.start_event.model_copy(deep=True)
-        clean_start_event.properties = []
-        return entity_to_expr(clean_start_event, self.team)
+        return self.entity_expr_no_props(self.start_event)
 
     @property
     def return_entity_expr(self) -> ast.Expr:
@@ -164,25 +187,33 @@ class RetentionBaseQueryBuilder(ABC):
     def events_timestamp_filter(self, field: ast.Expr | None = None) -> ast.Expr:
         return self.runner.events_timestamp_filter(field=field)
 
-    def get_first_time_anchor_expr(self) -> ast.Expr:
-        if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
-            start_entity_with_properties_expr = entity_to_expr(self.start_event, self.team)
-
-            if self.is_first_ever_occurrence:
-                # First-ever occurrence of the target event, then check filters.
-                # We find the timestamp of the first event of this type, and the first event of this type that also matches properties.
-                # If they are the same, this is the user's cohorting event.
-                min_ts_expr = parse_expr("minIf(events.timestamp, {expr})", {"expr": self.start_entity_expr_no_props})
-                min_ts_with_props_expr = parse_expr(
-                    "minIf(events.timestamp, {expr})", {"expr": start_entity_with_properties_expr}
-                )
-
-                return parse_expr(
-                    "if({min_ts} = {min_ts_with_props}, {min_ts}, NULL)",
-                    {"min_ts": min_ts_expr, "min_ts_with_props": min_ts_with_props_expr},
-                )
-            else:  # is_first_occurrence_matching_filters
-                # First occurrence of the target event that matches filters.
-                return parse_expr("minIf(events.timestamp, {expr})", {"expr": start_entity_with_properties_expr})
-        else:
+    def get_first_time_anchor_expr(self, entity: RetentionEntity) -> ast.Expr:
+        if not (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
             return ast.Constant(value=None)
+
+        timestamp_field = self.entity_timestamp_field(entity)
+        entity_with_properties_expr = self.entity_expr_with_props(entity)
+
+        if self.is_first_ever_occurrence:
+            # First-ever occurrence of the target entity, then check filters.
+            # We find the timestamp of the first row of this entity, and the first row that also matches properties.
+            # If they are the same, this is the user's cohorting event.
+            min_ts_expr = parse_expr(
+                "minIf({ts}, {expr})",
+                {"ts": timestamp_field, "expr": self.entity_expr_no_props(entity)},
+            )
+            min_ts_with_props_expr = parse_expr(
+                "minIf({ts}, {expr})",
+                {"ts": timestamp_field, "expr": entity_with_properties_expr},
+            )
+
+            return parse_expr(
+                "if({min_ts} = {min_ts_with_props}, {min_ts}, NULL)",
+                {"min_ts": min_ts_expr, "min_ts_with_props": min_ts_with_props_expr},
+            )
+
+        # is_first_occurrence_matching_filters: first occurrence of the target entity that matches filters.
+        return parse_expr(
+            "minIf({ts}, {expr})",
+            {"ts": timestamp_field, "expr": entity_with_properties_expr},
+        )

--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -70,7 +70,11 @@ class RetentionBaseQueryBuilder(ABC):
 
     def entity_timestamp_field(self, entity: RetentionEntity) -> ast.Expr:
         if entity.type == EntityType.DATA_WAREHOUSE:
-            assert entity.table_name and entity.timestamp_field
+            if not entity.table_name or not entity.timestamp_field:
+                raise ValueError(
+                    f"DATA_WAREHOUSE RetentionEntity requires table_name and timestamp_field, "
+                    f"got table_name={entity.table_name!r}, timestamp_field={entity.timestamp_field!r}"
+                )
             return ast.Field(chain=[entity.table_name, entity.timestamp_field])
         return ast.Field(chain=["events", "timestamp"])
 

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -403,7 +403,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             return_event_values = None
 
         if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
-            min_timestamp_inner_expr = self.get_first_time_anchor_expr()
+            min_timestamp_inner_expr = self.get_first_time_anchor_expr(self.start_event)
 
             start_event_timestamps = parse_expr(
                 """

--- a/posthog/hogql_queries/insights/retention/retention_base_query_rolling.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_rolling.py
@@ -22,7 +22,7 @@ class RetentionRollingIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         t0_expr: ast.Expr
         if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
-            t0_expr = self.get_first_time_anchor_expr()
+            t0_expr = self.get_first_time_anchor_expr(self.start_event)
         else:
             t0_expr = parse_expr("minIf(events.timestamp, {expr})", {"expr": self.start_entity_expr})
 

--- a/posthog/hogql_queries/insights/retention/test/test_retention_first_time_anchor.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_first_time_anchor.py
@@ -1,0 +1,167 @@
+from typing import Any
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from posthog.schema import RetentionEntity
+
+from posthog.hogql import ast
+
+from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RetentionFixedIntervalBaseQueryBuilder
+
+
+def _collect_field_chains(node: Any) -> list[list[str | int]]:
+    chains: list[list[str | int]] = []
+
+    def visit(value: Any) -> None:
+        if isinstance(value, ast.Field):
+            chains.append(value.chain)
+        if hasattr(value, "__dataclass_fields__"):
+            for field_name in value.__dataclass_fields__:
+                visit(getattr(value, field_name))
+        elif isinstance(value, list | tuple):
+            for item in value:
+                visit(item)
+
+    visit(node)
+    return chains
+
+
+def _collect_constants(node: Any) -> list[Any]:
+    consts: list[Any] = []
+
+    def visit(value: Any) -> None:
+        if isinstance(value, ast.Constant):
+            consts.append(value.value)
+        if hasattr(value, "__dataclass_fields__"):
+            for field_name in value.__dataclass_fields__:
+                visit(getattr(value, field_name))
+        elif isinstance(value, list | tuple):
+            for item in value:
+                visit(item)
+
+    visit(node)
+    return consts
+
+
+def _collect_min_if_predicates(node: Any) -> list[ast.Expr]:
+    """Collect the second argument of every `minIf(...)` call in the AST."""
+    predicates: list[ast.Expr] = []
+
+    def visit(value: Any) -> None:
+        if isinstance(value, ast.Call) and value.name == "minIf" and len(value.args) >= 2:
+            predicates.append(value.args[1])
+        if hasattr(value, "__dataclass_fields__"):
+            for field_name in value.__dataclass_fields__:
+                visit(getattr(value, field_name))
+        elif isinstance(value, list | tuple):
+            for item in value:
+                visit(item)
+
+    visit(node)
+    return predicates
+
+
+def _make_builder(
+    *,
+    start_event: RetentionEntity,
+    is_first_ever: bool = False,
+    is_first_matching: bool = False,
+) -> RetentionFixedIntervalBaseQueryBuilder:
+    """Build a RetentionFixedIntervalBaseQueryBuilder with a stubbed runner.
+
+    The helpers under test only need `team`, `start_event`, and the two first-occurrence
+    flags from the runner, so we don't need a real Django Team or a live ClickHouse stack.
+    """
+    runner = MagicMock()
+    runner.team = MagicMock(pk=1)
+    runner.start_event = start_event
+    runner.is_first_ever_occurrence = is_first_ever
+    runner.is_first_occurrence_matching_filters = is_first_matching
+    return RetentionFixedIntervalBaseQueryBuilder(runner)
+
+
+class TestFirstTimeAnchorExpr(TestCase):
+    def test_events_entity_first_ever_references_events_timestamp(self) -> None:
+        entity = RetentionEntity(id="$user_signed_up", name="$user_signed_up", type="events")
+        builder = _make_builder(start_event=entity, is_first_ever=True)
+
+        expr = builder.get_first_time_anchor_expr(entity)
+
+        chains = _collect_field_chains(expr)
+        self.assertIn(["events", "timestamp"], chains)
+
+        constants = _collect_constants(expr)
+        self.assertIn("$user_signed_up", constants)
+
+    def test_events_entity_first_time_matching_filters_uses_events_predicate(self) -> None:
+        entity = RetentionEntity(
+            id="$user_signed_up",
+            name="$user_signed_up",
+            type="events",
+            properties=[
+                {"key": "$browser", "value": "Chrome", "operator": "exact", "type": "event"},
+            ],
+        )
+        builder = _make_builder(start_event=entity, is_first_matching=True)
+
+        expr = builder.get_first_time_anchor_expr(entity)
+
+        chains = _collect_field_chains(expr)
+        self.assertIn(["events", "timestamp"], chains)
+
+        constants = _collect_constants(expr)
+        self.assertIn("$user_signed_up", constants)
+        self.assertIn("Chrome", constants)
+
+    def test_dwh_entity_with_properties_uses_property_filter_predicate(self) -> None:
+        entity = RetentionEntity(
+            type="data_warehouse",
+            table_name="warehouse_activity",
+            timestamp_field="occurred_at",
+            aggregation_target_field="person_id",
+            id="warehouse_activity",
+            name="warehouse_activity",
+            properties=[
+                {"key": "event_type", "value": "signup", "operator": "exact", "type": "data_warehouse"},
+            ],
+        )
+        builder = _make_builder(start_event=entity, is_first_matching=True)
+
+        expr = builder.get_first_time_anchor_expr(entity)
+
+        chains = _collect_field_chains(expr)
+        self.assertIn(["warehouse_activity", "occurred_at"], chains)
+        self.assertNotIn(["events", "timestamp"], chains)
+
+        # property filter value should appear in the predicate (built via property_to_expr)
+        constants = _collect_constants(expr)
+        self.assertIn("signup", constants)
+
+    def test_dwh_entity_without_properties_uses_truthy_constant_predicate(self) -> None:
+        entity = RetentionEntity(
+            type="data_warehouse",
+            table_name="warehouse_activity",
+            timestamp_field="occurred_at",
+            aggregation_target_field="person_id",
+            id="warehouse_activity",
+            name="warehouse_activity",
+            properties=[],
+        )
+        # Use first-ever so both no-props and with-props minIf predicates are surfaced.
+        builder = _make_builder(start_event=entity, is_first_ever=True)
+
+        expr = builder.get_first_time_anchor_expr(entity)
+
+        chains = _collect_field_chains(expr)
+        self.assertIn(["warehouse_activity", "occurred_at"], chains)
+        self.assertNotIn(["events", "timestamp"], chains)
+
+        # Every minIf predicate must be a truthy constant — the with-props and no-props branches
+        # both collapse to True for a DWH entity without properties.
+        # (parse_expr substitution shares nodes so the walker can see more than 2.)
+        min_if_predicates = _collect_min_if_predicates(expr)
+        self.assertGreaterEqual(len(min_if_predicates), 2)
+        for pred in min_if_predicates:
+            self.assertIsInstance(pred, ast.Constant)
+            self.assertTrue(pred.value)  # type: ignore[union-attr]

--- a/posthog/hogql_queries/insights/retention/test/test_retention_first_time_anchor.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_first_time_anchor.py
@@ -1,7 +1,10 @@
+from collections.abc import Callable
 from typing import Any
 
 from unittest import TestCase
 from unittest.mock import MagicMock
+
+from parameterized import parameterized
 
 from posthog.schema import RetentionEntity
 
@@ -10,20 +13,29 @@ from posthog.hogql import ast
 from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RetentionFixedIntervalBaseQueryBuilder
 
 
+def _walk_ast(node: Any, visit: Callable[[Any], None]) -> None:
+    """Recursively visit every value in an AST tree (dataclass fields + list/tuple items)."""
+
+    def walk(value: Any) -> None:
+        visit(value)
+        if hasattr(value, "__dataclass_fields__"):
+            for field_name in value.__dataclass_fields__:
+                walk(getattr(value, field_name))
+        elif isinstance(value, list | tuple):
+            for item in value:
+                walk(item)
+
+    walk(node)
+
+
 def _collect_field_chains(node: Any) -> list[list[str | int]]:
     chains: list[list[str | int]] = []
 
     def visit(value: Any) -> None:
         if isinstance(value, ast.Field):
             chains.append(value.chain)
-        if hasattr(value, "__dataclass_fields__"):
-            for field_name in value.__dataclass_fields__:
-                visit(getattr(value, field_name))
-        elif isinstance(value, list | tuple):
-            for item in value:
-                visit(item)
 
-    visit(node)
+    _walk_ast(node, visit)
     return chains
 
 
@@ -33,14 +45,8 @@ def _collect_constants(node: Any) -> list[Any]:
     def visit(value: Any) -> None:
         if isinstance(value, ast.Constant):
             consts.append(value.value)
-        if hasattr(value, "__dataclass_fields__"):
-            for field_name in value.__dataclass_fields__:
-                visit(getattr(value, field_name))
-        elif isinstance(value, list | tuple):
-            for item in value:
-                visit(item)
 
-    visit(node)
+    _walk_ast(node, visit)
     return consts
 
 
@@ -51,14 +57,8 @@ def _collect_min_if_predicates(node: Any) -> list[ast.Expr]:
     def visit(value: Any) -> None:
         if isinstance(value, ast.Call) and value.name == "minIf" and len(value.args) >= 2:
             predicates.append(value.args[1])
-        if hasattr(value, "__dataclass_fields__"):
-            for field_name in value.__dataclass_fields__:
-                visit(getattr(value, field_name))
-        elif isinstance(value, list | tuple):
-            for item in value:
-                visit(item)
 
-    visit(node)
+    _walk_ast(node, visit)
     return predicates
 
 
@@ -81,87 +81,119 @@ def _make_builder(
     return RetentionFixedIntervalBaseQueryBuilder(runner)
 
 
+_EVENTS_FIRST_EVER_ENTITY = RetentionEntity(id="$user_signed_up", name="$user_signed_up", type="events")
+_EVENTS_FIRST_MATCHING_ENTITY = RetentionEntity(
+    id="$user_signed_up",
+    name="$user_signed_up",
+    type="events",
+    properties=[
+        {"key": "$browser", "value": "Chrome", "operator": "exact", "type": "event"},
+    ],
+)
+_DWH_WITH_PROPS_ENTITY = RetentionEntity(
+    type="data_warehouse",
+    table_name="warehouse_activity",
+    timestamp_field="occurred_at",
+    aggregation_target_field="person_id",
+    id="warehouse_activity",
+    name="warehouse_activity",
+    properties=[
+        {"key": "event_type", "value": "signup", "operator": "exact", "type": "data_warehouse"},
+    ],
+)
+_DWH_NO_PROPS_ENTITY = RetentionEntity(
+    type="data_warehouse",
+    table_name="warehouse_activity",
+    timestamp_field="occurred_at",
+    aggregation_target_field="person_id",
+    id="warehouse_activity",
+    name="warehouse_activity",
+    properties=[],
+)
+
+
 class TestFirstTimeAnchorExpr(TestCase):
-    def test_events_entity_first_ever_references_events_timestamp(self) -> None:
-        entity = RetentionEntity(id="$user_signed_up", name="$user_signed_up", type="events")
-        builder = _make_builder(start_event=entity, is_first_ever=True)
+    @parameterized.expand(
+        [
+            (
+                "events_first_ever_references_events_timestamp",
+                _EVENTS_FIRST_EVER_ENTITY,
+                True,  # is_first_ever
+                False,  # is_first_matching
+                [["events", "timestamp"]],  # expected_chains
+                [],  # unexpected_chains
+                ["$user_signed_up"],  # expected_constants
+                False,  # assert_min_if_predicates_truthy
+            ),
+            (
+                "events_first_time_matching_filters_uses_events_predicate",
+                _EVENTS_FIRST_MATCHING_ENTITY,
+                False,
+                True,
+                [["events", "timestamp"]],
+                [],
+                ["$user_signed_up", "Chrome"],
+                False,
+            ),
+            (
+                "dwh_with_properties_uses_property_filter_predicate",
+                _DWH_WITH_PROPS_ENTITY,
+                False,
+                True,
+                [["warehouse_activity", "occurred_at"]],
+                [["events", "timestamp"]],
+                ["signup"],
+                False,
+            ),
+            (
+                # First-ever so both no-props and with-props minIf predicates are surfaced.
+                "dwh_without_properties_uses_truthy_constant_predicate",
+                _DWH_NO_PROPS_ENTITY,
+                True,
+                False,
+                [["warehouse_activity", "occurred_at"]],
+                [["events", "timestamp"]],
+                [],
+                True,
+            ),
+        ]
+    )
+    def test_get_first_time_anchor_expr(
+        self,
+        _name: str,
+        entity: RetentionEntity,
+        is_first_ever: bool,
+        is_first_matching: bool,
+        expected_chains: list[list[str | int]],
+        unexpected_chains: list[list[str | int]],
+        expected_constants: list[Any],
+        assert_min_if_predicates_truthy: bool,
+    ) -> None:
+        builder = _make_builder(
+            start_event=entity,
+            is_first_ever=is_first_ever,
+            is_first_matching=is_first_matching,
+        )
 
         expr = builder.get_first_time_anchor_expr(entity)
 
         chains = _collect_field_chains(expr)
-        self.assertIn(["events", "timestamp"], chains)
+        for chain in expected_chains:
+            self.assertIn(chain, chains)
+        for chain in unexpected_chains:
+            self.assertNotIn(chain, chains)
 
         constants = _collect_constants(expr)
-        self.assertIn("$user_signed_up", constants)
+        for constant in expected_constants:
+            self.assertIn(constant, constants)
 
-    def test_events_entity_first_time_matching_filters_uses_events_predicate(self) -> None:
-        entity = RetentionEntity(
-            id="$user_signed_up",
-            name="$user_signed_up",
-            type="events",
-            properties=[
-                {"key": "$browser", "value": "Chrome", "operator": "exact", "type": "event"},
-            ],
-        )
-        builder = _make_builder(start_event=entity, is_first_matching=True)
-
-        expr = builder.get_first_time_anchor_expr(entity)
-
-        chains = _collect_field_chains(expr)
-        self.assertIn(["events", "timestamp"], chains)
-
-        constants = _collect_constants(expr)
-        self.assertIn("$user_signed_up", constants)
-        self.assertIn("Chrome", constants)
-
-    def test_dwh_entity_with_properties_uses_property_filter_predicate(self) -> None:
-        entity = RetentionEntity(
-            type="data_warehouse",
-            table_name="warehouse_activity",
-            timestamp_field="occurred_at",
-            aggregation_target_field="person_id",
-            id="warehouse_activity",
-            name="warehouse_activity",
-            properties=[
-                {"key": "event_type", "value": "signup", "operator": "exact", "type": "data_warehouse"},
-            ],
-        )
-        builder = _make_builder(start_event=entity, is_first_matching=True)
-
-        expr = builder.get_first_time_anchor_expr(entity)
-
-        chains = _collect_field_chains(expr)
-        self.assertIn(["warehouse_activity", "occurred_at"], chains)
-        self.assertNotIn(["events", "timestamp"], chains)
-
-        # property filter value should appear in the predicate (built via property_to_expr)
-        constants = _collect_constants(expr)
-        self.assertIn("signup", constants)
-
-    def test_dwh_entity_without_properties_uses_truthy_constant_predicate(self) -> None:
-        entity = RetentionEntity(
-            type="data_warehouse",
-            table_name="warehouse_activity",
-            timestamp_field="occurred_at",
-            aggregation_target_field="person_id",
-            id="warehouse_activity",
-            name="warehouse_activity",
-            properties=[],
-        )
-        # Use first-ever so both no-props and with-props minIf predicates are surfaced.
-        builder = _make_builder(start_event=entity, is_first_ever=True)
-
-        expr = builder.get_first_time_anchor_expr(entity)
-
-        chains = _collect_field_chains(expr)
-        self.assertIn(["warehouse_activity", "occurred_at"], chains)
-        self.assertNotIn(["events", "timestamp"], chains)
-
-        # Every minIf predicate must be a truthy constant — the with-props and no-props branches
-        # both collapse to True for a DWH entity without properties.
-        # (parse_expr substitution shares nodes so the walker can see more than 2.)
-        min_if_predicates = _collect_min_if_predicates(expr)
-        self.assertGreaterEqual(len(min_if_predicates), 2)
-        for pred in min_if_predicates:
-            self.assertIsInstance(pred, ast.Constant)
-            self.assertTrue(pred.value)  # type: ignore[union-attr]
+        if assert_min_if_predicates_truthy:
+            # Every minIf predicate must be a truthy constant — the with-props and no-props branches
+            # both collapse to True for a DWH entity without properties.
+            # (parse_expr substitution shares nodes so the walker can see more than 2.)
+            min_if_predicates = _collect_min_if_predicates(expr)
+            self.assertGreaterEqual(len(min_if_predicates), 2)
+            for pred in min_if_predicates:
+                self.assertIsInstance(pred, ast.Constant)
+                assert isinstance(pred, ast.Constant)  # narrow for mypy
+                self.assertTrue(pred.value)


### PR DESCRIPTION
Refactor to make "first time" feature possible in follow-up work.

## Problem

`RetentionBaseQueryBuilder.get_first_time_anchor_expr` is hard-coded to `minIf(events.timestamp, <events_entity_predicate>)`. That coupling blocks every downstream track that wants to resolve a first-ever anchor against a data warehouse entity from a single shared primitive — both the strict-calendar-date first-time parity work and the 24-hour-window DWH retrofit need to fan out from the same place.

## Changes

Make the first-time anchor primitive polymorphic over `RetentionEntity`:

- `get_first_time_anchor_expr(entity)` now takes a `RetentionEntity` and routes by `entity.type`.
- For `EntityType.EVENTS`, the produced expression is identical to before: `minIf(events.timestamp, <events_entity_predicate>)` with property-stripped and property-included variants for the first-ever case.
- For `EntityType.DATA_WAREHOUSE`, the expression becomes `minIf(<entity.table_name>.<entity.timestamp_field>, <predicate>)`, where the predicate is `property_to_expr(entity.properties)` if properties are configured and `Constant(True)` otherwise.
- The two existing call sites (`retention_base_query_fixed.py`, `retention_base_query_rolling.py`) pass `self.start_event` to the helper.
- `start_entity_expr_no_props` becomes a thin events-default wrapper around the new polymorphic `entity_expr_no_props(entity)` — the breakdown `argMinIf` caller is unchanged because DWH breakdowns are out of scope for this slice.

Pure refactor for events callers — zero behaviour change. No DWH call site uses the new branch yet; that wiring lands in subsequent slices.

## How did you test this code?

I'm an agent (Claude). I only ran automated tests:

- New focused unit tests in `posthog/hogql_queries/insights/retention/test/test_retention_first_time_anchor.py` exercise the four interesting shapes — events first-ever, events first-time-matching, DWH with properties, DWH without properties. All four pass.
- Confirmed the existing first-time retention test suite still collects 23 tests in `test_retention_query_runner.py` with the new signature. CI will run them against ClickHouse.
- Confirmed zero remaining `events.timestamp` references inside first-time anchor logic across `posthog/hogql_queries/insights/retention/`. Other hits (breakdown `argMinIf`, rolling-t0 non-first-time path, generic events-only paths) are deliberate and out of scope per the ticket.
- Confirmed `retention_base_query_variant_comparison_excluded_tests` in both test classes is byte-identical — this refactor closes no parity gap on its own.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7, 1M context) via the `/tdd` skill against a Notion ticket titled "Foundation: entity-polymorphic first-time anchor".

Approach:

- Followed the TDD skill's vertical-slice discipline: events-regression test → signature refactor; DWH-with-properties test → DWH branch; DWH-no-properties test → truthy-constant predicate.
- Picked unit tests over a full snapshot diff because the helper's contract is structural (which AST nodes appear where) and a stub `MagicMock` runner is enough — no Django Team, no ClickHouse. That bypassed a broken local CH setup without sacrificing coverage of the meaningful branches.
- One AST observation that surfaced via TDD: `parse_expr` substitution shares nodes, so a tree walk counts the reused `minIf` more than twice for the first-ever shape. The DWH-no-properties test asserts on the property of every predicate (`isinstance(..., Constant)` and truthy) rather than an exact count.
- The work was originally proven on the main checkout but kept getting reset by an external process touching these specific files; final application happened inside an isolated git worktree.

Decisions:

- Kept `start_entity_expr_no_props` as a `cached_property` wrapper instead of deleting it. The breakdown call site still depends on it for events, DWH breakdown is downstream work, and keeping the wrapper means existing snapshot tests don't move.
- Added `entity_timestamp_field`, `entity_expr_with_props`, and `entity_expr_no_props` as public methods on the builder rather than `_private` helpers — the next two tracks will compose them.
- Did not touch `RetentionBaseQueryVariantComparisonMixin` exclusion lists. The ticket explicitly says no parity gap is closed by this slice.