### PR TITLE
fix(insights): align hog-charts retention bar with legacy visual

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -449,11 +449,11 @@ snapshots:
     components-hogcharts-barchart--horizontal--light:
         hash: v1.k794b7964.c2d37efbb5f1a595f2ad8004b5b532ed557f5ef0cf8d66c6889c9ba60120d197.68oC5-4T8-zOosLcakG-rWYkDFsG_-GG6G60H69pI4g
     components-hogcharts-barchart--horizontal-aggregated-single--dark:
-        hash: v1.k794b7964.8608593ebfba3ffae5144e5be62baeed502949152b7ae382ec2529c870205aa7.fmgEKz_TwFIitbSD0dhjQKNyOgxmLegrv-xPzbZ22x0
+        hash: v1.k794b7964.5e126f50216e391db1736b494f928a25a67f667b1b1c9867f55e0a9693705069.Ulnv7t13CIS9PKTln2R09PCBupU4l6GdcgiPvJpBw34
     components-hogcharts-barchart--horizontal-aggregated-single--light:
         hash: v1.k794b7964.e3aeccafc937e33a26348c2760b8c27c4bcdfb93d1b52638bd3514b482d18ba6.AwaxzDrNr0PXQe5iu8yrhQmTf1ib0qe1FUsYp5M1I8s
     components-hogcharts-barchart--horizontal-grouped--dark:
-        hash: v1.k794b7964.f68e09df33fe1a42fa38a4c49b714f9f309995f5a9a76c45082cbfeefca19150.lfLphoQUP9BMClRf4sT9t3HD1DzyVZb99whBGWaVfqU
+        hash: v1.k794b7964.a9bbe5488b1e8b8f3dd2fde96564a7472ef6c8b0c9a1ec70b7629886ed165b1e.uRnihlAOH_HQAHkOvWnWU2o8teXidFawDVHP0lXYar8
     components-hogcharts-barchart--horizontal-grouped--light:
         hash: v1.k794b7964.beb8d534a94663d944290398d7c2946b739d8d6ad9af6e7cd5b5fa86eb53d4d9.0pZ70Z9dzCO4WrZNoZmeVP0ISM0vy8_QvWUggLAs-6o
     components-hogcharts-barchart--incomplete-period--dark:
@@ -465,7 +465,7 @@ snapshots:
     components-hogcharts-barchart--large-dataset--light:
         hash: v1.k794b7964.f2a511fd1da07d703c1098de939397a50d9974f9d8687901b0b45ddba2782a5f.UT09Z5anF_9S5egvdB5ZxMBPwPM3c-f1aOCcvO4FhJM
     components-hogcharts-barchart--negative-values--dark:
-        hash: v1.k794b7964.7be2972f8a3e14bda2fd7acfe74d6cad5689b1ae966c3e3842bad6c596a924a0.xxU22quViue9ppMauwToQCdHHC6ArDwE-LQljhF6dxE
+        hash: v1.k794b7964.0db8ce0f9b8adc438072d6cbcb39fc3f5d030f4a43d3ee83a6631880430b7728.fRvvQVmhY9eXBnCE7MuSuZZPxGeav7swdU4VxCuT7tE
     components-hogcharts-barchart--negative-values--light:
         hash: v1.k794b7964.2fdbc9b8c3e9cfa131f1f7fa1e1ab321ef9ed75f97b576fd03d36006660d97ee.ucknFjThmJmGxxdORpVbfKrl41FIPhVkls_cCuOV78c
     components-hogcharts-barchart--no-grid--dark:
@@ -509,7 +509,7 @@ snapshots:
     components-hogcharts-linechart--dual-y-axis--light:
         hash: v1.k794b7964.490e972dbbb2faa917ef54034663b0c394d4f597ac678ceca5ed49c18f4899b7.LZJCjrUK4dR1cTasi6aW91SkNljiZtB87DAf7KRflXI
     components-hogcharts-linechart--empty--dark:
