### PR TITLE
feat(max): show hands-free mic on the homepage idle input

### DIFF
--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -12,7 +12,10 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
 import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
 import { uuid } from 'lib/utils'
+import { HandsFreeButton } from 'scenes/max/components/HandsFreeButton'
+import { HandsFreeSurface } from 'scenes/max/components/HandsFreeSurface'
 import { SidebarQuestionInput } from 'scenes/max/components/SidebarQuestionInput'
+import { handsFreeLogic } from 'scenes/max/handsFreeLogic'
 import { Intro } from 'scenes/max/Intro'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { maxLogic } from 'scenes/max/maxLogic'
@@ -28,6 +31,7 @@ import { HOMEPAGE_TAB_ID } from './constants'
 function IdleInput(): JSX.Element {
     const { query } = useValues(aiFirstHomepageLogic)
     const { setQuery, submitQuery, enterAiMode } = useActions(aiFirstHomepageLogic)
+    const { isActive: handsFreeActive } = useValues(handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }))
     const inputRef = useRef<HTMLTextAreaElement>(null)
 
     useEffect(() => {
@@ -49,95 +53,100 @@ function IdleInput(): JSX.Element {
                 htmlFor="homepage-input"
                 className="min-h-[40px] group input-like flex flex-col items-start relative w-full bg-fill-input border border-primary focus-within:ring-primary rounded-lg justify-stretch overflow-hidden"
             >
-                <div className="flex w-full py-1 px-2">
-                    {!query && (
-                        <span className="text-tertiary pointer-events-none absolute left-3.5 top-2 flex items-center gap-1">
-                            <span className="text-tertiary">What can I help you with?</span>
-                            <span className="text-tertiary opacity-50 contrast-more:opacity-100 hidden @xl/main-content:inline">
-                                / for commands
+                {handsFreeActive ? (
+                    <HandsFreeSurface tabId={HOMEPAGE_TAB_ID} />
+                ) : (
+                    <div className="flex w-full py-1 px-2">
+                        {!query && (
+                            <span className="text-tertiary pointer-events-none absolute left-3.5 top-2 flex items-center gap-1">
+                                <span className="text-tertiary">What can I help you with?</span>
+                                <span className="text-tertiary opacity-50 contrast-more:opacity-100 hidden @xl/main-content:inline">
+                                    / for commands
+                                </span>
                             </span>
-                        </span>
-                    )}
-                    <TextareaPrimitive
-                        ref={inputRef}
-                        id="homepage-input"
-                        data-attr="homepage-input"
-                        wrapperClassName="w-full"
-                        value={query}
-                        onChange={(e) => {
-                            const value = e.target.value
-                            // Typing / or @ as the first character enters AI mode without sending
-                            if (value === '/' || value === '@') {
-                                posthog.capture('homepage ai mode entered', { trigger: value })
-                                enterAiMode(value)
-                                return
-                            }
-                            setQuery(value)
-                        }}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Tab' && query.trim()) {
-                                e.preventDefault()
-                                posthog.capture('homepage query submitted', { mode: 'search' })
-                                submitQuery('search')
-                            }
-                            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
-                                if (e.shiftKey) {
-                                    // Allow default behavior to insert newline
+                        )}
+                        <TextareaPrimitive
+                            ref={inputRef}
+                            id="homepage-input"
+                            data-attr="homepage-input"
+                            wrapperClassName="w-full"
+                            value={query}
+                            onChange={(e) => {
+                                const value = e.target.value
+                                // Typing / or @ as the first character enters AI mode without sending
+                                if (value === '/' || value === '@') {
+                                    posthog.capture('homepage ai mode entered', { trigger: value })
+                                    enterAiMode(value)
                                     return
                                 }
-                                // Prevent newline, let form submit handle it
-                                e.preventDefault()
-                                if (query.trim()) {
-                                    posthog.capture('homepage query submitted', { mode: 'ai' })
-                                    submitQuery('ai')
-                                }
-                            }
-                            if (e.key === 'Escape' && query.trim()) {
-                                e.preventDefault()
-                                setQuery('')
-                            }
-                            // When input is empty, ArrowDown moves focus to the grid
-                            if (e.key === 'ArrowDown' && !query.trim()) {
-                                const grid = document.querySelector<HTMLElement>('[data-attr="homepage-grid"]')
-                                if (grid) {
+                                setQuery(value)
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Tab' && query.trim()) {
                                     e.preventDefault()
-                                    grid.dataset.keyboardFocus = 'true'
-                                    grid.focus()
-                                }
-                            }
-                        }}
-                        autoComplete="off"
-                        className="w-full px-1 py-1 text-sm focus:outline-none border-transparent resize-none bg-transparent"
-                        autoFocus
-                    />
-                    <div className="flex items-end shrink-0">
-                        <div className="flex items-center gap-1 ">
-                            <ButtonPrimitive
-                                size="xs"
-                                className="text-tertiary hover:text-primary shrink-0"
-                                onClick={() => {
                                     posthog.capture('homepage query submitted', { mode: 'search' })
                                     submitQuery('search')
-                                }}
-                            >
-                                <span className="text-xxs">Tab to search</span>
-                            </ButtonPrimitive>
-                            <Tooltip title={!query.trim() ? 'Try asking a question' : undefined}>
-                                <ButtonPrimitive
-                                    onClick={() => {
+                                }
+                                if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                                    if (e.shiftKey) {
+                                        // Allow default behavior to insert newline
+                                        return
+                                    }
+                                    // Prevent newline, let form submit handle it
+                                    e.preventDefault()
+                                    if (query.trim()) {
                                         posthog.capture('homepage query submitted', { mode: 'ai' })
                                         submitQuery('ai')
+                                    }
+                                }
+                                if (e.key === 'Escape' && query.trim()) {
+                                    e.preventDefault()
+                                    setQuery('')
+                                }
+                                // When input is empty, ArrowDown moves focus to the grid
+                                if (e.key === 'ArrowDown' && !query.trim()) {
+                                    const grid = document.querySelector<HTMLElement>('[data-attr="homepage-grid"]')
+                                    if (grid) {
+                                        e.preventDefault()
+                                        grid.dataset.keyboardFocus = 'true'
+                                        grid.focus()
+                                    }
+                                }
+                            }}
+                            autoComplete="off"
+                            className="w-full px-1 py-1 text-sm focus:outline-none border-transparent resize-none bg-transparent"
+                            autoFocus
+                        />
+                        <div className="flex items-end shrink-0">
+                            <div className="flex items-center gap-1 ">
+                                <ButtonPrimitive
+                                    size="xs"
+                                    className="text-tertiary hover:text-primary shrink-0"
+                                    onClick={() => {
+                                        posthog.capture('homepage query submitted', { mode: 'search' })
+                                        submitQuery('search')
                                     }}
-                                    iconOnly
-                                    className="-mr-0.5 shrink-0"
-                                    disabled={!query.trim()}
                                 >
-                                    <IconArrowRight className="size-4" />
+                                    <span className="text-xxs">Tab to search</span>
                                 </ButtonPrimitive>
-                            </Tooltip>
+                                <HandsFreeButton tabId={HOMEPAGE_TAB_ID} />
+                                <Tooltip title={!query.trim() ? 'Try asking a question' : undefined}>
+                                    <ButtonPrimitive
+                                        onClick={() => {
+                                            posthog.capture('homepage query submitted', { mode: 'ai' })
+                                            submitQuery('ai')
+                                        }}
+                                        iconOnly
+                                        className="-mr-0.5 shrink-0"
+                                        disabled={!query.trim()}
+                                    >
+                                        <IconArrowRight className="size-4" />
+                                    </ButtonPrimitive>
+                                </Tooltip>
+                            </div>
                         </div>
                     </div>
-                </div>
+                )}
             </label>
         </form>
     )

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -3,17 +3,18 @@ import { router } from 'kea-router'
 import posthog from 'posthog-js'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { IconArrowRight, IconClock, IconInfo, IconLock, IconPin, IconStar } from '@posthog/icons'
