### PR TITLE
fix(security): mount personalAPIKeysLogic so review screen renders

### DIFF
--- a/frontend/src/scenes/authentication/credential-review/credentialReviewLogic.ts
+++ b/frontend/src/scenes/authentication/credential-review/credentialReviewLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, listeners, path } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path } from 'kea'
 import { router } from 'kea-router'
 
 import api from 'lib/api'
@@ -11,6 +11,13 @@ import type { credentialReviewLogicType } from './credentialReviewLogicType'
 
 export const credentialReviewLogic = kea<credentialReviewLogicType>([
     path(['scenes', 'authentication', 'credentialReviewLogic']),
+    // connect (not a bare import call) so personalAPIKeysLogic is mounted as a dependency
+    // of this scene logic. afterMount runs before the review component renders, so without
+    // this the loadKeys() call below hits an unmounted logic and throws, which sceneLogic
+    // catches and turns into a 404 for the whole credential review screen.
+    connect(() => ({
+        actions: [personalAPIKeysLogic, ['loadKeys']],
+    })),
     actions({
         markComplete: true,
     }),
@@ -30,10 +37,10 @@ export const credentialReviewLogic = kea<credentialReviewLogicType>([
             router.actions.push(urls.projectHomepage())
         },
     }),
-    afterMount(() => {
+    afterMount(({ actions }) => {
         // personalAPIKeysLogic only auto-loads teams (not keys) when it mounts; the
         // settings page calls loadKeys() from its own useEffect. Trigger it here so the
         // review table isn't dismissable while empty.
-        personalAPIKeysLogic.actions.loadKeys()
+        actions.loadKeys()
     }),
 ])


### PR DESCRIPTION
## Problem

The credential review screen at `/account/credential-review` renders as "Page not found" for users who are routed to it. `credentialReviewLogic`'s `afterMount` calls `personalAPIKeysLogic.actions.loadKeys()`, but `personalAPIKeysLogic` is not mounted at that point, so accessing `.actions` throws a kea "logic not mounted" error. `sceneLogic` catches the scene-logic mount failure and falls back to `Error404`, so the whole screen 404s (URL unchanged). This has affected the screen since it was introduced in #58841.

## Changes

- `connect` `personalAPIKeysLogic` into `credentialReviewLogic` so it is mounted as a dependency of the scene logic before `afterMount` runs.
- Call the now-connected `loadKeys` action through the logic's own `actions`.

Before: navigating to `/account/credential-review` → "Page not found".
After: the same URL renders the review screen with the account's API keys listed.

## How did you test this code?

I am an agent (Claude Code). Testing performed in a running local dev environment, driven through the browser:

- Reproduced the bug: navigating to `/account/credential-review` rendered "Page not found".
- Applied this change via hot-reload and confirmed the same URL then rendered the credential review screen with the user's API keys loaded into the table.
- Separately confirmed the underlying kea "not mounted" error as the root cause.

No automated test added — this is a kea logic-mounting wiring fix. A scene-mount smoke test would be a reasonable follow-up.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code (Claude Opus 4.7), agent-driven. Found while investigating why provisioned users land on a 404 at the credential review screen. The scene chunk loads fine; the failure is that mounting the scene logic threw because `personalAPIKeysLogic` was not mounted when `afterMount` called its action, and `sceneLogic` converts a scene-logic mount throw into `Error404`. Considered manually mounting in `afterMount` (awkward unmount lifecycle) vs `connect` — chose `connect` so kea manages mount/unmount, which is also what the kea error message recommends. Independent of #59751 (credential-review over-firing gating) and #60101 (E2E CI infra). Requires human review; do not self-merge.