-        hash: v1.k794b7964.63484323b9fad464aac034dc1c9075a006fe13f65b289fdd93f065436631b4bd.fFjhTQy_jkwlzaAzHz2TIBHNmuR0HiwwtscIExw5z4c
+        hash: v1.k794b7964.ab16f8d4f555a949074c9c1423fa273a8315f147be8a7552e0e4177f3c4a08e9.e6SrqIlxHqrfzUpC4L9N6d5BNxa9ew3dKSF8Fw39gs4
     components-hogcharts-linechart--empty--light:
         hash: v1.k794b7964.de2c4548e86b72f409c9eb6cb968915aa3d56f14ebb66947a81eff76a2569ed1.T1jDtKGrJPRIdx4gTNJyr7q4UNFL_b2J7Xkma1zva-E
     components-hogcharts-linechart--error-boundary--dark:
@@ -533,7 +533,7 @@ snapshots:
     components-hogcharts-linechart--in-progress-tail--light:
         hash: v1.k794b7964.e88cfa0b18df5fb5d2c455847301325e8136a3ee641f6d3b549f50bb52e7d31b.eMIEcugc6P2wg2v4TJX9sf58DrivKiCQLTs618gL8ys
     components-hogcharts-linechart--log-scale--dark:
-        hash: v1.k794b7964.5ec5cbb8147d50baf73ae6633d2fd3be4ce415b691858699ecd15a98e9cb06bc.v-1PMcu83YCtoHtF-kYuUz6w9XdBznRNro9y05y9-vc
+        hash: v1.k794b7964.527bf46403c42a2cd1313951bc66554a5251ee71598aa35006318f3ceaa9a5d9._joW9bDNUM54D4I8tzetmFM0K5iseAw0ey4LnbVVHRM
     components-hogcharts-linechart--log-scale--light:
         hash: v1.k794b7964.dfbdd21f8b36cdac550fd276708f1b933f345bb3050b58e5187113f374987cbb.BHKrPpQ84g9DG1gsa75PvYExI-Qy9oOU8bOlbCvu8_Y
     components-hogcharts-linechart--many-series--dark:
@@ -549,7 +549,7 @@ snapshots:
     components-hogcharts-linechart--percent-stacked--light:
         hash: v1.k794b7964.c05f8f8af8e691e2c53835f3a7d474225bc8207cd894c4d096e770c32308dc28.28OBU9vSfYWXxXrK_WXQP1NtBA6OscodzkzdXCNqtK0
     components-hogcharts-linechart--single-point--dark:
-        hash: v1.k794b7964.29f701b8f0d20465e62603c0652a1dd018c99b68e17001883fcc3fff92286683.O--AA-kWKVcgYBuFUBxs_3abKQov5NvpapBMn9BgCfg
+        hash: v1.k794b7964.1ca094793f8aa1b56b43985f2f3876f0fec7ce90f50915deafe3a0126dd2102c.g5uvPErB4oi0cOaBqd-uaiR65cTyAlKK5RUgsaZjQio
     components-hogcharts-linechart--single-point--light:
         hash: v1.k794b7964.4c9d7ddfa9835b3a6d1b1968ca8681d486ec6b58149037b30b9e004e9723c630.r8DnRepVSiC5bIlkAEae4oKfHXUV_B81O19moad48eE
     components-hogcharts-linechart--single-series--dark:
@@ -609,7 +609,7 @@ snapshots:
     components-hogcharts-referenceline--horizontal-variants--light:
         hash: v1.k794b7964.1ee7b0eb338bb930c2ae9467d9802e358f3664c6369f9c50e154759dd534a86c.ImOHfi0EunpIPJgtCE5zMPsZ7lGn14kZiYXPr69mB0Y
     components-hogcharts-referenceline--label-start-vs-end--dark:
-        hash: v1.k794b7964.e5e4de0e29ac4c67272199153d29b4d92797d9c7659470b50c797e047d946b74.91CoXOeCA3i2En0OtQWVDmgo0gdHut9saX2cln84L_I
+        hash: v1.k794b7964.fabcef88294104f29274ec587131942c155bf5ad07f7ccc44d5be4e043644c7c.8DxGcCR5SDI7WRkye1lRYYdqnoJyvsx29MIacSUYuUA
     components-hogcharts-referenceline--label-start-vs-end--light:
         hash: v1.k794b7964.90ff54e19bd1817ec0da4fdfea22c05b57e59d709ec1fc82fbedbb6dcb2880b2.RWS_aFWJpBqvcPhSYo6K8qCEiO9fS7TD6hkAOpgOr0I
     components-hogcharts-referenceline--vertical-reference-lines--dark:
