### PR TITLE
feat(devbox): add devbox:exec, devbox:doctor, and setup skill

### DIFF
--- a/.agents/skills/setting-up-devbox/SKILL.md
+++ b/.agents/skills/setting-up-devbox/SKILL.md
@@ -64,7 +64,7 @@ hogli devbox:setup --configure-dotfiles    # saves dotfiles_uri; synced on next 
 
 ### 4. Verify on the box, remotely
 
-`devbox:exec` runs one command over `coder ssh` and returns its exit code — use it to confirm the fan-out actually worked, and to prototype before moving steps into `install.sh`:
+`devbox:exec` runs one command on the box over SSH and propagates its exit code — use it to confirm the fan-out actually worked, and to prototype before moving steps into `install.sh`:
 
 ```bash
 hogli devbox:exec -- bash -lc 'gh auth status'
@@ -73,7 +73,7 @@ hogli devbox:exec -- bash -lc 'ls ~/dotfiles && type my-alias'
 hogli devbox:exec -n api -- bash -lc 'cd ~/posthog && git status'   # -n targets a named box
 ```
 
-Always wrap verify commands in `bash -lc '...'`: `coder ssh -- cmd` runs in a **non-login, non-interactive** shell that does not source `~/.bashrc`/`~/.zshrc`, so a bare `gh auth status` reports "command not found" for anything dotfiles put on a login-shell `PATH` (e.g. `~/.local/bin`) — a false negative, not a real failure. Use `--` to separate hogli's flags from the command's own.
+Always wrap verify commands in `bash -lc '...'`: a non-login shell doesn't reliably source `~/.bashrc`/`~/.zshrc`, so a bare `gh auth status` may report "command not found" for anything dotfiles put on a login-shell `PATH` (e.g. `~/.local/bin`) — a false negative, not a real failure. The login shell also makes the exit code trustworthy: `exec` returns the command's real status (so `&&` chaining and `if` checks work), but only if the command itself ran. Use `--` to separate hogli's flags from the command's own.
 
 `devbox:exec` runs a single command instead of opening a shell (unlike `devbox:ssh`), which is what lets an agent drive a box. It is not side-effect-free: like every `devbox:*` command it first runs the reachability check, which on Linux may `sudo tailscale set --accept-routes` and prompt for a password. Run `hogli devbox:setup` once interactively so routes are already accepted before an agent drives `devbox:exec` unattended.
 

--- a/.agents/skills/setting-up-devbox/SKILL.md
+++ b/.agents/skills/setting-up-devbox/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: setting-up-devbox
-description: Set up and personalize a PostHog remote devbox (Coder workspace) so the same config lands on every box you own, not just one. Use when asked to set up a devbox, personalize a devbox, configure remote dev, get gh CLI / Claude Code / PostHog MCP / aliases working on a devbox, write devbox dotfiles, or make a new devbox match an existing one. Covers hogli devbox commands, Coder user secrets, dotfiles, and verifying setup with devbox:exec.
+description: Guide a PostHog engineer through spinning up, connecting to, and running commands on a remote devbox (a Coder workspace running the full PostHog stack). Use when asked to set up a devbox, start or connect to a devbox, configure remote dev, get gh CLI / Claude Code authed on a devbox, run a command on a devbox, or diagnose why a devbox command fails. Covers the tailnet prerequisite, hogli devbox commands, Coder user secrets for auth, and verifying with devbox:exec. How each dev personalizes their box is left to them.
 ---
 
 # Setting up a PostHog devbox
 
