### PR TITLE
fix(hogql): push index/key filters into the groups argmax subquery

### DIFF
--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -48,7 +48,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0), equals(key, 'special-workspace'))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.team_id, 99999), 0), ifNull(equals(groups.index, 0), 0), ifNull(equals(groups.key, 'special-workspace'), 0))
@@ -82,7 +82,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0), ilike(key, '%org:%'))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.team_id, 99999), 0), ifNull(equals(groups.index, 0), 0), ifNull(ilike(groups.key, '%org:%'), 0))
@@ -133,7 +133,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.team_id, 99999), 0), ifNull(equals(groups.index, 0), 0), in(groups.properties___industry, tuple('0', '1', '2', '3')))
@@ -180,7 +180,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.team_id, 99999), 0), ifNull(equals(groups.index, 0), 0), and(in(groups.properties___industry, tuple('0', '1', '2', '3', '4')), in(groups.properties___industry, tuple('2', '3', '4', '5', '6'))))

--- a/posthog/hogql/database/argmax.py
+++ b/posthog/hogql/database/argmax.py
@@ -1,8 +1,13 @@
 from collections.abc import Callable
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
+from posthog.hogql import ast
 from posthog.hogql.ast import SelectQuery
 from posthog.hogql.parser import parse_expr
+from posthog.hogql.visitor import CloningVisitor, TraversingVisitor
+
+if TYPE_CHECKING:
+    from posthog.hogql.database.models import LazyTable
 
 
 def argmax_select(
@@ -37,8 +42,6 @@ def argmax_select(
 
     we use tuple to force nulls to be treated as values and tupleElement select it after the call
     """
-    from posthog.hogql import ast
-
     argmax_version: Callable[[ast.Expr], ast.Expr] = lambda field: ast.Call(
         name="tupleElement",
         args=[
@@ -83,3 +86,104 @@ def argmax_select(
         select_query.having = clause if select_query.having is None else ast.And(exprs=[select_query.having, clause])
 
     return select_query
+
+
+def _flatten_and(expr: ast.Expr) -> list[ast.Expr]:
+    if isinstance(expr, ast.And):
+        result: list[ast.Expr] = []
+        for child in expr.exprs:
+            result.extend(_flatten_and(child))
+        return result
+    return [expr]
+
+
+def _unwrap_table_type(table_type: ast.Type) -> ast.Type:
+    while isinstance(table_type, (ast.TableAliasType, ast.ColumnAliasedTableType, ast.VirtualTableType)):
+        table_type = table_type.table_type
+    return table_type
+
+
+class _PushdownChecker(TraversingVisitor):
+    """Walks an expression and stays True only if every Field reference resolves to
+    `lazy_table` and uses a field name in `allowed_field_names`. Function calls,
+    constants, and comparison operators are fine; subqueries and lambdas are not.
+    """
+
+    def __init__(self, lazy_table: "LazyTable", allowed_field_names: set[str]) -> None:
+        super().__init__()
+        self.lazy_table = lazy_table
+        self.allowed_field_names = allowed_field_names
+        self.is_pushable: bool = True
+        self.has_field_ref: bool = False
+
+    def visit_field(self, node: ast.Field) -> None:
+        if not self.is_pushable:
+            return
+        if not isinstance(node.type, ast.FieldType):
+            self.is_pushable = False
+            return
+        table_type = _unwrap_table_type(node.type.table_type)
+        if not isinstance(table_type, ast.LazyTableType) or table_type.table is not self.lazy_table:
+            self.is_pushable = False
+            return
+        if node.type.name not in self.allowed_field_names:
+            self.is_pushable = False
+            return
+        self.has_field_ref = True
+
+    def visit_lambda(self, node: ast.Lambda) -> None:
+        self.is_pushable = False
+
+    def visit_select_query(self, node: ast.SelectQuery) -> None:
+        self.is_pushable = False
+
+    def visit_select_set_query(self, node: ast.SelectSetQuery) -> None:
+        self.is_pushable = False
+
+
+class _PushdownCloner(CloningVisitor):
+    """Clones an expression with types cleared, replacing Field nodes whose original
+    type points to `lazy_table` with an unqualified `ast.Field(chain=[field_name])`.
+    The inner subquery's SELECT exposes each group_field by the same alias, so the
+    unqualified chain re-resolves there during `resolve_types`.
+    """
+
+    def __init__(self, lazy_table: "LazyTable") -> None:
+        super().__init__(clear_types=True, clear_locations=True)
+        self.lazy_table = lazy_table
+
+    def visit_field(self, node: ast.Field) -> ast.Field:
+        if isinstance(node.type, ast.FieldType):
+            table_type = _unwrap_table_type(node.type.table_type)
+            if isinstance(table_type, ast.LazyTableType) and table_type.table is self.lazy_table:
+                return ast.Field(chain=[node.type.name])
+        return super().visit_field(node)
+
+
+def pushdown_predicates_to_argmax_subquery(
+    subquery: ast.SelectQuery,
+    outer_where: ast.Expr | None,
+    lazy_table: "LazyTable",
+    pushdown_field_names: set[str],
+) -> None:
+    """Push conjuncts from the outer WHERE into `subquery.where` when they reference
+    only `pushdown_field_names` of `lazy_table`. The outer WHERE is left untouched
+    because pushing without removing is always safe: the outer filter is redundant
+    once the inner subquery has already applied it.
+
+    `pushdown_field_names` must be a subset of the argmax subquery's GROUP BY keys,
+    otherwise the filter would change result rows (the alias would point through an
+    argMax aggregate). Callers are responsible for that invariant.
+    """
+    if outer_where is None or not pushdown_field_names:
+        return
+    pushable: list[ast.Expr] = []
+    for conj in _flatten_and(outer_where):
+        checker = _PushdownChecker(lazy_table, pushdown_field_names)
+        checker.visit(conj)
+        if checker.is_pushable and checker.has_field_ref:
+            pushable.append(_PushdownCloner(lazy_table).visit(conj))
+    if not pushable:
+        return
+    combined: ast.Expr = pushable[0] if len(pushable) == 1 else ast.And(exprs=pushable)
+    subquery.where = combined if subquery.where is None else ast.And(exprs=[subquery.where, combined])

--- a/posthog/hogql/database/schema/groups.py
+++ b/posthog/hogql/database/schema/groups.py
@@ -1,6 +1,6 @@
 from posthog.hogql.ast import SelectQuery
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.argmax import argmax_select
+from posthog.hogql.database.argmax import argmax_select, pushdown_predicates_to_argmax_subquery
 from posthog.hogql.database.models import (
     DateTimeDatabaseField,
     FieldOrTable,
@@ -18,6 +18,12 @@ from posthog.hogql.database.schema.groups_revenue_analytics import (
     join_with_groups_revenue_analytics_table,
 )
 from posthog.hogql.errors import ResolutionError
+
+# GROUP BY keys of the argmax subquery built by `select_from_groups_table`. Filters
+# on these keys can be pushed into the inner subquery because they map to raw
+# columns (not argMax aggregates), so pre-aggregation filtering yields the same
+# rows while letting argMax skip groups the caller doesn't want.
+GROUPS_PUSHDOWN_FIELDS: frozenset[str] = frozenset({"index", "key"})
 
 GROUPS_TABLE_FIELDS: dict[str, FieldOrTable] = {
     "index": IntegerDatabaseField(name="group_type_index", nullable=False),
@@ -92,7 +98,14 @@ class GroupsTable(LazyTable):
     fields: dict[str, FieldOrTable] = GROUPS_TABLE_FIELDS
 
     def lazy_select(self, table_to_add: LazyTableToAdd, context, node):
-        return select_from_groups_table(table_to_add.fields_accessed)
+        select = select_from_groups_table(table_to_add.fields_accessed)
+        pushdown_predicates_to_argmax_subquery(
+            subquery=select,
+            outer_where=node.where if node is not None else None,
+            lazy_table=self,
+            pushdown_field_names=set(GROUPS_PUSHDOWN_FIELDS),
+        )
+        return select
 
     def to_printed_clickhouse(self, context):
         return "groups"

--- a/posthog/hogql/database/schema/test/__snapshots__/test_groups_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_groups_revenue_analytics.ambr
@@ -9,7 +9,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(key, 'lolol0:xxx'))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   LEFT JOIN
@@ -474,7 +474,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(key, 'lolol0:xxx'))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   LEFT JOIN
@@ -2312,7 +2312,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(key, 'lolol0:xxx'))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   LEFT JOIN
@@ -2421,7 +2421,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(key, 'lolol0:xxx'))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   LEFT JOIN

--- a/posthog/hogql/database/test/test_argmax.py
+++ b/posthog/hogql/database/test/test_argmax.py
@@ -1,7 +1,18 @@
-from posthog.test.base import BaseTest
+import datetime
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+from django.utils.timezone import now
 
 from posthog.hogql import ast
-from posthog.hogql.database.argmax import argmax_select
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.argmax import argmax_select, pushdown_predicates_to_argmax_subquery
+from posthog.hogql.database.schema.groups import GROUPS_PUSHDOWN_FIELDS, GroupsTable
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.models.group.util import create_group, raw_create_group_ch
 
 
 class TestArgmax(BaseTest):
@@ -98,3 +109,168 @@ class TestArgmax(BaseTest):
             ),
         )
         self.assertEqual(response, expected)
+
+
+class TestPushdownPredicatesToArgmaxSubquery(BaseTest):
+    """Direct unit tests of the helper that runs against an already-built subquery."""
+
+    def _build_subquery(self) -> ast.SelectQuery:
+        return argmax_select(
+            table_name="raw_groups",
+            select_fields={"properties": ["properties"], "index": ["index"], "key": ["key"]},
+            group_fields=["index", "key"],
+            argmax_field="updated_at",
+        )
+
+    def test_no_outer_where_is_noop(self):
+        subquery = self._build_subquery()
+        pushdown_predicates_to_argmax_subquery(
+            subquery=subquery,
+            outer_where=None,
+            lazy_table=GroupsTable(),
+            pushdown_field_names=set(GROUPS_PUSHDOWN_FIELDS),
+        )
+        self.assertIsNone(subquery.where)
+
+    def test_empty_pushdown_fields_is_noop(self):
+        subquery = self._build_subquery()
+        outer = ast.CompareOperation(
+            left=ast.Field(chain=["index"]), op=ast.CompareOperationOp.Eq, right=ast.Constant(value=0)
+        )
+        pushdown_predicates_to_argmax_subquery(
+            subquery=subquery,
+            outer_where=outer,
+            lazy_table=GroupsTable(),
+            pushdown_field_names=set(),
+        )
+        self.assertIsNone(subquery.where)
+
+
+class TestGroupsPushdownSQL(BaseTest):
+    """End-to-end tests that print SQL and assert the WHERE clause lands inside the
+    argmax subquery for `FROM groups WHERE <index/key filter>` queries."""
+
+    def _print(self, hogql: str) -> str:
+        return prepare_and_print_ast(
+            parse_select(hogql),
+            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+            "clickhouse",
+        )[0]
+
+    def test_index_filter_pushed_into_argmax_subquery(self):
+        sql = self._print("SELECT key FROM groups WHERE index = 0")
+        # Inner subquery's WHERE picks up `index = 0` next to the team_id guard.
+        self.assertIn("FROM groups WHERE and(equals(groups.team_id,", sql)
+        self.assertIn("equals(index, 0)) GROUP BY", sql)
+
+    def test_key_filter_pushed_into_argmax_subquery(self):
+        sql = self._print("SELECT key FROM groups WHERE key = 'abc'")
+        self.assertIn("equals(key, %(hogql_val_0)s)) GROUP BY", sql)
+
+    def test_compound_index_and_key_filter_pushed(self):
+        sql = self._print("SELECT key FROM groups WHERE index = 0 AND key = 'abc'")
+        self.assertIn("equals(index, 0)", sql.split("GROUP BY")[0])
+        self.assertIn("equals(key, %(hogql_val_0)s)", sql.split("GROUP BY")[0])
+
+    def test_non_group_by_field_is_not_pushed(self):
+        # `properties` reaches through argMax(); pre-aggregation filtering on it would
+        # change which row argMax picks, so it must stay above the subquery.
+        sql = self._print("SELECT key FROM groups WHERE properties = '{}'")
+        before_group_by, after_group_by = sql.split("GROUP BY", 1)
+        self.assertNotIn("properties", before_group_by[before_group_by.index("FROM groups") :])
+        self.assertIn("properties", after_group_by)
+
+    def test_mixed_filter_only_pushes_safe_conjuncts(self):
+        sql = self._print("SELECT key FROM groups WHERE index = 0 AND properties = '{}'")
+        before_group_by, after_group_by = sql.split("GROUP BY", 1)
+        self.assertIn("equals(index, 0)", before_group_by)
+        # `properties` stays in the outer WHERE only.
+        self.assertNotIn("properties", before_group_by[before_group_by.index("FROM groups WHERE") :])
+        self.assertIn("properties", after_group_by)
+
+    def test_no_where_clause_still_works(self):
+        # Regression: a query without any WHERE shouldn't blow up or add a stray WHERE.
+        sql = self._print("SELECT key FROM groups LIMIT 1")
+        # Inner subquery still gets the team_id guard but nothing more.
+        self.assertIn("FROM groups WHERE equals(groups.team_id,", sql)
+        # No `AND` next to the team_id guard inside the subquery.
+        # (a second AND would mean we incorrectly pushed something.)
+        before_group_by = sql.split("GROUP BY", 1)[0]
+        self.assertNotIn("AND", before_group_by.upper().replace("AND(", ""))
+
+    def test_in_filter_on_index_pushed(self):
+        sql = self._print("SELECT key FROM groups WHERE index IN (0, 1)")
+        before_group_by = sql.split("GROUP BY", 1)[0]
+        # The IN list lives inside the subquery WHERE alongside the team_id guard.
+        self.assertIn("in(index,", before_group_by)
+
+    def test_aliased_table_still_pushes(self):
+        sql = self._print("SELECT g.key FROM groups AS g WHERE g.index = 0")
+        before_group_by = sql.split("GROUP BY", 1)[0]
+        self.assertIn("equals(index, 0)", before_group_by)
+
+
+class TestGroupsPushdownExecution(ClickhouseTestMixin, BaseTest):
+    """Run real ClickHouse queries to confirm the pushdown produces the same rows
+    as the old behavior. The cheapest correctness guarantee for an optimization
+    that rewrites the AST."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        earlier = now() - datetime.timedelta(minutes=5)
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org_a",
+            properties={"name": "Org A"},
+            timestamp=earlier,
+        )
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org_b", properties={"name": "Org B"})
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=1,
+            group_key="account_c",
+            properties={"name": "Account C"},
+        )
+        # Second ClickHouse-only version of org_a with a later _timestamp so argMax has to pick it.
+        raw_create_group_ch(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org_a",
+            properties={"name": "Org A Updated"},
+            created_at=earlier,
+            timestamp=now(),
+        )
+
+    def test_index_filter_returns_only_matching_index(self):
+        result = execute_hogql_query(
+            team=self.team,
+            query="SELECT key FROM groups WHERE index = 0 ORDER BY key",
+        )
+        keys = [row[0] for row in result.results]
+        self.assertEqual(keys, ["org_a", "org_b"])
+
+    def test_index_and_key_filter_returns_single_row(self):
+        result = execute_hogql_query(
+            team=self.team,
+            query="SELECT JSONExtractString(properties, 'name') FROM groups WHERE index = 0 AND key = 'org_a'",
+        )
+        names = [row[0] for row in result.results]
+        # argMax must still resolve to the latest version of org_a.
+        self.assertEqual(names, ["Org A Updated"])
+
+    def test_filter_on_index_one_returns_only_account(self):
+        result = execute_hogql_query(
+            team=self.team,
+            query="SELECT key FROM groups WHERE index = 1",
+        )
+        keys = [row[0] for row in result.results]
+        self.assertEqual(keys, ["account_c"])
+
+    def test_no_filter_returns_all_groups(self):
+        result = execute_hogql_query(
+            team=self.team,
+            query="SELECT key FROM groups ORDER BY key",
+        )
+        keys = [row[0] for row in result.results]
+        self.assertEqual(keys, ["account_c", "org_a", "org_b"])

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
@@ -13,7 +13,7 @@
                groups.group_type_index AS index,
                groups.group_key AS key
         FROM groups
