### PR TITLE
feat(customer-analytics): account notes

### DIFF
--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -1021,11 +1021,13 @@ class TestAccessControlQueryCounts(BaseAccessControlTest):
 
         baseline = 8
         # Getting my own notebook is the same as a dashboard - 3 extra queries
-        with self.assertNumQueries(baseline + 6):
+        # +1 for the parent_resource lookup on NotebookSerializer
+        with self.assertNumQueries(baseline + 7):
             self.client.get(f"/api/projects/@current/notebooks/{self.notebook.short_id}")
 
         # Except when accessing a different notebook where we _also_ need to check as we are not the creator and the pk is not the same (short_id)
-        with self.assertNumQueries(baseline + 7):
+        # +1 for the parent_resource lookup on NotebookSerializer
+        with self.assertNumQueries(baseline + 8):
             self.client.get(f"/api/projects/@current/notebooks/{self.other_user_notebook.short_id}")
 
         baseline = 8
@@ -1065,11 +1067,13 @@ class TestAccessControlQueryCounts(BaseAccessControlTest):
         baseline = 8
 
         # Getting my own notebook is the same as a dashboard - 3 extra queries
-        with self.assertNumQueries(baseline + 6):
+        # +1 for the parent_resource lookup on NotebookSerializer
+        with self.assertNumQueries(baseline + 7):
             self.client.get(f"/api/projects/@current/notebooks/{self.notebook.short_id}")
 
         # Except when accessing a different notebook where we _also_ need to check as we are not the creator and the pk is not the same (short_id)
-        with self.assertNumQueries(baseline + 7):
+        # +1 for the parent_resource lookup on NotebookSerializer
+        with self.assertNumQueries(baseline + 8):
             self.client.get(f"/api/projects/@current/notebooks/{self.other_user_notebook.short_id}")
 
     def test_query_counts_stable_for_project_access(self):

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4055,17 +4055,25 @@ snapshots:
     scenes-app-batchexports--runs-with-data--light:
         hash: v1.k794b7964.f4a8d5cc4f5447f093d5ddbbcd8572e13f7297a7db8a89504f9290226e60a2bc._CkUe6i49hMMGaDUNDHeNZDgaVp5DJQCay44V8WqfR4
     scenes-app-customer-analytics-accounts--default--dark:
-        hash: v1.k794b7964.3238a24e463f3827b40563d9c5a9189bd8ee2ec78858f0dc20d4c41560b1a858.bFuIqVd9GZf6oGWeDP9T3cCXClf6wK4f6pRQP3ccd0A
+        hash: v1.k794b7964.8ddf102b0108b91a52951024c33339f08a6cbdd230f958b5f00160a5098def04.puKFKu2ZXvg0GZzKsGqUkx4KHnR_j_rFDLyl0L9DwzY
     scenes-app-customer-analytics-accounts--default--light:
-        hash: v1.k794b7964.c13dc63d3ccaf85d8bed2840d7abba59ddbf49cfe879cba28e75d8dc76f6d9f2.TuTzFLakjBSqBtiKnKyubF3rVo-r3nwj0u8vM28YiMw
+        hash: v1.k794b7964.fc8512f86a3d07c776d032b3749290ac0f02f87906d5877c9c03ff9be1b4d388.eB1OqmAMpy1uwUJQQuB8Sx8P646zyR4LwOKVqaMQSo4
     scenes-app-customer-analytics-accounts--empty--dark:
-        hash: v1.k794b7964.1db26d99c1ac9c7ea882bae7d36a3d4fcc234e21d8cd28cc1ededb941a687cdf.OcbjFe5xD5bLFViFj0meBcCEoxa2bhK9VzJRPF0dQHo
+        hash: v1.k794b7964.fa9e2a43db5870612712960e39941f70959c176409ff3a279c61d1b6d33ce453.aJmFmbFQdClkztlbYnbGonlJBKP3czl0XW2bS2YjSZ4
     scenes-app-customer-analytics-accounts--empty--light:
-        hash: v1.k794b7964.924b1f7107778ab02e2986a600cb325ffd6c3d7a1f1828cd2dcd4b5cc51e5b91.GGu3igWGbRQbv3o129YtgLqk_EcmpDePG3KDI4UhklE
+        hash: v1.k794b7964.d8ed0a191a6a50347d8cc250bdbebeea6dcf0fb0e542971ddf7a2177e8b3883f.FY-nlG9hzFq0_GZnGS2uZu2AMmxS_ycV1t-xMZsSWMY
     scenes-app-customer-analytics-accounts--feature-gate-off--dark:
         hash: v1.k794b7964.7750bce37ad591ab773135ad1a9b8738ac790727774c03d3aa7b5abbfc42fab0.KbXf74dR5pSVh6Wc8mSjrNGqL8LbTcsMl78W7WVvTXU
     scenes-app-customer-analytics-accounts--feature-gate-off--light:
         hash: v1.k794b7964.102431e5d999bc15bb9589ef2eccc8d0e44a779b9c820279aa1637d293edf403.AxkbpynMmXkyb0voFylEK03iBfJO43IXPpsGqxgzTkE
+    scenes-app-customer-analytics-accounts--row-expanded-empty--dark:
+        hash: v1.k794b7964.b4dc25994c12835e1d2c78db56ad115a5cdadd5ed15f6960bff256f20ee2032b.FG3qUrIgM9cvKzOhnnC5I-Og7t3VsSxmqPi9hAZDyrc
+    scenes-app-customer-analytics-accounts--row-expanded-empty--light:
+        hash: v1.k794b7964.2034a479b936c4532d32da344d97eb9165205165a3fa77db68a83553e3efeea7.KOchCQsonn3B1M9_mfH4CJyges_n9nXiffeu7zk5yl0
+    scenes-app-customer-analytics-accounts--row-expanded-with-note--dark:
+        hash: v1.k794b7964.2edbd8ec456cf2604474ac5653320b756331f86bfe73801df3bbeebc9c424da0.ykw_x-QQYJkmwUFDLH1GJg8HylDV2RA4YpyRSWSAuRw
+    scenes-app-customer-analytics-accounts--row-expanded-with-note--light:
+        hash: v1.k794b7964.fd505fec90590a232e951f4e76fe9c2fe9defcb8c13c1d5d49d791c7d1ac5747.WTfRLxuOo1ulkq2MW7SlqmKFbGMNI9tHh1EWJ6YSL0U
     scenes-app-customer-analytics-dashboard--b-2-b-mode-with-groups-enabled--dark:
         hash: v1.k794b7964.b1e7b3b4db44122983952ce49cdcb2721216d6e09cdda2e03d88250a66f9531d.XEmKGVDBb7ph1xN1zMKNGWDQAkJPR509WPM2orhsrZo
     scenes-app-customer-analytics-dashboard--b-2-b-mode-with-groups-enabled--light:
@@ -4809,7 +4817,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
         hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
-        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.EIwByuofuT77yP259A9ffqfjSFwW9MrUDOvsZNA_aZM
+        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
         hash: v1.k794b7964.d64808d2bfc36017f89b57feeaa373e20188738a622801207fa1beb59d02fdd9.cFuKF_Ow887Z3X3BoNhtTvkUWY2vips9HDBe-B02eQE
     scenes-app-insights-funnels--funnel-time-to-convert--light:

