### PR TITLE
feat(replay vision): add MCP get tools

### DIFF
--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -127,7 +127,7 @@ INTERNAL_API_SCOPE_OBJECTS: frozenset[APIScopeObject] = frozenset({"clickhouse_t
 # OAuth metadata. Used for alpha / not-yet-public products where a user can
 # manually paste the scope into a PAT but where we don't want OAuth-based
 # clients (the consent screen, MCP, third-party apps) to discover it.
-OAUTH_HIDDEN_SCOPE_OBJECTS: frozenset[APIScopeObject] = frozenset({"replay_scanner", "wizard_session"})
+OAUTH_HIDDEN_SCOPE_OBJECTS: frozenset[APIScopeObject] = frozenset({"wizard_session"})
 
 PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION: list[tuple[APIScopeObject, APIScopeActions]] = [("endpoint", "read")]
 

--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -1,0 +1,111 @@
+# MCP tool definition — tool entries are scaffolded from the OpenAPI schema.
+# The tool list and operation IDs are kept in sync automatically:
+#   pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+#
+# To enable a tool, set enabled: true and add required scopes + annotations.
+# All other fields (title, description, enrich_url, etc.) are yours to configure.
+category: Replay vision
+feature: replay_vision
+url_prefix: /replay-vision
+ui_apps: {}
+tools:
+    vision-scanners-create:
+        operation: vision_scanners_create
+        enabled: false
+    vision-scanners-destroy:
+        operation: vision_scanners_destroy
+        enabled: false
+    vision-scanners-list:
+        operation: vision_scanners_list
+        enabled: true
+        scopes:
+            - replay_scanner:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List replay vision scanners
+        description: >
+            List all replay vision scanners in the current project. A scanner watches a slice of session
+            recordings (defined by its `query` and `sampling_rate`) and runs one of five LLM analyses against
+            each matching session: `monitor` (open-ended observations), `classifier` (tag from a fixed label
+            set), `scorer` (numeric rubric), `summarizer` (free-text summary), or `indexer` (structured
+            extraction for downstream embedding). Each scanner returns its current configuration, enabled
+            state, sampling rate, and `last_swept_at` timestamp.
+        feature_flag: replay-vision
+    vision-scanners-observations-list:
+        operation: vision_scanners_observations_list
+        enabled: true
+        scopes:
+            - replay_scanner:read
+            - session_recording:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List scanner observations
+        description: >
+            List the observations recorded by a single scanner. Each observation is one scan of one session
+            and includes its `status` (pending/running/succeeded/failed), `triggered_by` (`schedule` or
+            `on_demand`), `workflow_id`, the `scanner_result` (the LLM output validated against the scanner's
+            response schema for that scanner_type), and the `session_id` of the recording it analysed. Use
+            this to inspect what a scanner has found over time.
+        feature_flag: replay-vision
+    vision-scanners-observations-get:
+        operation: vision_scanners_observations_retrieve
+        enabled: true
+        scopes:
+            - replay_scanner:read
+            - session_recording:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get scanner observation
+        description: >
+            Get a single scanner observation by ID. Returns the full `scanner_snapshot` (the scanner's
+            configuration as it was at run time, for reproducibility across `scanner_version` bumps) and the
+            full `scanner_result` including any event citations linking the LLM output back to specific
+            events in the originating session. Pair with the session-recording MCP tools or the
+            investigating-replay skill to inspect the underlying recording.
+        feature_flag: replay-vision
+    vision-scanners-scan-session:
+        operation: vision_scanners_observe_create
+        enabled: true
+        scopes:
+            - replay_scanner:write
+            - session_recording:read
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Run scanner against a session now
+        description: >
+            Trigger a scanner against a specific session immediately, bypassing the sampling rate and any
+            scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under
+            `vision-scanners-observations-list` once the Temporal workflow finishes (typically several
+            minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc
+            scanning during an investigation: pick a scanner that matches the question you want answered,
+            and point it at the session you're examining.
+        feature_flag: replay-vision
+    vision-scanners-partial-update:
+        operation: vision_scanners_partial_update
+        enabled: false
+    vision-scanners-get:
+        operation: vision_scanners_retrieve
+        enabled: true
+        scopes:
+            - replay_scanner:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get replay vision scanner
+        description: >
+            Get a single replay vision scanner by ID. Returns the full configuration including
+            `scanner_config` (the type-specific prompt and response schema parameters), the `RecordingsQuery`
+            used to select sessions, and operational fields like `enabled`, `sampling_rate`, `provider`,
+            `model`, `emits_signals`, `scanner_version`, and `last_swept_at`.
+        feature_flag: replay-vision

--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -116,3 +116,4 @@ tools:
             investigation: pick a scanner that matches the question you want answered, and point it at the session
             you're examining.
         feature_flag: replay-vision
+        requires_ai_consent: true

--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -115,5 +115,5 @@ tools:
             rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an
             investigation: pick a scanner that matches the question you want answered, and point it at the session
             you're examining.
-        feature_flag: replay-vision
         requires_ai_consent: true
+        feature_flag: replay-vision

--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -9,12 +9,37 @@ feature: replay_vision
 url_prefix: /replay-vision
 ui_apps: {}
 tools:
+    vision-observations-list:
+        operation: vision_observations_list
+        enabled: false
+    vision-observations-retrieve:
+        operation: vision_observations_retrieve
+        enabled: false
     vision-scanners-create:
         operation: vision_scanners_create
         enabled: false
     vision-scanners-destroy:
         operation: vision_scanners_destroy
         enabled: false
+    vision-scanners-estimate-create:
+        operation: vision_scanners_estimate_create
+        enabled: false
+    vision-scanners-get:
+        operation: vision_scanners_retrieve
+        enabled: true
+        scopes:
+            - replay_scanner:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get replay vision scanner
+        description: >
+            Get a single replay vision scanner by ID. Returns the full configuration including `scanner_config` (the
+            type-specific prompt and response schema parameters), the `RecordingsQuery` used to select sessions, and
+            operational fields like `enabled`, `sampling_rate`, `provider`, `model`, `emits_signals`, `scanner_version`,
+            and `last_swept_at`.
+        feature_flag: replay-vision
     vision-scanners-list:
         operation: vision_scanners_list
         enabled: true
@@ -27,12 +52,29 @@ tools:
         list: true
         title: List replay vision scanners
         description: >
-            List all replay vision scanners in the current project. A scanner watches a slice of session
-            recordings (defined by its `query` and `sampling_rate`) and runs one of five LLM analyses against
-            each matching session: `monitor` (open-ended observations), `classifier` (tag from a fixed label
-            set), `scorer` (numeric rubric), `summarizer` (free-text summary), or `indexer` (structured
-            extraction for downstream embedding). Each scanner returns its current configuration, enabled
-            state, sampling rate, and `last_swept_at` timestamp.
+            List all replay vision scanners in the current project. A scanner watches a slice of session recordings
+            (defined by its `query` and `sampling_rate`) and runs one of five LLM analyses against each matching
+            session: `monitor` (open-ended observations), `classifier` (tag from a fixed label set), `scorer` (numeric
+            rubric), `summarizer` (free-text summary), or `indexer` (structured extraction for downstream embedding).
+            Each scanner returns its current configuration, enabled state, sampling rate, and `last_swept_at` timestamp.
+        feature_flag: replay-vision
+    vision-scanners-observations-get:
+        operation: vision_scanners_observations_retrieve
+        enabled: true
+        scopes:
+            - replay_scanner:read
+            - session_recording:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get scanner observation
+        description: >
+            Get a single scanner observation by ID. Returns the full `scanner_snapshot` (the scanner's configuration as
+            it was at run time, for reproducibility across `scanner_version` bumps) and the full `scanner_result`
+            including any event citations linking the LLM output back to specific events in the originating session.
+            Pair with the session-recording MCP tools or the investigating-replay skill to inspect the underlying
+            recording.
         feature_flag: replay-vision
     vision-scanners-observations-list:
         operation: vision_scanners_observations_list
@@ -47,30 +89,14 @@ tools:
         list: true
         title: List scanner observations
         description: >
-            List the observations recorded by a single scanner. Each observation is one scan of one session
-            and includes its `status` (pending/running/succeeded/failed), `triggered_by` (`schedule` or
-            `on_demand`), `workflow_id`, the `scanner_result` (the LLM output validated against the scanner's
-            response schema for that scanner_type), and the `session_id` of the recording it analysed. Use
-            this to inspect what a scanner has found over time.
+            List the observations recorded by a single scanner. Each observation is one scan of one session and includes
+            its `status` (pending/running/succeeded/failed), `triggered_by` (`schedule` or `on_demand`), `workflow_id`,
+            the `scanner_result` (the LLM output validated against the scanner's response schema for that scanner_type),
+            and the `session_id` of the recording it analysed. Use this to inspect what a scanner has found over time.
         feature_flag: replay-vision
-    vision-scanners-observations-get:
-        operation: vision_scanners_observations_retrieve
-        enabled: true
-        scopes:
-            - replay_scanner:read
-            - session_recording:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        title: Get scanner observation
-        description: >
-            Get a single scanner observation by ID. Returns the full `scanner_snapshot` (the scanner's
-            configuration as it was at run time, for reproducibility across `scanner_version` bumps) and the
-            full `scanner_result` including any event citations linking the LLM output back to specific
-            events in the originating session. Pair with the session-recording MCP tools or the
-            investigating-replay skill to inspect the underlying recording.
-        feature_flag: replay-vision
+    vision-scanners-partial-update:
+        operation: vision_scanners_partial_update
+        enabled: false
     vision-scanners-scan-session:
         operation: vision_scanners_observe_create
         enabled: true
@@ -83,29 +109,10 @@ tools:
             idempotent: false
         title: Run scanner against a session now
         description: >
-            Trigger a scanner against a specific session immediately, bypassing the sampling rate and any
-            scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under
-            `vision-scanners-observations-list` once the Temporal workflow finishes (typically several
-            minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc
-            scanning during an investigation: pick a scanner that matches the question you want answered,
-            and point it at the session you're examining.
-        feature_flag: replay-vision
-    vision-scanners-partial-update:
-        operation: vision_scanners_partial_update
-        enabled: false
-    vision-scanners-get:
-        operation: vision_scanners_retrieve
-        enabled: true
-        scopes:
-            - replay_scanner:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        title: Get replay vision scanner
-        description: >
-            Get a single replay vision scanner by ID. Returns the full configuration including
-            `scanner_config` (the type-specific prompt and response schema parameters), the `RecordingsQuery`
-            used to select sessions, and operational fields like `enabled`, `sampling_rate`, `provider`,
-            `model`, `emits_signals`, `scanner_version`, and `last_swept_at`.
+            Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled
+            sweep. Returns 202 with a `workflow_id`; the resulting observation appears under
+            `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes —
+            rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an
+            investigation: pick a scanner that matches the question you want answered, and point it at the session
+            you're examining.
         feature_flag: replay-vision

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5533,6 +5533,38 @@
             "readOnlyHint": false
         }
     },
+    "vision-scanners-list": {
+        "description": "List all replay vision scanners in the current project. A scanner watches a slice of session recordings (defined by its `query` and `sampling_rate`) and runs one of five LLM analyses against each matching session: `monitor` (open-ended observations), `classifier` (tag from a fixed label set), `scorer` (numeric rubric), `summarizer` (free-text summary), or `indexer` (structured extraction for downstream embedding). Each scanner returns its current configuration, enabled state, sampling rate, and `last_swept_at` timestamp.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List replay vision scanners",
+        "title": "List replay vision scanners",
+        "required_scopes": ["replay_scanner:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-observations-list": {
+        "description": "List the observations recorded by a single scanner. Each observation is one scan of one session and includes its `status` (pending/running/succeeded/failed), `triggered_by` (`schedule` or `on_demand`), `workflow_id`, the `scanner_result` (the LLM output validated against the scanner's response schema for that scanner_type), and the `session_id` of the recording it analysed. Use this to inspect what a scanner has found over time.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List scanner observations",
+        "title": "List scanner observations",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
     "visual-review-repos-list": {
         "description": "List visual review repos (test suites) for the current project. A repo typically maps to a GitHub repository and owns the baselines, runs, and tolerated hashes for that codebase. Returns repo id, external id, full name, baseline file paths, and pr-comment configuration.",
         "category": "Visual review",
@@ -5737,5 +5769,53 @@
             "openWorldHint": true,
             "readOnlyHint": true
         }
+    },
+    "vision-scanners-get": {
+        "description": "Get a single replay vision scanner by ID. Returns the full configuration including `scanner_config` (the type-specific prompt and response schema parameters), the `RecordingsQuery` used to select sessions, and operational fields like `enabled`, `sampling_rate`, `provider`, `model`, `emits_signals`, `scanner_version`, and `last_swept_at`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get replay vision scanner",
+        "title": "Get replay vision scanner",
+        "required_scopes": ["replay_scanner:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-observations-get": {
+        "description": "Get a single scanner observation by ID. Returns the full `scanner_snapshot` (the scanner's configuration as it was at run time, for reproducibility across `scanner_version` bumps) and the full `scanner_result` including any event citations linking the LLM output back to specific events in the originating session. Pair with the session-recording MCP tools or the investigating-replay skill to inspect the underlying recording.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get scanner observation",
+        "title": "Get scanner observation",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-scan-session": {
+        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Run scanner against a session now",
+        "title": "Run scanner against a session now",
+        "required_scopes": ["replay_scanner:write", "session_recording:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "replay-vision"
     }
 }

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5533,6 +5533,22 @@
             "readOnlyHint": false
         }
     },
+    "vision-scanners-get": {
+        "description": "Get a single replay vision scanner by ID. Returns the full configuration including `scanner_config` (the type-specific prompt and response schema parameters), the `RecordingsQuery` used to select sessions, and operational fields like `enabled`, `sampling_rate`, `provider`, `model`, `emits_signals`, `scanner_version`, and `last_swept_at`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get replay vision scanner",
+        "title": "Get replay vision scanner",
+        "required_scopes": ["replay_scanner:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
     "vision-scanners-list": {
         "description": "List all replay vision scanners in the current project. A scanner watches a slice of session recordings (defined by its `query` and `sampling_rate`) and runs one of five LLM analyses against each matching session: `monitor` (open-ended observations), `classifier` (tag from a fixed label set), `scorer` (numeric rubric), `summarizer` (free-text summary), or `indexer` (structured extraction for downstream embedding). Each scanner returns its current configuration, enabled state, sampling rate, and `last_swept_at` timestamp.",
         "category": "Replay vision",
@@ -5540,6 +5556,22 @@
         "summary": "List replay vision scanners",
         "title": "List replay vision scanners",
         "required_scopes": ["replay_scanner:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-observations-get": {
+        "description": "Get a single scanner observation by ID. Returns the full `scanner_snapshot` (the scanner's configuration as it was at run time, for reproducibility across `scanner_version` bumps) and the full `scanner_result` including any event citations linking the LLM output back to specific events in the originating session. Pair with the session-recording MCP tools or the investigating-replay skill to inspect the underlying recording.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get scanner observation",
+        "title": "Get scanner observation",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
         "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
@@ -5562,6 +5594,22 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-scan-session": {
+        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Run scanner against a session now",
+        "title": "Run scanner against a session now",
+        "required_scopes": ["replay_scanner:write", "session_recording:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
         },
         "feature_flag": "replay-vision"
     },
@@ -5769,53 +5817,5 @@
             "openWorldHint": true,
             "readOnlyHint": true
         }
-    },
-    "vision-scanners-get": {
-        "description": "Get a single replay vision scanner by ID. Returns the full configuration including `scanner_config` (the type-specific prompt and response schema parameters), the `RecordingsQuery` used to select sessions, and operational fields like `enabled`, `sampling_rate`, `provider`, `model`, `emits_signals`, `scanner_version`, and `last_swept_at`.",
-        "category": "Replay vision",
-        "feature": "replay_vision",
-        "summary": "Get replay vision scanner",
-        "title": "Get replay vision scanner",
-        "required_scopes": ["replay_scanner:read"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "replay-vision"
-    },
-    "vision-scanners-observations-get": {
-        "description": "Get a single scanner observation by ID. Returns the full `scanner_snapshot` (the scanner's configuration as it was at run time, for reproducibility across `scanner_version` bumps) and the full `scanner_result` including any event citations linking the LLM output back to specific events in the originating session. Pair with the session-recording MCP tools or the investigating-replay skill to inspect the underlying recording.",
-        "category": "Replay vision",
-        "feature": "replay_vision",
-        "summary": "Get scanner observation",
-        "title": "Get scanner observation",
-        "required_scopes": ["replay_scanner:read", "session_recording:read"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "replay-vision"
-    },
-    "vision-scanners-scan-session": {
-        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining.",
-        "category": "Replay vision",
-        "feature": "replay_vision",
-        "summary": "Run scanner against a session now",
-        "title": "Run scanner against a session now",
-        "required_scopes": ["replay_scanner:write", "session_recording:read"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "replay-vision"
     }
 }

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5611,8 +5611,8 @@
             "openWorldHint": true,
             "readOnlyHint": false
         },
-        "feature_flag": "replay-vision",
-        "requires_ai_consent": true
+        "requires_ai_consent": true,
+        "feature_flag": "replay-vision"
     },
     "visual-review-repos-list": {
         "description": "List visual review repos (test suites) for the current project. A repo typically maps to a GitHub repository and owns the baselines, runs, and tolerated hashes for that codebase. Returns repo id, external id, full name, baseline file paths, and pr-comment configuration.",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5611,7 +5611,8 @@
             "openWorldHint": true,
             "readOnlyHint": false
         },
-        "feature_flag": "replay-vision"
+        "feature_flag": "replay-vision",
+        "requires_ai_consent": true
     },
     "visual-review-repos-list": {
         "description": "List visual review repos (test suites) for the current project. A repo typically maps to a GitHub repository and owns the baselines, runs, and tolerated hashes for that codebase. Returns repo id, external id, full name, baseline file paths, and pr-comment configuration.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6014,6 +6014,22 @@
             "readOnlyHint": false
         }
     },
+    "vision-scanners-get": {
+        "description": "Get a single replay vision scanner by ID. Returns the full configuration including `scanner_config` (the type-specific prompt and response schema parameters), the `RecordingsQuery` used to select sessions, and operational fields like `enabled`, `sampling_rate`, `provider`, `model`, `emits_signals`, `scanner_version`, and `last_swept_at`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get replay vision scanner",
+        "title": "Get replay vision scanner",
+        "required_scopes": ["replay_scanner:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
     "vision-scanners-list": {
         "description": "List all replay vision scanners in the current project. A scanner watches a slice of session recordings (defined by its `query` and `sampling_rate`) and runs one of five LLM analyses against each matching session: `monitor` (open-ended observations), `classifier` (tag from a fixed label set), `scorer` (numeric rubric), `summarizer` (free-text summary), or `indexer` (structured extraction for downstream embedding). Each scanner returns its current configuration, enabled state, sampling rate, and `last_swept_at` timestamp.",
         "category": "Replay vision",
@@ -6021,6 +6037,22 @@
         "summary": "List replay vision scanners",
         "title": "List replay vision scanners",
         "required_scopes": ["replay_scanner:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-observations-get": {
+        "description": "Get a single scanner observation by ID. Returns the full `scanner_snapshot` (the scanner's configuration as it was at run time, for reproducibility across `scanner_version` bumps) and the full `scanner_result` including any event citations linking the LLM output back to specific events in the originating session. Pair with the session-recording MCP tools or the investigating-replay skill to inspect the underlying recording.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get scanner observation",
+        "title": "Get scanner observation",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
         "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
@@ -6043,6 +6075,22 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-scan-session": {
+        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Run scanner against a session now",
+        "title": "Run scanner against a session now",
+        "required_scopes": ["replay_scanner:write", "session_recording:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
         },
         "feature_flag": "replay-vision"
     },
@@ -6250,53 +6298,5 @@
             "openWorldHint": true,
             "readOnlyHint": true
         }
-    },
-    "vision-scanners-get": {
-        "description": "Get a single replay vision scanner by ID. Returns the full configuration including `scanner_config` (the type-specific prompt and response schema parameters), the `RecordingsQuery` used to select sessions, and operational fields like `enabled`, `sampling_rate`, `provider`, `model`, `emits_signals`, `scanner_version`, and `last_swept_at`.",
-        "category": "Replay vision",
-        "feature": "replay_vision",
-        "summary": "Get replay vision scanner",
-        "title": "Get replay vision scanner",
-        "required_scopes": ["replay_scanner:read"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "replay-vision"
-    },
-    "vision-scanners-observations-get": {
-        "description": "Get a single scanner observation by ID. Returns the full `scanner_snapshot` (the scanner's configuration as it was at run time, for reproducibility across `scanner_version` bumps) and the full `scanner_result` including any event citations linking the LLM output back to specific events in the originating session. Pair with the session-recording MCP tools or the investigating-replay skill to inspect the underlying recording.",
-        "category": "Replay vision",
-        "feature": "replay_vision",
-        "summary": "Get scanner observation",
-        "title": "Get scanner observation",
-        "required_scopes": ["replay_scanner:read", "session_recording:read"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "replay-vision"
-    },
-    "vision-scanners-scan-session": {
-        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining.",
-        "category": "Replay vision",
-        "feature": "replay_vision",
-        "summary": "Run scanner against a session now",
-        "title": "Run scanner against a session now",
-        "required_scopes": ["replay_scanner:write", "session_recording:read"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "replay-vision"
     }
 }

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6092,7 +6092,8 @@
             "openWorldHint": true,
             "readOnlyHint": false
         },
-        "feature_flag": "replay-vision"
+        "feature_flag": "replay-vision",
+        "requires_ai_consent": true
     },
     "visual-review-repos-list": {
         "description": "List visual review repos (test suites) for the current project. A repo typically maps to a GitHub repository and owns the baselines, runs, and tolerated hashes for that codebase. Returns repo id, external id, full name, baseline file paths, and pr-comment configuration.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6092,8 +6092,8 @@
             "openWorldHint": true,
             "readOnlyHint": false
         },
-        "feature_flag": "replay-vision",
-        "requires_ai_consent": true
+        "requires_ai_consent": true,
+        "feature_flag": "replay-vision"
     },
     "visual-review-repos-list": {
         "description": "List visual review repos (test suites) for the current project. A repo typically maps to a GitHub repository and owns the baselines, runs, and tolerated hashes for that codebase. Returns repo id, external id, full name, baseline file paths, and pr-comment configuration.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6014,6 +6014,38 @@
             "readOnlyHint": false
         }
     },
+    "vision-scanners-list": {
+        "description": "List all replay vision scanners in the current project. A scanner watches a slice of session recordings (defined by its `query` and `sampling_rate`) and runs one of five LLM analyses against each matching session: `monitor` (open-ended observations), `classifier` (tag from a fixed label set), `scorer` (numeric rubric), `summarizer` (free-text summary), or `indexer` (structured extraction for downstream embedding). Each scanner returns its current configuration, enabled state, sampling rate, and `last_swept_at` timestamp.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List replay vision scanners",
+        "title": "List replay vision scanners",
+        "required_scopes": ["replay_scanner:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-observations-list": {
+        "description": "List the observations recorded by a single scanner. Each observation is one scan of one session and includes its `status` (pending/running/succeeded/failed), `triggered_by` (`schedule` or `on_demand`), `workflow_id`, the `scanner_result` (the LLM output validated against the scanner's response schema for that scanner_type), and the `session_id` of the recording it analysed. Use this to inspect what a scanner has found over time.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List scanner observations",
+        "title": "List scanner observations",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
     "visual-review-repos-list": {
         "description": "List visual review repos (test suites) for the current project. A repo typically maps to a GitHub repository and owns the baselines, runs, and tolerated hashes for that codebase. Returns repo id, external id, full name, baseline file paths, and pr-comment configuration.",
         "category": "Visual review",
@@ -6218,5 +6250,53 @@
             "openWorldHint": true,
             "readOnlyHint": true
         }
+    },
+    "vision-scanners-get": {
+        "description": "Get a single replay vision scanner by ID. Returns the full configuration including `scanner_config` (the type-specific prompt and response schema parameters), the `RecordingsQuery` used to select sessions, and operational fields like `enabled`, `sampling_rate`, `provider`, `model`, `emits_signals`, `scanner_version`, and `last_swept_at`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get replay vision scanner",
+        "title": "Get replay vision scanner",
+        "required_scopes": ["replay_scanner:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-observations-get": {
+        "description": "Get a single scanner observation by ID. Returns the full `scanner_snapshot` (the scanner's configuration as it was at run time, for reproducibility across `scanner_version` bumps) and the full `scanner_result` including any event citations linking the LLM output back to specific events in the originating session. Pair with the session-recording MCP tools or the investigating-replay skill to inspect the underlying recording.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get scanner observation",
+        "title": "Get scanner observation",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-scan-session": {
+        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Run scanner against a session now",
+        "title": "Run scanner against a session now",
+        "required_scopes": ["replay_scanner:write", "session_recording:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "replay-vision"
     }
 }

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -1,0 +1,123 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * MCP service uses these Zod schemas for generated tool handlers.
+ * To regenerate: hogli build:openapi
+ *
+ * PostHog API - MCP 5 enabled ops
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+/**
+ * CRUD for Replay Vision scanners.
+ */
+export const VisionScannersListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const VisionScannersListQueryParams = /* @__PURE__ */ zod.object({
+    emits_signals: zod.boolean().optional().describe('Filter to scanners that emit Signals.'),
+    enabled: zod.boolean().optional().describe('Filter to enabled vs disabled scanners.'),
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    order_by: zod
+        .array(zod.string())
+        .optional()
+        .describe(
+            'Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.\n\n* `name` - Name\n* `-name` - Name (descending)\n* `created_at` - Created at\n* `-created_at` - Created at (descending)\n* `updated_at` - Updated at\n* `-updated_at` - Updated at (descending)\n* `scanner_type` - Scanner type\n* `-scanner_type` - Scanner type (descending)'
+        ),
+    scanner_type: zod
+        .enum(['classifier', 'indexer', 'monitor', 'scorer', 'summarizer'])
+        .optional()
+        .describe(
+            'Filter by scanner type (monitor, classifier, scorer, summarizer, indexer).\n\n* `monitor` - Monitor\n* `classifier` - Classifier\n* `scorer` - Scorer\n* `summarizer` - Summarizer\n* `indexer` - Indexer'
+        ),
+})
+
+/**
+ * CRUD for Replay Vision scanners.
+ */
+export const VisionScannersRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this replay scanner.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Apply this scanner to one specific session, on demand. Returns 202 with the workflow handle.
+ */
+export const VisionScannersObserveCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this replay scanner.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const visionScannersObserveCreateBodySessionIdMax = 128
+
+export const VisionScannersObserveCreateBody = /* @__PURE__ */ zod
+    .object({
+        session_id: zod
+            .string()
+            .max(visionScannersObserveCreateBodySessionIdMax)
+            .describe('ID of the session recording to apply the scanner to.'),
+    })
+    .describe('Body of POST /vision/scanners/{id}/observe/.')
+
+/**
+ * Read-only access to observations produced by a scanner.
+ */
+export const VisionScannersObservationsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    scanner_id: zod.string(),
+})
+
+export const VisionScannersObservationsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    order_by: zod
+        .array(zod.string())
+        .optional()
+        .describe(
+            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.\n\n* `created_at` - Created at\n* `-created_at` - Created at (descending)\n* `started_at` - Started at\n* `-started_at` - Started at (descending)\n* `completed_at` - Completed at\n* `-completed_at` - Completed at (descending)\n* `status` - Status\n* `-status` - Status (descending)'
+        ),
+    session_id: zod.string().optional().describe('Filter to observations of a specific session recording.'),
+    status: zod
+        .enum(['failed', 'pending', 'running', 'succeeded'])
+        .optional()
+        .describe(
+            'Filter by observation status.\n\n* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed'
+        ),
+    triggered_by: zod
+        .enum(['on_demand', 'schedule'])
+        .optional()
+        .describe(
+            'Filter by trigger source (schedule or on_demand).\n\n* `schedule` - Schedule\n* `on_demand` - On demand'
+        ),
+})
+
+/**
+ * Read-only access to observations produced by a scanner.
+ */
+export const VisionScannersObservationsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this replay observation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    scanner_id: zod.string(),
+})

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -96,10 +96,10 @@ export const VisionScannersObservationsListQueryParams = /* @__PURE__ */ zod.obj
         ),
     session_id: zod.string().optional().describe('Filter to observations of a specific session recording.'),
     status: zod
-        .enum(['failed', 'pending', 'running', 'succeeded'])
+        .enum(['failed', 'ineligible', 'pending', 'running', 'succeeded'])
         .optional()
         .describe(
-            'Filter by observation status.\n\n* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed'
+            'Filter by observation status.\n\n* `pending` - Pending\n* `running` - Running\n* `succeeded` - Succeeded\n* `failed` - Failed\n* `ineligible` - Ineligible'
         ),
     triggered_by: zod
         .enum(['on_demand', 'schedule'])

--- a/services/mcp/src/lib/oauth-scopes.generated.ts
+++ b/services/mcp/src/lib/oauth-scopes.generated.ts
@@ -139,6 +139,8 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'property_definition:write',
     'query:read',
     'query:write',
+    'replay_scanner:read',
+    'replay_scanner:write',
     'revenue_analytics:read',
     'revenue_analytics:write',
     'session_recording:read',

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -29,6 +29,7 @@ import { GENERATED_TOOLS as product_analytics } from './product_analytics'
 import { GENERATED_TOOLS as proxyRecords } from './proxy-records'
 import { GENERATED_TOOLS as queryWrappers } from './query-wrappers'
 import { GENERATED_TOOLS as replay } from './replay'
+import { GENERATED_TOOLS as replay_vision } from './replay_vision'
 import { GENERATED_TOOLS as sdk_doctor } from './sdk_doctor'
 import { GENERATED_TOOLS as signals } from './signals'
 import { GENERATED_TOOLS as surveys } from './surveys'
@@ -67,6 +68,7 @@ export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = 
     ...proxyRecords,
     ...queryWrappers,
     ...replay,
+    ...replay_vision,
     ...sdk_doctor,
     ...signals,
     ...surveys,

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -14,6 +14,21 @@ import {
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
+const VisionScannersGetSchema = VisionScannersRetrieveParams.omit({ project_id: true })
+
+const visionScannersGet = (): ToolBase<typeof VisionScannersGetSchema, Schemas.ReplayScanner> => ({
+    name: 'vision-scanners-get',
+    schema: VisionScannersGetSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionScannersGetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ReplayScanner>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/vision/scanners/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
 const VisionScannersListSchema = VisionScannersListQueryParams
 
 const visionScannersList = (): ToolBase<
@@ -37,6 +52,24 @@ const visionScannersList = (): ToolBase<
             },
         })
         return await withPostHogUrl(context, result, '/replay-vision')
+    },
+})
+
+const VisionScannersObservationsGetSchema = VisionScannersObservationsRetrieveParams.omit({ project_id: true })
+
+const visionScannersObservationsGet = (): ToolBase<
+    typeof VisionScannersObservationsGetSchema,
+    Schemas.ReplayObservation
+> => ({
+    name: 'vision-scanners-observations-get',
+    schema: VisionScannersObservationsGetSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionScannersObservationsGetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ReplayObservation>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/vision/scanners/${encodeURIComponent(String(params.scanner_id))}/observations/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
     },
 })
 
@@ -68,24 +101,6 @@ const visionScannersObservationsList = (): ToolBase<
     },
 })
 
-const VisionScannersObservationsGetSchema = VisionScannersObservationsRetrieveParams.omit({ project_id: true })
-
-const visionScannersObservationsGet = (): ToolBase<
-    typeof VisionScannersObservationsGetSchema,
-    Schemas.ReplayObservation
-> => ({
-    name: 'vision-scanners-observations-get',
-    schema: VisionScannersObservationsGetSchema,
-    handler: async (context: Context, params: z.infer<typeof VisionScannersObservationsGetSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.ReplayObservation>({
-            method: 'GET',
-            path: `/api/environments/${encodeURIComponent(String(projectId))}/vision/scanners/${encodeURIComponent(String(params.scanner_id))}/observations/${encodeURIComponent(String(params.id))}/`,
-        })
-        return result
-    },
-})
-
 const VisionScannersScanSessionSchema = VisionScannersObserveCreateParams.omit({ project_id: true }).extend(
     VisionScannersObserveCreateBody.shape
 )
@@ -108,25 +123,10 @@ const visionScannersScanSession = (): ToolBase<typeof VisionScannersScanSessionS
     },
 })
 
-const VisionScannersGetSchema = VisionScannersRetrieveParams.omit({ project_id: true })
-
-const visionScannersGet = (): ToolBase<typeof VisionScannersGetSchema, Schemas.ReplayScanner> => ({
-    name: 'vision-scanners-get',
-    schema: VisionScannersGetSchema,
-    handler: async (context: Context, params: z.infer<typeof VisionScannersGetSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.ReplayScanner>({
-            method: 'GET',
-            path: `/api/environments/${encodeURIComponent(String(projectId))}/vision/scanners/${encodeURIComponent(String(params.id))}/`,
-        })
-        return result
-    },
-})
-
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
-    'vision-scanners-list': visionScannersList,
-    'vision-scanners-observations-list': visionScannersObservationsList,
-    'vision-scanners-observations-get': visionScannersObservationsGet,
-    'vision-scanners-scan-session': visionScannersScanSession,
     'vision-scanners-get': visionScannersGet,
+    'vision-scanners-list': visionScannersList,
+    'vision-scanners-observations-get': visionScannersObservationsGet,
+    'vision-scanners-observations-list': visionScannersObservationsList,
+    'vision-scanners-scan-session': visionScannersScanSession,
 }

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -1,0 +1,132 @@
+// AUTO-GENERATED from products/replay_vision/mcp/tools.yaml + OpenAPI — do not edit
+import { z } from 'zod'
+
+import type { Schemas } from '@/api/generated'
+import {
+    VisionScannersListQueryParams,
+    VisionScannersObservationsListParams,
+    VisionScannersObservationsListQueryParams,
+    VisionScannersObservationsRetrieveParams,
+    VisionScannersObserveCreateBody,
+    VisionScannersObserveCreateParams,
+    VisionScannersRetrieveParams,
+} from '@/generated/replay_vision/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const VisionScannersListSchema = VisionScannersListQueryParams
+
+const visionScannersList = (): ToolBase<
+    typeof VisionScannersListSchema,
+    WithPostHogUrl<Schemas.PaginatedReplayScannerList>
+> => ({
+    name: 'vision-scanners-list',
+    schema: VisionScannersListSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionScannersListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedReplayScannerList>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/vision/scanners/`,
+            query: {
+                emits_signals: params.emits_signals,
+                enabled: params.enabled,
+                limit: params.limit,
+                offset: params.offset,
+                order_by: params.order_by,
+                scanner_type: params.scanner_type,
+            },
+        })
+        return await withPostHogUrl(context, result, '/replay-vision')
+    },
+})
+
+const VisionScannersObservationsListSchema = VisionScannersObservationsListParams.omit({ project_id: true }).extend(
+    VisionScannersObservationsListQueryParams.shape
+)
+
+const visionScannersObservationsList = (): ToolBase<
+    typeof VisionScannersObservationsListSchema,
+    WithPostHogUrl<Schemas.PaginatedReplayObservationList>
+> => ({
+    name: 'vision-scanners-observations-list',
+    schema: VisionScannersObservationsListSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionScannersObservationsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedReplayObservationList>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/vision/scanners/${encodeURIComponent(String(params.scanner_id))}/observations/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+                order_by: params.order_by,
+                session_id: params.session_id,
+                status: params.status,
+                triggered_by: params.triggered_by,
+            },
+        })
+        return await withPostHogUrl(context, result, '/replay-vision')
+    },
+})
+
+const VisionScannersObservationsGetSchema = VisionScannersObservationsRetrieveParams.omit({ project_id: true })
+
+const visionScannersObservationsGet = (): ToolBase<
+    typeof VisionScannersObservationsGetSchema,
+    Schemas.ReplayObservation
+> => ({
+    name: 'vision-scanners-observations-get',
+    schema: VisionScannersObservationsGetSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionScannersObservationsGetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ReplayObservation>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/vision/scanners/${encodeURIComponent(String(params.scanner_id))}/observations/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const VisionScannersScanSessionSchema = VisionScannersObserveCreateParams.omit({ project_id: true }).extend(
+    VisionScannersObserveCreateBody.shape
+)
+
+const visionScannersScanSession = (): ToolBase<typeof VisionScannersScanSessionSchema, unknown> => ({
+    name: 'vision-scanners-scan-session',
+    schema: VisionScannersScanSessionSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionScannersScanSessionSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.session_id !== undefined) {
+            body['session_id'] = params.session_id
+        }
+        const result = await context.api.request<unknown>({
+            method: 'POST',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/vision/scanners/${encodeURIComponent(String(params.id))}/observe/`,
+            body,
+        })
+        return result
+    },
+})
+
+const VisionScannersGetSchema = VisionScannersRetrieveParams.omit({ project_id: true })
+
+const visionScannersGet = (): ToolBase<typeof VisionScannersGetSchema, Schemas.ReplayScanner> => ({
+    name: 'vision-scanners-get',
+    schema: VisionScannersGetSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionScannersGetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ReplayScanner>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/vision/scanners/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'vision-scanners-list': visionScannersList,
+    'vision-scanners-observations-list': visionScannersObservationsList,
+    'vision-scanners-observations-get': visionScannersObservationsGet,
+    'vision-scanners-scan-session': visionScannersScanSession,
+    'vision-scanners-get': visionScannersGet,
+}

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -683,9 +683,10 @@ describe('Tool Filtering - Feature Flags', () => {
                 'mcp-feedback-tool',
                 'user-interviews',
                 'customer-analytics-csp',
+                'replay-vision',
             ])
         )
-        expect(flags).toHaveLength(7)
+        expect(flags).toHaveLength(8)
     })
 
     // Test the filtering logic with a direct unit test approach using


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

Add round of MCP tools for simple get/list tools for Vision/Scanners

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Claude Desktop 

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->