### PR TITLE
chore: tighten AGENTS.md comment rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 - CSS: Use tailwind utility classes instead of inline styles
 - Error handling: Prefer explicit error handling with typed errors
 - Naming: Use descriptive names, camelCase for JS/TS, snake_case for Python
-- Comments: default to no comment. Explain _why_, not _what_, and only when a future reader (with no access to this PR or chat) would otherwise be confused
+- Comments: default to short or 1-line comments. Explain _why_, not _what_, and only when a future reader (with no access to this PR or chat) would otherwise be confused
 - Comments: never log change history or chat context in code — no "previously did X, now does Y", "per <task/PR>", "changed because…", or "AI:"/"agent:" notes. That goes in the commit message and PR description
 - Comments: when refactoring or moving code, preserve existing comments unless they are explicitly made obsolete by the change
 - Python tests: do not add doc comments

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,8 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 - CSS: Use tailwind utility classes instead of inline styles
 - Error handling: Prefer explicit error handling with typed errors
 - Naming: Use descriptive names, camelCase for JS/TS, snake_case for Python
-- Comments: explain _why_, not _what_ — if the reason isn't important, skip the comment
+- Comments: default to no comment. Explain _why_, not _what_, and only when a future reader (with no access to this PR or chat) would otherwise be confused
+- Comments: never log change history or chat context in code — no "previously did X, now does Y", "per <task/PR>", "changed because…", or "AI:"/"agent:" notes. That goes in the commit message and PR description
 - Comments: when refactoring or moving code, preserve existing comments unless they are explicitly made obsolete by the change
 - Python tests: do not add doc comments
 - Python: do not create empty `__init__.py` files


### PR DESCRIPTION
## Problem

Two failure modes show up a lot in agent-generated diffs (Opus 4.7 especially, but it's broader):

1. Verbose narration of what the code already says.
2. Using comments as a changelog of the current edit — `# previously did X, now does Y`, `// per <task / PR>`, `# changed because <reason from this chat>`, etc.

The existing `Comments: explain why, not what — if the reason isn't important, skip the comment` rule was easy for agents to talk around (they justify a verbose block as "explaining the why"), and there was nothing addressing the change-history-in-comments pattern at all.

## Changes

Two small bullets in `AGENTS.md` under Code Style:

- Default to no comment; only write one when a future reader (no PR/chat access) would otherwise be confused.
- Never log change history or chat context in code — that goes in the commit message and PR description.

`CLAUDE.md` is a symlink to `AGENTS.md`, so it gets the update for free.

## How did you test this code?

I'm an agent. No automated tests for this change — it's a docs/instructions edit. Verified locally that the diff is exactly the two rewritten bullets and nothing else.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Cursor agent (Opus 4.7) at @ahillen's request, in response to a #papercuts Slack thread where Andy, Paul, Fernando, and Arno all flagged the same pattern (agents adding long, verbose comments and using them to store conversation/change context).

Considered and rejected:

- A dedicated "comment improver" skill + hook — too heavy for what is really a single instruction-file tweak; can layer that on later if the rule alone doesn't move the needle.
- A separate `Comments: do not restate the code` bullet with `# increment counter`-style examples — cut because it's already covered by "default to no comment" + "explain why, not what." Kept the diff to +2/-1.
- Touching `.cursorrules` — left alone; it currently says "respect existing comments, don't remove them unless irrelevant," which doesn't conflict.

Made with [Cursor](https://cursor.com)