### PR TITLE
fix(hogql): restore single-arg toFloatOrDefault as toFloatOrZero

### DIFF
--- a/posthog/hogql/functions/clickhouse/conversions.py
+++ b/posthog/hogql/functions/clickhouse/conversions.py
@@ -51,14 +51,20 @@ TYPE_CONVERSION_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
         # ClickHouse's toFloat64OrDefault requires the default value to already be
         # Float64 — passing e.g. an integer 0 raises "Default value type should be
         # same as cast type". Cast the default so any numeric/string literal works.
+        # The 1-arg form is degenerate (equivalent to toFloatOrZero) and is
+        # rewritten in the printer before the placeholder template renders.
         "toFloat64OrDefault({0}, accurateCast({1}, 'Float64'))",
-        2,
+        1,
         2,
         using_placeholder_arguments=True,
         using_positional_arguments=True,
         # The default arg (second) may be an integer or float literal — the
         # template casts it to Float64 either way, so both must resolve.
         signatures=[
+            ((DecimalType(),), FloatType()),
+            ((IntegerType(),), FloatType()),
+            ((FloatType(),), FloatType()),
+            ((StringType(),), FloatType()),
             ((DecimalType(), FloatType()), FloatType()),
             ((DecimalType(), IntegerType()), FloatType()),
             ((IntegerType(), FloatType()), FloatType()),

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -962,6 +962,10 @@ class BasePrinter(Visitor[str]):
             # Handle format strings in function names before checking function type
             # HogQL preserves the macro in its original shape; SQL dialects expand it.
             if func_meta.using_placeholder_arguments and self._expands_placeholder_macros():
+                # Pre-#58714 behavior: single-arg toFloatOrDefault was degenerate and
+                # equivalent to toFloatOrZero. Rewrite here so saved queries still work.
+                if node.name == "toFloatOrDefault" and len(node.args) == 1:
+                    return self.visit(ast.Call(name="toFloatOrZero", args=node.args))
                 return self._render_placeholder_macro(
                     node=node,
                     clickhouse_name=func_meta.clickhouse_name,

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -1190,6 +1190,8 @@ class TestPrinter(BaseTest):
         self.assertEqual(
             self._expr("toDecimal('3.14', 2)", context), "accurateCastOrNull(%(hogql_val_6)s, %(hogql_val_7)s)"
         )
+        # Single-arg toFloatOrDefault is degenerate; rewritten to toFloatOrZero for ClickHouse.
+        self.assertEqual(self._expr("toFloatOrDefault('1.5')", context), "toFloat64OrZero(%(hogql_val_8)s)")
         self.assertEqual(self._expr("quantile(0.95)( event )"), "quantile(0.95)(events.event)")
 
         self.assertEqual(self._expr("groupArraySample(5)(event)"), "groupArraySample(5)(events.event)")

--- a/posthog/hogql/test/test_mapping.py
+++ b/posthog/hogql/test/test_mapping.py
@@ -315,6 +315,16 @@ class TestMappings(ClickhouseTestMixin, BaseTest):
         assert response.results is not None
         assert response.results[0] == (0.0, 2.5, 0.0)
 
+    def test_to_float_or_default_single_arg(self):
+        # Pre-#58714 single-arg form is degenerate (equivalent to toFloatOrZero);
+        # preserved so saved HogQL queries written before #58714 keep working.
+        response = execute_hogql_query(
+            "SELECT toFloatOrDefault('2.5'), toFloatOrDefault('bla'), toFloatOrDefault(NULL)",
+            self.team,
+        )
+        assert response.results is not None
+        assert response.results[0] == (2.5, 0.0, None)
+
     def test_map_function_with_multiple_key_value_pairs(self):
         """Test that the map function accepts multiple key-value pairs."""
         response = execute_hogql_query(


### PR DESCRIPTION
## Problem

#58714 changed `toFloatOrDefault` to require exactly 2 arguments by switching the registration to a positional placeholder template (`toFloat64OrDefault({0}, accurateCast({1}, 'Float64'))`). Any saved HogQL that still calls it with a single argument — insights with `math_hogql`, data warehouse model queries, ad-hoc saved queries written before #58714 — started failing with `QueryError: Invalid argument reference in function 'toFloatOrDefault'` (or, once #59835 lands, the standard arity error).

Before #58714, the 1-arg form was registered with `min_args=1, max_args=2` and was degenerate — equivalent to `toFloatOrZero`. Customers relying on that shape are broken.

## Changes

Restore the pre-#58714 behavior for the 1-arg form:

- `posthog/hogql/functions/clickhouse/conversions.py` — lower `toFloatOrDefault` `min_args` from 2 to 1 and register 1-arg signatures. The 2-arg form still uses the same positional placeholder template introduced in #58714.
- `posthog/hogql/printer/base.py` — in `visit_call`, before the placeholder-macro dispatch, rewrite `toFloatOrDefault(x)` to `toFloatOrZero(x)` so the template never sees a missing `{1}` placeholder. The rewrite is gated behind `_expands_placeholder_macros()`, so the HogQL printer still round-trips the original call shape.

Postgres translation already routed `toFloatOrDefault` through `_make_cast_handler("DOUBLE PRECISION")`, which ignores the default arg, so the 1-arg form works there without changes.

## How did you test this code?

Agent-authored. Automated tests only — added an executing test (`test_to_float_or_default_single_arg` in `test_mapping.py`) covering numeric / unparseable / NULL inputs against ClickHouse, and a printer assertion confirming the rewrite emits `toFloat64OrZero(...)` for the 1-arg form. Verified the existing 2-arg behavior (`test_function_mapping`, `test_to_float_or_default_with_integer_default`, the `test_expr_parse_errors` arity checks) still passes.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Surfaced from a customer report. Considered:

- **Special-casing in `_render_placeholder_macro`** — less invasive than the AST rewrite but would couple the generic placeholder renderer to a specific function name. Rejected.
- **Restoring the pre-#58714 ClickHouse name `toFloat64OrDefault`** with `min_args=1` — would re-introduce the `Default value type` ClickHouse error for integer-literal defaults that #58714 fixed. Rejected.

The chosen approach localizes the special-case to one branch in `visit_call`, keeps the placeholder template (and #58714's accurateCast fix) untouched for the 2-arg form, and preserves the original call shape for HogQL round-trip printing.

Related: #59835 (still open) improves the error message for *other* placeholder-macro arity bugs and is complementary — this PR makes the 1-arg `toFloatOrDefault` call succeed, #59835 makes any future arity violation produce a clean error instead of a cryptic IndexError.