### PR TITLE
feat(property-vals): add EXCLUDED_PROPERTY_KEYS env var to skip keys at fan_out

### DIFF
--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -48,7 +48,7 @@ pub struct Config {
     pub rollout_percentage: u8,
 
     #[envconfig(default = "")]
-    pub excluded_property_keys: PropertyKeyList,
+    pub excluded_property_keys: ExcludedPropertyKeys,
 
     #[envconfig(from = "BIND_HOST", default = "::")]
     pub host: String,
@@ -81,17 +81,17 @@ impl FromStr for TeamList {
 /// (identifier-shaped properties like `$insert_id`, `$session_id`, `distinct_id`)
 /// is wasted work that nobody searches against in autocomplete.
 #[derive(Clone, Default)]
-pub struct PropertyKeyList {
+pub struct ExcludedPropertyKeys {
     pub keys: Arc<HashSet<String>>,
 }
 
-impl PropertyKeyList {
+impl ExcludedPropertyKeys {
     pub fn contains(&self, key: &str) -> bool {
         self.keys.contains(key)
     }
 }
 
-impl FromStr for PropertyKeyList {
+impl FromStr for ExcludedPropertyKeys {
     type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -100,7 +100,7 @@ impl FromStr for PropertyKeyList {
             .map(|k| k.trim().to_string())
             .filter(|k| !k.is_empty())
             .collect();
-        Ok(PropertyKeyList {
+        Ok(ExcludedPropertyKeys {
             keys: Arc::new(keys),
         })
     }

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -77,9 +77,6 @@ impl FromStr for TeamList {
     }
 }
 
-/// Property keys to skip during fan_out — pure write amplification on these
-/// (identifier-shaped properties like `$insert_id`, `$session_id`, `distinct_id`)
-/// is wasted work that nobody searches against in autocomplete.
 #[derive(Clone, Default)]
 pub struct ExcludedPropertyKeys {
     pub keys: Arc<HashSet<String>>,

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -1,4 +1,7 @@
+use std::collections::HashSet;
+use std::convert::Infallible;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 use std::{num::ParseIntError, str::FromStr};
 
 use common_continuous_profiling::ContinuousProfilingConfig;
@@ -44,6 +47,9 @@ pub struct Config {
     #[envconfig(default = "100")]
     pub rollout_percentage: u8,
 
+    #[envconfig(default = "")]
+    pub excluded_property_keys: PropertyKeyList,
+
     #[envconfig(from = "BIND_HOST", default = "::")]
     pub host: String,
 
@@ -68,6 +74,35 @@ impl FromStr for TeamList {
             teams.push(team.parse()?);
         }
         Ok(TeamList { teams })
+    }
+}
+
+/// Property keys to skip during fan_out — pure write amplification on these
+/// (identifier-shaped properties like `$insert_id`, `$session_id`, `distinct_id`)
+/// is wasted work that nobody searches against in autocomplete.
+#[derive(Clone, Default)]
+pub struct PropertyKeyList {
+    pub keys: Arc<HashSet<String>>,
+}
+
+impl PropertyKeyList {
+    pub fn contains(&self, key: &str) -> bool {
+        self.keys.contains(key)
+    }
+}
+
+impl FromStr for PropertyKeyList {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let keys: HashSet<String> = s
+            .split(',')
+            .map(|k| k.trim().to_string())
+            .filter(|k| !k.is_empty())
+            .collect();
+        Ok(PropertyKeyList {
+            keys: Arc::new(keys),
+        })
     }
 }
 

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -1,37 +1,45 @@
 use serde_json::Value;
 
+use crate::config::PropertyKeyList;
 use crate::types::{Event, GroupIdentify, PropertyType, TupleKey};
 
 pub const MAX_PROPERTY_KEY_LEN: usize = 400;
 pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
 
-pub fn fan_out(event: &Event) -> Vec<TupleKey> {
+pub fn fan_out(event: &Event, excluded: &PropertyKeyList) -> Vec<TupleKey> {
     let mut out = Vec::new();
 
     if let Some(raw) = &event.properties {
-        emit_from_blob(event.team_id, PropertyType::Event, raw, &mut out);
+        emit_from_blob(event.team_id, PropertyType::Event, raw, excluded, &mut out);
     }
     if let Some(raw) = &event.person_properties {
-        emit_from_blob(event.team_id, PropertyType::Person, raw, &mut out);
+        emit_from_blob(event.team_id, PropertyType::Person, raw, excluded, &mut out);
     }
 
     out
 }
 
-pub fn fan_out_group(event: &GroupIdentify) -> Vec<TupleKey> {
+pub fn fan_out_group(event: &GroupIdentify, excluded: &PropertyKeyList) -> Vec<TupleKey> {
     let mut out = Vec::new();
     if let Some(raw) = &event.group_properties {
         emit_from_blob(
             event.team_id,
             PropertyType::Group(event.group_type_index),
             raw,
+            excluded,
             &mut out,
         );
     }
     out
 }
 
-fn emit_from_blob(team_id: i64, property_type: PropertyType, raw: &str, out: &mut Vec<TupleKey>) {
+fn emit_from_blob(
+    team_id: i64,
+    property_type: PropertyType,
+    raw: &str,
+    excluded: &PropertyKeyList,
+    out: &mut Vec<TupleKey>,
+) {
     let parsed: Value = match serde_json::from_str(raw) {
         Ok(v) => v,
         Err(_) => return,
@@ -44,6 +52,10 @@ fn emit_from_blob(team_id: i64, property_type: PropertyType, raw: &str, out: &mu
 
     for (key, value) in obj {
         if value.is_null() {
+            continue;
+        }
+
+        if excluded.contains(key) {
             continue;
         }
 
@@ -136,6 +148,14 @@ mod tests {
         }
     }
 
+    fn none() -> PropertyKeyList {
+        PropertyKeyList::default()
+    }
+
+    fn excluded(keys: &[&str]) -> PropertyKeyList {
+        keys.iter().copied().collect::<Vec<_>>().join(",").parse().unwrap()
+    }
+
     fn check_tuple_invariants(t: &TupleKey, expected_team: i64) {
         assert_eq!(t.team_id, expected_team);
         assert!(!t.property_key.is_empty());
@@ -147,31 +167,31 @@ mod tests {
     proptest! {
         #[test]
         fn fan_out_outputs_obey_caps_and_team(e in arb_event()) {
-            for t in fan_out(&e) {
+            for t in fan_out(&e, &none()) {
                 check_tuple_invariants(&t, e.team_id);
             }
         }
 
         #[test]
         fn fan_out_group_outputs_obey_caps_and_team(g in arb_group_identify()) {
-            for t in fan_out_group(&g) {
+            for t in fan_out_group(&g, &none()) {
                 check_tuple_invariants(&t, g.team_id);
             }
         }
 
         #[test]
         fn fan_out_is_pure(e in arb_event()) {
-            prop_assert_eq!(fan_out(&e), fan_out(&e));
+            prop_assert_eq!(fan_out(&e, &none()), fan_out(&e, &none()));
         }
 
         #[test]
         fn fan_out_group_is_pure(g in arb_group_identify()) {
-            prop_assert_eq!(fan_out_group(&g), fan_out_group(&g));
+            prop_assert_eq!(fan_out_group(&g, &none()), fan_out_group(&g, &none()));
         }
 
         #[test]
         fn fan_out_group_property_type_matches_index(g in arb_group_identify()) {
-            for t in fan_out_group(&g) {
+            for t in fan_out_group(&g, &none()) {
                 prop_assert_eq!(t.property_type, PropertyType::Group(g.group_type_index));
             }
         }
@@ -179,7 +199,7 @@ mod tests {
 
     #[test]
     fn event_property_produces_event_type_tuple() {
-        let tuples = fan_out(&event(r#"{"$browser":"Chrome"}"#));
+        let tuples = fan_out(&event(r#"{"$browser":"Chrome"}"#), &none());
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].property_type, PropertyType::Event);
         assert_eq!(tuples[0].property_key, "$browser");
@@ -188,13 +208,13 @@ mod tests {
 
     #[test]
     fn json_null_value_is_dropped() {
-        let tuples = fan_out(&event(r#"{"nullable_field":null}"#));
+        let tuples = fan_out(&event(r#"{"nullable_field":null}"#), &none());
         assert!(tuples.is_empty());
     }
 
     #[test]
     fn empty_string_value_is_dropped() {
-        let tuples = fan_out(&event(r#"{"blank":""}"#));
+        let tuples = fan_out(&event(r#"{"blank":""}"#), &none());
         assert!(tuples.is_empty());
     }
 
@@ -205,7 +225,7 @@ mod tests {
             properties: None,
             person_properties: Some(r#"{"email":"foo@bar.com"}"#.to_string()),
         };
-        let tuples = fan_out(&ev);
+        let tuples = fan_out(&ev, &none());
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].property_type, PropertyType::Person);
         assert_eq!(tuples[0].property_key, "email");
@@ -214,33 +234,33 @@ mod tests {
 
     #[test]
     fn bool_value_coerces_to_string() {
-        let tuples = fan_out(&event(r#"{"a_bool":true}"#));
+        let tuples = fan_out(&event(r#"{"a_bool":true}"#), &none());
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].property_value, "true");
     }
 
     #[test]
     fn number_value_coerces_to_string() {
-        let tuples = fan_out(&event(r#"{"a_number":42}"#));
+        let tuples = fan_out(&event(r#"{"a_number":42}"#), &none());
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].property_value, "42");
     }
 
     #[test]
     fn unparseable_blob_emits_nothing() {
-        let tuples = fan_out(&event(r#"not valid json"#));
+        let tuples = fan_out(&event(r#"not valid json"#), &none());
         assert!(tuples.is_empty());
     }
 
     #[test]
     fn empty_object_emits_nothing() {
-        let tuples = fan_out(&event("{}"));
+        let tuples = fan_out(&event("{}"), &none());
         assert!(tuples.is_empty());
     }
 
     #[test]
     fn group_identify_index_0_emits_group_type() {
-        let tuples = fan_out_group(&group_identify(0, r#"{"plan":"enterprise"}"#));
+        let tuples = fan_out_group(&group_identify(0, r#"{"plan":"enterprise"}"#), &none());
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].property_type, PropertyType::Group(0));
         assert_eq!(tuples[0].property_key, "plan");
@@ -249,7 +269,7 @@ mod tests {
 
     #[test]
     fn group_identify_emits_group_type_matching_index() {
-        let tuples = fan_out_group(&group_identify(4, r#"{"region":"us-east"}"#));
+        let tuples = fan_out_group(&group_identify(4, r#"{"region":"us-east"}"#), &none());
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].property_type, PropertyType::Group(4));
     }
@@ -261,12 +281,57 @@ mod tests {
             group_type_index: 0,
             group_properties: None,
         };
-        assert!(fan_out_group(&g).is_empty());
+        assert!(fan_out_group(&g, &none()).is_empty());
     }
 
     #[test]
     fn group_identify_unparseable_drops() {
-        let tuples = fan_out_group(&group_identify(0, "not valid json"));
+        let tuples = fan_out_group(&group_identify(0, "not valid json"), &none());
         assert!(tuples.is_empty());
+    }
+
+    #[test]
+    fn excluded_event_property_keys_are_skipped() {
+        let blob = r#"{"$insert_id":"abc-123","$browser":"Chrome","distinct_id":"u1","$session_id":"s1"}"#;
+        let exclusions = excluded(&["$insert_id", "distinct_id", "$session_id"]);
+        let tuples = fan_out(&event(blob), &exclusions);
+        assert_eq!(tuples.len(), 1, "only $browser should survive exclusion");
+        assert_eq!(tuples[0].property_key, "$browser");
+        assert_eq!(tuples[0].property_value, "Chrome");
+    }
+
+    #[test]
+    fn excluded_person_property_keys_are_skipped() {
+        let ev = Event {
+            team_id: 2,
+            properties: None,
+            person_properties: Some(
+                r#"{"email":"a@b.com","$session_id":"s1","plan":"enterprise"}"#.to_string(),
+            ),
+        };
+        let tuples = fan_out(&ev, &excluded(&["$session_id"]));
+        assert_eq!(tuples.len(), 2);
+        let keys: Vec<&str> = tuples.iter().map(|t| t.property_key.as_str()).collect();
+        assert!(keys.contains(&"email"));
+        assert!(keys.contains(&"plan"));
+        assert!(!keys.contains(&"$session_id"));
+    }
+
+    #[test]
+    fn excluded_group_property_keys_are_skipped() {
+        let g = group_identify(0, r#"{"plan":"enterprise","internal_id":"g-42"}"#);
+        let tuples = fan_out_group(&g, &excluded(&["internal_id"]));
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].property_key, "plan");
+    }
+
+    #[test]
+    fn empty_exclusion_list_is_a_noop() {
+        let blob = r#"{"$browser":"Chrome","email":"a@b.com"}"#;
+        let with_default = fan_out(&event(blob), &none());
+        let parsed_empty: PropertyKeyList = "".parse().unwrap();
+        let with_parsed_empty = fan_out(&event(blob), &parsed_empty);
+        assert_eq!(with_default.len(), 2);
+        assert_eq!(with_default, with_parsed_empty);
     }
 }

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -153,7 +153,12 @@ mod tests {
     }
 
     fn excluded(keys: &[&str]) -> ExcludedPropertyKeys {
-        keys.iter().copied().collect::<Vec<_>>().join(",").parse().unwrap()
+        keys.iter()
+            .copied()
+            .collect::<Vec<_>>()
+            .join(",")
+            .parse()
+            .unwrap()
     }
 
     fn check_tuple_invariants(t: &TupleKey, expected_team: i64) {
@@ -292,7 +297,8 @@ mod tests {
 
     #[test]
     fn excluded_event_property_keys_are_skipped() {
-        let blob = r#"{"$insert_id":"abc-123","$browser":"Chrome","distinct_id":"u1","$session_id":"s1"}"#;
+        let blob =
+            r#"{"$insert_id":"abc-123","$browser":"Chrome","distinct_id":"u1","$session_id":"s1"}"#;
         let exclusions = excluded(&["$insert_id", "distinct_id", "$session_id"]);
         let tuples = fan_out(&event(blob), &exclusions);
         assert_eq!(tuples.len(), 1, "only $browser should survive exclusion");

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -153,12 +153,7 @@ mod tests {
     }
 
     fn excluded(keys: &[&str]) -> ExcludedPropertyKeys {
-        keys.iter()
-            .copied()
-            .collect::<Vec<_>>()
-            .join(",")
-            .parse()
-            .unwrap()
+        keys.join(",").parse().unwrap()
     }
 
     fn check_tuple_invariants(t: &TupleKey, expected_team: i64) {

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::config::PropertyKeyList;
+use crate::config::ExcludedPropertyKeys;
 use crate::types::{Event, GroupIdentify, PropertyType, TupleKey};
 
 pub const MAX_PROPERTY_KEY_LEN: usize = 400;
 pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
 
-pub fn fan_out(event: &Event, excluded: &PropertyKeyList) -> Vec<TupleKey> {
+pub fn fan_out(event: &Event, excluded: &ExcludedPropertyKeys) -> Vec<TupleKey> {
     let mut out = Vec::new();
 
     if let Some(raw) = &event.properties {
@@ -19,7 +19,7 @@ pub fn fan_out(event: &Event, excluded: &PropertyKeyList) -> Vec<TupleKey> {
     out
 }
 
-pub fn fan_out_group(event: &GroupIdentify, excluded: &PropertyKeyList) -> Vec<TupleKey> {
+pub fn fan_out_group(event: &GroupIdentify, excluded: &ExcludedPropertyKeys) -> Vec<TupleKey> {
     let mut out = Vec::new();
     if let Some(raw) = &event.group_properties {
         emit_from_blob(
@@ -37,7 +37,7 @@ fn emit_from_blob(
     team_id: i64,
     property_type: PropertyType,
     raw: &str,
-    excluded: &PropertyKeyList,
+    excluded: &ExcludedPropertyKeys,
     out: &mut Vec<TupleKey>,
 ) {
     let parsed: Value = match serde_json::from_str(raw) {
@@ -148,11 +148,11 @@ mod tests {
         }
     }
 
-    fn none() -> PropertyKeyList {
-        PropertyKeyList::default()
+    fn none() -> ExcludedPropertyKeys {
+        ExcludedPropertyKeys::default()
     }
 
-    fn excluded(keys: &[&str]) -> PropertyKeyList {
+    fn excluded(keys: &[&str]) -> ExcludedPropertyKeys {
         keys.iter().copied().collect::<Vec<_>>().join(",").parse().unwrap()
     }
 
@@ -329,7 +329,7 @@ mod tests {
     fn empty_exclusion_list_is_a_noop() {
         let blob = r#"{"$browser":"Chrome","email":"a@b.com"}"#;
         let with_default = fan_out(&event(blob), &none());
-        let parsed_empty: PropertyKeyList = "".parse().unwrap();
+        let parsed_empty: ExcludedPropertyKeys = "".parse().unwrap();
         let with_parsed_empty = fan_out(&event(blob), &parsed_empty);
         assert_eq!(with_default.len(), 2);
         assert_eq!(with_default, with_parsed_empty);

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -119,19 +119,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let guard = manager.monitor_background();
 
+    let excluded_events = shared_config.excluded_property_keys.clone();
+    let excluded_groups = shared_config.excluded_property_keys.clone();
+
     tokio::spawn(worker_loop::<Event, _, _>(
         shared_config.clone(),
         events_consumer,
         events_producer,
         events_handle.clone(),
-        fan_out,
+        move |e: &Event| fan_out(e, &excluded_events),
     ));
     tokio::spawn(worker_loop::<GroupIdentify, _, _>(
         shared_config.clone(),
         groups_consumer,
         groups_producer,
         groups_handle.clone(),
-        fan_out_group,
+        move |g: &GroupIdentify| fan_out_group(g, &excluded_groups),
     ));
     drop(events_handle);
     drop(groups_handle);


### PR DESCRIPTION
## Problem

Identifier-shaped properties (`$insert_id`, `$session_id`, `$window_id`, `distinct_id`, etc.) amplify write throughput resulting in consumer lag because the table stores each row as a unique `(team_id, property_type, property_key, property_value)` tuple — so a property whose value is essentially unique per event (UUIDs, timestamps, request IDs) generates a new row for every event it appears on, with no aggregation collapse to absorb the volume.

Confirmed empirically by joining `property_values` row counts against autocomplete search frequency from `system.query_log` for team 2 over 30 days:

| Property key | % of rows | Avg value count | Searches (30d) |
|---|---|---|---|
| `$insert_id` | 14.49% | 1.2 | **0** |
| `$sent_at` | 14.22% | 3.0 | **0** |
| `$feature_flag_request_id` | 13.02% | 2.5 | **0** |
| `$time` | 12.80% | 1.4 | **0** |
| `$feature_flag_evaluated_at` | 9.55% | 1.6 | **0** |

24 of the top 25 keys (by row count) have **zero searches in 30 days**. The top 5 alone account for ~64% of all stored rows yet receive no autocomplete traffic — they're pure write amplification.

The exceptions to leave alone: `$session_id` (258 searches, real autocomplete usage despite high cardinality), `$current_url` (high cardinality but also high real search demand), `$set_once` (modest searches but worth preserving).

`Avg value count` is `avg(property_count)` per row — close to 1 means each value appears ~once (every event is a new row), which is the identifier signature. Compare to `$current_url=50.4` or `$set_once=65.7` where each unique value gets emitted dozens of times before a new one appears (real aggregation happening).

## Changes

- `config.rs`: add `EXCLUDED_PROPERTY_KEYS` env var, parsed via new `ExcludedPropertyKeys` type into an `Arc<HashSet<String>>`. Empty by default.
- `fan_out.rs`: `fan_out` and `fan_out_group` take the exclusion set as a parameter; `emit_from_blob` skips emission for keys in the set.
- `main.rs`: wraps `fan_out` and `fan_out_group` in closures that capture the config's exclusion set, passes them to `worker_loop`.

Tunable without code deploys — change the chart values, Argo syncs, pods pick it up on restart.

Companion charts PR adds the env var to `apps/property-vals-rs/values.yaml` so per-environment overrides can set the list.

## How did you test this code?

I am an agent. Local automated checks only:

- `cargo test -p property-vals-rs --lib` — all 38 tests pass (34 existing + 4 new)
- 4 new tests verify exclusion behavior:
  - `excluded_event_property_keys_are_skipped` — drops `$insert_id` / `distinct_id` / `$session_id`, only `$browser` survives
  - `excluded_person_property_keys_are_skipped` — filters `$session_id` from person properties, leaves `email` and `plan`
  - `excluded_group_property_keys_are_skipped` — same for group properties
  - `empty_exclusion_list_is_a_noop` — verifies `ExcludedPropertyKeys::default()` and `"".parse()` are both no-ops (production behavior preserved when env var unset)

## Publish to changelog?

no