@@ -625,7 +625,7 @@ snapshots:
     components-hogcharts-timeseriesbarchart--date-axis--light:
         hash: v1.k794b7964.d7e563085dc3084d542e4b052dd0d8c4b9f9d4b7c0f5ec71e62bd27a7213b659.7mc0isBHvoiB12nDHqLZzG1h5RoZe_1wOsroFeVYQCo
     components-hogcharts-timeseriesbarchart--grouped--dark:
-        hash: v1.k794b7964.2fe54f3bb728346aef94338597292c29fd27d117d4bab8b65ff5a368845a029e.FmtYOKsSQrzqo8wp_Mj-qUwoNf37DiH7ZWbNYB9qvg0
+        hash: v1.k794b7964.1f955c013f70db1cfe3ff0beed6c3e396a12e6e774deba35dea61dd100345156.DSV_MB6ahnnOaWNT5cnQG-3lQtCPDU5j7V8go9QfKUQ
     components-hogcharts-timeseriesbarchart--grouped--light:
         hash: v1.k794b7964.616f2405c8f0c2669592f3544fa1bd126c10f8e71f481b759d95e0f4a2304a64.jbC7Wp68t70yxq289nossg5_8mfBpM8C3f2x4Rsl0SU
     components-hogcharts-timeseriesbarchart--percent--dark:
@@ -1905,7 +1905,7 @@ snapshots:
     insights-funnelcorrelationtable--default--light:
         hash: v1.k794b7964.a5ccf40b74b63001bb7383ff53cb81b8f4f4a07308e0b6a2ad590ff821efc3ee.wCJ8wpYAyHJfnQB7k7qNZZKqiPtIq2sppx3qVS4IGQQ
     insights-funnelhistogramchart--default--dark:
-        hash: v1.k794b7964.e0eeac72672d73139955c1822f77a0f4b7c3120ab66b4803b7bdfee62aeaeb52.tdaIqudDsCaiQ8QSe1x2RNTG0QwLiCmTEfhk6_5WEu0
+        hash: v1.k794b7964.51d58d7f3b265db938e79437d943734519071a59804edbe8cce5e0f4e698dedc.5ZgbDL6d-dcxcEWTOLZFHBHeER7tW6f_Hzr32bEAd8Y
     insights-funnelhistogramchart--default--light:
         hash: v1.k794b7964.64f2986bdea7e5f61e7b7900a52c683c8223df30f550701fb08028c8b203c807.tdD0sW9MOaReK_5QRGviTL5QDK2jG126L3hQj5pd2Cw
     insights-funnellinechart--default--dark:
@@ -1913,7 +1913,7 @@ snapshots:
     insights-funnellinechart--default--light:
         hash: v1.k794b7964.bc3e2e9caee13301c07d79564d2c7e01a29c748a1f382496585f58f2ac283389.SDhk8kXtp9imHhdiYpRwgQfwSXvcH_oeQ8m1K729q0Q
     insights-funnellinechart--goal-line--dark:
-        hash: v1.k794b7964.bda4551694dc54902b3e46ffb327e0d713af760b1a53ae7b7453779fa1e26bbf.pFfUWaxERw1KCaA9ZcqwB0R8TKC4CDiD5ift8kApZM4
+        hash: v1.k794b7964.176a67cb5ae31de81b4f83b46de7739bc7baa48f7fcc30a5afb6534da7f9de80.gPAzOi1fzjS-KLvepRBzolSMu2HLk9SVR0S3csv9sRs
     insights-funnellinechart--goal-line--light:
         hash: v1.k794b7964.35b2f6e08b22e8b95c561f10f4a3eeee0ec5355d91aa166db2cc3595f2acc4ae.iqDGpipKH0res85GZFCYszkpygWdzEM7lweEmg62j6M
     insights-funnellinechart--value-labels--dark:
@@ -1957,39 +1957,39 @@ snapshots:
     insights-insightstable--is-legend--light:
         hash: v1.k794b7964.d9eec920b0b2f3c9ea87c9e0d2b298bc37339217e4211d0cf1a147630f09b75d.xGcJlQO8pvoNnHyoMNZ4F58uqKh5PDg_UiGlO5bAMn8
     insights-stickinesslinechart--default--dark:
