### PR TITLE
fix(signals): Resolve reports on PR merge by pr_url

### DIFF
--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -383,6 +383,96 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, SignalReport.Status.READY)
 
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_merge_resolves_report_when_find_task_run_picks_unrelated_run(self, _mock_capture, mock_get_secret):
+        # Regression: when a different (unrelated, non-signal) task also has
+        # output.pr_url set to this PR — e.g. a parallel user-initiated run —
+        # find_task_run may return that one via .first(). The resolver must
+        # still pick up the signal-linked report by looking up SignalReports
+        # whose linked tasks have any TaskRun matching the pr_url, not by
+        # routing through the single TaskRun find_task_run happened to pick.
+        mock_get_secret.return_value = self.webhook_secret
+        unrelated_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Unrelated user task",
+            description="Manually created run that opened the PR",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            repository="posthog/posthog",
+        )
+        TaskRun.objects.create(
+            task=unrelated_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/42"},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.RESOLVED)
+
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_merge_resolves_report_even_when_no_task_run_matches_for_analytics(self, _mock_capture, mock_get_secret):
+        # If find_task_run returns None (e.g. analytics-side attribution lost
+        # the run), the merge still resolves the signal report — the report
+        # link is keyed off pr_url through SignalReportTask.task.runs.
+        mock_get_secret.return_value = self.webhook_secret
+        report = SignalReport.objects.create(
+            team=self.team,
+            status=SignalReport.Status.READY,
+            title="Untraceable report",
+            summary="Run cannot be found via find_task_run",
+        )
+        orphan_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Orphan signal task",
+            description="No analytics-side TaskRun match",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+            repository="posthog/posthog",
+        )
+        TaskRun.objects.create(
+            task=orphan_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/777"},
+        )
+        SignalReportTask.objects.create(
+            team=self.team,
+            report=report,
+            task=orphan_task,
+            relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+        )
+
+        payload = {
+            "action": "closed",
+            "pull_request": {
+                "html_url": "https://github.com/posthog/posthog/pull/777",
+                "merged": True,
+            },
+        }
+        # Wipe find_task_run's matchable TaskRun for this PR by mutating the
+        # task_run's output so analytics attribution misses, but leave the
+        # SignalReport link intact via a separate run.
+        with patch("products.tasks.backend.webhooks.find_task_run", return_value=(None, None)):
+            payload_bytes = json.dumps(payload).encode("utf-8")
+            signature = generate_github_signature(payload_bytes, self.webhook_secret)
+            response = self.client.post(
+                "/webhooks/github/pr/",
+                data=payload_bytes,
+                content_type="application/json",
+                HTTP_X_HUB_SIGNATURE_256=signature,
+                HTTP_X_GITHUB_EVENT="pull_request",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        report.refresh_from_db()
+        self.assertEqual(report.status, SignalReport.Status.RESOLVED)
+
 
 class TestFindTaskRun(TestCase):
     def setUp(self):
@@ -405,8 +495,9 @@ class TestFindTaskRun(TestCase):
             status=TaskRun.Status.COMPLETED,
             output={"pr_url": "https://github.com/posthog/posthog/pull/123"},
         )
-        result = find_task_run(pr_url="https://github.com/posthog/posthog/pull/123")
+        result, strategy = find_task_run(pr_url="https://github.com/posthog/posthog/pull/123")
         self.assertEqual(result, task_run)
+        self.assertEqual(strategy, "pr_url")
 
     def test_finds_by_branch_when_no_pr_url_match(self):
         task_run = TaskRun.objects.create(
@@ -415,8 +506,9 @@ class TestFindTaskRun(TestCase):
             status=TaskRun.Status.IN_PROGRESS,
             branch="feature/my-branch",
         )
-        result = find_task_run(branch="feature/my-branch", repository="posthog/posthog")
+        result, strategy = find_task_run(branch="feature/my-branch", repository="posthog/posthog")
         self.assertEqual(result, task_run)
