### PR TITLE
chore(ci): Remove legacy audit-action workflow

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -18,18 +18,6 @@ env:
     SEMGREP_ENABLE_VERSION_CHECK: 'false'
 
 jobs:
-    ensure-pinned-actions:
-        runs-on: ubuntu-latest
-        timeout-minutes: 15
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-            - name: Ensure SHA pinned actions
-              uses: zgosalvez/github-actions-ensure-sha-pinned-actions@6124774845927d14c601359ab8138699fa5b70c3 # v4.0.1
-              with:
-                  allowlist: |
-                      PostHog/
-
     semgrep-python:
         runs-on: ubuntu-latest
         timeout-minutes: 15


### PR DESCRIPTION
We now enforce this directly via GitHub's built-in "Require actions to be pinned to a full-length commit SHA" setting.
