### PR TITLE
fix(slack): ignore app_mention events authored by other bots

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1074,19 +1074,27 @@ def _posthog_code_flag_subject(integration: Integration) -> User | None:
     return fallback.user if fallback else None
 
 
-def _is_app_mention_edit(event: dict[str, Any]) -> bool:
-    """Detect app_mention events Slack re-fires when a user edits a mentioning message.
+def _app_mention_ignore_reason(event: dict[str, Any]) -> str | None:
+    """Return a short reason if this app_mention shouldn't trigger the coding agent, else None.
 
-    Why: Slack sends a fresh app_mention with a new event_id when a previously-posted
-    mention is edited, which gives the resulting Temporal workflow a different
-    workflow_id and bypasses USE_EXISTING — so without this guard the edit kicks off
-    a second task in parallel with the original.
+    - "edit": Slack re-fires app_mention with a new event_id when a previously-posted
+      mention is edited. The new event_id bypasses Temporal workflow dedup, so without
+      this guard the edit spawns a duplicate task alongside the original.
+    - "bot_author": the message was authored by another Slack app/bot. Foreign bots
+      that quote `<@PostHog>` in their text (incident bots, alert relays, our own
+      notifications integration) would trigger reply loops on every re-post.
     """
-    if event.get("edited"):
-        return True
-    if event.get("subtype") == "message_changed":
-        return True
-    return False
+    if event.get("edited") or event.get("subtype") == "message_changed":
+        return "edit"
+    if (
+        event.get("bot_id")
+        or event.get("bot_profile")
+        or event.get("app_id")
+        or event.get("subtype") == "bot_message"
+        or event.get("user") == "USLACKBOT"
+    ):
+        return "bot_author"
+    return None
 
 
 def _posthog_code_enabled_for_integration(integration: Integration) -> bool:
@@ -1189,9 +1197,11 @@ def route_posthog_code_event_to_relevant_region(
 
     if local_match and not (settings.DEBUG and request.get_host() == SLACK_PRIMARY_REGION_DOMAIN):
         if event_type == "app_mention":
-            if _is_app_mention_edit(event):
+            ignore_reason = _app_mention_ignore_reason(event)
+            if ignore_reason:
                 logger.info(
-                    "posthog_code_event_edit_ignored",
+                    "posthog_code_event_app_mention_ignored",
+                    reason=ignore_reason,
                     slack_team_id=slack_team_id,
                     channel=event.get("channel"),
                     message_ts=event.get("ts"),

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1197,6 +1197,13 @@ def route_posthog_code_event_to_relevant_region(
 
     if local_match and not (settings.DEBUG and request.get_host() == SLACK_PRIMARY_REGION_DOMAIN):
         if event_type == "app_mention":
+            if not _posthog_code_enabled_for_integration(local_match):
+                logger.info(
+                    "posthog_code_event_flag_off",
+                    slack_team_id=slack_team_id,
+                    organization_id=str(local_match.team.organization_id),
+                )
+                return ROUTE_HANDLED_LOCALLY
             ignore_reason = _app_mention_ignore_reason(event)
             if ignore_reason:
                 logger.info(
@@ -1205,13 +1212,6 @@ def route_posthog_code_event_to_relevant_region(
                     slack_team_id=slack_team_id,
                     channel=event.get("channel"),
                     message_ts=event.get("ts"),
-                )
-                return ROUTE_HANDLED_LOCALLY
-            if not _posthog_code_enabled_for_integration(local_match):
-                logger.info(
-                    "posthog_code_event_flag_off",
-                    slack_team_id=slack_team_id,
-                    organization_id=str(local_match.team.organization_id),
                 )
                 return ROUTE_HANDLED_LOCALLY
             slack = SlackIntegration(local_match)

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -249,26 +249,31 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         [
             ("edited_field", {"edited": {"user": "U123", "ts": "1234.7777"}}),
             ("message_changed_subtype", {"subtype": "message_changed"}),
+            ("bot_id", {"bot_id": "B0ALERT"}),
+            ("bot_profile", {"bot_profile": {"name": "Mendral", "id": "B0ALERT"}}),
+            ("app_id", {"app_id": "A0ALERT"}),
+            ("bot_message_subtype", {"subtype": "bot_message"}),
+            ("slackbot_user", {"user": "USLACKBOT"}),
         ]
     )
     @patch("products.slack_app.backend.api._posthog_code_enabled_for_integration", return_value=True)
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
     @override_settings(DEBUG=False)
-    def test_app_mention_edit_does_not_start_workflow(
+    def test_app_mention_ignored_does_not_start_workflow(
         self,
         _name,
-        edit_marker: dict,
+        ignore_marker: dict,
         mock_sync_connect,
         mock_asyncio_run,
         _mock_flag,
     ):
         request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
-        edited_event = {**self.event, **edit_marker}
+        ignored_event = {**self.event, **ignore_marker}
 
         from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
 
-        result = route_posthog_code_event_to_relevant_region(request, edited_event, "T12345")
+        result = route_posthog_code_event_to_relevant_region(request, ignored_event, "T12345")
 
         assert result == ROUTE_HANDLED_LOCALLY
         mock_sync_connect.assert_not_called()


### PR DESCRIPTION
## Problem

When another Slack app posts a message whose body contains `<@PostHog>` (e.g. an incident bot that quotes a PR description mentioning `@PostHog/rrweb`), Slack delivers an `app_mention` event to the coding-agent webhook. We then try to act on that mention as if a real PostHog user had sent it — but the author is a bot, with no email and no PostHog account, so we can't link it to anyone in the org. Every reassessment / re-post from the foreign bot retriggers `app_mention` and we reply again, filling the thread with hundreds of canned "I couldn't find your email address" or "Only the person who started this task…" messages.

Bots authored elsewhere will never have access to PostHog — there's no useful action we can take for them. The right behavior is to ignore the event silently.

## Changes

- Extend the existing edit-ignore helper (#59517) into `_app_mention_ignore_reason(event) -> str | None`, which returns:
  - `"edit"` for `event.edited` / `subtype == "message_changed"` (unchanged behavior)
  - `"bot_author"` for any of `bot_id`, `bot_profile`, `app_id`, `subtype == "bot_message"`, `user == "USLACKBOT"`
  - `None` otherwise
- Single check in `route_posthog_code_event_to_relevant_region` — one log line `posthog_code_event_app_mention_ignored` with a `reason` field for observability.
- `link_shared` is intentionally not filtered — our own notifications bot is a bot, and unfurling its links is the intended behavior.

## How did you test this code?

Extended the existing parameterized test from 2 cases (edit markers) to 7 (added the 5 bot-author indicators). All 22 tests in `TestRoutePostHogCodeEventToRelevantRegion` pass locally. `ruff check` and `ruff format --check` clean.

## Publish to changelog?

no