-        hash: v1.k794b7964.41390e8fbafc9d75682179e198664c729a05ed3439fb99ad516fe1b1032cf6c0.dmsgYkZeOieitZlRh1HAveS5ej1pzamiMVQQdBstzIg
+        hash: v1.k794b7964.f6ce3c9177a7fa2b7d23d13e7121d089a2617f581baec1eaff9980bd40905199.A5l8DG-UgcNxzLuJwxvElIEzmOGud3QUrquboobhJvM
     insights-stickinesslinechart--default--light:
         hash: v1.k794b7964.e5281ee27e4687b2f9240f18fd0a61d70bf5b579e96e9c1200ba505eb36db3a4.0WBlzrCtDDl3Zk7GQDHpLr0MatZnxAwMwWPfUSmjc1o
     insights-trendsbarchart--aggregated-compare-breakdown--dark:
-        hash: v1.k794b7964.665af86c19c56e64090968d389ad70f6c31723e48a5c33dd09471fd7f7803ee1.t7lftFAyNVc_TMUt4thz6VWm9dbx1fVSXYwzEhbKYBw
+        hash: v1.k794b7964.e42c98abc59ab84f5ca78ca167d866e3096bd9ff2772b94ff5b4bf1b6206898f.v56fohZ2M455R1gh5x7thsAsQfLqBTXiEcbZr2_GhO8
     insights-trendsbarchart--aggregated-compare-breakdown--light:
         hash: v1.k794b7964.5af2e4097a7ae88260510ae1241589c25aa3bd21ab7700f9e544b4222a307382.QRE1QgbF1lgcnLkjiCYIT9rEgCUVOegdsbSOeZ77Acw
     insights-trendsbarchart--compare--dark:
-        hash: v1.k794b7964.68689d02aa245c2ccd04888b1c2bc578136eda4117f2fff911bde3f5c276b9da.svBnhEDDJ61_Vp6T3AUEjT3wlS2aamf9o-YNooKTRlw
+        hash: v1.k794b7964.b0d40760cfac355f23a86297c1f7efb9c513f71ae9f47392f38f7d9438be7492.EJMtgio8LgrUpRUDM62BEnvU8st4AVaf69502qXXync
     insights-trendsbarchart--compare--light:
         hash: v1.k794b7964.08db5d36c08b26300a7cd09fddd8f02e9ba973ffcf42e556e7f8ae01a27e907b.jN5qaeiDphtPJ90-0-bNC0jmD0MVkSCj6zjO8XzvZkI
     insights-trendsbarchart--percent-stack-breakdown--dark:
-        hash: v1.k794b7964.90b4877789670adc2780ca9dab0945b5350766fb7187bd93f01cb1a1dfcc377b.xYM0L_6dVhqxzW_EficHvSiV99A-LIrnYBkMAe_udjc
+        hash: v1.k794b7964.d73e4783a973a390039e8935cda19994770b91a4f4ff93247cdfabb87fcd6d94.63QY3eqYYlgpdVd-TgYqPLbEIrpm5h7ihk-QDXaZ_TI
     insights-trendsbarchart--percent-stack-breakdown--light:
         hash: v1.k794b7964.94dcced10754de4cf816cd83eb27f803082aee84fcf1b081bc98b8f4be366edd.KYJWPI86CCOx9TZf83eCCWbHwAlIqRJ8jcPZAK7-zyM
     insights-trendslifecyclechart--stacked--dark:
-        hash: v1.k794b7964.f01dae4d665fea93c451e5bb48d6409d586c89856ffb1fff155937c7eb9119d9.coUQ2-TFqEqeP38cPDoiz5RbwkfznST9H3pR5TRbpvg
+        hash: v1.k794b7964.a0b63c471c3939cbe79812a900b8f887ec600442e98d21627b874b5d8832c592.xjKULqFFbTBlaBNOQ-FWvGL_P1LfLzY3V1t-lj-gSy0
     insights-trendslifecyclechart--stacked--light:
         hash: v1.k794b7964.06299a8e05030704231ec0ab4031ff3193330c613a3b7f9688db9ce7e932fe49.-8nYhPa8-aLNwcTVGon6dY_Rn4KRC-l_frb-ikmvk1I
     insights-trendslifecyclechart--unstacked--dark:
