### PR TITLE
fix(data-warehouse): expose saved query dependency blockers

### DIFF
--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -208,8 +208,10 @@ tools:
         title: Update dashboard
         description: >
             Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and
-            restriction level. The returned tiles omit insight results to save context — use dashboard-insights-run to
-            fetch the actual data for each insight.
+            restriction level. Can also create or update text and button tiles via `tiles`; call dashboard-get first and
+            include existing tile layout fields you want to keep. Manage insight tiles with the insight tools and
+            dashboard-reorder-tiles. The returned tiles omit insight results to save context — use
+            dashboard-insights-run to fetch the actual data for each insight.
         exclude_params:
             - creation_mode
             - effective_restriction_level

--- a/products/data_modeling/backend/services/saved_query_dag_sync.py
+++ b/products/data_modeling/backend/services/saved_query_dag_sync.py
@@ -238,20 +238,28 @@ def clear_stale_dependent_edges(saved_query: "DataWarehouseSavedQuery") -> None:
         .exclude(saved_query__deleted=True)
     )
 
+    stale_target_nodes: list[tuple[Node, str]] = []
     for dependent_node in dependent_nodes:
         dependent = dependent_node.saved_query
         if not dependent or _saved_query_references_dependency(dependent, saved_query):
             continue
 
-        Edge.objects.filter(
-            team=saved_query.team,
-            source=source_node,
-            target=dependent_node,
-        ).delete()
+        stale_target_nodes.append((dependent_node, dependent.name))
+
+    if not stale_target_nodes:
+        return
+
+    Edge.objects.filter(
+        team=saved_query.team,
+        source=source_node,
+        target__in=[dependent_node for dependent_node, _ in stale_target_nodes],
+    ).delete()
+
+    for _, dependent_name in stale_target_nodes:
         logger.info(
             "Removed stale saved query dependency edge",
             saved_query_name=saved_query.name,
-            dependent_saved_query_name=dependent.name,
+            dependent_saved_query_name=dependent_name,
         )
 
 

