### PR TITLE
fix(llm-gateway): resolve team multiplier from token's scoped_teams

### DIFF
--- a/services/llm-gateway/src/llm_gateway/auth/authenticators.py
+++ b/services/llm-gateway/src/llm_gateway/auth/authenticators.py
@@ -62,7 +62,7 @@ class PersonalApiKeyAuthenticator(Authenticator):
         async with acquire_connection(pool) as conn:
             row = await conn.fetchrow(
                 """
-                SELECT pak.id, pak.user_id, pak.scopes, u.current_team_id, u.distinct_id
+                SELECT pak.id, pak.user_id, pak.scopes, pak.scoped_teams, u.current_team_id, u.distinct_id
                 FROM posthog_personalapikey pak
                 JOIN posthog_user u ON pak.user_id = u.id
                 WHERE pak.secure_value = $1 AND u.is_active = true
@@ -83,6 +83,7 @@ class PersonalApiKeyAuthenticator(Authenticator):
                 auth_method=self.auth_type,
                 distinct_id=row["distinct_id"],
                 scopes=scopes,
+                scoped_team_ids=row["scoped_teams"],
             )
 
 
@@ -107,7 +108,7 @@ class OAuthAccessTokenAuthenticator(Authenticator):
         async with acquire_connection(pool) as conn:
             row = await conn.fetchrow(
                 """
-                SELECT oat.id, oat.user_id, oat.scope, oat.expires,
+                SELECT oat.id, oat.user_id, oat.scope, oat.expires, oat.scoped_teams,
                        oat.application_id, u.current_team_id, u.distinct_id
                 FROM posthog_oauthaccesstoken oat
                 JOIN posthog_user u ON oat.user_id = u.id
@@ -138,4 +139,5 @@ class OAuthAccessTokenAuthenticator(Authenticator):
                 scopes=scopes,
                 token_expires_at=expires,
                 application_id=str(row["application_id"]),
+                scoped_team_ids=row["scoped_teams"],
             )

--- a/services/llm-gateway/src/llm_gateway/auth/models.py
+++ b/services/llm-gateway/src/llm_gateway/auth/models.py
@@ -11,6 +11,13 @@ class AuthenticatedUser:
     scopes: list[str] | None = None
     token_expires_at: datetime | None = None
     application_id: str | None = None
+    # Teams the bearer token (personal API key or OAuth access token) is scoped to.
+    # `team_id` itself is the user's `current_team_id` and can swap when the user
+    # switches teams in the UI — that's unreliable for resolving the rate-limit
+    # multiplier. `scoped_team_ids` is set on the token and stable for its lifetime,
+    # so we use it as the authoritative source for multiplier resolution when set.
+    # None / empty means unscoped (no constraint), and we fall back to `team_id`.
+    scoped_team_ids: list[int] | None = None
 
 
 def resolve_distinct_id(auth_user: AuthenticatedUser, end_user_id: str | None) -> str:

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -47,7 +47,7 @@ class CostThrottle(Throttle):
         self._limiters: dict[str, CostRateLimiter] = {}
 
     def _get_team_multiplier(self, context: ThrottleContext) -> int:
-        return get_team_multiplier(context.user.team_id)
+        return get_team_multiplier(context.user.team_id, context.user.scoped_team_ids)
 
     @abstractmethod
     def _get_cache_key(self, context: ThrottleContext) -> str: ...

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/denial_event.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/denial_event.py
@@ -42,6 +42,8 @@ class PosthogDenialCapturer:
         }
         if auth_user.team_id is not None:
             properties["team_id"] = auth_user.team_id
