### PR TITLE
feat(replay): pause player and prefetch collections on add-to-collection

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/AddToCollectionModal.stories.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/AddToCollectionModal.stories.tsx
@@ -37,7 +37,7 @@ const StoryWrapper = ({ initialSearch }: { initialSearch?: string }): JSX.Elemen
 
     useEffect(() => {
         setSelectedRecordingsIds(['rec-1', 'rec-2', 'rec-3'])
-        loadCollectionsForBulkAdd()
+        loadCollectionsForBulkAdd(null)
         setIsAddToCollectionModalOpen(true)
         if (initialSearch) {
             setAddToCollectionSearch(initialSearch)

--- a/frontend/src/scenes/session-recordings/playlist/AddToCollectionModal.stories.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/AddToCollectionModal.stories.tsx
@@ -28,11 +28,16 @@ const filterPlaylistsBySearch = (search: string | null): SavedSessionRecordingPl
 }
 
 const StoryWrapper = ({ initialSearch }: { initialSearch?: string }): JSX.Element => {
-    const { setIsAddToCollectionModalOpen, setAddToCollectionSearch, setSelectedRecordingsIds } =
-        useActions(sessionRecordingsPlaylistLogic)
+    const {
+        setIsAddToCollectionModalOpen,
+        setAddToCollectionSearch,
+        setSelectedRecordingsIds,
+        loadCollectionsForBulkAdd,
+    } = useActions(sessionRecordingsPlaylistLogic)
 
     useEffect(() => {
         setSelectedRecordingsIds(['rec-1', 'rec-2', 'rec-3'])
+        loadCollectionsForBulkAdd()
         setIsAddToCollectionModalOpen(true)
         if (initialSearch) {
             setAddToCollectionSearch(initialSearch)

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -12,6 +12,7 @@ import { SettingsBar, SettingsMenu } from 'scenes/session-recordings/components/
 import { AccessControlLevel, AccessControlResourceType, RecordingUniversalFilters } from '~/types'
 
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
+import { sessionRecordingPlayerLogic } from '../player/sessionRecordingPlayerLogic'
 import {
     DELETE_CONFIRMATION_TEXT,
     MAX_SELECTED_RECORDINGS,
@@ -357,9 +358,18 @@ export function SessionRecordingsPlaylistTopSettings({
         handleSelectUnselectAll,
         setIsDeleteSelectedRecordingsDialogOpen,
         setIsAddToCollectionModalOpen,
+        loadCollectionsForBulkAdd,
         handleBulkMarkAsViewed,
         handleBulkMarkAsNotViewed,
     } = useActions(sessionRecordingsPlaylistLogic)
+
+    const openAddToCollectionModal = (): void => {
+        for (const playerLogic of sessionRecordingPlayerLogic.findAllMounted()) {
+            playerLogic.actions.setPause()
+        }
+        loadCollectionsForBulkAdd()
+        setIsAddToCollectionModalOpen(true)
+    }
 
     const recordings = type === 'filters' ? otherRecordings : pinnedRecordings
     const checked = recordings.length > 0 && selectedRecordingsIds.length === recordings.length
@@ -373,7 +383,7 @@ export function SessionRecordingsPlaylistTopSettings({
         const menuItems: LemonMenuItem[] = [
             {
                 label: 'Add to collection...',
-                onClick: () => setIsAddToCollectionModalOpen(true),
+                onClick: openAddToCollectionModal,
                 'data-attr': 'add-to-collection',
                 disabledReason: accessControlDisabledReason,
             },

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -367,7 +367,7 @@ export function SessionRecordingsPlaylistTopSettings({
         for (const playerLogic of sessionRecordingPlayerLogic.findAllMounted()) {
             playerLogic.actions.setPause()
         }
-        loadCollectionsForBulkAdd()
+        loadCollectionsForBulkAdd(null)
         setIsAddToCollectionModalOpen(true)
     }
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -1277,11 +1277,6 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                 onSuccess()
             }
         },
-        setIsAddToCollectionModalOpen: ({ isAddToCollectionModalOpen }) => {
-            if (isAddToCollectionModalOpen) {
-                actions.loadCollectionsForBulkAdd(null)
-            }
-        },
         setAddToCollectionSearch: async (_, breakpoint) => {
             await breakpoint(200)
             actions.loadCollectionsForBulkAdd(null)


### PR DESCRIPTION
## Problem

Follow-up to #60099. Two issues surfaced after the unified Add to collection modal shipped:

1. Opening the modal didn't pause whatever recording was playing in the side panel, so audio (and the player clock) kept running while the user picked a destination.
2. The list of collections didn't load until the user typed in the search box. The expected behaviour is "a short page of the most recently modified collections, ready as soon as the modal opens." Behind the scenes the load was wired to fire from a kea listener triggered by the reducer update — by the time the load reducer caught up, the modal had already rendered with the initial empty state, producing the "No collections yet" flash and (in some renders) leaving the list empty until a search forced a second load.

## Changes

- `SessionRecordingsPlaylistTopSettings`: the "Add to collection..." menu item now goes through an `openAddToCollectionModal` helper that (a) pauses every mounted `sessionRecordingPlayerLogic` instance via `findAllMounted()`, (b) dispatches `loadCollectionsForBulkAdd()` synchronously, then (c) opens the modal. With the load dispatched in the same handler, the modal renders with the loader already in flight (loading spinner, no empty-state flash).
- `sessionRecordingsPlaylistLogic`: the now-redundant listener that fired the load on `setIsAddToCollectionModalOpen(true)` is removed — the explicit dispatch in the menu handler is the single source of truth.
- The storybook stories drive the same explicit `loadCollectionsForBulkAdd()` call so the existing snapshots continue to render correctly.

Player import lives behind a one-way edge (`playlist/Settings.tsx → player/sessionRecordingPlayerLogic.ts`) so the existing `player → playlist` type-only import is not a cycle.

## How did you test this code?

I'm an agent. I ran `pnpm --filter=@posthog/frontend typescript:check` against the workspace (it exits non-zero on unrelated `products/workflows/frontend/onboarding/steps.tsx` JSX errors that exist on master; no errors are reported in the touched files). I did not run the frontend in a browser.

## Publish to changelog?

do not publish to changelog

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) under @pauldambra's direction. Two distinct asks from the slack thread on PR #60099 after merge:

- Pause playback when the modal opens. Considered putting this in the kea logic, but doing so would force `playlist → player` to become a runtime edge (today's reverse `player → playlist` import is type-only); kept the playerLogic touch in the React component to avoid a runtime cycle.
- Make the initial list of recent collections visible without requiring a search. Tracing the listener showed it should already be firing the load on modal open — but the reducer-based path leaves a window where the modal renders before the listener runs, which the user observed as "didn't load". The fix dispatches the loader in the same React handler that opens the modal, so the loading state is set before the next render.

I did not change the API call shape (`limit=30`, `order=-last_modified_at`, `type=collection`) or the post-call `breakpoint()` for stale-response handling.