### PR TITLE
chore(mcp): default notion clients to single-exec mode

### DIFF
--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -59,6 +59,10 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     'aider',
     'copilot',
     'gemini-cli',
+    // Notion AI ships its own `notion-mcp-client` (not a coding agent per se,
+    // but an LLM-driven consumer that benefits from the same single-exec mode
+    // and formatted-text rendering as coding agents).
+    'notion',
 ] as const
 
 // Value sent in `x-posthog-mcp-consumer` by PostHog Code (the Tasks sandbox
@@ -67,14 +71,16 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
 // emission in single-exec mode. Slack-launched runs send `"slack"` instead.
 export const POSTHOG_CODE_CONSUMER = 'posthog-code'
 
-// OAuth application names (from token introspection) for vibe-coding platforms
-// that should default to single-exec mode. These match against the OAuth
+// OAuth application names (from token introspection) for upstream tools that
+// should default to single-exec mode. These match against the OAuth
 // `client_name` (the registered OAuth app name in PostHog), not the MCP
-// `clientInfo.name` self-report — those platforms typically connect through a
+// `clientInfo.name` self-report — many of these platforms connect through a
 // generic MCP client wrapper, so the OAuth name is what reliably identifies
 // the upstream tool. Substring match is case-insensitive and separator-agnostic
 // so "Lovable", "Lovable.dev", "Replit", and "Replit Agent" all resolve.
-export const VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS = ['lovable', 'replit'] as const
+// Notion is included here because a sizeable share of sessions only carry the
+// OAuth name without the `notion-mcp-client` self-report.
+export const VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS = ['lovable', 'replit', 'notion'] as const
 
 export type ClientCapabilities = {
     // MCP `initialize` response includes an `instructions` field that most

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -25,6 +25,7 @@ describe('isCodingAgentClient', () => {
             ['zed'],
             ['aider'],
             ['copilot'],
+            ['notion'],
         ])('returns true for %s', (clientName) => {
             expect(isCodingAgentClient(clientName)).toBe(true)
         })
@@ -42,6 +43,8 @@ describe('isCodingAgentClient', () => {
             ['GitHub Copilot Chat'],
             ['zed-editor'],
             ['Codex CLI'],
+            ['notion-mcp-client'],
+            ['Notion'],
         ])('returns true for variant %s (case-insensitive substring match)', (clientName) => {
             expect(isCodingAgentClient(clientName)).toBe(true)
         })
@@ -123,6 +126,8 @@ describe('isVibeCodingClient', () => {
         ['replit'],
         ['Replit Agent'],
         ['replit-ai'],
+        ['Notion'],
+        ['notion'],
     ])('returns true for OAuth client name %s', (oauthClientName) => {
         expect(isVibeCodingClient(oauthClientName)).toBe(true)
     })
@@ -165,6 +170,7 @@ describe('MCPClientProfile', () => {
             ['aider'],
             ['github.copilot'],
             ['GitHub Copilot Chat'],
+            ['notion-mcp-client'],
         ])('returns true for %s', (clientName) => {
             expect(new MCPClientProfile({ clientName }).isCodingAgent()).toBe(true)
         })
@@ -222,7 +228,7 @@ describe('MCPClientProfile', () => {
     })
 
     describe('isVibeCodingClient()', () => {
-        it.each([['Lovable'], ['lovable.dev'], ['Replit'], ['Replit Agent']])(
+        it.each([['Lovable'], ['lovable.dev'], ['Replit'], ['Replit Agent'], ['Notion']])(
             'returns true for OAuth client name %s',
             (oauthClientName) => {
                 expect(new MCPClientProfile({ oauthClientName }).isVibeCodingClient()).toBe(true)


### PR DESCRIPTION
## Problem

Notion AI is now one of the most active MCP clients hitting our server. Like Claude Code and other coding agents, Notion AI feeds tool output through an LLM rather than rendering `structuredContent` in a UI, so it benefits from the same single-exec / CLI mode and `formatted_results` text rendering we already use for those clients.

Today Notion sessions fall through to the default multi-tool mode unless the caller explicitly sets `mode=cli`.

## Changes

- Added `'notion'` to `CODING_AGENT_CLIENT_NAME_FRAGMENTS` so the `clientInfo.name=notion-mcp-client` self-report flips `isCodingAgent()` and the structured-content suppression in `build-tool-result.ts`.
- Added `'notion'` to `VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS` so the `Notion` OAuth `client_name` also triggers single-exec mode.

## How did you test this code?

- `vitest run tests/unit/client-detection.test.ts` — extended both `isCodingAgentClient` and `isVibeCodingClient` parameterized suites with Notion fixtures (`notion`, `notion-mcp-client`, `Notion`); 111/111 pass.
- Verified via PostHog SQL that 100% of Notion MCP events in the last 30 days carry an `mcp_session_id`, so the existing session-cache fallback in `request-state-resolver.ts` (which restores `mcpClientName` from `sessionCache` on follow-up requests) will keep the CLI-mode decision sticky across a session.

## Publish to changelog?

no