+        if auth_user.scoped_team_ids:
+            properties["scoped_team_ids"] = auth_user.scoped_team_ids
 
         capture_kwargs: dict[str, Any] = {
             "distinct_id": distinct_id,

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
@@ -1,17 +1,35 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.config import get_settings
 
 
-def get_team_multiplier(team_id: int | None) -> int:
-    if team_id is None:
-        return 1
+def get_team_multiplier(team_id: int | None, scoped_team_ids: Iterable[int] | None = None) -> int:
+    """Resolve the rate-limit multiplier for an authenticated user.
 
-    return get_settings().team_rate_limit_multipliers.get(team_id, 1)
+    `team_id` is the user's `current_team_id`, which can swap as the user changes
+    teams in the UI (so it's not stable across requests with the same key). When the
+    bearer token (personal API key or OAuth access token) is scoped to a fixed set
+    of teams, we resolve the multiplier across both: the token's scoped teams AND
+    the user's current team. The highest multiplier wins — a token scoped to a
+    multiplier team (e.g. team 2 at 25x) keeps its boost even if the user is
+    currently viewing a different team.
+    """
+    multipliers = get_settings().team_rate_limit_multipliers
+    if not multipliers:
+        return 1
+    candidates: list[int] = []
+    if scoped_team_ids:
+        candidates.extend(scoped_team_ids)
+    if team_id is not None:
+        candidates.append(team_id)
+    if not candidates:
+        return 1
+    return max((multipliers.get(t, 1) for t in candidates), default=1)
 
 
 @dataclass

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -103,6 +103,7 @@ def authenticated_client(mock_db_pool: MagicMock) -> Generator[TestClient, None,
             "scopes": ["llm_gateway:read"],
             "current_team_id": 1,
             "distinct_id": "test-distinct-id",
+            "scoped_teams": None,
         }
     )
     mock_db_pool.acquire = AsyncMock(return_value=conn)

--- a/services/llm-gateway/tests/integration/conftest.py
+++ b/services/llm-gateway/tests/integration/conftest.py
@@ -100,6 +100,7 @@ def create_mock_db_pool():
             "current_team_id": 456,
             "scopes": ["llm_gateway:read"],
             "distinct_id": "test-distinct-id",
+            "scoped_teams": None,
         }
     )
     pool.acquire = AsyncMock(return_value=conn)

--- a/services/llm-gateway/tests/test_auth.py
+++ b/services/llm-gateway/tests/test_auth.py
@@ -106,6 +106,7 @@ class TestAuthService:
                 "current_team_id": 456,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
+                "scoped_teams": None,
             }
         )
 
@@ -131,6 +132,7 @@ class TestAuthService:
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 101,
                 "distinct_id": "test-distinct-id",
+                "scoped_teams": None,
             }
         )
 
@@ -206,6 +208,7 @@ class TestPersonalApiKeyAuthenticator:
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 456,
                 "distinct_id": "test-distinct-id",
+                "scoped_teams": None,
             }
         )
 
@@ -307,6 +310,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "current_team_id": 456,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
+                "scoped_teams": None,
             }
         )
 
@@ -392,6 +396,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "current_team_id": 456,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
+                "scoped_teams": None,
             }
         )
 
@@ -415,6 +420,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "current_team_id": 456,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
+                "scoped_teams": None,
             }
         )
 
@@ -441,6 +447,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "current_team_id": None,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
+                "scoped_teams": None,
             }
         )
 

--- a/services/llm-gateway/tests/test_auth_cache.py
+++ b/services/llm-gateway/tests/test_auth_cache.py
@@ -237,6 +237,7 @@ class TestAuthServiceCaching:
                 "user_id": 123,
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 456,
+                "scoped_teams": None,
                 "distinct_id": "test-distinct-id",
             }
         )
@@ -275,6 +276,7 @@ class TestAuthServiceCaching:
                 "scope": "llm_gateway:read",
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "current_team_id": 456,
+                "scoped_teams": None,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -314,6 +316,7 @@ class TestAuthServiceCaching:
                 "scope": "llm_gateway:read",
                 "expires": None,
                 "current_team_id": 456,
+                "scoped_teams": None,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -370,6 +373,7 @@ class TestAuthServiceMetrics:
                 "scopes": ["llm_gateway:read"],
                 "scope": "llm_gateway:read",
                 "current_team_id": 456,
+                "scoped_teams": None,
                 "application_id": 789,
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "distinct_id": "test-distinct-id",
@@ -400,6 +404,7 @@ class TestAuthServiceMetrics:
                 "scopes": ["llm_gateway:read"],
                 "scope": "llm_gateway:read",
                 "current_team_id": 456,
