### PR TITLE
fix(error-tracking): gate mcp v3 query path

### DIFF
--- a/products/error_tracking/backend/api/query.py
+++ b/products/error_tracking/backend/api/query.py
@@ -83,7 +83,8 @@ def build_fingerprint_filter_group(fingerprints: list[str]) -> dict[str, object]
     filter_group = build_property_group(
         [{"type": "event", "key": "$exception_fingerprint", "operator": "exact", "value": fingerprints}]
     )
-    assert filter_group is not None
+    if filter_group is None:
+        raise ValueError("build_property_group unexpectedly returned None for a non-empty filter list")
     return filter_group
 
 

--- a/products/error_tracking/backend/api/query.py
+++ b/products/error_tracking/backend/api/query.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Literal, cast
 
 import structlog
+import posthoganalytics
 from drf_spectacular.utils import OpenApiResponse
 from rest_framework import status, viewsets
 from rest_framework.response import Response
@@ -15,9 +16,11 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.hogql_queries.events_query_runner import EventsQueryRunner
+from posthog.models.team.team import Team
+from posthog.models.user import User
 
 from products.error_tracking.backend.hogql_queries.error_tracking_query_runner import ErrorTrackingQueryRunner
-from products.error_tracking.backend.models import ErrorTrackingIssue
+from products.error_tracking.backend.models import ErrorTrackingIssue, resolve_fingerprints_for_issues
 
 from .query_serializers import (
     ErrorTrackingIssueDetailSerializer,
@@ -34,6 +37,8 @@ from .query_utils import (
     LIST_ISSUE_FIELDS,
     build_date_range,
     build_event_where,
+    build_fingerprint_event_where,
+    build_fingerprint_where,
     build_impact,
     build_issue_filters,
     build_issue_where,
@@ -50,6 +55,36 @@ from .query_utils import (
 )
 
 logger = structlog.get_logger(__name__)
+
+ERROR_TRACKING_FORCE_QUERY_V3_FLAG = "error-tracking-force-query-v3"
+
+
+def is_error_tracking_query_v3_enabled(user: User, team: Team) -> bool:
+    distinct_id = user.distinct_id or str(user.uuid)
+    organization_id = str(team.organization_id)
+    project_id = str(team.id)
+    return bool(
+        posthoganalytics.feature_enabled(
+            ERROR_TRACKING_FORCE_QUERY_V3_FLAG,
+            distinct_id,
+            groups={"organization": organization_id, "project": project_id},
+            group_properties={"organization": {"id": organization_id}, "project": {"id": project_id}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+    )
+
+
+def query_v3_volume_resolution(volume_resolution: int) -> int:
+    return max(volume_resolution, 1)
+
+
+def build_fingerprint_filter_group(fingerprints: list[str]) -> dict[str, object]:
+    filter_group = build_property_group(
+        [{"type": "event", "key": "$exception_fingerprint", "operator": "exact", "value": fingerprints}]
+    )
+    assert filter_group is not None
+    return filter_group
 
 
 @extend_schema(tags=[ProductKey.ERROR_TRACKING])
@@ -71,6 +106,8 @@ class ErrorTrackingQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         offset = cast(int, params.get("offset", 0))
         assignee = params.get("assignee")
         person_id = params.get("personId")
+        use_query_v3 = is_error_tracking_query_v3_enabled(cast(User, request.user), self.team)
+        volume_resolution = cast(int, params.get("volumeResolution", 0))
         query = ErrorTrackingQuery(
             kind="ErrorTrackingQuery",
             dateRange=DateRange(**build_date_range(params.get("dateRange"))),
@@ -83,8 +120,9 @@ class ErrorTrackingQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             orderDirection=cast(Literal["ASC", "DESC"], params.get("orderDirection", "DESC")),
             limit=limit,
             offset=offset,
-            volumeResolution=cast(int, params.get("volumeResolution", 0)),
+            volumeResolution=query_v3_volume_resolution(volume_resolution) if use_query_v3 else volume_resolution,
             personId=str(person_id) if person_id is not None else None,
+            useQueryV3=use_query_v3 or None,
             withAggregations=True,
             withFirstEvent=False,
             withLastEvent=False,
@@ -123,15 +161,22 @@ class ErrorTrackingQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         issue_model = ErrorTrackingIssue.objects.filter(team=self.team, id=issue_id).first()
         if issue_model is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
+        force_query_v3 = is_error_tracking_query_v3_enabled(cast(User, request.user), self.team)
+        fingerprints = (
+            resolve_fingerprints_for_issues(team_id=self.team.pk, issue_ids=[issue_id]) if force_query_v3 else []
+        )
+        use_query_v3 = force_query_v3 and bool(fingerprints)
         query = ErrorTrackingQuery(
             kind="ErrorTrackingQuery",
             issueId=issue_id,
             dateRange=DateRange(**date_range),
+            filterGroup=build_fingerprint_filter_group(fingerprints) if use_query_v3 else None,
             filterTestAccounts=cast(bool, params.get("filterTestAccounts", True)),
-            volumeResolution=volume_resolution,
+            volumeResolution=query_v3_volume_resolution(volume_resolution) if use_query_v3 else volume_resolution,
             limit=1,
             orderBy="last_seen",
             orderDirection="DESC",
+            useQueryV3=use_query_v3 or None,
             withAggregations=True,
             withFirstEvent=False,
             withLastEvent=False,
@@ -161,7 +206,7 @@ class ErrorTrackingQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                 kind="EventsQuery",
                 event="$exception",
                 select=CONTEXT_EVENT_SELECTS,
-                where=build_issue_where(issue_id),
+                where=build_fingerprint_where(fingerprints) if use_query_v3 else build_issue_where(issue_id),
                 filterTestAccounts=cast(bool, params.get("filterTestAccounts", True)),
                 after=date_range.get("date_from"),
                 before=date_range.get("date_to"),
@@ -219,11 +264,20 @@ class ErrorTrackingQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         if not ErrorTrackingIssue.objects.filter(team=self.team, id=issue_id).exists():
             return Response(status=status.HTTP_404_NOT_FOUND)
         date_range = build_date_range(params.get("dateRange"))
+        force_query_v3 = is_error_tracking_query_v3_enabled(cast(User, request.user), self.team)
+        fingerprints = (
+            resolve_fingerprints_for_issues(team_id=self.team.pk, issue_ids=[issue_id]) if force_query_v3 else []
+        )
+        use_query_v3 = force_query_v3 and bool(fingerprints)
         query = EventsQuery(
             kind="EventsQuery",
             event="$exception",
             select=EVENT_SELECTS,
-            where=build_event_where(issue_id, cast(str | None, params.get("searchQuery"))),
+            where=(
+                build_fingerprint_event_where(fingerprints, cast(str | None, params.get("searchQuery")))
+                if use_query_v3
+                else build_event_where(issue_id, cast(str | None, params.get("searchQuery")))
+            ),
             properties=cast(list[dict[str, object]], params.get("filterGroup", [])),
             filterTestAccounts=cast(bool, params.get("filterTestAccounts", True)),
             after=date_range.get("date_from"),

--- a/products/error_tracking/backend/api/query_utils.py
+++ b/products/error_tracking/backend/api/query_utils.py
@@ -428,8 +428,24 @@ def build_issue_where(issue_id: str) -> list[str]:
     return [f"(issue_id = {escaped_issue_id} OR properties.$exception_issue_id = {escaped_issue_id})"]
 
 
+def build_fingerprint_where(fingerprints: list[str]) -> list[str]:
+    if not fingerprints:
+        return ["1 = 0"]
+    escaped_fingerprints = ", ".join(escape_hogql_string(fingerprint) for fingerprint in fingerprints)
+    return [f"properties.$exception_fingerprint IN ({escaped_fingerprints})"]
+
+
 def build_event_where(issue_id: str, search_query: str | None) -> list[str]:
     where = build_issue_where(issue_id)
+    return add_event_search_where(where, search_query)
+
+
+def build_fingerprint_event_where(fingerprints: list[str], search_query: str | None) -> list[str]:
+    where = build_fingerprint_where(fingerprints)
+    return add_event_search_where(where, search_query)
+
+
+def add_event_search_where(where: list[str], search_query: str | None) -> list[str]:
     if search_query:
         search = escape_hogql_like_pattern(search_query)
         chunks = [f"ilike(toString({prop}), {search})" for prop in EVENT_SEARCH_PROPERTIES]

--- a/products/error_tracking/backend/api/test/test_query_api.py
+++ b/products/error_tracking/backend/api/test/test_query_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.utils.timezone import now
 
@@ -16,6 +16,7 @@ from products.error_tracking.backend.api.query_utils import (
     build_search_query,
     build_sparkline,
 )
+from products.error_tracking.backend.hogql_queries.error_tracking_query_runner import ErrorTrackingQueryRunner
 from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueAssignment,
@@ -73,6 +74,11 @@ class TestErrorTrackingQueryAPI(ClickhouseTestMixin, APIBaseTest):
 
     def setUp(self) -> None:
         super().setUp()
+        self.feature_flag_patcher = patch(
+            "products.error_tracking.backend.api.query.posthoganalytics.feature_enabled", return_value=False
+        )
+        self.mock_feature_enabled: Mock = self.feature_flag_patcher.start()
+        self.addCleanup(self.feature_flag_patcher.stop)
         _create_person(team=self.team, distinct_ids=["user-1"], is_identified=True)
         flush_persons_and_events()
 
@@ -88,21 +94,24 @@ class TestErrorTrackingQueryAPI(ClickhouseTestMixin, APIBaseTest):
         *,
         issue_id: str | None = None,
         fingerprint: str | None = None,
+        include_issue_id: bool = True,
         properties: dict[str, object] | None = None,
     ) -> None:
         resolved_issue_id = issue_id or self.issue_id
         resolved_fingerprint = fingerprint or self.fingerprint
+        event_properties = {
+            "$exception_fingerprint": resolved_fingerprint,
+            "$exception_types": ["TypeError"],
+            "$exception_values": ["Cannot read properties of undefined"],
+            **(properties or {}),
+        }
+        if include_issue_id:
+            event_properties["$exception_issue_id"] = resolved_issue_id
         _create_event(
             distinct_id="user-1",
             event="$exception",
             team=self.team,
-            properties={
-                "$exception_issue_id": resolved_issue_id,
-                "$exception_fingerprint": resolved_fingerprint,
-                "$exception_types": ["TypeError"],
-                "$exception_values": ["Cannot read properties of undefined"],
-                **(properties or {}),
-            },
+            properties=event_properties,
             timestamp=now() - relativedelta(hours=1),
         )
 
@@ -228,6 +237,53 @@ class TestErrorTrackingQueryAPI(ClickhouseTestMixin, APIBaseTest):
         assert response.status_code == 200
         assert observed_tags == [(Product.ERROR_TRACKING, Feature.QUERY)]
 
+    def test_issues_list_uses_v3_when_force_flag_enabled(self) -> None:
+        self.mock_feature_enabled.return_value = True
+        observed_use_query_v3: list[bool | None] = []
+        observed_volume_resolutions: list[int] = []
+
+        def calculate(runner: ErrorTrackingQueryRunner) -> FakeQueryResponse:
+            observed_use_query_v3.append(runner.query.useQueryV3)
+            observed_volume_resolutions.append(runner.query.volumeResolution)
+            return FakeQueryResponse({"results": [], "hasMore": False, "limit": 25, "offset": 0})
+
+        with patch("products.error_tracking.backend.api.query.ErrorTrackingQueryRunner.calculate", calculate):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/query/issues",
+                data={"volumeResolution": 0},
+                format="json",
+            )
+
+        assert response.status_code == 200
+        assert observed_use_query_v3 == [True]
+        assert observed_volume_resolutions == [1]
+        feature_flag_call = self.mock_feature_enabled.call_args
+        assert feature_flag_call is not None
+        assert feature_flag_call.kwargs["groups"] == {
+            "organization": str(self.organization.id),
+            "project": str(self.team.id),
+        }
+
+    def test_issues_list_keeps_legacy_query_when_force_flag_disabled(self) -> None:
+        observed_use_query_v3: list[bool | None] = []
+        observed_volume_resolutions: list[int] = []
+
+        def calculate(runner: ErrorTrackingQueryRunner) -> FakeQueryResponse:
+            observed_use_query_v3.append(runner.query.useQueryV3)
+            observed_volume_resolutions.append(runner.query.volumeResolution)
+            return FakeQueryResponse({"results": [], "hasMore": False, "limit": 25, "offset": 0})
+
+        with patch("products.error_tracking.backend.api.query.ErrorTrackingQueryRunner.calculate", calculate):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/query/issues",
+                data={"volumeResolution": 0},
+                format="json",
+            )
+
+        assert response.status_code == 200
+        assert observed_use_query_v3 == [None]
+        assert observed_volume_resolutions == [0]
+
     def test_issue_detail_tags_clickhouse_queries(self) -> None:
         self.create_issue()
         observed_tags: list[tuple[object, object]] = []
@@ -260,6 +316,78 @@ class TestErrorTrackingQueryAPI(ClickhouseTestMixin, APIBaseTest):
 
         assert response.status_code == 200
         assert observed_tags == [(Product.ERROR_TRACKING, Feature.QUERY), (Product.ERROR_TRACKING, Feature.QUERY)]
+
+    def test_issue_detail_uses_v3_when_force_flag_enabled(self) -> None:
+        self.mock_feature_enabled.return_value = True
+        self.create_issue()
+        observed_use_query_v3: list[bool | None] = []
+        observed_volume_resolutions: list[int] = []
+        observed_filter_groups: list[dict[str, object] | None] = []
+
+        def calculate_issue(runner: ErrorTrackingQueryRunner) -> FakeQueryResponse:
+            observed_use_query_v3.append(runner.query.useQueryV3)
+            observed_volume_resolutions.append(runner.query.volumeResolution)
+            observed_filter_groups.append(
+                runner.query.filterGroup.model_dump(mode="json") if runner.query.filterGroup else None
+            )
+            return FakeQueryResponse(
+                {
+                    "results": [
+                        {"id": self.issue_id, "name": "TypeError", "description": "Cannot read", "status": "active"}
+                    ]
+                }
+            )
+
+        def calculate_event(_runner: object) -> FakeQueryResponse:
+            return FakeQueryResponse({"columns": [], "results": []})
+
+        with (
+            patch("products.error_tracking.backend.api.query.ErrorTrackingQueryRunner.calculate", calculate_issue),
+            patch("products.error_tracking.backend.api.query.EventsQueryRunner.calculate", calculate_event),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/query/issue",
+                data={"issueId": self.issue_id, "volumeResolution": 0},
+                format="json",
+            )
+
+        assert response.status_code == 200
+        assert observed_use_query_v3 == [True]
+        assert observed_volume_resolutions == [1]
+        assert observed_filter_groups[0] is not None
+        assert "$exception_fingerprint" in str(observed_filter_groups[0])
+        assert self.fingerprint in str(observed_filter_groups[0])
+
+    def test_issue_detail_keeps_legacy_query_without_fingerprints(self) -> None:
+        self.mock_feature_enabled.return_value = True
+        ErrorTrackingIssue.objects.create(id=self.issue_id, team=self.team, name="TypeError")
+        observed_use_query_v3: list[bool | None] = []
+
+        def calculate_issue(runner: ErrorTrackingQueryRunner) -> FakeQueryResponse:
+            observed_use_query_v3.append(runner.query.useQueryV3)
+            return FakeQueryResponse(
+                {
+                    "results": [
+                        {"id": self.issue_id, "name": "TypeError", "description": "Cannot read", "status": "active"}
+                    ]
+                }
+            )
+
+        def calculate_event(_runner: object) -> FakeQueryResponse:
+            return FakeQueryResponse({"columns": [], "results": []})
+
+        with (
+            patch("products.error_tracking.backend.api.query.ErrorTrackingQueryRunner.calculate", calculate_issue),
+            patch("products.error_tracking.backend.api.query.EventsQueryRunner.calculate", calculate_event),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/query/issue",
+                data={"issueId": self.issue_id},
+                format="json",
+            )
+
+        assert response.status_code == 200
+        assert observed_use_query_v3 == [None]
 
     @freeze_time("2026-04-24T12:00:00Z")
     def test_issue_detail_returns_impact_top_frame_and_latest_release(self) -> None:
@@ -394,6 +522,75 @@ class TestErrorTrackingQueryAPI(ClickhouseTestMixin, APIBaseTest):
 
         assert response.status_code == 200
         assert observed_tags == [(Product.ERROR_TRACKING, Feature.QUERY)]
+
+    @freeze_time("2026-04-24T12:00:00Z")
+    def test_issue_events_uses_fingerprint_filter_when_force_flag_enabled(self) -> None:
+        self.mock_feature_enabled.return_value = True
+        self.create_issue()
+        self.create_exception_event(
+            issue_id="01936e80-45e5-70bd-baa1-bf2f2ca4c532",
+            properties={"$session_id": "session-id-1"},
+        )
+        flush_persons_and_events()
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/query/issue_events",
+            data={"issueId": self.issue_id, "dateRange": {"date_from": "-1d", "date_to": "2026-04-25T00:00:00Z"}},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["results"][0]["properties"]["$session_id"] == "session-id-1"
+
+    @freeze_time("2026-04-24T12:00:00Z")
+    def test_issue_events_uses_fingerprint_filter_without_legacy_issue_id(self) -> None:
+        self.mock_feature_enabled.return_value = True
+        self.create_issue()
+        self.create_exception_event(include_issue_id=False, properties={"$session_id": "session-id-1"})
+        flush_persons_and_events()
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/query/issue_events",
+            data={"issueId": self.issue_id, "dateRange": {"date_from": "-1d", "date_to": "2026-04-25T00:00:00Z"}},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["results"][0]["properties"]["$session_id"] == "session-id-1"
+
+    @freeze_time("2026-04-24T12:00:00Z")
+    def test_issue_events_keeps_issue_id_filter_when_force_flag_disabled(self) -> None:
+        self.create_issue()
+        self.create_exception_event(
+            issue_id="01936e80-45e5-70bd-baa1-bf2f2ca4c532",
+            properties={"$session_id": "session-id-1"},
+        )
+        flush_persons_and_events()
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/query/issue_events",
+            data={"issueId": self.issue_id, "dateRange": {"date_from": "-1d", "date_to": "2026-04-25T00:00:00Z"}},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["results"] == []
+
+    @freeze_time("2026-04-24T12:00:00Z")
+    def test_issue_events_uses_issue_id_filter_without_fingerprints(self) -> None:
+        self.mock_feature_enabled.return_value = True
+        ErrorTrackingIssue.objects.create(id=self.issue_id, team=self.team, name="TypeError")
+        self.create_exception_event(properties={"$session_id": "session-id-1"})
+        flush_persons_and_events()
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/query/issue_events",
+            data={"issueId": self.issue_id, "dateRange": {"date_from": "-1d", "date_to": "2026-04-25T00:00:00Z"}},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["results"][0]["properties"]["$session_id"] == "session-id-1"
 
     @freeze_time("2026-04-24T12:00:00Z")
     def test_issue_events_returns_plural_exception_arrays_and_truncates_summary_text(self) -> None:


### PR DESCRIPTION
## Problem

Error tracking MCP query endpoints should follow the product's V3 query rollout instead of always using the legacy query path. Without the feature-flag gate, MCP responses can diverge from the UI query path when V3 is enabled for a project.

## Changes

- Gate the MCP error tracking list, detail, and issue events endpoints on the `error-tracking-force-query-v3` feature flag.
- Resolve issue fingerprints for V3 detail and event queries, with a legacy fallback when no fingerprints are available.
- Clamp V3 volume resolution to at least one bucket to avoid invalid V3 bucket calculations.
- Add regression coverage for flag-on and flag-off MCP query behavior, fingerprint filtering, and fallback cases.

## How did you test this code?

tested locally for all query tools, compared with/without v3 to be exactly the same

Agent-tested with:

- `./bin/hogli test products/error_tracking/backend/api/test/test_query_api.py`
- `ruff check products/error_tracking/backend/api/query.py products/error_tracking/backend/api/query_utils.py products/error_tracking/backend/api/test/test_query_api.py --fix`
- `ruff format products/error_tracking/backend/api/query.py products/error_tracking/backend/api/query_utils.py products/error_tracking/backend/api/test/test_query_api.py`

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 Agent context

Authored with Codex. The implementation follows the existing project/org-scoped internal feature flag pattern used elsewhere in the codebase. Detail and event endpoints use fingerprint-based V3 filtering because V3 resolves current issue identity from fingerprint issue state rather than legacy event issue ids; list queries use V3 directly when the flag is enabled. During local verification, stale local ClickHouse fingerprint issue state caused list-result divergence until the existing error tracking fingerprint-state backfill was run.