+        self.assertEqual(strategy, "branch")
 
     def test_pr_url_takes_priority_over_branch(self):
         pr_run = TaskRun.objects.create(
@@ -432,12 +524,13 @@ class TestFindTaskRun(TestCase):
             status=TaskRun.Status.IN_PROGRESS,
             branch="feature/my-branch",
         )
-        result = find_task_run(
+        result, strategy = find_task_run(
             pr_url="https://github.com/posthog/posthog/pull/123",
             branch="feature/my-branch",
             repository="posthog/posthog",
         )
         self.assertEqual(result, pr_run)
+        self.assertEqual(strategy, "pr_url")
 
     def test_falls_back_to_branch_when_pr_url_not_found(self):
         branch_run = TaskRun.objects.create(
@@ -446,20 +539,23 @@ class TestFindTaskRun(TestCase):
             status=TaskRun.Status.IN_PROGRESS,
             branch="feature/my-branch",
         )
-        result = find_task_run(
+        result, strategy = find_task_run(
             pr_url="https://github.com/posthog/posthog/pull/999",
             branch="feature/my-branch",
             repository="posthog/posthog",
         )
         self.assertEqual(result, branch_run)
+        self.assertEqual(strategy, "branch")
 
     def test_returns_none_when_no_match(self):
-        result = find_task_run(pr_url="https://github.com/posthog/posthog/pull/999")
+        result, strategy = find_task_run(pr_url="https://github.com/posthog/posthog/pull/999")
         self.assertIsNone(result)
+        self.assertIsNone(strategy)
 
     def test_returns_none_with_no_args(self):
-        result = find_task_run()
+        result, strategy = find_task_run()
         self.assertIsNone(result)
+        self.assertIsNone(strategy)
 
     def test_branch_fallback_requires_repository(self):
         TaskRun.objects.create(
@@ -470,7 +566,9 @@ class TestFindTaskRun(TestCase):
         )
         # Without a repository the branch fallback must not match — bare branch
         # names like "main" collide across every team in the database.
-        self.assertIsNone(find_task_run(branch="main"))
+        result, strategy = find_task_run(branch="main")
+        self.assertIsNone(result)
+        self.assertIsNone(strategy)
 
     def test_branch_fallback_does_not_match_other_repositories(self):
         # The task's repository is "posthog/posthog"; a webhook from a foreign
@@ -481,8 +579,9 @@ class TestFindTaskRun(TestCase):
             status=TaskRun.Status.IN_PROGRESS,
             branch="main",
         )
-        result = find_task_run(branch="main", repository="ArkeroAI/arkero2")
+        result, strategy = find_task_run(branch="main", repository="ArkeroAI/arkero2")
         self.assertIsNone(result)
+        self.assertIsNone(strategy)
 
     def test_branch_fallback_matches_repository_case_insensitively(self):
         task_run = TaskRun.objects.create(
@@ -491,8 +590,9 @@ class TestFindTaskRun(TestCase):
             status=TaskRun.Status.IN_PROGRESS,
             branch="feature/my-branch",
         )
-        result = find_task_run(branch="feature/my-branch", repository="PostHog/PostHog")
+        result, strategy = find_task_run(branch="feature/my-branch", repository="PostHog/PostHog")
         self.assertEqual(result, task_run)
+        self.assertEqual(strategy, "branch")
 
     def test_branch_fallback_rejects_empty_repository(self):
         TaskRun.objects.create(
@@ -502,7 +602,9 @@ class TestFindTaskRun(TestCase):
             branch="main",
         )
         for value in ("", "   ", "\t"):
-            self.assertIsNone(find_task_run(branch="main", repository=value))
+            result, strategy = find_task_run(branch="main", repository=value)
+            self.assertIsNone(result)
+            self.assertIsNone(strategy)
 
 
 class TestGitHubWebhookFanout(TestCase):

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -20,11 +20,18 @@ def find_task_run(
     pr_url: str | None = None,
     branch: str | None = None,
     repository: str | None = None,
-) -> TaskRun | None:
+) -> tuple[TaskRun | None, str | None]:
+    """Locate the TaskRun that produced this PR for analytics attribution.
+
+    Returns ``(task_run, match_strategy)`` where ``match_strategy`` is
+    ``"pr_url"`` or ``"branch"`` when matched and ``None`` otherwise. The
+    strategy is logged so we can tell, from logs alone, which path matched
+    when diagnosing webhook attribution issues.
+    """
     if pr_url:
         task_run = TaskRun.objects.filter(output__pr_url=pr_url).select_related(*TASK_RUN_SELECT_RELATED).first()
         if task_run:
