### PR TITLE
chore(events): adds include_person qp to event GET endpoint

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -394,7 +394,7 @@ class EventViewSet(
                     )
 
             context = {**restricted_context}
-            if request.query_params.get("include_person", False):
+            if request.query_params.get("include_person", "").lower() in ("true", "1"):
                 context["people"] = self._get_people(query_result, team)
 
             result = ClickhouseEventSerializer(
@@ -456,7 +456,7 @@ class EventViewSet(
             raise NotFound(detail=f"No events exist for event UUID {pk}")
 
         query_context = {**self._get_restricted_properties_context(request, self.team)}
-        if request.query_params.get("include_person", False):
+        if request.query_params.get("include_person", "").lower() in ("true", "1"):
             query_context["people"] = self._get_people(query_result, self.team)
 
         res = ClickhouseEventSerializer(query_result[0], many=False, context=query_context).data

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -260,6 +260,11 @@ class EventViewSet(
                 deprecated=True,
             ),
             PropertiesSerializer(required=False),
+            OpenApiParameter(
+                "include_person",
+                OpenApiTypes.BOOL,
+                description="Include person details for each event. Default: false.",
+            ),
         ],
     )
     def list(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
@@ -388,13 +393,14 @@ class EventViewSet(
                         action_id=request.GET.get("action_id"),
                     )
 
+            context = {**restricted_context}
+            if request.query_params.get("include_person", False):
+                context["people"] = self._get_people(query_result, team)
+
             result = ClickhouseEventSerializer(
                 query_result[0:limit],
                 many=True,
-                context={
-                    "people": self._get_people(query_result, team),
-                    **restricted_context,
-                },
+                context=context,
             ).data
 
             next_url: Optional[str] = None

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -427,7 +427,14 @@ class EventViewSet(
         return get_persons_mapped_by_distinct_id(team.pk, distinct_ids)
 
     @extend_schema(
-        parameters=[OpenApiParameter("id", OpenApiTypes.STR, OpenApiParameter.PATH)],
+        parameters=[
+            OpenApiParameter("id", OpenApiTypes.STR, OpenApiParameter.PATH),
+            OpenApiParameter(
+                "include_person",
+                OpenApiTypes.BOOL,
+                description="Include person details for the event. Default: false.",
+            ),
+        ],
         responses={200: OpenApiTypes.OBJECT},
     )
     def retrieve(

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -66,7 +66,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2").json()
         assert response["results"][0]["person"] is None
 
@@ -873,7 +873,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         event_id = _create_event(team=self.team, event="event", distinct_id="1", timestamp=timezone.now())
         flush_persons_and_events()
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}")
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -66,7 +66,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(10):
             response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2").json()
         assert response["results"][0]["person"] is None
 
@@ -871,8 +871,9 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             is_identified=True,
         )
         event_id = _create_event(team=self.team, event="event", distinct_id="1", timestamp=timezone.now())
+        flush_persons_and_events()
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(10):
             response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}")
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -67,6 +67,9 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2").json()
+        assert response["results"][0]["person"] is None
+
+        response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2&include_person=true").json()
         assert response["results"][0]["person"] == {
             "distinct_ids": ["2"],
             "is_identified": True,
@@ -931,6 +934,24 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?limit=50000").json()
         assert len(response["results"]) == 2
+
+    @patch("posthog.api.event.get_persons_mapped_by_distinct_id")
+    def test_list_without_include_person_skips_person_lookup(self, mock_get_persons):
+        _create_person(team=self.team, distinct_ids=["1"], is_identified=True)
+        _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"$ip": "8.8.8.8"})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=1").json()
+        assert response["results"][0]["person"] is None
+        mock_get_persons.assert_not_called()
+
+    @patch("posthog.api.event.get_persons_mapped_by_distinct_id")
+    def test_list_with_include_person_calls_person_lookup(self, mock_get_persons):
+        _create_person(team=self.team, distinct_ids=["1"], is_identified=True)
+        _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"$ip": "8.8.8.8"})
+        mock_get_persons.return_value = {}
+
+        self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=1&include_person=true")
+        mock_get_persons.assert_called_once()
 
     def test_get_events_with_specified_token(self):
         _, _, user2 = User.objects.bootstrap("Test", "team2@posthog.com", None)

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -66,10 +66,12 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
 
-        response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2").json()
+        with self.assertNumQueries(9):
+            response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2").json()
         assert response["results"][0]["person"] is None
 
