### PR TITLE
feat(experiments): warn when multiple-variant exposure share is high

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -601,6 +601,10 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             warningKey,
         }),
         reportExperimentBiasWarningShown: (experiment: Experiment) => ({ experiment }),
+        reportExperimentHighMultipleExposureWarningShown: (
+            experiment: Experiment,
+            multipleVariantPercentage: number
+        ) => ({ experiment, multipleVariantPercentage }),
         reportExperimentMetricsRefreshed: (
             experiment: Experiment,
             forceRefresh: boolean,
@@ -1609,6 +1613,12 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportExperimentBiasWarningShown: ({ experiment }) => {
             posthog.capture('experiment bias warning shown', {
                 ...getEventPropertiesForExperiment(experiment),
+            })
+        },
+        reportExperimentHighMultipleExposureWarningShown: ({ experiment, multipleVariantPercentage }) => {
+            posthog.capture('experiment high multiple exposure warning shown', {
+                ...getEventPropertiesForExperiment(experiment),
+                multiple_variant_percentage: multipleVariantPercentage,
             })
         },
         reportExperimentMetricsRefreshed: ({ experiment, forceRefresh, context }) => {

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -35,6 +35,7 @@ import { EditConclusionModal } from './ExperimentModals'
 import { ExperimentWarningBanner } from './ExperimentWarningBanners'
 import { ExposureCriteriaModal } from './ExposureCriteria'
 import { Exposures } from './Exposures'
+import { HighMultipleExposureWarning } from './HighMultipleExposureWarning'
 import { Info } from './Info'
 import { LoadingState } from './LoadingState'
 import { MultiVariantBiasWarning } from './MultiVariantBiasWarning'
@@ -82,6 +83,7 @@ const MetricsTab = (): JSX.Element => {
             <div className="w-full mb-4">
                 <Exposures />
                 <MultiVariantBiasWarning />
+                <HighMultipleExposureWarning />
             </div>
 
             {/* Modern metrics view */}

--- a/frontend/src/scenes/experiments/ExperimentView/HighMultipleExposureWarning.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/HighMultipleExposureWarning.tsx
@@ -1,0 +1,86 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { LemonBanner, LemonButton, Link } from '@posthog/lemon-ui'
+
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+
+import { EXPERIMENT_VARIANT_MULTIPLE } from '../constants'
+import { experimentLogic } from '../experimentLogic'
+import { exposureCriteriaModalLogic } from './exposureCriteriaModalLogic'
+
+// Threshold above which a high `$multiple` exposure share is surfaced as a
+// contamination warning. Below this, the share is generally not large enough
+// to materially distort metric estimates.
+const HIGH_MULTIPLE_EXPOSURE_THRESHOLD_PERCENT = 10
+
+/**
+ * Surfaces a high share of users exposed to multiple variants. Above the
+ * threshold, results can be contaminated regardless of how `$multiple` is
+ * handled. Complementary to `MultiVariantBiasWarning`, which targets the
+ * uneven-split + EXCLUDE asymmetric-exclusion case; suppressed when that
+ * warning already fires to avoid stacking two banners about the same data.
+ */
+export function HighMultipleExposureWarning(): JSX.Element | null {
+    const { experiment, exposures, exposureCriteria } = useValues(experimentLogic)
+    const { openExposureCriteriaModal } = useActions(exposureCriteriaModalLogic)
+    const { reportExperimentHighMultipleExposureWarningShown } = useActions(eventUsageLogic)
+
+    let multiplePercentage = 0
+    if (exposures?.total_exposures) {
+        let total = 0
+        for (const value of Object.values(exposures.total_exposures)) {
+            total += Number(value)
+        }
+        const multipleCount = Number(exposures.total_exposures[EXPERIMENT_VARIANT_MULTIPLE] || 0)
+        multiplePercentage = total > 0 ? (multipleCount / total) * 100 : 0
+    }
+
+    const shouldShow = multiplePercentage > HIGH_MULTIPLE_EXPOSURE_THRESHOLD_PERCENT && !exposures?.bias_risk
+
+    useEffect(() => {
+        if (shouldShow) {
+            reportExperimentHighMultipleExposureWarningShown(experiment, multiplePercentage)
+        }
+    }, [reportExperimentHighMultipleExposureWarningShown, shouldShow, experiment, multiplePercentage])
+
+    if (!shouldShow) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="warning" className="mt-4">
+            <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div className="flex-1 min-w-[300px]">
+                    <div className="font-semibold">High multiple-variant exposure rate</div>
+                    <p className="m-0">
+                        <strong>{multiplePercentage.toFixed(1)}%</strong> of users were exposed to more than one variant
+                        (above the {HIGH_MULTIPLE_EXPOSURE_THRESHOLD_PERCENT}% threshold). These users contribute
+                        behavior from multiple variants, which can contaminate your results and make it harder to
+                        measure each variant's true impact.
+                    </p>
+                    <p className="m-0 mt-1">
+                        Common causes include feature flag changes mid-experiment, users switching devices or browsers
+                        before identification, or short cookie lifetimes. See{' '}
+                        <Link
+                            to="https://posthog.com/docs/experiments/exposures#handling-multiple-exposures"
+                            target="_blank"
+                        >
+                            handling multiple exposures
+                        </Link>{' '}
+                        for guidance.
+                    </p>
+                </div>
+                <div className="flex gap-2 items-center flex-shrink-0">
+                    <LemonButton
+                        size="small"
+                        type="secondary"
+                        onClick={() => openExposureCriteriaModal(exposureCriteria)}
+                    >
+                        Edit exposure criteria
+                    </LemonButton>
+                </div>
+            </div>
+        </LemonBanner>
+    )
+}


### PR DESCRIPTION
## Problem

When a large share of experiment users get exposed to more than one variant (the `$multiple` bucket), metric estimates get contaminated and per-variant impact is hard to read. Today we only warn about the narrower uneven-split + EXCLUDE asymmetric-exclusion case (`MultiVariantBiasWarning`).

## Changes

- New `HighMultipleExposureWarning` banner on the experiment metrics tab. Fires when `$multiple` exceeds 10% of total exposures.
- Suppressed when `exposures.bias_risk` is set so it doesn't stack on top of `MultiVariantBiasWarning`.
- Links to docs and offers a shortcut to edit exposure criteria.
- Adds `experiment high multiple exposure warning shown` event via `eventUsageLogic` for tracking how often this triggers.

## How did you test this code?

Agent-authored. No automated tests added; no manual browser testing performed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Threshold of 10% picked as a starting point — easy to tune. Reused the existing `exposureCriteriaModalLogic` action so the CTA matches the sibling bias warning.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*