-        hash: v1.k794b7964.2a10bee9748692b8389454027a29ca4aae1fd5ec54df435f337658ccb14e88ac.byw6nfFw97UeuEpXKPkAlWMXDYhMvcqzPgZFGxST0hk
+        hash: v1.k794b7964.6b5f1e5ce04e682f39d957a57192db9dc38d29deae409146c45c275d8575341e.1wwEDPbO-jOXRNDOTT81-gPNbyMM2C5QpussoL6iEPA
     insights-trendslifecyclechart--unstacked--light:
         hash: v1.k794b7964.3467d1d62a847176237a5278030dcd296df1283111f6260f86f2d467e2cc457b.xxTvFm43ZodSjCbtbMNLpjn20JZLLK6h4-MElnqQa5I
     insights-trendslinechart--breakdown--dark:
-        hash: v1.k794b7964.4228a311a626ebf45a34acead267954b6b05686aa012ed54242b7a0c5ba298f1.MC_47zRRkXLTsrbhhq1hf2BuXmW8uRCu4fohSF303Is
+        hash: v1.k794b7964.26e070b747cdce14d42696be55405981bf7149f088bd0def208f50cd7f8abedd.VZhMtciuCaFsReKDPdj_svmfFGvxR_TsXGdwIPHd-34
     insights-trendslinechart--breakdown--light:
         hash: v1.k794b7964.518e2fe68fa15e8723fa5e1b6e837b2361b11f2c55a476e34b33e81efa6b676c.Ec7nhxUV6ArfOvRIV4GERg0Kq7hROoYJ-Tt0SiKeNI4
     insights-trendslinechart--default--dark:
-        hash: v1.k794b7964.cd6a4a176d7b90c562e21a085e6b14b7166d609b6b21c73eeba226eb57e5c63b.9hBnUcRgbwGS-d635MjAmMyECdDIIbZg2tMyiirsLvs
+        hash: v1.k794b7964.a43e713ba161507c3c2097e087b223fc3e0aee502fa8fd94796539075e625697.Iv0jhVpolvE8xeS-dRF2qWRyj0VBAIyfEf6WXPx_M00
     insights-trendslinechart--default--light:
         hash: v1.k794b7964.2a41ea2b702aa15bd4ec9c98e37a4268db6d0480f984a61243e3a1aa3e5aa42a.K-TpvzcRCmyQLuuzbxovQu2IPoza-kqQkuQOqPz2LK0
     insights-trendslinechart--single-series--dark:
-        hash: v1.k794b7964.a00352433e596553684495be247c9d0476214c944ebb8f969cb790ddbe1cfb87.IR86LYH4Y3nWPFcqvV5YOtRAENQdgoq0Mw0Zndb04Sc
+        hash: v1.k794b7964.9353b60c827a8e4563ac5b680274a55e4e9c1cefeebe765331636ae824e8d2d5.t75gvt_uBTQe_ABbuxW4JiJEW4CZk-IBfvJIkyTGlPU
     insights-trendslinechart--single-series--light:
         hash: v1.k794b7964.e8d7c90005769112e971e55319b5e27731c8363aa977f21d5dbe8b9ec14b30ce.aaLz4Eg-X0FQkUCC9VXBjoVw902yotIdFJ4W5GzGu_8
     layout-feature-previews--basic--dark:
@@ -4735,9 +4735,9 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.gaL7vRk-pWoOUkiPi-NGCd1W72x-M5l9jk5Qu-UcjwI
+        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
-        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.dtIb8VK_HAoAvzi8YbVjGpt2Y8yONsVV7mEiD9DrclQ
+        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
         hash: v1.k794b7964.dad9df902a133cafd6b3314a3800fcb45dabbbb59a0766c87c226549392104fc.u8mciTuIKrwI-d3yiUx6dVpr3oLoJJ7tgvRU7hutwhU
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--light:

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
@@ -453,13 +453,15 @@ describe('hog-charts canvas-renderer', () => {
             expect(fromY).toBe(toY)
         })
 
