### PR TITLE
fix(mcp): cap ui-apps build concurrency to avoid oom

### DIFF
--- a/services/mcp/scripts/build-ui-apps.ts
+++ b/services/mcp/scripts/build-ui-apps.ts
@@ -66,8 +66,11 @@ function buildAppAsync(appName: string): Promise<void> {
 }
 
 async function buildAllAppsParallel(apps: string[]): Promise<void> {
-    // CI environments have limited memory — limit concurrency to avoid OOM kills
-    const concurrency = process.env.CI ? 4 : apps.length
+    // Each Vite build peaks at a few hundred MB, so cap parallelism: the summed
+    // peak of an unbounded run (one process per app) OOM-kills memory-constrained
+    // builders — e.g. the Docker image build, where 27 concurrent Vite processes
+    // saturated the builder. The constraint is memory, not which environment we run in.
+    const concurrency = Math.min(apps.length, 4)
 
     if (concurrency < apps.length) {
         console.info(`\n📦 Building ${apps.length} apps (concurrency: ${concurrency})...`)


### PR DESCRIPTION
## Problem

The MCP container image build OOM-kills Vite (exit 137, e.g. `generated/session-summary`) at the `build:ui-apps` step. `build-ui-apps.ts` defaulted concurrency to `apps.length` and only capped it to 4 when `process.env.CI` was set — but Docker `RUN` layers don't inherit the runner's `CI` env, so inside the image build all 28 apps spawned at once and saturated the builder (~98% peak memory in Depot telemetry).

## Changes

Cap the default to `Math.min(apps.length, 4)` and drop the `CI` gating. The constraint is memory, not which environment we run in, so the default should be safe everywhere — CI, the Docker build, and local dev — with no Dockerfile or Depot changes.

## How did you test this code?

Agent-authored (Claude Code), automated only — no manual UI testing. Ran the full `build:ui-apps` at concurrency 4 (the path this fix selects) end-to-end: all 28 apps built successfully, including `generated/session-summary`. Confirmed via Depot build telemetry that the failing builds peaked at 97–98% memory and OOM-killed a Vite process.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with Claude Code (Bash, Edit, Depot telemetry probing via session cookie).

Diagnosed from the failing Depot builds: 28 Vite processes ran concurrently because the existing 4-worker limiter was gated on `CI`, which BuildKit `RUN` steps never see. Considered and rejected the env-based fixes — `ENV CI=true` in the Dockerfile (overloads a semantic flag, bakes build intent into an image layer) and a `--max-old-space-size=512` heap cap (a single `session-summary` build already peaks at ~650 MB RSS, so the cap has no headroom and would turn an intermittent infra OOM into a deterministic per-app crash). Chose to fix the actual defect: the unbounded default. Requires human review.