-        WHERE equals(groups.team_id, 99999)
+        WHERE and(equals(groups.team_id, 99999), equals(index, 0))
         GROUP BY groups.group_type_index,
                  groups.group_key) AS groups ARRAY
      JOIN arrayEnumerate([toString(groups.properties___industry)]) AS prop_index,
@@ -48,7 +48,7 @@
                groups.group_type_index AS index,
                groups.group_key AS key
         FROM groups
-        WHERE equals(groups.team_id, 99999)
+        WHERE and(equals(groups.team_id, 99999), equals(index, 0))
         GROUP BY groups.group_type_index,
                  groups.group_key) AS groups ARRAY
      JOIN arrayEnumerate([toString(groups.`properties___does not exist`)]) AS prop_index,
@@ -83,7 +83,7 @@
                groups.group_type_index AS index,
                groups.group_key AS key
         FROM groups
-        WHERE equals(groups.team_id, 99999)
+        WHERE and(equals(groups.team_id, 99999), equals(index, 0))
         GROUP BY groups.group_type_index,
                  groups.group_key) AS groups ARRAY
      JOIN arrayEnumerate([toString(groups.properties___employee_count)]) AS prop_index,

--- a/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
+++ b/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
@@ -8,7 +8,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE ifNull(equals(groups.index, 0), 0)
@@ -38,7 +38,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE ifNull(equals(groups.index, 0), 0)
@@ -95,7 +95,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.index, 0), 0), ifNull(greater(accurateCastOrNull(groups.properties___arr, 'Float64'), 100.0), 0))
@@ -122,7 +122,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE ifNull(equals(groups.index, 0), 0)
@@ -151,7 +151,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE ifNull(equals(groups.index, 0), 0)
@@ -180,7 +180,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE ifNull(equals(groups.index, 0), 0)
@@ -206,7 +206,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE ifNull(equals(groups.index, 0), 0)
@@ -236,7 +236,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE ifNull(equals(groups.index, 0), 0)
@@ -290,7 +290,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.index, 0), 0), ifNull(equals(groups.properties___name, 'org0.inc'), 0))
@@ -317,7 +317,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%org2%'), 0), ilike(toString(groups.key), '%org2%')))
@@ -346,7 +346,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%test%'), 0), ilike(toString(groups.key), '%test%')))
@@ -403,7 +403,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%test%'), 0), ilike(toString(groups.key), '%test%')))
@@ -430,7 +430,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%api%'), 0), ilike(toString(groups.key), '%api%')))
@@ -460,7 +460,7 @@
             groups.group_type_index AS index,
             groups.group_key AS key
      FROM groups
