### PR TITLE
fix(notifications): collapse pipeline selector by default

### DIFF
--- a/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
+++ b/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
@@ -210,7 +210,7 @@ function PipelineNotificationSelector(): JSX.Element {
     const { updatePipelineNotification, updatePipelineNotificationForAll } = useActions(userLogic)
     const { pipelines, pipelinesLoading, pipelinesByTeam, allPipelineIds, isPipelineDisabled } =
         useValues(pipelineNotificationsLogic)
-    const [expanded, setExpanded] = useState(true)
+    const [expanded, setExpanded] = useState(false)
 
     return (
         <div>


### PR DESCRIPTION
## Problem

The "Select pipelines to receive notifications for" dropdown on the user notifications settings page was expanded by default, pushing other notification settings far down the page on accounts with many pipelines.

## Changes

- Collapse the pipeline notification selector by default

## How did you test this code?

No automated tests added — single-line default state change. Manually verified the dropdown renders collapsed on initial load and still toggles open/closed.

## Publish to changelog?

no