### PR TITLE
fix(hogql): allow 1-arg toFloatOrDefault in clickhouse printer

### DIFF
--- a/posthog/hogql/functions/clickhouse/conversions.py
+++ b/posthog/hogql/functions/clickhouse/conversions.py
@@ -48,17 +48,19 @@ TYPE_CONVERSION_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "toFloat": HogQLFunctionMeta("accurateCastOrNull", 1, 1, suffix_args=[ast.Constant(value="Float64")]),
     "toFloatOrZero": HogQLFunctionMeta("toFloat64OrZero", 1, 1, signatures=[((StringType(),), FloatType())]),
     "toFloatOrDefault": HogQLFunctionMeta(
-        # ClickHouse's toFloat64OrDefault requires the default value to already be
-        # Float64 — passing e.g. an integer 0 raises "Default value type should be
-        # same as cast type". Cast the default so any numeric/string literal works.
+        # accurateCast wraps the default so any numeric/string literal works;
+        # CH otherwise rejects mismatched default types. 1-arg calls have 0.0
+        # injected by the CH printer before this template runs.
         "toFloat64OrDefault({0}, accurateCast({1}, 'Float64'))",
-        2,
+        1,
         2,
         using_placeholder_arguments=True,
         using_positional_arguments=True,
-        # The default arg (second) may be an integer or float literal — the
-        # template casts it to Float64 either way, so both must resolve.
         signatures=[
+            ((DecimalType(),), FloatType()),
+            ((IntegerType(),), FloatType()),
+            ((FloatType(),), FloatType()),
+            ((StringType(),), FloatType()),
             ((DecimalType(), FloatType()), FloatType()),
             ((DecimalType(), IntegerType()), FloatType()),
             ((IntegerType(), FloatType()), FloatType()),

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -1385,6 +1385,17 @@ class ClickHousePrinter(BasePrinter):
         if optimized_property_group_call := self._get_optimized_property_group_call(node):
             return optimized_property_group_call
 
+        if node.name == "toFloatOrDefault" and len(node.args) == 1:
+            node = ast.Call(
+                name=node.name,
+                args=[node.args[0], ast.Constant(value=0.0)],
+                params=node.params,
+                distinct=node.distinct,
+                within_group=node.within_group,
+                filter_expr=node.filter_expr,
+                order_by=node.order_by,
+            )
+
         return super().visit_call(node)
 
     def visit_array_slice(self, node: ast.ArraySlice):

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -1192,6 +1192,15 @@ class TestPrinter(BaseTest):
         )
         self.assertEqual(self._expr("quantile(0.95)( event )"), "quantile(0.95)(events.event)")
 
+        self.assertEqual(
+            self._expr("toFloatOrDefault('1.5', 0)", context),
+            "toFloat64OrDefault(%(hogql_val_8)s, accurateCast(0, 'Float64'))",
+        )
+        self.assertEqual(
+            self._expr("toFloatOrDefault('1.5')", context),
+            "toFloat64OrDefault(%(hogql_val_9)s, accurateCast(0.0, 'Float64'))",
+        )
+
         self.assertEqual(self._expr("groupArraySample(5)(event)"), "groupArraySample(5)(events.event)")
         self.assertEqual(self._expr("groupArraySample(5, 123456)(event)"), "groupArraySample(5, 123456)(events.event)")
         self.assertEqual(


### PR DESCRIPTION
## Problem

ClickHouse accepts `toFloat64OrDefault(x[, default])` with an optional second argument, but our printer template `toFloat64OrDefault({0}, accurateCast({1}, 'Float64'))` hard-coded both placeholders. Calls like `toFloatOrDefault(x)` were hitting `_render_placeholder_macro`'s `format()` step before `validate_function_args` could intervene, surfacing `Invalid argument reference in function 'toFloatOrDefault': Replacement index 1 out of range` to downstream consumers. The new analyzer made this path consistent enough to trip the format error every time.

## Changes

- `posthog/hogql/printer/clickhouse.py` — `visit_call` injects `ast.Constant(value=0.0)` as the missing default when `toFloatOrDefault` is called with a single argument, so the existing template renders cleanly.
- `posthog/hogql/functions/clickhouse/conversions.py` — `toFloatOrDefault` is now `min_args=1`, with matching 1-arg signatures so the resolver returns `Float` instead of `Unknown` (which would otherwise break nesting in calls like `coalesce(toFloatOrDefault(x), …)`).

The Postgres path already only used `args[0]` via `_make_cast_handler("DOUBLE PRECISION")`, so no PG-side change was needed.

## How did you test this code?

I'm an agent. I added two assertions to `TestPrinter::test_functions` covering the 1-arg and 2-arg forms. I was unable to execute the full Django test suite in this sandbox (no ClickHouse/sqlx available), so verification is via the new assertions plus walking through the placeholder-expansion path manually.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Investigated the symptom traced back to `posthog/hogql/printer/base.py:1122-1125`, where `clickhouse_name.format(*arg_arr)` raises before `validate_function_args` runs for placeholder-template functions. Considered (1) moving validation earlier so 1-arg calls get a clean error, and (2) supporting the 1-arg form directly. Chose (2) because ClickHouse itself accepts the 1-arg shape and the customer's queries are valid HogQL — surfacing a friendlier error would still break them. Default-injection happens in CH's `visit_call` so the template stays a single source of truth and other dialects (Postgres handler already arity-tolerant; HogQL preserves the literal call) are unaffected.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*