--- a/products/data_modeling/backend/services/saved_query_dag_sync.py
+++ b/products/data_modeling/backend/services/saved_query_dag_sync.py
@@ -175,7 +175,9 @@ def sync_saved_query_to_dag(
 class HasDependentsError(Exception):
     """Raised when attempting to delete a saved query that has dependents."""
 
-    pass
+    def __init__(self, dependents: list["DataWarehouseSavedQuery"]) -> None:
+        self.dependents = dependents
+        super().__init__("Node cannot be deleted because it has dependents")
 
 
 def get_dependent_saved_queries(saved_query: "DataWarehouseSavedQuery") -> list["DataWarehouseSavedQuery"]:
@@ -188,12 +190,92 @@ def get_dependent_saved_queries(saved_query: "DataWarehouseSavedQuery") -> list[
     node = Node.objects.filter(team=saved_query.team, saved_query=saved_query).first()
     if not node:
         return []
-    deps = Node.objects.filter(
-        team=saved_query.team,
-        incoming_edges__source=node,
-        saved_query__isnull=False,
-    ).select_related("saved_query")
+    deps = (
+        Node.objects.filter(
+            team=saved_query.team,
+            incoming_edges__source=node,
+            saved_query__isnull=False,
+        )
+        .select_related("saved_query")
+        .order_by("saved_query__name")
+    )
     return [d.saved_query for d in deps if d.saved_query and not d.saved_query.deleted]
+
+
+def _saved_query_references_dependency(
+    saved_query: "DataWarehouseSavedQuery", dependency: "DataWarehouseSavedQuery"
+) -> bool:
+    query = saved_query.query.get("query") if saved_query.query else None
+    if not query:
+        return False
+
+    try:
+        parents = get_parents_from_model_query(saved_query.team, saved_query.name, query)
+    except Exception:
+        logger.exception(
+            "Failed to verify saved query dependency while deleting view",
+            saved_query_name=saved_query.name,
+            dependency_name=dependency.name,
+        )
+        return True
+
+    return dependency.name in parents
+
+
+def clear_stale_dependent_edges(saved_query: "DataWarehouseSavedQuery") -> None:
+    """Remove DAG edges whose dependent query no longer references this saved query."""
+    source_node = Node.objects.filter(team=saved_query.team, saved_query=saved_query).first()
+    if not source_node:
+        return
+
+    dependent_nodes = (
+        Node.objects.filter(
+            team=saved_query.team,
+            incoming_edges__source=source_node,
+            saved_query__isnull=False,
+        )
+        .select_related("saved_query")
+        .exclude(saved_query__deleted=True)
+    )
+
+    for dependent_node in dependent_nodes:
+        dependent = dependent_node.saved_query
+        if not dependent or _saved_query_references_dependency(dependent, saved_query):
+            continue
+
+        Edge.objects.filter(
+            team=saved_query.team,
+            source=source_node,
+            target=dependent_node,
+        ).delete()
+        logger.info(
+            "Removed stale saved query dependency edge",
+            saved_query_name=saved_query.name,
+            dependent_saved_query_name=dependent.name,
+        )
+
+
+def get_blocking_dependent_saved_queries(saved_query: "DataWarehouseSavedQuery") -> list["DataWarehouseSavedQuery"]:
+    clear_stale_dependent_edges(saved_query)
+    return get_dependent_saved_queries(saved_query)
+
+
+def get_dependent_saved_query_summaries(
+    saved_query: "DataWarehouseSavedQuery", refresh_stale_edges: bool = False
+) -> list[dict[str, str]]:
+    dependents = (
+        get_blocking_dependent_saved_queries(saved_query)
+        if refresh_stale_edges
+        else get_dependent_saved_queries(saved_query)
+    )
+    return [{"id": str(dependent.id), "name": dependent.name} for dependent in dependents]
+
+
+def _delete_saved_query_node(saved_query: "DataWarehouseSavedQuery") -> None:
+    Node.objects.filter(
+        team=saved_query.team,
+        saved_query=saved_query,
+    ).delete()
 
 
 def delete_node_from_dag(saved_query: "DataWarehouseSavedQuery") -> None:
@@ -202,10 +284,10 @@ def delete_node_from_dag(saved_query: "DataWarehouseSavedQuery") -> None:
 
     Must be called BEFORE soft_delete() due to on_delete=PROTECT on the saved_query FK.
     """
-    deps = get_dependent_saved_queries(saved_query)
+    deps = get_blocking_dependent_saved_queries(saved_query)
     if deps:
-        raise HasDependentsError("Node cannot be deleted because it has dependents")
-    Node.objects.filter(team=saved_query.team, saved_query=saved_query).delete()
+        raise HasDependentsError(deps)
+    _delete_saved_query_node(saved_query)
 
 
 def update_node_type(saved_query: "DataWarehouseSavedQuery", type: NodeType) -> None:

--- a/products/data_modeling/backend/test/test_saved_query_dag_sync.py
+++ b/products/data_modeling/backend/test/test_saved_query_dag_sync.py
@@ -298,8 +298,9 @@ class TestDeleteNodeFromDag(BaseTest):
             query={"query": "SELECT * FROM upstream_view", "kind": "HogQLQuery"},
         )
         sync_saved_query_to_dag(downstream)
-        with self.assertRaises(HasDependentsError):
+        with self.assertRaises(HasDependentsError) as context:
             delete_node_from_dag(upstream)
+        self.assertEqual(context.exception.dependents, [downstream])
 
     def test_delete_succeeds_when_no_dependents(self):
         upstream = DataWarehouseSavedQuery.objects.create(

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -184,6 +184,17 @@ class DataWarehouseSavedQueryMinimalSerializer(
         read_only_fields = fields
 
 
+class DataWarehouseSavedQueryDependencySummarySerializer(serializers.Serializer):
+    id = serializers.CharField()
+    name = serializers.CharField()
+
+
+class DataWarehouseSavedQueryDependenciesSerializer(serializers.Serializer):
+    upstream_count = serializers.IntegerField()
+    downstream_count = serializers.IntegerField()
+    downstream_saved_queries = DataWarehouseSavedQueryDependencySummarySerializer(many=True)
+
+
 class DataWarehouseSavedQuerySerializer(
     DataWarehouseSavedQuerySerializerMixin, UserAccessControlSerializerMixin, serializers.ModelSerializer
 ):
@@ -813,9 +824,18 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
         instance: DataWarehouseSavedQuery = self.get_object()
         try:
             delete_saved_query(instance)
-        except HasDependentsError:
+        except HasDependentsError as error:
             raise serializers.ValidationError(
-                "Cannot delete this view because other views depend on it. Delete or update those views first."
+                {
+                    "detail": "Cannot delete this view because other views depend on it. Delete or update those views first.",
+                    "dependents": [
+                        {
+                            "id": str(dependent.id),
+                            "name": dependent.name,
+                        }
+                        for dependent in error.dependents
+                    ],
+                }
             )
 
         return response.Response(status=status.HTTP_204_NO_CONTENT)
@@ -1118,9 +1138,12 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
 
         return response.Response(status=status.HTTP_200_OK)
 
+    @extend_schema(responses=DataWarehouseSavedQueryDependenciesSerializer)
     @action(methods=["GET"], detail=True)
     def dependencies(self, request: request.Request, *args, **kwargs) -> response.Response:
         """Return the count of immediate upstream and downstream dependencies for this saved query."""
+        from products.data_modeling.backend.services.saved_query_dag_sync import get_dependent_saved_query_summaries
+
         saved_query = self.get_object()
         saved_query_id = saved_query.id.hex
 
@@ -1151,7 +1174,13 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
             except ValueError:
                 continue
 
-        return response.Response({"upstream_count": len(upstream_ids), "downstream_count": len(downstream_ids)})
+        return response.Response(
+            {
+                "upstream_count": len(upstream_ids),
+                "downstream_count": len(downstream_ids),
+                "downstream_saved_queries": get_dependent_saved_query_summaries(saved_query),
+            }
+        )
 
     @action(methods=["GET"], detail=True, required_scopes=["warehouse_view:read"])
     def run_history(self, request: request.Request, *args, **kwargs) -> response.Response:

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -1158,27 +1158,13 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
                 parent_id = path.path[-2]
                 upstream_ids.add(parent_id)
 
-        # Count immediate downstream (children) - get unique children that reference this node
-        downstream_paths = DataWarehouseModelPath.objects.filter(
-            team=saved_query.team, path__lquery=f"*.{saved_query_id}.*"
-        )
-        downstream_ids: set[str] = set()
-        for path in downstream_paths:
-            # Find position of current view in path
-            try:
-                idx = path.path.index(saved_query_id)
-                if idx + 1 < len(path.path):
-                    # Get immediate child (next node after current)
-                    child_id = path.path[idx + 1]
-                    downstream_ids.add(child_id)
-            except ValueError:
-                continue
+        downstream_saved_queries = get_dependent_saved_query_summaries(saved_query, refresh_stale_edges=True)
 
         return response.Response(
             {
                 "upstream_count": len(upstream_ids),
-                "downstream_count": len(downstream_ids),
-                "downstream_saved_queries": get_dependent_saved_query_summaries(saved_query),
+                "downstream_count": len(downstream_saved_queries),
+                "downstream_saved_queries": downstream_saved_queries,
             }
         )
 

--- a/products/data_warehouse/backend/api/test/test_saved_query.py
+++ b/products/data_warehouse/backend/api/test/test_saved_query.py
@@ -11,6 +11,7 @@ from posthog.models import ActivityLog
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJob
 from products.data_modeling.backend.models.datawarehouse_managed_viewset import DataWarehouseManagedViewSet
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_modeling.backend.models.edge import Edge
 from products.data_modeling.backend.models.modeling import DataWarehouseModelPath
 from products.data_tools.backend.models.datawarehouse_saved_query_folder import DataWarehouseSavedQueryFolder
 from products.data_warehouse.backend.types import DataWarehouseManagedViewSetKind
@@ -1420,6 +1421,115 @@ class TestSavedQuery(APIBaseTest):
         data = response.json()
         self.assertEqual(data["upstream_count"], 1)  # child_view (only immediate parent)
         self.assertEqual(data["downstream_count"], 0)  # No downstream
+
+    def test_dependencies_returns_downstream_saved_query_details(self):
+        response_parent = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
+            {
+                "name": "parent_view",
+                "query": {
+                    "kind": "HogQLQuery",
+                    "query": "select event as event from events LIMIT 100",
+                },
+            },
+        )
+        self.assertEqual(response_parent.status_code, 201)
+        parent_id = response_parent.json()["id"]
+
+        response_child = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
+            {
+                "name": "child_view",
+                "query": {
+                    "kind": "HogQLQuery",
+                    "query": "select event as event from parent_view LIMIT 50",
+                },
+            },
+        )
+        self.assertEqual(response_child.status_code, 201)
+        child_id = response_child.json()["id"]
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{parent_id}/dependencies",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["downstream_saved_queries"], [{"id": child_id, "name": "child_view"}])
+
+    def test_destroy_with_dependents_returns_blocking_view_details(self):
+        response_parent = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
+            {
+                "name": "parent_view",
+                "query": {
+                    "kind": "HogQLQuery",
+                    "query": "select event as event from events LIMIT 100",
+                },
+            },
+        )
+        self.assertEqual(response_parent.status_code, 201)
+        parent_id = response_parent.json()["id"]
+
+        response_child = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
+            {
+                "name": "child_view",
+                "query": {
+                    "kind": "HogQLQuery",
+                    "query": "select event as event from parent_view LIMIT 50",
+                },
+            },
+        )
+        self.assertEqual(response_child.status_code, 201)
+        child_id = response_child.json()["id"]
+
+        response = self.client.delete(f"/api/environments/{self.team.id}/warehouse_saved_queries/{parent_id}")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["detail"],
+            "Cannot delete this view because other views depend on it. Delete or update those views first.",
+        )
+        self.assertEqual(response.json()["dependents"], [{"id": child_id, "name": "child_view"}])
+
+    def test_destroy_clears_stale_dag_edges_before_blocking_delete(self):
+        response_parent = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
+            {
+                "name": "parent_view",
+                "query": {
+                    "kind": "HogQLQuery",
+                    "query": "select event as event from events LIMIT 100",
+                },
+            },
+        )
+        self.assertEqual(response_parent.status_code, 201)
+        parent_id = response_parent.json()["id"]
+
+        response_child = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
+            {
+                "name": "child_view",
+                "query": {
+                    "kind": "HogQLQuery",
+                    "query": "select event as event from parent_view LIMIT 50",
+                },
+            },
+        )
+        self.assertEqual(response_child.status_code, 201)
+        child_id = response_child.json()["id"]
+
+        child = DataWarehouseSavedQuery.objects.get(id=child_id)
+        child.query = {"kind": "HogQLQuery", "query": "select event as event from events LIMIT 50"}
+        child.save(update_fields=["query"])
+        self.assertTrue(Edge.objects.filter(source__saved_query_id=parent_id, target__saved_query_id=child_id).exists())
+
+        response = self.client.delete(f"/api/environments/{self.team.id}/warehouse_saved_queries/{parent_id}")
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(
+            Edge.objects.filter(source__saved_query_id=parent_id, target__saved_query_id=child_id).exists()
+        )
 
     def test_run_history_no_runs(self):
         """Test run_history endpoint returns empty array for a view with no runs"""

--- a/products/data_warehouse/backend/api/test/test_saved_query.py
+++ b/products/data_warehouse/backend/api/test/test_saved_query.py
@@ -1524,6 +1524,17 @@ class TestSavedQuery(APIBaseTest):
         child.save(update_fields=["query"])
         self.assertTrue(Edge.objects.filter(source__saved_query_id=parent_id, target__saved_query_id=child_id).exists())
 
+        dependencies_response = self.client.get(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{parent_id}/dependencies",
+        )
+
+        self.assertEqual(dependencies_response.status_code, 200)
+        self.assertEqual(dependencies_response.json()["downstream_count"], 0)
+        self.assertEqual(dependencies_response.json()["downstream_saved_queries"], [])
+        self.assertFalse(
+            Edge.objects.filter(source__saved_query_id=parent_id, target__saved_query_id=child_id).exists()
+        )
+
         response = self.client.delete(f"/api/environments/{self.team.id}/warehouse_saved_queries/{parent_id}")
 
         self.assertEqual(response.status_code, 204)

--- a/products/data_warehouse/mcp/tools.yaml
+++ b/products/data_warehouse/mcp/tools.yaml
@@ -575,8 +575,25 @@ tools:
         description: >
             Delete a data warehouse saved query (view) by ID. This is a soft delete — the view is marked as deleted and
             will no longer appear in lists or be queryable in HogQL. Any materialization schedule is also removed.
-            Cannot delete views that have downstream dependencies or views from managed viewsets.
+            Cannot delete views that have downstream dependencies or views from managed viewsets. When deletion is
+            blocked by dependent views, the error includes the blocking view IDs and names; call view-dependencies first
+            when you need to inspect blockers without attempting deletion.
         soft_delete: true
+    view-dependencies:
+        operation: warehouse_saved_queries_dependencies_retrieve
+        enabled: true
+        scopes:
+            - warehouse_view:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        enrich_url: ?open_view={params.id}
+        title: Get saved query dependencies
+        description: >
+            Get immediate dependency information for a data warehouse saved query (view). Returns upstream and
+            downstream dependency counts plus the downstream saved-query IDs and names that would block deletion. Use
+            this before deleting or renaming a view that may be referenced by other views.
     view-get:
         operation: warehouse_saved_queries_retrieve
         enabled: true
@@ -718,9 +735,6 @@ tools:
         enabled: false
     warehouse-saved-queries-cancel-create:
         operation: warehouse_saved_queries_cancel_create
-        enabled: false
-    warehouse-saved-queries-dependencies-retrieve:
-        operation: warehouse_saved_queries_dependencies_retrieve
         enabled: false
     warehouse-saved-queries-descendants-create:
         operation: warehouse_saved_queries_descendants_create

--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -151,7 +151,9 @@ tools:
         description: >
             Update a saved insight by numeric `id` or `short_id`. Can update name, description, query, tags, favorited
             status, and dashboards. Returns insight metadata only — after updating the query, call the insight-query
-            tool with the same identifier if you want to see the recomputed results.
+            tool with the same identifier if you want to see the recomputed results. Before changing only part of the
+            query, call insight-get and submit the full updated query object so existing chart, table, formula, and
+            interval settings are preserved.
         exclude_params:
             - query
         include_params:
@@ -163,6 +165,9 @@ tools:
         param_overrides:
             query:
                 schema_ref: InsightQuery
+                description: >
+                    Full replacement query object for the insight. Call insight-get first, copy the existing query, and
+                    change only the fields you intend to update; omitting nested settings can reset them.
             dashboards:
                 description: >
                     Dashboard IDs this insight should belong to. This is a full replacement — always include all

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1110,7 +1110,7 @@
         }
     },
     "dashboard-update": {
-        "description": "Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and restriction level. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
+        "description": "Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and restriction level. Can also create or update text and button tiles via `tiles`; call dashboard-get first and include existing tile layout fields you want to keep. Manage insight tiles with the insight tools and dashboard-reorder-tiles. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Update dashboard",
@@ -2610,7 +2610,7 @@
         }
     },
     "insight-update": {
-        "description": "Update a saved insight by numeric `id` or `short_id`. Can update name, description, query, tags, favorited status, and dashboards. Returns insight metadata only — after updating the query, call the insight-query tool with the same identifier if you want to see the recomputed results.",
+        "description": "Update a saved insight by numeric `id` or `short_id`. Can update name, description, query, tags, favorited status, and dashboards. Returns insight metadata only — after updating the query, call the insight-query tool with the same identifier if you want to see the recomputed results. Before changing only part of the query, call insight-get and submit the full updated query object so existing chart, table, formula, and interval settings are preserved.",
         "category": "Product analytics",
         "feature": "product_analytics",
         "summary": "Update insight",
@@ -5414,7 +5414,7 @@
         }
     },
     "view-delete": {
-        "description": "Delete a data warehouse saved query (view) by ID. This is a soft delete — the view is marked as deleted and will no longer appear in lists or be queryable in HogQL. Any materialization schedule is also removed. Cannot delete views that have downstream dependencies or views from managed viewsets.",
+        "description": "Delete a data warehouse saved query (view) by ID. This is a soft delete — the view is marked as deleted and will no longer appear in lists or be queryable in HogQL. Any materialization schedule is also removed. Cannot delete views that have downstream dependencies or views from managed viewsets. When deletion is blocked by dependent views, the error includes the blocking view IDs and names; call view-dependencies first when you need to inspect blockers without attempting deletion.",
         "category": "Data warehouse",
         "feature": "data_warehouse",
         "summary": "Delete saved query",
@@ -5426,6 +5426,21 @@
             "idempotentHint": false,
             "openWorldHint": true,
             "readOnlyHint": false
+        }
+    },
+    "view-dependencies": {
+        "description": "Get immediate dependency information for a data warehouse saved query (view). Returns upstream and downstream dependency counts plus the downstream saved-query IDs and names that would block deletion. Use this before deleting or renaming a view that may be referenced by other views.",
+        "category": "Data warehouse",
+        "feature": "data_warehouse",
+        "summary": "Get saved query dependencies",
+        "title": "Get saved query dependencies",
+        "required_scopes": ["warehouse_view:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         }
     },
     "view-get": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1127,7 +1127,7 @@
         }
     },
     "dashboard-update": {
-        "description": "Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and restriction level. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
+        "description": "Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and restriction level. Can also create or update text and button tiles via `tiles`; call dashboard-get first and include existing tile layout fields you want to keep. Manage insight tiles with the insight tools and dashboard-reorder-tiles. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Update dashboard",
@@ -2923,7 +2923,7 @@
         }
     },
     "insight-update": {
-        "description": "Update a saved insight by numeric `id` or `short_id`. Can update name, description, query, tags, favorited status, and dashboards. Returns insight metadata only — after updating the query, call the insight-query tool with the same identifier if you want to see the recomputed results.",
+        "description": "Update a saved insight by numeric `id` or `short_id`. Can update name, description, query, tags, favorited status, and dashboards. Returns insight metadata only — after updating the query, call the insight-query tool with the same identifier if you want to see the recomputed results. Before changing only part of the query, call insight-get and submit the full updated query object so existing chart, table, formula, and interval settings are preserved.",
         "category": "Product analytics",
         "feature": "product_analytics",
         "summary": "Update insight",
@@ -5895,7 +5895,7 @@
         }
     },
     "view-delete": {
-        "description": "Delete a data warehouse saved query (view) by ID. This is a soft delete — the view is marked as deleted and will no longer appear in lists or be queryable in HogQL. Any materialization schedule is also removed. Cannot delete views that have downstream dependencies or views from managed viewsets.",
+        "description": "Delete a data warehouse saved query (view) by ID. This is a soft delete — the view is marked as deleted and will no longer appear in lists or be queryable in HogQL. Any materialization schedule is also removed. Cannot delete views that have downstream dependencies or views from managed viewsets. When deletion is blocked by dependent views, the error includes the blocking view IDs and names; call view-dependencies first when you need to inspect blockers without attempting deletion.",
         "category": "Data warehouse",
         "feature": "data_warehouse",
         "summary": "Delete saved query",
@@ -5907,6 +5907,21 @@
             "idempotentHint": false,
             "openWorldHint": true,
             "readOnlyHint": false
+        }
+    },
+    "view-dependencies": {
+        "description": "Get immediate dependency information for a data warehouse saved query (view). Returns upstream and downstream dependency counts plus the downstream saved-query IDs and names that would block deletion. Use this before deleting or renaming a view that may be referenced by other views.",
+        "category": "Data warehouse",
+        "feature": "data_warehouse",
+        "summary": "Get saved query dependencies",
+        "title": "Get saved query dependencies",
+        "required_scopes": ["warehouse_view:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         }
     },
     "view-get": {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11538,6 +11538,17 @@ export namespace Schemas {
       readonly user_access_level: string | null;
     }
 
+    export interface DataWarehouseSavedQueryDependencySummary {
+      id: string;
+      name: string;
+    }
+
+    export interface DataWarehouseSavedQueryDependencies {
+      upstream_count: number;
+      downstream_count: number;
+      downstream_saved_queries: DataWarehouseSavedQueryDependencySummary[];
+    }
+
     export interface DataWarehouseSavedQueryDraft {
       readonly id: string;
       readonly created_at: string;

--- a/services/mcp/src/generated/data_warehouse/api.ts
+++ b/services/mcp/src/generated/data_warehouse/api.ts
@@ -1064,6 +1064,18 @@ export const WarehouseSavedQueriesRetrieveParams = /* @__PURE__ */ zod.object({
 /**
  * Create, Read, Update and Delete Warehouse Tables.
  */
+export const WarehouseSavedQueriesDependenciesRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this data warehouse saved query.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Create, Read, Update and Delete Warehouse Tables.
+ */
 export const WarehouseSavedQueriesPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this data warehouse saved query.'),
     project_id: zod

--- a/services/mcp/src/tools/generated/data_warehouse.ts
+++ b/services/mcp/src/tools/generated/data_warehouse.ts
@@ -38,6 +38,7 @@ import {
     InsightVariablesPartialUpdateBody,
     InsightVariablesPartialUpdateParams,
     WarehouseSavedQueriesCreateBody,
+    WarehouseSavedQueriesDependenciesRetrieveParams,
     WarehouseSavedQueriesDestroyParams,
     WarehouseSavedQueriesListQueryParams,
     WarehouseSavedQueriesMaterializeCreateBody,
@@ -861,6 +862,24 @@ const viewDelete = (): ToolBase<typeof ViewDeleteSchema, Schemas.DataWarehouseSa
     },
 })
 
+const ViewDependenciesSchema = WarehouseSavedQueriesDependenciesRetrieveParams.omit({ project_id: true })
+
+const viewDependencies = (): ToolBase<
+    typeof ViewDependenciesSchema,
+    WithPostHogUrl<Schemas.DataWarehouseSavedQueryDependencies>
+> => ({
+    name: 'view-dependencies',
+    schema: ViewDependenciesSchema,
+    handler: async (context: Context, params: z.infer<typeof ViewDependenciesSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.DataWarehouseSavedQueryDependencies>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/warehouse_saved_queries/${encodeURIComponent(String(params.id))}/dependencies/`,
+        })
+        return await withPostHogUrl(context, result, `/sql/?open_view=${params.id}`)
+    },
+})
+
 const ViewGetSchema = WarehouseSavedQueriesRetrieveParams.omit({ project_id: true })
 
 const viewGet = (): ToolBase<typeof ViewGetSchema, WithPostHogUrl<Schemas.DataWarehouseSavedQuery>> => ({
@@ -1129,6 +1148,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'sql-variables-update': sqlVariablesUpdate,
     'view-create': viewCreate,
     'view-delete': viewDelete,
+    'view-dependencies': viewDependencies,
     'view-get': viewGet,
     'view-list': viewList,
     'view-materialize': viewMaterialize,


### PR DESCRIPTION
## Summary

- Remove stale saved-query DAG edges before delete dependency checks so obsolete edges do not keep blocking view deletion.
- Return blocking dependent saved query IDs and names from delete failures and the dependencies endpoint.
- Expose the saved-query dependencies endpoint as the `view-dependencies` MCP tool.
- Tighten MCP guidance for saved-query delete, insight query updates, and dashboard tile updates so agents preserve existing state.

## Validation

- `uv run ruff check products/data_modeling/backend/services/saved_query_dag_sync.py products/data_modeling/backend/test/test_saved_query_dag_sync.py products/data_warehouse/backend/api/saved_query.py products/data_warehouse/backend/api/test/test_saved_query.py`
- `uv run ruff format --check products/data_modeling/backend/services/saved_query_dag_sync.py products/data_modeling/backend/test/test_saved_query_dag_sync.py products/data_warehouse/backend/api/saved_query.py products/data_warehouse/backend/api/test/test_saved_query.py`
- `pnpm --filter=@posthog/mcp run lint-tool-names`
- `pnpm --filter=@posthog/mcp run typecheck`
- JSON parse check for `services/mcp/schema/generated-tool-definitions.json` and `services/mcp/schema/tool-definitions-all.json`
- Commit hook ran staged YAML/JS/Python format and Python `uv run ty check`

## Notes

I could not run the targeted Django tests locally because this environment has no Docker and the test database host `db` does not resolve. The failing command stopped during database setup before test execution.