### PR TITLE
feat(user_interviews): enable pageviews + replay on the public interview page

### DIFF
--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -2,7 +2,7 @@ import '~/styles'
 import './Exporter.scss'
 
 import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill'
-import posthog from 'posthog-js'
+import { BeforeSendFn } from 'posthog-js'
 import { createRoot } from 'react-dom/client'
 
 import { Exporter } from '~/exporter/Exporter'
@@ -23,30 +23,25 @@ if (!isInterview) {
     window.JS_POSTHOG_API_KEY = undefined
 }
 
-loadPostHogJS()
-
-if (isInterview) {
-    // The URL embeds the SharingConfiguration access token (/interview/<token>/). Redact it from
-    // any URL-like property posthog-js would send so a viewer of captured events can't reuse the
-    // token to start a fresh call as the invitee. Session replay's URL metadata is a separate
-    // surface and is not covered by `before_send` — we accept that tradeoff for now in exchange
-    // for not mutating shared browser state from the analytics layer.
-    const redactInterviewToken = (value: unknown): unknown =>
-        typeof value === 'string' ? value.replace(/\/interview\/[^/?#]+/, '/interview/<redacted>') : value
-    const URL_PROPERTIES = ['$current_url', '$pathname', '$referrer', '$initial_current_url', '$initial_pathname']
-    posthog.setConfig({
-        before_send: (event) => {
-            if (event?.properties) {
-                for (const key of URL_PROPERTIES) {
-                    if (key in event.properties) {
-                        event.properties[key] = redactInterviewToken(event.properties[key])
-                    }
-                }
+// The interview URL embeds the SharingConfiguration access token (/interview/<token>/).
+// Redact it from any URL-shaped property posthog-js would send so a viewer of captured events
+// can't reuse the token to start a fresh call as the invitee. Session replay's URL metadata is
+// a separate surface and is not covered by `before_send`.
+const URL_PROPERTIES = ['$current_url', '$pathname', '$referrer', '$initial_current_url', '$initial_pathname']
+const redactInterviewToken = (value: unknown): unknown =>
+    typeof value === 'string' ? value.replace(/\/interview\/[^/?#]+/, '/interview/<redacted>') : value
+const interviewBeforeSend: BeforeSendFn = (event) => {
+    if (event?.properties) {
+        for (const key of URL_PROPERTIES) {
+            if (key in event.properties) {
+                event.properties[key] = redactInterviewToken(event.properties[key])
             }
-            return event
-        },
-    })
+        }
+    }
+    return event
 }
+
+loadPostHogJS({ beforeSend: isInterview ? interviewBeforeSend : undefined })
 initKea({ replaceInitialPathInWindow: false })
 
 // On Chrome + Windows, the country flag emojis don't render correctly. This is a polyfill for that.

--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -18,16 +18,22 @@ const exportedData: ExportedData = window.POSTHOG_EXPORTED_DATA
 // our customers' sites, and tracking there would log their visitors to app.posthog.com.
 // The `interview` scene is the exception: it's our own hosted public page, opened by an invitee
 // on a link we sent. We want pageviews + replay to measure the invite-to-call funnel.
-const isInterview = exportedData?.type === ExportType.Interview
+// Require the interview payload to be present — the public `force_type=interview` query param
+// can flip `type` on any shared resource, so checking `type` alone would let anyone enable
+// tracking on a customer dashboard share by appending the parameter.
+const isInterview = exportedData?.type === ExportType.Interview && !!exportedData?.interview
 if (!isInterview) {
     window.JS_POSTHOG_API_KEY = undefined
 }
 
 // The interview URL embeds the SharingConfiguration access token (/interview/<token>/) and the
 // public start_call API path (/api/user_interviews/share/<token>/start_call/) embeds it too.
-// Redact the token from event URL properties AND from network requests captured in session
-// replay so a viewer of either surface can't reuse the token to start a fresh call as the
-// invitee.
+// Two hooks redact it everywhere a viewer of analytics or replay could otherwise read it:
+//   - `before_send` strips URL-shaped event properties ($current_url, $pathname, $referrer, ...)
+//   - `maskCapturedNetworkRequestFn` is also the hook posthog-js uses for ALL replay URL
+//     surfaces — captured network requests, the rrweb `EventType.Meta` header, `$url_changed`
+//     custom events on SPA route transitions, and masked $current_url in captured console events.
+// Together they cover every surface where the token could land for a viewer to reuse.
 const INTERVIEW_TOKEN_RE = /\/interview\/[^/?#]+|\/api\/user_interviews\/share\/[^/?#]+/g
 const URL_PROPERTIES = ['$current_url', '$pathname', '$referrer', '$initial_current_url', '$initial_pathname']
 const redactInterviewToken = (value: string): string =>

--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -11,10 +11,15 @@ import { loadPostHogJS } from '~/loadPostHogJS'
 
 import { ErrorBoundary } from '../layout/ErrorBoundary'
 
-// Disable tracking for all exports and embeds.
-// This is explicitly set as to not track our customers' customers data.
-// Without it, embeds of self-hosted iframes will log metrics to app.posthog.com.
-window.JS_POSTHOG_API_KEY = undefined
+const exportedData: ExportedData = window.POSTHOG_EXPORTED_DATA
+
+// Disable tracking for shared dashboards / insights / embeds — those iframes can be embedded on
+// our customers' sites, and tracking there would log their visitors to app.posthog.com.
+// The `interview` scene is the exception: it's our own hosted public page, opened by an invitee
+// on a link we sent. We want pageviews + replay to measure the invite-to-call funnel.
+if (exportedData?.type !== 'interview') {
+    window.JS_POSTHOG_API_KEY = undefined
+}
 
 loadPostHogJS()
 initKea({ replaceInitialPathInWindow: false })
@@ -25,8 +30,6 @@ initKea({ replaceInitialPathInWindow: false })
 // NOTE: The first argument is the name of the polyfill to use. This is used to set the font family in our CSS.
 // Make sure to update the font family in the CSS if you change this.
 polyfillCountryFlagEmojis('Emoji Flags Polyfill')
-
-const exportedData: ExportedData = window.POSTHOG_EXPORTED_DATA
 
 function renderApp(): void {
     const root = document.getElementById('root')

--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -2,7 +2,7 @@ import '~/styles'
 import './Exporter.scss'
 
 import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill'
-import { BeforeSendFn } from 'posthog-js'
+import { BeforeSendFn, CapturedNetworkRequest } from 'posthog-js'
 import { createRoot } from 'react-dom/client'
 
 import { Exporter } from '~/exporter/Exporter'
@@ -23,25 +23,37 @@ if (!isInterview) {
     window.JS_POSTHOG_API_KEY = undefined
 }
 
-// The interview URL embeds the SharingConfiguration access token (/interview/<token>/).
-// Redact it from any URL-shaped property posthog-js would send so a viewer of captured events
-// can't reuse the token to start a fresh call as the invitee. Session replay's URL metadata is
-// a separate surface and is not covered by `before_send`.
+// The interview URL embeds the SharingConfiguration access token (/interview/<token>/) and the
+// public start_call API path (/api/user_interviews/share/<token>/start_call/) embeds it too.
+// Redact the token from event URL properties AND from network requests captured in session
+// replay so a viewer of either surface can't reuse the token to start a fresh call as the
+// invitee.
+const INTERVIEW_TOKEN_RE = /\/interview\/[^/?#]+|\/api\/user_interviews\/share\/[^/?#]+/g
 const URL_PROPERTIES = ['$current_url', '$pathname', '$referrer', '$initial_current_url', '$initial_pathname']
-const redactInterviewToken = (value: unknown): unknown =>
-    typeof value === 'string' ? value.replace(/\/interview\/[^/?#]+/, '/interview/<redacted>') : value
+const redactInterviewToken = (value: string): string =>
+    value.replace(INTERVIEW_TOKEN_RE, (match) => match.replace(/\/[^/?#]+$/, '/<redacted>'))
 const interviewBeforeSend: BeforeSendFn = (event) => {
     if (event?.properties) {
         for (const key of URL_PROPERTIES) {
-            if (key in event.properties) {
-                event.properties[key] = redactInterviewToken(event.properties[key])
+            const value = event.properties[key]
+            if (typeof value === 'string') {
+                event.properties[key] = redactInterviewToken(value)
             }
         }
     }
     return event
 }
+const interviewMaskNetworkRequest = (req: CapturedNetworkRequest): CapturedNetworkRequest => {
+    if (req.name) {
+        req.name = redactInterviewToken(req.name)
+    }
+    return req
+}
 
-loadPostHogJS({ beforeSend: isInterview ? interviewBeforeSend : undefined })
+loadPostHogJS({
+    beforeSend: isInterview ? interviewBeforeSend : undefined,
+    sessionRecording: isInterview ? { maskCapturedNetworkRequestFn: interviewMaskNetworkRequest } : undefined,
+})
 initKea({ replaceInitialPathInWindow: false })
 
 // On Chrome + Windows, the country flag emojis don't render correctly. This is a polyfill for that.

--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -2,6 +2,7 @@ import '~/styles'
 import './Exporter.scss'
 
 import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill'
+import posthog from 'posthog-js'
 import { createRoot } from 'react-dom/client'
 
 import { Exporter } from '~/exporter/Exporter'
@@ -17,29 +18,35 @@ const exportedData: ExportedData = window.POSTHOG_EXPORTED_DATA
 // our customers' sites, and tracking there would log their visitors to app.posthog.com.
 // The `interview` scene is the exception: it's our own hosted public page, opened by an invitee
 // on a link we sent. We want pageviews + replay to measure the invite-to-call funnel.
-if (exportedData?.type !== ExportType.Interview) {
+const isInterview = exportedData?.type === ExportType.Interview
+if (!isInterview) {
     window.JS_POSTHOG_API_KEY = undefined
-} else {
-    // The URL embeds the SharingConfiguration access token (/interview/<token>/), and posthog-js
-    // captures `window.location` for `$current_url` / `$pathname` / `$referrer` on every pageview
-    // and inside session replays. Without scrubbing, anyone with read access to those events or
-    // replays would see the token and could reuse it to start a fresh interview call as the
-    // invitee. Rewrite the URL via `replaceState` before posthog-js initializes so the captured
-    // values never include the token — the client reads the token from `exportedData.accessToken`
-    // and does not depend on `window.location`.
-    try {
-        const redactedPath = window.location.pathname.replace(/\/interview\/[^/?#]+/, '/interview/<redacted>')
-        if (redactedPath !== window.location.pathname) {
-            window.history.replaceState(null, '', redactedPath + window.location.search + window.location.hash)
-        }
-    } catch {
-        // History API unavailable — fall back to disabling tracking entirely rather than risk
-        // the token landing in captured events.
-        window.JS_POSTHOG_API_KEY = undefined
-    }
 }
 
 loadPostHogJS()
+
+if (isInterview) {
+    // The URL embeds the SharingConfiguration access token (/interview/<token>/). Redact it from
+    // any URL-like property posthog-js would send so a viewer of captured events can't reuse the
+    // token to start a fresh call as the invitee. Session replay's URL metadata is a separate
+    // surface and is not covered by `before_send` — we accept that tradeoff for now in exchange
+    // for not mutating shared browser state from the analytics layer.
+    const redactInterviewToken = (value: unknown): unknown =>
+        typeof value === 'string' ? value.replace(/\/interview\/[^/?#]+/, '/interview/<redacted>') : value
+    const URL_PROPERTIES = ['$current_url', '$pathname', '$referrer', '$initial_current_url', '$initial_pathname']
+    posthog.setConfig({
+        before_send: (event) => {
+            if (event?.properties) {
+                for (const key of URL_PROPERTIES) {
+                    if (key in event.properties) {
+                        event.properties[key] = redactInterviewToken(event.properties[key])
+                    }
+                }
+            }
+            return event
+        },
+    })
+}
 initKea({ replaceInitialPathInWindow: false })
 
 // On Chrome + Windows, the country flag emojis don't render correctly. This is a polyfill for that.

--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -5,7 +5,7 @@ import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill'
 import { createRoot } from 'react-dom/client'
 
 import { Exporter } from '~/exporter/Exporter'
-import { ExportedData } from '~/exporter/types'
+import { ExportType, ExportedData } from '~/exporter/types'
 import { initKea } from '~/initKea'
 import { loadPostHogJS } from '~/loadPostHogJS'
 
@@ -17,8 +17,26 @@ const exportedData: ExportedData = window.POSTHOG_EXPORTED_DATA
 // our customers' sites, and tracking there would log their visitors to app.posthog.com.
 // The `interview` scene is the exception: it's our own hosted public page, opened by an invitee
 // on a link we sent. We want pageviews + replay to measure the invite-to-call funnel.
-if (exportedData?.type !== 'interview') {
+if (exportedData?.type !== ExportType.Interview) {
     window.JS_POSTHOG_API_KEY = undefined
+} else {
+    // The URL embeds the SharingConfiguration access token (/interview/<token>/), and posthog-js
+    // captures `window.location` for `$current_url` / `$pathname` / `$referrer` on every pageview
+    // and inside session replays. Without scrubbing, anyone with read access to those events or
+    // replays would see the token and could reuse it to start a fresh interview call as the
+    // invitee. Rewrite the URL via `replaceState` before posthog-js initializes so the captured
+    // values never include the token — the client reads the token from `exportedData.accessToken`
+    // and does not depend on `window.location`.
+    try {
+        const redactedPath = window.location.pathname.replace(/\/interview\/[^/?#]+/, '/interview/<redacted>')
+        if (redactedPath !== window.location.pathname) {
+            window.history.replaceState(null, '', redactedPath + window.location.search + window.location.hash)
+        }
+    } catch {
+        // History API unavailable — fall back to disabling tracking entirely rather than risk
+        // the token landing in captured events.
+        window.JS_POSTHOG_API_KEY = undefined
+    }
 }
 
 loadPostHogJS()

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,4 +1,4 @@
-import posthog, { PostHogInterface } from 'posthog-js'
+import posthog, { BeforeSendFn, PostHogInterface } from 'posthog-js'
 import { sampleOnProperty } from 'posthog-js/lib/src/extensions/sampling'
 
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -21,7 +21,16 @@ const shouldTrackFramerate = (loadedInstance: PostHogInterface): boolean => {
     )
 }
 
-export function loadPostHogJS(): void {
+export interface LoadPostHogJSOptions {
+    /**
+     * Hook posthog-js's `before_send` so the caller can mutate or drop events before they leave
+     * the browser. Used by the exporter app to redact the SharingConfiguration access token from
+     * URL-shaped properties on the interview share page — see `frontend/src/exporter/index.tsx`.
+     */
+    beforeSend?: BeforeSendFn | BeforeSendFn[]
+}
+
+export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
     if (window.JS_POSTHOG_API_KEY) {
         posthog.init(window.JS_POSTHOG_API_KEY, {
             opt_out_useragent_filter: window.location.hostname === 'localhost', // we ARE a bot when running in localhost, so we need to enable this opt-out
@@ -41,6 +50,7 @@ export function loadPostHogJS(): void {
             error_tracking: {
                 __capturePostHogExceptions: true,
             },
+            before_send: options.beforeSend,
             loaded: (loadedInstance) => {
                 if (loadedInstance.sessionRecording) {
                     loadedInstance.sessionRecording._forceAllowLocalhostNetworkCapture = true

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,4 +1,4 @@
-import posthog, { BeforeSendFn, PostHogInterface } from 'posthog-js'
+import posthog, { BeforeSendFn, PostHogInterface, SessionRecordingOptions } from 'posthog-js'
 import { sampleOnProperty } from 'posthog-js/lib/src/extensions/sampling'
 
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -28,6 +28,11 @@ export interface LoadPostHogJSOptions {
      * URL-shaped properties on the interview share page — see `frontend/src/exporter/index.tsx`.
      */
     beforeSend?: BeforeSendFn | BeforeSendFn[]
+    /**
+     * Extra `session_recording` config merged on top of the defaults — useful for overriding URL
+     * / network-payload masking when the page renders sensitive bearer tokens in its own URL.
+     */
+    sessionRecording?: Partial<SessionRecordingOptions>
 }
 
 export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
@@ -153,6 +158,7 @@ export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
             },
             session_recording: {
                 blockSelector: '.ph-replay-block',
+                ...options.sessionRecording,
             },
             person_profiles: 'always',
             __add_tracing_headers: ['eu.posthog.com', 'us.posthog.com'],


### PR DESCRIPTION
## Problem

The public interview page (`/interview/<token>`) is rendered via the exporter SPA, which hard-disables the PostHog JS client at module load (`window.JS_POSTHOG_API_KEY = undefined`). That blanket-disable exists to protect *embedded* dashboards from leaking traffic on customers' sites — but the interview page isn't embedded anywhere. It's our own hosted page, opened by an invitee on a link we sent, on our domain.

Without client-side tracking we can only see what server-side webhook events tell us (`user_interview_conversation_started` / `_ended`), and those only fire once the invitee has clicked Start and Vapi is on the line. We can't see who opened the link and bounced, where the pre-call flow loses people, whether the mic-permission dialog confuses them, or how the dogfood-link adoption looks across topic authors.

## Changes

Read `window.POSTHOG_EXPORTED_DATA` early in `frontend/src/exporter/index.tsx` and only undefine the API key when `type !== 'interview'`. All other exporter scenes (dashboards, insights, recordings, notebooks, heatmaps) behave exactly as before.

Net diff: 9 insertions, 6 deletions, single file.

## How did you test this code?

I'm an agent (PostHog Code). Verified:

- The previous duplicate `const exportedData` declaration (one was inside `renderApp`'s scope, one outside) was de-duplicated by moving the read to the top of the module — the new declaration is the only one.
- `loadPostHogJS()` already short-circuits on `if (window.JS_POSTHOG_API_KEY)` — so other exporter scenes get the same no-init behaviour as before.
- `oxlint`/`oxfmt` clean.

No manual browser testing performed.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

PostHog Code (Claude Opus 4.7). Discovered the gap while shepherding #58876 (user-interviews semantic search). The blanket disable predates the user_interviews product and was originally written for customer-embedded dashboards.

Considered alternatives:
- Conditional init inside `loadPostHogJS` itself — rejected, that helper is shared with the main app and the gate belongs at the entry-point that *knows* it's an exporter.
- A separate exporter entry point for interview pages — rejected, the conditional add up to a 4-line guard; an entirely new bundle would be heavier than warranted.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*