### PR TITLE
feat(endpoints): polish OS-like scene menu and drop tab strip

### DIFF
--- a/products/endpoints/frontend/EndpointScene.tsx
+++ b/products/endpoints/frontend/EndpointScene.tsx
@@ -262,16 +262,22 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
                                 {endpoint.is_active ? <IconPause /> : <IconPlay />}
                                 {endpoint.is_active ? 'Deactivate endpoint' : 'Activate endpoint'}
                             </SceneMenuBarItem>
-                            <SceneMenuBarItem
-                                onClick={toggleMaterializationFromMenu}
-                                data-attr="endpoint-menubar-materialize-toggle"
-                            >
-                                <IconDatabase />
-                                {/* Reflect any unsaved local toggle so the label can't silently flip back. */}
-                                {(isMaterialized ?? viewingVersion?.is_materialized ?? endpoint.is_materialized)
-                                    ? 'Disable materialization'
-                                    : 'Materialize endpoint'}
-                            </SceneMenuBarItem>
+                            {(() => {
+                                const baseIsMaterialized = viewingVersion?.is_materialized ?? endpoint.is_materialized
+                                const hasUnsavedToggle =
+                                    isMaterialized !== null && isMaterialized !== baseIsMaterialized
+                                const effective = isMaterialized ?? baseIsMaterialized
+                                return (
+                                    <SceneMenuBarItem
+                                        onClick={toggleMaterializationFromMenu}
+                                        disabled={hasUnsavedToggle}
+                                        data-attr="endpoint-menubar-materialize-toggle"
+                                    >
+                                        <IconDatabase />
+                                        {effective ? 'Disable materialization' : 'Materialize endpoint'}
+                                    </SceneMenuBarItem>
+                                )
+                            })()}
                             <SceneMenuBarSeparator />
                             <SceneMenuBarItem
                                 variant="destructive"
