### PR TITLE
fix(navigation): preserve leading digit in project menu name

### DIFF
--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -68,9 +68,9 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
     const { showCreateProjectModal } = useActions(globalModalsLogic)
     const { showCreateOrganizationModal } = useActions(globalModalsLogic)
 
-    const projectNameStartsWithEmoji = currentTeam?.name?.match(/^\p{Emoji}/u) !== null
+    const projectNameStartsWithEmoji = currentTeam?.name?.match(/^\p{Extended_Pictographic}/u) !== null
     const projectNameWithoutFirstEmoji = projectNameStartsWithEmoji
-        ? currentTeam?.name?.replace(/^\p{Emoji}/u, '').trimStart()
+        ? currentTeam?.name?.replace(/^\p{Extended_Pictographic}/u, '').trimStart()
         : currentTeam?.name
 
     return (


### PR DESCRIPTION
## Problem

In the account menu (top-level trigger and the "all projects" submenu trigger), project names whose first character is an ASCII digit have that first character silently dropped — e.g. a project named `100Ddefault project` renders as `00Ddefault project`. `#`- and `*`-prefixed names are affected the same way.

The intent of the existing code is to strip a leading emoji from the displayed name (so `🎉 Party project` shows as `Party project`), but the regex used to detect that emoji also matches characters most people would not consider emoji.

## Changes

`frontend/src/lib/components/Account/NewAccountMenu.tsx` used `\p{Emoji}` to detect and strip a leading emoji from the project name. Per Unicode, the `Emoji` property is `Yes` for ASCII digits `0–9`, `#`, and `*` — so `/^\p{Emoji}/u` matched and stripped the first character on any name starting with those.

Swap both occurrences to `\p{Extended_Pictographic}`, which is the Unicode property designed for "characters that should be considered emoji" and excludes ASCII digits, `#`, and `*`. Actual emoji prefixes continue to be stripped as before.

## How did you test this code?

I'm an agent. No automated tests were added or run for this change. The author manually verified locally that:

- a project renamed to `100Ddefault project` now displays in full in the account menu and the "all projects" submenu (previously rendered as `00Ddefault project`)
- emoji-prefixed names (e.g. `🎉 Party project`) continue to have the leading emoji stripped

## Publish to changelog?

no

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.7). The user spotted the bug locally and correctly hypothesized that the project-menu code was stripping the first character because it mistook a digit for an emoji.

The fix was narrowed to a single file after grepping the whole repo for `\p{Emoji}` — only this one component uses the pattern, and there is no shared emoji-stripping utility to update. `\p{Extended_Pictographic}` was chosen over alternatives like `\p{Emoji_Presentation}` because the latter does not match emoji that need a variation selector (e.g. `❤`), so it would regress on some existing project names. The `Lettermark` glyph elsewhere in the same file uses `codePointAt(0)` independently and is unaffected.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*