### PR TITLE
feat(error-tracking): match logs empty state pattern

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1851,7 +1851,7 @@ snapshots:
     filters-taxonomic-filter-headless--properties--dark:
         hash: v1.k794b7964.4ee695e5751c6f73e9742ab0cfeecf61b5adfe829cf3a0d49ab2877cae8b212f.jPN9l5TDgLRy9NzHenXHCU903UDg8-GdeGpf4PXt7aA
     filters-taxonomic-filter-headless--properties--light:
-        hash: v1.k794b7964.7af6b884e5d826df422db99e4a99d2172f3316561a499dbe386ea098b1fc54a9.rti2DMpqC0WEtd_AtG838vQlgQMHfwjBAR4uLN_HnUk
+        hash: v1.k794b7964.bd715b36b456df8730e934366a35faed4556dffa881456db1272e2804047a036.IH74-bf3miZ6nC3E0bqbzIb0km4fBh97_2XubTpcmns
     filters-taxonomic-filter-headless--suggested-filters-with-recents--dark:
         hash: v1.k794b7964.c3a6cd419610bc486261efa753816547f080f00c838bde0b8720cf12067b3b22.nxBtExiDfJ3USkhV9RY1VPU_U2dGyEYCMFbhvtOcuVs
     filters-taxonomic-filter-headless--suggested-filters-with-recents--light:
@@ -4435,13 +4435,13 @@ snapshots:
     scenes-app-error-project-unavailable--no-selectable-projects--light:
         hash: v1.k794b7964.481d253ac770b475315f72305fa5b2a7b130e4af6e01f1004890f100ead896cc.Zjd5lM7ZRgfmBCNcsxfTbTyV54MFbOC2EAPAdj5r7aY
     scenes-app-errortracking--group-page--dark:
-        hash: v1.k794b7964.cb6d52160f954b621f4b074d227b5462260be4abe49f3f13a2894be66dbd46a7.r6Mo_2kewO6mWtyR-_aNa1k6SDjPZd4rCEYTX_48iao
+        hash: v1.k794b7964.c8e6860882c2adc15d79721f8790d613bded5df4d64424016547083a73b00b6a.2HqMTs3tTi5AWTdmpXCXHJF8_hZSC9pUVrodRXR1eZk
     scenes-app-errortracking--group-page--light:
-        hash: v1.k794b7964.d9a5c517361eb5288df3629e9b038a52df61bf37a8f434ca9e9773d42ea21841.tt_bn2Aa2QfUdoo9W_8jn4W04SAC7ZiqI8leK-O4814
+        hash: v1.k794b7964.4bd10265cf91f93b2a9c664d72298e9f0082a9dd79baa1fc39511fd55ea53043.QePUCAYH9IthBk624aP_Kihxv_2Ba3yhFXTr52R9WhQ
     scenes-app-errortracking--list-page--dark:
-        hash: v1.k794b7964.79a41b5832521be25c9af99c7b72a70ffc8848d890b5c7f7685d4fd90efb9d36.Rb1LUbf-_EZGprpJ38H1ADeWLcc1M3kqTCKe9GyYirg
+        hash: v1.k794b7964.cf80259337e4fa435ea90833a58f8dbd0aac70d897dbe793a2fb3f4b3d2ee2cd.8KYx7tA4PK4N_b282q4IWOwTON6T4Hjyyb8KS7ukc18
     scenes-app-errortracking--list-page--light:
-        hash: v1.k794b7964.d8bb86d449be2de765a5dd1e478144aeb04512edde37c7da1b5e16a55a280060.hFJOm-25oxi1zB37vWoQLL45M-A-58giqIYs8aYlpMM
+        hash: v1.k794b7964.8bc611cf5218844d5f958152a71e2a074a73302d8dbc3c9e2310b148578f1979.eBUZACFFoGzBFveQeEVGz0qOB8AIIL4NH49hogTEepQ
     scenes-app-events--event-explorer--dark:
         hash: v1.k794b7964.255bb3a04f42d5dc5922480078098194199f9ab2654ef6923d7e725ff7968ba1.NqAiq7rAZkXlnjCi3_nZCTo3qi16OjXPDyE7wa8epHY
     scenes-app-events--event-explorer--light:
@@ -4721,9 +4721,9 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
         hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