-     WHERE equals(groups.team_id, 99999)
+     WHERE and(equals(groups.team_id, 99999), equals(index, 0))
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE ifNull(equals(groups.index, 0), 0)

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -2972,7 +2972,7 @@
                   groups.group_type_index AS index,
                   groups.group_key AS key
            FROM groups
-           WHERE equals(groups.team_id, 99999)
+           WHERE and(equals(groups.team_id, 99999), equals(index, 0))
            GROUP BY groups.group_type_index,
                     groups.group_key) AS groups
         WHERE ifNull(equals(groups.index, 0), 0)) AS groups_0 ON equals(funnel_actors.actor_id, groups_0.key)) AS aggregation_target_with_props
@@ -3407,7 +3407,7 @@
                   groups.group_type_index AS index,
                   groups.group_key AS key
            FROM groups
-           WHERE equals(groups.team_id, 99999)
+           WHERE and(equals(groups.team_id, 99999), equals(index, 0))
            GROUP BY groups.group_type_index,
                     groups.group_key) AS groups
         WHERE ifNull(equals(groups.index, 0), 0)) AS groups_0 ON equals(funnel_actors.actor_id, groups_0.key)) AS aggregation_target_with_props
@@ -4096,7 +4096,7 @@
                   groups.group_type_index AS index,
                   groups.group_key AS key
            FROM groups