+                "scoped_teams": None,
                 "application_id": 789,
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "distinct_id": "test-distinct-id",

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -5,13 +5,19 @@ from llm_gateway.config import get_settings
 from llm_gateway.rate_limiting.throttles import ThrottleContext
 
 
-def make_user(user_id: int = 1, team_id: int = 1, auth_method: str = "oauth_access_token") -> AuthenticatedUser:
+def make_user(
+    user_id: int = 1,
+    team_id: int = 1,
+    auth_method: str = "oauth_access_token",
+    scoped_team_ids: list[int] | None = None,
+) -> AuthenticatedUser:
     return AuthenticatedUser(
         user_id=user_id,
         team_id=team_id,
         auth_method=auth_method,
         distinct_id=f"test-distinct-id-{user_id}",
         scopes=["llm_gateway:read"],
+        scoped_team_ids=scoped_team_ids,
     )
 
 
@@ -894,6 +900,58 @@ class TestTeamRateLimitMultipliers:
 
         assert (await throttle.get_status(team_99_ctx)).used_usd == pytest.approx(0.0)
         assert (await throttle.get_status(team_2_ctx)).used_usd == pytest.approx(4_000.0)
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_token_scoped_to_multiplier_team_keeps_boost_when_current_team_swaps(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Production failure mode: a PostHog employee scopes their personal API key (or
+        consents an OAuth token) to team 2, but their `current_team_id` is swapped to a
+        customer's team because they were investigating that customer in the UI. Before
+        this fix the multiplier resolved off `current_team_id` and the employee silently
+        lost the 25x boost — manifesting as 429s the chart was supposed to prevent.
+
+        With the token's `scoped_team_ids` plumbed through, the multiplier resolves off
+        the *token* (which is stable) instead of the *user's current UI selection*."""
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle, UserCostBurstThrottle
+
+        # Token is scoped to team 2; user is currently viewing customer team 56923.
+        user = make_user(user_id=999, team_id=56923, scoped_team_ids=[2])
+        context = make_context(user=user, product="posthog_code")
+
+        burst = UserCostBurstThrottle(redis=None)
+        # Default posthog_code burst is $200/24h; 25x = $5000. Spending $1000 is well
+        # past the unmultiplied cap but a fraction of the multiplied cap.
+        await burst.record_cost(context, 1_000.0)
+        assert (await burst.allow_request(context)).allowed is True
+
+        # And the bucket gets the tm25 suffix even though the user's current_team_id is a customer team.
+        key = burst._get_cache_key(context)
+        assert key.endswith(":tm25"), f"expected scoped multiplier suffix, got {key}"
+
+        # ProductCostThrottle picks up the same scoped-team multiplier.
+        product_throttle = ProductCostThrottle(redis=None)
+        product_key = product_throttle._get_cache_key(context)
+        assert product_key.endswith(":tm25"), f"expected scoped multiplier suffix, got {product_key}"
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_unscoped_token_still_uses_current_team_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unscoped token (no scoped_team_ids set) is fine to use `current_team_id` —
+        this is the unchanged behavior. PostHog employees who never scope their keys
+        and have current_team_id=2 still get the boost."""
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        user = make_user(user_id=42, team_id=2, scoped_team_ids=None)
+        context = make_context(user=user, product="posthog_code")
+
+        throttle = UserCostBurstThrottle(redis=None)
+        assert throttle._get_cache_key(context).endswith(":tm25")
         get_settings.cache_clear()
 
 

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -767,6 +767,135 @@ class TestTeamRateLimitMultipliers:
         assert key == "cost:product:wizard:tm10"
         get_settings.cache_clear()
 
+    @pytest.mark.parametrize("multiplier", [2, 10, 25, 100])
+    @pytest.mark.asyncio
+    async def test_product_throttle_limit_scales_with_multiplier(
+        self, monkeypatch: pytest.MonkeyPatch, multiplier: int
+    ) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", f'{{"2": {multiplier}}}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle
+
+        throttle = ProductCostThrottle(redis=None)
+        context = make_context(user=make_user(team_id=2), product="llm_gateway")
+
+        base = get_settings().product_cost_limits["llm_gateway"].limit_usd
+        limit, _ = throttle._get_limit_and_window(context)
+        assert limit == base * multiplier
+        get_settings.cache_clear()
+
+    @pytest.mark.parametrize("multiplier", [2, 10, 25, 100])
+    @pytest.mark.asyncio
+    async def test_user_burst_throttle_limit_scales_with_multiplier(
+        self, monkeypatch: pytest.MonkeyPatch, multiplier: int
+    ) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", f'{{"2": {multiplier}}}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(user=make_user(team_id=2), product="posthog_code")
+
+        base = get_settings().user_cost_limits["posthog_code"].burst_limit_usd
+        limit, _ = throttle._get_limit_and_window(context)
+        assert limit == base * multiplier
+        get_settings.cache_clear()
+
+    @pytest.mark.parametrize("multiplier", [2, 10, 25, 100])
+    @pytest.mark.asyncio
+    async def test_user_sustained_throttle_limit_scales_with_multiplier(
+        self, monkeypatch: pytest.MonkeyPatch, multiplier: int
+    ) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", f'{{"2": {multiplier}}}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
+
+        throttle = UserCostSustainedThrottle(redis=None)
+        context = make_context(user=make_user(team_id=2), product="posthog_code")
+
+        base = get_settings().user_cost_limits["posthog_code"].sustained_limit_usd
+        limit, _ = throttle._get_limit_and_window(context)
+        assert limit == base * multiplier
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_multiplier_team_bucket_isolated_from_shared_bucket(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Team-2 spend lands in a suffixed bucket and must not bleed into the shared (default) bucket,
+        otherwise a single multiplier team could burn down everyone else's product cap."""
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle
+
+        throttle = ProductCostThrottle(redis=None)
+        # default limit for wizard product = $2000/day
+        team_2_ctx = make_context(user=make_user(user_id=10, team_id=2), product="wizard")
+        team_other_ctx = make_context(user=make_user(user_id=20, team_id=42), product="wizard")
+
+        await throttle.record_cost(team_2_ctx, 1500.0)
+
+        # Shared bucket should still be empty.
+        other_status = await throttle.get_status(team_other_ctx)
+        assert other_status.used_usd == pytest.approx(0.0)
+        # Team-2's own bucket records its own spend.
+        team_2_status = await throttle.get_status(team_2_ctx)
+        assert team_2_status.used_usd == pytest.approx(1500.0)
+        # And both can still serve traffic.
+        assert (await throttle.allow_request(team_other_ctx)).allowed is True
+        assert (await throttle.allow_request(team_2_ctx)).allowed is True
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_multiplier_team_denied_above_multiplied_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle
+
+        throttle = ProductCostThrottle(redis=None)
+        context = make_context(user=make_user(team_id=2), product="llm_gateway")
+        # Default llm_gateway limit is $1000; 25x = $25_000.
+        await throttle.record_cost(context, 25_001.0)
+
+        result = await throttle.allow_request(context)
+        assert result.allowed is False, "spending past 25x the base cap must still be rejected"
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_multiplier_routes_by_team_id_not_user_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The multiplier must key off team_id; configuring '{"2": 25}' should not boost a user_id=2 on team_id=99."""
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        # user_id 2 but on team 99 — should NOT get the 25x multiplier.
+        context = make_context(user=make_user(user_id=2, team_id=99), product="posthog_code")
+
+        base = get_settings().user_cost_limits["posthog_code"].burst_limit_usd
+        limit, _ = throttle._get_limit_and_window(context)
+        assert limit == base, "multiplier must key on team_id, not user_id"
+        assert ":tm" not in throttle._get_cache_key(context)
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_multiplier_team_does_not_affect_other_team_user_buckets(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two users on different teams (one with a multiplier, one without) must keep separate
+        per-user buckets — spending by one user on team 2 must not deplete a different user's quota on team 99."""
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        team_2_ctx = make_context(user=make_user(user_id=100, team_id=2), product="posthog_code")
+        team_99_ctx = make_context(user=make_user(user_id=200, team_id=99), product="posthog_code")
+
+        await throttle.record_cost(team_2_ctx, 4_000.0)
+
+        assert (await throttle.get_status(team_99_ctx)).used_usd == pytest.approx(0.0)
+        assert (await throttle.get_status(team_2_ctx)).used_usd == pytest.approx(4_000.0)
+        get_settings.cache_clear()
+
 
 class TestUnconfiguredProductsUseDefaults:
     """Products without user_cost_limits config use default limits ($100/24h burst, $1000/30d sustained)."""

--- a/services/llm-gateway/tests/test_rate_limiting.py
+++ b/services/llm-gateway/tests/test_rate_limiting.py
@@ -230,6 +230,7 @@ class TestRateLimitResponseHeaders:
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 1,
                 "distinct_id": "test-distinct-id",
+                "scoped_teams": None,
             }
         )
         mock_db_pool.acquire = AsyncMock(return_value=conn)

