### PR TITLE
feat(data-warehouse): add workflow_jobs endpoint

### DIFF
--- a/posthog/temporal/data_imports/sources/github/github.py
+++ b/posthog/temporal/data_imports/sources/github/github.py
@@ -103,9 +103,10 @@ def _resolve_sort_mode(
     pagination via sort=created&direction=asc) and only flip to their
     configured sort once a cutoff exists. workflow_runs is different: it ignores
     sort/direction and always returns newest-first, so it emits desc on every
-    sync — including the first.
+    sync — including the first. workflow_jobs inherits that order: it fans out
+    over workflow_runs newest-first, so its jobs land newest-first too.
     """
-    if endpoint == "workflow_runs":
+    if endpoint in ("workflow_runs", "workflow_jobs"):
         return config.sort_mode
     if should_use_incremental_field and db_incremental_field_last_value:
         return config.sort_mode
@@ -265,6 +266,146 @@ def _get_item_filter(endpoint: str) -> Callable[[dict[str, Any]], bool] | None:
     return None
 
 
+@retry(
+    retry=retry_if_exception_type((GithubRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch_page(page_url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> requests.Response:
+    response = make_tracked_session().get(page_url, headers=headers, timeout=60)
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise GithubRetryableError(f"Github API error (retryable): status={response.status_code}, url={page_url}")
+
+    if not response.ok:
+        logger.error(f"Github API error: status={response.status_code}, body={response.text}, url={page_url}")
+        response.raise_for_status()
+
+    return response
+
+
+def _iter_pages(
+    url: str,
+    headers: dict[str, str],
+    response_data_path: str | None,
+    logger: FilteringBoundLogger,
+    max_pages: int | None = None,
+    page_cap_context: dict[str, Any] | None = None,
+) -> Iterator[tuple[list[dict[str, Any]], str, str | None]]:
+    """Yield (items, page_url, next_url) for each page of a paginated GitHub list,
+    unwrapping the envelope and following the Link header. Stops at ``max_pages``,
+    logging a structured warning when the cap is reached. An empty or ``null``
+    envelope body simply ends iteration — there is nothing to truncate."""
+    page_count = 0
+    while True:
+        response = _fetch_page(url, headers, logger)
+        data = response.json()
+        if response_data_path and isinstance(data, dict):
+            data = data.get(response_data_path) or []
+        if not isinstance(data, list) or not data:
+            return
+        next_url = _parse_next_url(response.headers.get("Link", ""))
+        yield data, url, next_url
+        page_count += 1
+        if not next_url:
+            return
+        if max_pages is not None and page_count >= max_pages:
+            logger.warning(
+                "Github: per-parent page cap reached; remaining pages skipped",
+                max_pages=max_pages,
+                **(page_cap_context or {}),
+            )
+            return
+        url = next_url
+
+
+def _iter_jobs_for_run(
+    repository: str,
+    run_id: Any,
+    headers: dict[str, str],
+    logger: FilteringBoundLogger,
+    config: GithubEndpointConfig,
+) -> Iterator[dict[str, Any]]:
+    path = config.path.format(repository=repository, run_id=run_id)
+    params: dict[str, Any] = {"per_page": config.page_size, **(config.extra_params or {})}
+    url = f"{GITHUB_BASE_URL}{path}?{urlencode(params)}"
+    for jobs, _page_url, _next_url in _iter_pages(
+        url,
+        headers,
+        config.response_data_path,
+        logger,
+        max_pages=config.max_pages_per_parent,
+        page_cap_context={"repository": repository, "run_id": run_id},
+    ):
+        yield from jobs
+
+
+def _fan_out_get_rows(
+    personal_access_token: str,
+    repository: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[GithubResumeConfig],
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+    incremental_field: str | None,
+) -> Iterator[Any]:
+    """Single-hop parent->child fan-out: walk the parent endpoint newest-first and
+    emit every child row for each parent. Incremental bounding happens on the
+    parent's created_at cursor (the same desc early-stop workflow_runs uses);
+    children upsert by primary key, so re-reading a boundary parent is harmless.
+
+    The child cursor value (max job created_at) is compared against the parent's
+    created_at — they coincide closely since a job is created when its run starts,
+    so the watermark sits slightly above the newest run's timestamp. Re-reading a
+    boundary parent is harmless (jobs upsert by id), but note the inverse: a run
+    that was in_progress when first synced drops below the watermark once it
+    finishes, so its terminal job conclusions and any later-added jobs are not
+    re-fetched. This is the same created_at-cursor staleness workflow_runs carries;
+    the workflow_run webhook (followup) is the fix, not re-scanning history.
+    """
+    child_config = GITHUB_ENDPOINTS[endpoint]
+    assert child_config.fan_out_parent is not None  # guarded by the get_rows dispatch
+    parent_config = GITHUB_ENDPOINTS[child_config.fan_out_parent]
+    headers = _get_headers(personal_access_token, endpoint)
+    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
+
+    parent_field = incremental_field or parent_config.default_incremental_field or "created_at"
+    parent_cutoff = db_incremental_field_last_value if should_use_incremental_field else None
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume_config is not None:
+        parent_url: str = resume_config.next_url
+        logger.debug(f"Github: resuming {endpoint} fan-out from parent URL: {parent_url}")
+    else:
+        parent_url = _build_initial_url(parent_config, repository, {"per_page": parent_config.page_size})
+
+    for runs, page_url, _next_url in _iter_pages(parent_url, headers, parent_config.response_data_path, logger):
+        stop_after_this_page = _should_stop_desc(runs, "desc", parent_field, parent_cutoff)
+
+        for run in runs:
+            run_id = run.get("id")
+            if run_id is None:
+                continue
+            # Only fan out parents at/above the watermark; older ones were synced before.
+            if parent_cutoff is not None and _is_older_than_cutoff(run.get(parent_field), parent_cutoff):
+                continue
+            for job in _iter_jobs_for_run(repository, run_id, headers, logger, child_config):
+                batcher.batch(job)
+                if batcher.should_yield():
+                    yield batcher.get_table()
+                    # Checkpoint the parent page; resume re-fans it out and dedupes by id.
+                    if not stop_after_this_page:
+                        resumable_source_manager.save_state(GithubResumeConfig(next_url=page_url))
+
+        if stop_after_this_page:
+            break
+
+    if batcher.should_yield(include_incomplete_chunk=True):
+        yield batcher.get_table()
+
+
 def get_rows(
     personal_access_token: str,
     repository: str,
@@ -276,6 +417,19 @@ def get_rows(
     incremental_field: str | None = None,
 ) -> Iterator[Any]:
     config = GITHUB_ENDPOINTS[endpoint]
+    if config.fan_out_parent is not None:
+        yield from _fan_out_get_rows(
+            personal_access_token=personal_access_token,
+            repository=repository,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+            incremental_field=incremental_field,
+        )
+        return
+
     headers = _get_headers(personal_access_token, endpoint)
     batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
 
@@ -303,26 +457,8 @@ def get_rows(
     else:
         url = _build_initial_url(config, repository, initial_params)
 
-    @retry(
-        retry=retry_if_exception_type((GithubRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> requests.Response:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=60)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise GithubRetryableError(f"Github API error (retryable): status={response.status_code}, url={page_url}")
-
-        if not response.ok:
-            logger.error(f"Github API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response
-
     while True:
-        response = fetch_page(url)
+        response = _fetch_page(url, headers, logger)
 
         data = response.json()
         # Most GitHub list endpoints return a JSON array at the top level,

--- a/posthog/temporal/data_imports/sources/github/settings.py
+++ b/posthog/temporal/data_imports/sources/github/settings.py
@@ -18,6 +18,16 @@ class GithubEndpointConfig:
     # (e.g. /actions/runs returns {"total_count": N, "workflow_runs": [...]}).
     # None means the response body is itself the list.
     response_data_path: Optional[str] = None
+    # Fan-out: name of the parent endpoint whose rows seed this child's path.
+    # When set, the endpoint is fetched by walking the parent (reusing its
+    # pagination/incremental bounding) and calling this child once per parent
+    # row, substituting the parent id into the {run_id} path placeholder.
+    fan_out_parent: Optional[str] = None
+    # Extra static query params for the request (e.g. {"filter": "all"}).
+    extra_params: Optional[dict[str, str]] = None
+    # Hard cap on pages fetched per parent in a fan-out, to bound runaway
+    # pagination. A structured warning is logged if the cap is reached.
+    max_pages_per_parent: int = 50
 
 
 GITHUB_ENDPOINTS: dict[str, GithubEndpointConfig] = {
@@ -118,6 +128,37 @@ GITHUB_ENDPOINTS: dict[str, GithubEndpointConfig] = {
         default_incremental_field="created_at",
         sort_mode="desc",  # API always returns newest-first; sort/direction are ignored
         response_data_path="workflow_runs",
+    ),
+    "workflow_jobs": GithubEndpointConfig(
+        name="workflow_jobs",
+        # Child of workflow_runs: {run_id} is filled per parent run during fan-out.
+        path="/repos/{repository}/actions/runs/{run_id}/jobs",
+        partition_key="created_at",  # Set at job creation; non-null even while queued/running.
+        incremental_fields=[
+            # The jobs endpoint exposes no server-side time filter, so workflow_jobs
+            # cannot have its own cursor. We bound incremental syncs at the parent:
+            # walk workflow_runs newest-first, stop once run.created_at crosses below
+            # the watermark, and fan out jobs only for runs at/above it (see
+            # github.py). Jobs upsert by id, so re-reading a boundary run is harmless.
+            #
+            # Same created_at-cursor staleness as workflow_runs applies: a run whose
+            # jobs finish well after newer runs have landed won't be re-fanned-out
+            # once it drops below the watermark. The eventual fix is the workflow_run
+            # webhook (followup), not re-scanning history.
+            {
+                "label": "created_at",
+                "type": IncrementalFieldType.DateTime,
+                "field": "created_at",
+                "field_type": IncrementalFieldType.DateTime,
+            },
+        ],
+        default_incremental_field="created_at",
+        sort_mode="desc",  # Emitted parent-newest-first, so jobs land newest-first too.
+        response_data_path="jobs",
+        fan_out_parent="workflow_runs",
+        # filter=all returns jobs across every run_attempt (retries), not just the
+        # latest execution — required for retry/runner-utilization analysis.
+        extra_params={"filter": "all"},
     ),
 }
 

--- a/posthog/temporal/tests/data_imports/github/conftest.py
+++ b/posthog/temporal/tests/data_imports/github/conftest.py
@@ -7,7 +7,14 @@ import pytest
 from dateutil import parser as dateutil_parser
 
 from posthog.temporal.data_imports.sources.github.settings import GITHUB_ENDPOINTS
-from posthog.temporal.tests.data_imports.github.data import COMMITS, ISSUES, PULL_REQUESTS, STARGAZERS, WORKFLOW_RUNS
+from posthog.temporal.tests.data_imports.github.data import (
+    COMMITS,
+    ISSUES,
+    PULL_REQUESTS,
+    STARGAZERS,
+    WORKFLOW_JOBS,
+    WORKFLOW_RUNS,
+)
 
 
 class MockGithubAPI:
@@ -61,11 +68,15 @@ class MockGithubAPI:
         path = urlparse(request.url).path
         resource = path.split("/")[-1]
 
-        if resource not in self.RESOURCES:
+        if resource == "jobs":
+            # Fan-out child: /repos/{owner}/{repo}/actions/runs/{run_id}/jobs
+            run_id = int(path.split("/")[-2])
+            data = [dict(job) for job in WORKFLOW_JOBS if job.get("run_id") == run_id]
+        elif resource not in self.RESOURCES:
             context.status_code = 404
             return []
-
-        data = list(self.RESOURCES[resource])
+        else:
+            data = list(self.RESOURCES[resource])
 
         if self.max_updated is not None:
             max_dt = dateutil_parser.parse(self.max_updated)

--- a/posthog/temporal/tests/data_imports/github/data.py
+++ b/posthog/temporal/tests/data_imports/github/data.py
@@ -183,6 +183,83 @@ WORKFLOW_RUNS = [
     },
 ]
 
+# Jobs fan out from WORKFLOW_RUNS by run_id. steps[] stays nested exactly as the
+# API returns it — the pipeline JSON-serializes nested struct/list columns on write.
+WORKFLOW_JOBS = [
+    {
+        "id": 20001,
+        "run_id": 1001,
+        "run_attempt": 1,
+        "name": "build",
+        "status": "completed",
+        "conclusion": "success",
+        "workflow_name": "CI",
+        "head_branch": "master",
+        "runner_name": "ubuntu-latest",
+        "created_at": "2026-01-20T10:00:05Z",
+        "started_at": "2026-01-20T10:00:30Z",
+        "completed_at": "2026-01-20T10:10:00Z",
+        "steps": [
+            {"name": "Set up job", "status": "completed", "conclusion": "success", "number": 1},
+            {"name": "Build", "status": "completed", "conclusion": "success", "number": 2},
+        ],
+    },
+    {
+        "id": 20002,
+        "run_id": 1001,
+        "run_attempt": 1,
+        "name": "test",
+        "status": "completed",
+        "conclusion": "success",
+        "workflow_name": "CI",
+        "head_branch": "master",
+        "runner_name": "ubuntu-latest",
+        "created_at": "2026-01-20T10:00:06Z",
+        "started_at": "2026-01-20T10:10:05Z",
+        "completed_at": "2026-01-20T10:20:00Z",
+        "steps": [
+            {"name": "Set up job", "status": "completed", "conclusion": "success", "number": 1},
+            {"name": "Run tests", "status": "completed", "conclusion": "success", "number": 2},
+        ],
+    },
+    {
+        "id": 20003,
+        "run_id": 1002,
+        "run_attempt": 1,
+        "name": "test",
+        "status": "completed",
+        "conclusion": "failure",
+        "workflow_name": "CI",
+        "head_branch": "feature/foo",
+        "runner_name": "ubuntu-latest",
+        "created_at": "2026-01-22T10:00:05Z",
+        "started_at": "2026-01-22T10:00:40Z",
+        "completed_at": "2026-01-22T10:15:00Z",
+        "steps": [
+            {"name": "Set up job", "status": "completed", "conclusion": "success", "number": 1},
+            {"name": "Run tests", "status": "completed", "conclusion": "failure", "number": 2},
+        ],
+    },
+    {
+        "id": 20004,
+        "run_id": 1003,
+        "run_attempt": 1,
+        "name": "deploy",
+        "status": "in_progress",
+        "conclusion": None,
+        "workflow_name": "Deploy",
+        "head_branch": "master",
+        "runner_name": "ubuntu-latest",
+        "created_at": "2026-01-25T10:00:05Z",
+        "started_at": "2026-01-25T10:00:20Z",
+        "completed_at": None,  # still running
+        "steps": [
+            {"name": "Set up job", "status": "completed", "conclusion": "success", "number": 1},
+            {"name": "Deploy", "status": "in_progress", "conclusion": None, "number": 2},
+        ],
+    },
+]
+
 STARGAZERS = [
     {
         "starred_at": "2026-01-10T10:00:00Z",

--- a/posthog/temporal/tests/data_imports/github/test_github_integration.py
+++ b/posthog/temporal/tests/data_imports/github/test_github_integration.py
@@ -5,7 +5,7 @@ import pytest
 from unittest import mock
 
 from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
-from posthog.temporal.tests.data_imports.github.data import COMMITS, ISSUES, PULL_REQUESTS, WORKFLOW_RUNS
+from posthog.temporal.tests.data_imports.github.data import COMMITS, ISSUES, PULL_REQUESTS, WORKFLOW_JOBS, WORKFLOW_RUNS
 
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -92,6 +92,17 @@ def external_data_schema_workflow_runs_incremental(external_data_source, team):
         source_id=external_data_source.pk,
         sync_type="incremental",
         sync_type_config={"incremental_field": "created_at", "incremental_field_type": "datetime"},
+    )
+
+
+@pytest.fixture
+def external_data_schema_workflow_jobs_full_refresh(external_data_source, team):
+    return ExternalDataSchema.objects.create(
+        name="workflow_jobs",
+        team_id=team.pk,
+        source_id=external_data_source.pk,
+        sync_type="full_refresh",
+        sync_type_config={},
     )
 
 
@@ -284,3 +295,40 @@ async def test_github_workflow_runs_incremental(
     assert "sort" not in first_call_params
     assert "direction" not in first_call_params
     assert "state" not in first_call_params
+
+
+@mock.patch("posthog.temporal.data_imports.pipelines.pipeline.batcher.DEFAULT_CHUNK_SIZE", 1)
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_github_workflow_jobs_full_refresh(
+    team, mock_github_api, external_data_source, external_data_schema_workflow_jobs_full_refresh
+):
+    # workflow_jobs fans out over workflow_runs: one parent runs request, then one
+    # jobs request per run. Single sync only — cross-sync merge is the pipeline's
+    # job and is flaky to exercise in-harness, so the desc early-stop overlap is
+    # covered deterministically in test_github_source.py instead.
+    expected_num_rows = len(WORKFLOW_JOBS)
+
+    await run_external_data_job_workflow(
+        team=team,
+        external_data_source=external_data_source,
+        external_data_schema=external_data_schema_workflow_jobs_full_refresh,
+        table_name="github_workflow_jobs",
+        expected_rows_synced=expected_num_rows,
+        expected_total_rows=expected_num_rows,
+    )
+
+    api_calls = mock_github_api.get_all_api_calls()
+    # 1 parent runs page + 1 jobs request per run (3 runs).
+    assert len(api_calls) == 1 + len({job["run_id"] for job in WORKFLOW_JOBS})
+    parent_calls = [c for c in api_calls if c.url.rstrip("/").endswith("/actions/runs") or "/actions/runs?" in c.url]
+    jobs_calls = [c for c in api_calls if "/jobs" in c.url]
+    assert len(parent_calls) == 1
+    assert len(jobs_calls) == 3
+    # Every job request carries filter=all (jobs across all run_attempts) and no
+    # search-cap-tripping filters.
+    for call in jobs_calls:
+        params = parse_qs(urlparse(call.url).query)
+        assert params["filter"] == ["all"]
+        assert "created" not in params
+        assert "since" not in params

--- a/posthog/temporal/tests/data_imports/github/test_github_source.py
+++ b/posthog/temporal/tests/data_imports/github/test_github_source.py
@@ -1,5 +1,7 @@
+import dataclasses
 from datetime import UTC, date, datetime
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 from unittest import mock
 
@@ -15,6 +17,8 @@ from posthog.temporal.data_imports.sources.github.github import (
     _format_incremental_value,
     _is_issue_not_pr,
     _is_older_than_cutoff,
+    _iter_jobs_for_run,
+    _iter_pages,
     _parse_next_url,
     _should_stop_desc,
     get_rows,
@@ -475,6 +479,17 @@ class TestGithubSourceSortMode:
                 datetime(2026, 1, 15, tzinfo=UTC),
                 "desc",
             ),
+            # workflow_jobs fans out over workflow_runs newest-first, so it emits
+            # desc on every sync — same as its parent.
+            ("workflow_jobs_full_refresh", "workflow_jobs", False, None, "desc"),
+            ("workflow_jobs_first_sync_no_cutoff", "workflow_jobs", True, None, "desc"),
+            (
+                "workflow_jobs_incremental_with_cutoff",
+                "workflow_jobs",
+                True,
+                datetime(2026, 1, 15, tzinfo=UTC),
+                "desc",
+            ),
         ]
     )
     def test_sort_mode(
@@ -795,3 +810,268 @@ class _ChunkingBatcher:
             self._buffer = []
             return table
         raise Exception("No chunks available to yield")
+
+
+class _RoutingSession:
+    """Routes GitHub GET calls by URL so two-level runs->jobs fan-out can be mocked
+    without depending on request order. Records every requested URL."""
+
+    def __init__(
+        self,
+        runs_pages: list[tuple[Any, str]],
+        jobs_by_run: dict[int, tuple[Any, str]],
+    ) -> None:
+        self._runs_pages = list(runs_pages)
+        self._jobs_by_run = jobs_by_run
+        self.calls: list[str] = []
+
+    def get(self, url: str, headers: Any = None, timeout: Any = None) -> Any:
+        self.calls.append(url)
+        if "/jobs" in url:
+            run_id = int(urlparse(url).path.split("/")[-2])
+            body, link = self._jobs_by_run.get(run_id, ({"total_count": 0, "jobs": []}, ""))
+            return _make_response(body=body, link=link)
+        body, link = self._runs_pages.pop(0)
+        return _make_response(body=body, link=link)
+
+
+def _run(created_at: str, run_id: int) -> dict[str, Any]:
+    return {"id": run_id, "created_at": created_at}
+
+
+def _runs_envelope(*runs: dict[str, Any]) -> dict[str, Any]:
+    return {"total_count": len(runs), "workflow_runs": list(runs)}
+
+
+def _jobs_envelope(*jobs: dict[str, Any]) -> dict[str, Any]:
+    return {"total_count": len(jobs), "jobs": list(jobs)}
+
+
+class TestFanOutJobs:
+    """workflow_jobs fans out over workflow_runs and emits each run's jobs."""
+
+    def _patch_batcher(self) -> Any:
+        return mock.patch(
+            "posthog.temporal.data_imports.sources.github.github.Batcher",
+            autospec=False,
+            side_effect=lambda logger, chunk_size, chunk_size_bytes: _ImmediateBatcher(),
+        )
+
+    def _fan_out(self, session: _RoutingSession, **kwargs: Any) -> list[Any]:
+        with (
+            self._patch_batcher(),
+            mock.patch(
+                "posthog.temporal.data_imports.sources.github.github.make_tracked_session",
+                return_value=session,
+            ),
+        ):
+            return list(
+                get_rows(
+                    personal_access_token="tok",
+                    repository="owner/repo",
+                    endpoint="workflow_jobs",
+                    logger=mock.Mock(),
+                    resumable_source_manager=_make_manager(),
+                    **kwargs,
+                )
+            )
+
+    def test_each_job_carries_run_id_and_nested_steps(self) -> None:
+        session = _RoutingSession(
+            runs_pages=[(_runs_envelope(_run("2026-01-22T00:00:00Z", 1002), _run("2026-01-20T00:00:00Z", 1001)), "")],
+            jobs_by_run={
+                1002: (_jobs_envelope({"id": 3, "run_id": 1002, "steps": [{"name": "test", "number": 1}]}), ""),
+                1001: (
+                    _jobs_envelope(
+                        {"id": 1, "run_id": 1001, "steps": [{"name": "build", "number": 1}]},
+                        {"id": 2, "run_id": 1001, "steps": []},
+                    ),
+                    "",
+                ),
+            },
+        )
+
+        rows = self._fan_out(session, should_use_incremental_field=False)
+
+        assert [row["id"] for row in rows] == [3, 1, 2]
+        assert all("run_id" in row for row in rows)
+        # steps[] is yielded nested (a list), not pre-flattened or stringified —
+        # the pipeline JSON-serializes it on write.
+        assert rows[0]["steps"] == [{"name": "test", "number": 1}]
+        assert isinstance(rows[1]["steps"], list)
+
+    def test_child_request_uses_filter_all_and_per_page_only(self) -> None:
+        session = _RoutingSession(
+            runs_pages=[(_runs_envelope(_run("2026-01-20T00:00:00Z", 1001)), "")],
+            jobs_by_run={1001: (_jobs_envelope({"id": 1, "run_id": 1001}), "")},
+        )
+
+        self._fan_out(session, should_use_incremental_field=False)
+
+        jobs_calls = [c for c in session.calls if "/jobs" in c]
+        assert len(jobs_calls) == 1
+        assert "/repos/owner/repo/actions/runs/1001/jobs" in jobs_calls[0]
+        params = parse_qs(urlparse(jobs_calls[0]).query)
+        assert params["filter"] == ["all"]
+        assert params["per_page"] == ["100"]
+        # No params that would trip the parent's 1,000-result search cap or are
+        # unsupported on the jobs endpoint.
+        assert "since" not in params
+        assert "created" not in params
+        assert "sort" not in params
+        assert "state" not in params
+
+    def test_null_jobs_envelope_does_not_crash_or_truncate(self) -> None:
+        session = _RoutingSession(
+            runs_pages=[(_runs_envelope(_run("2026-01-22T00:00:00Z", 1002), _run("2026-01-20T00:00:00Z", 1001)), "")],
+            jobs_by_run={
+                1002: ({"total_count": 0, "jobs": None}, ""),  # run with no jobs yet
+                1001: (_jobs_envelope({"id": 1, "run_id": 1001}), ""),
+            },
+        )
+
+        rows = self._fan_out(session, should_use_incremental_field=False)
+
+        # Empty/null envelope for one run contributes nothing; the other run's
+        # jobs still land.
+        assert [row["id"] for row in rows] == [1]
+
+    def test_incremental_fans_out_only_runs_at_or_above_cutoff(self) -> None:
+        cutoff = datetime(2026, 1, 22, tzinfo=UTC)
+        # Runs are newest-first. 1003 is above the cutoff; 1001 is below it.
+        session = _RoutingSession(
+            runs_pages=[(_runs_envelope(_run("2026-01-25T00:00:00Z", 1003), _run("2026-01-20T00:00:00Z", 1001)), "")],
+            jobs_by_run={
+                1003: (_jobs_envelope({"id": 9, "run_id": 1003}), ""),
+                1001: (_jobs_envelope({"id": 1, "run_id": 1001}), ""),
+            },
+        )
+
+        rows = self._fan_out(
+            session,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=cutoff,
+            incremental_field="created_at",
+        )
+
+        # Only the run above the cutoff is fanned out; the older run is skipped
+        # entirely — no jobs request is made for it.
+        assert [row["id"] for row in rows] == [9]
+        jobs_calls = [c for c in session.calls if "/jobs" in c]
+        assert any("/runs/1003/jobs" in c for c in jobs_calls)
+        assert not any("/runs/1001/jobs" in c for c in jobs_calls)
+
+    def test_resume_starts_from_saved_parent_page_url(self) -> None:
+        saved_url = "https://api.github.com/repos/owner/repo/actions/runs?per_page=100&page=3"
+        manager = _make_manager(can_resume=True, resume_state=GithubResumeConfig(next_url=saved_url))
+        session = _RoutingSession(
+            runs_pages=[(_runs_envelope(_run("2026-01-20T00:00:00Z", 1001)), "")],
+            jobs_by_run={1001: (_jobs_envelope({"id": 1, "run_id": 1001}), "")},
+        )
+
+        with (
+            self._patch_batcher(),
+            mock.patch(
+                "posthog.temporal.data_imports.sources.github.github.make_tracked_session",
+                return_value=session,
+            ),
+        ):
+            list(
+                get_rows(
+                    personal_access_token="tok",
+                    repository="owner/repo",
+                    endpoint="workflow_jobs",
+                    logger=mock.Mock(),
+                    resumable_source_manager=manager,
+                    should_use_incremental_field=False,
+                )
+            )
+
+        assert session.calls[0] == saved_url
+        manager.load_state.assert_called_once()
+
+
+class TestIterPages:
+    """Generic paginator shared by the fan-out: envelope unwrap, Link following,
+    and the per-parent page cap."""
+
+    def test_unwraps_envelope_and_follows_link(self) -> None:
+        responses = [
+            _make_response(
+                body={"total_count": 3, "jobs": [{"id": 1}]},
+                link='<https://api.github.com/x?page=2>; rel="next"',
+            ),
+            _make_response(body={"total_count": 3, "jobs": [{"id": 2}]}, link=""),
+        ]
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.github.github.make_tracked_session",
+        ) as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            pages = list(_iter_pages("https://api.github.com/x", {}, "jobs", mock.Mock()))
+
+        assert [items for items, _url, _next in pages] == [[{"id": 1}], [{"id": 2}]]
+
+    @parameterized.expand(
+        [
+            ("null_body", {"total_count": 0, "jobs": None}),
+            ("empty_dict", {}),
+            ("empty_list", {"total_count": 0, "jobs": []}),
+        ]
+    )
+    def test_empty_or_null_envelope_yields_no_pages(self, _name: str, body: Any) -> None:
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.github.github.make_tracked_session",
+        ) as mock_get:
+            mock_get.return_value.get.side_effect = [_make_response(body=body, link="")]
+            pages = list(_iter_pages("https://api.github.com/x", {}, "jobs", mock.Mock()))
+
+        assert pages == []
+
+    def test_page_cap_stops_and_logs(self) -> None:
+        # Every page links to a next page; the cap must halt pagination.
+        responses = [
+            _make_response(body={"jobs": [{"id": i}]}, link='<https://api.github.com/x?page=n>; rel="next"')
+            for i in range(5)
+        ]
+        logger = mock.Mock()
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.github.github.make_tracked_session",
+        ) as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            pages = list(
+                _iter_pages(
+                    "https://api.github.com/x",
+                    {},
+                    "jobs",
+                    logger,
+                    max_pages=2,
+                    page_cap_context={"repository": "owner/repo", "run_id": 1001},
+                )
+            )
+
+        assert len(pages) == 2
+        logger.warning.assert_called_once()
+        assert logger.warning.call_args.kwargs["max_pages"] == 2
+        assert logger.warning.call_args.kwargs["run_id"] == 1001
+
+    def test_iter_jobs_for_run_builds_path_and_passes_cap(self) -> None:
+        config = dataclasses.replace(GITHUB_ENDPOINTS["workflow_jobs"], max_pages_per_parent=1)
+        responses = [
+            _make_response(
+                body=_jobs_envelope({"id": 1, "run_id": 1001}),
+                link='<https://api.github.com/x?page=2>; rel="next"',
+            ),
+        ]
+        logger = mock.Mock()
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.github.github.make_tracked_session",
+        ) as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            jobs = list(_iter_jobs_for_run("owner/repo", 1001, {}, logger, config))
+
+        assert [job["id"] for job in jobs] == [1]
+        url = mock_get.return_value.get.call_args_list[0].args[0]
+        assert "/repos/owner/repo/actions/runs/1001/jobs" in url
+        assert "filter=all" in url
+        # Cap of 1 page reached (a next link exists) → warning emitted.
+        logger.warning.assert_called_once()