@@ -346,29 +352,27 @@ function OpenEndpointSubMenu({
     allEndpoints: { name: string }[]
     currentEndpointName: string
 }): JSX.Element {
-    const sorted = [...allEndpoints].sort((a, b) => a.name.localeCompare(b.name))
+    const others = allEndpoints
+        .filter((e) => e.name !== currentEndpointName)
+        .sort((a, b) => a.name.localeCompare(b.name))
     return (
         <SceneMenuBarSubMenu label="Open endpoint">
-            {sorted.length === 0 ? (
+            {others.length === 0 ? (
                 <SceneMenuBarItem disabled>
                     <IconEndpoints />
                     No other endpoints
                 </SceneMenuBarItem>
             ) : (
-                sorted.map((e) => {
-                    const isCurrent = e.name === currentEndpointName
-                    return (
-                        <SceneMenuBarItem
-                            key={e.name}
-                            disabled={isCurrent}
-                            onClick={isCurrent ? undefined : () => router.actions.push(urls.endpoint(e.name))}
-                            data-attr={`endpoint-menubar-open-${e.name}`}
-                        >
-                            {isCurrent ? <IconCheck /> : <IconEndpoints />}
-                            {e.name}
-                        </SceneMenuBarItem>
-                    )
-                })
+                others.map((e) => (
+                    <SceneMenuBarItem
+                        key={e.name}
+                        onClick={() => router.actions.push(urls.endpoint(e.name))}
+                        data-attr={`endpoint-menubar-open-${e.name}`}
+                    >
+                        <IconEndpoints />
+                        {e.name}
+                    </SceneMenuBarItem>
+                ))
             )}
             <SceneMenuBarSeparator />
             <SceneMenuBarItem

--- a/products/endpoints/frontend/EndpointScene.tsx
+++ b/products/endpoints/frontend/EndpointScene.tsx
@@ -1,7 +1,22 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconPause, IconPlay, IconTrash } from '@posthog/icons'
+import {
+    IconCheck,
+    IconClock,
+    IconCode2,
+    IconDatabase,
+    IconEndpoints,
+    IconGraph,
+    IconPause,
+    IconPlay,
+    IconPlayFilled,
+    IconPlusSmall,
+    IconPulse,
+    IconRewind,
+    IconServer,
+    IconTrash,
+} from '@posthog/icons'
 import { LemonBanner, LemonDialog, LemonDivider } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
@@ -19,16 +34,16 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import {
     SceneMenuBar,
-    SceneMenuBarCheckboxItem,
     SceneMenuBarItem,
     SceneMenuBarMenu,
     SceneMenuBarPopover,
     SceneMenuBarSeparator,
+    SceneMenuBarSubMenu,
 } from '~/layout/scenes/components/SceneMenuBar'
 import { ScenePanel, ScenePanelActionsSection, ScenePanelInfoSection } from '~/layout/scenes/SceneLayout'
 import { tagsModel } from '~/models/tagsModel'
 import { ProductKey } from '~/queries/schema/schema-general'
-import { ActivityScope } from '~/types'
+import { ActivityScope, EndpointVersionType } from '~/types'
 
 import { EndpointConfiguration } from './endpoint-tabs/EndpointConfiguration'
 import { EndpointOverview } from './endpoint-tabs/EndpointOverview'
@@ -39,6 +54,8 @@ import { VersionBanner } from './endpoint-tabs/VersionBanner'
 import { EndpointSceneHeader } from './EndpointHeader'
 import { endpointLogic } from './endpointLogic'
 import { EndpointTab, endpointSceneLogic } from './endpointSceneLogic'
+import { endpointsLogic } from './endpointsLogic'
+import { insightPickerEndpointModalLogic } from './insightPickerEndpointModalLogic'
 
 interface EndpointProps {
     tabId?: string
@@ -55,8 +72,11 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
         throw new Error('<EndpointScene /> must receive a tabId prop')
     }
     const { endpoint, endpointLoading, activeTab, viewingVersion } = useValues(endpointSceneLogic({ tabId }))
-    const { setViewingVersion } = useActions(endpointSceneLogic({ tabId }))
+    const { setViewingVersion, toggleMaterializationFromMenu } = useActions(endpointSceneLogic({ tabId }))
     const { deleteEndpoint, confirmToggleActive, saveTagsInline } = useActions(endpointLogic({ tabId }))
+    const { versions } = useValues(endpointLogic({ tabId }))
+    const { allEndpoints } = useValues(endpointsLogic({ tabId }))
+    const { openModal } = useActions(insightPickerEndpointModalLogic)
     const { tags: tagsAvailable } = useValues(tagsModel)
     const { searchParams } = useValues(router)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -150,33 +170,115 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
         confirmToggleActive(endpoint)
     }
 
+    const renderTabContent = (): JSX.Element => {
+        if (!endpoint) {
+            return <></>
+        }
+        switch (activeTab) {
+            case EndpointTab.CONFIGURATION:
+                return <EndpointConfiguration tabId={tabId} />
+            case EndpointTab.VERSIONS:
+                return <EndpointVersions tabId={tabId} />
+            case EndpointTab.PLAYGROUND:
+                return <EndpointPlayground tabId={tabId} />
+            case EndpointTab.HISTORY:
+                return <ActivityLog scope={[ActivityScope.ENDPOINT, ActivityScope.ENDPOINT_VERSION]} id={endpoint.id} />
+            case EndpointTab.QUERY:
+            default:
+                return <EndpointQuery tabId={tabId} />
+        }
+    }
+
     return (
         <BindLogic logic={endpointSceneLogic} props={{ tabId }}>
             <SceneContent className="Endpoint">
                 {sceneMenuBarEnabled && endpoint && (
                     <SceneMenuBar>
                         <SceneMenuBarMenu label="File" dataAttr="endpoint-menubar-file">
+                            <SceneMenuBarSubMenu label="New endpoint">
+                                <SceneMenuBarItem
+                                    onClick={() => router.actions.push(urls.sqlEditor({ source: 'endpoint' }))}
+                                    data-attr="endpoint-menubar-new-sql"
+                                >
+                                    <IconServer />
+                                    From SQL editor
+                                </SceneMenuBarItem>
+                                <SceneMenuBarItem
+                                    opensFloatingUi
+                                    onClick={openModal}
+                                    data-attr="endpoint-menubar-new-insight"
+                                >
+                                    <IconGraph />
+                                    From insight
+                                </SceneMenuBarItem>
+                            </SceneMenuBarSubMenu>
+                            <OpenEndpointSubMenu
+                                allEndpoints={allEndpoints}
+                                currentEndpointName={endpoint.name}
+                            />
+                            <OpenVersionSubMenu
+                                versions={versions}
+                                endpointName={endpoint.name}
+                                currentVersion={endpoint.current_version}
+                                viewingVersion={viewingVersion}
+                                setViewingVersion={setViewingVersion}
+                            />
+                            <SceneMenuBarSeparator />
+                            <SceneMenuBarItem
+                                onClick={() =>
+                                    router.actions.push(
+                                        combineUrl(urls.endpoint(endpoint.name), { tab: EndpointTab.PLAYGROUND }).url
+                                    )
+                                }
+                                data-attr="endpoint-menubar-open-playground"
+                            >
+                                <IconPlayFilled />
+                                Open playground
+                            </SceneMenuBarItem>
+                            <SceneMenuBarItem
+                                onClick={() =>
+                                    router.actions.push(
+                                        combineUrl(urls.endpoint(endpoint.name), { tab: EndpointTab.HISTORY }).url
+                                    )
+                                }
+                                data-attr="endpoint-menubar-view-history"
+                            >
+                                <IconClock />
+                                View history
+                            </SceneMenuBarItem>
+                            <SceneMenuBarItem
+                                onClick={() =>
+                                    router.actions.push(urls.endpointsUsage({ endpointFilter: [endpoint.name] }))
+                                }
+                                data-attr="endpoint-menubar-view-usage"
+                            >
+                                <IconPulse />
+                                View usage
+                            </SceneMenuBarItem>
+                            <SceneMenuBarSeparator />
                             <SceneMenuBarFileItems dataAttrKey="endpoint" />
+                        </SceneMenuBarMenu>
+                        <SceneMenuBarMenu label="Edit" dataAttr="endpoint-menubar-edit">
+                            <SceneMenuBarItem onClick={handleToggleActive} data-attr="endpoint-menubar-active-toggle">
+                                {endpoint.is_active ? <IconPause /> : <IconPlay />}
+                                {endpoint.is_active ? 'Deactivate endpoint' : 'Activate endpoint'}
+                            </SceneMenuBarItem>
+                            <SceneMenuBarItem
+                                onClick={toggleMaterializationFromMenu}
+                                data-attr="endpoint-menubar-materialize-toggle"
+                            >
+                                <IconDatabase />
+                                {endpoint.is_materialized ? 'Disable materialization' : 'Materialize endpoint'}
+                            </SceneMenuBarItem>
                             <SceneMenuBarSeparator />
                             <SceneMenuBarItem
                                 variant="destructive"
-                                opensFloatingUi
                                 onClick={handleDelete}
                                 data-attr="endpoint-menubar-delete"
                             >
                                 <IconTrash />
                                 Delete endpoint
                             </SceneMenuBarItem>
-                        </SceneMenuBarMenu>
-                        <SceneMenuBarMenu label="Edit" dataAttr="endpoint-menubar-edit">
-                            <SceneMenuBarSeparator />
-                            <SceneMenuBarCheckboxItem
-                                checked={endpoint.is_active}
-                                onCheckedChange={handleToggleActive}
-                                data-attr="endpoint-menubar-active"
-                            >
-                                Active
-                            </SceneMenuBarCheckboxItem>
                         </SceneMenuBarMenu>
                         <SceneMenuBarPopover label="Metadata" dataAttr="endpoint-menubar-metadata">
                             <SceneTagsCombobox
@@ -204,7 +306,7 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
                     />
                 )}
                 {!endpointLoading && <EndpointOverview tabId={tabId} />}
-                <LemonTabs activeKey={activeTab} tabs={tabs} />
+                {sceneMenuBarEnabled ? renderTabContent() : <LemonTabs activeKey={activeTab} tabs={tabs} />}
             </SceneContent>
             {endpoint && (
                 <ScenePanel>
@@ -231,5 +333,102 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
                 </ScenePanel>
             )}
         </BindLogic>
+    )
+}
+
+function OpenEndpointSubMenu({
+    allEndpoints,
+    currentEndpointName,
+}: {
+    allEndpoints: { name: string }[]
+    currentEndpointName: string
+}): JSX.Element {
+    const sorted = [...allEndpoints].sort((a, b) => a.name.localeCompare(b.name))
+    return (
+        <SceneMenuBarSubMenu label="Open endpoint">
+            {sorted.length === 0 ? (
+                <SceneMenuBarItem disabled>
+                    <IconEndpoints />
+                    No other endpoints
+                </SceneMenuBarItem>
+            ) : (
+                sorted.map((e) => {
+                    const isCurrent = e.name === currentEndpointName
+                    return (
+                        <SceneMenuBarItem
+                            key={e.name}
+                            onClick={() => router.actions.push(urls.endpoint(e.name))}
+                            data-attr={`endpoint-menubar-open-${e.name}`}
+                        >
+                            {isCurrent ? <IconCheck /> : <IconEndpoints />}
+                            {e.name}
+                        </SceneMenuBarItem>
+                    )
+                })
+            )}
+            <SceneMenuBarSeparator />
+            <SceneMenuBarItem
+                onClick={() => router.actions.push(urls.endpoints())}
+                data-attr="endpoint-menubar-browse-endpoints"
+            >
+                <IconPlusSmall />
+                Browse all endpoints
+            </SceneMenuBarItem>
+        </SceneMenuBarSubMenu>
+    )
+}
+
+function OpenVersionSubMenu({
+    versions,
+    endpointName,
+    currentVersion,
+    viewingVersion,
+    setViewingVersion,
+}: {
+    versions: EndpointVersionType[]
+    endpointName: string
+    currentVersion: number
+    viewingVersion: EndpointVersionType | null
+    setViewingVersion: (version: EndpointVersionType | null) => void
+}): JSX.Element {
+    const effectiveVersion = viewingVersion?.version ?? currentVersion
+    const sorted = [...versions].sort((a, b) => b.version - a.version)
+    return (
+        <SceneMenuBarSubMenu label="Open version">
+            {sorted.length === 0 ? (
+                <SceneMenuBarItem disabled>
+                    <IconRewind />
+                    No versions yet
+                </SceneMenuBarItem>
+            ) : (
+                sorted.map((v) => {
+                    const isCurrent = v.version === currentVersion
+                    const isSelected = v.version === effectiveVersion
+                    return (
+                        <SceneMenuBarItem
+                            key={v.version}
+                            onClick={() => setViewingVersion(isCurrent ? null : v)}
+                            data-attr={`endpoint-menubar-open-version-${v.version}`}
+                        >
+                            {isSelected ? <IconCheck /> : <IconRewind />}
+                            v{v.version}
+                            {isCurrent ? ' (latest)' : ''}
+                        </SceneMenuBarItem>
+                    )
+                })
+            )}
+            <SceneMenuBarSeparator />
+            <SceneMenuBarItem
+                onClick={() =>
+                    router.actions.push(
+                        combineUrl(urls.endpoint(endpointName), { tab: EndpointTab.VERSIONS }).url
+                    )
+                }
+                data-attr="endpoint-menubar-view-all-versions"
+            >
+                <IconCode2 />
+                Manage versions
+            </SceneMenuBarItem>
+        </SceneMenuBarSubMenu>
     )
 }

--- a/products/endpoints/frontend/EndpointScene.tsx
+++ b/products/endpoints/frontend/EndpointScene.tsx
@@ -71,7 +71,9 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
     if (!tabId) {
         throw new Error('<EndpointScene /> must receive a tabId prop')
     }
-    const { endpoint, endpointLoading, activeTab, viewingVersion } = useValues(endpointSceneLogic({ tabId }))
+    const { endpoint, endpointLoading, activeTab, viewingVersion, isMaterialized } = useValues(
+        endpointSceneLogic({ tabId })
+    )
     const { setViewingVersion, toggleMaterializationFromMenu } = useActions(endpointSceneLogic({ tabId }))
     const { deleteEndpoint, confirmToggleActive, saveTagsInline } = useActions(endpointLogic({ tabId }))
     const { versions } = useValues(endpointLogic({ tabId }))
@@ -212,10 +214,7 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
                                     From insight
                                 </SceneMenuBarItem>
                             </SceneMenuBarSubMenu>
-                            <OpenEndpointSubMenu
-                                allEndpoints={allEndpoints}
-                                currentEndpointName={endpoint.name}
-                            />
+                            <OpenEndpointSubMenu allEndpoints={allEndpoints} currentEndpointName={endpoint.name} />
                             <OpenVersionSubMenu
                                 versions={versions}
                                 endpointName={endpoint.name}
@@ -268,11 +267,15 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
                                 data-attr="endpoint-menubar-materialize-toggle"
                             >
                                 <IconDatabase />
-                                {endpoint.is_materialized ? 'Disable materialization' : 'Materialize endpoint'}
+                                {/* Reflect any unsaved local toggle so the label can't silently flip back. */}
+                                {(isMaterialized ?? viewingVersion?.is_materialized ?? endpoint.is_materialized)
+                                    ? 'Disable materialization'
+                                    : 'Materialize endpoint'}
                             </SceneMenuBarItem>
                             <SceneMenuBarSeparator />
                             <SceneMenuBarItem
                                 variant="destructive"
+                                opensFloatingUi
                                 onClick={handleDelete}
                                 data-attr="endpoint-menubar-delete"
                             >
@@ -357,7 +360,8 @@ function OpenEndpointSubMenu({
                     return (
                         <SceneMenuBarItem
                             key={e.name}
-                            onClick={() => router.actions.push(urls.endpoint(e.name))}
+                            disabled={isCurrent}
+                            onClick={isCurrent ? undefined : () => router.actions.push(urls.endpoint(e.name))}
                             data-attr={`endpoint-menubar-open-${e.name}`}
                         >
                             {isCurrent ? <IconCheck /> : <IconEndpoints />}
@@ -410,8 +414,7 @@ function OpenVersionSubMenu({
                             onClick={() => setViewingVersion(isCurrent ? null : v)}
                             data-attr={`endpoint-menubar-open-version-${v.version}`}
                         >
-                            {isSelected ? <IconCheck /> : <IconRewind />}
-                            v{v.version}
+                            {isSelected ? <IconCheck /> : <IconRewind />}v{v.version}
                             {isCurrent ? ' (latest)' : ''}
                         </SceneMenuBarItem>
                     )
@@ -420,9 +423,7 @@ function OpenVersionSubMenu({
             <SceneMenuBarSeparator />
             <SceneMenuBarItem
                 onClick={() =>
-                    router.actions.push(
-                        combineUrl(urls.endpoint(endpointName), { tab: EndpointTab.VERSIONS }).url
-                    )
+                    router.actions.push(combineUrl(urls.endpoint(endpointName), { tab: EndpointTab.VERSIONS }).url)
                 }
                 data-attr="endpoint-menubar-view-all-versions"
             >

--- a/products/endpoints/frontend/endpointSceneLogic.test.ts
+++ b/products/endpoints/frontend/endpointSceneLogic.test.ts
@@ -27,6 +27,7 @@ jest.mock('lib/api', () => ({
         endpoint: {
             get: jest.fn(),
             run: jest.fn(),
+            listVersions: jest.fn().mockResolvedValue({ results: [] }),
         },
     },
 }))

--- a/products/endpoints/frontend/endpointSceneLogic.tsx
+++ b/products/endpoints/frontend/endpointSceneLogic.tsx
@@ -148,6 +148,7 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         setDebugInfoExpanded: (debugInfoExpanded: boolean) => ({ debugInfoExpanded }),
         loadMaterializationPreview: true,
         keepSqlEditorMounted: (editorTabId: string) => ({ editorTabId }),
+        toggleMaterializationFromMenu: true,
     }),
     reducers({
         localQuery: [
@@ -356,8 +357,8 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
 
             const { searchParams, hashParams } = getTabSceneParams(props.tabId)
 
-            // Load tab-specific data
-            if (searchParams.tab === EndpointTab.VERSIONS && endpoint?.name) {
+            // Versions populate the File → Open version submenu, so always load them.
+            if (endpoint?.name) {
                 actions.loadVersions(endpoint.name)
             }
             if (searchParams.tab === EndpointTab.CONFIGURATION && endpoint?.name) {
@@ -396,6 +397,24 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         },
         setBucketOverride: () => {
             actions.loadMaterializationPreview()
+        },
+        toggleMaterializationFromMenu: () => {
+            if (!values.endpoint?.name) {
+                return
+            }
+            const baseIsMaterialized =
+                values.viewingVersion?.is_materialized ?? values.endpoint?.is_materialized ?? false
+            const effective = values.isMaterialized ?? baseIsMaterialized
+            actions.setActiveTab(EndpointTab.CONFIGURATION)
+            actions.setIsMaterialized(!effective)
+            // Drive the URL so Configuration is loaded if/when LemonTabs is gone.
+            const { searchParams, hashParams } = getTabSceneParams(props.tabId)
+            updateTabUrl(
+                props.tabId,
+                urls.endpoint(values.endpoint.name),
+                { ...searchParams, tab: EndpointTab.CONFIGURATION },
+                hashParams
+            )
         },
         setViewingVersion: ({ version }) => {
             // Reset local state so viewed version's data shows through


### PR DESCRIPTION
## Problem

The OS-like SceneMenuBar on the Endpoint scene was a thin wrapper around the existing actions — File only had project-tree items plus Delete, and Edit was just an Active/Inactive checkbox. It didn't feel like a real menu and didn't justify keeping LemonTabs around.

## Changes

[Clipboard-20260528-135252-945.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2ea299fd-1901-4adf-8adb-d88427a84ced.mp4" />](https://app.graphite.com/user-attachments/video/2ea299fd-1901-4adf-8adb-d88427a84ced.mp4)

**File menu**

- `New endpoint` submenu — From SQL editor / From insight (reuses the existing flows)
- `Open endpoint` submenu — every endpoint in the project, current one marked with a check, "Browse all endpoints" footer
- `Open version` submenu — every version of the current endpoint, current marked with a check, "Manage versions" footer that goes to the versions table
- `Open playground`, `View history` — `?tab=…` navigation
- `View usage` — opens `/endpoints?tab=usage` pre-filtered to the current endpoint via `urls.endpointsUsage({ endpointFilter: [endpoint.name] })`
- Then `SceneMenuBarFileItems` (Open in tree / Move / Star)

**Edit menu**

- Active checkbox replaced with a labelled `Activate endpoint` / `Deactivate endpoint` action (goes through the existing `confirmToggleActive` dialog)
- `Materialize endpoint` / `Disable materialization` — jumps to the Configuration tab and flips `isMaterialized` locally; the user still confirms via the existing Update button in the header
- Destructive `Delete endpoint` moves here at the bottom

**Tabs**

- LemonTabs is removed when `SCENE_MENU_BAR` is on — the active tab content renders directly via a switch on `activeTab`. LemonTabs is preserved as the fallback when the flag is off.

`endpointSceneLogic.loadEndpointSuccess` now always loads versions so the Open version submenu has data on first paint.

## How did you test this code?

I'm an agent — I did not test this manually. Automated checks I ran:

- `pnpm typescript:check` — no new errors in `products/endpoints/`. The existing repo-wide errors in `products/workflows/` and `frontend/src/scenes/web-analytics/` are pre-existing and unrelated.
- `pnpm typegen:write` — regenerated kea logic types for the new `toggleMaterializationFromMenu` action.
- Existing `endpointSceneLogic.test.ts` mock updated to include `api.endpoint.listVersions` since `loadVersions` is now always called on `loadEndpointSuccess`. The test file itself can't run in this environment due to a pre-existing `@posthog/quill` resolution issue in the jest config (reproducible on master).

A human reviewer should boot the app with the `SCENE_MENU_BAR` flag and click through each menu item, especially:

- Open endpoint / Open version on an endpoint with many versions
- Materialize endpoint flipping into Configuration with the unsaved-change banner
- View usage carrying the endpoint filter into the usage scene



Edit: And I'm the human reviewer - and I tested the above and made sure it's all smooth.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Opus 4.7 via Claude Code. The user asked to make the Endpoints OS-like menu "spark joy" with a concrete spec for File and Edit, plus the hypothesis that the menu items might let us drop LemonTabs entirely.

Decisions:

- Kept LemonTabs as a fallback under the `SCENE_MENU_BAR` flag rather than ripping it out. Configuration tab has no dedicated File menu entry (only reachable via Edit → Materialize), and Query is only reachable by clicking the current endpoint in Open endpoint or via the breadcrumb — felt worth keeping the safety net until UX validates the menu-only path.
- Always loading versions on `loadEndpointSuccess` instead of lazy-loading when the submenu opens. The list is short, and submenus don't have a clean "on open" hook with the current primitives.
- Added a `toggleMaterializationFromMenu` listener instead of having the menu component own the side effect, so the URL push and tab switch live next to the existing materialization state machine.