--- a/services/llm-gateway/tests/test_throttles.py
+++ b/services/llm-gateway/tests/test_throttles.py
@@ -185,3 +185,46 @@ class TestGetTeamMultiplier:
         assert get_team_multiplier(2) == 10
         assert get_team_multiplier(5) == 5
         get_settings.cache_clear()
+
+    def test_scoped_team_ids_unlocks_multiplier_when_current_team_does_not(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The production failure mode: a PostHog employee's `current_team_id` swaps to a
+        customer's team when they investigate that customer, so passing only team_id
+        loses the multiplier. With the token's `scoped_teams` field passed through, the
+        multiplier still applies because the *token* is scoped to team 2."""
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        # current_team_id = 56923 (some customer's team), token scoped to [2]
+        assert get_team_multiplier(56923, scoped_team_ids=[2]) == 25
+        get_settings.cache_clear()
+
+    def test_scoped_team_ids_keeps_multiplier_when_current_team_also_matches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        assert get_team_multiplier(2, scoped_team_ids=[2]) == 25
+        get_settings.cache_clear()
+
+    def test_max_multiplier_wins_across_scoped_teams(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25, "5": 10}')
+        get_settings.cache_clear()
+        # Token scoped to both 2 and 5 — should land on the more generous 25x.
+        assert get_team_multiplier(99, scoped_team_ids=[5, 2]) == 25
+        get_settings.cache_clear()
+
+    def test_empty_scoped_teams_falls_back_to_team_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        assert get_team_multiplier(2, scoped_team_ids=None) == 25
+        assert get_team_multiplier(2, scoped_team_ids=[]) == 25
+        get_settings.cache_clear()
+
+    def test_none_scoped_team_in_multipliers_still_uses_team_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If the token is scoped to teams that aren't in the multiplier list but the
+        user's current team IS, we should still apply the current-team multiplier."""
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 25}')
+        get_settings.cache_clear()
+        assert get_team_multiplier(2, scoped_team_ids=[99, 100]) == 25
+        get_settings.cache_clear()

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -68,6 +68,7 @@ class TestUsageEndpoint:
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 1,
                 "distinct_id": "test-distinct-id",