### PR DESCRIPTION
## Problem

The GitHub warehouse source syncs workflow *runs* but not the jobs inside them. Engineering analytics needs job-level data for CI queue time, per-job duration, runner utilization, failed-job names, step timing, and retries.

## Changes

- New `workflow_jobs` endpoint, fanned out over `workflow_runs` → one `/actions/runs/{run_id}/jobs` call per run. Lands as `github_workflow_jobs`.
- `filter=all` so every `run_attempt` (retries) is captured, not just the latest.
- `steps[]` yielded nested as-is; the pipeline JSON-serializes nested columns on write (no flattening, no steps table).
- Incremental reuses the parent's `created_at` desc early-stop; jobs upsert by `id`. Partition `created_at` (week), `sort_mode=desc`.
- Per-parent page cap with a structured warning. `GithubEndpointConfig` gains `fan_out_parent` / `extra_params` / `max_pages_per_parent`.

## How did you test this code?

Agent-authored; no manual testing. Automated only:
- Live API contract verified via `gh api` (envelope, fields, `filter` semantics, `created_at` non-null, no server-side time filter).
- Unit (`test_github_source.py`): fan-out row shape, `run_id` + nested `steps[]` preserved, child params (`filter=all`/`per_page` only), null/empty envelope safety, page-cap + log, `sort_mode=desc`, incremental skips runs below cutoff, resume.
- Integration (full-refresh): one parent request + one jobs request per run; stable across 3 randomized runs.
- `ty` + ruff clean.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude Code on Raúl's behalf. Agent-authored; requires human review.

- **`filter=all`** chosen over default `latest` so retry/runner analysis sees every attempt.
- **`steps[]` left nested** — pipeline JSON-serializes nested columns, so it lands with zero reshaping; a flat view is a downstream HogQL concern.
- **Incremental is parent-bounded.** The jobs endpoint has no server-side time filter, so the cursor is the parent run's `created_at` desc early-stop; jobs upsert by `id`. Same documented `created_at` staleness as `workflow_runs`: a run that was in_progress at sync time drops below the watermark once it finishes, so its terminal job conclusions / later-added jobs aren't re-fetched. The `workflow_run` webhook is the eventual fix, not history re-scans.
- **Architecture.** This source uses its own custom iterator (not the generic `rest_source` dependent-resource path), so fan-out is a custom iterator over shared `_iter_pages`/`_fetch_page` helpers. The existing `workflow_runs` loop is unchanged.
- A multi-angle code review found no blocking bug; remaining items are latent/operational (resume re-fan cost, page-cap truncation only at unrealistic job counts).