--- a/frontend/src/scenes/notebooks/notebookSceneLogic.ts
+++ b/frontend/src/scenes/notebooks/notebookSceneLogic.ts
@@ -36,19 +36,30 @@ export const notebookSceneLogic = kea<notebookSceneLogicType>([
 
         breadcrumbs: [
             (s) => [s.notebook, s.loading],
-            (notebook, loading): Breadcrumb[] => [
-                {
-                    key: Scene.Notebooks,
-                    name: 'Notebooks',
-                    path: urls.notebooks(),
-                    iconType: 'notebook',
-                },
-                {
-                    key: [Scene.Notebook, notebook?.short_id || 'new'],
-                    name: notebook ? notebook?.title || 'Unnamed' : loading ? null : 'Notebook not found',
-                    iconType: 'notebook',
-                },
-            ],
+            (notebook, loading): Breadcrumb[] => {
+                const parent: Breadcrumb =
+                    notebook?.parent_resource?.type === 'account'
+                        ? {
+                              key: Scene.CustomerAnalytics,
+                              name: 'Accounts',
+                              path: urls.customerAnalyticsAccounts(),
+                              iconType: 'group',
+                          }
+                        : {
+                              key: Scene.Notebooks,
+                              name: 'Notebooks',
+                              path: urls.notebooks(),
+                              iconType: 'notebook',
+                          }
+                return [
+                    parent,
+                    {
+                        key: [Scene.Notebook, notebook?.short_id || 'new'],
+                        name: notebook ? notebook?.title || 'Unnamed' : loading ? null : 'Notebook not found',
+                        iconType: 'notebook',
+                    },
+                ]
+            },
         ],
 
         projectTreeRef: [

--- a/frontend/src/scenes/notebooks/types.ts
+++ b/frontend/src/scenes/notebooks/types.ts
@@ -27,12 +27,20 @@ export type NotebookListItemType = {
     _create_in_folder?: string
 }
 
+export type NotebookParentResource = {
+    type: 'account'
+    id: string
+}
+
 export type NotebookType = NotebookListItemType &
     WithAccessControl & {
         content: JSONContent | null
         version: number
         // used to power text-based search
         text_content?: string | null
+        // null when the notebook is standalone; set when it belongs to a resource (e.g. an
+        // account note) so the scene can route breadcrumbs back to that resource's list
+        parent_resource?: NotebookParentResource | null
     }
 
 export enum NotebookNodeType {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,7 +448,7 @@ importers:
         version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       '@storybook/react-webpack5':
         specifier: ^7.6.4
-        version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
+        version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/test-runner':
         specifier: ^0.16.0
         version: 0.16.0(encoding@0.1.13)
@@ -502,7 +502,7 @@ importers:
         version: 2.0.0(webpack@5.88.2)
       webpack:
         specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+        version: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.88.2)
@@ -1474,7 +1474,7 @@ importers:
         version: 0.4.8(express@5.2.1)
       '@segment/action-destinations':
         specifier: ^3.383.0
-        version: 3.387.0(ajv@8.12.0)(encoding@0.1.13)
+        version: 3.387.0(ajv@8.18.0)(encoding@0.1.13)
       '@temporalio/activity':
         specifier: 1.15.0
         version: 1.15.0
@@ -2253,6 +2253,12 @@ importers:
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
+      '@testing-library/dom':
+        specifier: '*'
+        version: 9.3.4
+      '@testing-library/user-event':
+        specifier: '*'
+        version: 14.6.1(@testing-library/dom@9.3.4)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -32355,7 +32361,7 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
     optionalDependencies:
       type-fest: 4.41.0
       webpack-hot-middleware: 2.25.4
@@ -33570,7 +33576,7 @@ snapshots:
 
   '@segment/a1-notation@2.1.4': {}
 
-  '@segment/action-destinations@3.387.0(ajv@8.12.0)(encoding@0.1.13)':
+  '@segment/action-destinations@3.387.0(ajv@8.18.0)(encoding@0.1.13)':
     dependencies:
       '@amplitude/ua-parser-js': 0.7.33
       '@aws-sdk/client-eventbridge': 3.806.0
@@ -33580,7 +33586,7 @@ snapshots:
       '@segment/actions-core': 3.153.0(encoding@0.1.13)
       '@segment/actions-shared': 1.134.0(encoding@0.1.13)
       '@types/node': 22.18.8
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-formats: 2.1.1(ajv@8.18.0)
       aws4: 1.13.2
       cheerio: 1.0.0
       dayjs: 1.11.11(patch_hash=2e3e09d22bbc20d8961e0392c318f12ffada0babb6422f03b5538af8b2707852)
@@ -34394,7 +34400,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-webpack5@7.6.4(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@6.0.3)(webpack-cli@5.1.4)':
+  '@storybook/builder-webpack5@7.6.4(encoding@0.1.13)(postcss@8.5.6)(typescript@6.0.3)(webpack-cli@5.1.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@storybook/channels': 7.6.4
@@ -34424,12 +34430,12 @@ snapshots:
       semver: 7.7.4
       style-loader: 3.3.3(webpack@5.88.2)
       swc-loader: 0.2.3(@swc/core@1.15.18)(webpack@5.88.2)
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.88.2)
+      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(postcss@8.5.6)(webpack@5.88.2)
       ts-dedent: 2.2.0
       url: 0.11.1
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.1.3(webpack@5.88.2)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
@@ -34518,7 +34524,7 @@ snapshots:
       get-port: 5.1.1
       giget: 1.2.5
       globby: 11.1.0
-      jscodeshift: 0.15.2(@babel/preset-env@7.23.5(@babel/core@7.26.0))
+      jscodeshift: 0.15.2(@babel/preset-env@7.23.5(@babel/core@7.29.0))
       leven: 3.1.0
       ora: 5.4.1
       prettier: 2.8.8
@@ -34564,7 +34570,7 @@ snapshots:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.6
       globby: 11.1.0
-      jscodeshift: 0.15.2(@babel/preset-env@7.23.5(@babel/core@7.26.0))
+      jscodeshift: 0.15.2(@babel/preset-env@7.23.5(@babel/core@7.29.0))
       lodash: 4.18.1
       prettier: 2.8.8
       recast: 0.23.11
@@ -34904,7 +34910,7 @@ snapshots:
 
   '@storybook/postinstall@7.6.4': {}
 
-  '@storybook/preset-react-webpack@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.23.3(@babel/core@7.26.0)
       '@babel/preset-react': 7.23.3(@babel/core@7.26.0)
@@ -34924,7 +34930,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       semver: 7.7.4
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
     optionalDependencies:
       '@babel/core': 7.26.0
       typescript: 6.0.3
@@ -35033,7 +35039,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@6.0.3)
       tslib: 2.8.1
       typescript: 6.0.3
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -35067,10 +35073,10 @@ snapshots:
       - typescript
       - vite-plugin-glimmerx
 
-  '@storybook/react-webpack5@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.4(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@6.0.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.4(encoding@0.1.13)(postcss@8.5.6)(typescript@6.0.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -37642,17 +37648,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@xmldom/xmldom@0.8.13': {}
@@ -38257,14 +38263,14 @@ snapshots:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   babel-loader@9.1.3(@babel/core@7.29.0)(webpack@5.88.2):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   babel-plugin-add-react-displayname@0.0.5: {}
 
@@ -39488,7 +39494,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   css-loader@6.8.1(webpack@5.88.2):
     dependencies:
@@ -39500,7 +39506,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.8.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.2):
     dependencies:
@@ -41277,7 +41283,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   file-system-cache@2.3.0:
     dependencies:
@@ -41435,7 +41441,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.0
       typescript: 6.0.3
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   form-data@4.0.5:
     dependencies:
@@ -42140,7 +42146,7 @@ snapshots:
   html-webpack-harddisk-plugin@2.0.0(html-webpack-plugin@5.5.3(webpack@5.88.2))(webpack@5.88.2):
     dependencies:
       html-webpack-plugin: 5.5.3(webpack@5.88.2)
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   html-webpack-plugin@5.5.3(webpack@5.88.2):
     dependencies:
@@ -42149,7 +42155,7 @@ snapshots:
       lodash: 4.18.1
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   htmlnano@2.1.1(cssnano@7.0.6(postcss@8.5.6))(postcss@8.5.6)(relateurl@0.2.7)(svgo@3.3.3)(terser@5.46.0)(typescript@6.0.3):
     dependencies:
@@ -44168,7 +44174,7 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jscodeshift@0.15.2(@babel/preset-env@7.23.5(@babel/core@7.26.0)):
+  jscodeshift@0.15.2(@babel/preset-env@7.23.5(@babel/core@7.29.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.3
@@ -44191,7 +44197,7 @@ snapshots:
       temp: 0.8.4
       write-file-atomic: 2.4.3
     optionalDependencies:
-      '@babel/preset-env': 7.23.5(@babel/core@7.26.0)
+      '@babel/preset-env': 7.23.5(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -44471,7 +44477,7 @@ snapshots:
       less: 4.2.2
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   less@3.13.1:
     dependencies:
@@ -46962,7 +46968,7 @@ snapshots:
       postcss: 8.5.6
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   postcss-logical@8.0.0(postcss@8.5.2):
     dependencies:
@@ -47956,7 +47962,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   rc-cascader@3.34.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -49095,7 +49101,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
     optionalDependencies:
       sass: 1.56.0
 
@@ -49825,11 +49831,11 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   style-loader@3.3.3(webpack@5.88.2):
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   style-search@0.1.0: {}
 
@@ -50033,7 +50039,7 @@ snapshots:
   swc-loader@0.2.3(@swc/core@1.15.18)(webpack@5.88.2):
     dependencies:
       '@swc/core': 1.15.18
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   symbol-tree@3.2.4: {}
 
@@ -50221,18 +50227,6 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.88.2):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@swc/core': 1.15.18
-      esbuild: 0.18.20
-      postcss: 8.5.6
-
   terser-webpack-plugin@5.6.0(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.6)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.6)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
@@ -50243,6 +50237,17 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.18
       esbuild: 0.27.7
+      postcss: 8.5.6
+
+  terser-webpack-plugin@5.6.0(@swc/core@1.15.18)(postcss@8.5.6)(webpack@5.88.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.0
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
+    optionalDependencies:
+      '@swc/core': 1.15.18
       postcss: 8.5.6
 
   terser@5.19.1:
@@ -51487,7 +51492,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-merge: 5.8.0
 
   webpack-dev-middleware@6.1.3(webpack@5.88.2):
@@ -51498,7 +51503,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   webpack-hot-middleware@2.25.4:
     dependencies:
@@ -51558,7 +51563,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4):
+  webpack@5.88.2(@swc/core@1.15.18)(postcss@8.5.6)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.4
       '@types/estree': 1.0.1
@@ -51581,7 +51586,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.88.2)
+      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(postcss@8.5.6)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
+++ b/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
@@ -87,6 +87,47 @@
 # ---
 # name: TestNotebooks.test_updates_notebook.10
   '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."is_ai_training_opted_in",
+         "posthog_organization"."is_ai_training_locked",
+         "posthog_organization"."is_ai_training_cta_shown",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."is_pending_deletion",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestNotebooks.test_updates_notebook.11
+  '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
          "posthog_team"."organization_id",
@@ -217,7 +258,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.11
+# name: TestNotebooks.test_updates_notebook.12
   '''
   SELECT "posthog_project"."id",
          "posthog_project"."organization_id",
@@ -229,7 +270,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.12
+# name: TestNotebooks.test_updates_notebook.13
   '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -279,7 +320,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.13
+# name: TestNotebooks.test_updates_notebook.14
   '''
   SELECT "ee_accesscontrol"."id",
          "ee_accesscontrol"."team_id",