+                "scoped_teams": None,
             }
         )
         mock_db_pool.acquire = AsyncMock(return_value=conn)


### PR DESCRIPTION
## Problem

The team rate-limit multiplier on the LLM gateway (`LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS={"2": 25}` in `prod-us`) was set up in Jan 2026 but in practice the boost was leaking. Production query:

```sql
SELECT distinct_id, properties.team_id, count() AS gens
FROM events WHERE event = '$ai_generation' AND timestamp > now() - INTERVAL 30 DAY
  AND distinct_id IN (heavy-spenders-on-team-2)
GROUP BY distinct_id, properties.team_id
```

shows the same PostHog employees recording generations under `team_id=2` **and** under customer teams like `56923`. That's the failure mode: the gateway resolves the multiplier off `posthog_user.current_team_id`, which silently swaps every time the employee switches teams in the PostHog UI (e.g. to investigate a customer's project). For the customer-team requests the configured `{"2": 25}` multiplier never applied — the employee got 429s the chart was supposed to prevent.

## Changes

Both personal API keys (`PersonalAPIKey.scoped_teams`) and OAuth access tokens (`OAuthAccessToken.scoped_teams`) already carry a *token-stable* list of teams the bearer is scoped to. This PR plumbs that through:

- `AuthenticatedUser` gains `scoped_team_ids: list[int] | None`.
- Both authenticators fetch `scoped_teams` in their SQL and populate it.
- `get_team_multiplier(team_id, scoped_team_ids)` resolves the multiplier as the max across the token's scoped teams ∪ `current_team_id`. A token scoped to a multiplier team keeps its boost regardless of the user's current UI selection. Unscoped tokens keep the prior behavior.
- `llm_gateway_rate_limit_denied` events now include `scoped_team_ids`, so post-deploy we can verify in PostHog whether scoped teams are actually reaching the gateway.