-A devbox is a Coder workspace running the full PostHog stack on an EC2 instance. `hogli devbox:*` is the only supported interface — this skill drives those commands, it does not reimplement them.
+A devbox is a Coder workspace running the full PostHog stack on an EC2 instance, managed through `hogli devbox:*` (the only supported interface — drive those commands, don't reimplement them). It ships ready to use: the repo cloned at `~/posthog`, the stack pre-warmed, and Claude Code installed. This skill gets a dev connected and working; how they personalize beyond that is their choice, not something to push.
 
 ## Prerequisite: tailnet access (the thing people miss)
 
@@ -13,84 +13,70 @@ The devbox control plane lives inside a private VPC reachable only over Tailscal
 
 If `hogli devbox:doctor` reports the control plane unreachable, the fix is a PR adding the user to `group:engineering` in `tailnet-policy.hujson` (then ask Team DevEx if still blocked). Diagnose this before touching anything else.
 
-## The one rule: personalize the human, not the box
-
-People run **more than one devbox**, and a box's compute is rebuilt from a golden image. So anything you hand-install inside a single box is a pet — it does not follow you to box #2, and a rebuild can wipe it. Setup is "done" only when it is **portable**: it re-applies automatically to every box you create. Two mechanisms give you that, and almost everything belongs in one of them:
-
-| Mechanism                        | Scope           | Fans out to all boxes?                    | Holds                                                                           |
-| -------------------------------- | --------------- | ----------------------------------------- | ------------------------------------------------------------------------------- |
-| **Dotfiles repo** (`install.sh`) | your git repo   | yes — cloned + run on every box start     | tools, aliases, MCP registration, `gh` install, shell config, skills/extensions |
-| **Coder user secrets**           | your Coder user | yes — injected as env vars into every box | `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, API keys, signing key                    |
-
-If you find yourself `ssh`-ing in to install something, stop — that change belongs in the dotfiles `install.sh` so it replays. Use `devbox:exec` to _verify_ and to _prototype_, then move what worked into `install.sh`.
-
 ## Workflow
 
-### 1. Read current state first — don't ask what you can detect
+### 1. Check state — `hogli devbox:doctor`
 
 ```bash
-hogli devbox:doctor          # read-only: tailnet access, reachability, auth, saved setup
+hogli devbox:doctor          # read-only: tailnet access, reachability, auth, ssh config, saved setup
 ```
 
-`devbox:doctor` is the safe probe — it never prompts or mutates host config (unlike `devbox:setup`). It confirms the tailnet prerequisite above, then reports git identity, dotfiles URI, and which user secrets are set. If it flags the control plane unreachable, resolve the tailnet grant before anything else. For more detail: `hogli devbox:list` (boxes), `hogli devbox:status` (state/template freshness), `hogli devbox:secret:list` (secret names only).
+A safe probe — it never prompts or mutates host config (unlike `devbox:setup`). If it flags the control plane unreachable, resolve the tailnet grant before anything else. For more detail: `hogli devbox:list` (your boxes), `hogli devbox:status` (state, template freshness), `hogli devbox:secret:list` (secret names only).
 
-### 2. Local access + identity (once per machine)
+### 2. One-time local setup — `hogli devbox:setup`
+
+Interactive: checks Tailscale + Coder reachability, installs and authenticates the `coder` CLI, and writes the SSH host entries that `devbox:ssh`/`devbox:exec` rely on. It then _offers_ git identity, git signing, a dotfiles repo, and your Claude token — all optional; `--skip-*` anything you don't want. Re-run one step with its flag, e.g. `hogli devbox:setup --configure-git-signing`.
+
+### 3. Start and connect — `hogli devbox:start`
 
 ```bash
-hogli devbox:setup
+hogli devbox:start           # create or resume your box
+hogli devbox:ssh             # shell in
+hogli devbox:open --vscode   # or --cursor / --web
+hogli devbox:stop            # when done — preserves disk, stops billing
 ```
 
-Interactive; checks Tailscale + Coder reachability, installs/auths the `coder` CLI, then walks: SSH host entries, git name/email, git signing key, dotfiles URI, Claude token. Non-interactive flags exist for each: `--configure-ssh`, `--configure-git-identity`, `--configure-git-signing`, `--configure-dotfiles`, `--configure-claude` (each has a `--skip-*` form). Run targeted re-config with a single flag, e.g. `hogli devbox:setup --configure-dotfiles`.
+### 4. Auth, if you want it (optional)
 
-### 3. Portable identity — the part that fans out
-
-**Secrets** (user-scoped, land in every box as env vars; restart a running box to pick up changes):
+To have `gh` or Claude Code authenticated on the box, store the token once as a Coder user secret. It's injected as an env var into every box you start, so you set it once rather than per box:
 
 ```bash
-hogli devbox:secret:set GH_TOKEN --env GH_TOKEN        # gh CLI + git over HTTPS; prompts hidden
+hogli devbox:secret:set GH_TOKEN --env GH_TOKEN
 hogli devbox:secret:set CLAUDE_CODE_OAUTH_TOKEN --env CLAUDE_CODE_OAUTH_TOKEN
 # also supported: ANTHROPIC_API_KEY, OPENAI_API_KEY, OP_SERVICE_ACCOUNT_TOKEN, AWS_CREDENTIALS (--file)
 ```
 
-Yes, authing `gh` / Claude on a devbox is fine — that is what these secrets are for. Set the value from a file or the hidden prompt; never paste a token into a command line or into this conversation.
+Authing `gh` / Claude on a devbox is fine — that's what these are for. Set the value from `--file` or the hidden prompt; never paste a token into a command line or into this conversation. Restart a running box to pick up a newly set secret.
 
-**Dotfiles** are where agentic tooling and shell config live. The Coder dotfiles module clones your `dotfiles_uri` into `~` on every box and runs an executable `~/dotfiles/install.sh` if present (otherwise it symlinks dotfiles). This is the portable home for everything people otherwise hand-roll per box: install `gh`, register the PostHog MCP server, write Claude `settings.json`, add aliases, clone extra repos, sync skills/`pi` extensions.
+### 5. Make it yours — your call
 
-If the user has no dotfiles repo, offer to scaffold a minimal one with an `install.sh` doing their setup (it must be `chmod +x` and committed). Point the box at it:
+The box is usable as shipped; personalize it however suits you, or not at all. Two supported paths, neither required, don't push one over the other:
 
-```bash
-hogli devbox:setup --configure-dotfiles    # saves dotfiles_uri; synced on next start
-```
+- **Tweak the box directly** — `devbox:ssh` in and install tools, add aliases, clone repos. Changes under `/home` survive stop/start and template updates, but a `devbox:destroy` (or a brand-new box) starts fresh.
+- **A dotfiles repo** — if you'd rather keep portable, version-controlled config that re-applies to every box: `hogli devbox:setup --configure-dotfiles` points the box at your `dotfiles_uri`, and Coder clones it (running an executable `~/dotfiles/install.sh` if present) on each start.
 
-### 4. Verify on the box, remotely
+### 6. Run commands on the box — `hogli devbox:exec`
 
-`devbox:exec` runs one command on the box over SSH and propagates its exit code — use it to confirm the fan-out actually worked, and to prototype before moving steps into `install.sh`:
+`devbox:exec` runs one command over SSH and propagates its exit code — handy for scripts, agents, and quick checks without opening a shell:
 
 ```bash
 hogli devbox:exec -- bash -lc 'gh auth status'
-hogli devbox:exec -- bash -lc 'claude mcp list'
-hogli devbox:exec -- bash -lc 'ls ~/dotfiles && type my-alias'
-hogli devbox:exec -n api -- bash -lc 'cd ~/posthog && git status'   # -n targets a named box
+hogli devbox:exec -- bash -lc 'cd ~/posthog && git status'
+hogli devbox:exec -n api -- bash -lc 'uname -a'    # -n targets a labeled box
 ```
 
-Always wrap verify commands in `bash -lc '...'`: a non-login shell doesn't reliably source `~/.bashrc`/`~/.zshrc`, so a bare `gh auth status` may report "command not found" for anything dotfiles put on a login-shell `PATH` (e.g. `~/.local/bin`) — a false negative, not a real failure. The login shell also makes the exit code trustworthy: `exec` returns the command's real status (so `&&` chaining and `if` checks work), but only if the command itself ran. Use `--` to separate hogli's flags from the command's own.
+Wrap commands in `bash -lc '...'`: a non-login shell doesn't reliably source `~/.bashrc`/`~/.zshrc`, so a bare `gh auth status` can report "command not found" for anything on a login-shell `PATH` (e.g. `~/.local/bin`) — a false negative. The login shell also keeps the exit code trustworthy, so `&&` chaining and `if` checks work. Use `--` to separate hogli's flags from the command's own.
 
-`devbox:exec` runs a single command instead of opening a shell (unlike `devbox:ssh`), which is what lets an agent drive a box. It is not side-effect-free: like every `devbox:*` command it first runs the reachability check, which on Linux may `sudo tailscale set --accept-routes` and prompt for a password. Run `hogli devbox:setup` once interactively so routes are already accepted before an agent drives `devbox:exec` unattended.
+`devbox:exec` is not side-effect-free: like every `devbox:*` command it runs the reachability check first, which on Linux may `sudo tailscale set --accept-routes` and prompt for a password. Run `hogli devbox:setup` once interactively so routes and SSH config are in place before an agent drives `devbox:exec` unattended.
 
-### 5. Definition of done
+## Persistence & multiple boxes
 
-Not "this box works." It is: **dotfiles URI set, the secrets you need set, and `devbox:exec` confirms tooling is present** — so the next box you create is configured with zero extra steps. State that explicitly when finishing.
-
-## Answers to the common questions
-
-- **Will my box get removed?** Stop/start and template/AMI updates preserve `/home` (the instance is stopped, not terminated; the template pins `ignore_changes = [ami, user_data]`). A full `devbox:destroy` wipes it — intentional. Because identity lives in dotfiles + user secrets, a destroyed box is recreated fully configured. Don't keep anything irreplaceable only inside a box.
-- **Do I need ansible?** No. Dotfiles `install.sh` + user secrets cover personalization declaratively.
-- **Multiple boxes?** That is the whole reason to use dotfiles + secrets rather than configuring each box.
+- `devbox:stop` → `devbox:start` and template/AMI updates preserve `/home` (the instance is stopped, not terminated). A `devbox:destroy` wipes it — intentional, so don't keep anything irreplaceable only inside a box.
+- You can run more than one box. Box-local changes don't carry between them; user secrets do (user-scoped), and a dotfiles repo does if you use one. That's the practical reason to reach for those if you find yourself re-doing setup — but it's a choice, not a requirement.
 
 ## Gotchas
 
 - **Never echo secret values** into the transcript, logs, a PR, or a command line. `devbox:secret:set` reads from a hidden prompt or `--file`; `secret:list` shows names only. Keep it that way.
-- **Secrets need a restart.** Setting/changing a secret only affects boxes started afterward — `hogli devbox:restart` to pick it up on a running box.
-- **`install.sh` must be executable and committed**, or the dotfiles module silently falls back to plain symlinking and your setup script never runs.
+- **Secrets need a restart.** A new or changed secret only reaches boxes started afterward — `hogli devbox:restart` to pick it up on a running box.
+- **`devbox:exec`/`devbox:ssh` need `devbox:setup` to have run** (it writes the `coder.*` SSH host config). Without it they fail at connection; `devbox:doctor` shows whether SSH access is configured.
 - **`code-server` (browser IDE) has no SSH agent forwarding**, so commit signing via a forwarded key won't work there — use VS Code Desktop / Cursor / JetBrains (SSH-based) when you need to sign.
-- **Don't hand-install on a box as the endpoint.** It's fine to prototype with `devbox:exec`, but the change isn't "done" until it's in `install.sh` or a secret.

--- a/.agents/skills/setting-up-devbox/SKILL.md
+++ b/.agents/skills/setting-up-devbox/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: setting-up-devbox
+description: Set up and personalize a PostHog remote devbox (Coder workspace) so the same config lands on every box you own, not just one. Use when asked to set up a devbox, personalize a devbox, configure remote dev, get gh CLI / Claude Code / PostHog MCP / aliases working on a devbox, write devbox dotfiles, or make a new devbox match an existing one. Covers hogli devbox commands, Coder user secrets, dotfiles, and verifying setup with devbox:exec.
+---
+
+# Setting up a PostHog devbox
+
+A devbox is a Coder workspace running the full PostHog stack on an EC2 instance. `hogli devbox:*` is the only supported interface — this skill drives those commands, it does not reimplement them.
+
+## Prerequisite: tailnet access (the thing people miss)
+
+The devbox control plane lives inside a private VPC reachable only over Tailscale. The ACL that grants the route is [`tailnet-policy.hujson`](https://github.com/PostHog/posthog-cloud-infra/blob/main/tailnet-policy.hujson) in `posthog-cloud-infra`: your email must be in **`group:engineering`**. Without that grant, the Coder control plane (`10.70.0.1:443`) is simply unroutable and _every_ `hogli devbox:*` command dies at the reachability check — not an auth or install problem, and no amount of re-running `devbox:setup` fixes it.
+
+If `hogli devbox:doctor` reports the control plane unreachable, the fix is a PR adding the user to `group:engineering` in `tailnet-policy.hujson` (then ask Team DevEx if still blocked). Diagnose this before touching anything else.
+
+## The one rule: personalize the human, not the box
+
+People run **more than one devbox**, and a box's compute is rebuilt from a golden image. So anything you hand-install inside a single box is a pet — it does not follow you to box #2, and a rebuild can wipe it. Setup is "done" only when it is **portable**: it re-applies automatically to every box you create. Two mechanisms give you that, and almost everything belongs in one of them:
+
+| Mechanism                        | Scope           | Fans out to all boxes?                    | Holds                                                                           |
+| -------------------------------- | --------------- | ----------------------------------------- | ------------------------------------------------------------------------------- |
+| **Dotfiles repo** (`install.sh`) | your git repo   | yes — cloned + run on every box start     | tools, aliases, MCP registration, `gh` install, shell config, skills/extensions |
+| **Coder user secrets**           | your Coder user | yes — injected as env vars into every box | `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, API keys, signing key                    |
+
+If you find yourself `ssh`-ing in to install something, stop — that change belongs in the dotfiles `install.sh` so it replays. Use `devbox:exec` to _verify_ and to _prototype_, then move what worked into `install.sh`.
+
+## Workflow
+
+### 1. Read current state first — don't ask what you can detect
+
+```bash
+hogli devbox:doctor          # read-only: tailnet access, reachability, auth, saved setup
+```
+
+`devbox:doctor` is the safe probe — it never prompts or mutates host config (unlike `devbox:setup`). It confirms the tailnet prerequisite above, then reports git identity, dotfiles URI, and which user secrets are set. If it flags the control plane unreachable, resolve the tailnet grant before anything else. For more detail: `hogli devbox:list` (boxes), `hogli devbox:status` (state/template freshness), `hogli devbox:secret:list` (secret names only).
+
+### 2. Local access + identity (once per machine)
+
+```bash
+hogli devbox:setup
+```
+
+Interactive; checks Tailscale + Coder reachability, installs/auths the `coder` CLI, then walks: SSH host entries, git name/email, git signing key, dotfiles URI, Claude token. Non-interactive flags exist for each: `--configure-ssh`, `--configure-git-identity`, `--configure-git-signing`, `--configure-dotfiles`, `--configure-claude` (each has a `--skip-*` form). Run targeted re-config with a single flag, e.g. `hogli devbox:setup --configure-dotfiles`.
+
+### 3. Portable identity — the part that fans out
+
+**Secrets** (user-scoped, land in every box as env vars; restart a running box to pick up changes):
+
+```bash
+hogli devbox:secret:set GH_TOKEN --env GH_TOKEN        # gh CLI + git over HTTPS; prompts hidden
+hogli devbox:secret:set CLAUDE_CODE_OAUTH_TOKEN --env CLAUDE_CODE_OAUTH_TOKEN
+# also supported: ANTHROPIC_API_KEY, OPENAI_API_KEY, OP_SERVICE_ACCOUNT_TOKEN, AWS_CREDENTIALS (--file)
+```
+
+Yes, authing `gh` / Claude on a devbox is fine — that is what these secrets are for. Set the value from a file or the hidden prompt; never paste a token into a command line or into this conversation.
+
+**Dotfiles** are where agentic tooling and shell config live. The Coder dotfiles module clones your `dotfiles_uri` into `~` on every box and runs an executable `~/dotfiles/install.sh` if present (otherwise it symlinks dotfiles). This is the portable home for everything Andy/Catalin hand-roll: install `gh`, register the PostHog MCP server, write Claude `settings.json`, add aliases, clone extra repos, sync skills/`pi` extensions.
+
+If the user has no dotfiles repo, offer to scaffold a minimal one with an `install.sh` doing their setup (it must be `chmod +x` and committed). Point the box at it:
+
+```bash
+hogli devbox:setup --configure-dotfiles    # saves dotfiles_uri; synced on next start
+```
+
+### 4. Verify on the box, remotely
+
+`devbox:exec` runs one command over `coder ssh` and returns its exit code — use it to confirm the fan-out actually worked, and to prototype before moving steps into `install.sh`:
+
+```bash
+hogli devbox:exec -- bash -lc 'gh auth status'
+hogli devbox:exec -- bash -lc 'claude mcp list'
+hogli devbox:exec -- bash -lc 'ls ~/dotfiles && type my-alias'
+hogli devbox:exec -n api -- bash -lc 'cd ~/posthog && git status'   # -n targets a named box
+```
+
+Always wrap verify commands in `bash -lc '...'`: `coder ssh -- cmd` runs in a **non-login, non-interactive** shell that does not source `~/.bashrc`/`~/.zshrc`, so a bare `gh auth status` reports "command not found" for anything dotfiles put on a login-shell `PATH` (e.g. `~/.local/bin`) — a false negative, not a real failure. Use `--` to separate hogli's flags from the command's own.
+
+`devbox:exec` runs a single command instead of opening a shell (unlike `devbox:ssh`), which is what lets an agent drive a box. It is not side-effect-free: like every `devbox:*` command it first runs the reachability check, which on Linux may `sudo tailscale set --accept-routes` and prompt for a password. Run `hogli devbox:setup` once interactively so routes are already accepted before an agent drives `devbox:exec` unattended.
+
+### 5. Definition of done
+
+Not "this box works." It is: **dotfiles URI set, the secrets you need set, and `devbox:exec` confirms tooling is present** — so the next box you create is configured with zero extra steps. State that explicitly when finishing.
+
+## Answers to the common questions
+
+- **Will my box get removed?** Stop/start and template/AMI updates preserve `/home` (the instance is stopped, not terminated; the template pins `ignore_changes = [ami, user_data]`). A full `devbox:destroy` wipes it — intentional. Because identity lives in dotfiles + user secrets, a destroyed box is recreated fully configured. Don't keep anything irreplaceable only inside a box.
+- **Do I need ansible?** No. Dotfiles `install.sh` + user secrets cover personalization declaratively.
+- **Multiple boxes?** That is the whole reason to use dotfiles + secrets rather than configuring each box.
+
+## Gotchas
+
+- **Never echo secret values** into the transcript, logs, a PR, or a command line. `devbox:secret:set` reads from a hidden prompt or `--file`; `secret:list` shows names only. Keep it that way.
+- **Secrets need a restart.** Setting/changing a secret only affects boxes started afterward — `hogli devbox:restart` to pick it up on a running box.
+- **`install.sh` must be executable and committed**, or the dotfiles module silently falls back to plain symlinking and your setup script never runs.
+- **`code-server` (browser IDE) has no SSH agent forwarding**, so commit signing via a forwarded key won't work there — use VS Code Desktop / Cursor / JetBrains (SSH-based) when you need to sign.
+- **Don't hand-install on a box as the endpoint.** It's fine to prototype with `devbox:exec`, but the change isn't "done" until it's in `install.sh` or a secret.

--- a/.agents/skills/setting-up-devbox/SKILL.md
+++ b/.agents/skills/setting-up-devbox/SKILL.md
@@ -54,7 +54,7 @@ hogli devbox:secret:set CLAUDE_CODE_OAUTH_TOKEN --env CLAUDE_CODE_OAUTH_TOKEN
 
 Yes, authing `gh` / Claude on a devbox is fine — that is what these secrets are for. Set the value from a file or the hidden prompt; never paste a token into a command line or into this conversation.
 
-**Dotfiles** are where agentic tooling and shell config live. The Coder dotfiles module clones your `dotfiles_uri` into `~` on every box and runs an executable `~/dotfiles/install.sh` if present (otherwise it symlinks dotfiles). This is the portable home for everything Andy/Catalin hand-roll: install `gh`, register the PostHog MCP server, write Claude `settings.json`, add aliases, clone extra repos, sync skills/`pi` extensions.
+**Dotfiles** are where agentic tooling and shell config live. The Coder dotfiles module clones your `dotfiles_uri` into `~` on every box and runs an executable `~/dotfiles/install.sh` if present (otherwise it symlinks dotfiles). This is the portable home for everything people otherwise hand-roll per box: install `gh`, register the PostHog MCP server, write Claude `settings.json`, add aliases, clone extra repos, sync skills/`pi` extensions.
 
 If the user has no dotfiles repo, offer to scaffold a minimal one with an `install.sh` doing their setup (it must be `chmod +x` and committed). Point the box at it:
 

--- a/docs/internal/coder-workspaces.md
+++ b/docs/internal/coder-workspaces.md
@@ -10,6 +10,17 @@ Use this when you want a remote PostHog dev environment instead of running the f
 - You want a persistent remote workspace that is easy to stop and resume
 - You are working from a machine where local Docker setup is inconvenient
 
+## Setting up with a coding agent
+
+If you use a coding agent (Claude Code, Cursor, etc.), the `setting-up-devbox` skill teaches it this whole workflow — ask it to "set up my devbox" and it will check prerequisites, run setup, start a box, and verify access. It leans on two read/run helpers you can also use directly:
+
+```bash
+hogli devbox:doctor              # read-only health check: tailnet access, reachability, auth, ssh config
+hogli devbox:exec -- bash -lc 'gh auth status'   # run one command on the box and get its exit code
+```
+
+`devbox:doctor` is the first thing to run when a devbox command misbehaves — it names the likely cause (most often the Tailscale ACL grant) instead of failing cryptically.
+
 ## Common scenarios
 
 **Connecting your IDE** —
@@ -101,6 +112,7 @@ Run `hogli devbox` to see all available commands, and `hogli <command> --help` f
 
 Runtime commands assume setup is already complete.
 If they fail with `Run hogli devbox:setup`, rerun setup on your laptop first.
+When in doubt, `hogli devbox:doctor` reports which prerequisite is missing.
 
 ## Managing Coder user secrets
 

--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -254,6 +254,8 @@ When running `uv sync`, you may see a `Failed to parse` warning related to `pypr
 
 If you work at PostHog and want a remote workspace instead of running the stack on your laptop, see the [internal Coder workspaces guide](https://github.com/PostHog/posthog/blob/master/docs/internal/coder-workspaces.md).
 
+If you drive your workflow with a coding agent (Claude Code, Cursor, etc.), the `setting-up-devbox` skill walks the agent through the whole flow — the tailnet prerequisite, `hogli devbox:setup`, starting a box, storing auth as Coder user secrets, and running commands on the box with `hogli devbox:exec`. Just ask it to set up your devbox.
+
 ## Testing
 
 For a PostHog PR to be merged, all tests must be green, and ideally you should be introducing new ones as well – that's why you must be able to run tests with ease.

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -138,6 +138,9 @@ devbox:
     devbox:setup:
         click: hogli_commands.devbox.cli:devbox_setup
         description: Install and configure local access to Coder devboxes
+    devbox:doctor:
+        click: hogli_commands.devbox.cli:devbox_doctor
+        description: Diagnose devbox prerequisites and setup (read-only)
     devbox:start:
         click: hogli_commands.devbox.cli:devbox_start
         description: Start or create your remote devbox
@@ -156,6 +159,9 @@ devbox:
     devbox:ssh:
         click: hogli_commands.devbox.cli:devbox_ssh
         description: SSH into your devbox
+    devbox:exec:
+        click: hogli_commands.devbox.cli:devbox_remote_exec
+        description: Run a command inside your devbox (non-interactive)
     devbox:open:
         click: hogli_commands.devbox.cli:devbox_open
         description: Open devbox in browser, VS Code, or Cursor

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -44,6 +44,7 @@ from .coder import (
     ensure_runtime_ready,
     ensure_tailscale_connected,
     ensure_tailscale_routes_accepted,
+    exec_replace,
     extract_workspace_label,
     get_coder_url,
     get_coder_user_info,
@@ -67,7 +68,6 @@ from .coder import (
     parse_workspace_target,
     port_forward_replace,
     print_setup_summary,
-    replace_with_workspace_command,
     restart_workspace,
     server_supports_user_secrets,
     share_workspace,
@@ -1207,7 +1207,7 @@ def devbox_remote_exec(workspace_name: str | None, command: tuple[str, ...]) -> 
     """
     ensure_runtime_ready()
     name, _ = resolve_workspace_name(workspace_name)
-    replace_with_workspace_command(name, list(command))
+    exec_replace(name, list(command))
 
 
 @click.command(name="devbox:open", help="Open devbox in browser, VS Code, or Cursor")

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -29,7 +29,11 @@ from .coder import (
     GIT_EMAIL_PARAMETER,
     GIT_NAME_PARAMETER,
     GIT_SIGNING_KEY_SECRET,
+    _diagnose_unreachable_coder,
     _fail,
+    coder_authenticated,
+    coder_installed,
+    coder_reachable,
     create_task,
     create_workspace,
     delete_user_secret,
@@ -63,12 +67,14 @@ from .coder import (
     parse_workspace_target,
     port_forward_replace,
     print_setup_summary,
+    replace_with_workspace_command,
     restart_workspace,
     server_supports_user_secrets,
     share_workspace,
     ssh_replace,
     start_workspace,
     stop_workspace,
+    tailscale_connected,
     unshare_workspace,
     update_workspace,
     update_workspace_parameters,
@@ -86,6 +92,17 @@ from .config import (
 
 _LEGACY_KEYCHAIN_SERVICE = "posthog-claude-oauth-token"
 _POSTHOG_COMMIT_SIGNING_HANDBOOK_URL = "https://posthog.com/handbook/engineering/security#commit-signing"
+
+# Reaching a devbox requires a Tailscale ACL grant. Engineers get it from
+# group:engineering in the cloud-infra tailnet policy; without it the Coder
+# control plane (10.70.0.1:443) is simply unroutable and every devbox command
+# fails at the reachability check.
+_TAILNET_POLICY_URL = "https://github.com/PostHog/posthog-cloud-infra/blob/main/tailnet-policy.hujson"
+_TAILNET_ACCESS_PREREQ = (
+    "Devbox access needs your email in `group:engineering` in "
+    "posthog-cloud-infra/tailnet-policy.hujson.\n"
+    f"    Not granted yet? Add yourself via PR: {_TAILNET_POLICY_URL}"
+)
 
 WORKSPACE_STATUS_COLORS = {
     "running": "green",
@@ -513,6 +530,68 @@ def maybe_configure_dotfiles(configure_dotfiles: bool | None) -> None:
         click.echo(f"Saved dotfiles repo for new workspaces: {dotfiles_uri}")
     else:
         click.echo("No dotfiles repo configured.")
+
+
+def _doctor_check(label: str, ok: bool) -> None:
+    """Print one read-only doctor check line."""
+    mark = click.style("ok", fg="green") if ok else click.style("missing", fg="red")
+    click.echo(f"  [{mark}] {label}")
+
+
+def _doctor_footer() -> None:
+    """Point at the deterministic fix and the guided (agentic) one."""
+    click.echo()
+    click.echo("  Fix setup:    hogli devbox:setup")
+    click.echo("  Guided setup: run the `setting-up-devbox` skill in your coding agent")
+
+
+@click.command(name="devbox:doctor", help="Diagnose devbox prerequisites and setup (read-only).")
+def devbox_doctor() -> None:
+    """Read-only health check: tailnet access, Coder reachability, auth, saved setup.
+
+    Safe for an agent to run as a probe -- it never prompts or mutates host
+    config the way `devbox:setup` does. Run it first when a devbox command
+    fails, and as step zero of the `setting-up-devbox` skill. The tailnet ACL
+    grant is the prerequisite people most often miss, so it is surfaced
+    explicitly whenever the control plane is unreachable.
+    """
+    click.echo(click.style("Devbox doctor", bold=True))
+    click.echo(f"  Coder URL: {get_coder_url()}")
+    click.echo()
+
+    _doctor_check("Tailscale connected", tailscale_connected())
+
+    reachable = coder_reachable()
+    _doctor_check("Coder control plane reachable", reachable)
+
+    if not reachable:
+        diagnosis = _diagnose_unreachable_coder()
+        click.echo()
+        click.echo(click.style(f"  Cause: {diagnosis.cause}", fg="yellow"))
+        click.echo(f"  Next:  {diagnosis.next_step}")
+        for fact in diagnosis.facts:
+            click.echo(f"    - {fact}")
+        click.echo()
+        click.echo(click.style("  Prerequisite:", bold=True))
+        click.echo(f"    {_TAILNET_ACCESS_PREREQ}")
+        _doctor_footer()
+        return
+
+    installed = coder_installed()
+    _doctor_check("coder CLI installed", installed)
+    authenticated = installed and coder_authenticated()
+    _doctor_check("Coder authenticated", authenticated)
+
+    if not authenticated:
+        _doctor_footer()
+        return
+
+    # _print_setup_status emits its own "Currently configured:" header when
+    # anything is set; only print a fallback line when it stays silent.
+    if not _print_setup_status(_collect_setup_status()):
+        click.echo()
+        click.echo("Nothing configured yet.")
+    _doctor_footer()
 
 
 @click.command(name="devbox", help="Show available devbox commands")
@@ -1106,6 +1185,29 @@ def devbox_ssh(workspace: str | None) -> None:
     ensure_runtime_ready()
     name, _ = resolve_workspace_name(workspace)
     ssh_replace(name)
+
+
+@click.command(
+    name="devbox:exec",
+    help="Run a command inside your devbox (non-interactive).",
+    context_settings={"ignore_unknown_options": True},
+)
+@click.option("--name", "-n", "workspace_name", default=None, help="Workspace label or @user[/label] target")
+@click.argument("command", nargs=-1, type=click.UNPROCESSED, required=True)
+def devbox_remote_exec(workspace_name: str | None, command: tuple[str, ...]) -> None:
+    """Run COMMAND in the devbox over `coder ssh` and propagate its exit code.
+
+    Unlike `devbox:ssh`, this runs a single command instead of opening an
+    interactive shell, so agents and scripts can drive a devbox remotely:
+
+        hogli devbox:exec -- gh auth status
+        hogli devbox:exec -n api -- bash -lc 'cd ~/posthog && git status'
+
+    Use `--` to separate hogli's flags from the command's own flags.
+    """
+    ensure_runtime_ready()
+    name, _ = resolve_workspace_name(workspace_name)
+    replace_with_workspace_command(name, list(command))
 
 
 @click.command(name="devbox:open", help="Open devbox in browser, VS Code, or Cursor")

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -34,6 +34,7 @@ from .coder import (
     coder_authenticated,
     coder_installed,
     coder_reachable,
+    coder_ssh_alias_configured,
     create_task,
     create_workspace,
     delete_user_secret,
@@ -581,6 +582,9 @@ def devbox_doctor() -> None:
     _doctor_check("coder CLI installed", installed)
     authenticated = installed and coder_authenticated()
     _doctor_check("Coder authenticated", authenticated)
+    # The Host coder.* block is a wildcard, so any name probes whether
+    # `coder config-ssh` has run -- the prerequisite for devbox:ssh/exec.
+    _doctor_check("SSH access configured (devbox:ssh/exec)", coder_ssh_alias_configured("probe"))
 
     if not authenticated:
         _doctor_footer()
@@ -1207,6 +1211,10 @@ def devbox_remote_exec(workspace_name: str | None, command: tuple[str, ...]) -> 
     """
     ensure_runtime_ready()
     name, _ = resolve_workspace_name(workspace_name)
+    if not coder_ssh_alias_configured(name):
+        _fail(
+            "SSH access for devboxes isn't configured. Run `hogli devbox:setup` (it runs `coder config-ssh`), then retry."
+        )
     exec_replace(name, list(command))
 
 

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -1253,6 +1253,29 @@ def exec_replace(name: str, command: list[str]) -> None:
     os.execvp("ssh", ["ssh", _ssh_host_alias(name), shlex.join(command)])
 
 
+def coder_ssh_alias_configured(name: str) -> bool:
+    """Return whether ssh resolves a Coder ``ProxyCommand`` for the workspace host alias.
+
+    :func:`exec_replace` and :func:`ssh_replace` connect through the
+    ``Host coder.*`` block that ``coder config-ssh`` writes during
+    ``devbox:setup``. When that block is absent, ``ssh coder.<name>`` fails with
+    an opaque ``Could not resolve hostname``; callers check this first so they
+    can point at setup instead. The block is a wildcard, so any ``name`` probes
+    it. Returns ``False`` if ``ssh`` is missing or errors.
+    """
+    try:
+        result = subprocess.run(["ssh", "-G", _ssh_host_alias(name)], capture_output=True, text=True)
+    except OSError:
+        return False
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        if line.startswith("proxycommand "):
+            value = line[len("proxycommand ") :].strip()
+            return bool(value) and value.lower() != "none"
+    return False
+
+
 def port_forward_replace(name: str, local_port: int, remote_port: int) -> None:
     """Port-forward to a workspace and replace the current process."""
     _run_or_exit(["coder", "port-forward", name, f"--tcp={local_port}:{remote_port}"])
@@ -1291,19 +1314,6 @@ def create_task(
     else:
         args.append(prompt)
     _run_or_exit(args)
-
-
-def run_in_workspace(
-    name: str, command: list[str], *, capture_output: bool = False
-) -> subprocess.CompletedProcess[str]:
-    """Run a command in the workspace via `coder ssh`."""
-    args = ["coder", "ssh", name, "--", *command]
-    return _run(args, capture_output=capture_output)
-
-
-def replace_with_workspace_command(name: str, command: list[str]) -> None:
-    """Run a workspace command and replace the current process."""
-    _run_or_exit(["coder", "ssh", name, "--", *command])
 
 
 def open_in_browser(name: str) -> None:

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -1233,6 +1233,26 @@ def ssh_replace(name: str) -> None:
     os.execvp("ssh", ["ssh", _ssh_host_alias(name)])
 
 
+def exec_replace(name: str, command: list[str]) -> None:
+    """Run a single command in the workspace over the ssh host alias, replacing the process.
+
+    Goes through ``ssh coder.<name>`` rather than ``coder ssh <name> -- cmd``
+    for two reasons:
+
+    1. ``coder ssh`` does not propagate the remote command's exit code -- it
+       prints ``Process exited with status N`` to stderr but exits 0 itself,
+       so callers and agents can't tell success from failure. Real ssh
+       forwards the exit code faithfully.
+    2. The ``Host coder.*`` block applies the user's ssh config (IdentityAgent
+       forwarding), same as :func:`ssh_replace`.
+
+    ``command`` tokens are shell-quoted into one string so the remote login
+    shell preserves argument boundaries -- ssh otherwise space-joins argv,
+    which would split a token like ``"uname -sm"`` back into two.
+    """
+    os.execvp("ssh", ["ssh", _ssh_host_alias(name), shlex.join(command)])
+
+
 def port_forward_replace(name: str, local_port: int, remote_port: int) -> None:
     """Port-forward to a workspace and replace the current process."""
     _run_or_exit(["coder", "port-forward", name, f"--tcp={local_port}:{remote_port}"])


### PR DESCRIPTION
## Problem

Setting up a PostHog devbox to be useful for agentic work (gh CLI, Claude Code, PostHog MCP, aliases) is hand-rolled and per-box. Since engineers run more than one devbox and compute is rebuilt from a golden image, anything installed inside a single box is a pet that doesn't follow you to the next box. There's also no read-only way to diagnose why a devbox command fails — the most common cause (missing tailnet ACL grant) surfaces only as a generic "unreachable."

## Changes

- **`hogli devbox:exec`** — run a single command inside a devbox over `coder ssh` (non-interactive, propagates exit code), so agents and scripts can drive a box remotely instead of opening a shell.
- **`hogli devbox:doctor`** — read-only health check (tailnet access, control-plane reachability, CLI install, auth, saved setup). Never prompts or mutates host config. When the control plane is unreachable it names the exact prerequisite: your email in `group:engineering` in `posthog-cloud-infra/tailnet-policy.hujson`.
- **`setting-up-devbox` skill** — guides an agent to make personalization portable (dotfiles `install.sh` + Coder user secrets) rather than configuring one box, leans on `devbox:doctor` as step zero, and points back to `devbox:setup`.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run: `ruff check`, `ruff format --check`, `py_compile`, `hogli lint:skills`, and the pre-commit `ty check` — all pass. Verified `devbox:exec --help`, `devbox:doctor --help`, and a live `devbox:doctor` run against the dev deployment (all checks `ok`, status renders correctly). No unit tests added yet — `devbox:doctor`'s probes are mockable if we want coverage.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code.