-        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
+        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.dtIb8VK_HAoAvzi8YbVjGpt2Y8yONsVV7mEiD9DrclQ
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
-        hash: v1.k794b7964.8887db0213a228a0f958496f8de814bd30d4735f99f8dcd886fbc9740a703afd.U7j0SBm9JuPzdVQVGChjxt-Iw1svrkRV06tAv9pg-mM
+        hash: v1.k794b7964.dad9df902a133cafd6b3314a3800fcb45dabbbb59a0766c87c226549392104fc.u8mciTuIKrwI-d3yiUx6dVpr3oLoJJ7tgvRU7hutwhU
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--light:
         hash: v1.k794b7964.1dd3425e658b907855610a715527654f68a242ed0c1427803dcf4d2289806fed.xd6ZnWiKWTOAglDDiM771sUAuByJ76icZNkrOre_orA
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--superwide--dark:
@@ -4731,9 +4731,9 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--superwide--light:
         hash: v1.k794b7964.c95c5a49f7a20b7fcb1041dd26c73ee87c9a906cb229247a44fd4633bbdc9173.StrJ2VBA5acLqvnsiO2CS_o6qadxeaeO6ST8lxf5UdI
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
-        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.URrKOLP9uUjbKWcui2yOA7hm_JsXsbkAlOcWJshoQrI
+        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
-        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.EIwByuofuT77yP259A9ffqfjSFwW9MrUDOvsZNA_aZM
+        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
         hash: v1.k794b7964.d64808d2bfc36017f89b57feeaa373e20188738a622801207fa1beb59d02fdd9.cFuKF_Ow887Z3X3BoNhtTvkUWY2vips9HDBe-B02eQE
     scenes-app-insights-funnels--funnel-time-to-convert--light:

--- a/products/error_tracking/frontend/components/SetupPrompt/SetupPrompt.tsx
+++ b/products/error_tracking/frontend/components/SetupPrompt/SetupPrompt.tsx
@@ -1,16 +1,44 @@
 import { useActions, useValues } from 'kea'
 
-import { IconExternal } from '@posthog/icons'
-import { LemonButton, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, Link, Spinner } from '@posthog/lemon-ui'
 
+import { WarningHog } from 'lib/components/hedgehogs'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TeamMembershipLevel } from 'lib/constants'
+import androidImage from 'scenes/onboarding/sdks/logos/android.svg'
+import flutterImage from 'scenes/onboarding/sdks/logos/flutter.svg'
+import javascriptImage from 'scenes/onboarding/sdks/logos/javascript_web.svg'
+import nextjsImage from 'scenes/onboarding/sdks/logos/nextjs.svg'
+import nodejsImage from 'scenes/onboarding/sdks/logos/nodejs.svg'
+import pythonImage from 'scenes/onboarding/sdks/logos/python.svg'
+import reactImage from 'scenes/onboarding/sdks/logos/react.svg'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import { exceptionIngestionLogic } from './exceptionIngestionLogic'
+
+const FRAMEWORK_LINKS: { name: string; image?: string; docsLink: string }[] = [
+    {
+        name: 'JavaScript',
+        image: javascriptImage,
+        docsLink: 'https://posthog.com/docs/error-tracking/installation/web',
+    },
+    { name: 'Next.js', image: nextjsImage, docsLink: 'https://posthog.com/docs/error-tracking/installation/nextjs' },
+    { name: 'React', image: reactImage, docsLink: 'https://posthog.com/docs/error-tracking/installation/react' },
+    { name: 'Node.js', image: nodejsImage, docsLink: 'https://posthog.com/docs/error-tracking/installation/nodejs' },
+    { name: 'Python', image: pythonImage, docsLink: 'https://posthog.com/docs/error-tracking/installation/python' },
+    { name: 'iOS', docsLink: 'https://posthog.com/docs/error-tracking/installation/ios' },
+    { name: 'Android', image: androidImage, docsLink: 'https://posthog.com/docs/error-tracking/installation/android' },
+    {
+        name: 'React Native',
+        image: reactImage,
+        docsLink: 'https://posthog.com/docs/error-tracking/installation/react-native',
+    },
+    { name: 'Flutter', image: flutterImage, docsLink: 'https://posthog.com/docs/error-tracking/installation/flutter' },
+    { name: 'Other', docsLink: 'https://posthog.com/docs/error-tracking/installation' },
+]
 
 export const ErrorTrackingSetupPrompt = ({
     children,
@@ -41,44 +69,69 @@ const IngestionStatusCheck = ({ className }: { className?: string }): JSX.Elemen
         scope: RestrictionScope.Project,
     })
 