@@ -325,7 +366,7 @@
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.14
+# name: TestNotebooks.test_updates_notebook.15
   '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -373,7 +414,7 @@
   WHERE "posthog_organizationmembership"."user_id" = 99999
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.15
+# name: TestNotebooks.test_updates_notebook.16
   '''
   SELECT "posthog_notebook"."id",
          "posthog_notebook"."short_id",
@@ -575,7 +616,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.16
+# name: TestNotebooks.test_updates_notebook.17
   '''
   SELECT "posthog_notebook"."id",
          "posthog_notebook"."short_id",
@@ -598,7 +639,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.17
+# name: TestNotebooks.test_updates_notebook.18
   '''
   SELECT "posthog_notebook"."id",
          "posthog_notebook"."short_id",
@@ -623,7 +664,7 @@
   UPDATE
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.18
+# name: TestNotebooks.test_updates_notebook.19
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -725,28 +766,6 @@
   FROM "posthog_team"
   WHERE "posthog_team"."id" = 99999
   LIMIT 21
-  '''
-# ---
-# name: TestNotebooks.test_updates_notebook.19
-  '''
-  SELECT "posthog_filesystem"."team_id",
-         "posthog_filesystem"."id",
-         "posthog_filesystem"."path",
-         "posthog_filesystem"."depth",
-         "posthog_filesystem"."type",
-         "posthog_filesystem"."ref",
-         "posthog_filesystem"."href",
-         "posthog_filesystem"."shortcut",
-         "posthog_filesystem"."meta",
-         "posthog_filesystem"."created_at",
-         "posthog_filesystem"."created_by_id",
-         "posthog_filesystem"."project_id"
-  FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
-         AND "posthog_filesystem"."team_id" = 99999
-         AND "posthog_filesystem"."type" = 'notebook'
-         AND NOT ("posthog_filesystem"."shortcut"
-                  AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
 # name: TestNotebooks.test_updates_notebook.2
@@ -883,6 +902,28 @@
 # ---
 # name: TestNotebooks.test_updates_notebook.20
   '''
+  SELECT "posthog_filesystem"."team_id",
+         "posthog_filesystem"."id",
+         "posthog_filesystem"."path",
+         "posthog_filesystem"."depth",
+         "posthog_filesystem"."type",
+         "posthog_filesystem"."ref",
+         "posthog_filesystem"."href",
+         "posthog_filesystem"."shortcut",
+         "posthog_filesystem"."meta",
+         "posthog_filesystem"."created_at",
+         "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."project_id"
+  FROM "posthog_filesystem"
+  WHERE ("posthog_filesystem"."ref" = '0001'
+         AND "posthog_filesystem"."team_id" = 99999
+         AND "posthog_filesystem"."type" = 'notebook'
+         AND NOT ("posthog_filesystem"."shortcut"
+                  AND "posthog_filesystem"."shortcut" IS NOT NULL))
+  '''
+# ---
+# name: TestNotebooks.test_updates_notebook.21
+  '''
   SELECT "posthog_filesystemshortcut"."id",
          "posthog_filesystemshortcut"."team_id",
          "posthog_filesystemshortcut"."user_id",
@@ -899,25 +940,6 @@
          AND NOT ("posthog_filesystemshortcut"."path" = 'New title'
                   AND "posthog_filesystemshortcut"."href" = '__skipped__'
                   AND "posthog_filesystemshortcut"."href" IS NOT NULL))
-  '''
-# ---
-# name: TestNotebooks.test_updates_notebook.21
-  '''
-  SELECT "posthog_sharingconfiguration"."id",
-         "posthog_sharingconfiguration"."team_id",
-         "posthog_sharingconfiguration"."dashboard_id",
-         "posthog_sharingconfiguration"."insight_id",
-         "posthog_sharingconfiguration"."recording_id",
-         "posthog_sharingconfiguration"."notebook_id",
-         "posthog_sharingconfiguration"."interviewee_context_id",
-         "posthog_sharingconfiguration"."created_at",
-         "posthog_sharingconfiguration"."enabled",
-         "posthog_sharingconfiguration"."access_token",
-         "posthog_sharingconfiguration"."expires_at",
-         "posthog_sharingconfiguration"."settings",
-         "posthog_sharingconfiguration"."password_required"
-  FROM "posthog_sharingconfiguration"
-  WHERE "posthog_sharingconfiguration"."notebook_id" = '00000000000000000000000000000000'::uuid
   '''
 # ---
 # name: TestNotebooks.test_updates_notebook.22
@@ -941,12 +963,21 @@
 # ---
 # name: TestNotebooks.test_updates_notebook.23
   '''
-  SELECT "posthog_resourcenotebook"."id",
-         "posthog_resourcenotebook"."notebook_id",
-         "posthog_resourcenotebook"."group_id",
-         "posthog_resourcenotebook"."account_id"
-  FROM "posthog_resourcenotebook"
-  WHERE "posthog_resourcenotebook"."notebook_id" = '00000000000000000000000000000000'::uuid
+  SELECT "posthog_sharingconfiguration"."id",
+         "posthog_sharingconfiguration"."team_id",
+         "posthog_sharingconfiguration"."dashboard_id",
+         "posthog_sharingconfiguration"."insight_id",
+         "posthog_sharingconfiguration"."recording_id",
+         "posthog_sharingconfiguration"."notebook_id",
+         "posthog_sharingconfiguration"."interviewee_context_id",
+         "posthog_sharingconfiguration"."created_at",
+         "posthog_sharingconfiguration"."enabled",
+         "posthog_sharingconfiguration"."access_token",
+         "posthog_sharingconfiguration"."expires_at",
+         "posthog_sharingconfiguration"."settings",
+         "posthog_sharingconfiguration"."password_required"
+  FROM "posthog_sharingconfiguration"
+  WHERE "posthog_sharingconfiguration"."notebook_id" = '00000000000000000000000000000000'::uuid
   '''
 # ---
 # name: TestNotebooks.test_updates_notebook.24
@@ -960,6 +991,16 @@
   '''
 # ---
 # name: TestNotebooks.test_updates_notebook.25
+  '''
+  SELECT "posthog_resourcenotebook"."id",
+         "posthog_resourcenotebook"."notebook_id",
+         "posthog_resourcenotebook"."group_id",
+         "posthog_resourcenotebook"."account_id"
+  FROM "posthog_resourcenotebook"
+  WHERE "posthog_resourcenotebook"."notebook_id" = '00000000000000000000000000000000'::uuid
+  '''
+# ---
+# name: TestNotebooks.test_updates_notebook.26
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -1005,7 +1046,18 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.26
+# name: TestNotebooks.test_updates_notebook.27
+  '''
+  SELECT "posthog_resourcenotebook"."id",
+         "posthog_resourcenotebook"."account_id"
+  FROM "posthog_resourcenotebook"
+  WHERE ("posthog_resourcenotebook"."notebook_id" = '00000000000000000000000000000000'::uuid
+         AND "posthog_resourcenotebook"."account_id" IS NOT NULL)
+  ORDER BY "posthog_resourcenotebook"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestNotebooks.test_updates_notebook.28
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -1050,7 +1102,7 @@
          AND "posthog_user"."id" = 99999)
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.27
+# name: TestNotebooks.test_updates_notebook.29
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -1091,7 +1143,19 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.28
+# name: TestNotebooks.test_updates_notebook.3
+  '''
+  SELECT "posthog_project"."id",
+         "posthog_project"."organization_id",
+         "posthog_project"."name",
+         "posthog_project"."created_at",
+         "posthog_project"."product_description"
+  FROM "posthog_project"
+  WHERE "posthog_project"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestNotebooks.test_updates_notebook.30
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1223,7 +1287,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.29
+# name: TestNotebooks.test_updates_notebook.31
   '''
   SELECT "posthog_project"."id",
          "posthog_project"."organization_id",
@@ -1235,19 +1299,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.3
-  '''
-  SELECT "posthog_project"."id",
-         "posthog_project"."organization_id",
-         "posthog_project"."name",
-         "posthog_project"."created_at",
-         "posthog_project"."product_description"
-  FROM "posthog_project"
-  WHERE "posthog_project"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestNotebooks.test_updates_notebook.30
+# name: TestNotebooks.test_updates_notebook.32
   '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -1297,7 +1349,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.31
+# name: TestNotebooks.test_updates_notebook.33
   '''
   SELECT "ee_accesscontrol"."id",
          "ee_accesscontrol"."team_id",
@@ -1343,7 +1395,7 @@
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.32
+# name: TestNotebooks.test_updates_notebook.34
   '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -1391,7 +1443,7 @@
   WHERE "posthog_organizationmembership"."user_id" = 99999
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.33
+# name: TestNotebooks.test_updates_notebook.35
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_activitylog"
@@ -1399,7 +1451,7 @@
          AND "posthog_activitylog"."team_id" = 99999)
   '''
 # ---
-# name: TestNotebooks.test_updates_notebook.34
+# name: TestNotebooks.test_updates_notebook.36
   '''
   SELECT "posthog_activitylog"."id",
          "posthog_activitylog"."team_id",
@@ -1628,6 +1680,17 @@
 # ---
 # name: TestNotebooks.test_updates_notebook.8
   '''
+  SELECT "posthog_resourcenotebook"."id",
+         "posthog_resourcenotebook"."account_id"
+  FROM "posthog_resourcenotebook"
+  WHERE ("posthog_resourcenotebook"."notebook_id" = '00000000000000000000000000000000'::uuid
+         AND "posthog_resourcenotebook"."account_id" IS NOT NULL)
+  ORDER BY "posthog_resourcenotebook"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestNotebooks.test_updates_notebook.9
+  '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -1669,46 +1732,5 @@
   FROM "posthog_user"
   WHERE ("posthog_user"."is_active"
          AND "posthog_user"."id" = 99999)
