### PR TITLE
fix(flags): preserve multivariate shape when syncing from API

### DIFF
--- a/posthog/management/commands/sync_feature_flags_from_api.py
+++ b/posthog/management/commands/sync_feature_flags_from_api.py
@@ -9,6 +9,17 @@ from posthog.models import FeatureFlag, Project, User
 from posthog.ph_client import PH_US_API_KEY
 
 
+def _build_filters(flag_data: dict) -> dict:
+    # /flags?v=2 only exposes the single variant the distinct_id evaluated to,
+    # so for multivariate flags we seed with that one variant at 100% and let
+    # the user fill in the rest — better than silently dropping to boolean.
+    variant = flag_data.get("variant")
+    base: dict = {"groups": [{"properties": [], "rollout_percentage": 100}], "payloads": {}}
+    if variant:
+        base["multivariate"] = {"variants": [{"key": variant, "name": variant, "rollout_percentage": 100}]}
+    return base
+
+
 def sync_feature_flags_from_api(
     distinct_id: str,
     groups: dict[str, str] | None = None,
@@ -87,7 +98,7 @@ def sync_feature_flags_from_api(
                     key=flag_key,
                     created_by=first_user,
                     active=True,
-                    filters={"groups": [{"properties": [], "rollout_percentage": 100}], "payloads": {}},
+                    filters=_build_filters(flag_data),
                 )
                 output_fn(f"Created feature flag '{flag_key}'")
                 created_count += 1


### PR DESCRIPTION
## Problem

Running `sync-feature-flags` (i.e. `python manage.py sync_feature_flags_from_api`) against the production `/flags?v=2` endpoint always created new local feature flags as **boolean**, even when the production flag was multivariate. That made it impossible to bootstrap a local dev project with multivariate flags — they'd all come back as plain booleans and the existing multivariate workflow would break.

## Changes

When the `/flags?v=2` response includes a non-null `variant` for an enabled flag, seed the newly-created local flag as multivariate with that variant at 100% rollout instead of as a boolean flag. The API only returns the single variant the supplied `distinct_id` resolved to, so the flag still needs the remaining variants filled in by hand — but it no longer gets silently downgraded to boolean.

Boolean flags (variant is null/absent) are unchanged.

## How did you test this code?

I'm an agent. I made the targeted code change to `_build_filters` in `posthog/management/commands/sync_feature_flags_from_api.py` and validated the file parses. I did **not** run the management command end-to-end against the live `/flags?v=2` endpoint, and did not add an automated test for this command (there isn't one today). Reviewer should sanity-check by running the command locally with a `distinct_id` that resolves multivariate flags and confirming the new local flags have a `multivariate.variants` block.

## Publish to changelog?

no

## Docs update

No docs change needed — this is a dev-tooling fix, not a product feature.

## 🤖 Agent context

- Tool: PostHog Code (Claude).
- The reporter's symptom was "every run of `sync-feature-flags` creates boolean flags and messes up multivariate ones." Reading the command, the only place that writes `filters` is the new-flag branch, which hard-coded a boolean shape. Existing flags only get their `active` field touched, so we did not change that path.
- Considered fetching the full flag definition via `/api/feature_flag/local_evaluation`, but that needs a personal API key which the command does not have. Settled on extracting the single observed variant from the public `/flags?v=2` response, since that is enough to keep the flag multivariate.
- Considered seeding with a placeholder `control` variant alongside the observed one. Rejected — the observed variant could be anything (`blue`, `red`, etc.) and adding `control` at 0% would be misleading.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*