### PR TITLE
chore: Explicitly disable multi-statements in Snowflake

### DIFF
--- a/products/batch_exports/backend/api/destination_tests/snowflake.py
+++ b/products/batch_exports/backend/api/destination_tests/snowflake.py
@@ -8,6 +8,12 @@ from products.batch_exports.backend.api.destination_tests.base import (
     Status,
 )
 
+# Pin Snowflake's per-session statement count to 1 to block multi-statement
+# execution. This is already the connector default, but setting it explicitly
+# means an account-level override cannot accidentally enable multi-statement
+# execution.
+_SNOWFLAKE_SESSION_PARAMETERS: dict[str, str | int] = {"MULTI_STATEMENT_COUNT": 1}
+
 
 def try_load_private_key(
     private_key: str | None = None, private_key_passphrase: str | None = None
@@ -90,6 +96,7 @@ class SnowflakeEstablishConnectionTestStep(DestinationTestStep):
                 private_key=private_key,
                 # wrap role in quotes in case it contains lowercase or special characters
                 role=f'"{self.role}"' if self.role is not None else None,
+                session_parameters=_SNOWFLAKE_SESSION_PARAMETERS,
             )
         except (OperationalError, InterfaceError, DatabaseError) as err:
             if err.msg is not None and "404 Not Found" in err.msg:
@@ -172,6 +179,7 @@ class SnowflakeWarehouseTestStep(DestinationTestStep):
             account=self.account,
             private_key=private_key,
             role=f'"{self.role}"' if self.role is not None else None,
+            session_parameters=_SNOWFLAKE_SESSION_PARAMETERS,
         )
 
         with connection.cursor() as cursor:
@@ -261,6 +269,7 @@ class SnowflakeDatabaseTestStep(DestinationTestStep):
             private_key=private_key,
             role=f'"{self.role}"' if self.role is not None else None,
             warehouse=self.warehouse,
+            session_parameters=_SNOWFLAKE_SESSION_PARAMETERS,
         )
 
         with connection:
@@ -355,6 +364,7 @@ class SnowflakeSchemaTestStep(DestinationTestStep):
             private_key=private_key,
             role=f'"{self.role}"' if self.role is not None else None,
             warehouse=self.warehouse,
+            session_parameters=_SNOWFLAKE_SESSION_PARAMETERS,
         )
 
         with connection:

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -585,6 +585,11 @@ class SnowflakeClient:
                     role=f'"{self.role}"' if self.role is not None else None,
                     private_key=self.private_key,
                     login_timeout=5,
+                    # Pin Snowflake's per-session statement count to 1 to block
+                    # multi-statement execution. This is already the connector default,
+                    # but setting it explicitly means an account-level override cannot
+                    # accidentally enable multi-statement execution.
+                    session_parameters={"MULTI_STATEMENT_COUNT": 1},
                 )
             connection.telemetry_enabled = False
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Multi-statements are disabled in Snowflake, but this is implicit.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Make it explicit by setting the approppiate session parameter.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran Snowflake tests. All passing.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Used it to write it, then formatted the comment.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