-  '''
-# ---
-# name: TestNotebooks.test_updates_notebook.9
-  '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."logo_media_id",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."is_active",
-         "posthog_organization"."is_not_active_reason",
-         "posthog_organization"."session_cookie_age",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."is_ai_data_processing_approved",
-         "posthog_organization"."is_ai_training_opted_in",
-         "posthog_organization"."is_ai_training_locked",
-         "posthog_organization"."is_ai_training_cta_shown",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."members_can_invite",
-         "posthog_organization"."members_can_use_personal_api_keys",
-         "posthog_organization"."allow_publicly_shared_resources",
-         "posthog_organization"."default_role_id",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."default_experiment_stats_method",
-         "posthog_organization"."default_anonymize_ips",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."is_pending_deletion",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."is_platform"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
   '''
 # ---

--- a/posthog/api/test/notebooks/test_notebook.py
+++ b/posthog/api/test/notebooks/test_notebook.py
@@ -100,6 +100,7 @@ class TestNotebooks(APIBaseTest, QueryMatchingTest):
             "last_modified_at": mock.ANY,
             "last_modified_by": response.json()["last_modified_by"],
             "user_access_level": "manager",
+            "parent_resource": None,
         }
 
         self.assert_notebook_activity(

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -1188,6 +1188,19 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertEqual(first_node["type"], "paragraph")
         self.assertEqual(first_node["content"][0]["text"], "Just a sentence.")
 
+    def test_create_with_empty_valid_prosemirror_doc_respects_caller(self):
+        empty_doc = {"type": "doc", "content": []}
+        response = self.client.post(
+            self.endpoint_base,
+            {"title": "Empty doc", "content": empty_doc, "text_content": "ignored"},
+            format="json",
+        )
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
+        # nosemgrep: idor-lookup-without-team (test assertion)
+        notebook = Notebook.objects.get(short_id=response.json()["short_id"])
+        self.assertEqual(notebook.content, empty_doc)
+
     def test_notebook_detail_includes_parent_resource_for_linked_account(self):
         notebook = Notebook.objects.create(
             team=self.team, title="Account note", content={}, visibility=Notebook.Visibility.INTERNAL

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -1213,6 +1213,37 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertEqual(first_node["type"], "paragraph")
         self.assertEqual(first_node["content"][0]["text"], "Just a sentence.")
 
+    def test_notebook_detail_includes_parent_resource_for_linked_account(self):
+        from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+        notebook = Notebook.objects.create(
+            team=self.team, title="Account note", content={}, visibility=Notebook.Visibility.INTERNAL
+        )
+        ResourceNotebook.objects.create(notebook=notebook, account=self.account)
+
+        # The frontend NotebookScene fetches via /api/projects/{team}/notebooks/{short_id}/
+        # (not the customer-analytics nested endpoint), so the parent_resource field must be
+        # present on NotebookSerializer responses.
+        response = self.client.get(f"/api/projects/{self.team.id}/notebooks/{notebook.short_id}/")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code, response.json())
+        self.assertEqual(
+            response.json()["parent_resource"],
+            {"type": "account", "id": str(self.account.id)},
+        )
+
+    def test_notebook_detail_parent_resource_is_null_for_standalone(self):
+        from products.notebooks.backend.models import Notebook
+
+        notebook = Notebook.objects.create(
+            team=self.team, title="Standalone", content={}, visibility=Notebook.Visibility.DEFAULT
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/notebooks/{notebook.short_id}/")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code, response.json())
+        self.assertIsNone(response.json()["parent_resource"])
+
 
 @pytest.mark.ee
 class TestCustomerAnalyticsAccessControl(APIBaseTest):

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -1134,6 +1134,85 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertIn(internal_notebook.short_id, short_ids)
         self.assertNotIn(default_notebook.short_id, short_ids)
 
+    def test_create_derives_content_from_markdown_text_content(self):
+        from products.notebooks.backend.models import Notebook
+
+        response = self.client.post(
+            self.endpoint_base,
+            {"title": "Call notes", "text_content": "# Heading\n\nSome **bold** text."},
+            format="json",
+        )
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
+        # nosemgrep: idor-lookup-without-team (test assertion)
+        notebook = Notebook.objects.get(short_id=response.json()["short_id"])
+        self.assertEqual(notebook.text_content, "# Heading\n\nSome **bold** text.")
+        self.assertIsInstance(notebook.content, dict)
+        self.assertEqual(notebook.content["type"], "doc")
+        first_node = notebook.content["content"][0]
+        self.assertEqual(first_node["type"], "heading")
+        self.assertEqual(first_node["attrs"]["level"], 1)
+        self.assertEqual(first_node["content"][0]["text"], "Heading")
+
+    def test_create_preserves_caller_supplied_content(self):
+        from products.notebooks.backend.models import Notebook
+
+        explicit_content = {
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "from caller"}]}],
+        }
+        response = self.client.post(
+            self.endpoint_base,
+            {"title": "Provided", "content": explicit_content, "text_content": "# ignored"},
+            format="json",
+        )
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
+        # nosemgrep: idor-lookup-without-team (test assertion)
+        notebook = Notebook.objects.get(short_id=response.json()["short_id"])
+        self.assertEqual(notebook.content, explicit_content)
+
+    def test_create_with_neither_field_leaves_content_null(self):
+        from products.notebooks.backend.models import Notebook
+
+        response = self.client.post(self.endpoint_base, {"title": "Empty"}, format="json")
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
+        # nosemgrep: idor-lookup-without-team (test assertion)
+        notebook = Notebook.objects.get(short_id=response.json()["short_id"])
+        self.assertIsNone(notebook.content)
+
+    def test_create_with_empty_text_content_does_not_synthesize_content(self):
+        from products.notebooks.backend.models import Notebook
+
+        response = self.client.post(
+            self.endpoint_base,
+            {"title": "Empty body", "text_content": ""},
+            format="json",
+        )
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
+        # nosemgrep: idor-lookup-without-team (test assertion)
+        notebook = Notebook.objects.get(short_id=response.json()["short_id"])
+        self.assertIsNone(notebook.content)
+
+    def test_create_with_empty_dict_content_falls_back_to_markdown(self):
+        from products.notebooks.backend.models import Notebook
+
+        response = self.client.post(
+            self.endpoint_base,
+            {"title": "Plain", "content": {}, "text_content": "Just a sentence."},
+            format="json",
+        )
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
+        # nosemgrep: idor-lookup-without-team (test assertion)
+        notebook = Notebook.objects.get(short_id=response.json()["short_id"])
+        self.assertEqual(notebook.content["type"], "doc")
+        first_node = notebook.content["content"][0]
+        self.assertEqual(first_node["type"], "paragraph")
+        self.assertEqual(first_node["content"][0]["text"], "Just a sentence.")
+
 
 @pytest.mark.ee
 class TestCustomerAnalyticsAccessControl(APIBaseTest):

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -17,6 +17,8 @@ from products.customer_analytics.backend.models.account import AccountAssignment
 from products.notebooks.backend.models import Notebook, ResourceNotebook
 from products.product_analytics.backend.models.insight import Insight
 
+from ee.models.rbac.access_control import AccessControl
+
 
 class TestCustomerProfileConfigViewSet(APIBaseTest):
     def setUp(self):
@@ -945,8 +947,6 @@ class TestAccountViewSet(APIBaseTest):
         self.assertEqual(response.json()["notebooks"], [])
 
     def test_retrieve_returns_all_linked_notebooks(self):
