### PR TITLE
feat(warehouse): log host-safety decisions

### DIFF
--- a/posthog/temporal/data_imports/sources/common/mixins.py
+++ b/posthog/temporal/data_imports/sources/common/mixins.py
@@ -3,12 +3,19 @@ from collections.abc import Callable, Generator
 from contextlib import _GeneratorContextManager, contextmanager
 from typing import Any
 
+import structlog
+
 from posthog.cloud_utils import is_cloud
 from posthog.models.integration import Integration
 from posthog.utils import get_instance_region
 
 from products.warehouse_sources.backend.models.ssh_tunnel import SSHTunnel
 from products.warehouse_sources.backend.models.util import _is_safe_public_ip
+
+logger = structlog.get_logger(__name__)
+
+_INTERNAL_IP_ERROR = "Hosts with internal IP addresses are not allowed"
+_DNS_FAILURE_ERROR = "Host could not be resolved"
 
 
 def _is_host_safe(host: str, team_id: int) -> tuple[bool, str | None]:
@@ -24,40 +31,68 @@ def _is_host_safe(host: str, team_id: int) -> tuple[bool, str | None]:
     team whitelist: team_id 2 in US, team_id 1 in EU are allowed
     to use internal IPs.
     """
+
+    def _log(decision: str, stage: str, reason: str | None, resolved_ips: list[str] | None = None) -> None:
+        if decision == "block":
+            log_fn = logger.warning  # SSRF attempt — always logged
+        elif stage in ("not_cloud", "e2e"):
+            log_fn = logger.debug  # never fires on cloud / spammy on self-hosted
+        else:
+            log_fn = logger.info
+
+        log_fn(
+            "data_imports.host_check",
+            host=host,
+            team_id=team_id,
+            decision=decision,
+            stage=stage,
+            reason=reason,
+            resolved_ips=resolved_ips,
+        )
+
     if not is_cloud():
+        _log("allow", "not_cloud", None)
         return True, None
 
     region = get_instance_region()
     if region == "E2E":
+        _log("allow", "e2e", None)
         return True, None
 
     if (region == "US" and team_id == 2) or (region == "EU" and team_id == 1):
+        _log("allow", "team_allowlist", None)
         return True, None
 
     normalized = host.lower().strip().rstrip(".")
 
     # PostHog-managed DuckLake hosts resolve to internal IPs but are safe.
     if normalized.endswith(".postwh.com"):
+        _log("allow", "postwh_managed", None)
         return True, None
 
     if normalized in {"localhost"}:
-        return False, "Hosts with internal IP addresses are not allowed"
+        _log("block", "localhost", _INTERNAL_IP_ERROR)
+        return False, _INTERNAL_IP_ERROR
 
     try:
         if not _is_safe_public_ip(host):
-            return False, "Hosts with internal IP addresses are not allowed"
+            _log("block", "literal_ip", _INTERNAL_IP_ERROR)
+            return False, _INTERNAL_IP_ERROR
     except ValueError:
         pass
 
     try:
         addrinfo = socket.getaddrinfo(normalized, None, proto=socket.IPPROTO_TCP)
-        for _family, _type, _proto, _canonname, sockaddr in addrinfo:
-            resolved_ip = sockaddr[0]
-            if not _is_safe_public_ip(str(resolved_ip)):
-                return False, "Hosts with internal IP addresses are not allowed"
+        resolved_ips = [str(sockaddr[0]) for *_meta, sockaddr in addrinfo]
+        for resolved_ip in resolved_ips:
+            if not _is_safe_public_ip(resolved_ip):
+                _log("block", "resolved_ip", _INTERNAL_IP_ERROR, resolved_ips)
+                return False, _INTERNAL_IP_ERROR
     except socket.gaierror:
-        return False, "Host could not be resolved"
+        _log("block", "dns_failure", _DNS_FAILURE_ERROR)
+        return False, _DNS_FAILURE_ERROR
 
+    _log("allow", "resolved_ip", None, resolved_ips)
     return True, None
 
 

--- a/posthog/temporal/data_imports/sources/common/test_mixins.py
+++ b/posthog/temporal/data_imports/sources/common/test_mixins.py
@@ -121,6 +121,36 @@ class TestIsHostSafe(SimpleTestCase):
             assert not valid
             assert error == "Host could not be resolved"
 
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_blocked_host_logs_warning(self):
+        with patch("posthog.temporal.data_imports.sources.common.mixins.logger") as mock_logger:
+            valid, _ = _is_host_safe("10.0.0.1", team_id=999)
+            assert not valid
+            mock_logger.warning.assert_called_once()
+            _args, kwargs = mock_logger.warning.call_args
+            assert kwargs["decision"] == "block"
+            assert kwargs["stage"] == "literal_ip"
+            assert kwargs["host"] == "10.0.0.1"
+            mock_logger.info.assert_not_called()
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_allowed_resolved_host_logs_info_with_resolved_ips(self):
+        with (
+            patch(
+                "posthog.temporal.data_imports.sources.common.mixins.socket.getaddrinfo",
+                return_value=[(None, None, None, None, ("52.1.2.3", 0))],
+            ),
+            patch("posthog.temporal.data_imports.sources.common.mixins.logger") as mock_logger,
+        ):
+            valid, _ = _is_host_safe("good.example.com", team_id=999)
+            assert valid
+            mock_logger.info.assert_called_once()
+            _args, kwargs = mock_logger.info.call_args
+            assert kwargs["decision"] == "allow"
+            assert kwargs["stage"] == "resolved_ip"
+            assert kwargs["resolved_ips"] == ["52.1.2.3"]
+            mock_logger.warning.assert_not_called()
+
 
 class TestValidateDatabaseHostMixin(SimpleTestCase):
     @override_settings(CLOUD_DEPLOYMENT="US")


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Sometimes we want to investigate connections to certain hosts, but we don't have enough logs. This PR adds logging to the `_is_host_safe()` function.

## Changes

- Rewrote `_is_host_safe` in `sources/common/mixins.py` so every decision exits through one structured log line, `data_imports.host_check`, via a nested `_log()` helper. Fields: `host`, `team_id`, `decision` (`allow`/`block`), `stage`, `reason`, `resolved_ips`.
- Log levels: blocks → `warning` (SSRF attempt, always retained); `not_cloud`/`e2e` short-circuits → `debug` (never fires on cloud / noisy on self-hosted); all other allows → `info`, so a public-resolving callback host is kept.
- Stages map one-to-one to the existing return branches: `not_cloud`, `e2e`, `team_allowlist`, `postwh_managed`, `localhost`, `literal_ip`, `resolved_ip` (allow or block), `dns_failure`. Return tuples are unchanged on every branch.
- The only logic tweak: resolved IPs are materialized into `resolved_ips` before the safety loop (and `str()` moved into that comprehension) so the allow path can report which IPs the host resolved to. Only the host is ever logged - never the connection string or password.
- Event name is `data_imports.host_check`.


## How did you test this code?

Automated tests.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7).