-           WHERE equals(groups.team_id, 99999)
+           WHERE and(equals(groups.team_id, 99999), equals(index, 0))
            GROUP BY groups.group_type_index,
                     groups.group_key) AS groups
         WHERE ifNull(equals(groups.index, 0), 0)) AS groups_0 ON equals(funnel_actors.actor_id, groups_0.key)) AS aggregation_target_with_props
@@ -4531,7 +4531,7 @@
                   groups.group_type_index AS index,
                   groups.group_key AS key
            FROM groups
-           WHERE equals(groups.team_id, 99999)
+           WHERE and(equals(groups.team_id, 99999), equals(index, 0))
            GROUP BY groups.group_type_index,
                     groups.group_key) AS groups
         WHERE ifNull(equals(groups.index, 0), 0)) AS groups_0 ON equals(funnel_actors.actor_id, groups_0.key)) AS aggregation_target_with_props


### PR DESCRIPTION
## Problem

`FROM groups WHERE index = N` in HogQL hits the ClickHouse memory limit on
teams with many groups. The expanded SQL aggregates across every
`group_type_index` first and applies the filter afterward, so the
intermediate argMax state holds entries for groups the caller never
wanted.

Current expansion for `FROM groups WHERE index = 0`:

```sql
SELECT ... FROM (
    SELECT argMax(tuple(group_properties), _timestamp) AS properties,
           group_type_index AS index, group_key AS key
    FROM groups
    WHERE equals(groups.team_id, ?)
    GROUP BY group_type_index, group_key   -- aggregates all types
) AS groups
WHERE ifNull(equals(groups.index, 0), 0)   -- filter applied too late
```