-        from products.notebooks.backend.models import Notebook, ResourceNotebook
-
         account = self._create_account()
         notebook_a = Notebook.objects.create(
             team=self.team, title="A", content=[], visibility=Notebook.Visibility.INTERNAL
@@ -963,8 +963,6 @@ class TestAccountViewSet(APIBaseTest):
         self.assertEqual(set(response.json()["notebooks"]), {notebook_a.short_id, notebook_b.short_id})
 
     def test_list_includes_notebooks_field(self):
-        from products.notebooks.backend.models import Notebook, ResourceNotebook
-
         account = self._create_account()
         notebook = Notebook.objects.create(
             team=self.team, title="Existing", content=[], visibility=Notebook.Visibility.INTERNAL
@@ -985,8 +983,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.endpoint_base = f"/api/environments/{self.team.id}/accounts/{self.account.id}/notebooks/"
 
     def test_create_account_notebook_uses_internal_visibility(self):
-        from products.notebooks.backend.models import Notebook, ResourceNotebook
-
         response = self.client.post(
             self.endpoint_base,
             {"title": "Q3 call", "content": {"type": "doc", "content": []}},
@@ -1043,8 +1039,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertEqual(data["content"], {"foo": "bar"})
 
     def test_retrieve_notebook_not_linked_to_account_returns_404(self):
-        from products.notebooks.backend.models import Notebook
-
         unrelated = Notebook.objects.create(
             team=self.team, title="Unrelated", content={}, visibility=Notebook.Visibility.DEFAULT
         )
@@ -1126,8 +1120,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertNotIn(default_notebook.short_id, short_ids)
 
     def test_create_derives_content_from_markdown_text_content(self):
-        from products.notebooks.backend.models import Notebook
-
         response = self.client.post(
             self.endpoint_base,
             {"title": "Call notes", "text_content": "# Heading\n\nSome **bold** text."},
@@ -1146,8 +1138,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertEqual(first_node["content"][0]["text"], "Heading")
 
     def test_create_preserves_caller_supplied_content(self):
-        from products.notebooks.backend.models import Notebook
-
         explicit_content = {
             "type": "doc",
             "content": [{"type": "paragraph", "content": [{"type": "text", "text": "from caller"}]}],
@@ -1164,8 +1154,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertEqual(notebook.content, explicit_content)
 
     def test_create_with_neither_field_leaves_content_null(self):
-        from products.notebooks.backend.models import Notebook
-
         response = self.client.post(self.endpoint_base, {"title": "Empty"}, format="json")
 
         self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
@@ -1174,8 +1162,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertIsNone(notebook.content)
 
     def test_create_with_empty_text_content_does_not_synthesize_content(self):
-        from products.notebooks.backend.models import Notebook
-
         response = self.client.post(
             self.endpoint_base,
             {"title": "Empty body", "text_content": ""},
@@ -1188,8 +1174,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertIsNone(notebook.content)
 
     def test_create_with_empty_dict_content_falls_back_to_markdown(self):
-        from products.notebooks.backend.models import Notebook
-
         response = self.client.post(
             self.endpoint_base,
             {"title": "Plain", "content": {}, "text_content": "Just a sentence."},
@@ -1274,8 +1258,6 @@ class TestCustomerAnalyticsAccessControl(APIBaseTest):
 
     def _set_access_level(self, user: User, resource: str = "customer_analytics", access_level: str = "viewer") -> None:
         try:
-            from ee.models.rbac.access_control import AccessControl
-
             membership = OrganizationMembership.objects.get(user=user, organization=self.organization)
             AccessControl.objects.create(
                 team=self.team,
@@ -1469,8 +1451,6 @@ class TestCustomerAnalyticsAccessControl(APIBaseTest):
     # -- Account notebooks inherit object-level access from the parent account --
 
     def test_account_notebooks_404_when_parent_account_access_denied(self):
-        from ee.models.rbac.access_control import AccessControl
-
         AccessControl.objects.create(
             team=self.team,
             resource="account",

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -14,6 +14,7 @@ from posthog.models.user import User
 
 from products.customer_analytics.backend.models import Account, CustomerJourney, CustomerProfileConfig
 from products.customer_analytics.backend.models.account import AccountAssignment
+from products.notebooks.backend.models import Notebook, ResourceNotebook
 from products.product_analytics.backend.models.insight import Insight
 
 
@@ -1008,8 +1009,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         )
 
     def test_list_returns_only_notebooks_for_account(self):
-        from products.notebooks.backend.models import Notebook, ResourceNotebook
-
         account_notebook = Notebook.objects.create(
             team=self.team, title="Account note", content={}, visibility=Notebook.Visibility.INTERNAL
         )
@@ -1030,8 +1029,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertEqual(short_ids, [account_notebook.short_id])
 
     def test_retrieve_returns_notebook_for_account(self):
-        from products.notebooks.backend.models import Notebook, ResourceNotebook
-
         notebook = Notebook.objects.create(
             team=self.team, title="Note", content={"foo": "bar"}, visibility=Notebook.Visibility.INTERNAL
         )
@@ -1057,8 +1054,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
 
     def test_destroy_notebook_for_account(self):
-        from products.notebooks.backend.models import Notebook, ResourceNotebook
-
         notebook = Notebook.objects.create(
             team=self.team, title="Note", content={}, visibility=Notebook.Visibility.INTERNAL
         )
@@ -1089,8 +1084,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
 
     def test_internal_account_notebooks_do_not_appear_in_notebooks_list(self):
-        from products.notebooks.backend.models import Notebook, ResourceNotebook
-
         notebook = Notebook.objects.create(
             team=self.team, title="Account note", content={}, visibility=Notebook.Visibility.INTERNAL
         )
@@ -1115,8 +1108,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
                 self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
 
     def test_list_excludes_non_internal_notebooks_linked_to_account(self):
-        from products.notebooks.backend.models import Notebook, ResourceNotebook
-
         internal_notebook = Notebook.objects.create(
             team=self.team, title="Internal", content={}, visibility=Notebook.Visibility.INTERNAL
         )
@@ -1214,8 +1205,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         self.assertEqual(first_node["content"][0]["text"], "Just a sentence.")
 
     def test_notebook_detail_includes_parent_resource_for_linked_account(self):
-        from products.notebooks.backend.models import Notebook, ResourceNotebook
-
         notebook = Notebook.objects.create(
             team=self.team, title="Account note", content={}, visibility=Notebook.Visibility.INTERNAL
         )
@@ -1233,8 +1222,6 @@ class TestAccountNotebookViewSet(APIBaseTest):
         )
 
     def test_notebook_detail_parent_resource_is_null_for_standalone(self):
-        from products.notebooks.backend.models import Notebook
-
         notebook = Notebook.objects.create(
             team=self.team, title="Standalone", content={}, visibility=Notebook.Visibility.DEFAULT
         )

--- a/products/customer_analytics/backend/api/views.py
+++ b/products/customer_analytics/backend/api/views.py
@@ -17,6 +17,8 @@ from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from products.customer_analytics.backend.models import Account, CustomerJourney, CustomerProfileConfig
 from products.notebooks.backend.models import Notebook, ResourceNotebook
 
+from ee.hogai.tools.create_notebook.tiptap import markdown_to_tiptap_nodes
+
 from .serializers import (
     AccountNotebookSerializer,
     AccountSerializer,
@@ -266,12 +268,28 @@ class AccountNotebookViewSet(
     @transaction.atomic
     def perform_create(self, serializer):
         account = self._get_account()
-        notebook = serializer.save(
-            team=self.team,
-            created_by=self.request.user,
-            last_modified_by=self.request.user,
-            visibility=Notebook.Visibility.INTERNAL,
-        )
+        save_kwargs: dict = {
+            "team": self.team,
+            "created_by": self.request.user,
+            "last_modified_by": self.request.user,
+            "visibility": Notebook.Visibility.INTERNAL,
+        }
+
+        # Agents calling the MCP `accounts-notebooks-create` tool typically pass `text_content`
+        # (Markdown) without a ProseMirror `content` tree, since hand-writing ProseMirror is
+        # awkward. NotebookScene only renders `content`, so the result is a blank page. Treat
+        # `text_content` as Markdown and synthesize `content` from it when the caller hasn't.
+        validated = serializer.validated_data
+        text_content = validated.get("text_content")
+        existing_content = validated.get("content")
+        has_usable_content = isinstance(existing_content, dict) and existing_content.get("content")
+        if text_content and not has_usable_content:
+            save_kwargs["content"] = {
+                "type": "doc",
+                "content": markdown_to_tiptap_nodes(text_content) or [{"type": "paragraph"}],
+            }
+
+        notebook = serializer.save(**save_kwargs)
         ResourceNotebook.objects.create(notebook=notebook, account=account)
 
     @transaction.atomic

--- a/products/customer_analytics/backend/api/views.py
+++ b/products/customer_analytics/backend/api/views.py
@@ -282,7 +282,11 @@ class AccountNotebookViewSet(
         validated = serializer.validated_data
         text_content = validated.get("text_content")
         existing_content = validated.get("content")
-        has_usable_content = isinstance(existing_content, dict) and existing_content.get("content")
+        has_usable_content = (
+            isinstance(existing_content, dict)
+            and existing_content.get("type") == "doc"
+            and isinstance(existing_content.get("content"), list)
+        )
         if text_content and not has_usable_content:
             save_kwargs["content"] = {
                 "type": "doc",

--- a/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
@@ -81,9 +81,13 @@ export function AccountNotebooksExpansion({ accountId }: { accountId: string }):
                 embedded
                 dataSource={notebooks ?? []}
                 rowKey="short_id"
-                loading={notebooks === null || notebooksLoading}
+                loading={notebooksLoading}
                 columns={columns}
-                emptyState="No notebooks linked to this account yet."
+                emptyState={
+                    notebooks === null
+                        ? 'Failed to load account notebooks.'
+                        : 'No notebooks linked to this account yet.'
+                }
             />
         </div>
     )

--- a/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
@@ -1,0 +1,48 @@
+import { useValues } from 'kea'
+
+import { Link } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { urls } from 'scenes/urls'
+
+import { accountNotebooksLogic } from './accountNotebooksLogic'
+
+export function AccountNotebooksExpansion({ accountId }: { accountId: string }): JSX.Element {
+    const logic = accountNotebooksLogic({ accountId })
+    const { notebooks, notebooksLoading } = useValues(logic)
+
+    if (notebooks === null || notebooksLoading) {
+        return (
+            <div className="flex items-center gap-2 p-3 text-muted">
+                <Spinner />
+                <span>Loading notebooks…</span>
+            </div>
+        )
+    }
+
+    if (notebooks.length === 0) {
+        return <div className="p-3 text-muted">No notebooks linked to this account yet.</div>
+    }
+
+    return (
+        <div className="p-3">
+            <div className="text-xs uppercase tracking-wide text-muted mb-2">Notebooks</div>
+            <ul className="flex flex-col gap-1">
+                {notebooks.map((notebook) => (
+                    <li key={notebook.short_id} className="flex items-center justify-between gap-3">
+                        <Link to={urls.notebook(notebook.short_id)} className="font-medium">
+                            {notebook.title || 'Untitled notebook'}
+                        </Link>
+                        <span className="text-xs text-muted">
+                            {notebook.last_modified_by?.email
+                                ? `${notebook.last_modified_by.email} · `
+                                : ''}
+                            {dayjs(notebook.last_modified_at).fromNow()}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    )
+}

--- a/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
@@ -34,7 +34,7 @@ export function AccountNotebooksExpansion({ accountId }: { accountId: string }):
                 return (
                     <div className="flex flex-col gap-1 py-1 max-w-2xl">
                         <Link to={urls.notebook(notebook.short_id)} className="font-medium">
-                            {notebook.title || 'Untitled notebook'}
+                            {notebook.title || 'Untitled note'}
                         </Link>
                         {preview ? (
                             <span className="text-xs text-muted line-clamp-2">{preview}</span>
@@ -84,9 +84,7 @@ export function AccountNotebooksExpansion({ accountId }: { accountId: string }):
                 loading={notebooksLoading}
                 columns={columns}
                 emptyState={
-                    notebooks === null
-                        ? 'Failed to load account notebooks.'
-                        : 'No notebooks linked to this account yet.'
+                    notebooks === null ? 'Failed to load account notes.' : 'No notes linked to this account yet.'
                 }
             />
         </div>

--- a/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
@@ -1,48 +1,90 @@
 import { useValues } from 'kea'
 
-import { Link } from '@posthog/lemon-ui'
+import { LemonTable, LemonTableColumns, Link, ProfilePicture } from '@posthog/lemon-ui'
 
-import { dayjs } from 'lib/dayjs'
-import { Spinner } from 'lib/lemon-ui/Spinner'
+import { TZLabel } from 'lib/components/TZLabel'
+import { fullName } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
+import type { AccountNotebookApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+
 import { accountNotebooksLogic } from './accountNotebooksLogic'
+
+const PREVIEW_MAX_CHARS = 200
+
+function getPreview(notebook: AccountNotebookApi): string {
+    const text = (notebook.text_content ?? '').trim()
+    if (!text) {
+        return ''
+    }
+    const collapsed = text.replace(/\s+/g, ' ')
+    return collapsed.length > PREVIEW_MAX_CHARS ? `${collapsed.slice(0, PREVIEW_MAX_CHARS).trimEnd()}…` : collapsed
+}
 
 export function AccountNotebooksExpansion({ accountId }: { accountId: string }): JSX.Element {
     const logic = accountNotebooksLogic({ accountId })
     const { notebooks, notebooksLoading } = useValues(logic)
 
-    if (notebooks === null || notebooksLoading) {
-        return (
-            <div className="flex items-center gap-2 p-3 text-muted">
-                <Spinner />
-                <span>Loading notebooks…</span>
-            </div>
-        )
-    }
-
-    if (notebooks.length === 0) {
-        return <div className="p-3 text-muted">No notebooks linked to this account yet.</div>
-    }
-
-    return (
-        <div className="p-3">
-            <div className="text-xs uppercase tracking-wide text-muted mb-2">Notebooks</div>
-            <ul className="flex flex-col gap-1">
-                {notebooks.map((notebook) => (
-                    <li key={notebook.short_id} className="flex items-center justify-between gap-3">
+    const columns: LemonTableColumns<AccountNotebookApi> = [
+        {
+            title: 'Note',
+            key: 'title',
+            render: (_, notebook) => {
+                const preview = getPreview(notebook)
+                return (
+                    <div className="flex flex-col gap-1 py-1 max-w-2xl">
                         <Link to={urls.notebook(notebook.short_id)} className="font-medium">
                             {notebook.title || 'Untitled notebook'}
                         </Link>
-                        <span className="text-xs text-muted">
-                            {notebook.last_modified_by?.email
-                                ? `${notebook.last_modified_by.email} · `
-                                : ''}
-                            {dayjs(notebook.last_modified_at).fromNow()}
-                        </span>
-                    </li>
-                ))}
-            </ul>
+                        {preview ? (
+                            <span className="text-xs text-muted line-clamp-2">{preview}</span>
+                        ) : (
+                            <span className="text-xs text-muted italic">No content yet</span>
+                        )}
+                    </div>
+                )
+            },
+        },
+        {
+            title: 'Created by',
+            key: 'created_by',
+            width: 220,
+            render: (_, notebook) => {
+                const user = notebook.created_by
+                if (!user) {
+                    return <span className="text-muted italic">Unknown</span>
+                }
+                const name = fullName(user) || user.email
+                return (
+                    <div className="flex items-center gap-2">
+                        <ProfilePicture
+                            user={{ email: user.email, first_name: user.first_name, last_name: user.last_name }}
+                            size="sm"
+                        />
+                        <span className="text-sm">{name}</span>
+                    </div>
+                )
+            },
+        },
+        {
+            title: 'Created at',
+            key: 'created_at',
+            width: 180,
+            render: (_, notebook) => <TZLabel time={notebook.created_at} />,
+        },
+    ]
+
+    return (
+        <div className="p-3 bg-bg-light">
+            <LemonTable<AccountNotebookApi>
+                size="small"
+                embedded
+                dataSource={notebooks ?? []}
+                rowKey="short_id"
+                loading={notebooks === null || notebooksLoading}
+                columns={columns}
+                emptyState="No notebooks linked to this account yet."
+            />
         </div>
     )
 }

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
@@ -1,4 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
+import { within } from '@testing-library/dom'
+import userEvent from '@testing-library/user-event'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { App } from 'scenes/App'
@@ -7,6 +9,30 @@ import { urls } from 'scenes/urls'
 import { mswDecorator } from '~/mocks/browser'
 
 const ACCOUNTS_ENDPOINT = 'api/environments/:team_id/accounts/'
+const ACCOUNT_NOTEBOOKS_ENDPOINT = 'api/environments/:team_id/accounts/:account_id/notebooks/'
+
+const SINGLE_ACCOUNT_RESULTS = [
+    {
+        id: 'acc-1',
+        name: 'Acme Inc',
+        external_id: 'cust_acme_001',
+        properties: {
+            csm: { id: 1, email: 'alice@posthog.com' },
+            account_executive: { id: 2, email: 'bob@posthog.com' },
+            account_owner: null,
+        },
+        tags: ['enterprise', 'priority'],
+        created_at: '2026-05-01T00:00:00Z',
+        created_by: 1,
+        updated_at: '2026-05-20T00:00:00Z',
+    },
+]
+
+async function expandFirstRow(canvasElement: HTMLElement): Promise<void> {
+    const canvas = within(canvasElement)
+    const expandBtn = await canvas.findByTitle('Show more')
+    await userEvent.click(expandBtn)
+}
 
 const meta: Meta = {
     component: App,
@@ -101,5 +127,77 @@ export const FeatureGateOff: Story = {
         testOptions: {
             waitForSelector: '[data-attr="not-found-page"]',
         },
+    },
+}
+
+export const RowExpandedEmpty: Story = {
+    render: () => <App />,
+    decorators: [
+        mswDecorator({
+            get: {
+                [ACCOUNTS_ENDPOINT]: {
+                    count: SINGLE_ACCOUNT_RESULTS.length,
+                    next: null,
+                    previous: null,
+                    results: SINGLE_ACCOUNT_RESULTS,
+                },
+                [ACCOUNT_NOTEBOOKS_ENDPOINT]: { count: 0, next: null, previous: null, results: [] },
+            },
+        }),
+    ],
+    play: async ({ canvasElement }) => {
+        await expandFirstRow(canvasElement)
+    },
+}
+
+export const RowExpandedWithNote: Story = {
+    render: () => <App />,
+    decorators: [
+        mswDecorator({
+            get: {
+                [ACCOUNTS_ENDPOINT]: {
+                    count: SINGLE_ACCOUNT_RESULTS.length,
+                    next: null,
+                    previous: null,
+                    results: SINGLE_ACCOUNT_RESULTS,
+                },
+                [ACCOUNT_NOTEBOOKS_ENDPOINT]: {
+                    count: 1,
+                    next: null,
+                    previous: null,
+                    results: [
+                        {
+                            id: '11111111-1111-1111-1111-111111111111',
+                            short_id: 'abc12345',
+                            title: 'Q2 expansion call',
+                            content: null,
+                            text_content:
+                                'Discussed expansion plans for Q2. They want to add the data warehouse integration and roll out session replay to their EU team. Decision-makers: VP Eng (Priya) and CTO (Marco). Follow-up scheduled for next week to scope pricing.',
+                            created_at: '2026-05-15T10:30:00Z',
+                            created_by: {
+                                id: 1,
+                                uuid: '00000000-0000-0000-0000-000000000001',
+                                email: 'alice@posthog.com',
+                                first_name: 'Alice',
+                                last_name: 'Anderson',
+                                is_email_verified: true,
+                            },
+                            last_modified_at: '2026-05-15T10:30:00Z',
+                            last_modified_by: {
+                                id: 1,
+                                uuid: '00000000-0000-0000-0000-000000000001',
+                                email: 'alice@posthog.com',
+                                first_name: 'Alice',
+                                last_name: 'Anderson',
+                                is_email_verified: true,
+                            },
+                        },
+                    ],
+                },
+            },
+        }),
+    ],
+    play: async ({ canvasElement }) => {
+        await expandFirstRow(canvasElement)
     },
 }

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
@@ -8,6 +8,7 @@ import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 
 import type { AccountApi } from 'products/customer_analytics/frontend/generated/api.schemas'
 
+import { AccountNotebooksExpansion } from './AccountNotebooksExpansion'
 import { ACCOUNTS_PAGE_SIZE, AccountRoleKey, accountsLogic } from './accountsLogic'
 
 type AccountAssignment = { id: number; email: string } | null
@@ -50,15 +51,6 @@ export function AccountsTable(): JSX.Element {
                 ),
         },
         {
-            title: 'Notebooks',
-            key: 'notebooks',
-            dataIndex: 'notebooks',
-            render: (_, account) => {
-                const count = account.notebooks?.length ?? 0
-                return count > 0 ? <span>{count}</span> : <span className="text-muted">—</span>
-            },
-        },
-        {
             title: 'CSM',
             key: 'csm',
             render: (_, account) => <RoleAssignmentCell account={account} role="csm" />,
@@ -81,6 +73,11 @@ export function AccountsTable(): JSX.Element {
             rowKey="id"
             loading={accountsLoading}
             columns={columns}
+            expandable={{
+                noIndent: true,
+                rowExpandable: (account) => (account.notebooks?.length ?? 0) > 0,
+                expandedRowRender: (account) => <AccountNotebooksExpansion accountId={account.id} />,
+            }}
             pagination={{
                 controlled: true,
                 currentPage,

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
@@ -75,7 +75,6 @@ export function AccountsTable(): JSX.Element {
             columns={columns}
             expandable={{
                 noIndent: true,
-                rowExpandable: (account) => (account.notebooks?.length ?? 0) > 0,
                 expandedRowRender: (account) => <AccountNotebooksExpansion accountId={account.id} />,
             }}
             pagination={{

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
@@ -51,7 +51,7 @@ export function AccountsTable(): JSX.Element {
                 ),
         },
         {
-            title: 'Notebooks',
+            title: 'Notes',
             key: 'notebooks',
             dataIndex: 'notebooks',
             render: (_, account) => {

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
@@ -51,6 +51,15 @@ export function AccountsTable(): JSX.Element {
                 ),
         },
         {
+            title: 'Notebooks',
+            key: 'notebooks',
+            dataIndex: 'notebooks',
+            render: (_, account) => {
+                const count = account.notebooks?.length ?? 0
+                return count > 0 ? <span>{count}</span> : <span className="text-muted">—</span>
+            },
+        },
+        {
             title: 'CSM',
             key: 'csm',
             render: (_, account) => <RoleAssignmentCell account={account} role="csm" />,

--- a/products/customer_analytics/frontend/components/Accounts/accountNotebooksLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountNotebooksLogic.ts
@@ -36,7 +36,7 @@ export const accountNotebooksLogic = kea<accountNotebooksLogicType>([
                             posthog.captureException(error as Error, {
                                 scope: 'accountNotebooksLogic.loadNotebooks',
                             })
-                            lemonToast.error('Failed to load account notebooks')
+                            lemonToast.error('Failed to load account notes')
                         }
                         throw error
                     }

--- a/products/customer_analytics/frontend/components/Accounts/accountNotebooksLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountNotebooksLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, isBreakpoint, kea, key, path, props } from 'kea'
+import { afterMount, connect, isBreakpoint, kea, key, path, props } from 'kea'
 import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
@@ -21,9 +21,6 @@ export const accountNotebooksLogic = kea<accountNotebooksLogicType>([
     connect(() => ({
         values: [teamLogic, ['currentTeamId']],
     })),
-    actions({
-        refresh: true,
-    }),
     loaders(({ props, values }) => ({
         notebooks: [
             null as AccountNotebookApi[] | null,

--- a/products/customer_analytics/frontend/components/Accounts/accountNotebooksLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountNotebooksLogic.ts
@@ -1,0 +1,53 @@
+import { actions, afterMount, connect, isBreakpoint, kea, key, path, props } from 'kea'
+import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { accountsNotebooksList } from 'products/customer_analytics/frontend/generated/api'
+import type { AccountNotebookApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import type { accountNotebooksLogicType } from './accountNotebooksLogicType'
+
+export interface AccountNotebooksLogicProps {
+    accountId: string
+}
+
+export const accountNotebooksLogic = kea<accountNotebooksLogicType>([
+    path((key) => ['scenes', 'customerAnalytics', 'accounts', 'accountNotebooksLogic', key]),
+    props({} as AccountNotebooksLogicProps),
+    key((props) => props.accountId),
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId']],
+    })),
+    actions({
+        refresh: true,
+    }),
+    loaders(({ props, values }) => ({
+        notebooks: [
+            null as AccountNotebookApi[] | null,
+            {
+                loadNotebooks: async (_ = null, breakpoint) => {
+                    const projectId = String(values.currentTeamId)
+                    try {
+                        const response = await accountsNotebooksList(projectId, props.accountId)
+                        breakpoint()
+                        return response.results
+                    } catch (error) {
+                        if (!isBreakpoint(error as Error)) {
+                            posthog.captureException(error as Error, {
+                                scope: 'accountNotebooksLogic.loadNotebooks',
+                            })
+                            lemonToast.error('Failed to load account notebooks')
+                        }
+                        throw error
+                    }
+                },
+            },
+        ],
+    })),
+    afterMount(({ actions }) => {
+        actions.loadNotebooks()
+    }),
+])

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -87,8 +87,12 @@ tools:
         title: Create account notebook
         description: >
             Create a notebook attached to a Customer Analytics account. Use for persisting investigations, call notes,
-            and other free-form context. Provide `title` and optional `content` (ProseMirror JSON document structure).
-            The notebook is created with internal visibility so it does not appear in the global notebooks list.
+            and other free-form context. Provide `title` and the note body as Markdown via `text_content` — the server
+            converts it into a formatted notebook (headings `#` through `######`, bullet lists `-`, ordered lists `1.`,
+            fenced code blocks, `**bold**`, `*italic*`, `` `code` ``, and `[label](url)` links). Pass `content`
+            (ProseMirror JSON) only if you already have a structured document; in most cases leave it unset and write
+            Markdown in `text_content`. The notebook is created with internal visibility so it does not appear in the
+            global notebooks list.
         feature_flag: customer-analytics-csp
     accounts-notebooks-destroy:
         operation: accounts_notebooks_destroy

--- a/products/customer_analytics/package.json
+++ b/products/customer_analytics/package.json
@@ -13,6 +13,8 @@
     "peerDependencies": {
         "@posthog/icons": "*",
         "@storybook/react": "*",
+        "@testing-library/dom": "*",
+        "@testing-library/user-event": "*",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -11,7 +11,13 @@ from django.utils.timezone import now
 import structlog
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    extend_schema,
+    extend_schema_field,
+    extend_schema_view,
+)
 from loginas.utils import is_impersonated_session
 from rest_framework import serializers, viewsets
 from rest_framework.request import Request
@@ -90,6 +96,21 @@ _NOTEBOOK_FIELD_HELP_TEXTS = {
     "deleted": {"help_text": "Whether the notebook has been soft-deleted."},
 }
 
+_PARENT_RESOURCE_SCHEMA = {
+    "type": "object",
+    "nullable": True,
+    "description": (
+        "Parent resource this notebook is attached to, if any. Used by the notebook scene "
+        "to render context-aware breadcrumbs (e.g. account notebooks link back to the "
+        "Customer analytics accounts list)."
+    ),
+    "properties": {
+        "type": {"type": "string", "enum": ["account"]},
+        "id": {"type": "string", "format": "uuid"},
+    },
+    "required": ["type", "id"],
+}
+
 
 class NotebookMinimalSerializer(serializers.ModelSerializer, UserAccessControlSerializerMixin):
     created_by = UserBasicSerializer(read_only=True)
@@ -115,6 +136,14 @@ class NotebookMinimalSerializer(serializers.ModelSerializer, UserAccessControlSe
 
 
 class NotebookSerializer(NotebookMinimalSerializer):
+    parent_resource = serializers.SerializerMethodField(
+        help_text=(
+            "Parent resource this notebook is attached to, or `null` if it has no parent. "
+            "Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this "
+            "to route breadcrumbs back to the resource's list instead of the global Notebooks list."
+        ),
+    )
+
     class Meta:
         model = Notebook
         fields = [
@@ -130,6 +159,7 @@ class NotebookSerializer(NotebookMinimalSerializer):
             "last_modified_at",
             "last_modified_by",
             "user_access_level",
+            "parent_resource",
             "_create_in_folder",
         ]
         read_only_fields = [
@@ -140,6 +170,7 @@ class NotebookSerializer(NotebookMinimalSerializer):
             "last_modified_at",
             "last_modified_by",
             "user_access_level",
+            "parent_resource",
         ]
         extra_kwargs = {
             **_NOTEBOOK_FIELD_HELP_TEXTS,
@@ -149,6 +180,15 @@ class NotebookSerializer(NotebookMinimalSerializer):
                 "help_text": "Version number for optimistic concurrency control. Must match the current version when updating content."
             },
         }
+
+    @extend_schema_field(_PARENT_RESOURCE_SCHEMA)
+    def get_parent_resource(self, obj: Notebook) -> dict | None:
+        # Notebooks today have at most one parent resource link (ResourceNotebook). Future
+        # parent types (e.g. groups) should extend the schema's `type` enum and this lookup.
+        link = obj.resources.filter(account_id__isnull=False).only("account_id").first()
+        if link is None:
+            return None
+        return {"type": "account", "id": str(link.account_id)}
 
     def create(self, validated_data: dict, *args, **kwargs) -> Notebook:
         request = self.context["request"]

--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -138,9 +138,9 @@ class NotebookMinimalSerializer(serializers.ModelSerializer, UserAccessControlSe
 class NotebookSerializer(NotebookMinimalSerializer):
     parent_resource = serializers.SerializerMethodField(
         help_text=(
-            "Parent resource this notebook is attached to, or `null` if it has no parent. "
-            "Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this "
-            "to route breadcrumbs back to the resource's list instead of the global Notebooks list."
+            "Parent resource this notebook is attached to, or `null`. Returns "
+            "`{type: 'account', id: <uuid>}` for account-linked notebooks; used by the "
+            "frontend to route breadcrumbs back to the resource's list."
         ),
     )
 
@@ -183,8 +183,7 @@ class NotebookSerializer(NotebookMinimalSerializer):
 
     @extend_schema_field(_PARENT_RESOURCE_SCHEMA)
     def get_parent_resource(self, obj: Notebook) -> dict | None:
-        # Notebooks today have at most one parent resource link (ResourceNotebook). Future
-        # parent types (e.g. groups) should extend the schema's `type` enum and this lookup.
+        # Group parents are skipped: ResourceNotebook stores group PK but personhog has no get-by-pk RPC.
         link = obj.resources.filter(account_id__isnull=False).only("account_id").first()
         if link is None:
             return None

--- a/products/notebooks/frontend/generated/api.schemas.ts
+++ b/products/notebooks/frontend/generated/api.schemas.ts
@@ -96,7 +96,7 @@ export interface PaginatedNotebookMinimalListApi {
 }
 
 /**
- * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+ * Parent resource this notebook is attached to, or `null`. Returns `{type: 'account', id: <uuid>}` for account-linked notebooks; used by the frontend to route breadcrumbs back to the resource's list.
  * @nullable
  */
 export type NotebookApiParentResource = {
@@ -140,7 +140,7 @@ export interface NotebookApi {
      */
     readonly user_access_level: string | null
     /**
-     * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+     * Parent resource this notebook is attached to, or `null`. Returns `{type: 'account', id: <uuid>}` for account-linked notebooks; used by the frontend to route breadcrumbs back to the resource's list.
      * @nullable
      */
     readonly parent_resource: NotebookApiParentResource
@@ -170,7 +170,7 @@ export interface SharingConfigurationApi {
 }
 
 /**
- * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+ * Parent resource this notebook is attached to, or `null`. Returns `{type: 'account', id: <uuid>}` for account-linked notebooks; used by the frontend to route breadcrumbs back to the resource's list.
  * @nullable
  */
 export type PatchedNotebookApiParentResource = {
@@ -214,7 +214,7 @@ export interface PatchedNotebookApi {
      */
     readonly user_access_level?: string | null
     /**
-     * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+     * Parent resource this notebook is attached to, or `null`. Returns `{type: 'account', id: <uuid>}` for account-linked notebooks; used by the frontend to route breadcrumbs back to the resource's list.
      * @nullable
      */
     readonly parent_resource?: PatchedNotebookApiParentResource

--- a/products/notebooks/frontend/generated/api.schemas.ts
+++ b/products/notebooks/frontend/generated/api.schemas.ts
@@ -95,6 +95,15 @@ export interface PaginatedNotebookMinimalListApi {
     results: NotebookMinimalApi[]
 }
 
+/**
+ * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+ * @nullable
+ */
+export type NotebookApiParentResource = {
+    readonly type: 'account'
+    readonly id: string
+} | null
+
 export interface NotebookApi {
     /** UUID of the notebook. */
     readonly id: string
@@ -130,6 +139,11 @@ export interface NotebookApi {
      * @nullable
      */
     readonly user_access_level: string | null
+    /**
+     * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+     * @nullable
+     */
+    readonly parent_resource: NotebookApiParentResource
     _create_in_folder?: string
 }
 
@@ -154,6 +168,15 @@ export interface SharingConfigurationApi {
     password_required?: boolean
     readonly share_passwords: readonly SharePasswordApi[]
 }
+
+/**
+ * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+ * @nullable
+ */
+export type PatchedNotebookApiParentResource = {
+    readonly type: 'account'
+    readonly id: string
+} | null
 
 export interface PatchedNotebookApi {
     /** UUID of the notebook. */
@@ -190,6 +213,11 @@ export interface PatchedNotebookApi {
      * @nullable
      */
     readonly user_access_level?: string | null
+    /**
+     * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+     * @nullable
+     */
+    readonly parent_resource?: PatchedNotebookApiParentResource
     _create_in_folder?: string
 }
 

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -48,7 +48,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "accounts-notebooks-create": {
-        "description": "Create a notebook attached to a Customer Analytics account. Use for persisting investigations, call notes, and other free-form context. Provide `title` and optional `content` (ProseMirror JSON document structure). The notebook is created with internal visibility so it does not appear in the global notebooks list.",
+        "description": "Create a notebook attached to a Customer Analytics account. Use for persisting investigations, call notes, and other free-form context. Provide `title` and the note body as Markdown via `text_content` — the server converts it into a formatted notebook (headings `#` through `######`, bullet lists `-`, ordered lists `1.`, fenced code blocks, `**bold**`, `*italic*`, `` `code` ``, and `[label](url)` links). Pass `content` (ProseMirror JSON) only if you already have a structured document; in most cases leave it unset and write Markdown in `text_content`. The notebook is created with internal visibility so it does not appear in the global notebooks list.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Create account notebook",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -48,7 +48,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "accounts-notebooks-create": {
-        "description": "Create a notebook attached to a Customer Analytics account. Use for persisting investigations, call notes, and other free-form context. Provide `title` and optional `content` (ProseMirror JSON document structure). The notebook is created with internal visibility so it does not appear in the global notebooks list.",
+        "description": "Create a notebook attached to a Customer Analytics account. Use for persisting investigations, call notes, and other free-form context. Provide `title` and the note body as Markdown via `text_content` — the server converts it into a formatted notebook (headings `#` through `######`, bullet lists `-`, ordered lists `1.`, fenced code blocks, `**bold**`, `*italic*`, `` `code` ``, and `[label](url)` links). Pass `content` (ProseMirror JSON) only if you already have a structured document; in most cases leave it unset and write Markdown in `text_content`. The notebook is created with internal visibility so it does not appear in the global notebooks list.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Create account notebook",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21611,7 +21611,7 @@ export namespace Schemas {
     }
 
     /**
-     * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+     * Parent resource this notebook is attached to, or `null`. Returns `{type: 'account', id: <uuid>}` for account-linked notebooks; used by the frontend to route breadcrumbs back to the resource's list.
      * @nullable
      */
     export type NotebookParentResource = {
@@ -21655,7 +21655,7 @@ export namespace Schemas {
          */
       readonly user_access_level: string | null;
       /**
-         * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+         * Parent resource this notebook is attached to, or `null`. Returns `{type: 'account', id: <uuid>}` for account-linked notebooks; used by the frontend to route breadcrumbs back to the resource's list.
          * @nullable
          */
       readonly parent_resource: NotebookParentResource;
@@ -28870,7 +28870,7 @@ export namespace Schemas {
     }
 
     /**
-     * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+     * Parent resource this notebook is attached to, or `null`. Returns `{type: 'account', id: <uuid>}` for account-linked notebooks; used by the frontend to route breadcrumbs back to the resource's list.
      * @nullable
      */
     export type PatchedNotebookParentResource = {
@@ -28914,7 +28914,7 @@ export namespace Schemas {
          */
       readonly user_access_level?: string | null;
       /**
-         * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+         * Parent resource this notebook is attached to, or `null`. Returns `{type: 'account', id: <uuid>}` for account-linked notebooks; used by the frontend to route breadcrumbs back to the resource's list.
          * @nullable
          */
       readonly parent_resource?: PatchedNotebookParentResource;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21610,6 +21610,15 @@ export namespace Schemas {
       readonly sync_interval: string | null;
     }
 
+    /**
+     * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+     * @nullable
+     */
+    export type NotebookParentResource = {
+      readonly type: 'account';
+      readonly id: string;
+    } | null;
+
     export interface Notebook {
       /** UUID of the notebook. */
       readonly id: string;
@@ -21645,6 +21654,11 @@ export namespace Schemas {
          * @nullable
          */
       readonly user_access_level: string | null;
+      /**
+         * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+         * @nullable
+         */
+      readonly parent_resource: NotebookParentResource;
       _create_in_folder?: string;
     }
 
@@ -28855,6 +28869,15 @@ export namespace Schemas {
       readonly sync_interval?: string | null;
     }
 
+    /**
+     * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+     * @nullable
+     */
+    export type PatchedNotebookParentResource = {
+      readonly type: 'account';
+      readonly id: string;
+    } | null;
+
     export interface PatchedNotebook {
       /** UUID of the notebook. */
       readonly id?: string;
@@ -28890,6 +28913,11 @@ export namespace Schemas {
          * @nullable
          */
       readonly user_access_level?: string | null;
+      /**
+         * Parent resource this notebook is attached to, or `null` if it has no parent. Account notebooks return `{type: 'account', id: <uuid>}`; the frontend uses this to route breadcrumbs back to the resource's list instead of the global Notebooks list.
+         * @nullable
+         */
+      readonly parent_resource?: PatchedNotebookParentResource;
       _create_in_folder?: string;
     }
 


### PR DESCRIPTION
## Problem
There is no way to review account notes.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Closes https://github.com/PostHog/posthog/issues/57026
## Changes
- Make accounts rows expandable
- Display account notebooks in the expanded state
- Clicking the note opens the notebook
- Fix notebook creation via API, where we were only setting the `text_content`, but not the markdown `content` (the notebook looked empty in TipTap)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="1639" height="386" alt="image" src="https://github.com/user-attachments/assets/f986cc7c-bd0a-4d24-84c2-94e633ac530b" />

## How did you test this code?
Unit tests and manually in the UI
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
