### PR TITLE
chore(capture): reduce client-error log noise in analytics, AI, and replay paths

### DIFF
--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use std::collections::HashSet;
 use time::format_description::well_known::Iso8601;
 use time::OffsetDateTime;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 // Blob metrics
@@ -155,7 +155,6 @@ async fn ai_handler_inner(
 
     // Check for empty body
     if body.is_empty() {
-        warn!("AI endpoint received empty body");
         return Err(CaptureError::EmptyPayload);
     }
 
@@ -166,7 +165,6 @@ async fn ai_handler_inner(
         .unwrap_or("");
 
     if !auth_header.starts_with("Bearer ") {
-        warn!("AI endpoint missing or invalid Authorization header");
         return Err(CaptureError::NoTokenError);
     }
 
@@ -193,10 +191,6 @@ async fn ai_handler_inner(
         .unwrap_or("");
 
     if !content_type.starts_with("multipart/form-data") {
-        warn!(
-            "AI endpoint received non-multipart content type: {}",
-            content_type
-        );
         return Err(CaptureError::RequestDecodingError(
             "Content-Type must be multipart/form-data".to_string(),
         ));
@@ -204,7 +198,6 @@ async fn ai_handler_inner(
 
     // Extract boundary from Content-Type header using multer's built-in parser
     let boundary = parse_boundary(content_type).map_err(|e| {
-        warn!("Failed to parse boundary from Content-Type: {}", e);
         CaptureError::RequestDecodingError(format!("Invalid boundary in Content-Type: {e}"))
     })?;
 
@@ -316,7 +309,7 @@ async fn ai_handler_inner(
     // Upload blobs to S3 and insert URLs into event properties
     if !parsed.blob_parts.is_empty() {
         let blob_storage = state.ai_blob_storage.as_ref().ok_or_else(|| {
-            warn!("AI endpoint received blobs but S3 is not configured");
+            error!("AI endpoint received blobs but S3 is not configured");
             CaptureError::ServiceUnavailable("blob storage not configured".to_string())
         })?;
 

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -591,15 +591,11 @@ fn process_event_part(
     }
 
     // Parse the event JSON
-    let event_json_str = std::str::from_utf8(&field_data).map_err(|e| {
-        warn!("Event part is not valid UTF-8: {}", e);
-        CaptureError::RequestParsingError("Event part must be valid UTF-8".to_string())
-    })?;
+    let event_json_str = std::str::from_utf8(&field_data)
+        .map_err(|_| CaptureError::RequestParsingError("Event part must be valid UTF-8".to_string()))?;
 
-    let event_json = serde_json::from_str(event_json_str).map_err(|e| {
-        warn!("Event part is not valid JSON: {}", e);
-        CaptureError::RequestParsingError("Event part must be valid JSON".to_string())
-    })?;
+    let event_json = serde_json::from_str(event_json_str)
+        .map_err(|_| CaptureError::RequestParsingError("Event part must be valid JSON".to_string()))?;
 
     let part_info = PartInfo {
         name: "event".to_string(),
@@ -619,13 +615,11 @@ fn process_properties_part(
     content_encoding: Option<String>,
 ) -> Result<(Value, PartInfo), CaptureError> {
     // Parse the properties JSON
-    let properties_json_str = std::str::from_utf8(&field_data).map_err(|e| {
-        warn!("Properties part is not valid UTF-8: {}", e);
+    let properties_json_str = std::str::from_utf8(&field_data).map_err(|_| {
         CaptureError::RequestParsingError("Properties part must be valid UTF-8".to_string())
     })?;
 
-    let properties_json = serde_json::from_str(properties_json_str).map_err(|e| {
-        warn!("Properties part is not valid JSON: {}", e);
+    let properties_json = serde_json::from_str(properties_json_str).map_err(|_| {
         CaptureError::RequestParsingError("Properties part must be valid JSON".to_string())
     })?;
 
@@ -783,8 +777,6 @@ async fn retrieve_multipart_parts(
             blob_parts.push(blob_part);
             accepted_parts.push(part_info);
         } else {
-            warn!("Unknown multipart field: {}", field_name);
-
             // Reject unknown fields that don't match expected patterns
             return Err(CaptureError::RequestParsingError(format!(
                 "Unknown multipart field: '{field_name}'. Expected 'event', 'event.properties', or 'event.properties.<property_name>'"
@@ -891,10 +883,8 @@ fn parse_multipart_data(
         .and_then(|v| v.as_str())
         .ok_or_else(|| CaptureError::RequestParsingError("Event UUID is required".to_string()))
         .and_then(|uuid_str| {
-            Uuid::parse_str(uuid_str).map_err(|e| {
-                warn!("Invalid UUID format: {}", e);
-                CaptureError::RequestParsingError(format!("Invalid UUID format: {e}"))
-            })
+            Uuid::parse_str(uuid_str)
+                .map_err(|e| CaptureError::RequestParsingError(format!("Invalid UUID format: {e}")))
         })?;
 
     let timestamp = event
@@ -931,7 +921,6 @@ fn parse_multipart_data(
 fn validate_event_structure(event: &Value) -> Result<(), CaptureError> {
     // Check if event is an object
     let event_obj = event.as_object().ok_or_else(|| {
-        warn!("Event must be a JSON object");
         CaptureError::RequestParsingError("Event must be a JSON object".to_string())
     })?;
 
@@ -940,7 +929,6 @@ fn validate_event_structure(event: &Value) -> Result<(), CaptureError> {
         .get("event")
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            warn!("Event missing 'event' field");
             CaptureError::RequestParsingError("Event missing 'event' field".to_string())
         })?;
 
@@ -973,7 +961,6 @@ fn validate_event_structure(event: &Value) -> Result<(), CaptureError> {
         .get("distinct_id")
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            warn!("Event missing 'distinct_id' field");
             CaptureError::RequestParsingError("Event missing 'distinct_id' field".to_string())
         })?;
 
@@ -988,7 +975,6 @@ fn validate_event_structure(event: &Value) -> Result<(), CaptureError> {
         .get("properties")
         .and_then(|v| v.as_object())
         .ok_or_else(|| {
-            warn!("Event missing 'properties' field");
             CaptureError::RequestParsingError("Event missing 'properties' field".to_string())
         })?;
 
@@ -1003,7 +989,6 @@ fn validate_event_structure(event: &Value) -> Result<(), CaptureError> {
         .get("$ai_model")
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            warn!("$ai_model must be a string");
             CaptureError::RequestParsingError("$ai_model must be a string".to_string())
         })?;
 

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -29,7 +29,7 @@ use crate::event_restrictions::{
 use crate::events::overflow_stamping::stamp_overflow_reason;
 use crate::extractors::extract_body_with_timeout;
 use crate::payload::decompression::decompress_gzip_to_bytes;
-use crate::prometheus::report_dropped_events;
+use crate::prometheus::{report_dropped_events, report_internal_error_metrics};
 use crate::router::State as AppState;
 use crate::timestamp;
 use crate::token::validate_token;
@@ -122,6 +122,18 @@ struct ParsedMultipartData {
 
 pub async fn ai_handler(
     State(state): State<AppState>,
+    ip: Option<InsecureClientIp>,
+    path: MatchedPath,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<Json<AIEndpointResponse>, CaptureError> {
+    ai_handler_inner(state, ip, path, headers, body)
+        .await
+        .inspect_err(|err| report_internal_error_metrics(err.to_metric_tag(), "ai"))
+}
+
+async fn ai_handler_inner(
+    state: AppState,
     ip: Option<InsecureClientIp>,
     path: MatchedPath,
     headers: HeaderMap,

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -408,10 +408,7 @@ async fn retrieve_event_metadata(
     let field = multipart
         .next_field()
         .await
-        .map_err(|e| {
-            warn!("Multipart parsing error: {}", e);
-            CaptureError::RequestDecodingError(format!("Multipart parsing failed: {e}"))
-        })?
+        .map_err(|e| CaptureError::RequestDecodingError(format!("Multipart parsing failed: {e}")))?
         .ok_or_else(|| {
             CaptureError::RequestParsingError(
                 "Missing required 'event' part in multipart data".to_string(),
@@ -435,7 +432,6 @@ async fn retrieve_event_metadata(
 
     // Read the field data
     let field_data = field.bytes().await.map_err(|e| {
-        warn!("Failed to read event field data: {}", e);
         CaptureError::RequestDecodingError(format!("Failed to read field data: {e}"))
     })?;
 
@@ -520,7 +516,7 @@ fn build_kafka_event(
 
     // Serialize the event to JSON (this is what goes in the "data" field)
     let data = serde_json::to_string(&parsed.event).map_err(|e| {
-        warn!("Failed to serialize AI event: {}", e);
+        error!("Failed to serialize AI event: {}", e);
         CaptureError::NonRetryableSinkError
     })?;
 
@@ -720,7 +716,6 @@ async fn retrieve_multipart_parts(
 
     // Parse each part
     while let Some(field) = multipart.next_field().await.map_err(|e| {
-        warn!("Multipart parsing error: {}", e);
         CaptureError::RequestDecodingError(format!("Multipart parsing failed: {e}"))
     })? {
         part_count += 1;
@@ -748,7 +743,6 @@ async fn retrieve_multipart_parts(
 
         // Read the field data to get the length (this consumes the field)
         let field_data = field.bytes().await.map_err(|e| {
-            warn!("Failed to read field data for '{}': {}", field_name, e);
             CaptureError::RequestDecodingError(format!("Failed to read field data: {e}"))
         })?;
 

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -591,11 +591,13 @@ fn process_event_part(
     }
 
     // Parse the event JSON
-    let event_json_str = std::str::from_utf8(&field_data)
-        .map_err(|_| CaptureError::RequestParsingError("Event part must be valid UTF-8".to_string()))?;
+    let event_json_str = std::str::from_utf8(&field_data).map_err(|_| {
+        CaptureError::RequestParsingError("Event part must be valid UTF-8".to_string())
+    })?;
 
-    let event_json = serde_json::from_str(event_json_str)
-        .map_err(|_| CaptureError::RequestParsingError("Event part must be valid JSON".to_string()))?;
+    let event_json = serde_json::from_str(event_json_str).map_err(|_| {
+        CaptureError::RequestParsingError("Event part must be valid JSON".to_string())
+    })?;
 
     let part_info = PartInfo {
         name: "event".to_string(),
@@ -709,9 +711,11 @@ async fn retrieve_multipart_parts(
     accepted_parts.push(event_metadata.event_part_info);
 
     // Parse each part
-    while let Some(field) = multipart.next_field().await.map_err(|e| {
-        CaptureError::RequestDecodingError(format!("Multipart parsing failed: {e}"))
-    })? {
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| CaptureError::RequestDecodingError(format!("Multipart parsing failed: {e}")))?
+    {
         part_count += 1;
 
         // Extract all field information before consuming the field

--- a/rust/capture/src/otel/filtering.rs
+++ b/rust/capture/src/otel/filtering.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use common_types::CapturedEvent;
 use serde_json::json;
-use tracing::warn;
+use tracing::error;
 use uuid::Uuid;
 
 use crate::api::CaptureError;
@@ -95,7 +95,7 @@ pub fn build_events(
         });
 
         let data = serde_json::to_string(&event_data).map_err(|e| {
-            warn!("Failed to serialize OTel event data: {}", e);
+            error!("Failed to serialize OTel event data: {}", e);
             CaptureError::InternalError(format!("failed to serialize event data: {e}"))
         })?;
 

--- a/rust/capture/src/otel/ingestion.rs
+++ b/rust/capture/src/otel/ingestion.rs
@@ -3,7 +3,6 @@ use bytes::Bytes;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
 use serde_json::Value;
-use tracing::warn;
 
 use crate::api::CaptureError;
 use crate::payload::decompression::decompress_gzip_to_bytes;
@@ -78,27 +77,17 @@ pub fn parse_request(
     let is_json = content_type.starts_with("application/json");
 
     if is_protobuf {
-        ExportTraceServiceRequest::decode(&body[..]).map_err(|e| {
-            warn!("Failed to decode OTEL protobuf: {}", e);
-            CaptureError::RequestParsingError(format!("Invalid protobuf: {e}"))
-        })
+        ExportTraceServiceRequest::decode(&body[..])
+            .map_err(|e| CaptureError::RequestParsingError(format!("Invalid protobuf: {e}")))
     } else if is_json {
-        let mut json_value: Value = serde_json::from_slice(&body).map_err(|e| {
-            warn!("Failed to parse OTEL JSON: {}", e);
-            CaptureError::RequestParsingError(format!("Invalid JSON: {e}"))
-        })?;
+        let mut json_value: Value = serde_json::from_slice(&body)
+            .map_err(|e| CaptureError::RequestParsingError(format!("Invalid JSON: {e}")))?;
 
         patch_otel_json(&mut json_value);
 
-        serde_json::from_value(json_value).map_err(|e| {
-            warn!("Failed to parse OTEL trace request: {}", e);
-            CaptureError::RequestParsingError(format!("Invalid OTLP trace format: {e}"))
-        })
+        serde_json::from_value(json_value)
+            .map_err(|e| CaptureError::RequestParsingError(format!("Invalid OTLP trace format: {e}")))
     } else {
-        warn!(
-            "OTEL endpoint received unsupported content type: {}",
-            content_type
-        );
         Err(CaptureError::RequestDecodingError(
             "Content-Type must be application/x-protobuf or application/json".to_string(),
         ))

--- a/rust/capture/src/otel/ingestion.rs
+++ b/rust/capture/src/otel/ingestion.rs
@@ -85,8 +85,9 @@ pub fn parse_request(
 
         patch_otel_json(&mut json_value);
 
-        serde_json::from_value(json_value)
-            .map_err(|e| CaptureError::RequestParsingError(format!("Invalid OTLP trace format: {e}")))
+        serde_json::from_value(json_value).map_err(|e| {
+            CaptureError::RequestParsingError(format!("Invalid OTLP trace format: {e}"))
+        })
     } else {
         Err(CaptureError::RequestDecodingError(
             "Content-Type must be application/x-protobuf or application/json".to_string(),

--- a/rust/capture/src/otel/mod.rs
+++ b/rust/capture/src/otel/mod.rs
@@ -134,10 +134,6 @@ pub async fn otel_handler(
     // size limit (4 MB) bounds the absolute maximum, but compact protobuf can
     // pack many spans into that budget.
     if raw_span_count > MAX_RAW_SPANS_PER_REQUEST {
-        warn!(
-            "OTEL request contains {} raw spans, exceeding limit of {}",
-            raw_span_count, MAX_RAW_SPANS_PER_REQUEST
-        );
         let err = CaptureError::RequestParsingError(format!(
             "Too many spans: {raw_span_count} exceeds limit of {MAX_RAW_SPANS_PER_REQUEST}"
         ));
@@ -162,10 +158,6 @@ pub async fn otel_handler(
         return Ok(Json(json!({})));
     }
     if span_count > MAX_SPANS_PER_REQUEST {
-        warn!(
-            "OTEL request contains {} AI spans, exceeding limit of {} ({} raw spans received)",
-            span_count, MAX_SPANS_PER_REQUEST, raw_span_count
-        );
         let err = CaptureError::RequestParsingError(format!(
             "Too many AI spans: {span_count} exceeds limit of {MAX_SPANS_PER_REQUEST}"
         ));

--- a/rust/capture/src/payload/common.rs
+++ b/rust/capture/src/payload/common.rs
@@ -6,7 +6,7 @@
 
 use axum::http::{HeaderMap, Method};
 use bytes::Bytes;
-use tracing::{error, Span};
+use tracing::{debug, Span};
 
 use crate::{
     api::CaptureError,
@@ -81,7 +81,6 @@ pub fn extract_payload_bytes(
     } else if !body.is_empty() {
         body
     } else {
-        error!("missing payload on {:?} request", method);
         return Err(CaptureError::EmptyPayload);
     };
 
@@ -119,7 +118,7 @@ pub fn extract_payload_bytes(
                 let max_chars = std::cmp::min(payload.len(), MAX_PAYLOAD_SNIPPET_SIZE);
                 let form_data_snippet = String::from_utf8(payload[..max_chars].to_vec())
                     .unwrap_or(String::from("INVALID_UTF8"));
-                error!(
+                debug!(
                     form_data = form_data_snippet,
                     "expected form data in {} request payload", *method
                 );

--- a/rust/capture/src/payload/decompression.rs
+++ b/rust/capture/src/payload/decompression.rs
@@ -8,7 +8,7 @@ use std::io::prelude::*;
 use bytes::Bytes;
 use flate2::read::GzDecoder;
 use metrics;
-use tracing::{debug, error, instrument, warn, Span};
+use tracing::{debug, instrument, warn, Span};
 
 use crate::{
     api::CaptureError,
@@ -42,8 +42,7 @@ pub fn decompress_gzip_to_bytes(compressed: &[u8], limit: usize) -> Result<Vec<u
     loop {
         let got = match zipstream.read(&mut chunk) {
             Ok(got) => got,
-            Err(e) => {
-                error!("decompress_gzip_to_bytes: failed to read GZIP chunk: {}", e);
+            Err(_) => {
                 return Err(CaptureError::RequestDecodingError(String::from(
                     "invalid GZIP data",
                 )));
@@ -54,12 +53,6 @@ pub fn decompress_gzip_to_bytes(compressed: &[u8], limit: usize) -> Result<Vec<u
         }
 
         if total_read + got > limit {
-            error!(
-                decompressed_size = total_read + got,
-                compressed_size = len,
-                limit = limit,
-                "decompress_gzip_to_bytes: GZIP decompression would exceed size limit"
-            );
             metrics::counter!(METRIC_PAYLOAD_SIZE_EXCEEDED, "kind" => "gzip").increment(1);
             metrics::histogram!("capture_full_payload_size", "oversize" => "true")
                 .record((total_read + got) as f64);
@@ -131,8 +124,7 @@ pub fn decompress_payload(
 
         match String::from_utf8(buf) {
             Ok(s) => s,
-            Err(e) => {
-                error!("decompress_payload: failed to decode gzip: {e:#}");
+            Err(_) => {
                 return Err(CaptureError::RequestDecodingError(String::from(
                     "invalid gzip data",
                 )));
@@ -143,13 +135,7 @@ pub fn decompress_payload(
             payload_len = bytes.len(),
             "decompress_payload: matched LZ64 compression"
         );
-        match decompress_lz64(&bytes, limit) {
-            Ok(payload) => payload,
-            Err(e) => {
-                error!("decompress_payload: failed LZ64 decompress: {e:#}");
-                return Err(e);
-            }
-        }
+        decompress_lz64(&bytes, limit)?
     } else {
         debug!(
             path = path,
@@ -158,14 +144,13 @@ pub fn decompress_payload(
         );
 
         let s = String::from_utf8(bytes.into()).map_err(|e| {
-            error!(
+            debug!(
                 valid_up_to = &e.utf8_error().valid_up_to(),
                 "decompress_payload: failed to convert request payload to UTF8: {e:#}"
             );
             CaptureError::RequestDecodingError(String::from("invalid UTF8 in request payload"))
         })?;
         if s.len() > limit {
-            error!("decompress_payload: request size limit reached");
             metrics::counter!(METRIC_PAYLOAD_SIZE_EXCEEDED, "kind" => "none").increment(1);
             metrics::histogram!("capture_full_payload_size", "oversize" => "true")
                 .record(s.len() as f64);
@@ -190,8 +175,6 @@ pub fn decompress_payload(
                     Ok(unwrapped_payload) => {
                         let unwrapped_size = unwrapped_payload.len();
                         if unwrapped_size > limit {
-                            error!(unwrapped_size,
-                                    "decompress_payload: request size limit exceeded after post-decode base64 unwrap");
                             report_dropped_events("event_too_big", 1);
                             return Err(CaptureError::EventTooBig(format!(
                                     "decompress_payload: payload size limit {limit} exceeded after post-decode base64 unwrap: {unwrapped_size}",
@@ -199,18 +182,9 @@ pub fn decompress_payload(
                         }
                         unwrapped_payload
                     }
-                    Err(e) => {
-                        error!("decompress_payload: failed UTF8 conversion after post-decode base64: {e:#}");
-                        payload
-                    }
+                    Err(_) => payload,
                 },
-                Err(e) => {
-                    error!(
-                        path = path,
-                        "decompress_payload: failed post-decode base64 unwrap: {e:#}"
-                    );
-                    payload
-                }
+                Err(_) => payload,
             }
         } else {
             debug!("decompress_payload: payload may be LZ64 or other after decoding step");

--- a/rust/capture/src/payload/decompression.rs
+++ b/rust/capture/src/payload/decompression.rs
@@ -8,7 +8,7 @@ use std::io::prelude::*;
 use bytes::Bytes;
 use flate2::read::GzDecoder;
 use metrics;
-use tracing::{debug, instrument, warn, Span};
+use tracing::{debug, info, instrument, warn, Span};
 
 use crate::{
     api::CaptureError,
@@ -182,9 +182,20 @@ pub fn decompress_payload(
                         }
                         unwrapped_payload
                     }
-                    Err(_) => payload,
+                    Err(e) => {
+                        info!(
+                            "decompress_payload: failed UTF8 conversion after post-decode base64: {e:#}"
+                        );
+                        payload
+                    }
                 },
-                Err(_) => payload,
+                Err(e) => {
+                    info!(
+                        path = path,
+                        "decompress_payload: failed post-decode base64 unwrap: {e:#}"
+                    );
+                    payload
+                }
             }
         } else {
             debug!("decompress_payload: payload may be LZ64 or other after decoding step");

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -9,7 +9,7 @@ use axum::extract::{MatchedPath, State};
 use axum::http::{HeaderMap, Method};
 use axum_client_ip::InsecureClientIp;
 use metrics::counter;
-use tracing::{instrument, Span};
+use tracing::{info, instrument, Span};
 
 use crate::{
     api::CaptureError,
@@ -99,6 +99,7 @@ pub async fn handle_recording_payload(
     debug_or_info!(chatty_debug_enabled, metadata=?metadata, event_count=?events.len(), "hydrated events");
 
     if events.is_empty() {
+        info!(metadata = ?metadata, "rejected empty recording batch");
         return Err(CaptureError::EmptyBatch);
     }
 

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -9,7 +9,7 @@ use axum::extract::{MatchedPath, State};
 use axum::http::{HeaderMap, Method};
 use axum_client_ip::InsecureClientIp;
 use metrics::counter;
-use tracing::{instrument, warn, Span};
+use tracing::{instrument, Span};
 
 use crate::{
     api::CaptureError,
@@ -99,7 +99,6 @@ pub async fn handle_recording_payload(
     debug_or_info!(chatty_debug_enabled, metadata=?metadata, event_count=?events.len(), "hydrated events");
 
     if events.is_empty() {
-        warn!("rejected empty recording batch");
         return Err(CaptureError::EmptyBatch);
     }
 

--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -3,7 +3,7 @@ use base64::Engine;
 use common_types::RawEvent;
 use rand::RngCore;
 use std::collections::HashSet;
-use tracing::error;
+use tracing::debug;
 use uuid::Uuid;
 
 use crate::{
@@ -149,7 +149,7 @@ pub fn decode_base64(payload: &[u8], location: &str) -> Result<Vec<u8>, CaptureE
             let max_chars = std::cmp::min(payload.len(), MAX_PAYLOAD_SNIPPET_SIZE);
             let data_snippet = String::from_utf8(payload[..max_chars].to_vec())
                 .unwrap_or(String::from("INVALID_UTF8"));
-            error!(
+            debug!(
                 location = location,
                 data_snippet = data_snippet,
                 "decode_base64 failure: {}",
@@ -170,7 +170,7 @@ pub fn decode_form(payload: &[u8]) -> Result<EventFormData, CaptureError> {
             let max_chars: usize = std::cmp::min(payload.len(), MAX_PAYLOAD_SNIPPET_SIZE);
             let form_data_snippet = String::from_utf8(payload[..max_chars].to_vec())
                 .unwrap_or(String::from("INVALID_UTF8"));
-            error!(
+            debug!(
                 form_data = form_data_snippet,
                 "failed to decode urlencoded form body: {e:#}"
             );
@@ -190,7 +190,7 @@ pub fn decompress_lz64(payload: &[u8], limit: usize) -> Result<String, CaptureEr
             let max_chars: usize = std::cmp::min(payload.len(), MAX_PAYLOAD_SNIPPET_SIZE);
             let payload_snippet = String::from_utf8(payload[..max_chars].to_vec())
                 .unwrap_or(String::from("INVALID_UTF8"));
-            error!(
+            debug!(
                 payload_snippet = payload_snippet,
                 "decompress_lz64: failed decompress to UTF16"
             );
@@ -204,11 +204,7 @@ pub fn decompress_lz64(payload: &[u8], limit: usize) -> Result<String, CaptureEr
     // obtain the JSON event batch payload we've come to know and love
     let decompressed = match String::from_utf16(&decomp_utf16) {
         Ok(result) => result,
-        Err(e) => {
-            error!(
-                "decompress_lz64: failed UTF16 to UTF8 conversion, got: {}",
-                e
-            );
+        Err(_) => {
             return Err(CaptureError::RequestDecodingError(String::from(
                 "decompress_lz64: failed UTF16 to UTF8 conversion",
             )));
@@ -216,10 +212,6 @@ pub fn decompress_lz64(payload: &[u8], limit: usize) -> Result<String, CaptureEr
     };
 
     if decompressed.len() > limit {
-        error!(
-            "lz64 request payload size limit exceeded: {}",
-            decompressed.len()
-        );
         report_dropped_events("event_too_big", 1);
         return Err(CaptureError::EventTooBig(String::from(
             "lz64 request payload size limit exceeded",

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -3,7 +3,7 @@ use axum::extract::{MatchedPath, Query, State};
 use axum::http::{HeaderMap, Method};
 use axum::{debug_handler, Json};
 use axum_client_ip::InsecureClientIp;
-use tracing::{error, instrument, warn, Span};
+use tracing::{instrument, Span};
 
 use crate::{
     api::{CaptureError, CaptureResponse, CaptureResponseCode},
@@ -64,7 +64,6 @@ pub async fn event(
 
         Err(err) => {
             report_internal_error_metrics(err.to_metric_tag(), "parsing");
-            error!("event: request payload parsing error: {err:#}");
             Err(err)
         }
 
@@ -84,7 +83,6 @@ pub async fn event(
             {
                 report_dropped_events(err.to_metric_tag(), event_count);
                 report_internal_error_metrics(err.to_metric_tag(), "processing");
-                warn!("event: rejected payload: {err:#}");
                 return Err(err);
             }
 
@@ -133,7 +131,6 @@ pub async fn recording(
         }),
         Err(err) => {
             report_internal_error_metrics(err.to_metric_tag(), "parsing");
-            error!("recordings: request payload parsing error: {err:#}");
             Err(err)
         }
         Ok((context, events)) => {
@@ -149,7 +146,6 @@ pub async fn recording(
             {
                 report_dropped_events(err.to_metric_tag(), count);
                 report_internal_error_metrics(err.to_metric_tag(), "processing");
-                warn!("recordings: rejected payload: {err:#}");
                 return Err(err);
             }
             Ok(CaptureResponse {

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -4,7 +4,7 @@ use common_types::{CapturedEvent, RawEngageEvent, RawEvent};
 use serde::Deserialize;
 use time::format_description::well_known::Iso8601;
 use time::OffsetDateTime;
-use tracing::{error, instrument, warn, Span};
+use tracing::{instrument, Span};
 
 use crate::{
     api::CaptureError,
@@ -84,9 +84,9 @@ impl RawRequest {
                         properties: engage_event.properties,
                     }])
                 } else {
-                    let err_msg = String::from("non-engage request missing event name attribute");
-                    error!("event hydration from request failed: {err_msg}");
-                    Err(CaptureError::RequestHydrationError(err_msg))
+                    Err(CaptureError::RequestHydrationError(String::from(
+                        "non-engage request missing event name attribute",
+                    )))
                 }
             }
         };
@@ -95,7 +95,6 @@ impl RawRequest {
         match result {
             Ok(mut events) => {
                 if events.is_empty() {
-                    warn!("rejected empty batch");
                     return Err(CaptureError::EmptyBatch);
                 }
 


### PR DESCRIPTION
## Problem

Capture sits at the network edge: a single misconfigured SDK or scraper can produce thousands of malformed requests per second. Today the v0, payload, AI, and OTel handlers log every one of these at `warn!` or `error!`, even though metrics already classify them. The result is high-volume noise that buries the few logs operators actually want to see — Kafka outages, S3 errors, gzip-bomb attempts.

This PR adopts v1's existing discipline (`log_level()` mapping 4xx → WARN, 5xx → ERROR) across the rest of the codebase, drops logs that duplicate counters, and adds the one missing piece of metric coverage (AI handler had no `capture_error_by_stage_and_type` counters).

## Changes

Around 50 client-error log sites cleaned across analytics, AI, and replay paths. Categorization summary:

### Guiding principles

1. **Don't log per-request what a counter already captures.** The counter label set is richer than the log line.
2. **`error!` should be operator-actionable.** If nobody pages on a single occurrence, it isn't an `error!`.
3. **Errors returned to the client in the 400 body don't need a server-side warn.** The SDK developer already sees the detail.

### Category A — Client-driven request noise (this PR)

All sites dropped or downgraded. Detailed breakdown per file:

| File | Sites | Outcome |
|---|---|---|
| `v0_endpoint.rs` | 4 | dropped — `report_internal_error_metrics` + `report_dropped_events` already adjacent |
| `v0_request.rs` | 2 | dropped — `req_hydration` / `empty_batch` tags |
| `payload/common.rs` | 2 | 1 dropped, 1 → `debug!` (keeps form-data snippet for SDK debug) |
| `payload/recordings.rs` | 1 | restored at `info!` with metadata context after review — empty-recording bursts have triggered oncall pages, the log helps identify the offending client |
| `payload/decompression.rs` | 10 | 6 dropped (counters adjacent), 1 → `debug!`, 2 restored at `info!` after review (legacy base64-unwrap fallback paths that do fire in production), 1 **kept** (gzip-bomb warn — security signal) |
| `utils.rs` | 5 | 3 → `debug!` (keep payload snippet), 2 dropped (no info beyond error variant) |
| `ai_endpoint.rs` | 21 | dropped — all wrap their underlying error into `RequestDecodingError`/`RequestParsingError` which `IntoResponse` returns to the client verbatim |
| `otel/ingestion.rs` | 4 | dropped — same response-body story |
| `otel/mod.rs` | 2 | dropped — same response-body story |
| `otel/filtering.rs` | 1 | **promoted to `error!`** — returns `InternalError` which is masked in the response, so the log is the only diagnostic surface |

### Intentional promotions to `error!`

Three sites were upgraded because they signal real bugs or misconfigs, not client errors:

- `ai_endpoint.rs:307` "blobs but S3 is not configured" — deployment misconfig
- `ai_endpoint.rs:517` "Failed to serialize AI event" — we built the event ourselves
- `otel/filtering.rs:98` "Failed to serialize OTel event data" — same, also masked behind `InternalError` in the response

### Intentional retentions

- `ai_endpoint.rs:334` S3 upload failure
- `ai_endpoint.rs:371` Kafka send failure
- `otel/mod.rs:223` Kafka send failure
- `payload/decompression.rs:84` gzip bomb detection

All four are infrastructure or security signals, not per-request client noise.

### Restored after review at `info!`

Three sites were restored from drop to `info!` based on review feedback. `info!` is the right level: they fire on real production paths and are operator-actionable when an incident or SDK regression hits, but they are not error/warning conditions (the system recovers in two of them, and the third is a 400 to the client).

- `payload/recordings.rs:102` "rejected empty recording batch" — empty-payload bursts have triggered global oncall pages. Restored with structured `metadata` context (user_agent, content_type, content_encoding, request_id) so an operator grepping the log can identify the offending token / SDK.
- `payload/decompression.rs` two arms in the post-decode base64 unwrap heuristic. Legacy capture accepts base64 via several paths, and this fallback fires when the caller misleads us or omits required compression/encoding info.

### New metric coverage

The AI handler previously had no `capture_error_by_stage_and_type` counters — every failure mode collapsed into the HTTP status histogram with no error-type breakdown. This PR wraps `ai_handler` so any returned `CaptureError` calls `report_internal_error_metrics(err.to_metric_tag(), "ai")`, matching v0's pattern. The handler body moves into `ai_handler_inner` unchanged.

This made the rest of the AI cleanup safe: per-request warns can drop to debug without losing observability because the counter now carries the breakdown.

### Categories deferred to follow-up PRs

- **B. Steady-state operational warnings** (per-batch rate-limit logs, body read timeouts, restriction-fetch failures) — 9 sites (PR #60273)
- **C. rdkafka / sink callback noise** (per-broker transients, per-batch produce errors) — 13 sites, in progress
- **D. Infra errors to sample** (S3 sinks, fallback) — 12 sites
- **G. v1 "purposely chatty" INFO entries** — 2 sites marked TODO in the code

## Follow-ups worth tracking

- **AI handler error variants**: every malformed field currently lumps into `RequestParsingError`. v0 has dedicated `MissingEventName` / `MissingDistinctId` variants — adopting them in the AI handler would let the new `capture_error_by_stage_and_type{stage="ai"}` counter carry per-field breakdown.
- **OTel span-overflow tagging**: both span-count overflows reduce to the generic `req_parsing` tag. A dedicated counter (or sub-variants) would let dashboards distinguish "too many raw spans" from "too many AI spans" if limit-exceeded becomes a recurring signal.
- **SDK identity on error counters**: adding an `sdk_name` / `sdk_version` label to error counters would let us spot "all `req_decoding` errors come from posthog-android@3.7.2" without re-enabling logs.

## How did you test this code?

I'm an agent. I ran:

- `cargo check -p capture` — clean after every commit
- `cargo fmt -p capture --check` — clean
- `cargo clippy -p capture --all-targets -- -D warnings` — clean
- `cargo test -p capture --test integration_ai_endpoint` — 61 tests pass
- `cargo test -p capture --test integration_otel_endpoint` — 21 tests pass
- `cargo test -p capture --lib otel` — 51 unit tests pass
- `cargo test -p capture --lib payload` — 25 tests pass

No manual traffic testing.

## Publish to changelog?

no

## Docs update

Not applicable.

## 🤖 Agent context

Agent-authored audit and cleanup. Worked iteratively in numbered passes:

1. Inventoried all 161 `warn!`/`error!`/`info!`/`debug!` sites in `rust/capture/src` (scope limited to analytics, AI, replay — `capture-logs` crate excluded).
2. Categorized by failure domain: client-driven noise vs. operational warnings vs. infra errors vs. lifecycle / startup.
3. For each pass, surfaced the relevant sites, explained metric coverage, and asked whether to drop / downgrade / keep / promote / sample.
4. Built one commit per file (or per logical sub-unit for `ai_endpoint.rs`) so reviewers can read each diff on its own and revert individual decisions if needed.

Decisions made along the way:
- Adopted the v1 `log_level()` discipline (4xx → WARN, 5xx → ERROR) as the model for the rest of the code.
- Added the AI metric wrapper **before** touching the warns, so downgrading wouldn't lose observability.
- Promoted three `warn!` calls to `error!` where the underlying failure is a real bug or deployment misconfig and there is no other diagnostic surface (one is masked behind `InternalError`'s generic response).
- Kept the gzip-bomb warn and all Kafka/S3-send warns deliberately — they're the operator-relevant infrastructure signals that were previously buried in client-error noise.
- After initial review, restored three logs at `info!` per reviewer feedback: one in `payload/recordings.rs` (empty-batch bursts have triggered oncall pages) and two in `payload/decompression.rs` (legacy base64-unwrap fallback arms that fire in production).

Tests run are listed above. No manual traffic testing.
