### PR TITLE
feat(capture): update v1 endpoint path

### DIFF
--- a/rust/capture/src/v1/analytics/constants.rs
+++ b/rust/capture/src/v1/analytics/constants.rs
@@ -20,10 +20,10 @@ pub const SUPPORTED_ENCODINGS: &[&str] = &["gzip", "deflate", "br", "zstd"];
 // ---------------------------------------------------------------------------
 
 /// Primary route path for the v1 events endpoint.
-pub const CAPTURE_V1_PATH: &str = "/i/v1/general/events";
+pub const CAPTURE_V1_PATH: &str = "/i/v1/analytics/events";
 
 /// Trailing-slash variant registered so both URL forms resolve to the same handler.
-pub(super) const CAPTURE_V1_PATH_TRAILING: &str = "/i/v1/general/events/";
+pub(super) const CAPTURE_V1_PATH_TRAILING: &str = "/i/v1/analytics/events/";
 
 // ---------------------------------------------------------------------------
 // Metrics keys

--- a/rust/capture/src/v1/analytics/handler.rs
+++ b/rust/capture/src/v1/analytics/handler.rs
@@ -149,15 +149,13 @@ mod tests {
     use uuid::Uuid;
 
     use crate::router;
+    use crate::v1::analytics::constants::CAPTURE_V1_PATH;
     use crate::v1::constants::*;
     use crate::v1::test_utils::{batch_payload, compressed_payload, valid_event, TestStateBuilder};
 
     fn test_app(state: router::State) -> Router {
         Router::new()
-            .route(
-                "/i/v1/general/events",
-                axum::routing::post(super::handle_request),
-            )
+            .route(CAPTURE_V1_PATH, axum::routing::post(super::handle_request))
             .layer(axum::middleware::from_fn(
                 super::super::router::v1_common_headers,
             ))
@@ -167,7 +165,7 @@ mod tests {
     fn valid_request() -> axum::http::request::Builder {
         Request::builder()
             .method("POST")
-            .uri("/i/v1/general/events")
+            .uri(CAPTURE_V1_PATH)
             .header("Authorization", "Bearer phc_test_token")
             .header("Content-Type", "application/json")
             .header("X-Forwarded-For", "127.0.0.1")
@@ -235,7 +233,7 @@ mod tests {
         let payload = batch_payload(&[valid_event()]);
         let req = Request::builder()
             .method("POST")
-            .uri("/i/v1/general/events")
+            .uri(CAPTURE_V1_PATH)
             .header("Content-Type", "application/json")
             .header("X-Forwarded-For", "127.0.0.1")
             .header(POSTHOG_SDK_INFO, "posthog-rust/1.0.0")
@@ -259,7 +257,7 @@ mod tests {
         // Only Authorization and Content-Type — missing SDK-Info, Attempt, etc.
         let req = Request::builder()
             .method("POST")
-            .uri("/i/v1/general/events")
+            .uri(CAPTURE_V1_PATH)
             .header("Authorization", "Bearer phc_test_token")
             .header("Content-Type", "application/json")
             .header("X-Forwarded-For", "127.0.0.1")
@@ -324,7 +322,7 @@ mod tests {
 
         let req = Request::builder()
             .method("POST")
-            .uri("/i/v1/general/events")
+            .uri(CAPTURE_V1_PATH)
             .header("Authorization", "Bearer phc_test_token")
             .header("Content-Type", "application/json")
             .header("Content-Encoding", "gzip")
@@ -355,7 +353,7 @@ mod tests {
 
         let req = Request::builder()
             .method("POST")
-            .uri("/i/v1/general/events")
+            .uri(CAPTURE_V1_PATH)
             .header("Authorization", "Bearer phc_test_token")
             .header("Content-Type", "application/json")
             .header("Content-Encoding", "zstd")
@@ -382,7 +380,7 @@ mod tests {
         let payload = batch_payload(&[valid_event()]);
         let req = Request::builder()
             .method("POST")
-            .uri("/i/v1/general/events")
+            .uri(CAPTURE_V1_PATH)
             .header("Authorization", "Bearer phc_test_token")
             .header("Content-Type", "application/json")
             .header("Content-Encoding", "lz4")

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -503,6 +503,7 @@ mod tests {
     use crate::event_restrictions::{
         Pipeline, Restriction, RestrictionManager, RestrictionScope, RestrictionType,
     };
+    use crate::v1::analytics::constants::CAPTURE_V1_PATH;
     use crate::v1::analytics::types::{Batch, Event, Options};
     use crate::v1::sinks::Destination;
     use crate::v1::test_utils::{
@@ -867,7 +868,7 @@ mod tests {
             client_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
             query: crate::v1::analytics::query::Query::default(),
             method: axum::http::Method::POST,
-            path: "/i/v1/general/events",
+            path: CAPTURE_V1_PATH,
             server_received_at,
             created_at: None,
             capture_internal: false,

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use serde_json::value::RawValue;
 use uuid::Uuid;
 
+use crate::v1::analytics::constants::CAPTURE_V1_PATH;
 use crate::v1::analytics::query::Query;
 use crate::v1::analytics::types::{Event, EventResult, Options, WrappedEvent};
 use crate::v1::context::Context;
@@ -38,7 +39,7 @@ pub fn test_context() -> Context {
         client_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
         query: Query::default(),
         method: Method::POST,
-        path: "/i/v1/general/events",
+        path: CAPTURE_V1_PATH,
         server_received_at: Utc::now(),
         created_at: Some("2026-03-19T14:30:00.000Z".to_string()),
         capture_internal: false,

--- a/rust/capture/tests/v1_sink_integration.rs
+++ b/rust/capture/tests/v1_sink_integration.rs
@@ -5,7 +5,7 @@
 //!
 //! Requires Docker Kafka (same rig as legacy integration tests).
 //!
-//! TODO(v1): add HTTP-level integration tests (ServerHandle + POST /i/v1/general/events)
+//! TODO(v1): add HTTP-level integration tests (ServerHandle + POST /i/v1/analytics/events)
 //! and process_batch orchestration tests once the v1 HTTP router is merged into the
 //! main application and process_batch is fully implemented (currently a stub).
 


### PR DESCRIPTION
## Problem
Since the capture v1 analytics endpoint path was decided, the team has ditched the "general" label. Let's update it before we ship.

Feedback welcome if you don't agree with the new naming scheme. **If this ships, I'll make a corresponding update to the RFC and OpenAPI spec we'll be shipping with the v1 analytics endpoint release.**
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Update the capture v1 analytics endpoint path:
    * Current: `/i/v1/general/events/`
    * New: `/i/v1/events/analytics/`

☝️ this makes the new scheme `/i/v<N>/<payload>/<scope>/` which makes more sense for near term (`ai`, `replay`) v1 migrations on the horizon, and if we adopt alternate capture products in the future (`logs` etc.)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
