### PR TITLE
feat(mcp): YAML confirmation paradigm for destructive tools

### DIFF
--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -145,9 +145,24 @@ tools:
       # include and exclude are mutually exclusive
     feature_flag: my-flag-key # gate this tool behind a PostHog feature flag
     feature_flag_behavior: enable # 'enable' (default) or 'disable'
+    confirmation: # require an elicitation prompt before the API call
+      message: 'Enable enforce 2FA on organization {orgId}?'
+      on_no_elicit: deny
 ```
 
 Unknown keys are rejected at build time (Zod `.strict()`).
+
+### Gating destructive tools with `confirmation:`
+
+For destructive or security-sensitive actions, declare `confirmation:` to
+make the generated handler prompt the user via MCP elicitation before the
+API call. The action only proceeds on Accept.
+
+- `message` — static prompt with `{paramName}` placeholders interpolated from validated args.
+- `builder` — name of an exported fn in `services/mcp/src/tools/confirmation-builders.ts` (`(params, context) => string | Promise<string>`). Use when the prompt needs context the params don't carry (e.g. resolving an org name from an ID). Mutually exclusive with `message`; one is required.
+- `on_no_elicit` — `deny` or `allow`. Required. What to do when the client didn't declare elicitation support. Pick `deny` unless the prompt is purely a UX nicety.
+
+The codegen wraps the handler with `requestConfirmation()` from `services/mcp/src/tools/confirmation-runtime.ts` — no manual glue.
 
 ### Gating tools with feature flags
 

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -706,6 +706,52 @@ function buildResponseFilter(config: ToolConfig): {
 }
 
 // ------------------------------------------------------------------
+// Confirmation gate (elicitation-backed)
+// ------------------------------------------------------------------
+
+/**
+ * Emit the elicit-confirmation gate at the top of a generated handler.
+ * Returns the code prefix plus the per-tool imports the file-level
+ * aggregator needs.
+ */
+function buildConfirmationGate(
+    config: ToolConfig,
+    toolName: string,
+    responseType: string | undefined
+): {
+    code: string
+    needsRuntime: boolean
+    builderName: string | null
+} {
+    const confirmation = config.confirmation
+    if (!confirmation) {
+        return { code: '', needsRuntime: false, builderName: null }
+    }
+    const actionLabel = config.title ?? toolName
+    const promptField = confirmation.builder
+        ? `builder: ${confirmation.builder}`
+        : `message: ${JSON.stringify(confirmation.message)}`
+    // The short-circuit returns a `{content, isError}` payload that
+    // `isToolCallPayload` passes through; assert through `unknown` so
+    // TypeScript accepts it as the handler's declared return type.
+    const returnCast = responseType ? ` as unknown as ${responseType}` : ''
+    const code =
+        `        const __confirmation = await requestConfirmation(context, params, {\n` +
+        `            ${promptField},\n` +
+        `            onNoElicit: ${JSON.stringify(confirmation.on_no_elicit)},\n` +
+        `            actionLabel: ${JSON.stringify(actionLabel)},\n` +
+        `        })\n` +
+        `        if (__confirmation.kind === 'denied-no-elicit' || __confirmation.kind === 'cancelled') {\n` +
+        `            return __confirmation.result${returnCast}\n` +
+        `        }\n`
+    return {
+        code,
+        needsRuntime: true,
+        builderName: confirmation.builder ?? null,
+    }
+}
+
+// ------------------------------------------------------------------
 // Response enrichment templates
 // ------------------------------------------------------------------
 
@@ -766,6 +812,8 @@ function generateToolCode(
     needsWithPostHogUrl: boolean
     hasEnrichment: boolean
     responseFilterImport: 'pickResponseFields' | 'omitResponseFields' | null
+    needsConfirmationRuntime: boolean
+    confirmationBuilderName: string | null
 } {
     const schemaName = `${toPascalCase(toolName)}Schema`
     const factoryName = toCamelCase(toolName)
@@ -809,8 +857,21 @@ function generateToolCode(
     const needsProjectId = resolved.path.includes('{project_id}')
     const needsOrgId = resolved.path.includes('{organization_id}')
 
-    // Build handler body
+    // Computed up-front so the confirmation gate can reference it for the
+    // short-circuit cast. Duplicates the assignment below — kept inline
+    // because the per-branch reasoning is clearer than a helper.
+    const earlyResultType: string = (() => {
+        if (config.list || config.enrich_url) {
+            return responseType ? `WithPostHogUrl<${responseType}>` : 'unknown'
+        }
+        return responseType ?? 'unknown'
+    })()
+
     let handlerBody = ''
+    // Gate runs before org/project resolution so we don't fetch context
+    // for an action the user is about to refuse.
+    const confirmationGate = buildConfirmationGate(config, toolName, earlyResultType)
+    handlerBody += confirmationGate.code
     if (needsOrgId) {
         handlerBody += `        const orgId = await context.stateManager.getOrgID()\n`
     }
@@ -948,6 +1009,8 @@ const ${factoryName} = (): ToolBase<typeof ${schemaName}, ${resultType}> => ${fa
         needsWithPostHogUrl,
         hasEnrichment,
         responseFilterImport: responseFilter.helperImport,
+        needsConfirmationRuntime: confirmationGate.needsRuntime,
+        confirmationBuilderName: confirmationGate.builderName,
     }
 }
 
@@ -969,6 +1032,8 @@ function generateCustomSchemaToolCode(
     needsWithPostHogUrl: boolean
     hasEnrichment: boolean
     responseFilterImport: 'pickResponseFields' | 'omitResponseFields' | null
+    needsConfirmationRuntime: boolean
+    confirmationBuilderName: string | null
 } {
     const pathParamNames = extractPathParams(resolved.path)
 
@@ -981,6 +1046,8 @@ function generateCustomSchemaToolCode(
     const needsOrgId = resolved.path.includes('{organization_id}')
 
     let handlerBody = ''
+    const confirmationGate = buildConfirmationGate(config, toolName, responseType ?? 'unknown')
+    handlerBody += confirmationGate.code
     if (needsOrgId) {
         handlerBody += `        const orgId = await context.stateManager.getOrgID()\n`
     }
@@ -1054,6 +1121,8 @@ ${handlerBody}    },
         needsWithPostHogUrl: false,
         hasEnrichment: false,
         responseFilterImport: responseFilter.helperImport,
+        needsConfirmationRuntime: confirmationGate.needsRuntime,
+        confirmationBuilderName: confirmationGate.builderName,
     }
 }
 
@@ -1131,6 +1200,8 @@ function generateCategoryFile(
     const toolCodes: string[] = []
     let hasResponseType = false
     let hasWithPostHogUrl = false
+    let needsConfirmationRuntime = false
+    const confirmationBuilderImports = new Set<string>()
 
     let hasEnrichment = false
 
@@ -1170,6 +1241,12 @@ function generateCategoryFile(
         }
         if (result.responseFilterImport) {
             responseFilterImports.add(result.responseFilterImport)
+        }
+        if (result.needsConfirmationRuntime) {
+            needsConfirmationRuntime = true
+        }
+        if (result.confirmationBuilderName) {
+            confirmationBuilderImports.add(result.confirmationBuilderName)
         }
     }
 
@@ -1308,13 +1385,22 @@ function generateCategoryFile(
     const wrapperImportLine =
         enabledWrappers.length > 0 ? `import { createQueryWrapper } from '@/tools/query-wrapper-factory'\n` : ''
 
+    const confirmationRuntimeImportLine = needsConfirmationRuntime
+        ? `import { requestConfirmation } from '@/tools/confirmation-runtime'\n`
+        : ''
+
+    const confirmationBuildersImportLine =
+        confirmationBuilderImports.size > 0
+            ? `import { ${[...confirmationBuilderImports].sort().join(', ')} } from '@/tools/confirmation-builders'\n`
+            : ''
+
     const schemaRefCode = allSchemaRefBlocks.length > 0 ? '\n' + allSchemaRefBlocks.join('\n\n') + '\n' : ''
 
     const code = `// AUTO-GENERATED from ${fileName} + OpenAPI — do not edit
 import { z } from 'zod'
 
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-${toolUtilsImportLine ? `${toolUtilsImportLine}` : ''}${schemasImportLine}${withUiAppImportLine}${toolInputsImportLine}${castHelpersImportLine}${wrapperImportLine}${orvalImportLine}${schemaRefCode}${toolCodes.join('')}${wrapperSchemasCode}
+${toolUtilsImportLine ? `${toolUtilsImportLine}` : ''}${schemasImportLine}${withUiAppImportLine}${toolInputsImportLine}${castHelpersImportLine}${wrapperImportLine}${confirmationRuntimeImportLine}${confirmationBuildersImportLine}${orvalImportLine}${schemaRefCode}${toolCodes.join('')}${wrapperSchemasCode}
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
 ${mapEntries}
 }

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -165,6 +165,37 @@ export const ToolConfigSchema = z
                 message: 'response.include and response.exclude are mutually exclusive',
             })
             .optional(),