ClickHouse's predicate-expression optimizer cannot push the outer filter
through GROUP BY because the HogQL printer wraps it in `ifNull(...)`.
The user's workaround was to hand-roll the CTE against `raw_groups` with
their own argMax, which is exactly what `select_from_groups_table`
already does internally, just with the filter in the right place.

The JOIN-via-`groupN` path already plants `index = N` inside the inner
subquery (`join_with_group_n_table` in `groups.py`). This PR extends the
same idea to the direct-SELECT path.

## Changes

- `posthog/hogql/database/argmax.py`: new helper
  `pushdown_predicates_to_argmax_subquery` that walks the outer WHERE,
  picks conjuncts that reference only a configurable set of fields on
  the target LazyTable, clones them with types cleared, rewrites field
  chains to the inner SELECT alias, and ANDs them into the subquery's
  WHERE. Lambdas and inner subqueries are not pushed.
- `posthog/hogql/database/schema/groups.py`: `GroupsTable.lazy_select`
  passes the outer WHERE through the helper, restricted to `{index, key}`
  which are the GROUP BY columns of `select_from_groups_table`. Other
  fields like `properties` resolve through the argMax aggregate and
  must stay above the subquery.
- The outer WHERE is left intact. Pushing without removing is always
  safe: the duplicate filter is a no-op once the inner subquery has
  applied it. Skipping the removal also keeps the change to a single
  call site.