No chart change needed — `argocd/llm-gateway/values/values.prod-us.yaml` is already at `'{"2": 25}'`.

## How did you test this code?

I'm an agent. Verified end-to-end against the existing throttle stack and the broader gateway suite:

- New tests in `test_throttles.py` cover the multiplier-resolution function (scoped overrides current; max wins across scoped; empty/null falls back to `team_id`; current team still wins when scoped teams aren't in the multiplier list).
- New tests in `test_cost_throttles.py` simulate the production failure mode: a user with `team_id=56923, scoped_team_ids=[2]` lands in the `tm25` bucket on both `UserCostBurstThrottle` and `ProductCostThrottle`, and is allowed to spend past the unmultiplied user cap.
- Existing parametric tests for limit scaling (2x/10x/25x/100x) across Product / UserBurst / UserSustained, isolation, and team-vs-user-id routing remain green.
- Updated auth fixtures to include `scoped_teams: None` so existing auth tests stay representative of the post-fix DB row shape.
- Full gateway suite: `pytest services/llm-gateway/tests/` (ignoring integration/cli) — 901 passed.
- `ruff check` and `ruff format --check` clean.

Not tested: a live cluster deploy. The new field arrives populated on every fresh auth — the in-memory auth cache (15-min TTL) will roll old entries over within the cache window.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by the PostHog Code agent on behalf of @joshsny.

Original brief: bump the team-2 LLM gateway multiplier to 25x and "make sure it works, last time it didn't." The chart was already at `{"2": 25}` since Jan 2026 (PR #7894 / #7897 in `posthog/charts`). After a first pass that only added tests around the existing code path, the user pushed back: "are your tests actually real enough? I don't think these are working in production."

Investigation (via the PostHog MCP):

1. `llm_gateway_rate_limit_denied` events for the last 90 days — **zero** denials with `team_id=2`. Looked like the multiplier was working.
2. `$ai_generation` cost by team — `team_id=2` racked up ~$15.7k in 7 days, with top users individually crossing $5.5k / 30d on `posthog_code` (default sustained cap $1k/30d). Multiplier was clearly active for events that landed under `team_id=2`.
3. **Smoking gun**: cross-referencing distinct_ids that ever appear on `team_id=2` against events on *other* teams, the same humans show up under customer teams (e.g. one user with 600k generations on team 345145, 270k on team 56923). The gateway treats those requests as customer requests because it pulled `team_id` from `posthog_user.current_team_id`, which is the UI-selected team and swaps freely. Multiplier doesn't fire on those.

Fix: rely on the token's own `scoped_teams` (stable for the token's lifetime) rather than the user's current UI selection. Max-wins across `scoped_team_ids ∪ team_id` keeps unscoped tokens working as before.

Trade-off considered: I did not change what we record as `team_id` on events / denials — that still reflects `current_team_id` for attribution. Only the multiplier resolution changed. The new `scoped_team_ids` field on denial events lets us check the field is populating correctly in production without changing existing dashboards.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*