### PR TITLE
feat(capture): parallelize mutli-sink flush in graceful shutdown drain step

### DIFF
--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use axum::extract::ConnectInfo;
@@ -228,17 +229,29 @@ pub async fn serve(listener: TcpListener, components: CaptureComponents) {
         graceful.shutdown().await;
         info!("Hyper accept loop (shutdown): graceful shutdown completed");
 
-        // Legacy sink flush is synchronous (rdkafka); v1 sinks use spawn_blocking
-        // internally (see KafkaSink::flush). Sequential here until legacy is retired.
+        // Flush both sink layers concurrently. Legacy flush is synchronous
+        // (rdkafka), so it runs on the blocking thread pool. V1 sinks already
+        // use spawn_blocking internally (see KafkaSink::flush).
         info!("Flushing sinks...");
-        if let Err(e) = sink.flush() {
-            error!("Sink flush failed: {e:#}");
-        }
-        if let Some(ref v1_router) = v1_sink_router {
-            if let Err(e) = v1_router.flush().await {
-                error!("V1 sink router flush failed: {e:#}");
+        let legacy_flush = {
+            let sink = Arc::clone(&sink);
+            async move {
+                let result = tokio::task::spawn_blocking(move || sink.flush()).await;
+                match result {
+                    Ok(Err(e)) => error!("Sink flush failed: {e:#}"),
+                    Err(e) => error!("Sink flush task panicked: {e}"),
+                    Ok(Ok(())) => {}
+                }
             }
-        }
+        };
+        let v1_flush = async {
+            if let Some(ref v1_router) = v1_sink_router {
+                if let Err(e) = v1_router.flush().await {
+                    error!("V1 sink router flush failed: {e:#}");
+                }
+            }
+        };
+        tokio::join!(legacy_flush, v1_flush);
         info!("Sink flush complete");
 
         // _scope drops here -> ProcessScopeGuard signals WorkCompleted


### PR DESCRIPTION


<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
Requested in prior PR review: instead of parallelizing only the v1 multi-sink `flush()` during graceful shutdown, let's wrap the legacy flush call as well and fan them all out.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
As stated above. Tiny change
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (new tests not required for this)
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
Eli planned, Claude coded, Eli reviewed
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
