### PR TITLE
fix(insights): render stickiness area chart with fill

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1956,6 +1956,10 @@ snapshots:
         hash: v1.k794b7964.d669cc7bd939e7cd9bae4003a228e194a6c383d827feb04baf491a89dfc0b698.eD11DZ4cr8p1GMBdBaTW1doXInEVj9CIhnyMP8RNpFo
     insights-insightstable--is-legend--light:
         hash: v1.k794b7964.d9eec920b0b2f3c9ea87c9e0d2b298bc37339217e4211d0cf1a147630f09b75d.xGcJlQO8pvoNnHyoMNZ4F58uqKh5PDg_UiGlO5bAMn8
+    insights-stickinesslinechart--area--dark:
+        hash: v1.k794b7964.c8f70afcdd044f3df9c45bd8f83a5f7b9b6c2ff56fd36da9f74f196ebc0b56b9.0zlUNlGlxnyFebgcM3MlWfSHhFSI2YJb2jxigbCMjkQ
+    insights-stickinesslinechart--area--light:
+        hash: v1.k794b7964.5d7b49d8f4ebb24543f100ed4014d0f8a5832a5db40525f482fb096eadd7acb4.DMdwu1bhfT1dAJWNVYf72l00l5XMKia53ratuSW3CyE
     insights-stickinesslinechart--default--dark:
         hash: v1.k794b7964.41390e8fbafc9d75682179e198664c729a05ed3439fb99ad516fe1b1032cf6c0.dmsgYkZeOieitZlRh1HAveS5ej1pzamiMVQQdBstzIg
     insights-stickinesslinechart--default--light:
@@ -4735,9 +4739,9 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.gaL7vRk-pWoOUkiPi-NGCd1W72x-M5l9jk5Qu-UcjwI
+        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
-        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.dtIb8VK_HAoAvzi8YbVjGpt2Y8yONsVV7mEiD9DrclQ
+        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
         hash: v1.k794b7964.dad9df902a133cafd6b3314a3800fcb45dabbbb59a0766c87c226549392104fc.u8mciTuIKrwI-d3yiUx6dVpr3oLoJJ7tgvRU7hutwhU
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--light:

--- a/products/product_analytics/frontend/insights/trends/StickinessLineChart/StickinessLineChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/trends/StickinessLineChart/StickinessLineChart.stories.tsx
@@ -10,7 +10,7 @@ import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { getCachedResults } from '~/queries/nodes/InsightViz/utils'
-import { InsightLogicProps, InsightShortId } from '~/types'
+import { ChartDisplayType, InsightLogicProps, InsightShortId } from '~/types'
 
 import { StickinessLineChart } from './StickinessLineChart'
 
@@ -73,4 +73,19 @@ function StickinessLineChartStory({ insightFixture }: { insightFixture: any }): 
 
 export const Default: Story = {
     render: () => <StickinessLineChartStory insightFixture={stickinessFixture} />,
+}
+
+const areaFixture = {
+    ...stickinessFixture,
+    query: {
+        ...stickinessFixture.query,
+        source: {
+            ...stickinessFixture.query.source,
+            stickinessFilter: { display: ChartDisplayType.ActionsAreaGraph },
+        },
+    },
+}
+
+export const Area: Story = {
+    render: () => <StickinessLineChartStory insightFixture={areaFixture} />,
 }

--- a/products/product_analytics/frontend/insights/trends/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/StickinessLineChart/StickinessLineChart.tsx
@@ -41,6 +41,7 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
 
     const {
         indexedResults,
+        display,
         interval,
         yAxisScaleType,
         showMultipleYAxes,
@@ -72,11 +73,12 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
         () =>
             buildStickinessSeries<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
                 showMultipleYAxes: showMultipleYAxes ?? undefined,
+                display: display ?? undefined,
                 getColor: getTrendsColor,
                 getHidden: getTrendsHidden,
                 buildMeta: buildTrendsSeriesMeta,
             }),