+    const onDocsLinkClick = (): void => {
+        addProductIntent({
+            product_type: ProductKey.ERROR_TRACKING,
+            intent_context: ProductIntentContext.ERROR_TRACKING_DOCS_VIEWED,
+        })
+    }
+
     return (
         <ProductIntroduction
             productName="Error tracking"
             thingName="issue"
             titleOverride="You haven't captured any exceptions"
-            description="To start capturing exceptions you need to enable exception autocapture. Exception autocapture only applies to the JS SDK. Installation for other platforms are described in the docs."
+            description="PostHog captures exceptions from any of our SDKs. JavaScript apps can flip on exception autocapture; other platforms wire it up in code – the docs have per-SDK instructions."
             isEmpty={true}
             productKey={ProductKey.ERROR_TRACKING}
             className={className}
+            customHog={WarningHog}
             actionElementOverride={
-                <>
-                    <LemonButton
-                        type="primary"
-                        disabledReason={restrictionReason}
-                        onClick={() => {
-                            addProductIntent({
-                                product_type: ProductKey.ERROR_TRACKING,
-                                intent_context: ProductIntentContext.ERROR_TRACKING_EXCEPTION_AUTOCAPTURE_ENABLED,
-                            })
-                            updateCurrentTeam({ autocapture_exceptions_opt_in: true })
-                        }}
-                    >
-                        Enable exception autocapture
-                    </LemonButton>
-                    <LemonButton
-                        targetBlank
-                        sideIcon={<IconExternal className="w-5 h-5" />}
-                        to="https://posthog.com/docs/error-tracking/installation"
-                        onClick={() => {
-                            addProductIntent({
-                                product_type: ProductKey.ERROR_TRACKING,
-                                intent_context: ProductIntentContext.ERROR_TRACKING_DOCS_VIEWED,
-                            })
-                        }}
-                    >
-                        Read the docs
-                    </LemonButton>
-                </>
+                <div className="flex flex-col items-start gap-4">
+                    <p className="text-sm text-secondary m-0">
+                        Read our{' '}
+                        <Link to="https://posthog.com/docs/error-tracking" onClick={onDocsLinkClick}>
+                            error tracking docs
+                        </Link>
+                        , or pick a framework to get started:
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                        {FRAMEWORK_LINKS.map(({ name, image, docsLink }) => (
+                            <LemonButton
+                                key={name}
+                                type="secondary"
+                                size="small"
+                                to={docsLink}
+                                targetBlank
+                                onClick={onDocsLinkClick}
+                                icon={
+                                    image ? (
+                                        <img src={image} alt="" aria-hidden="true" className="w-5 h-5" />
+                                    ) : undefined
+                                }
+                            >
+                                {name}
+                            </LemonButton>
+                        ))}
+                    </div>
+                    <p className="text-sm text-secondary m-0">
+                        Already using <code>posthog-js</code>?{' '}
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            disabledReason={restrictionReason}
+                            onClick={() => {
+                                addProductIntent({
+                                    product_type: ProductKey.ERROR_TRACKING,
+                                    intent_context: ProductIntentContext.ERROR_TRACKING_EXCEPTION_AUTOCAPTURE_ENABLED,
+                                })
+                                updateCurrentTeam({ autocapture_exceptions_opt_in: true })
+                            }}
+                        >
+                            Enable exception autocapture
+                        </LemonButton>
+                    </p>
+                </div>
             }
         />
     )

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -72,14 +72,14 @@ export function ErrorTrackingScene(): JSX.Element {
             key: 'issues',
             label: 'Issues',
             content: (
-                <>
+                <ErrorTrackingSetupPrompt>
                     <ErrorTrackingIssueFilteringTool />
                     {hasSentExceptionEventLoading || hasSentExceptionEvent ? null : <IngestionStatusCheck />}
                     <div className="border rounded bg-surface-primary p-2">
                         <IssuesFilters />
                     </div>
                     <IssuesList />
-                </>
+                </ErrorTrackingSetupPrompt>
             ),
         },
         {
@@ -117,17 +117,10 @@ export function ErrorTrackingScene(): JSX.Element {
         <StyleVariables>
             <BindLogic logic={issueFiltersLogic} props={{ logicKey: ERROR_TRACKING_SCENE_LOGIC_KEY }}>
                 <BindLogic logic={issueQueryOptionsLogic} props={{ logicKey: ERROR_TRACKING_SCENE_LOGIC_KEY }}>
-                    <ErrorTrackingSetupPrompt>
-                        <SceneContent>
-                            <Header />
-                            <LemonTabs
-                                activeKey={activeTab}
-                                onChange={(key) => setActiveTab(key)}
-                                tabs={tabs}
-                                sceneInset
-                            />
-                        </SceneContent>
-                    </ErrorTrackingSetupPrompt>
+                    <SceneContent>
+                        <Header />
+                        <LemonTabs activeKey={activeTab} onChange={(key) => setActiveTab(key)} tabs={tabs} sceneInset />
+                    </SceneContent>
                 </BindLogic>
             </BindLogic>
         </StyleVariables>


### PR DESCRIPTION
## Problem

When a project has no exceptions captured and exception autocapture is off, the Error tracking scene replaces the entire page with the `ProductIntroduction` empty state. That hides the scene title, the tabs (Issues / Insights / Configuration), and offers only one button each for "Enable exception autocapture" and "Read the docs". Users on non-JS SDKs land here with no orientation — no per-SDK docs, no way to navigate to other tabs, no project context.

The Logs scene already handles this nicely: the title and tabs stay rendered and the empty state is scoped to the viewer tab's content area, with a framework picker for SDK-specific docs. This PR brings Error tracking in line with that pattern.

### Before
<img width="1920" height="992" alt="Screenshot 2026-05-26 at 16 34 26" src="https://github.com/user-attachments/assets/e74506c3-44e0-48b0-95b9-46e068adaed6" />

### After
<img width="1342" height="951" alt="Screenshot 2026-05-26 at 16 34 38" src="https://github.com/user-attachments/assets/c71c9e72-4214-4745-a943-7a21dd2355ea" />

## Changes

1. `products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx` — moved `<ErrorTrackingSetupPrompt>` from wrapping `<SceneContent>` to wrapping only the Issues tab content. Scene title + tabs are now always visible. Insights / Configuration / Recommendations tabs are reachable from the empty state.
2. `products/error_tracking/frontend/components/SetupPrompt/SetupPrompt.tsx` — redesigned the `IngestionStatusCheck` empty state to mirror the logs page:
   - Docs link + per-SDK framework picker (JavaScript / Next.js / React / Node.js / Python / iOS / Android / React Native / Flutter / Other), using the existing SVG logos in `frontend/src/scenes/onboarding/sdks/logos/`.
   - "Enable exception autocapture" preserved as a primary action under an "Already using posthog-js?" prompt — same `addProductIntent` telemetry as before.
   - Uses `WarningHog` via the `customHog` prop.

## How did you test this code?

Agent-authored. I did not manually open the dev server. Automated checks:

- `pnpm --filter=@posthog/frontend typescript:check` — no new errors in the changed files (pre-existing env/codegen errors elsewhere in `products/` are unrelated).
- `pnpm --filter=@posthog/frontend format` — clean.

Reviewer manual check should cover:
- Visit `/project/<id>/error_tracking` with autocapture off and no exceptions — confirm the scene title and all tabs are visible, and the Issues tab content shows the new empty state with framework picker + autocapture button.
- Switch to Insights / Configuration tabs from the empty state — confirm they render normally.
- Click "Enable exception autocapture" — confirm autocapture flips on and the empty state disappears.
- Each framework button should open the matching `posthog.com/docs/error-tracking/installation/<framework>` page in a new tab.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Opus 4.7 via PostHog Code.
- Approach was to follow the `LogsScene` precedent: move the setup prompt inside the relevant tab's content rather than at the scene root, and reuse the `FRAMEWORK_LINKS` pattern with PostHog's error tracking installation docs URLs.
- Considered using `ListHog` (logs uses it) but picked `WarningHog` as a more thematic illustration for the errors empty state.
- Per-issue scenes (`ErrorTrackingIssueScene`, `ErrorTrackingIssueFingerprintsScene`) were intentionally left unchanged — they're entered via a specific issue ID, so the full-page swap remains correct there.