-            return task_run
+            return task_run, "pr_url"
 
     # Branch-only lookups must be scoped to the repository the webhook came from.
     # Without this, a PR opened on an unrelated repo with a colliding branch name
@@ -37,9 +44,9 @@ def find_task_run(
             .first()
         )
         if task_run:
-            return task_run
+            return task_run, "branch"
 
-    return None
+    return None, None
 
 
 def verify_github_signature(payload: bytes, signature: str | None, secret: str) -> bool:
@@ -100,7 +107,7 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
 
     branch = pull_request.get("head", {}).get("ref")
     repository_full_name = (payload.get("repository") or {}).get("full_name")
-    task_run = find_task_run(pr_url=pr_url, branch=branch, repository=repository_full_name)
+    task_run, match_strategy = find_task_run(pr_url=pr_url, branch=branch, repository=repository_full_name)
 
     if not task_run:
         logger.debug(
@@ -109,6 +116,12 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
             pr_url=pr_url,
             message="No TaskRun found with this PR URL",
         )
+        # A merged PR may still resolve linked SignalReports even when we cannot
+        # attribute it to a TaskRun for analytics — the SignalReportTask link
+        # is what matters for resolution, and it's keyed off pr_url, not the
+        # particular TaskRun that produced the PR.
+        if action == "closed" and merged:
+            _resolve_signal_reports_for_pr(pr_url)
         return HttpResponse(status=200)
 
     logger.info(
@@ -118,6 +131,7 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
         pr_url=pr_url,
         task_id=str(task_run.task_id),
         run_id=str(task_run.id),
+        match_strategy=match_strategy,
     )
 
     # Generate a deterministic UUID from the PR URL and event type so that
@@ -126,13 +140,20 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
     task_run.capture_event(analytics_event, {"pr_url": pr_url}, event_uuid=event_uuid)
 
     if action == "closed" and merged:
-        _resolve_signal_reports_for_task(task_run.task_id, pr_url)
+        _resolve_signal_reports_for_pr(pr_url)
 
     return HttpResponse(status=200)
 
 
-def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
-    """Mark signal reports linked to a merged PR's task as resolved.
+def _resolve_signal_reports_for_pr(pr_url: str) -> None:
+    """Mark signal reports linked to a merged PR as resolved.
+
+    Looks up reports via ``report_tasks.task.runs.output.pr_url`` instead of
+    routing through the single TaskRun that ``find_task_run`` happened to pick.
+    Multiple TaskRuns can carry the same ``pr_url`` (reruns, parallel attempts,
+    or user-initiated runs that opened the PR after a signal-initiated run
+    pushed the branch). Filtering on ``task_id`` of just one of them meant any
+    SignalReport linked through a different run was silently skipped.
 
     Kept tolerant: a single bad transition should not fail the whole webhook,
     since GitHub retries 5xx responses and we've already acknowledged the PR event.
@@ -142,7 +163,9 @@ def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
         SignalReport.Status.DELETED,
         SignalReport.Status.SUPPRESSED,
     )
-    linked_reports = list(SignalReport.objects.filter(report_tasks__task_id=task_id).distinct().only("id", "status"))
+    linked_reports = list(
+        SignalReport.objects.filter(report_tasks__task__runs__output__pr_url=pr_url).distinct().only("id", "status")
+    )
     reports_to_resolve = [r for r in linked_reports if r.status not in terminal_statuses]
     skipped_terminal = [r for r in linked_reports if r.status in terminal_statuses]
 
