### PR TITLE
fix(replay-vision): align frontend model strings with backend ScannerModel

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
@@ -29,7 +29,7 @@ function makeScanner(overrides: Partial<ReplayScanner> = {}): ReplayScanner {
         sampling_rate: 0.1,
         query: null,
         provider: 'google',
-        model: 'gemini-3-flash',
+        model: 'gemini-3-flash-preview',
         emits_signals: false,
         scanner_version: 1,
         last_swept_at: '2026-05-12T00:00:00Z',

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -7,7 +7,7 @@ export type ScannerType = 'monitor' | 'classifier' | 'scorer' | 'summarizer' | '
 export type EnabledFilter = 'enabled' | 'disabled'
 
 export const DEFAULT_PROVIDER = 'google'
-export const DEFAULT_MODEL = 'gemini-3-flash'
+export const DEFAULT_MODEL = 'gemini-3-flash-preview'
 
 export const ENABLED_OPTIONS: { value: EnabledFilter; label: string }[] = [
     { value: 'enabled', label: 'Enabled' },
@@ -15,8 +15,8 @@ export const ENABLED_OPTIONS: { value: EnabledFilter; label: string }[] = [
 ]
 
 export const MODEL_OPTIONS: { value: string; label: string }[] = [
-    { value: 'gemini-3-flash', label: 'Gemini 3 Flash' },
-    { value: 'gemini-3-flash-lite', label: 'Gemini 3 Flash Lite' },
+    { value: 'gemini-3-flash-preview', label: 'Gemini 3 Flash' },
+    { value: 'gemini-3.1-flash-lite-preview', label: 'Gemini 3 Flash Lite' },
 ]
 
 export const SCANNER_TYPE_OPTIONS: { value: ScannerType; label: string; description: string }[] = [


### PR DESCRIPTION
## Problem

`MODEL_OPTIONS` and `DEFAULT_MODEL` in `replay_scanners/types.ts` used `gemini-3-flash` and `gemini-3-flash-lite`, but the backend `ScannerModel` enum is `gemini-3-flash-preview` and `gemini-3.1-flash-lite-preview`. Creating a scanner from the UI fails validation with an invalid-choice error.

The backend rename happened in migration `0005_alter_replaylens_model.py`; the frontend wasn't updated.

## Changes

Three string replacements in `types.ts` plus one in the existing logic test fixture. No schema or behavior change beyond what the user picks from the existing dropdown.

## How did you test this code?

Agent-authored. Eyeballed the diff against `backend/models/replay_scanner.py:ScannerModel`. Jest tests for replay_scanners fail locally on `master` too with a pre-existing `Cannot find module 'posthog-js/rrweb-types'` env issue, so no useful local test signal; CI will exercise the test fixture.

## Publish to changelog?

no

## 🤖 Agent context

Tool: Claude Code. Surfaced while triaging which `model` values were valid for the `POST /vision/scanners/` endpoint — the frontend `MODEL_OPTIONS` strings would have round-tripped to an HTTP 400.