The same pattern applies to other argmax-based LazyTables (persons,
person_distinct_ids, the override tables) but those each have more
elaborate `lazy_select` flows and I would rather land the targeted fix
first.

After this PR:

```sql
SELECT ... FROM (
    SELECT argMax(tuple(group_properties), _timestamp) AS properties,
           group_type_index AS index, group_key AS key
    FROM groups
    WHERE and(equals(groups.team_id, ?), equals(index, 0))   -- pushed
    GROUP BY group_type_index, group_key
) AS groups
WHERE ifNull(equals(groups.index, 0), 0)
```

## How did you test this code?

I am an agent (Claude Code). I did not perform manual UI testing. I ran:

- `hogli test posthog/hogql/database/test/test_argmax.py` (16 tests) covering:
  - The helper short-circuiting when there is no outer WHERE or no
    pushdown fields.
  - SQL-printer assertions for `index = N`, `key = 'x'`, the AND
    combination, `IN (...)`, table-aliased queries, and the
    non-pushable cases (`properties = '...'`, mixed predicates).
  - Real ClickHouse execution: a team with two group types and a
    second ClickHouse-only row of `org_a` so argMax has to pick the
    latest version. The pushdown path returns the same rows.
- `hogli test posthog/hogql/database/schema/test/test_groups_revenue_analytics.py --snapshot-update`
  - Snapshot diff confirms `equals(key, '...')` is now inside the
    inner WHERE for the existing revenue-analytics queries. Four
    snapshots updated.
