### PR TITLE
chore(event): smaller limits for event list api

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -26,7 +26,7 @@ from rest_framework_csv import renderers as csvrenderers
 from posthog.schema import ProductKey
 
 from posthog.hogql import ast
-from posthog.hogql.constants import DEFAULT_RETURNED_ROWS, MAX_SELECT_RETURNED_ROWS
+from posthog.hogql.constants import DEFAULT_RETURNED_ROWS
 from posthog.hogql.property_utils import create_property_conditions
 from posthog.hogql.query import execute_hogql_query
 
@@ -70,7 +70,8 @@ EVENT_VALUES_COUNTER = Counter(
     labelnames=["has_event_name", "auth"],
 )
 
-QUERY_DEFAULT_EXPORT_LIMIT = 3_500
+QUERY_DEFAULT_EXPORT_LIMIT = 1_000
+EVENT_LIST_MAX_LIMIT = 1_000
 
 # Progressive time windows in seconds: 1min, 5min, 15min, 1hr, 6hr, 24hr
 EVENT_LIST_TIME_WINDOWS = [60, 300, 900, 3600, 21600, 86400]
@@ -273,7 +274,7 @@ class EventViewSet(
             else:
                 limit = DEFAULT_RETURNED_ROWS
 
-            limit = min(limit, MAX_SELECT_RETURNED_ROWS)
+            limit = min(limit, EVENT_LIST_MAX_LIMIT)
 
             try:
                 offset = int(request.GET["offset"]) if request.GET.get("offset") else 0

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -923,25 +923,14 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.id}/events/?limit=2").json()
         assert len(response["results"]) == 2
 
+    @patch("posthog.api.event.EVENT_LIST_MAX_LIMIT", 2)
     def test_limit_is_capped_at_event_list_max(self):
-        from posthog.api.event import EVENT_LIST_MAX_LIMIT
-
-        _create_person(
-            properties={"email": "tim@posthog.com"},
-            team=self.team,
-            distinct_ids=["1"],
-            is_identified=True,
-        )
-        _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"$ip": "8.8.8.8"})
+        _create_person(team=self.team, distinct_ids=["1"], is_identified=True)
+        for _i in range(3):
+            _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"$ip": "8.8.8.8"})
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?limit=50000").json()
-        assert "results" in response
-        # The query should have been capped — verify via the next URL which reflects the actual limit used.
-        # With only 1 event and limit capped to EVENT_LIST_MAX_LIMIT, there should be no next page.
-        assert response["next"] is None
-
-        # Verify the constant itself
-        assert EVENT_LIST_MAX_LIMIT == 1_000
+        assert len(response["results"]) == 2
 
     def test_get_events_with_specified_token(self):
         _, _, user2 = User.objects.bootstrap("Test", "team2@posthog.com", None)

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -923,6 +923,26 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.id}/events/?limit=2").json()
         assert len(response["results"]) == 2
 
+    def test_limit_is_capped_at_event_list_max(self):
+        from posthog.api.event import EVENT_LIST_MAX_LIMIT
+
+        _create_person(
+            properties={"email": "tim@posthog.com"},
+            team=self.team,
+            distinct_ids=["1"],
+            is_identified=True,
+        )
+        _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"$ip": "8.8.8.8"})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/events/?limit=50000").json()
+        assert "results" in response
+        # The query should have been capped — verify via the next URL which reflects the actual limit used.
+        # With only 1 event and limit capped to EVENT_LIST_MAX_LIMIT, there should be no next page.
+        assert response["next"] is None
+
+        # Verify the constant itself
+        assert EVENT_LIST_MAX_LIMIT == 1_000
+
     def test_get_events_with_specified_token(self):
         _, _, user2 = User.objects.bootstrap("Test", "team2@posthog.com", None)
         assert user2.team is not None

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -1299,6 +1299,7 @@ class TestEventListTimeWindowOptimization(ClickhouseTestMixin, APIBaseTest):
         # Should NOT update cache when data is identical (optimization)
         mock_cache.set.assert_not_called()
 
+    @patch("posthog.api.event.EVENT_LIST_MAX_LIMIT", 6000)
     @patch("posthog.api.event.cache")
     @patch("posthog.api.event.query_events_list")
     def test_ignores_cached_window_when_result_count_below_threshold(self, mock_query_events_list, mock_cache):


### PR DESCRIPTION
## Problem

The `/api/projects/:id/events/` endpoint is deprecated but still serves some amount of traffic. For each request, it fetches full Person records for every distinct_id in the result set, just to extract 3 property keys (`email`, `name`, `username`) and a boolean (`is_identified`) per person.

The endpoint previously allowed up to 50,000 events per request (via `?limit=50000`) and defaulted to 3,500 for CSV exports. At the fat tail this produces person lookups returning thousands of full Person records with complete properties blobs.


## Changes

Cap the deprecated events list API to return at most 1,000 events per request, down from 50,000.

- `QUERY_DEFAULT_EXPORT_LIMIT` (CSV export default): 3,500 → **1,000**
- New `EVENT_LIST_MAX_LIMIT = 1_000`: replaces the global `MAX_SELECT_RETURNED_ROWS` (50,000) as the cap for this endpoint only

This is scoped entirely to `posthog/api/event.py` — no other endpoints are affected.

The PostHog frontend does not call this API (it uses the HogQL events query runner instead), so this only impacts external API consumers using a deprecated endpoint.

## How did you test this code?

- existing tests should cover existing behaviour
- added test to make sure we adhere to limit

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
