### PR TITLE
test(surveys): add qa frontend self-test fixture

### DIFF
--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -515,7 +515,7 @@ export const defaultSurveyTemplates: SurveyTemplate[] = [
             url: '',
             seenSurveyWaitPeriodInDays: 14,
             actions: null,
-            events: { repeatedActivation: true, values: [{ name: '$exception' }] },
+            events: { repeatedActivation: true, values: [{ name: '$pageview' }] },
         },
         description: 'Get user context when errors occur to debug faster.',
         tagType: 'default',


### PR DESCRIPTION
Test-only draft PR. We do not plan to merge this PR; it exists only to exercise the repo-local `qa-frontend` skill against a small frontend fixture change.

## Problem

We need a repeatable draft PR for validating the internal QA frontend skill against a compact, browser-observable change.

## Changes

- Adjusts one survey template fixture value.
- Keeps the diff intentionally narrow so a QA run should focus on the affected survey-template flow.

## How did you test this code?

Not tested. This PR intentionally exists as a QA skill self-test fixture.

## Publish to changelog?

do not publish to changelog

## Docs update

skip-inkeep-docs