- `hogli test posthog/hogql/transforms/test/test_property_types.py`
  - Confirms the existing JOIN-via-`groupN` snapshot
    (`equals(index, 0)` inside the inner WHERE) is unchanged.
- `hogli test posthog/hogql/ -x --snapshot-update`
  - 4340 passed, 1 unrelated flake (`test_system_tables` IntegrityError,
    passes on rerun, not related to this change).

I also ran a local ClickHouse benchmark on 500k rows in `groups`
(100k unique group_keys across 5 group_type_indexes, ~4KB JSON per row)
with `log_comment` set so I could read `system.query_log`:

| Variant | read_rows | bytes_read | duration_ms |
|---------|-----------|------------|-------------|
| BEFORE  | 207,665 to 500,000 | 3.05 to 3.33 MiB | 16-28 |
| AFTER   | 107,685 (consistent) | 2.15 MiB | 9-33 |

`BEFORE` is non-deterministic because the ClickHouse optimizer sometimes
manages to push through GROUP BY and sometimes does not, depending on
whether the `ifNull` wrapper makes it into the rewrite. `AFTER` is
consistent. The local memory_usage is dominated by per-query overhead
at this dataset size, so the headline memory delta in production is not
visible locally. The read_rows reduction (and the corresponding
reduction in argMax hash-table entries) is the mechanism that fixes the
OOM.

For prod confirmation, run the same EXPLAIN/log_comment pair on a team
with many group_type_indexes on Metabase or ClickHouse-US-Prod and
compare `memory_usage` from `system.query_log`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (opus 4.7) with andyzzhao reviewing.

Session built up the diagnosis by:

- Reading `select_from_groups_table` and `argmax_select` to confirm what
  HogQL expands `FROM groups` into.
- Confirming via a one-off printer test that the user-reported query
  shape (`SELECT key, JSONExtractString(properties, 'name') FROM groups
  WHERE index = 0`) puts the filter outside the inner subquery and that
  the `ifNull(...)` wrapper is what the printer always emits for the
  outer comparison.
- Comparing with `join_with_group_n_table`, which has been doing exactly
  this pushdown for the JOIN case for a long time, confirming the
  rewrite path is well-trodden.

Trade-offs considered:

- A general predicate pushdown layer inside `lazy_tables.py` would
  benefit `persons` and `person_distinct_ids` too, but each of those
  tables has its own already-complex `lazy_select` (`PersonsArgMaxVersion`,
  `WhereClauseExtractor`) and I did not want to touch those in the same
  PR. Keeping the call site narrow to `GroupsTable.lazy_select` makes
  the change easy to review and revert.
- Removing the outer filter once it has been pushed would shave a
  fraction of work in ClickHouse, but it requires rewriting the outer
  node's WHERE in place and complicates reasoning about identity of
  AST nodes elsewhere. The duplicate filter is harmless once the inner
  one cuts the row set.
- The helper uses field-type matching, not alias matching, so multiple
  `groups`-aliased tables in the same FROM each get their own pushdown
  without confusion.