### PR TITLE
feat(hog-charts): add useAnimatedNumber and resolveDelta helpers

### DIFF
--- a/frontend/src/lib/hog-charts/blocks/Metric/resolveDelta.test.ts
+++ b/frontend/src/lib/hog-charts/blocks/Metric/resolveDelta.test.ts
@@ -1,0 +1,71 @@
+import { type MetricChange, resolveDelta } from './resolveDelta'
+
+const formatChange = (p: number): string => (p > 0 ? `+${p.toFixed(1)}%` : `${p.toFixed(1)}%`)
+
+interface NullCase {
+    name: string
+    showChange: boolean
+    change?: MetricChange | null
+    fallbackChangePercent?: number | null
+}
+
+describe('resolveDelta', () => {
+    it.each<NullCase>([
+        { name: 'showChange is false, with a supplied change', showChange: false, change: { value: 5 } },
+        { name: 'showChange is false, with a fallback percent', showChange: false, fallbackChangePercent: 5 },
+        { name: 'change is null (suppression)', showChange: true, change: null },
+        { name: 'no change and no fallback', showChange: true, fallbackChangePercent: null },
+        { name: 'no change and fallback is NaN', showChange: true, fallbackChangePercent: NaN },
+        { name: 'no change and fallback is Infinity', showChange: true, fallbackChangePercent: Infinity },
+    ])('returns null when $name', ({ showChange, change, fallbackChangePercent }) => {
+        expect(
+            resolveDelta({
+                showChange,
+                change,
+                fallbackChangePercent: fallbackChangePercent ?? null,
+                formatChange,
+            })
+        ).toBeNull()
+    })
+
+    it('uses the supplied change label verbatim when provided', () => {
+        const result = resolveDelta({
+            showChange: true,
+            change: { value: 12.5, label: '+12.5% vs. last week' },
+            fallbackChangePercent: 42,
+            formatChange,
+        })
+        expect(result).toEqual({ value: 12.5, label: '+12.5% vs. last week' })
+    })
+
+    it('formats the supplied change value when no label is provided', () => {
+        const result = resolveDelta({
+            showChange: true,
+            change: { value: -8 },
+            fallbackChangePercent: null,
+            formatChange,
+        })
+        expect(result).toEqual({ value: -8, label: '-8.0%' })
+    })
+
+    it('prefers the supplied change over the fallback percent', () => {
+        const result = resolveDelta({
+            showChange: true,
+            change: { value: 1 },
+            fallbackChangePercent: 99,
+            formatChange,
+        })
+        expect(result?.value).toBe(1)
+        expect(result?.label).toBe('+1.0%')
+    })
+
+    it('falls back to the computed percent when change is undefined', () => {
+        const result = resolveDelta({
+            showChange: true,
+            change: undefined,
+            fallbackChangePercent: 42.5,
+            formatChange,
+        })
+        expect(result).toEqual({ value: 42.5, label: '+42.5%' })
+    })
+})