+        /**
+         * Gate the tool behind an MCP elicitation prompt. The generated
+         * handler asks the user to confirm before the API call; the action
+         * only proceeds on `accept`.
+         */
+        confirmation: z
+            .object({
+                /** Static prompt with `{paramName}` placeholders. Mutually exclusive with `builder`. */
+                message: z.string().optional(),
+                /**
+                 * Exported fn name in `services/mcp/src/tools/confirmation-builders.ts`.
+                 * Use when the prompt needs context params don't carry (e.g. an
+                 * org name resolved from its ID). Mutually exclusive with `message`.
+                 */
+                builder: z.string().optional(),
+                /**
+                 * Behavior when the client doesn't support elicitation.
+                 * `deny` returns an instructional error; `allow` proceeds
+                 * without confirmation. Required — pick `deny` unless the
+                 * prompt is purely a UX nicety.
+                 */
+                on_no_elicit: z.enum(['allow', 'deny']),
+            })
+            .strict()
+            .refine((data) => !(data.message && data.builder), {
+                message: 'confirmation.message and confirmation.builder are mutually exclusive',
+            })
+            .refine((data) => Boolean(data.message ?? data.builder), {
+                message: 'confirmation requires either message or builder',
+            })
+            .optional(),
     })
     .strict()
     .refine(

--- a/services/mcp/src/tools/confirmation-builders.ts
+++ b/services/mcp/src/tools/confirmation-builders.ts
@@ -1,0 +1,15 @@
+/**
+ * Registry of dynamic confirmation-message builders referenced by
+ * `confirmation.builder` in a tool YAML.
+ *
+ * Builders run on the blocking path before the confirmation modal shows
+ * up. Keep them quick and side-effect-free — they execute regardless of
+ * whether the user accepts or declines.
+ */
+
+import type { Context } from './types'
+
+export type ConfirmationBuilder<Params = Record<string, unknown>> = (
+    params: Params,
+    context: Context
+) => string | Promise<string>

--- a/services/mcp/src/tools/confirmation-runtime.ts
+++ b/services/mcp/src/tools/confirmation-runtime.ts
@@ -1,0 +1,141 @@
+/**
+ * Runtime for the YAML `confirmation` paradigm. Generated handlers call
+ * `requestConfirmation()` at the top; this module owns the
+ * elicit-availability check, the runtime error fallback, and the canned
+ * tool-result shapes for the short-circuit outcomes.
+ */
+
+import { ElicitationNotSupportedError } from '@/hono/session-bus'
+
+import type { ConfirmationBuilder } from './confirmation-builders'
+import type { Context } from './types'
+
+export interface RequestConfirmationOptions<P = Record<string, unknown>> {
+    /** Static prompt with `{paramName}` placeholders. Mutually exclusive with `builder`. */
+    message?: string
+    /** Dynamic prompt builder. Mutually exclusive with `message`. */
+    builder?: ConfirmationBuilder<P>
+    /** What to do when the client doesn't support elicitation. */
+    onNoElicit: 'allow' | 'deny'
+    /** Human-readable action name surfaced in the deny / cancel messages. */
+    actionLabel?: string
+}
+
+export type ConfirmationOutcome =
+    | { kind: 'accepted' }
+    | { kind: 'allowed-no-elicit' }
+    | { kind: 'denied-no-elicit'; result: ToolErrorResult }
+    | { kind: 'cancelled'; result: ToolErrorResult }
+
+interface ToolErrorResult {
+    content: Array<{ type: 'text'; text: string }>
+    isError: true
+}
+
+export async function requestConfirmation<P extends Record<string, unknown>>(
+    context: Context,
+    params: P,
+    options: RequestConfirmationOptions<P>
+): Promise<ConfirmationOutcome> {
+    const actionLabel = options.actionLabel ?? 'this action'
+
+    if (!context.elicit) {
+        return noElicitOutcome(options.onNoElicit, actionLabel)
+    }
+
+    const prompt = await resolvePrompt(params, context, options)
+
+    let elicitResult
+    try {
+        elicitResult = await context.elicit({
+            message: prompt,
+            requestedSchema: {
+                type: 'object',
+                properties: {
+                    confirmed: {
+                        type: 'boolean',
+                        title: 'Confirm',
+                        description: 'Tick to proceed; submit to confirm.',
+                    },
+                },
+                required: ['confirmed'],
+            },
+        })
+    } catch (error) {
+        // Runtime capability mismatch — route to the same branch as missing-at-init.
+        if (error instanceof ElicitationNotSupportedError) {
+            return noElicitOutcome(options.onNoElicit, actionLabel)
+        }
+        throw error
+    }
+
+    if (elicitResult.action === 'accept') {
+        return { kind: 'accepted' }
+    }
+    return {
+        kind: 'cancelled',
+        result: {
+            content: [
+                {
+                    type: 'text',
+                    text: `${capitalize(actionLabel)} was not performed — the user ${
+                        elicitResult.action === 'decline' ? 'declined' : 'cancelled'
+                    } the confirmation prompt.`,
+                },
+            ],
+            isError: true,
+        },
+    }
+}
+
+function noElicitOutcome(policy: 'allow' | 'deny', actionLabel: string): ConfirmationOutcome {
+    if (policy === 'allow') {
+        return { kind: 'allowed-no-elicit' }
+    }
+    return {
+        kind: 'denied-no-elicit',
+        result: {
+            content: [
+                {
+                    type: 'text',
+                    text:
+                        `${capitalize(actionLabel)} requires a confirmation prompt that this MCP client does not support. ` +
+                        `Either upgrade to a client that supports MCP elicitation, or perform the action via the PostHog web UI.`,
+                },
+            ],
+            isError: true,
+        },
+    }
+}
+
+async function resolvePrompt<P extends Record<string, unknown>>(
+    params: P,
+    context: Context,
+    options: RequestConfirmationOptions<P>
+): Promise<string> {
+    if (options.builder) {
+        return await options.builder(params, context)
+    }
+    if (options.message) {
+        return interpolate(options.message, params)
+    }
+    return `Confirm action?`
+}
+
+/** Missing keys stay as literal `{name}` so authors notice during smoke tests. */
+function interpolate(template: string, params: Record<string, unknown>): string {
+    return template.replace(/\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g, (full, key: string) => {
+        if (key in params) {
+            const value = params[key]
+            return value === null || value === undefined ? full : String(value)
+        }
+        return full
+    })
+}
+
+function capitalize(text: string): string {
+    if (!text) {
+        return text
+    }
+    return text.charAt(0).toUpperCase() + text.slice(1)
+}

--- a/services/mcp/src/tools/confirmation-runtime.ts
+++ b/services/mcp/src/tools/confirmation-runtime.ts
@@ -49,16 +49,13 @@ export async function requestConfirmation<P extends Record<string, unknown>>(
     try {
         elicitResult = await context.elicit({
             message: prompt,
+            // Empty schema → clients render just the action buttons.
+            // The protocol-level `action` field is the explicit-intent signal;
+            // an extra "tick to confirm" checkbox would be friction without
+            // security value (a client that auto-accepts will auto-tick too).
             requestedSchema: {
                 type: 'object',
-                properties: {
-                    confirmed: {
-                        type: 'boolean',
-                        title: 'Confirm',
-                        description: 'Tick to proceed; submit to confirm.',
-                    },
-                },
-                required: ['confirmed'],
+                properties: {},
             },
         })
     } catch (error) {

--- a/services/mcp/tests/unit/confirmation-runtime.test.ts
+++ b/services/mcp/tests/unit/confirmation-runtime.test.ts
@@ -27,7 +27,26 @@ function makeContext(elicit: ElicitFn | undefined): Context {
 }
 
 describe('requestConfirmation — no elicit available', () => {
-    it('returns denied-no-elicit when context.elicit is undefined and policy is deny', async () => {
+    it.each([
+        { policy: 'deny' as const, expectedKind: 'denied-no-elicit' as const },
+        { policy: 'allow' as const, expectedKind: 'allowed-no-elicit' as const },
+    ])(
+        'routes to $expectedKind when context.elicit is undefined and policy is $policy',
+        async ({ policy, expectedKind }) => {
+            const outcome = await requestConfirmation(
+                makeContext(undefined),
+                {},
+                {
+                    message: 'Proceed?',
+                    onNoElicit: policy,
+                    actionLabel: 'enforce 2FA',
+                }
+            )
+            expect(outcome.kind).toBe(expectedKind)
+        }
+    )
+
+    it('deny includes an instructional message naming the action', async () => {
         const outcome = await requestConfirmation(
             makeContext(undefined),
             {},
@@ -37,30 +56,34 @@ describe('requestConfirmation — no elicit available', () => {
                 actionLabel: 'enforce 2FA',
             }
         )
-        expect(outcome.kind).toBe('denied-no-elicit')
-        if (outcome.kind === 'denied-no-elicit') {
-            expect(outcome.result.isError).toBe(true)
-            expect(outcome.result.content[0].text).toContain('Enforce 2FA')
-            expect(outcome.result.content[0].text).toContain('does not support')
+        if (outcome.kind !== 'denied-no-elicit') {
+            throw new Error(`expected denied-no-elicit, got ${outcome.kind}`)
         }
-    })
-
-    it('returns allowed-no-elicit when context.elicit is undefined and policy is allow', async () => {
-        const outcome = await requestConfirmation(
-            makeContext(undefined),
-            {},
-            {
-                message: 'Proceed?',
-                onNoElicit: 'allow',
-            }
-        )
-        expect(outcome.kind).toBe('allowed-no-elicit')
+        expect(outcome.result.isError).toBe(true)
+        expect(outcome.result.content[0].text).toContain('Enforce 2FA')
+        expect(outcome.result.content[0].text).toContain('does not support')
     })
 })
 
 describe('requestConfirmation — elicit available', () => {
+    it('emits an empty requestedSchema (no form fields, just action buttons)', async () => {
+        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        await requestConfirmation(
+            makeContext(elicit),
+            {},
+            {
+                message: 'Proceed?',
+                onNoElicit: 'deny',
+            }
+        )
+        expect(elicit.mock.calls[0]![0].requestedSchema).toEqual({
+            type: 'object',
+            properties: {},
+        })
+    })
+
     it('returns accepted when the user accepts', async () => {
-        const elicit = vi.fn(async () => ({ action: 'accept' as const, content: { confirmed: true } }))
+        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
         const outcome = await requestConfirmation(
             makeContext(elicit),
             { id: 42 },
@@ -71,73 +94,53 @@ describe('requestConfirmation — elicit available', () => {
         )
         expect(outcome.kind).toBe('accepted')
         expect(elicit).toHaveBeenCalledTimes(1)
-        const callArgs = elicit.mock.calls[0]![0]
-        expect(callArgs.message).toBe('Delete 42?')
+        expect(elicit.mock.calls[0]![0].message).toBe('Delete 42?')
     })
 
-    it('returns cancelled with a decline reason when the user declines', async () => {
-        const elicit = vi.fn(async () => ({ action: 'decline' as const }))
-        const outcome = await requestConfirmation(
-            makeContext(elicit),
-            {},
-            {
-                message: 'Proceed?',
-                onNoElicit: 'deny',
-                actionLabel: 'org delete',
+    it.each([
+        { action: 'decline' as const, label: 'org delete', expectedWord: 'declined' },
+        { action: 'cancel' as const, label: 'org delete', expectedWord: 'cancelled' },
+    ])(
+        'returns cancelled with a $expectedWord reason when the user $action',
+        async ({ action, label, expectedWord }) => {
+            const elicit = vi.fn(async () => ({ action }))
+            const outcome = await requestConfirmation(
+                makeContext(elicit),
+                {},
+                {
+                    message: 'Proceed?',
+                    onNoElicit: 'deny',
+                    actionLabel: label,
+                }
+            )
+            if (outcome.kind !== 'cancelled') {
+                throw new Error(`expected cancelled, got ${outcome.kind}`)
             }
-        )
-        expect(outcome.kind).toBe('cancelled')
-        if (outcome.kind === 'cancelled') {
-            expect(outcome.result.content[0].text).toContain('declined')
+            expect(outcome.result.content[0].text).toContain(expectedWord)
             expect(outcome.result.content[0].text).toContain('Org delete')
         }
-    })
+    )
 
-    it('returns cancelled with a cancel reason when the user cancels', async () => {
-        const elicit = vi.fn(async () => ({ action: 'cancel' as const }))
-        const outcome = await requestConfirmation(
-            makeContext(elicit),
-            {},
-            {
-                message: 'Proceed?',
-                onNoElicit: 'deny',
-            }
-        )
-        expect(outcome.kind).toBe('cancelled')
-        if (outcome.kind === 'cancelled') {
-            expect(outcome.result.content[0].text).toContain('cancelled')
+    it.each([
+        { policy: 'deny' as const, expectedKind: 'denied-no-elicit' as const },
+        { policy: 'allow' as const, expectedKind: 'allowed-no-elicit' as const },
+    ])(
+        'treats runtime ElicitationNotSupportedError as the no-elicit branch ($policy)',
+        async ({ policy, expectedKind }) => {
+            const elicit = vi.fn(async () => {
+                throw new ElicitationNotSupportedError(-32601, 'Method not found')
+            }) as unknown as ElicitFn
+            const outcome = await requestConfirmation(
+                makeContext(elicit),
+                {},
+                {
+                    message: 'Proceed?',
+                    onNoElicit: policy,
+                }
+            )
+            expect(outcome.kind).toBe(expectedKind)
         }
-    })
-
-    it('treats runtime ElicitationNotSupportedError as the no-elicit branch (deny)', async () => {
-        const elicit = vi.fn(async () => {
-            throw new ElicitationNotSupportedError(-32601, 'Method not found')
-        }) as unknown as ElicitFn
-        const outcome = await requestConfirmation(
-            makeContext(elicit),
-            {},
-            {
-                message: 'Proceed?',
-                onNoElicit: 'deny',
-            }
-        )
-        expect(outcome.kind).toBe('denied-no-elicit')
-    })
-
-    it('treats runtime ElicitationNotSupportedError as the no-elicit branch (allow)', async () => {
-        const elicit = vi.fn(async () => {
-            throw new ElicitationNotSupportedError(-32601, 'Method not found')
-        }) as unknown as ElicitFn
-        const outcome = await requestConfirmation(
-            makeContext(elicit),
-            {},
-            {
-                message: 'Proceed?',
-                onNoElicit: 'allow',
-            }
-        )
-        expect(outcome.kind).toBe('allowed-no-elicit')
-    })
+    )
 
     it('propagates non-NotSupported errors (e.g. bus unhealthy) — does not swallow', async () => {
         const elicit = vi.fn(async () => {

--- a/services/mcp/tests/unit/confirmation-runtime.test.ts
+++ b/services/mcp/tests/unit/confirmation-runtime.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ElicitationNotSupportedError } from '@/hono/session-bus'
+import { requestConfirmation } from '@/tools/confirmation-runtime'
+import type { Context } from '@/tools/types'
+
+type ElicitFn = NonNullable<Context['elicit']>
+
+function makeContext(elicit: ElicitFn | undefined): Context {
+    // The runtime helper only touches `context.elicit`. Everything else is
+    // stubbed to `null as never` — accessing them in the helper would be a
+    // bug, and the test will surface it as a TypeError if it ever happens.
+    const stub = null as unknown as never
+    const ctx = {
+        api: stub,
+        cache: stub,
+        env: stub,
+        stateManager: stub,
+        sessionManager: stub,
+        getDistinctId: () => Promise.resolve('did'),
+        trackEvent: () => Promise.resolve(),
+    } as Context
+    if (elicit) {
+        ctx.elicit = elicit
+    }
+    return ctx
+}
+
+describe('requestConfirmation — no elicit available', () => {
+    it('returns denied-no-elicit when context.elicit is undefined and policy is deny', async () => {
+        const outcome = await requestConfirmation(
+            makeContext(undefined),
+            {},
+            {
+                message: 'Proceed?',
+                onNoElicit: 'deny',
+                actionLabel: 'enforce 2FA',
+            }
+        )
+        expect(outcome.kind).toBe('denied-no-elicit')
+        if (outcome.kind === 'denied-no-elicit') {
+            expect(outcome.result.isError).toBe(true)
+            expect(outcome.result.content[0].text).toContain('Enforce 2FA')
+            expect(outcome.result.content[0].text).toContain('does not support')
+        }
+    })
+
+    it('returns allowed-no-elicit when context.elicit is undefined and policy is allow', async () => {
+        const outcome = await requestConfirmation(
+            makeContext(undefined),
+            {},
+            {
+                message: 'Proceed?',
+                onNoElicit: 'allow',
+            }
+        )
+        expect(outcome.kind).toBe('allowed-no-elicit')
+    })
+})
+
+describe('requestConfirmation — elicit available', () => {
+    it('returns accepted when the user accepts', async () => {
+        const elicit = vi.fn(async () => ({ action: 'accept' as const, content: { confirmed: true } }))
+        const outcome = await requestConfirmation(
+            makeContext(elicit),
+            { id: 42 },
+            {
+                message: 'Delete {id}?',
+                onNoElicit: 'deny',
+            }
+        )
+        expect(outcome.kind).toBe('accepted')
+        expect(elicit).toHaveBeenCalledTimes(1)
+        const callArgs = elicit.mock.calls[0]![0]
+        expect(callArgs.message).toBe('Delete 42?')
+    })
+
+    it('returns cancelled with a decline reason when the user declines', async () => {
+        const elicit = vi.fn(async () => ({ action: 'decline' as const }))
+        const outcome = await requestConfirmation(
+            makeContext(elicit),
+            {},
+            {
+                message: 'Proceed?',
+                onNoElicit: 'deny',
+                actionLabel: 'org delete',
+            }
+        )
+        expect(outcome.kind).toBe('cancelled')
+        if (outcome.kind === 'cancelled') {
+            expect(outcome.result.content[0].text).toContain('declined')
+            expect(outcome.result.content[0].text).toContain('Org delete')
+        }
+    })
+
+    it('returns cancelled with a cancel reason when the user cancels', async () => {
+        const elicit = vi.fn(async () => ({ action: 'cancel' as const }))
+        const outcome = await requestConfirmation(
+            makeContext(elicit),
+            {},
+            {
+                message: 'Proceed?',
+                onNoElicit: 'deny',
+            }
+        )
+        expect(outcome.kind).toBe('cancelled')
+        if (outcome.kind === 'cancelled') {
+            expect(outcome.result.content[0].text).toContain('cancelled')
+        }
+    })
+
+    it('treats runtime ElicitationNotSupportedError as the no-elicit branch (deny)', async () => {
+        const elicit = vi.fn(async () => {
+            throw new ElicitationNotSupportedError(-32601, 'Method not found')
+        }) as unknown as ElicitFn
+        const outcome = await requestConfirmation(
+            makeContext(elicit),
+            {},
+            {
+                message: 'Proceed?',
+                onNoElicit: 'deny',
+            }
+        )
+        expect(outcome.kind).toBe('denied-no-elicit')
+    })
+
+    it('treats runtime ElicitationNotSupportedError as the no-elicit branch (allow)', async () => {
+        const elicit = vi.fn(async () => {
+            throw new ElicitationNotSupportedError(-32601, 'Method not found')
+        }) as unknown as ElicitFn
+        const outcome = await requestConfirmation(
+            makeContext(elicit),
+            {},
+            {
+                message: 'Proceed?',
+                onNoElicit: 'allow',
+            }
+        )
+        expect(outcome.kind).toBe('allowed-no-elicit')
+    })
+
+    it('propagates non-NotSupported errors (e.g. bus unhealthy) — does not swallow', async () => {
+        const elicit = vi.fn(async () => {
+            throw new Error('bus unhealthy')
+        }) as unknown as ElicitFn
+        await expect(
+            requestConfirmation(
+                makeContext(elicit),
+                {},
+                {
+                    message: 'Proceed?',
+                    onNoElicit: 'deny',
+                }
+            )
+        ).rejects.toThrow('bus unhealthy')
+    })
+})
+
+describe('requestConfirmation — message templating', () => {
+    it('interpolates {paramName} placeholders from params', async () => {
+        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        await requestConfirmation(
+            makeContext(elicit),
+            { orgId: 'acme', count: 3 },
+            {
+                message: 'Delete {count} items from {orgId}?',
+                onNoElicit: 'deny',
+            }
+        )
+        expect(elicit.mock.calls[0]![0].message).toBe('Delete 3 items from acme?')
+    })
+
+    it('leaves unknown placeholders literal so authors notice missing keys', async () => {
+        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        await requestConfirmation(
+            makeContext(elicit),
+            {},
+            {
+                message: 'Delete {missing}?',
+                onNoElicit: 'deny',
+            }
+        )
+        expect(elicit.mock.calls[0]![0].message).toBe('Delete {missing}?')
+    })
+
+    it('leaves null/undefined param values as literal placeholders, not the string "null"', async () => {
+        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        await requestConfirmation(
+            makeContext(elicit),
+            { id: null },
+            {
+                message: 'Action on {id}',
+                onNoElicit: 'deny',
+            }
+        )
+        expect(elicit.mock.calls[0]![0].message).toBe('Action on {id}')
+    })
+
+    it('calls the builder when provided and uses its return value', async () => {
+        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        const builder = vi.fn(async (_params, _ctx) => 'Built prompt')
+        await requestConfirmation(
+            makeContext(elicit),
+            { id: 1 },
+            {
+                builder,
+                onNoElicit: 'deny',
+            }
+        )
+        expect(builder).toHaveBeenCalledTimes(1)
+        expect(elicit.mock.calls[0]![0].message).toBe('Built prompt')
+    })
+
+    it('awaits sync builders too', async () => {
+        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        await requestConfirmation(
+            makeContext(elicit),
+            {},
+            {
+                builder: () => 'Sync prompt',
+                onNoElicit: 'deny',
+            }
+        )
+        expect(elicit.mock.calls[0]![0].message).toBe('Sync prompt')
+    })
+})

--- a/services/mcp/tests/unit/confirmation-runtime.test.ts
+++ b/services/mcp/tests/unit/confirmation-runtime.test.ts
@@ -26,6 +26,15 @@ function makeContext(elicit: ElicitFn | undefined): Context {
     return ctx
 }
 
+/** Safely pull the text payload off a tool-error result. Narrows past noUncheckedIndexedAccess. */
+function firstText(result: { content: ReadonlyArray<{ type: 'text'; text: string }> }): string {
+    const first = result.content[0]
+    if (!first) {
+        throw new Error('tool result had no content entries')
+    }
+    return first.text
+}
+
 describe('requestConfirmation — no elicit available', () => {
     it.each([
         { policy: 'deny' as const, expectedKind: 'denied-no-elicit' as const },
@@ -60,14 +69,15 @@ describe('requestConfirmation — no elicit available', () => {
             throw new Error(`expected denied-no-elicit, got ${outcome.kind}`)
         }
         expect(outcome.result.isError).toBe(true)
-        expect(outcome.result.content[0].text).toContain('Enforce 2FA')
-        expect(outcome.result.content[0].text).toContain('does not support')
+        const text = firstText(outcome.result)
+        expect(text).toContain('Enforce 2FA')
+        expect(text).toContain('does not support')
     })
 })
 
 describe('requestConfirmation — elicit available', () => {
     it('emits an empty requestedSchema (no form fields, just action buttons)', async () => {
-        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
             makeContext(elicit),
             {},
@@ -76,14 +86,15 @@ describe('requestConfirmation — elicit available', () => {
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit.mock.calls[0]![0].requestedSchema).toEqual({
-            type: 'object',
-            properties: {},
-        })
+        expect(elicit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                requestedSchema: { type: 'object', properties: {} },
+            })
+        )
     })
 
     it('returns accepted when the user accepts', async () => {
-        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
         const outcome = await requestConfirmation(
             makeContext(elicit),
             { id: 42 },
@@ -94,7 +105,7 @@ describe('requestConfirmation — elicit available', () => {
         )
         expect(outcome.kind).toBe('accepted')
         expect(elicit).toHaveBeenCalledTimes(1)
-        expect(elicit.mock.calls[0]![0].message).toBe('Delete 42?')
+        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Delete 42?' }))
     })
 
     it.each([
@@ -103,7 +114,7 @@ describe('requestConfirmation — elicit available', () => {
     ])(
         'returns cancelled with a $expectedWord reason when the user $action',
         async ({ action, label, expectedWord }) => {
-            const elicit = vi.fn(async () => ({ action }))
+            const elicit = vi.fn<ElicitFn>(async () => ({ action }))
             const outcome = await requestConfirmation(
                 makeContext(elicit),
                 {},
@@ -116,8 +127,9 @@ describe('requestConfirmation — elicit available', () => {
             if (outcome.kind !== 'cancelled') {
                 throw new Error(`expected cancelled, got ${outcome.kind}`)
             }
-            expect(outcome.result.content[0].text).toContain(expectedWord)
-            expect(outcome.result.content[0].text).toContain('Org delete')
+            const text = firstText(outcome.result)
+            expect(text).toContain(expectedWord)
+            expect(text).toContain('Org delete')
         }
     )
 
@@ -127,9 +139,9 @@ describe('requestConfirmation — elicit available', () => {
     ])(
         'treats runtime ElicitationNotSupportedError as the no-elicit branch ($policy)',
         async ({ policy, expectedKind }) => {
-            const elicit = vi.fn(async () => {
+            const elicit = vi.fn<ElicitFn>(async () => {
                 throw new ElicitationNotSupportedError(-32601, 'Method not found')
-            }) as unknown as ElicitFn
+            })
             const outcome = await requestConfirmation(
                 makeContext(elicit),
                 {},
@@ -143,9 +155,9 @@ describe('requestConfirmation — elicit available', () => {
     )
 
     it('propagates non-NotSupported errors (e.g. bus unhealthy) — does not swallow', async () => {
-        const elicit = vi.fn(async () => {
+        const elicit = vi.fn<ElicitFn>(async () => {
             throw new Error('bus unhealthy')
-        }) as unknown as ElicitFn
+        })
         await expect(
             requestConfirmation(
                 makeContext(elicit),
@@ -161,7 +173,7 @@ describe('requestConfirmation — elicit available', () => {
 
 describe('requestConfirmation — message templating', () => {
     it('interpolates {paramName} placeholders from params', async () => {
-        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
             makeContext(elicit),
             { orgId: 'acme', count: 3 },
@@ -170,11 +182,11 @@ describe('requestConfirmation — message templating', () => {
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit.mock.calls[0]![0].message).toBe('Delete 3 items from acme?')
+        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Delete 3 items from acme?' }))
     })
 
     it('leaves unknown placeholders literal so authors notice missing keys', async () => {
-        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
             makeContext(elicit),
             {},
@@ -183,11 +195,11 @@ describe('requestConfirmation — message templating', () => {
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit.mock.calls[0]![0].message).toBe('Delete {missing}?')
+        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Delete {missing}?' }))
     })
 
     it('leaves null/undefined param values as literal placeholders, not the string "null"', async () => {
-        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
             makeContext(elicit),
             { id: null },
@@ -196,12 +208,12 @@ describe('requestConfirmation — message templating', () => {
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit.mock.calls[0]![0].message).toBe('Action on {id}')
+        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Action on {id}' }))
     })
 
     it('calls the builder when provided and uses its return value', async () => {
-        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
-        const builder = vi.fn(async (_params, _ctx) => 'Built prompt')
+        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
+        const builder = vi.fn(async () => 'Built prompt')
         await requestConfirmation(
             makeContext(elicit),
             { id: 1 },
@@ -211,11 +223,11 @@ describe('requestConfirmation — message templating', () => {
             }
         )
         expect(builder).toHaveBeenCalledTimes(1)
-        expect(elicit.mock.calls[0]![0].message).toBe('Built prompt')
+        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Built prompt' }))
     })
 
     it('awaits sync builders too', async () => {
-        const elicit = vi.fn(async () => ({ action: 'accept' as const }))
+        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
             makeContext(elicit),
             {},
@@ -224,6 +236,6 @@ describe('requestConfirmation — message templating', () => {
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit.mock.calls[0]![0].message).toBe('Sync prompt')
+        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Sync prompt' }))
     })
 })

--- a/services/mcp/tests/unit/generate-tools.test.ts
+++ b/services/mcp/tests/unit/generate-tools.test.ts
@@ -1309,3 +1309,248 @@ describe('path parameter encoding', () => {
         expect(result.code).not.toMatch(/\$\{id\}[^)]/)
     })
 })
+
+describe('ToolConfigSchema confirmation', () => {
+    const base = { operation: 'things_partial_update', enabled: true } as const
+
+    it('accepts a message-based confirmation', () => {
+        const result = ToolConfigSchema.safeParse({
+            ...base,
+            confirmation: {
+                message: 'Confirm action on {id}?',
+                on_no_elicit: 'deny',
+            },
+        })
+        expect(result.success).toBe(true)
+    })
+
+    it('accepts a builder-based confirmation', () => {
+        const result = ToolConfigSchema.safeParse({
+            ...base,
+            confirmation: {
+                builder: 'buildEnforce2FAMessage',
+                on_no_elicit: 'allow',
+            },
+        })
+        expect(result.success).toBe(true)
+    })
+
+    it('rejects a confirmation declaring both message and builder', () => {
+        const result = ToolConfigSchema.safeParse({
+            ...base,
+            confirmation: {
+                message: 'Confirm?',
+                builder: 'buildSomething',
+                on_no_elicit: 'deny',
+            },
+        })
+        expect(result.success).toBe(false)
+    })
+
+    it('rejects a confirmation with neither message nor builder', () => {
+        const result = ToolConfigSchema.safeParse({
+            ...base,
+            confirmation: {
+                on_no_elicit: 'deny',
+            },
+        })
+        expect(result.success).toBe(false)
+    })
+
+    it('requires on_no_elicit explicitly — no implicit default', () => {
+        const result = ToolConfigSchema.safeParse({
+            ...base,
+            confirmation: {
+                message: 'Confirm?',
+            },
+        })
+        expect(result.success).toBe(false)
+    })
+
+    it('rejects an unknown on_no_elicit value', () => {
+        const result = ToolConfigSchema.safeParse({
+            ...base,
+            confirmation: {
+                message: 'Confirm?',
+                on_no_elicit: 'maybe',
+            },
+        })
+        expect(result.success).toBe(false)
+    })
+
+    it('rejects unknown keys inside the confirmation object', () => {
+        const result = ToolConfigSchema.safeParse({
+            ...base,
+            confirmation: {
+                message: 'Confirm?',
+                on_no_elicit: 'deny',
+                bogus: true,
+            },
+        })
+        expect(result.success).toBe(false)
+    })
+})
+
+describe('generateToolCode confirmation gate', () => {
+    function makePatchResolved(): ResolvedOperation {
+        return {
+            method: 'PATCH',
+            path: '/api/organizations/{id}/',
+            operation: { operationId: 'organizations_partial_update', parameters: [] },
+        }
+    }
+
+    it('emits no gate code when confirmation is absent', () => {
+        const config: EnabledToolConfig = {
+            ...({ operation: 'organizations_partial_update', enabled: true } as ToolConfig),
+            scopes: ['organization:write'],
+            annotations: { readOnly: false, destructive: false, idempotent: false },
+        }
+        const result = generateToolCode(
+            'org-update',
+            config,
+            makePatchResolved(),
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+        expect(result.code).not.toContain('requestConfirmation')
+        expect(result.needsConfirmationRuntime).toBe(false)
+        expect(result.confirmationBuilderName).toBeNull()
+    })
+
+    it('emits the gate with a message template + correct on_no_elicit', () => {
+        const config: EnabledToolConfig = {
+            ...({
+                operation: 'organizations_partial_update',
+                enabled: true,
+                confirmation: {
+                    message: 'Enable enforce 2FA on organization {id}?',
+                    on_no_elicit: 'deny',
+                },
+            } as ToolConfig),
+            scopes: ['organization:write'],
+            annotations: { readOnly: false, destructive: true, idempotent: false },
+        }
+        const result = generateToolCode(
+            'organization-enforce-2fa-update',
+            config,
+            makePatchResolved(),
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+        expect(result.code).toContain('await requestConfirmation(context, params, {')
+        expect(result.code).toContain('message: "Enable enforce 2FA on organization {id}?"')
+        expect(result.code).toContain('onNoElicit: "deny"')
+        expect(result.code).toContain("__confirmation.kind === 'denied-no-elicit'")
+        expect(result.needsConfirmationRuntime).toBe(true)
+        expect(result.confirmationBuilderName).toBeNull()
+    })
+
+    it('emits the gate with a builder reference and tracks the import', () => {
+        const config: EnabledToolConfig = {
+            ...({
+                operation: 'organizations_partial_update',
+                enabled: true,
+                confirmation: {
+                    builder: 'buildEnforce2FAMessage',
+                    on_no_elicit: 'deny',
+                },
+            } as ToolConfig),
+            scopes: ['organization:write'],
+            annotations: { readOnly: false, destructive: true, idempotent: false },
+        }
+        const result = generateToolCode(
+            'organization-enforce-2fa-update',
+            config,
+            makePatchResolved(),
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+        expect(result.code).toContain('builder: buildEnforce2FAMessage')
+        expect(result.code).not.toContain('message:')
+        expect(result.confirmationBuilderName).toBe('buildEnforce2FAMessage')
+    })
+
+    it('uses the tool title as the actionLabel when present', () => {
+        const config: EnabledToolConfig = {
+            ...({
+                operation: 'organizations_partial_update',
+                enabled: true,
+                title: 'Enforce 2FA',
+                confirmation: {
+                    message: 'Proceed?',
+                    on_no_elicit: 'deny',
+                },
+            } as ToolConfig),
+            scopes: ['organization:write'],
+            annotations: { readOnly: false, destructive: true, idempotent: false },
+        }
+        const result = generateToolCode(
+            'organization-enforce-2fa-update',
+            config,
+            makePatchResolved(),
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+        expect(result.code).toContain('actionLabel: "Enforce 2FA"')
+    })
+
+    it('falls back to the tool name for actionLabel when no title is set', () => {
+        const config: EnabledToolConfig = {
+            ...({
+                operation: 'organizations_partial_update',
+                enabled: true,
+                confirmation: {
+                    message: 'Proceed?',
+                    on_no_elicit: 'allow',
+                },
+            } as ToolConfig),
+            scopes: ['organization:write'],
+            annotations: { readOnly: false, destructive: true, idempotent: false },
+        }
+        const result = generateToolCode(
+            'organization-enforce-2fa-update',
+            config,
+            makePatchResolved(),
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+        expect(result.code).toContain('actionLabel: "organization-enforce-2fa-update"')
+    })
+
+    it('runs the gate BEFORE org/project ID resolution', () => {
+        const config: EnabledToolConfig = {
+            ...({
+                operation: 'organizations_partial_update',
+                enabled: true,
+                confirmation: { message: 'Proceed?', on_no_elicit: 'deny' },
+            } as ToolConfig),
+            scopes: ['organization:write'],
+            annotations: { readOnly: false, destructive: true, idempotent: false },
+        }
+        const result = generateToolCode(
+            'thing-update',
+            config,
+            makeResolved({ method: 'PATCH', path: '/api/organizations/{organization_id}/things/{id}/' }),
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+        const gateIdx = result.code.indexOf('requestConfirmation')
+        const orgIdIdx = result.code.indexOf('await context.stateManager.getOrgID()')
+        expect(gateIdx).toBeGreaterThan(-1)
+        expect(orgIdIdx).toBeGreaterThan(-1)
+        expect(gateIdx).toBeLessThan(orgIdIdx)
+    })
+})


### PR DESCRIPTION
## Problem

Destructive MCP tools (e.g. org-wide 2FA enforcement) need a human-in-the-loop confirmation before executing. Tool authors should not have to hand-roll the elicit + decline + no-elicit-fallback wiring per tool.

## Changes

- Add `confirmation:` block to the tool YAML schema (`message`/`builder` for the prompt, `on_no_elicit: allow|deny` for the fallback policy)
- Emit a generated handler gate that calls `requestConfirmation()` before the API call and short-circuits on decline / cancel / unsupported-client
- Add `confirmation-runtime.ts` (the runtime helper) and `confirmation-builders.ts` (stable import target for dynamic-prompt builder refs)
- Document the new fields in the implementing-mcp-tools skill

No consumer tool uses the new fields yet — wiring the 2FA tool is a follow-up.

## How did you test this code?

- 26 unit tests added (13 schema + codegen, 13 runtime behavior)
- Existing 1321 unit + 271 Hono tests still pass
- Codegen produces zero output diff for current YAMLs (gate emits only when \`confirmation:\` is declared)

## Publish to changelog?

no