-        it('draws a vertical y-axis line at plotLeft as the final stroke', () => {
+        it('frames the plot area with left and right vertical axis lines', () => {
             const ctx = mockCanvasContext()
             drawGrid(makeDrawContext(ctx, ['a', 'b']))
-            const lastMove = ctx.moveTo.mock.calls.at(-1)
-            const lastLine = ctx.lineTo.mock.calls.at(-1)
-            expect(lastMove).toEqual([dimensions.plotLeft + 0.5, dimensions.plotTop])
-            expect(lastLine).toEqual([dimensions.plotLeft + 0.5, dimensions.plotTop + dimensions.plotHeight])
+            const leftX = dimensions.plotLeft + 0.5
+            const rightX = dimensions.plotLeft + dimensions.plotWidth - 0.5
+            expect(ctx.moveTo.mock.calls).toContainEqual([leftX, dimensions.plotTop])
+            expect(ctx.lineTo.mock.calls).toContainEqual([leftX, dimensions.plotTop + dimensions.plotHeight])
+            expect(ctx.moveTo.mock.calls).toContainEqual([rightX, dimensions.plotTop])
+            expect(ctx.lineTo.mock.calls).toContainEqual([rightX, dimensions.plotTop + dimensions.plotHeight])
         })
 
         it('uses the provided gridColor', () => {
@@ -478,13 +480,15 @@ describe('hog-charts canvas-renderer', () => {
             expect(toY).toBe(dimensions.plotTop + dimensions.plotHeight)
         })
 
-        it('draws a horizontal top baseline as the final stroke (horizontal orientation)', () => {
+        it('frames the plot area with top and bottom baselines (horizontal orientation)', () => {
             const ctx = mockCanvasContext()
             drawGrid(makeDrawContext(ctx, ['a', 'b']), { orientation: 'horizontal' })
-            const lastMove = ctx.moveTo.mock.calls.at(-1)
-            const lastLine = ctx.lineTo.mock.calls.at(-1)
-            expect(lastMove).toEqual([dimensions.plotLeft, dimensions.plotTop + 0.5])
-            expect(lastLine).toEqual([dimensions.plotLeft + dimensions.plotWidth, dimensions.plotTop + 0.5])
+            const topY = dimensions.plotTop + 0.5
+            const bottomY = dimensions.plotTop + dimensions.plotHeight - 0.5
+            expect(ctx.moveTo.mock.calls).toContainEqual([dimensions.plotLeft, topY])
+            expect(ctx.lineTo.mock.calls).toContainEqual([dimensions.plotLeft + dimensions.plotWidth, topY])
+            expect(ctx.moveTo.mock.calls).toContainEqual([dimensions.plotLeft, bottomY])
+            expect(ctx.lineTo.mock.calls).toContainEqual([dimensions.plotLeft + dimensions.plotWidth, bottomY])
         })
 
         describe('categoryTicks', () => {

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -297,11 +297,11 @@ export interface DrawGridOptions {
     categoryTicks?: number[]
 }
 
-/** Draws the grid lines and the categorical-axis baseline.
+/** Draws the grid lines and the full plot-area frame.
  *
  * `orientation`:
- *  - `'vertical'` (default): horizontal grid lines at value-axis (y) tick positions, vertical baseline on the left.
- *  - `'horizontal'`: vertical grid lines at value-axis (x) tick positions, horizontal baseline on the top.
+ *  - `'vertical'` (default): horizontal grid lines at value-axis (y) tick positions, vertical baselines on both left and right.
+ *  - `'horizontal'`: vertical grid lines at value-axis (x) tick positions, horizontal baselines on both top and bottom.
  *
  * In both modes, `yScale` maps a value to a pixel on the value axis — for vertical that's a y-pixel,
  * for horizontal that's an x-pixel. The function uses `dimensions` to size the perpendicular axis.
@@ -347,6 +347,13 @@ export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): v
         ctx.moveTo(dimensions.plotLeft, axisY)
         ctx.lineTo(dimensions.plotLeft + dimensions.plotWidth, axisY)
         ctx.stroke()
+        // Far-edge snap uses `- 0.5` (mirror of the `+ 0.5` near edge above) so the
+        // closing stroke lands just inside `plotTop + plotHeight` and stays within the plot rect.
+        const closingY = Math.round(dimensions.plotTop + dimensions.plotHeight) - 0.5
+        ctx.beginPath()
+        ctx.moveTo(dimensions.plotLeft, closingY)
+        ctx.lineTo(dimensions.plotLeft + dimensions.plotWidth, closingY)
+        ctx.stroke()
         return
     }
 
@@ -373,6 +380,13 @@ export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): v
     ctx.beginPath()
     ctx.moveTo(axisX, dimensions.plotTop)
     ctx.lineTo(axisX, dimensions.plotTop + dimensions.plotHeight)
+    ctx.stroke()
+
+    // See the horizontal-mode block for the `- 0.5` snap rationale (mirror of the near-edge `+ 0.5`).
+    const closingX = Math.round(dimensions.plotLeft + dimensions.plotWidth) - 0.5
+    ctx.beginPath()
+    ctx.moveTo(closingX, dimensions.plotTop)
+    ctx.lineTo(closingX, dimensions.plotTop + dimensions.plotHeight)
     ctx.stroke()
 }
 

--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
@@ -59,7 +59,6 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
         hasValidBreakdown,
         retentionFilter,
         filteredTrendSeries,
-        incompletenessOffsetFromEnd,
         labelGroupType,
         shouldShowMeanPerBreakdown,
         xAxisLabels,
@@ -74,13 +73,13 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
     // Shared (public) views don't have the persons modal mounted — disable click-to-open there.
     const canClick = !shouldShowMeanPerBreakdown && !inSharedMode
 
+    // Legacy parity: in-progress stroke is line-only.
     const series = useMemo(
         () =>
             buildRetentionSeries(filteredTrendSeries as RetentionTrendSeriesEntry[], {
-                incompletenessOffsetFromEnd,
                 isIntervalView,
             }),
-        [filteredTrendSeries, incompletenessOffsetFromEnd, isIntervalView]
+        [filteredTrendSeries, isIntervalView]
     )
 
     const groupTypeLabel = resolveGroupTypeLabel(labelGroupType, aggregationLabel)


### PR DESCRIPTION
## Problem

The retention bar chart looks different depending on whether the
`product-analytics-hog-charts-retention` flag is on. Compared to the legacy
chart.js version, the hog-charts version:

1. Renders a **diagonal-hatch (striped) pattern** on bars that fall inside the
   in-progress (partial) period tail. The legacy chart only uses the
   incompleteness indicator on the line view — the bar view shows nothing
   special.
2. Leaves the grid **open on the right** — the plot area reads as an
   "L-shape" rather than a closed rectangle.

This is a re-PR of #60129 (closed because the branch went stale against master).
The substantive code change is identical; storybook baselines will be
regenerated by the visual-review bot on this branch.

## Changes

- `RetentionBarChart` stops forwarding `incompletenessOffsetFromEnd` to
  `buildRetentionSeries`, so no `stroke.partial` is set and the bar chart no
  longer hatches in-progress bars. The line chart still receives the offset
  and continues to dash the in-progress tail.
- `drawGrid` always frames the plot area: vertical mode now draws both left
  and right value-axis lines; horizontal mode draws top and bottom. Retention
  bar (and every other hog-charts consumer) now reads as a closed rectangle
  instead of an L-shape.

## How did you test this code?

I'm an agent (Claude Code). Manual UI verification was not performed.
Automated tests run locally on the original branch:

- \`pnpm exec jest products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.test.ts\`
- \`pnpm exec jest src/lib/hog-charts/core/canvas-renderer.test.ts\`
- \`pnpm exec jest src/lib/hog-charts/charts\` (full hog-charts chart suites)

Visual coverage comes from existing storybook stories — \`Scenes-App/Insights/Retention - RetentionBar\`
(gated on the hog-charts retention flag) plus the hog-charts bar/line/timeseries
stories that now read the framed plot area.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Re-PR of #60129 authored by Claude Code (Opus 4.7) at the request of @sammyp.
The previous branch was closed after a stale-checkout incident produced a
broken commit (later reverted in-branch); rather than continue on that
history, this branch is freshly cut from master with the substantive code
commits cherry-picked. The bot-generated snapshot baseline commit from the
old PR was intentionally dropped because the baselines now conflict with
unrelated master changes — the visual-review bot will regenerate them here.

Decisions worth flagging:

- Plot-area framing is the new default in \`drawGrid\` rather than an opt-in
  flag. That keeps the API smaller and matches the legacy chart.js box-style
  grid for every hog-charts consumer (trends bar, funnel steps, line charts,
  retention) in one move. The original PR briefly went through an opt-in
  shape before consolidating on this default — the consolidated version is
  what ships here.
- \`RetentionBarChart\` just drops the offset arg rather than gaining a new
  parameter on \`buildRetentionSeries\` to suppress the partial stroke. Same
  outcome, smaller surface area, and the line chart keeps the existing
  behavior.