### PR TITLE
fix(web-analytics): use HogQL toInt instead of toInt64 in goals lazy insert

### DIFF
--- a/products/web_analytics/backend/hogql_queries/web_goals_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_goals_lazy_precompute.py
@@ -203,7 +203,7 @@ def _build_insert_query(actions: Sequence) -> str:
     denominator rows in one expression.
     """
     # Per-session COUNT columns + ORM-known action ids for the arrayJoin.
-    # Every tuple element is wrapped in an explicit `toInt64(...)` so the
+    # Every tuple element is wrapped in an explicit `toInt(...)` so the
     # tuple types unify cleanly across the array. ClickHouse requires
     # uniform element types within an array of tuples; without the explicit
     # cast the denominator's literal `0` (Int32) and the per-action
@@ -212,7 +212,8 @@ def _build_insert_query(actions: Sequence) -> str:
     # precompute paths, and the round-trip parity test is skipped pending
     # the read-after-write CI flake — so a type error would only surface in
     # production through the failure counter and silent fall-through to the
-    # live path.
+    # live path. (HogQL exposes `toInt`, which compiles to ClickHouse's
+    # `toInt64`; `toInt64` itself is not a valid HogQL identifier.)
     # `countIf` is bounded by the per-job time window so events that occur
     # in the SESSION_FORWARD_PAD_MINUTES tail (past `time_window_max`) do
     # NOT contribute to this job's counts. The pad lets `min(start_timestamp)`
@@ -227,11 +228,11 @@ def _build_insert_query(actions: Sequence) -> str:
         for n in range(len(actions))
     )
     array_join_pairs = ",\n            ".join(
-        f"tuple({{action_{n}_id}}, toInt64(count_{n}))" for n in range(len(actions))
+        f"tuple({{action_{n}_id}}, toInt(count_{n}))" for n in range(len(actions))
     )
     # The literal `-1` anchors the per-hour denominator row; `0` is just a
     # placeholder because the denominator row's `count_state` is never read.
-    array_join_literal = f"tuple(toInt64({DENOMINATOR_ACTION_ID}), toInt64(0)), {array_join_pairs}"
+    array_join_literal = f"tuple(toInt({DENOMINATOR_ACTION_ID}), toInt(0)), {array_join_pairs}"
 
     return f"""
 SELECT


### PR DESCRIPTION
## Problem

Every web_goals_preaggregated INSERT in production was failing — for example, on us.posthog.com team 2's queries:

> `Unsupported function call 'toInt64(...)'. Perhaps you meant 'toInt(...)'?`

The `array_join_pairs` / `array_join_literal` builders in `web_goals_lazy_precompute.py` wrap tuple elements in `toInt64(...)` to keep the arrayJoin tuple types unified. HogQL only exposes `toInt` (which compiles to ClickHouse's `toInt64` under the hood) — `toInt64` itself isn't a valid HogQL identifier.

The framework retry loop kept failing → `outcome=max_retries_exceeded` → empty `job_ids` → goals queries silently fell back to the live HogQL path. `usedLazyPrecompute` never reached `true` in production, so the `web_goals_preaggregated` table has zero rows and the lazy goals badge never renders.

The original PR's round-trip parity test is skipped pending a read-after-write CI flake, so this slipped through.

## Changes

| File | Change |
|---|---|
| `products/web_analytics/backend/hogql_queries/web_goals_lazy_precompute.py` | Replace 3 `toInt64(...)` call sites with `toInt(...)`; update the explanatory comment to clarify HogQL exposes `toInt` (not `toInt64`) so future readers don't reintroduce the same mistake |

## How did you test this code?

Agent-authored. Manual testing not performed.

Automated tests:
- `pytest products/web_analytics/backend/hogql_queries/test/test_web_goals_lazy_precompute.py` — 10 passed, 1 skipped (the round-trip test that was already skipped pre-fix)

Production verification (read-only, Loki via Grafana MCP):
- Pre-fix: `lazy_computation.job_failed` warnings for `table=web_goals_preaggregated`, `error="Unsupported function call 'toInt64(...)'"`, and `lazy_computation.executed` with `outcome=max_retries_exceeded, jobs_created=2, jobs_waited_for=0`. Post-fix verification will land after this rolls out.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7, 1M context). Discovered while investigating why the merged goals lazy precompute (#59993) was still serving from the live path. Production Loki showed `lazy_computation.job_failed` warnings pointing at the bad HogQL identifier. The cast was added intentionally in #59993's commit `266331a` ("Int64 cast, memoize actions, regen MCP types, tooltip") for arrayJoin tuple-type unification, but the cast itself rejected by the HogQL parser.

The comment explaining the cast is preserved (and updated) — the rationale for the cast itself is still correct; only the spelling was wrong.