-        response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2&include_person=true").json()
+        with self.assertNumQueries(10):
+            response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2&include_person=true").json()
         assert response["results"][0]["person"] == {
             "distinct_ids": ["2"],
             "is_identified": True,
@@ -101,8 +103,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         # Django session, PostHog user, PostHog team, PostHog org membership,
-        # instance setting check, person and distinct id
-        with self.assertNumQueries(10):
+        # instance setting check
+        with self.assertNumQueries(9):
             response = self.client.get(f"/api/projects/{self.team.id}/events/?event=event_name").json()
             assert response["results"][0]["event"] == "event_name"
 
@@ -128,8 +130,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         # Django session, PostHog user, PostHog team, PostHog org membership,
-        # access control, instance settings (poe, rate limit), person and distinct id
-        expected_queries = 11
+        # access control, instance settings (poe, rate limit)
+        expected_queries = 10
 
         with self.assertNumQueries(expected_queries):
             response = self.client.get(
@@ -870,13 +872,17 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         )
         event_id = _create_event(team=self.team, event="event", distinct_id="1", timestamp=timezone.now())
 
-        response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}")
+        with self.assertNumQueries(9):
+            response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}")
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
         assert response_json["event"] == "event"
         assert response_json["person"] is None
 
-        with_person_response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}?include_person=true")
+        with self.assertNumQueries(10):
+            with_person_response = self.client.get(
+                f"/api/projects/{self.team.id}/events/{event_id}?include_person=true"
+            )
         assert with_person_response.status_code == status.HTTP_200_OK
         with_person_response_json = with_person_response.json()
         assert with_person_response_json["event"] == "event"

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -66,12 +66,10 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
 
-        with self.assertNumQueries(9):
-            response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2").json()
+        response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2").json()
         assert response["results"][0]["person"] is None
 
-        with self.assertNumQueries(10):
-            response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2&include_person=true").json()
+        response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2&include_person=true").json()
         assert response["results"][0]["person"] == {
             "distinct_ids": ["2"],
             "is_identified": True,
@@ -873,17 +871,13 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         event_id = _create_event(team=self.team, event="event", distinct_id="1", timestamp=timezone.now())
         flush_persons_and_events()
 
-        with self.assertNumQueries(9):
-            response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}")
+        response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}")
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
         assert response_json["event"] == "event"
         assert response_json["person"] is None
 
-        with self.assertNumQueries(10):
-            with_person_response = self.client.get(
-                f"/api/projects/{self.team.id}/events/{event_id}?include_person=true"
-            )
+        with_person_response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}?include_person=true")
         assert with_person_response.status_code == status.HTTP_200_OK
         with_person_response_json = with_person_response.json()
         assert with_person_response_json["event"] == "event"

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -38779,6 +38779,10 @@ export namespace Schemas {
 
     export type EnvironmentsEventsRetrieveParams = {
     format?: EnvironmentsEventsRetrieveFormat;
+    /**
+     * Include person details for the event. Default: false.
+     */
+    include_person?: boolean;
     };
 
     export type EnvironmentsEventsRetrieveFormat = typeof EnvironmentsEventsRetrieveFormat[keyof typeof EnvironmentsEventsRetrieveFormat];
@@ -43861,6 +43865,10 @@ export namespace Schemas {
 
     export type EventsRetrieveParams = {
     format?: EventsRetrieveFormat;
+    /**
+     * Include person details for the event. Default: false.
+     */
+    include_person?: boolean;
     };
 
     export type EventsRetrieveFormat = typeof EventsRetrieveFormat[keyof typeof EventsRetrieveFormat];

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -38740,6 +38740,10 @@ export namespace Schemas {
     event?: string;
     format?: EnvironmentsEventsListFormat;
     /**
+     * Include person details for each event. Default: false.
+     */
+    include_person?: boolean;
+    /**
      * The maximum number of results to return
      */
     limit?: number;
@@ -43817,6 +43821,10 @@ export namespace Schemas {
      */
     event?: string;
     format?: EventsListFormat;
+    /**
+     * Include person details for each event. Default: false.
+     */
+    include_person?: boolean;
     /**
      * The maximum number of results to return
      */


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

The deprecated `/api/projects/:id/events/` endpoint unconditionally fetches full Person records for every distinct_id in the result set.

This drives significant load and data over the wire to load all these Person records when they may or may not be needed. The entire person lookup burden comes from external API consumers hitting a deprecated endpoint.


## Changes

Make person enrichment opt-in on the events list endpoint via `?include_person=true`, matching the pattern already used on the retrieve endpoint (`GET /api/projects/:id/events/:id`).

Without the parameter, `person` is `null` on each event — no person lookup occurs at all.

- Added `include_person` OpenAPI parameter to the list endpoint schema
- Person lookup (`get_persons_mapped_by_distinct_id`) is only called when `include_person=true` is passed
- Updated `test_filter_events` to assert `person` is `null` by default and populated with `include_person=true`



## How did you test this code?

- Added `test_list_without_include_person_skips_person_lookup` — patches `get_persons_mapped_by_distinct_id` and asserts it is never called without the param
- Added `test_list_with_include_person_calls_person_lookup` — asserts the lookup is called when the param is present

