### PR TITLE
feat(mcp-analytics): session details loading animations

### DIFF
--- a/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
@@ -38,71 +38,91 @@ export function MCPSessionDetail(): JSX.Element {
         ? selectedSession.person_name || selectedSession.person_email || selectedSession.distinct_id
         : selectedSession.distinct_id || 'unknown'
 
+    // While the selected session's tool calls load, animate the whole detail panel
+    const loading = toolCallsLoading
+
     return (
         <div className="flex flex-col">
             <header className="flex flex-col gap-2 shrink-0 border-b border-primary px-3 pt-3 pb-2">
                 <div className="flex items-center gap-2 min-w-0">
-                    <div
-                        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${
-                            identifiedPerson ? 'bg-accent/20 text-accent' : 'bg-surface-secondary text-secondary'
-                        }`}
-                    >
-                        <IconUser className="text-2xl" />
-                    </div>
-                    <div className="flex flex-col min-w-0 flex-1">
-                        <span
-                            className={`truncate font-semibold ${
-                                identifiedPerson ? 'text-default text-sm' : 'font-mono text-xs text-secondary'
+                    {loading ? (
+                        <LemonSkeleton.Circle className="h-9 w-9" />
+                    ) : (
+                        <div
+                            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${
+                                identifiedPerson ? 'bg-accent/20 text-accent' : 'bg-surface-secondary text-secondary'
                             }`}
                         >
-                            {primaryLabel}
-                        </span>
-                        {selectedSession.distinct_id ? (
-                            <CopyToClipboardInline
-                                explicitValue={selectedSession.distinct_id}
-                                description="distinct id"
-                                iconSize="xsmall"
-                                className="truncate font-mono text-[11px] text-secondary"
-                            >
-                                {selectedSession.distinct_id}
-                            </CopyToClipboardInline>
-                        ) : null}
+                            <IconUser className="text-2xl" />
+                        </div>
+                    )}
+                    <div className="flex flex-col min-w-0 flex-1 gap-1">
+                        {loading ? (
+                            <>
+                                <LemonSkeleton className="h-4 w-40" />
+                                <LemonSkeleton className="h-3 w-28" />
+                            </>
+                        ) : (
+                            <>
+                                <span
+                                    className={`truncate font-semibold ${
+                                        identifiedPerson ? 'text-default text-sm' : 'font-mono text-xs text-secondary'
+                                    }`}
+                                >
+                                    {primaryLabel}
+                                </span>
+                                {selectedSession.distinct_id ? (
+                                    <CopyToClipboardInline
+                                        explicitValue={selectedSession.distinct_id}
+                                        description="distinct id"
+                                        iconSize="xsmall"
+                                        className="truncate font-mono text-[11px] text-secondary"
+                                    >
+                                        {selectedSession.distinct_id}
+                                    </CopyToClipboardInline>
+                                ) : null}
+                            </>
+                        )}
                     </div>
                 </div>
 
                 <div className="flex flex-wrap items-center gap-1.5">
-                    {selectedSession.mcp_client_name ? (
-                        <MetaBadge icon={<IconSparkles />} label={selectedSession.mcp_client_name} />
-                    ) : null}
-                    <MetaBadge icon={<IconBolt />} label={`${calls} tool call${calls === 1 ? '' : 's'}`} />
-                    <MetaBadge icon={<IconClock />} label={formatDuration(durationMs)} />
-                    <Tooltip
-                        title={
-                            <div className="max-w-xs break-all">
-                                Session ID: <span className="font-mono">{selectedSession.session_id}</span>
-                            </div>
-                        }
-                    >
-                        <span className="inline-flex items-center gap-1 rounded-full bg-surface-secondary px-2 py-0.5 text-[11px] text-secondary font-mono">
-                            <CopyToClipboardInline
-                                explicitValue={selectedSession.session_id}
-                                description="session id"
-                                iconSize="xsmall"
-                                className="font-mono"
+                    {loading ? (
+                        <LemonSkeleton repeat={4} className="h-5 w-20 rounded-full" />
+                    ) : (
+                        <>
+                            {selectedSession.mcp_client_name ? (
+                                <MetaBadge icon={<IconSparkles />} label={selectedSession.mcp_client_name} />
+                            ) : null}
+                            <MetaBadge icon={<IconBolt />} label={`${calls} tool call${calls === 1 ? '' : 's'}`} />
+                            <MetaBadge icon={<IconClock />} label={formatDuration(durationMs)} />
+                            <Tooltip
+                                title={
+                                    <div className="max-w-xs break-all">
+                                        Session ID: <span className="font-mono">{selectedSession.session_id}</span>
+                                    </div>
+                                }
                             >
-                                {shortenSessionId(selectedSession.session_id)}
-                            </CopyToClipboardInline>
-                        </span>
-                    </Tooltip>
+                                <span className="inline-flex items-center gap-1 rounded-full bg-surface-secondary px-2 py-0.5 text-[11px] text-secondary font-mono">
+                                    <CopyToClipboardInline
+                                        explicitValue={selectedSession.session_id}
+                                        description="session id"
+                                        iconSize="xsmall"
+                                        className="font-mono"
+                                    >
+                                        {shortenSessionId(selectedSession.session_id)}
+                                    </CopyToClipboardInline>
+                                </span>
+                            </Tooltip>
+                        </>
+                    )}
                 </div>
             </header>
 
             <section className="px-3 py-3" style={{ overflowY: 'scroll', maxHeight: 'calc(100vh - 32rem)' }}>
-                {toolCallsLoading ? (
+                {loading ? (
                     <div className="flex flex-col gap-2">
-                        {[0, 1, 2].map((i) => (
-                            <LemonSkeleton key={i} className="h-16 w-full" />
-                        ))}
+                        <LemonSkeleton repeat={3} className="h-16 w-full" />
                     </div>
                 ) : toolCalls.length === 0 ? (
                     <div className="text-sm text-secondary">No tool calls captured for this session.</div>
@@ -163,7 +183,9 @@ export function MCPSessionDetail(): JSX.Element {
             <hr className="shrink-0 border-t border-primary my-0" />
 
             <footer className="shrink-0 bg-gradient-to-br from-accent/15 via-accent/5 to-surface-primary px-3 py-3">
-                {selectedSessionIntent ? (
+                {loading ? (
+                    <LemonSkeleton className="h-7 w-48" />
+                ) : selectedSessionIntent ? (
                     <>
                         <div className="flex items-center gap-2 mb-1.5">
                             <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent/20 text-accent">


### PR DESCRIPTION
## Problem

When navigating between sessions, we just replace the session details (metadata, tools, intent) when they got loaded. Add skeleton animations for smoother UX

## Changes



https://github.com/user-attachments/assets/ebf8da3c-59be-43b8-94ab-138949c13d65



## How did you test this code?

Manually


## Publish to changelog?

No

## Docs update

No