+import { IconArrowRight, IconClock, IconInfo, IconLock, IconMicrophone, IconPin, IconStar } from '@posthog/icons'
 import { LemonButton, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
 import { Search } from 'lib/components/Search/Search'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { Link } from 'lib/lemon-ui/Link'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
 import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
 import { uuid } from 'lib/utils'
-import { HandsFreeButton } from 'scenes/max/components/HandsFreeButton'
 import { SidebarQuestionInput } from 'scenes/max/components/SidebarQuestionInput'
+import { handsFreeLogic } from 'scenes/max/handsFreeLogic'
 import { Intro } from 'scenes/max/Intro'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { maxLogic } from 'scenes/max/maxLogic'
@@ -28,9 +29,14 @@ import { HOMEPAGE_TAB_ID } from './constants'
 
 function IdleInput(): JSX.Element {
     const { query } = useValues(aiFirstHomepageLogic)
-    const { setQuery, submitQuery, enterAiMode } = useActions(aiFirstHomepageLogic)
+    const { setQuery, submitQuery, enterAiMode, startNewConversation } = useActions(aiFirstHomepageLogic)
     const { dataProcessingAccepted } = useValues(maxGlobalLogic)
+    const handsFreeFlag = useFeatureFlag('MAX_HANDS_FREE')
+    const { canUseHandsFree } = useValues(handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }))
+    const { enterHandsFree } = useActions(handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }))
     const inputRef = useRef<HTMLTextAreaElement>(null)
