### PR TITLE
chore(signals): log every pr-merge report resolution outcome

### DIFF
--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -142,9 +142,7 @@ def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
         SignalReport.Status.DELETED,
         SignalReport.Status.SUPPRESSED,
     )
-    linked_reports = list(
-        SignalReport.objects.filter(report_tasks__task_id=task_id).distinct().only("id", "status")
-    )
+    linked_reports = list(SignalReport.objects.filter(report_tasks__task_id=task_id).distinct().only("id", "status"))
     reports_to_resolve = [r for r in linked_reports if r.status not in terminal_statuses]
     skipped_terminal = [r for r in linked_reports if r.status in terminal_statuses]
 

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -137,33 +137,59 @@ def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
     Kept tolerant: a single bad transition should not fail the whole webhook,
     since GitHub retries 5xx responses and we've already acknowledged the PR event.
     """
-    reports = (
-        SignalReport.objects.filter(report_tasks__task_id=task_id)
-        .exclude(
-            status__in=[
-                SignalReport.Status.RESOLVED,
-                SignalReport.Status.DELETED,
-                SignalReport.Status.SUPPRESSED,
-            ]
-        )
-        .distinct()
+    terminal_statuses = (
+        SignalReport.Status.RESOLVED,
+        SignalReport.Status.DELETED,
+        SignalReport.Status.SUPPRESSED,
+    )
+    linked_reports = list(
+        SignalReport.objects.filter(report_tasks__task_id=task_id).distinct().only("id", "status")
+    )
+    reports_to_resolve = [r for r in linked_reports if r.status not in terminal_statuses]
+    skipped_terminal = [r for r in linked_reports if r.status in terminal_statuses]
+
+    # Always emit a summary so we can tell, from logs alone, whether the merge handler
+    # ran, how many reports were linked, and why we did/didn't transition any of them.
+    logger.info(
+        "github_pr_webhook_signal_report_resolution_started",
+        task_id=str(task_id),
+        pr_url=pr_url,
+        linked_report_count=len(linked_reports),
+        candidate_report_count=len(reports_to_resolve),
+        skipped_terminal_count=len(skipped_terminal),
+        skipped_terminal_report_ids=[str(r.id) for r in skipped_terminal],
+        candidate_report_ids=[str(r.id) for r in reports_to_resolve],
     )
 
-    for report in reports:
+    resolved_count = 0
+    invalid_transition_count = 0
+    for report in reports_to_resolve:
         try:
             updated_fields = report.transition_to(SignalReport.Status.RESOLVED)
         except InvalidStatusTransition:
+            invalid_transition_count += 1
             logger.warning(
                 "github_pr_webhook_signal_report_invalid_transition",
                 report_id=str(report.id),
                 from_status=report.status,
+                task_id=str(task_id),
                 pr_url=pr_url,
             )
             continue
         report.save(update_fields=updated_fields)
+        resolved_count += 1
         logger.info(
             "github_pr_webhook_signal_report_resolved",
             report_id=str(report.id),
             task_id=str(task_id),
             pr_url=pr_url,
         )
+
+    logger.info(
+        "github_pr_webhook_signal_report_resolution_finished",
+        task_id=str(task_id),
+        pr_url=pr_url,
+        resolved_count=resolved_count,
+        invalid_transition_count=invalid_transition_count,
+        skipped_terminal_count=len(skipped_terminal),
+    )


### PR DESCRIPTION
## Problem

The signals PR-merge webhook was silently doing nothing for some merged
PRs whose linked reports never transitioned to `resolved`. From logs we
could see `github_pr_webhook_processed` fire and match the TaskRun, but
nothing followed — no `signal_report_resolved`, no
`signal_report_invalid_transition`.

Concretely, for PR #56919 (merged 2026-04-30 16:22 UTC) the webhook
processed fine and the report's implementation task was linked, yet
report `019dc615-fb1e-7dc3-bf11-fd67d4c012b4` stayed unresolved and was
later dismissed manually. From the logs alone there's no way to tell
whether `_resolve_signal_reports_for_task` found zero linked reports or
found reports that were all already terminal (`resolved`/`deleted`/
`suppressed`) and got excluded by the queryset.

## Changes

`products/tasks/backend/webhooks.py`
- Split the resolver query so we can log the linked-report set before
  filtering: emit `github_pr_webhook_signal_report_resolution_started`
  with `linked_report_count`, `candidate_report_count`,
  `skipped_terminal_count`, and both id lists, so the empty-queryset
  case is now distinguishable from the all-terminal case in logs.
- Emit `github_pr_webhook_signal_report_resolution_finished` with
  `resolved_count` / `invalid_transition_count` / `skipped_terminal_count`
  as a per-merge summary.
- Added `task_id` to the existing `signal_report_invalid_transition`
  warning so it can be joined with the per-task summary log lines.

No behavior change: same filter set, same transition path, same
`InvalidStatusTransition` tolerance.

## How did you test this code?

I'm an agent (PostHog Code). I did not run the test suite — the
environment didn't have the Python test runner available. The change is
log-only on a function that already has 4 unit tests in
`products/tasks/backend/tests/test_webhooks.py` covering the
`merged → READY → RESOLVED`, `closed-without-merge`, `suppressed-is-skipped`,
and `no-linked-report` paths; existing assertions are status-based and
don't inspect log output, so they should continue to pass.

A human reviewer should run the webhooks test suite locally before
merging.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code in response to a Slack thread from Andy about a
signal report that wasn't auto-resolved when its linked agent PR was
merged. The investigation walked the logs (`query-logs` MCP), the
SignalReport / SignalReportTask / TaskRun rows (`execute-sql`), and the
webhook code path, and found that the merge handler had run end-to-end
but `_resolve_signal_reports_for_task` produced no follow-up log line.

The minimal change that closes the observability gap is to log the
linked-report set before the terminal-status exclude, and a summary
after the loop. We didn't change the resolver's behavior — the root
cause for that specific report still needs root-cause work, but now a
repeat case will be diagnosable from logs alone.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*