### PR TITLE
chore(hogli): exclude phrocs binary from manifest auto-discovery

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -13,6 +13,10 @@ config:
         - mprocs-test.yaml
         - sandbox-entrypoint.py
         - lint-feature-flag-sorting.mjs
+        # Locally-built, gitignored binary (tools/phrocs). Referenced via cmd:/process
+        # name, not bin_script:, so exclude it from auto-discovery to stop the manifest
+        # regenerating a stub entry on every hogli run.
+        - phrocs
     env:
         files:
             - .env.development


### PR DESCRIPTION
## Problem

`hogli`'s manifest auto-discovery (`tools/hogli/src/hogli/validate.py:auto_update_manifest`) scans the scripts dir (the repo `bin/`) on every run and appends a stub entry for any executable not registered under a `bin_script:` key.

`bin/phrocs` is a locally-built, gitignored binary (built from `tools/phrocs` during flox activation). On `master`, phrocs is referenced only via `cmd:`/process name — never as a `bin_script:` — so auto-discovery treats it as a missing manifest entry and re-appends a `TODO: add description for phrocs` stub to `hogli.yaml` on every hogli invocation.

This means anyone who has built phrocs locally repeatedly sees a spurious `hogli.yaml` diff and risks accidentally committing the stub.

## Changes

Add `phrocs` to `config.scripts_exclude` in `hogli.yaml` so auto-discovery skips the binary. This matches the existing convention for non-`bin_script` entries already in the exclude list (config files, the `.mjs` linter script).

## How did you test this code?

I'm an agent. I reproduced the regeneration locally (the stub reappeared in `hogli.yaml` after running a hogli command), applied the exclude, and confirmed a subsequent hogli run no longer regenerates the stub. No automated tests were added — this is a one-line config exclusion.

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) at the request of @andrewm4894 while investigating why `hogli.yaml` kept showing an uncommitted diff locally.

Investigation path:
- Traced the recurring `TODO: add description for phrocs` stub to `auto_update_manifest()` in `tools/hogli/src/hogli/validate.py`, which auto-registers executables found in the scripts dir (`bin/`) that lack a `bin_script:` entry.
- Confirmed the stub was not present on local `master` or `origin/master` — purely locally generated.
- Considered deleting the local `bin/phrocs` binary instead, but rejected it: the binary is intentionally built and gitignored, so the regeneration would affect every contributor who runs phrocs. The durable fix is excluding it from discovery in the tracked config.

Requires human review; not self-merged.