-        [indexedResults, getTrendsColor, getTrendsHidden, showMultipleYAxes]
+        [indexedResults, display, getTrendsColor, getTrendsHidden, showMultipleYAxes]
     )
 
     const chartConfig: TimeSeriesLineChartConfig = useMemo(

--- a/products/product_analytics/frontend/insights/trends/StickinessLineChart/stickinessChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/StickinessLineChart/stickinessChartTransforms.test.ts
@@ -1,6 +1,8 @@
 import { DEFAULT_Y_AXIS_ID } from 'lib/hog-charts'
 import type { TooltipConfig } from 'lib/hog-charts'
 
+import { ChartDisplayType } from '~/types'
+
 import {
     buildStickinessLabels,
     buildStickinessLineTimeSeriesConfig,
@@ -90,6 +92,22 @@ describe('stickinessChartTransforms', () => {
                 showMultipleYAxes: true,
             })
             expect(series.yAxisId).toBe(DEFAULT_Y_AXIS_ID)
+        })
+
+        it('attaches an empty fill object when display is ActionsAreaGraph', () => {
+            const series = buildStickinessMainSeries(makeResult(), 0, {
+                getColor: () => RED,
+                display: ChartDisplayType.ActionsAreaGraph,
+            })
+            expect(series.fill).toEqual({})
+        })
+
+        it('leaves fill undefined for non-area displays', () => {
+            const series = buildStickinessMainSeries(makeResult(), 0, {
+                getColor: () => RED,
+                display: ChartDisplayType.ActionsLineGraph,
+            })
+            expect(series.fill).toBeUndefined()
         })
 
         it('passes the result index through to getColor and buildMeta', () => {

--- a/products/product_analytics/frontend/insights/trends/StickinessLineChart/stickinessChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/StickinessLineChart/stickinessChartTransforms.test.ts
@@ -94,20 +94,16 @@ describe('stickinessChartTransforms', () => {
             expect(series.yAxisId).toBe(DEFAULT_Y_AXIS_ID)
         })
 
-        it('attaches an empty fill object when display is ActionsAreaGraph', () => {
+        it.each<[string, ChartDisplayType | undefined, Record<string, never> | undefined]>([
+            ['ActionsAreaGraph sets fill', ChartDisplayType.ActionsAreaGraph, {}],
+            ['ActionsLineGraph leaves fill undefined', ChartDisplayType.ActionsLineGraph, undefined],
+            ['undefined display leaves fill undefined', undefined, undefined],
+        ])('%s', (_, display, expected) => {
             const series = buildStickinessMainSeries(makeResult(), 0, {
                 getColor: () => RED,
-                display: ChartDisplayType.ActionsAreaGraph,
+                display,
             })
-            expect(series.fill).toEqual({})
-        })
-
-        it('leaves fill undefined for non-area displays', () => {
-            const series = buildStickinessMainSeries(makeResult(), 0, {
-                getColor: () => RED,
-                display: ChartDisplayType.ActionsLineGraph,
-            })
-            expect(series.fill).toBeUndefined()
+            expect(series.fill).toEqual(expected)
         })
 
         it('passes the result index through to getColor and buildMeta', () => {

--- a/products/product_analytics/frontend/insights/trends/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/StickinessLineChart/stickinessChartTransforms.ts
@@ -2,6 +2,8 @@ import { DEFAULT_Y_AXIS_ID } from 'lib/hog-charts'
 import type { Series, TimeSeriesLineChartConfig, TooltipConfig, YAxisConfig } from 'lib/hog-charts'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
+import { ChartDisplayType } from '~/types'
+
 // Shape both IndexedTrendResult (kea) and StickinessResultItem (MCP) satisfy.
 export interface StickinessResultLike {
     id?: string | number
@@ -21,6 +23,7 @@ export type StickinessYAxisScaleType = string | null | undefined
 
 export interface BuildStickinessSeriesOpts<R extends StickinessResultLike, M = unknown> {
     showMultipleYAxes?: boolean
+    display?: ChartDisplayType | null
     getColor: (r: R, index: number) => string
     getHidden?: (r: R, index: number) => boolean
     buildMeta?: (r: R, index: number) => M
@@ -50,6 +53,7 @@ export function buildStickinessMainSeries<R extends StickinessResultLike, M = un
         color: opts.getColor(r, index),
         yAxisId,
         meta,
+        fill: opts.display === ChartDisplayType.ActionsAreaGraph ? {} : undefined,
         visibility: excluded ? { excluded: true } : undefined,
     }
 }


### PR DESCRIPTION
## Problem

The new hog-charts stickiness chart rendered as a plain line chart when the user selected the area display — the `fill` was never set on the series. `Trends.tsx` routes `ActionsLineGraph`, `ActionsLineGraphCumulative`, and `ActionsAreaGraph` all to `StickinessLineChart`, and the new port didn't differentiate between them (legacy `ActionsLineGraph.tsx` did via `isArea`).

## Changes

- `stickinessChartTransforms.ts`: added an optional `display` field to `BuildStickinessSeriesOpts` and set `fill: {}` on the series when `display === ActionsAreaGraph` (mirrors the same line in `trendsChartTransforms.ts`).
- `StickinessLineChart.tsx`: pull `display` out of `trendsDataLogic` and pass it through.
- Added two unit tests covering the area / non-area branches.
- Added an `Area` story so the chromium snapshot locks this in going forward.

## How did you test this code?

I'm an agent. I ran the jest tests for `stickinessChartTransforms` (all 34 pass, including the two new ones), and rendered both stories locally via Storybook to visually confirm the area fill shows up for the Area story and that the Default story is unchanged.

## Publish to changelog?

## 🤖 Agent context

Authored by Claude Opus 4.7 via Claude Code. The user spotted that the new hog-charts stickiness chart rendered area display as a line and asked me to look into it. I traced the routing in `Trends.tsx`, compared against the trends port (`trendsChartTransforms.ts:74`) and legacy `ActionsLineGraph.tsx:204`, and confirmed the new stickiness transform never set `fill`. Mirrored the trends port's approach rather than introducing a new pattern. Added a story to cover the gap so the existing snapshot job catches future regressions — no Area variant existed before.