### PR TITLE
chore(ci): add permissions to visual regression job

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -258,6 +258,9 @@ jobs:
         # Talk to #team-devex before changing.
         runs-on: depot-ubuntu-latest-8
         timeout-minutes: 45
+        permissions:
+            contents: read
+            pull-requests: write
         outputs:
             vr_run_id: ${{ steps.vr-create.outputs.run_id }}
         steps:

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -269,10 +269,6 @@ jobs:
                   ref: ${{ github.event.pull_request.head.sha || github.sha }}
                   repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
                   clean: false
-                  # PR-controlled code runs in this job (pnpm installs, Playwright tests). Don't leave
-                  # GITHUB_TOKEN in .git/config where that code could read it — the comment step
-                  # below receives the token explicitly via its `github-token:` input instead.
-                  persist-credentials: false
             - name: Clean up data directories with container permissions
               run: |
                   # Use docker to clean up files created by containers

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -269,6 +269,10 @@ jobs:
                   ref: ${{ github.event.pull_request.head.sha || github.sha }}
                   repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
                   clean: false
+                  # PR-controlled code runs in this job (pnpm installs, Playwright tests). Don't leave
+                  # GITHUB_TOKEN in .git/config where that code could read it — the comment step
+                  # below receives the token explicitly via its `github-token:` input instead.
+                  persist-credentials: false
             - name: Clean up data directories with container permissions
               run: |
                   # Use docker to clean up files created by containers


### PR DESCRIPTION
## Problem

The visual regression job in the Playwright E2E CI workflow needs explicit permissions to write pull request comments when reporting visual regression results.

## Changes

Added `permissions` configuration to the visual regression job:
- `contents: read` — allows reading repository contents
- `pull-requests: write` — allows writing comments to pull requests

This enables the job to post visual regression reports as PR comments.

## How did you test this code?

No testing needed — this is a CI configuration change that will be validated when the workflow runs.

## Publish to changelog?

no

https://claude.ai/code/session_01XaTPc98EK8n9pCpDfxRHUX