### PR TITLE
fix(home): show Max thread when started via a slash command

### DIFF
--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.test.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.test.ts
@@ -1,0 +1,85 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { maxLogic } from 'scenes/max/maxLogic'
+import { maxMocks } from 'scenes/max/testUtils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { aiFirstHomepageLogic } from './aiFirstHomepageLogic'
+import { HOMEPAGE_TAB_ID } from './constants'
+
+describe('aiFirstHomepageLogic', () => {
+    let logic: ReturnType<typeof aiFirstHomepageLogic.build>
+    let homepageMaxLogic: ReturnType<typeof maxLogic.build>
+
+    beforeEach(() => {
+        localStorage.clear()
+        useMocks({
+            ...maxMocks,
+            get: {
+                ...maxMocks.get,
+                '/api/environments/:team_id/dashboards/': { results: [] },
+                '/api/projects/:team_id/file_system/': { results: [] },
+                '/api/projects/:team_id/file_system_shortcut/': { results: [] },
+            },
+        })
+        initKeaTests()
+        homepageMaxLogic = maxLogic({ panelId: HOMEPAGE_TAB_ID })
+        homepageMaxLogic.mount()
+        logic = aiFirstHomepageLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        if (homepageMaxLogic?.isMounted()) {
+            homepageMaxLogic.actions.startNewConversation()
+        }
+        homepageMaxLogic?.unmount()
+    })
+
+    it('starts the thread when a question is submitted in AI mode', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setQuery('What are my top events?')
+            logic.actions.submitQuery('ai')
+        }).toMatchValues({
+            threadStarted: true,
+        })
+    })
+
+    it('starts the thread when a slash command is sent after entering AI mode via the / trigger', async () => {
+        // Typing "/" on the homepage enters AI mode without submitting a query (e.g. to run /init).
+        await expectLogic(logic, () => {
+            logic.actions.enterAiMode('/')
+        }).toMatchValues({
+            mode: 'ai',
+            // No query was submitted yet, so the thread hasn't started.
+            threadStarted: false,
+        })
+
+        // Submitting the slash command goes through Max's askMax (on the homepage tab), not submitQuery.
+        await expectLogic(logic, () => {
+            homepageMaxLogic.actions.askMax('/init')
+        }).toMatchValues({
+            threadStarted: true,
+        })
+    })
+
+    it('resets threadStarted when (re-)entering AI mode via a trigger', async () => {
+        // A previously-sent message leaves the thread flag set.
+        await expectLogic(logic, () => {
+            homepageMaxLogic.actions.askMax('/init')
+        }).toMatchValues({
+            threadStarted: true,
+        })
+
+        // (Re-)entering AI mode via the "/" or "@" trigger opens command mode without sending, so the
+        // thread flag must reset — a stale flag would otherwise flash an empty thread.
+        await expectLogic(logic, () => {
+            logic.actions.enterAiMode('@')
+        }).toMatchValues({
+            threadStarted: false,
+        })
+    })
+})

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -93,7 +93,7 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         ],
         actions: [
             maxLogic({ panelId: HOMEPAGE_TAB_ID }),
-            ['openConversation', 'startNewConversation', 'setQuestion'],
+            ['openConversation', 'startNewConversation', 'setQuestion', 'askMax'],
             handsFreeLogic({ panelId: HOMEPAGE_TAB_ID }),
             ['enterHandsFree'],
             sceneLogic,
@@ -150,6 +150,13 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             false,
             {
                 submitQuery: (_, { mode }) => mode === 'ai',
+                // Entering AI mode via the "/" or "@" trigger opens command mode without submitting a
+                // query, so there's no thread yet — reset, so a stale flag can't show an empty thread.
+                enterAiMode: () => false,
+                // Once a message is actually sent (e.g. a /init slash command submitted through Max's
+                // input), askMax fires on the homepage tab and the thread must become visible —
+                // otherwise the conversation streams into a blank, hidden thread.
+                askMax: () => true,
                 returnToIdle: () => false,
             },
         ],


### PR DESCRIPTION
## Problem

Closes #60183

On the project homepage, typing `/init` (or any slash command) into the "What can I help you with?" box leaves the conversation invisible:

1. You type `/init` and press Enter.
2. PostHog AI appears to accept it — the title changes to *"Setting up PostHog project configurations"* and the input shows *"Thinking…"*.
3. But the message area stays **completely blank** — you can't see the AI's questions or reply.
4. The conversation is actually running: open it from **Chat** in the sidebar and the full thread is there. Only the homepage entry point is broken.

## Changes

Root cause: the homepage renders the thread only when `threadStarted` is set (`AiFirstHomepage.tsx`: `{isAi && threadStarted && <HomepageThread />}`), and `threadStarted` was set **only** by `submitQuery('ai')` (type-a-question-and-Enter). Typing `/` instead goes through `enterAiMode` (opens command mode without sending) and never set the flag; the slash command is then sent via Max's input (`maxThreadLogic.askMax`), so the thread never mounted.

Fix: react to `askMax` — which on the homepage tab is the connected `maxLogic({ tabId: HOMEPAGE_TAB_ID }).askMax` — so the thread mounts on any real send (typed question, `/` or `@` trigger). Also reset the flag on `enterAiMode` so a stale value can't flash an empty thread.

```ts
threadStarted: [ false, {
    submitQuery: (_, { mode }) => mode === 'ai',
    enterAiMode: () => false,
    askMax: () => true,
    returnToIdle: () => false,
}],
```

This mirrors how `maxThreadLogic` already reacts to the connected `askMax` in its own reducers.

**Demo** (recorded against the real component with a mocked conversation stream — the rendered thread shows mock content; the point is thread mounts vs. stays blank):

**Before** — message area stays blank after `/init`:

<img width="900" alt="before" src="https://github.com/user-attachments/assets/ed36dc33-5b92-46e3-bce8-33e4129dd5ee" />

**After** — the thread renders:

<img width="900" alt="after" src="https://github.com/user-attachments/assets/f3b7adf3-58a2-4bba-9c80-6059331517de" />

### Out of scope (follow-up)

Refreshing `/home?mode=ai` after starting via the `/` trigger still loses the conversation, because that path doesn't write `?chat=<id>` to the URL (`setConversationId` routes to the standalone `/ai` URL instead). Pre-existing and separate — happy to follow up.

## How did you test this code?

I'm an agent; I ran the automated tests below and the human author verified the before/after manually.

Automated — `aiFirstHomepageLogic.test.ts` (3 tests, all passing):
- typed-question path still sets `threadStarted`;
- `/`-trigger → `askMax('/init')` now sets it (this test fails before the fix — it's the regression guard);
- `enterAiMode` resets it.

Manual — verified before/after in Storybook against a mocked conversation stream (no LLM key needed): blank thread before, rendered thread after (see demo above).

## Publish to changelog?

No — bug fix.

## Docs update

No docs needed (internal logic fix). Adding the `skip-inkeep-docs` label.

## 🤖 Agent context

Agent-assisted, human-driven. Tool: Claude Code (Opus 4.7). The change was cross-reviewed by Codex and a code-review agent before submission; all automated tests above were run by the agent.

Key decisions:
- Reacting to the connected `askMax` action was chosen over gating on the conversation id / URL — the latter would deadlock the existing `submitQuery` path, which mounts the thread *before* a conversation id exists so its own `askMax` can fire.
- The `enterAiMode: () => false` reset was added defensively to prevent a stale flag from flashing an empty thread.
- A Storybook story was prototyped to verify the fix visually, then dropped from the diff to keep it focused.
- URL persistence on refresh was deliberately scoped out as a separate issue (noted above).