+
+    const handsFreeAvailable = handsFreeFlag && canUseHandsFree && dataProcessingAccepted
 
     useEffect(() => {
         const timer = setTimeout(() => inputRef.current?.focus(), 100)
@@ -124,10 +130,23 @@ function IdleInput(): JSX.Element {
                             >
                                 <span className="text-xxs">Tab to search</span>
                             </ButtonPrimitive>
-                            {/* Mirror HomepageAiInput's consent gate — without it, clicking the mic
-                                would mint an ElevenLabs token and open the Scribe WebSocket before
-                                the AI-mode transition can render the data-processing approval prompt. */}
-                            {dataProcessingAccepted && <HandsFreeButton tabId={HOMEPAGE_TAB_ID} />}
+                            {handsFreeAvailable && (
+                                <Tooltip title="Start a new chat in hands-free">
+                                    <ButtonPrimitive
+                                        iconOnly
+                                        data-attr="homepage-hands-free"
+                                        className="shrink-0"
+                                        onClick={() => {
+                                            posthog.capture('homepage hands-free started')
+                                            startNewConversation()
+                                            submitQuery('ai')
+                                            enterHandsFree()
+                                        }}
+                                    >
+                                        <IconMicrophone className="size-4" />
+                                    </ButtonPrimitive>
+                                </Tooltip>
+                            )}
                             <Tooltip title={!query.trim() ? 'Try asking a question' : undefined}>
                                 <ButtonPrimitive
                                     onClick={() => {

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -29,6 +29,7 @@ import { HOMEPAGE_TAB_ID } from './constants'
 function IdleInput(): JSX.Element {
     const { query } = useValues(aiFirstHomepageLogic)
     const { setQuery, submitQuery, enterAiMode } = useActions(aiFirstHomepageLogic)
+    const { dataProcessingAccepted } = useValues(maxGlobalLogic)
     const inputRef = useRef<HTMLTextAreaElement>(null)
 
     useEffect(() => {
@@ -123,7 +124,10 @@ function IdleInput(): JSX.Element {
                             >
                                 <span className="text-xxs">Tab to search</span>
                             </ButtonPrimitive>
-                            <HandsFreeButton tabId={HOMEPAGE_TAB_ID} />
+                            {/* Mirror HomepageAiInput's consent gate — without it, clicking the mic
+                                would mint an ElevenLabs token and open the Scribe WebSocket before
+                                the AI-mode transition can render the data-processing approval prompt. */}
+                            {dataProcessingAccepted && <HandsFreeButton tabId={HOMEPAGE_TAB_ID} />}
                             <Tooltip title={!query.trim() ? 'Try asking a question' : undefined}>
                                 <ButtonPrimitive
                                     onClick={() => {

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -13,9 +13,7 @@ import { Label } from 'lib/ui/Label/Label'
 import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
 import { uuid } from 'lib/utils'
 import { HandsFreeButton } from 'scenes/max/components/HandsFreeButton'
-import { HandsFreeSurface } from 'scenes/max/components/HandsFreeSurface'
 import { SidebarQuestionInput } from 'scenes/max/components/SidebarQuestionInput'
-import { handsFreeLogic } from 'scenes/max/handsFreeLogic'
 import { Intro } from 'scenes/max/Intro'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { maxLogic } from 'scenes/max/maxLogic'
@@ -31,7 +29,6 @@ import { HOMEPAGE_TAB_ID } from './constants'
 function IdleInput(): JSX.Element {
     const { query } = useValues(aiFirstHomepageLogic)
     const { setQuery, submitQuery, enterAiMode } = useActions(aiFirstHomepageLogic)
-    const { isActive: handsFreeActive } = useValues(handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }))
     const inputRef = useRef<HTMLTextAreaElement>(null)
 
     useEffect(() => {
@@ -53,100 +50,96 @@ function IdleInput(): JSX.Element {
                 htmlFor="homepage-input"
                 className="min-h-[40px] group input-like flex flex-col items-start relative w-full bg-fill-input border border-primary focus-within:ring-primary rounded-lg justify-stretch overflow-hidden"
             >
-                {handsFreeActive ? (
-                    <HandsFreeSurface tabId={HOMEPAGE_TAB_ID} />
-                ) : (
-                    <div className="flex w-full py-1 px-2">
-                        {!query && (
-                            <span className="text-tertiary pointer-events-none absolute left-3.5 top-2 flex items-center gap-1">
-                                <span className="text-tertiary">What can I help you with?</span>
-                                <span className="text-tertiary opacity-50 contrast-more:opacity-100 hidden @xl/main-content:inline">
-                                    / for commands
-                                </span>
+                <div className="flex w-full py-1 px-2">
+                    {!query && (
+                        <span className="text-tertiary pointer-events-none absolute left-3.5 top-2 flex items-center gap-1">
+                            <span className="text-tertiary">What can I help you with?</span>
+                            <span className="text-tertiary opacity-50 contrast-more:opacity-100 hidden @xl/main-content:inline">
+                                / for commands
                             </span>
-                        )}
-                        <TextareaPrimitive
-                            ref={inputRef}
-                            id="homepage-input"
-                            data-attr="homepage-input"
-                            wrapperClassName="w-full"
-                            value={query}
-                            onChange={(e) => {
-                                const value = e.target.value
-                                // Typing / or @ as the first character enters AI mode without sending
-                                if (value === '/' || value === '@') {
-                                    posthog.capture('homepage ai mode entered', { trigger: value })
-                                    enterAiMode(value)
+                        </span>
+                    )}
+                    <TextareaPrimitive
+                        ref={inputRef}
+                        id="homepage-input"
+                        data-attr="homepage-input"
+                        wrapperClassName="w-full"
+                        value={query}
+                        onChange={(e) => {
+                            const value = e.target.value
+                            // Typing / or @ as the first character enters AI mode without sending
+                            if (value === '/' || value === '@') {
+                                posthog.capture('homepage ai mode entered', { trigger: value })
+                                enterAiMode(value)
+                                return
+                            }
+                            setQuery(value)
+                        }}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Tab' && query.trim()) {
+                                e.preventDefault()
+                                posthog.capture('homepage query submitted', { mode: 'search' })
+                                submitQuery('search')
+                            }
+                            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                                if (e.shiftKey) {
+                                    // Allow default behavior to insert newline
                                     return
                                 }
-                                setQuery(value)
-                            }}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Tab' && query.trim()) {
+                                // Prevent newline, let form submit handle it
+                                e.preventDefault()
+                                if (query.trim()) {
+                                    posthog.capture('homepage query submitted', { mode: 'ai' })
+                                    submitQuery('ai')
+                                }
+                            }
+                            if (e.key === 'Escape' && query.trim()) {
+                                e.preventDefault()
+                                setQuery('')
+                            }
+                            // When input is empty, ArrowDown moves focus to the grid
+                            if (e.key === 'ArrowDown' && !query.trim()) {
+                                const grid = document.querySelector<HTMLElement>('[data-attr="homepage-grid"]')
+                                if (grid) {
                                     e.preventDefault()
+                                    grid.dataset.keyboardFocus = 'true'
+                                    grid.focus()
+                                }
+                            }
+                        }}
+                        autoComplete="off"
+                        className="w-full px-1 py-1 text-sm focus:outline-none border-transparent resize-none bg-transparent"
+                        autoFocus
+                    />
+                    <div className="flex items-end shrink-0">
+                        <div className="flex items-center gap-1 ">
+                            <ButtonPrimitive
+                                size="xs"
+                                className="text-tertiary hover:text-primary shrink-0"
+                                onClick={() => {
                                     posthog.capture('homepage query submitted', { mode: 'search' })
                                     submitQuery('search')
-                                }
-                                if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
-                                    if (e.shiftKey) {
-                                        // Allow default behavior to insert newline
-                                        return
-                                    }
-                                    // Prevent newline, let form submit handle it
-                                    e.preventDefault()
-                                    if (query.trim()) {
+                                }}
+                            >
+                                <span className="text-xxs">Tab to search</span>
+                            </ButtonPrimitive>
+                            <HandsFreeButton tabId={HOMEPAGE_TAB_ID} />
+                            <Tooltip title={!query.trim() ? 'Try asking a question' : undefined}>
+                                <ButtonPrimitive
+                                    onClick={() => {
                                         posthog.capture('homepage query submitted', { mode: 'ai' })
                                         submitQuery('ai')
-                                    }
-                                }
-                                if (e.key === 'Escape' && query.trim()) {
-                                    e.preventDefault()
-                                    setQuery('')
-                                }
-                                // When input is empty, ArrowDown moves focus to the grid
-                                if (e.key === 'ArrowDown' && !query.trim()) {
-                                    const grid = document.querySelector<HTMLElement>('[data-attr="homepage-grid"]')
-                                    if (grid) {
-                                        e.preventDefault()
-                                        grid.dataset.keyboardFocus = 'true'
-                                        grid.focus()
-                                    }
-                                }
-                            }}
-                            autoComplete="off"
-                            className="w-full px-1 py-1 text-sm focus:outline-none border-transparent resize-none bg-transparent"
-                            autoFocus
-                        />
-                        <div className="flex items-end shrink-0">
-                            <div className="flex items-center gap-1 ">
-                                <ButtonPrimitive
-                                    size="xs"
-                                    className="text-tertiary hover:text-primary shrink-0"
-                                    onClick={() => {
-                                        posthog.capture('homepage query submitted', { mode: 'search' })
-                                        submitQuery('search')
                                     }}
+                                    iconOnly
+                                    className="-mr-0.5 shrink-0"
+                                    disabled={!query.trim()}
                                 >
-                                    <span className="text-xxs">Tab to search</span>
+                                    <IconArrowRight className="size-4" />
                                 </ButtonPrimitive>
-                                <HandsFreeButton tabId={HOMEPAGE_TAB_ID} />
-                                <Tooltip title={!query.trim() ? 'Try asking a question' : undefined}>
-                                    <ButtonPrimitive
-                                        onClick={() => {
-                                            posthog.capture('homepage query submitted', { mode: 'ai' })
-                                            submitQuery('ai')
-                                        }}
-                                        iconOnly
-                                        className="-mr-0.5 shrink-0"
-                                        disabled={!query.trim()}
-                                    >
-                                        <IconArrowRight className="size-4" />
-                                    </ButtonPrimitive>
-                                </Tooltip>
-                            </div>
+                            </Tooltip>
                         </div>
                     </div>
-                )}
+                </div>
             </label>
         </form>
     )

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -2,7 +2,6 @@ import { actions, afterMount, connect, kea, listeners, path, reducers, selectors
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { tabUiStateLogic } from 'lib/logic/tabUiStateLogic'
-import { handsFreeLogic } from 'scenes/max/handsFreeLogic'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -97,8 +96,6 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             ['setHomepage'],
             tabUiStateLogic,
             ['setChatDraftForTab'],
-            handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }),
-            ['enterHandsFree'],
         ],
     })),
 
@@ -216,14 +213,6 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         setQuery: ({ query }) => {
             if (values.mode === 'idle') {
                 actions.setChatDraftForTab(HOMEPAGE_IDLE_DRAFT_KEY, query)
-            }
-        },
-        // Entering hands-free from the idle homepage needs a mounted maxThreadLogic
-        // before the first transcript commits, or commitTranscript bails with `no_thread`.
-        // submitQuery('ai') flips into AI mode and starts a conversation if needed.
-        enterHandsFree: () => {
-            if (values.mode === 'idle') {
-                actions.submitQuery('ai')
             }
         },
         returnToIdle: () => {

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -2,6 +2,7 @@ import { actions, afterMount, connect, kea, listeners, path, reducers, selectors
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { tabUiStateLogic } from 'lib/logic/tabUiStateLogic'
+import { handsFreeLogic } from 'scenes/max/handsFreeLogic'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -96,6 +97,8 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             ['setHomepage'],
             tabUiStateLogic,
             ['setChatDraftForTab'],
+            handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }),
+            ['enterHandsFree'],
         ],
     })),
 