--- a/frontend/src/lib/hog-charts/blocks/Metric/resolveDelta.test.ts
+++ b/frontend/src/lib/hog-charts/blocks/Metric/resolveDelta.test.ts
@@ -17,6 +17,13 @@ describe('resolveDelta', () => {
         { name: 'no change and no fallback', showChange: true, fallbackChangePercent: null },
         { name: 'no change and fallback is NaN', showChange: true, fallbackChangePercent: NaN },
         { name: 'no change and fallback is Infinity', showChange: true, fallbackChangePercent: Infinity },
+        { name: 'change.value is NaN', showChange: true, change: { value: NaN } },
+        { name: 'change.value is Infinity', showChange: true, change: { value: Infinity } },
+        {
+            name: 'change.value is -Infinity, even with a label',
+            showChange: true,
+            change: { value: -Infinity, label: 'overridden' },
+        },
     ])('returns null when $name', ({ showChange, change, fallbackChangePercent }) => {
         expect(
             resolveDelta({

--- a/frontend/src/lib/hog-charts/blocks/Metric/resolveDelta.ts
+++ b/frontend/src/lib/hog-charts/blocks/Metric/resolveDelta.ts
@@ -1,13 +1,13 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 
 export interface MetricChange {
     value: number
-    label?: React.ReactNode
+    label?: ReactNode
 }
 
 export interface ResolvedDelta {
     value: number
-    label: React.ReactNode
+    label: ReactNode
 }
 
 export function resolveDelta({
@@ -25,7 +25,7 @@ export function resolveDelta({
         return null
     }
     if (change !== undefined) {
-        if (change === null) {
+        if (change === null || !Number.isFinite(change.value)) {
             return null
         }
         return {

--- a/frontend/src/lib/hog-charts/blocks/Metric/resolveDelta.ts
+++ b/frontend/src/lib/hog-charts/blocks/Metric/resolveDelta.ts
@@ -1,0 +1,43 @@
+import React from 'react'
+
+export interface MetricChange {
+    value: number
+    label?: React.ReactNode
+}
+
+export interface ResolvedDelta {
+    value: number
+    label: React.ReactNode
+}
+
+export function resolveDelta({
+    showChange,
+    change,
+    fallbackChangePercent,
+    formatChange,
+}: {
+    showChange: boolean
+    change: MetricChange | null | undefined
+    fallbackChangePercent: number | null
+    formatChange: (p: number) => string
+}): ResolvedDelta | null {
+    if (!showChange) {
+        return null
+    }
+    if (change !== undefined) {
+        if (change === null) {
+            return null
+        }
+        return {
+            value: change.value,
+            label: change.label ?? formatChange(change.value),
+        }
+    }
+    if (fallbackChangePercent == null || !Number.isFinite(fallbackChangePercent)) {
+        return null
+    }
+    return {
+        value: fallbackChangePercent,
+        label: formatChange(fallbackChangePercent),
+    }
+}

--- a/frontend/src/lib/hog-charts/blocks/Metric/useAnimatedNumber.test.tsx
+++ b/frontend/src/lib/hog-charts/blocks/Metric/useAnimatedNumber.test.tsx
@@ -1,0 +1,149 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useAnimatedNumber } from './useAnimatedNumber'
+
+interface RafController {
+    step: (now: number) => void
+    pendingCount: () => number
+    teardown: () => void
+}
+
+function installControllableRaf(): RafController {
+    const queue: FrameRequestCallback[] = []
+    const originalRaf = global.requestAnimationFrame
+    const originalCancel = global.cancelAnimationFrame
+    const originalPerf = global.performance.now
+    let nextId = 1
+    const handles = new Map<number, FrameRequestCallback>()
+
+    global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+        const id = nextId++
+        handles.set(id, cb)
+        queue.push(cb)
+        return id
+    }) as typeof global.requestAnimationFrame
+
+    global.cancelAnimationFrame = ((id: number) => {
+        const cb = handles.get(id)
+        if (cb) {
+            const i = queue.indexOf(cb)
+            if (i >= 0) {
+                queue.splice(i, 1)
+            }
+            handles.delete(id)
+        }
+    }) as typeof global.cancelAnimationFrame
+
+    global.performance.now = jest.fn(() => 0)
+
+    return {
+        step: (now: number) => {
+            ;(global.performance.now as jest.Mock).mockReturnValue(now)
+            const callbacks = queue.splice(0, queue.length)
+            handles.clear()
+            act(() => {
+                callbacks.forEach((cb) => cb(now))
+            })
+        },
+        pendingCount: () => queue.length,
+        teardown: () => {
+            global.requestAnimationFrame = originalRaf
+            global.cancelAnimationFrame = originalCancel
+            global.performance.now = originalPerf
+        },
+    }
+}
+
+describe('useAnimatedNumber', () => {
+    let raf: RafController
+
+    beforeEach(() => {
+        raf = installControllableRaf()
+    })
+
+    afterEach(() => {
+        raf.teardown()
+    })
+
+    it('returns the target on initial render', () => {
+        const { result } = renderHook(() => useAnimatedNumber(42))
+        expect(result.current).toBe(42)
+    })
+
+    it.each([
+        ['zero', 0],
+        ['negative', -10],
+    ])('snaps immediately when duration is %s', (_label, duration) => {
+        const { result, rerender } = renderHook(({ target }) => useAnimatedNumber(target, duration), {
+            initialProps: { target: 0 },
+        })
+        rerender({ target: 100 })
+        expect(result.current).toBe(100)
+        expect(raf.pendingCount()).toBe(0)
+    })
+
+    it.each([
+        ['NaN', NaN],
+        ['Infinity', Infinity],
+        ['-Infinity', -Infinity],
+    ])('snaps immediately when target is %s', (_label, target) => {
+        const { result, rerender } = renderHook(({ t }: { t: number }) => useAnimatedNumber(t, 350), {
+            initialProps: { t: 0 },
+        })
+        rerender({ t: target })
+        expect(result.current).toBe(target)
+        expect(raf.pendingCount()).toBe(0)
+    })
+
+    it('does not schedule animation when target is unchanged', () => {
+        const { rerender } = renderHook(({ target }) => useAnimatedNumber(target, 350), {
+            initialProps: { target: 10 },
+        })
+        rerender({ target: 10 })
+        expect(raf.pendingCount()).toBe(0)
+    })
+
+    it('animates from the previous value toward the new target across frames', () => {
+        const { result, rerender } = renderHook(({ target }) => useAnimatedNumber(target, 100), {
+            initialProps: { target: 0 },
+        })
+        rerender({ target: 100 })
+        expect(raf.pendingCount()).toBe(1)
+        expect(result.current).toBe(0)
+
+        raf.step(50)
+        expect(result.current).toBeGreaterThan(0)
+        expect(result.current).toBeLessThan(100)
+
+        raf.step(100)
+        expect(result.current).toBe(100)
+        expect(raf.pendingCount()).toBe(0)
+    })
+
+    it('restarts from the currently-displayed value when target changes mid-animation', () => {
+        const { result, rerender } = renderHook(({ target }) => useAnimatedNumber(target, 100), {
+            initialProps: { target: 0 },
+        })
+        rerender({ target: 100 })
+        raf.step(40)
+        const midValue = result.current
+        expect(midValue).toBeGreaterThan(0)
+        expect(midValue).toBeLessThan(100)
+
+        rerender({ target: 200 })
+        expect(result.current).toBe(midValue)
+
+        raf.step(100)
+        expect(result.current).toBeGreaterThan(midValue)
+    })
+
+    it('cancels the pending frame on unmount', () => {
+        const { rerender, unmount } = renderHook(({ target }) => useAnimatedNumber(target, 100), {
+            initialProps: { target: 0 },
+        })
+        rerender({ target: 100 })
+        expect(raf.pendingCount()).toBe(1)
+        unmount()
+        expect(raf.pendingCount()).toBe(0)
+    })
+})

--- a/frontend/src/lib/hog-charts/blocks/Metric/useAnimatedNumber.ts
+++ b/frontend/src/lib/hog-charts/blocks/Metric/useAnimatedNumber.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+import { useLatest } from '../../core/hooks/useLatest'
+
+/** When `target` changes mid-animation, animation restarts from the currently-displayed value (no snap). */
+export function useAnimatedNumber(target: number, duration = 350): number {
+    const [value, setValue] = useState(target)
+    const valueRef = useLatest(value)
+
+    useEffect(() => {
+        if (duration <= 0 || !Number.isFinite(target)) {
+            setValue(target)
+            return
+        }
+        const from = valueRef.current
+        if (from === target) {
+            return
+        }
+        const start = performance.now()
+        let raf = 0
+        const tick = (now: number): void => {
+            const t = Math.min(1, (now - start) / duration)
+            const eased = 1 - Math.pow(1 - t, 3)
+            setValue(from + (target - from) * eased)
+            if (t < 1) {
+                raf = requestAnimationFrame(tick)
+            }
+        }
+        raf = requestAnimationFrame(tick)
+        return () => cancelAnimationFrame(raf)
+    }, [target, duration, valueRef])
+
+    return value
+}


### PR DESCRIPTION
## Problem

Two small helpers for the upcoming `Metric` block: an animated-number hook for the headline tween, and a pure derivation that decides what the change pill should say. They land here on their own with focused unit tests so reviewers can sign off on the logic without paging in the full `Metric` UI.

PR 1 of 2. The `Metric` component that consumes both is #59851 (now stacked on this branch).

## Changes

- `useAnimatedNumber(target, duration)` — cubic-ease tween between successive targets. Snaps when the duration is non-positive or the target is non-finite; restarts from the currently-displayed value when the target changes mid-animation; cancels its pending frame on unmount.
- `resolveDelta(...)` — derives the change pill: respects `showChange`, treats `change: null` as suppression, prefers a supplied `change` over the hover-derived percent, and rejects non-finite fallbacks.

Both files live under `frontend/src/lib/hog-charts/blocks/Metric/`; they have no consumer in this PR (the `Metric` component lands in #59851).

## How did you test this code?

I'm an agent — no manual testing. Added the two test files in this PR:
- `useAnimatedNumber.test.tsx` covers initial render, snap on `duration <= 0`, snap on non-finite target, no-op on unchanged target, frame-by-frame interpolation, mid-animation retarget, and unmount cleanup. Uses a controllable RAF + `performance.now()` mock to step through frames deterministically.
- `resolveDelta.test.ts` covers the null-returning paths (parameterized), the supplied-change label/format paths, and the fallback-percent path.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Sonnet) at the request of @sampennington while splitting the original `Metric` component PR (#59851) into two reviewable pieces. The split was proposed and approved in chat: PR 1 (this one) for the pure logic + unit tests; PR 2 (#59851, rebased to stack on this branch) for the `Metric` UI component, stories, snapshots, and `index.ts` exports.

`resolveDelta` was originally a private helper inside `Metric.tsx`; extracted to its own file so it could be unit-tested without rendering the component. `useAnimatedNumber` was already its own file in the original PR but had no dedicated tests — added here.