### PR TITLE
fix(data-warehouse): pass log kwargs via extra for workflow.logger

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -378,8 +378,10 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
             if skip_post_import_activities:
                 workflow.logger.info(
                     "Skipping post-import activities for externally managed schema",
-                    schema_id=str(inputs.external_data_schema_id),
-                    source_id=str(inputs.external_data_source_id),
+                    extra={
+                        "schema_id": str(inputs.external_data_schema_id),
+                        "source_id": str(inputs.external_data_source_id),
+                    },
                 )
                 return
 
@@ -439,7 +441,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
             except WorkflowAlreadyStartedError:
                 workflow.logger.warning(
                     "DuckLake copy already running, skipping",
-                    schema_id=str(inputs.external_data_schema_id),
+                    extra={"schema_id": str(inputs.external_data_schema_id)},
                 )
 
         except exceptions.ActivityError as e:


### PR DESCRIPTION
## Problem

Postgres CDC schemas were failing their first scheduled run after the initial snapshot finished. Stack trace from a worker:

```
File "/code/posthog/temporal/data_imports/external_data_job.py", line 379, in run
    workflow.logger.info(
  ...
TypeError: Logger._log() got an unexpected keyword argument 'schema_id'
```

`workflow.logger` from the Temporal SDK is a `LoggerAdapter` over stdlib `Logger`, which rejects unknown kwargs — passing `schema_id=...`/`source_id=...` directly raises `TypeError`.

The CDC-streaming skip branch hits this every time `import_data_activity_sync` returns `skip_post_import_activities=True` (raised by `CDCHandledExternally` when a schema transitions to `cdc_mode=streaming`). The activity had already marked the job `Completed` and paused the schedule, then the workflow crashed and the `finally` block flipped the row to `Failed`. The same pattern exists in the DuckLake `WorkflowAlreadyStartedError` branch a few lines below.

## Changes

Wrap the structured kwargs in `extra={...}` so they reach the LoggerAdapter the standard way. Two call sites in `posthog/temporal/data_imports/external_data_job.py`.

## How did you test this code?

I'm an agent. I did not run tests. The diff is small and the failure mode is well-attested: stdlib `Logger._log` raises on unknown kwargs, `extra={...}` is the documented way to attach structured fields through a `LoggerAdapter`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) in a debugging session. The user shared two CSV log dumps from prod workers and pointed at a working vs. failing Postgres CDC schema. I read the worker trace, traced the kwargs path through `temporalio.workflow.LoggerAdapter`, confirmed it forwards directly to stdlib, and patched both call sites. An adjacent issue surfaced during analysis — schemas without primary keys can still enter CDC streaming mode and then get stuck after this fix — but that's a separate change tracked outside this PR.