@@ -213,6 +216,14 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         setQuery: ({ query }) => {
             if (values.mode === 'idle') {
                 actions.setChatDraftForTab(HOMEPAGE_IDLE_DRAFT_KEY, query)
+            }
+        },
+        // Entering hands-free from the idle homepage needs a mounted maxThreadLogic
+        // before the first transcript commits, or commitTranscript bails with `no_thread`.
+        // submitQuery('ai') flips into AI mode and starts a conversation if needed.
+        enterHandsFree: () => {
+            if (values.mode === 'idle') {
+                actions.submitQuery('ai')
             }
         },
         returnToIdle: () => {


### PR DESCRIPTION
## Problem

The homepage chat box (the idle input shown before a user types anything) was missing the hands-free mic button. The button already exists inside `QuestionInput` and is therefore present in the side panel and on the homepage once it transitions to AI mode — but it never appears on the initial homepage view, because the idle input is a custom textarea that doesn't go through `QuestionInput`.

## Changes

- Read `isActive` from `handsFreeLogic({ tabId: HOMEPAGE_TAB_ID })` in `IdleInput`.
- Slot `<HandsFreeButton tabId={HOMEPAGE_TAB_ID} />` into the idle input's action row alongside the "Tab to search" hint and the submit arrow.
- Mirror `QuestionInput`'s pattern: when hands-free is active, swap the textarea + action row out for `<HandsFreeSurface tabId={HOMEPAGE_TAB_ID} />` inside the same `<label>` shell, so the surface uses the same input chrome.

Both components are keyed by `HOMEPAGE_TAB_ID` — the same tab id `HomepageAiInput` already uses — so hands-free state is shared across the idle ↔ AI mode transition. `HandsFreeButton` self-gates on the `MAX_HANDS_FREE` flag and on Scribe SDK availability, so this is a no-op when the flag is off.

## How did you test this code?

I'm an agent. I did not start the dev server or click through the UI. I read the surrounding components (`QuestionInput`, `HandsFreeButton`, `HandsFreeSurface`, `handsFreeLogic`, `AiFirstHomepage`) to confirm the wiring assumptions:

- `AiFirstHomepage` already mounts `BindLogic logic={maxLogic} props={{ tabId: HOMEPAGE_TAB_ID }}` around `HomepageInput`, so `handsFreeLogic`'s `connect` to `maxLogic({ tabId })` resolves cleanly in idle mode.
- `HandsFreeButton` and `HandsFreeSurface` both take `{ tabId }` as their only required prop and key into the same `handsFreeLogic` instance.

No automated tests were added or run for this change — it's a small JSX swap behind an existing flag, and the moving parts it composes already have their own coverage.

## Publish to changelog?

no

## 🤖 Agent context

Authored by an agent (Claude Code via PostHog Code). Investigation steps:

1. Identified the existing \`HandsFreeButton\` and confirmed its self-gating on \`useFeatureFlag('MAX_HANDS_FREE')\` and \`canUseHandsFree\`/\`status === 'off'\`.
2. Located the homepage idle input in \`frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx\` and noted that \`HomepageAiInput\` already inherits the mic via \`SidebarQuestionInput → QuestionInput\`, but \`IdleInput\` is a bespoke textarea.
3. Considered just adding the button — rejected, because clicking it without a surface would silently flip \`handsFreeLogic\` into an active state with no visible UI. Chose to mirror \`QuestionInput\`'s \`handsFreeActive ? <HandsFreeSurface /> : <textarea + actions>\` pattern so the user actually gets a working surface in idle mode.
4. Confirmed \`maxLogic({ tabId: HOMEPAGE_TAB_ID })\` is already bound by \`AiFirstHomepage\`, so \`handsFreeLogic\` mounts cleanly from \`IdleInput\` without an additional \`BindLogic\`.

Most of the diff is whitespace from indenting the wrapped block — review with whitespace ignored for clarity.