@@ -150,7 +173,6 @@ def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
     # ran, how many reports were linked, and why we did/didn't transition any of them.
     logger.info(
         "github_pr_webhook_signal_report_resolution_started",
-        task_id=str(task_id),
         pr_url=pr_url,
         linked_report_count=len(linked_reports),
         candidate_report_count=len(reports_to_resolve),
@@ -170,7 +192,6 @@ def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
                 "github_pr_webhook_signal_report_invalid_transition",
                 report_id=str(report.id),
                 from_status=report.status,
-                task_id=str(task_id),
                 pr_url=pr_url,
             )
             continue
@@ -179,13 +200,11 @@ def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
         logger.info(
             "github_pr_webhook_signal_report_resolved",
             report_id=str(report.id),
-            task_id=str(task_id),
             pr_url=pr_url,
         )
 
     logger.info(
         "github_pr_webhook_signal_report_resolution_finished",
-        task_id=str(task_id),
         pr_url=pr_url,
         resolved_count=resolved_count,
         invalid_transition_count=invalid_transition_count,


### PR DESCRIPTION
## Problem

When a PR merge webhook arrives, `_resolve_signal_reports_for_task` routed report resolution through the single `TaskRun` that `find_task_run` happened to return via `.first()`. That's brittle: when multiple `TaskRun`s carry the same `output.pr_url` — reruns, parallel attempts, or a user-initiated run that opened the PR after a signal-initiated run pushed the branch — the chosen run's `task_id` may not be the one a `SignalReportTask` is keyed off, and the report is silently skipped.

This is the failure mode that swallowed report `019dc615-fb1e-7dc3-bf11-fd67d4c012b4` for PostHog/posthog#56919: the webhook fired and was attributed to a `TaskRun`, but the resolver came back empty because no `SignalReportTask` matched that particular `task_id`.

## Changes

- Replace `_resolve_signal_reports_for_task(task_id, pr_url)` with `_resolve_signal_reports_for_pr(pr_url)`, querying `SignalReport.objects.filter(report_tasks__task__runs__output__pr_url=pr_url)`. Report resolution no longer depends on which TaskRun `find_task_run` happened to pick.
- Resolve linked reports even when `find_task_run` returns `None` for analytics attribution — the SignalReportTask link is keyed off `pr_url`, not the analytics-side run match.
- Return `(task_run, match_strategy)` from `find_task_run` and log `match_strategy` (`pr_url` vs `branch`) on `github_pr_webhook_processed`, so the matching path is diagnosable from logs alone (complements the resolution-side observability shipped in the parent PR).

## How did you test this code?

Agent-authored — automated test coverage only, no manual webhook hits against staging.

Added regression coverage in `products/tasks/backend/tests/test_webhooks.py`:

- `test_merge_resolves_report_when_find_task_run_picks_unrelated_run` — two tasks share `output.pr_url`; only one carries the `SignalReportTask` link. Verifies the report still transitions to `RESOLVED`.
- `test_merge_resolves_report_even_when_no_task_run_matches_for_analytics` — `find_task_run` returns `(None, None)`; resolution still fires off the pr_url path.

Updated existing `TestFindTaskRun` cases for the new return tuple and added `match_strategy` assertions.

`hogli test products/tasks/backend/tests/test_webhooks.py` — 36 passed.

## Publish to changelog?

no

## 🤖 Agent context

- Claude Code (Opus 4.7, 1M context) explored the webhook + signals models and proposed the change.
- Rejected option: a narrower fix to add ordering to `find_task_run`'s `.first()` — kept getting tangled in tie-breaker semantics across reruns. Decoupling resolution from `find_task_run` is structurally simpler and removes the indirection entirely.
- Stacked on top of #60132 (observability-only change), since this builds on the logging contract added there.