### PR TITLE
feat(capture): handle additive changes to event.options in v1

### DIFF
--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -53,7 +53,7 @@ pub struct Batch {
     pub batch: Vec<Event>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cookieless_mode: Option<bool>,
@@ -73,6 +73,7 @@ pub struct Event {
     pub timestamp: String,
     pub session_id: Option<String>,
     pub window_id: Option<String>,
+    #[serde(default)]
     pub options: Options,
     #[serde(default = "empty_raw_object")]
     pub properties: Box<RawValue>,
@@ -640,7 +641,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_event_missing_options_fails() {
+    fn parse_event_missing_options_defaults() {
         let json = r#"{
             "created_at": "2026-03-19T14:30:00.000Z",
             "batch": [{
@@ -650,7 +651,12 @@ mod tests {
                 "timestamp": "2026-03-19T14:29:58.123Z"
             }]
         }"#;
-        assert!(serde_json::from_str::<Batch>(json).is_err());
+        let batch: Batch = serde_json::from_str(json).unwrap();
+        let event = &batch.batch[0];
+        assert_eq!(event.options.cookieless_mode, None);
+        assert_eq!(event.options.disable_skew_correction, None);
+        assert_eq!(event.options.product_tour_id, None);
+        assert_eq!(event.options.process_person_profile, None);
     }
 
     #[test]


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
By adding an `event.options` KV map to the capture v1 event payloads, we can avoid deserializing the large `event.properties` maps entirely, and ensure that the (few) conditional properties capture must hydrate and act on in v1 are isolated.

However, in order to ensure SDKs can be upgraded lazily as end user clients upgrade (mobile etc.) we don't want to fix the client side schema for `event.options`. This PR (and a related one to the RFC/OpenAPI spec) propose the following plan:
* Rust code should apply reasonable defaults for all `event.options` fields
* Rust code should apply an empty all-default-values `event.options` if the map is missing from submitted events
* SDKs should apply keys and values to `event.options` only when the user sets them on `capture_v1` submitted events (i.e. when the new endpoint is configured for capture calls)

This allows safe, additive feature evolution for the SDKs and the capture service. A new feature (`event.options` property) can be added to the Rust code with a reasonable default value, and each SDK can roll out matching support in isolation. End users of the SDKs can also update lazily to pick up the new feature at their own speed (mobile etc.)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Make `event.options` conditional on incoming event payloads
* Ensure capture v1 applies a default Options struct if `event.options` is missing on payloads
* Ensure reasonable defaults are applied for all `event.options` keys that are not set
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
Eli planned; Claude coded
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
