### PR TITLE
fix(test): bump async timeout for TrendsLineChart tests

### DIFF
--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import { cleanup, configure, fireEvent, screen, waitFor } from '@testing-library/react'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { setupJsdom, setupSyncRaf } from 'lib/hog-charts/testing'
@@ -17,6 +17,10 @@ import {
 } from '~/test/insight-testing'
 import { buildAnnotation } from '~/test/insight-testing/test-data'
 import { AnnotationScope, ChartDisplayType } from '~/types'
+
+// The full InsightViz tree is heavy to mount under jsdom; on contended CI shards
+// the default 1s waitFor / findBy timeout is too tight and flakes randomly.
+configure({ asyncUtilTimeout: 5000 })
 
 let cleanupJsdom: () => void
 let cleanupRaf: () => void


### PR DESCRIPTION
## Problem

`TrendsLineChart` jest tests use the default 1s `waitFor` / `findBy*` timeout from testing-library. On contended CI shards (e.g. `Jest test (EE - 1)`), mounting the full `InsightViz` tree under jsdom occasionally takes longer than that, and tests flake with `Unable to find role="img" and name "/chart with N data series/i"`. Seen on a recent unrelated PR run (#59109).

#60177 fixed the equivalent issue on `TrendsBarChart` by adding `{ timeout: 5000 }` to every individual `waitFor` and `findByRole` call. That works but it's noisy and easy to forget on new tests.

## Changes

- Add a single `configure({ asyncUtilTimeout: 5000 })` at the top of `TrendsLineChart.test.tsx`, which raises the default timeout for every `waitFor` / `findBy*` in that file.
- No per-call timeout changes, no readiness guards added.

## How did you test this code?

I'm an agent. Ran the full test file locally — 48/48 pass (~17s). Did not run on CI from this branch yet.

## Publish to changelog?

🤖 Generated with [Claude Code](https://claude.com/claude-code)