### PR TITLE
fix(experiments): prevent the creation of multiple experiments using the feature flag cross sell form

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentTabContent.tsx
+++ b/frontend/src/scenes/experiments/ExperimentTabContent.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { LemonBanner, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonSkeleton, Link } from '@posthog/lemon-ui'
 
 import type { FeatureFlagType } from '~/types'
 
@@ -49,7 +49,16 @@ export const ExperimentTabContent = ({
 
     return (
         <div className="space-y-4">
-            {relatedExperiments.length === 0 && <CreateDraftExperimentCard featureFlag={featureFlag} />}
+            {relatedExperimentsLoading ? (
+                <div className="border rounded p-4 bg-bg-light space-y-3">
+                    <LemonSkeleton className="h-6 w-1/2" />
+                    <LemonSkeleton className="h-4 w-3/4" />
+                    <LemonSkeleton className="h-9 w-full" />
+                    <LemonSkeleton className="h-9 w-32" />
+                </div>
+            ) : (
+                relatedExperiments.length === 0 && <CreateDraftExperimentCard featureFlag={featureFlag} />
+            )}
             <RelatedExperimentsTable
                 relatedExperiments={relatedExperiments}
                 relatedExperimentsLoading={relatedExperimentsLoading}

--- a/frontend/src/scenes/experiments/ExperimentTabContent.tsx
+++ b/frontend/src/scenes/experiments/ExperimentTabContent.tsx
@@ -1,9 +1,12 @@
+import { useValues } from 'kea'
+
 import { LemonBanner, Link } from '@posthog/lemon-ui'
 
 import type { FeatureFlagType } from '~/types'
 
 import { CreateDraftExperimentCard } from './ExperimentTabContent/CreateDraftExperimentCard'
 import { RelatedExperimentsTable } from './ExperimentTabContent/RelatedExperimentsTable'
+import { experimentTabLogic } from './experimentTabLogic'
 
 type ExperimentTabContentProps = {
     featureFlag: FeatureFlagType
@@ -14,6 +17,13 @@ export const ExperimentTabContent = ({
     featureFlag,
     multipleExperimentsBannerMessage,
 }: ExperimentTabContentProps): JSX.Element | null => {
+    /**
+     * we only operate with existing feature flags, so id will never be null.
+     */
+    const { relatedExperiments, relatedExperimentsLoading } = useValues(
+        experimentTabLogic({ featureFlagId: featureFlag.id! })
+    )
+
     const isValidMultivariateFlag =
         featureFlag.filters.multivariate &&
         featureFlag.filters.multivariate.variants.length > 1 &&
@@ -39,9 +49,10 @@ export const ExperimentTabContent = ({
 
     return (
         <div className="space-y-4">
-            <CreateDraftExperimentCard featureFlag={featureFlag} />
+            {relatedExperiments.length === 0 && <CreateDraftExperimentCard featureFlag={featureFlag} />}
             <RelatedExperimentsTable
-                featureFlag={featureFlag}
+                relatedExperiments={relatedExperiments}
+                relatedExperimentsLoading={relatedExperimentsLoading}
                 multipleExperimentsBannerMessage={multipleExperimentsBannerMessage}
             />
         </div>

--- a/frontend/src/scenes/experiments/ExperimentTabContent/RelatedExperimentsTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentTabContent/RelatedExperimentsTable.tsx
@@ -1,5 +1,3 @@
-import { useValues } from 'kea'
-
 import { LemonBanner, LemonTable, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
@@ -10,16 +8,19 @@ import type { LemonTableColumn } from 'lib/lemon-ui/LemonTable/types'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import { urls } from 'scenes/urls'
 
-import type { Experiment, FeatureFlagType } from '~/types'
+import {
+    getExperimentStatus,
+    getShippedVariantKey,
+    isSingleVariantShipped,
+} from '~/scenes/experiments/experimentsLogic'
+import { StatusTag } from '~/scenes/experiments/ExperimentView/StatusTag'
+import { isLegacyExperiment } from '~/scenes/experiments/utils'
+import type { Experiment } from '~/types'
 import { ExperimentStatus } from '~/types'
 
-import { getExperimentStatus, getShippedVariantKey, isSingleVariantShipped } from '../experimentsLogic'
-import { StatusTag } from '../ExperimentView/StatusTag'
-import { isLegacyExperiment } from '../utils'
-import { featureFlagRelatedExperimentsLogic } from './featureFlagRelatedExperimentsLogic'
-
 type RelatedExperimentsTableProps = {
-    featureFlag: FeatureFlagType
+    relatedExperiments: Experiment[]
+    relatedExperimentsLoading: boolean
     multipleExperimentsBannerMessage: React.ReactNode
 }
 
@@ -32,16 +33,10 @@ const getExperimentDuration = (experiment: Experiment): number | undefined => {
 }
 
 export const RelatedExperimentsTable = ({
-    featureFlag,
+    relatedExperiments,
+    relatedExperimentsLoading,
     multipleExperimentsBannerMessage,
 }: RelatedExperimentsTableProps): JSX.Element | null => {
-    /**
-     * we only operate with existing feature flags, so id will never be null.
-     */
-    const { relatedExperiments, relatedExperimentsLoading } = useValues(
-        featureFlagRelatedExperimentsLogic({ featureFlagId: featureFlag.id! })
-    )
-
     return (
         <div className="space-y-6">
             <LemonBanner type="info">{multipleExperimentsBannerMessage}</LemonBanner>

--- a/frontend/src/scenes/experiments/experimentTabLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTabLogic.ts
@@ -6,15 +6,15 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import type { Experiment } from '~/types'
 
-import type { featureFlagRelatedExperimentsLogicType } from './featureFlagRelatedExperimentsLogicType'
+import type { experimentTabLogicType } from './experimentTabLogicType'
 
-export interface FeatureFlagRelatedExperimentsLogicProps {
+export interface ExperimentTabLogicProps {
     featureFlagId: number
 }
 
-export const featureFlagRelatedExperimentsLogic = kea<featureFlagRelatedExperimentsLogicType>([
-    path(['scenes', 'experiments', 'featureFlagRelatedExperimentsLogic']),
-    props({} as FeatureFlagRelatedExperimentsLogicProps),
+export const experimentTabLogic = kea<experimentTabLogicType>([
+    path(['scenes', 'experiments', 'experimentTabLogic']),
+    props({} as ExperimentTabLogicProps),
     key((props) => props.featureFlagId),
     connect(() => ({ values: [teamLogic, ['currentProjectId']] })),
     loaders(({ props, values }) => ({

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -323,9 +323,6 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
         label: (
             <div className="flex flex-row">
                 <div>Experiments</div>
-                <LemonTag className="ml-2 float-right uppercase" type="primary">
-                    New
-                </LemonTag>
             </div>
         ),
         key: FeatureFlagsTab.EXPERIMENTS,


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

The Experiments tab on a feature flag offers a cross sell form (`CreateDraftExperimentCard`) that spins up a draft experiment from the flag. The card was always rendered, even when the flag already backed an experiment. That let a user create a second experiment on a flag that already had one, which is not a supported configuration: a feature flag is meant to drive a single experiment, and multiple experiments sharing one flag produce overlapping rollouts and ambiguous results.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR hides the cross sell form once the flag already has a related experiment, so a flag can only ever seed one experiment from this entry point.

As part of moving the logic out of the table component, I renamed `featureFlagRelatedExperimentsLogic` to `experimentTabLogic` to reflect that it now backs the whole tab rather than just the table. I also dropped the "New" tag from the Experiments tab label, since the tab is no longer new.

- `frontend/src/scenes/experiments/ExperimentTabContent.tsx`
- `frontend/src/scenes/experiments/ExperimentTabContent/RelatedExperimentsTable.tsx`
- `frontend/src/scenes/experiments/experimentTabLogic.ts` (renamed from `ExperimentTabContent/featureFlagRelatedExperimentsLogic.ts`)
- `frontend/src/scenes/feature-flags/FeatureFlag.tsx`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

Verified manually in the running app: on a flag with no experiment the create card shows; after creating one, the card disappears and only the related-experiments table remains, with no way to start a second experiment from the tab.

<!-- screenshots / gif to be added -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

<!-- Add the \`skip-inkeep-docs\` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->