### PR TITLE
fix(data-table): keep "save as default" toggle visible in column configurator

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -174,7 +174,7 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
             onClose={hideModal}
             footer={
                 <>
-                    <div className="flex-1">
+                    <div className="flex-1 flex flex-wrap items-center gap-2">
                         <LemonButton
                             type="secondary"
                             onClick={() =>
@@ -183,6 +183,21 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                         >
                             Reset to defaults
                         </LemonButton>
+                        {showPersistedColumnReorder && query.showPersistentColumnConfigurator && (
+                            <LemonCheckbox
+                                label={
+                                    context?.type === 'groups'
+                                        ? 'Save as default columns for this group type'
+                                        : context?.type === 'event_definition'
+                                          ? 'Save as default columns for this event type'
+                                          : 'Save as default for all project members'
+                                }
+                                data-attr="events-table-save-columns-as-default-toggle"
+                                checked={saveAsDefault}
+                                onChange={toggleSaveAsDefault}
+                                disabledReason={restrictionReason}
+                            />
+                        )}
                     </div>
                     <LemonButton type="secondary" onClick={hideModal}>
                         Close
@@ -255,23 +270,6 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                         </div>
                     </div>
                 </div>
-                {showPersistedColumnReorder && query.showPersistentColumnConfigurator && (
-                    <LemonCheckbox
-                        label={
-                            context?.type === 'groups'
-                                ? 'Save as default columns for this group type'
-                                : context?.type === 'event_definition'
-                                  ? 'Save as default columns for this event type'
-                                  : 'Save as default for all project members'
-                        }
-                        className="mt-2"
-                        data-attr="events-table-save-columns-as-default-toggle"
-                        bordered
-                        checked={saveAsDefault}
-                        onChange={toggleSaveAsDefault}
-                        disabledReason={restrictionReason}
-                    />
-                )}
             </div>
         </LemonModal>
     )


### PR DESCRIPTION
## Problem

In the data-table column configurator modal (Activity view and other tables that show "Configure columns"), the "Save as default for all project members" checkbox is hard to discover. The modal body contains an inner scrollable taxonomic filter (`h-[min(480px,60vh)]`), and on shorter viewports the modal body itself also overflows — so the checkbox, which lived below the inner scroll area, gets pushed out of sight behind the outer scroll. Users have to scroll twice and in the right place to even know the option exists.

## Changes

Move the checkbox into the modal footer, next to "Reset to defaults". The footer doesn't scroll, so the toggle is always visible no matter the viewport size.

- Drops the `bordered` style since the footer already provides visual separation.
- Wraps the left footer slot in `flex flex-wrap items-center gap-2` so "Reset to defaults" + the checkbox stack gracefully on narrow screens instead of clipping.
- No behavioral change: same condition guards (`showPersistedColumnReorder && query.showPersistentColumnConfigurator`), same `data-attr`, same labels, same `disabledReason` handling.

<img width="3024" height="1722" alt="CleanShot 2026-05-27 at 14 03 45@2x" src="https://github.com/user-attachments/assets/51127935-4837-413c-8527-ec5ee8160d7f" />

## How did you test this code?

I'm an agent. I made the structural edit and ran `pnpm --filter=@posthog/frontend typescript:check` — no new errors in this file. The remaining errors in the run are from missing `node_modules` in the sandbox environment and are unrelated to this change. The PR author will test the modal on desktop and mobile viewports to confirm the toggle stays visible and the footer wraps cleanly.

Christiaan tested this out locally, and it worked.

## Publish to changelog?

no

## 🤖 Agent context

User flagged the discoverability problem in a support thread: the activity-view column configurator has a nested scroll (inner taxonomic filter + outer modal body), and the "Save as default for all project members" checkbox sits below the inner scroll inside the modal body. On smaller viewports the checkbox slides behind the outer scroll and is easy to miss.

Considered three options:
1. **Move the checkbox into the footer** alongside "Reset to defaults" — footer doesn't scroll, smallest diff, matches the pattern of placing persistence/scope toggles next to reset/cancel actions in other modals.
2. **Split-button "Save" / "Save as default…"** — most discoverable but introduces a UI pattern we don't use elsewhere and loses the sticky/checkbox affordance.
3. **Remove the inner fixed-height scroll** so only the outer modal scrolls — simplest in theory but the `TaxonomicFilter` virtualizer needs a bounded height, so it would require larger refactoring.

Chose option 1. The user confirmed they'll verify the mobile layout themselves.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*