### PR TITLE
fix(data-warehouse): accept qualified table names in postgres discovery

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -414,7 +414,19 @@ def _get_discovered_tables(
     if names is None:
         return all_tables, qualify_with_schema
 
-    return {name: all_tables[name] for name in names if name in all_tables}, qualify_with_schema
+    # Accept both qualified (`schema.table`) and unqualified (`table`) lookup names regardless of
+    # how `all_tables` is keyed. The multi-schema migration rewrites legacy row names to qualified
+    # form even when the source still has `config.schema` set, so callers passing a row's name in
+    # to filter by would otherwise get an empty result.
+    filtered: dict[str, tuple[str | None, str, str]] = {}
+    for name in names:
+        if name in all_tables:
+            filtered[name] = all_tables[name]
+        elif "." in name:
+            _, _, unqualified = name.partition(".")
+            if unqualified in all_tables:
+                filtered[name] = all_tables[unqualified]
+    return filtered, qualify_with_schema
 
 
 def _row_counts_from_conn(

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -414,10 +414,7 @@ def _get_discovered_tables(
     if names is None:
         return all_tables, qualify_with_schema
 
-    # Accept both qualified (`schema.table`) and unqualified (`table`) lookup names regardless of
-    # how `all_tables` is keyed. The multi-schema migration rewrites legacy row names to qualified
-    # form even when the source still has `config.schema` set, so callers passing a row's name in
-    # to filter by would otherwise get an empty result.
+    # Match qualified (`schema.table`) and bare `table` names — keys may differ after multi-schema migration.
     filtered: dict[str, tuple[str | None, str, str]] = {}
     for name in names:
         if name in all_tables:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -442,6 +442,64 @@ class TestPostgresSchemaDiscovery:
         assert schemas["analytics.events"].source_schema == "analytics"
         assert schemas["analytics.events"].source_table_name == "events"
 
+    @pytest.mark.parametrize(
+        "selected_schema,requested_name,fetchall_results,expected_keys",
+        [
+            # Qualified lookup against a schema that's keyed unqualified (config.schema set).
+            # This is the multi-schema migration scenario: row name was rewritten to
+            # `public.tracking_link` while the source still has `schema="public"` configured.
+            (
+                "public",
+                "public.tracking_link",
+                (
+                    [("public", "tracking_link")],
+                    [("public", "tracking_link", "id", "integer", "NO", 1)],
+                ),
+                {"public.tracking_link"},
+            ),
+            # Unqualified lookup against an unqualified keyspace — the legacy path.
+            (
+                "public",
+                "tracking_link",
+                (
+                    [("public", "tracking_link")],
+                    [("public", "tracking_link", "id", "integer", "NO", 1)],
+                ),
+                {"tracking_link"},
+            ),
+            # Qualified lookup against a qualified keyspace (no config.schema, multi-schema mode).
+            (
+                "",
+                "public.tracking_link",
+                (
+                    [("public", "tracking_link")],
+                    [("public", "tracking_link", "id", "integer", "NO", 1)],
+                ),
+                {"public.tracking_link"},
+            ),
+        ],
+    )
+    def test_get_schemas_accepts_qualified_and_unqualified_names(
+        self, selected_schema, requested_name, fetchall_results, expected_keys
+    ):
+        connection = self._mock_connection(*fetchall_results)
+
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.postgres.postgres._connect_to_postgres",
+            return_value=connection,
+        ):
+            schemas = get_schemas(
+                host="localhost",
+                port=5432,
+                database="postgres",
+                user="postgres",
+                password="postgres",
+                schema=selected_schema,
+                names=[requested_name],
+            )
+
+        assert set(schemas.keys()) == expected_keys
+
     def test_get_foreign_keys_qualifies_target_table_names_when_schema_is_blank(self):
         connection = self._mock_connection(
             [("public", "users"), ("analytics", "events")],


### PR DESCRIPTION
## Problem

After the multi-schema migration qualifies a Postgres warehouse row's name in place (e.g. \`tracking_link\` → \`public.tracking_link\` via \`_qualify_legacy_row\`), the sync-method config page returns 400 \"Schema with name public.foo not found\".

Root cause: callers like the \`incremental_fields\` action in \`ExternalDataSchemaViewset\` pass the row's \`name\` straight back into the Postgres source via \`get_schemas(config, ..., names=[instance.name])\`. \`_get_discovered_tables\` keys its lookup dict unqualified whenever \`config.schema\` is set (\`qualify_with_schema=False\`), so the qualified name never matches. The sync workflow already self-heals this on the writer path by splitting the dotted name (\`source_for_pipeline\` in \`postgres/source.py\`), but the discovery path wasn't updated.

## Changes

Make \`_get_discovered_tables\` accept both forms in the \`names\` filter. When a requested name has a \`.\` and isn't in the lookup table, fall back to matching the unqualified suffix and return the entry under the requested name so callers keep getting back exactly what they asked for. No behavioral change when names are already in the lookup table.

Parameterized test covers:
- Qualified \`public.tracking_link\` lookup against a config-schema-set (unqualified-keyed) source — the bug scenario.
- Unqualified \`tracking_link\` lookup against the same source — legacy path.
- Qualified \`public.tracking_link\` lookup against a blank-schema (qualified-keyed) source — multi-schema mode.

## How did you test this code?

I'm an agent. I added a parameterized test in \`test_postgres.py\` covering the three lookup combinations and ran \`hogli test posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSchemaDiscovery\` — all 7 tests in that class pass. No manual UI testing.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) in a debugging session. The user surfaced the 400 from the sync-method page after clicking \"Pull new schemas\" on a Postgres source. Database inspection showed the migration had qualified the row name and stored a \`dwh_storage_key\` to preserve the Delta path; the qualified name then failed the discovery name filter. Fixing the writer side was an option but the discovery layer is the actual mismatch point, and a layered fix at the source covers all downstream callers (\`incremental_fields\`, \`refresh_schemas\`, anything else that round-trips a row's \`name\`).