### PR TITLE
chore(error-tracking): drop 7 orphaned feature flag constants

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -190,7 +190,6 @@ export const FEATURE_FLAGS = {
     BOX_PLOT_INSIGHT: 'box-plot-insight', // owner: @pauldambra #team-product-analytics
     CALENDAR_HEATMAP_INSIGHT: 'calendar-heatmap-insight', // owner: @jabahamondes #team-web-analytics
     COOKIELESS_SERVER_HASH_MODE_SETTING: 'cookieless-server-hash-mode-setting', // owner: #team-web-analytics
-    ERROR_TRACKING_ALERT_ROUTING: 'error-tracking-alert-routing', // owner: #team-error-tracking
     EXPERIMENT_INTERVAL_TIMESERIES: 'experiments-interval-timeseries', // owner: @jurajmajerik #team-experiments
     /* The below flag is used to activate unmounting charts outside the viewport, as we're currently investigating frontend performance
     issues related to this and want to know the impact of having it on vs. off. */
@@ -276,21 +275,15 @@ export const FEATURE_FLAGS = {
     DWH_SOURCE_METRICS: 'dwh-source-metrics', // owner: #team-warehouse-sources
     EDITOR_DRAFTS: 'editor-drafts', // owner: @EDsCODE #team-data-tools
     ENDPOINTS: 'embedded-analytics', // owner: @sakce #team-clickhouse
-    ERROR_TRACKING_ALERTS_WIZARD: 'error-tracking-alerts-wizard', // owner: @aleks #team-error-tracking
-    ERROR_TRACKING_FORCE_QUERY_V2: 'error-tracking-force-query-v2', // owner: #team-error-tracking
     ERROR_TRACKING_FORCE_QUERY_V3: 'error-tracking-force-query-v3', // owner: #team-error-tracking
-    ERROR_TRACKING_INGESTION_CONTROLS: 'error-tracking-ingestion-controls', // owner: #team-error-tracking
     ERROR_TRACKING_ISSUE_CORRELATION: 'error-tracking-issue-correlation', // owner: @david #team-error-tracking
     ERROR_TRACKING_ISSUE_SPLITTING: 'error-tracking-issue-splitting', // owner: @david #team-error-tracking
-    ERROR_TRACKING_JIRA_INTEGRATION: 'error-tracking-jira-integration', // owner: #team-error-tracking
     ERROR_TRACKING_QUERY_V2: 'error-tracking-query-v2', // owner: #team-error-tracking
     ERROR_TRACKING_QUERY_V3: 'error-tracking-query-v3', // owner: #team-error-tracking
     ERROR_TRACKING_RATE_LIMITING: 'error-tracking-rate-limiting', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_RATE_LIMITING_PER_ISSUE: 'error-tracking-rate-limiting-per-issue', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_RECOMMENDATIONS: 'error-tracking-recommendations', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_RELATED_ISSUES: 'error-tracking-related-issues', // owner: #team-error-tracking
-    ERROR_TRACKING_REVENUE_SORTING: 'error-tracking-revenue-sorting', // owner: @david #team-error-tracking
-    ERROR_TRACKING_SETTINGS_SPLIT: 'error-tracking-settings-split', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_WEEKLY_DIGEST: 'error-tracking-weekly-digest', // owner: #team-error-tracking
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
     EXPERIMENT_CUPED: 'experiment-cuped', // owner: @andehen #team-experiments


### PR DESCRIPTION
## Problem

`frontend/src/lib/constants.tsx` accumulated several error-tracking `FEATURE_FLAGS` entries whose features are fully released. Seven of them no longer have a single reference anywhere in the repo (frontend or backend), so the constants are dead weight and make the flag list harder to reason about.

This follows the same cleanup already underway in the team's other flag-removal PRs (e.g. `error-tracking-insights`, `error-tracking-spike-alerting`).

## Changes

Removed 7 orphaned constants from `FEATURE_FLAGS`. Each was confirmed to have zero references outside `constants.tsx` via a fixed-string search across the whole repo:

| Constant | Flag key | PostHog flag state |
| --- | --- | --- |
| `ERROR_TRACKING_ALERT_ROUTING` | `error-tracking-alert-routing` | active |
| `ERROR_TRACKING_ALERTS_WIZARD` | `error-tracking-alerts-wizard` | active |
| `ERROR_TRACKING_FORCE_QUERY_V2` | `error-tracking-force-query-v2` | no flag exists |
| `ERROR_TRACKING_INGESTION_CONTROLS` | `error-tracking-ingestion-controls` | active (disabled) |
| `ERROR_TRACKING_JIRA_INTEGRATION` | `error-tracking-jira-integration` | active |
| `ERROR_TRACKING_REVENUE_SORTING` | `error-tracking-revenue-sorting` | active |
| `ERROR_TRACKING_SETTINGS_SPLIT` | `error-tracking-settings-split` | active (disabled) |

This is a **code-only** change — it removes the unused TypeScript constants. The underlying PostHog feature flags are intentionally left in place and unchanged; cleaning those up (delete/disable) is a separate decision for the flag owners.

**Kept:**
- `ERROR_TRACKING_QUERY_V2` — explicitly out of scope for this cleanup.
- `ERROR_TRACKING_ISSUE_CORRELATION` — still referenced in `frontend/src/scenes/max/max-constants.tsx` (a Max AI tool definition), so it is **not** orphaned.

The `error-tracking-query-v3` / `error-tracking-force-query-v3` flags and every other still-referenced error-tracking flag are unaffected.

## How did you test this code?

I'm an agent (Claude Code). No manual/UI testing was performed. Automated checks I actually ran against the worktree:

- `oxfmt --check` and `oxlint` on `constants.tsx` → clean (0/0).
- Fixed-string `git grep` for every dropped constant and its flag-key string across `*.ts/*.tsx/*.py/*.rs/*.go` → no references outside `constants.tsx`. (The lone `error-tracking-ingestion-controls` string in `frontend/src/scenes/settings/types.ts` is an unrelated settings-section slug, not a flag lookup.)
- `pnpm install` + `kea-typegen write` + `tsc --noEmit` → no type errors reference the removed constants or `constants.tsx`. (The worktree surfaced unrelated errors from the `@posthog/quill` workspace package not being linked in the isolated checkout; those are environmental and untouched by this change.)

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude Code at the request of the human PR owner.

- **Tools used:** Claude Code (file edits, git, `gh`, local `oxfmt`/`oxlint`/`tsc`/`kea-typegen`); PostHog MCP (`feature-flag-get-all`, `feature-flag-get-definition`, `feature-flags-status-retrieve`) to verify each flag's rollout/state read-only against the production project. No changes were made through the MCP.
- **How candidates were found:** grepped latest `master` for every `ERROR_TRACKING_*` constant to find ones with no remaining code references.
- **Correction during review:** an initial pass used a `git grep -E "\b…\b"` pattern; POSIX `grep -E` does not honor `\b`, so references that used the *constant* (not the raw flag string) were missed and `ERROR_TRACKING_ISSUE_CORRELATION` was wrongly flagged as orphaned and removed. This was caught by the typecheck, re-verified with a fixed-string search, and the constant was restored. The final set of 7 was re-confirmed with fixed-string matching.
- **Decisions:** code-only cleanup; PostHog flags left untouched. `ERROR_TRACKING_FORCE_QUERY_V2` is included because it has neither code references nor a corresponding PostHog flag.
- Note: most of these flags still show "called today" in PostHog, which reflects bulk SDK flag evaluation, not a code read — the zero-reference fixed-string grep is the authoritative signal that the constants are unused.
