### PR TITLE
fix(metrics): unblock OTLP/JSON histogram, expo, summary ingestion

### DIFF
--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -23,9 +23,42 @@ use crate::kafka::KafkaSink;
 
 use tracing::{debug, error, instrument};
 
-// due to a bug in the otel proto rust library we need to patch the json to support (valid) empty Values
-// see https://github.com/open-telemetry/opentelemetry-rust/issues/1253
-// FIXME: remove once upstream has fixed the issue, OR we should fork upstream and fix the issue ourselves
+// `patch_otel_json` normalises an OTLP/JSON payload so it can be deserialized by
+// upstream `opentelemetry-proto`'s generated types. This is a workaround layer
+// for three known upstream gaps; each `FIXME` below is independently removable
+// once its upstream issue lands. We string-match JSON keys to compensate for type
+// system gaps in a third-party crate — it is not elegant. The function is bounded,
+// idempotent, and side-effect-free, and the regression tests in tests/metrics_test.rs
+// (the `#[ignore]`-d `edge_*_should_error` tests in particular) will surface upstream
+// changes — un-ignore them when the silencing pattern is fixed.
+//
+// FIXME(upstream-1253): empty `value: {}` AnyValue objects fail to deserialize.
+//   https://github.com/open-telemetry/opentelemetry-rust/issues/1253
+//   Workaround: replace empty `value`/`body` objects with `null`.
+//
+// FIXME(upstream-3328): several fixed64/uint64/sfixed64 fields in the metrics
+//   protos lack the `deserialize_string_to_u64` annotation, so the OTLP/JSON
+//   spec-canonical string encoding fails. Combined with the silencing pattern
+//   below, affected metrics end up with `data: None` instead of erroring.
+//   https://github.com/open-telemetry/opentelemetry-rust/issues/3328
+//   https://github.com/open-telemetry/opentelemetry-rust/pull/3329  (stale)
+//   Workaround: coerce string-encoded integers to JSON numbers for the affected
+//   fields (`count`, `zeroCount`, `asInt`, `bucketCounts[*]`, and timestamp
+//   descendants under `exponentialHistogram` / `summary` / `exemplars`).
+//
+// FIXME(upstream-unreported): `ExponentialHistogram`, `ExponentialHistogramDataPoint`,
+//   `SummaryDataPoint`, `Buckets`, and `Exemplar` all lack `#[serde(default)]`
+//   upstream, so any missing non-Option proto field hard-errors and trips the
+//   silencing pattern. No upstream issue filed yet — open one alongside removing
+//   this workaround. Workaround: the `fill_*_defaults` functions inject defaults
+//   for every required-by-serde field below.
+//
+// Silencing pattern (the reason these gaps silently drop metrics rather than
+// returning a 400): `Metric` declares `data` as `#[serde(flatten)] Option<Data>`
+// on a `#[serde(default)]` struct, so any error deserializing the inner oneof
+// variant is swallowed and `data` becomes `None`. `flatten_metric` then emits
+// zero rows with no log line. Until upstream changes the silencing structure
+// itself, the only defense is to never let the inner deserialization fail.
 pub fn patch_otel_json(v: &mut Value) {
     match v {
         Value::Object(map) => {
@@ -44,6 +77,37 @@ pub fn patch_otel_json(v: &mut Value) {
                     *inner = Value::Null;
                 }
             }
+            // Universal string→integer coercions for u64/i64 fields that have NO custom
+            // deserializer in upstream opentelemetry-proto. Safe in any context.
+            for key in ["count", "zeroCount", "asInt"] {
+                if let Some(inner) = map.get_mut(key) {
+                    coerce_string_to_integer(inner);
+                }
+            }
+            if let Some(Value::Array(arr)) = map.get_mut("bucketCounts") {
+                for el in arr.iter_mut() {
+                    coerce_string_to_integer(el);
+                }
+            }
+            // Context-aware fixes for the metric variants whose data point types lack both
+            // the string→u64 deserializer and #[serde(default)] upstream. We coerce
+            // timestamp strings to numbers AND inject defaults for every non-Option proto
+            // field, since any missing field hard-errors and trips the silencing pattern.
+            if let Some(inner) = map.get_mut("exponentialHistogram") {
+                coerce_unix_nano_descendants(inner);
+                fill_exponential_histogram_defaults(inner);
+            }
+            if let Some(inner) = map.get_mut("summary") {
+                coerce_unix_nano_descendants(inner);
+                fill_summary_defaults(inner);
+            }
+            // Exemplar also lacks #[serde(default)] upstream — missing fields silently drop
+            // the parent metric, not just the exemplar. Fill defaults wherever we see one.
+            if let Some(Value::Array(arr)) = map.get_mut("exemplars") {
+                for el in arr.iter_mut() {
+                    fill_exemplar_defaults(el);
+                }
+            }
             // Recurse through all other keys
             for (_, val) in map.iter_mut() {
                 patch_otel_json(val);
@@ -52,6 +116,146 @@ pub fn patch_otel_json(v: &mut Value) {
         Value::Array(arr) => {
             for val in arr.iter_mut() {
                 patch_otel_json(val);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn coerce_string_to_integer(v: &mut Value) {
+    let Value::String(s) = v else { return };
+    if let Ok(n) = s.parse::<i64>() {
+        *v = Value::Number(n.into());
+    } else if let Ok(n) = s.parse::<u64>() {
+        *v = Value::Number(n.into());
+    }
+}
+
+fn number_u64(n: u64) -> Value {
+    Value::Number(n.into())
+}
+
+fn number_zero_f64() -> Value {
+    // serde_json::Number::from_f64 only fails for NaN/Infinity — never for 0.0.
+    Value::Number(serde_json::Number::from_f64(0.0).expect("0.0 is finite"))
+}
+
+fn empty_string() -> Value {
+    Value::String(String::new())
+}
+
+fn empty_array() -> Value {
+    Value::Array(Vec::new())
+}
+
+fn fill_exponential_histogram_defaults(variant: &mut Value) {
+    let Value::Object(map) = variant else { return };
+    // ExponentialHistogram itself lacks #[serde(default)].
+    map.entry("aggregationTemporality".to_string())
+        .or_insert_with(|| number_u64(0));
+    map.entry("dataPoints".to_string())
+        .or_insert_with(empty_array);
+    if let Some(Value::Array(arr)) = map.get_mut("dataPoints") {
+        for dp in arr.iter_mut() {
+            fill_exponential_histogram_dp_defaults(dp);
+        }
+    }
+}
+
+fn fill_exponential_histogram_dp_defaults(dp: &mut Value) {
+    let Value::Object(obj) = dp else { return };
+    obj.entry("attributes".to_string())
+        .or_insert_with(empty_array);
+    obj.entry("startTimeUnixNano".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("timeUnixNano".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("count".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("scale".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("zeroCount".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("flags".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("exemplars".to_string())
+        .or_insert_with(empty_array);
+    obj.entry("zeroThreshold".to_string())
+        .or_insert_with(number_zero_f64);
+    if let Some(buckets) = obj.get_mut("positive") {
+        fill_buckets_defaults(buckets);
+    }
+    if let Some(buckets) = obj.get_mut("negative") {
+        fill_buckets_defaults(buckets);
+    }
+}
+
+fn fill_buckets_defaults(buckets: &mut Value) {
+    let Value::Object(obj) = buckets else { return };
+    obj.entry("offset".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("bucketCounts".to_string())
+        .or_insert_with(empty_array);
+}
+
+fn fill_summary_defaults(variant: &mut Value) {
+    // Summary itself has #[serde(default)] upstream, so the variant-level fields
+    // (dataPoints, aggregationTemporality if present) are tolerated when missing.
+    // SummaryDataPoint is the level that needs help.
+    let Value::Object(map) = variant else { return };
+    if let Some(Value::Array(arr)) = map.get_mut("dataPoints") {
+        for dp in arr.iter_mut() {
+            fill_summary_dp_defaults(dp);
+        }
+    }
+}
+
+fn fill_summary_dp_defaults(dp: &mut Value) {
+    let Value::Object(obj) = dp else { return };
+    obj.entry("attributes".to_string())
+        .or_insert_with(empty_array);
+    obj.entry("startTimeUnixNano".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("timeUnixNano".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("count".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("sum".to_string()).or_insert_with(number_zero_f64);
+    obj.entry("quantileValues".to_string())
+        .or_insert_with(empty_array);
+    obj.entry("flags".to_string())
+        .or_insert_with(|| number_u64(0));
+}
+
+fn fill_exemplar_defaults(exemplar: &mut Value) {
+    let Value::Object(obj) = exemplar else { return };
+    obj.entry("filteredAttributes".to_string())
+        .or_insert_with(empty_array);
+    obj.entry("timeUnixNano".to_string())
+        .or_insert_with(|| number_u64(0));
+    obj.entry("spanId".to_string()).or_insert_with(empty_string);
+    obj.entry("traceId".to_string())
+        .or_insert_with(empty_string);
+    if let Some(t) = obj.get_mut("timeUnixNano") {
+        coerce_string_to_integer(t);
+    }
+}
+
+fn coerce_unix_nano_descendants(v: &mut Value) {
+    match v {
+        Value::Object(map) => {
+            for key in ["timeUnixNano", "startTimeUnixNano"] {
+                if let Some(inner) = map.get_mut(key) {
+                    coerce_string_to_integer(inner);
+                }
+            }
+            for (_, val) in map.iter_mut() {
+                coerce_unix_nano_descendants(val);
+            }
+        }
+        Value::Array(arr) => {
+            for val in arr.iter_mut() {
+                coerce_unix_nano_descendants(val);
             }
         }
         _ => {}

--- a/rust/capture-logs/tests/metrics_test.rs
+++ b/rust/capture-logs/tests/metrics_test.rs
@@ -1,0 +1,489 @@
+use bytes::Bytes;
+use capture_logs::service::parse_otel_metrics_message;
+use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+
+/// When an OTLP/JSON payload mixes a sum (counter) and a histogram, the
+/// histogram's `Metric.data` was silently set to `None` after deserialization
+/// while the counter's survived — even though parsing returned `Ok`.
+/// See opentelemetry-rust#3328 for the upstream root cause.
+#[test]
+fn histogram_with_string_u64s_alongside_sum() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[{"key":"service.name","value":{"stringValue":"demo"}}]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"demo.counter","sum":{
+              "aggregationTemporality":2,
+              "isMonotonic":true,
+              "dataPoints":[{"timeUnixNano":"1700000000000000000","asDouble":42.0}]
+            }},
+            {"name":"demo.histogram","histogram":{
+              "aggregationTemporality":2,
+              "dataPoints":[{
+                "timeUnixNano":"1700000000000000000",
+                "count":"10",
+                "sum":234.5,
+                "bucketCounts":["3","4","2","1"],
+                "explicitBounds":[10,50,100]
+              }]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let result = parse_otel_metrics_message(&Bytes::from(json));
+    let request = match result {
+        Ok(r) => r,
+        Err(e) => panic!("parse_otel_metrics_message returned Err: {e}"),
+    };
+
+    let metrics = &request.resource_metrics[0].scope_metrics[0].metrics;
+    assert_eq!(metrics.len(), 2, "both metrics should be present");
+
+    let counter = &metrics[0];
+    let histogram = &metrics[1];
+
+    eprintln!("counter.data is_some = {}", counter.data.is_some());
+    eprintln!("histogram.data is_some = {}", histogram.data.is_some());
+    if let Some(Data::Histogram(h)) = &histogram.data {
+        eprintln!("histogram.data_points.len = {}", h.data_points.len());
+        if let Some(dp) = h.data_points.first() {
+            eprintln!(
+                "dp.count={} sum={:?} bucket_counts={:?} explicit_bounds={:?}",
+                dp.count, dp.sum, dp.bucket_counts, dp.explicit_bounds
+            );
+        }
+    }
+
+    assert!(
+        matches!(histogram.data, Some(Data::Histogram(_))),
+        "histogram.data is None — silently dropped during JSON deserialization"
+    );
+}
+
+/// Same payload as the bug ticket but with the histogram's u64 fields encoded
+/// as JSON numbers instead of strings. If this passes, it proves the silent
+/// drop is caused by string-encoded u64 fields (count, bucketCounts) lacking a
+/// custom serde deserializer in upstream opentelemetry-proto.
+#[test]
+fn histogram_with_unquoted_u64_works() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"demo.histogram","histogram":{
+              "aggregationTemporality":2,
+              "dataPoints":[{
+                "timeUnixNano":"1700000000000000000",
+                "count":10,
+                "sum":234.5,
+                "bucketCounts":[3,4,2,1],
+                "explicitBounds":[10,50,100]
+              }]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let request = parse_otel_metrics_message(&Bytes::from(json)).expect("parse ok");
+    let histogram = &request.resource_metrics[0].scope_metrics[0].metrics[0];
+    eprintln!(
+        "unquoted-u64 path: histogram.data is_some = {}",
+        histogram.data.is_some()
+    );
+    assert!(matches!(histogram.data, Some(Data::Histogram(_))));
+}
+
+#[test]
+fn exponential_histogram_with_string_u64s() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"demo.expo","exponentialHistogram":{
+              "aggregationTemporality":2,
+              "dataPoints":[{
+                "timeUnixNano":"1700000000000000000",
+                "startTimeUnixNano":"1700000000000000000",
+                "count":"5",
+                "sum":11.5,
+                "scale":1,
+                "zeroCount":"0",
+                "positive":{"offset":0,"bucketCounts":["1","2","2"]}
+              }]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let request = parse_otel_metrics_message(&Bytes::from(json)).expect("parse ok");
+    let metric = &request.resource_metrics[0].scope_metrics[0].metrics[0];
+    eprintln!("expo.data is_some = {}", metric.data.is_some());
+    if let Some(Data::ExponentialHistogram(eh)) = &metric.data {
+        eprintln!("expo.data_points.len = {}", eh.data_points.len());
+        if let Some(dp) = eh.data_points.first() {
+            eprintln!(
+                "dp.count={} sum={:?} scale={} zero_count={} positive={:?}",
+                dp.count, dp.sum, dp.scale, dp.zero_count, dp.positive
+            );
+        }
+    }
+    assert!(matches!(metric.data, Some(Data::ExponentialHistogram(_))));
+}
+
+#[test]
+fn summary_with_string_u64s() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"demo.summary","summary":{
+              "dataPoints":[{
+                "timeUnixNano":"1700000000000000000",
+                "startTimeUnixNano":"1700000000000000000",
+                "count":"100",
+                "sum":500.0,
+                "quantileValues":[
+                  {"quantile":0.5,"value":2.5},
+                  {"quantile":0.99,"value":9.9}
+                ]
+              }]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let request = parse_otel_metrics_message(&Bytes::from(json)).expect("parse ok");
+    let metric = &request.resource_metrics[0].scope_metrics[0].metrics[0];
+    eprintln!("summary.data is_some = {}", metric.data.is_some());
+    if let Some(Data::Summary(s)) = &metric.data {
+        eprintln!("summary.data_points.len = {}", s.data_points.len());
+        if let Some(dp) = s.data_points.first() {
+            eprintln!(
+                "dp.count={} sum={} quantile_values={:?}",
+                dp.count, dp.sum, dp.quantile_values
+            );
+        }
+    }
+    assert!(matches!(metric.data, Some(Data::Summary(_))));
+}
+
+/// NumberDataPoint.asInt as a JSON string (per OTLP spec) should produce a
+/// NumberDataPoint with value=AsInt(42), not None / 0. See
+/// opentelemetry-rust#3328 — same upstream root cause as the histogram bug.
+#[test]
+fn number_data_point_as_int_string() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"demo.counter","sum":{
+              "aggregationTemporality":2,
+              "isMonotonic":true,
+              "dataPoints":[{"timeUnixNano":"1700000000000000000","asInt":"42"}]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let request = parse_otel_metrics_message(&Bytes::from(json)).expect("parse ok");
+    let counter = &request.resource_metrics[0].scope_metrics[0].metrics[0];
+    let Some(Data::Sum(sum)) = &counter.data else {
+        panic!(
+            "counter.data not a Sum variant: {:?}",
+            counter.data.is_some()
+        );
+    };
+    let dp = &sum.data_points[0];
+    eprintln!("dp.value = {:?}", dp.value);
+    assert!(
+        dp.value.is_some(),
+        "asInt as string yields value=None instead of AsInt(42)"
+    );
+}
+
+// ---------- Edge-case regression tests for patch_otel_json ----------
+
+/// HistogramDataPoint.count is u64 and the OTLP/JSON spec allows values up to
+/// u64::MAX. Our `coerce_string_to_integer` tries i64 first then u64; this test
+/// confirms that values > i64::MAX still round-trip correctly via the u64 path.
+#[test]
+fn edge_u64_above_i64_max_round_trips() {
+    let big = u64::MAX; // 18446744073709551615
+    let json = format!(
+        r#"{{
+          "resourceMetrics":[{{
+            "resource":{{"attributes":[]}},
+            "scopeMetrics":[{{
+              "scope":{{"name":"x"}},
+              "metrics":[
+                {{"name":"big.histogram","histogram":{{
+                  "aggregationTemporality":2,
+                  "dataPoints":[{{
+                    "timeUnixNano":"1700000000000000000",
+                    "count":"{big}",
+                    "sum":1.0,
+                    "bucketCounts":["{big}"],
+                    "explicitBounds":[]
+                  }}]
+                }}}}
+              ]
+            }}]
+          }}]
+        }}"#
+    );
+
+    let req = parse_otel_metrics_message(&Bytes::from(json)).expect("parse ok");
+    let metric = &req.resource_metrics[0].scope_metrics[0].metrics[0];
+    let Some(Data::Histogram(h)) = &metric.data else {
+        panic!("histogram silently dropped for u64::MAX count");
+    };
+    let dp = &h.data_points[0];
+    assert_eq!(dp.count, u64::MAX, "count must round-trip as u64::MAX");
+    assert_eq!(
+        dp.bucket_counts,
+        vec![u64::MAX],
+        "bucket_counts must round-trip as u64::MAX"
+    );
+}
+
+/// asInt at i64::MAX and i64::MIN — boundary check on the i64-first path of
+/// `coerce_string_to_integer`. NumberDataPoint.value::AsInt is sfixed64 (i64),
+/// so signed boundaries must round-trip exactly.
+#[test]
+fn edge_as_int_signed_boundaries() {
+    for &value in &[i64::MAX, i64::MIN, 0_i64, -1_i64, 1_i64] {
+        let json = format!(
+            r#"{{
+              "resourceMetrics":[{{
+                "resource":{{"attributes":[]}},
+                "scopeMetrics":[{{
+                  "scope":{{"name":"x"}},
+                  "metrics":[
+                    {{"name":"as.int","sum":{{
+                      "aggregationTemporality":2,
+                      "isMonotonic":true,
+                      "dataPoints":[{{
+                        "timeUnixNano":"1700000000000000000",
+                        "asInt":"{value}"
+                      }}]
+                    }}}}
+                  ]
+                }}]
+              }}]
+            }}"#
+        );
+
+        let req = parse_otel_metrics_message(&Bytes::from(json))
+            .unwrap_or_else(|e| panic!("parse failed for asInt={value}: {e}"));
+        let metric = &req.resource_metrics[0].scope_metrics[0].metrics[0];
+        let Some(Data::Sum(sum)) = &metric.data else {
+            panic!("counter silently dropped for asInt={value}");
+        };
+        use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NdpValue;
+        match sum.data_points[0].value {
+            Some(NdpValue::AsInt(n)) => assert_eq!(n, value, "asInt round-trip mismatch"),
+            other => panic!("expected AsInt({value}), got {other:?}"),
+        }
+    }
+}
+
+/// Mixed encoding: per the OTLP/JSON spec ("either numbers or strings are
+/// accepted when decoding"), a payload that mixes string-encoded u64s with
+/// number-encoded u64s in the same Metric must parse identically. Tests that
+/// the string→number coercion doesn't break the unquoted path either.
+#[test]
+fn edge_mixed_string_and_number_encodings() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"mixed.histogram","histogram":{
+              "aggregationTemporality":2,
+              "dataPoints":[{
+                "timeUnixNano":"1700000000000000000",
+                "count":10,
+                "sum":99.0,
+                "bucketCounts":["3",4,"2",1],
+                "explicitBounds":[10,50,100]
+              }]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let req = parse_otel_metrics_message(&Bytes::from(json)).expect("parse ok");
+    let metric = &req.resource_metrics[0].scope_metrics[0].metrics[0];
+    let Some(Data::Histogram(h)) = &metric.data else {
+        panic!("mixed-encoding histogram silently dropped");
+    };
+    let dp = &h.data_points[0];
+    assert_eq!(dp.count, 10);
+    assert_eq!(dp.bucket_counts, vec![3, 4, 2, 1]);
+}
+
+/// Negative value in a u64 field is a spec violation by the client and should be
+/// rejected with a parse error (translating to 400 BAD_REQUEST at the HTTP layer).
+/// Currently silenced by the upstream `flatten + Option<oneof> + default` pattern;
+/// un-ignore when upstream changes that.
+#[test]
+#[ignore = "upstream silencing pattern not yet fixed — opentelemetry-rust#3328 + missing-default follow-up"]
+fn edge_negative_value_in_u64_field_should_error() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"bad.histogram","histogram":{
+              "aggregationTemporality":2,
+              "dataPoints":[{
+                "timeUnixNano":"1700000000000000000",
+                "count":"-1",
+                "sum":1.0,
+                "bucketCounts":["1"],
+                "explicitBounds":[]
+              }]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let result = parse_otel_metrics_message(&Bytes::from(json));
+    assert!(
+        result.is_err(),
+        "spec-violating count=\"-1\" must be rejected, not silently dropped"
+    );
+}
+
+/// Non-numeric string in a u64 field — same as above. Should reject, currently
+/// silenced by the upstream pattern.
+#[test]
+#[ignore = "upstream silencing pattern not yet fixed — opentelemetry-rust#3328 + missing-default follow-up"]
+fn edge_non_numeric_string_in_u64_field_should_error() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"bad.histogram","histogram":{
+              "aggregationTemporality":2,
+              "dataPoints":[{
+                "timeUnixNano":"1700000000000000000",
+                "count":"not-a-number",
+                "sum":1.0,
+                "bucketCounts":["1"],
+                "explicitBounds":[]
+              }]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let result = parse_otel_metrics_message(&Bytes::from(json));
+    assert!(
+        result.is_err(),
+        "spec-violating count=\"not-a-number\" must be rejected, not silently dropped"
+    );
+}
+
+/// Regression for the gap that necessitated the expanded EXPONENTIAL_HISTOGRAM
+/// defaults: client sends a minimal spec-valid expo without any of the upstream-
+/// undeclared-default fields. Without our defaults, this hard-errors and the
+/// metric silently drops.
+#[test]
+fn edge_expo_with_minimal_fields_only() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"minimal.expo","exponentialHistogram":{
+              "aggregationTemporality":2,
+              "dataPoints":[{"timeUnixNano":"1700000000000000000"}]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let req = parse_otel_metrics_message(&Bytes::from(json)).expect("parse ok");
+    let metric = &req.resource_metrics[0].scope_metrics[0].metrics[0];
+    let Some(Data::ExponentialHistogram(eh)) = &metric.data else {
+        panic!("minimal expo silently dropped — defaults missing for required-by-serde field");
+    };
+    assert_eq!(eh.data_points.len(), 1);
+}
+
+/// Same as above for summary: required-by-serde fields (sum is non-Option!)
+/// must be defaulted when the client omits them, or the metric silently drops.
+#[test]
+fn edge_summary_with_minimal_fields_only() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"minimal.summary","summary":{
+              "dataPoints":[{"timeUnixNano":"1700000000000000000"}]
+            }}
+          ]
+        }]
+      }]
+    }"#;
+
+    let req = parse_otel_metrics_message(&Bytes::from(json)).expect("parse ok");
+    let metric = &req.resource_metrics[0].scope_metrics[0].metrics[0];
+    let Some(Data::Summary(s)) = &metric.data else {
+        panic!("minimal summary silently dropped — defaults missing for required-by-serde field");
+    };
+    assert_eq!(s.data_points.len(), 1);
+}
+
+/// Empty `"exponentialHistogram": {}` — no dataPoints, no aggregationTemporality.
+/// ExponentialHistogram itself lacks serde(default), so without our variant-level
+/// defaults this would silently drop too.
+#[test]
+fn edge_empty_exponential_histogram_variant() {
+    let json = r#"{
+      "resourceMetrics":[{
+        "resource":{"attributes":[]},
+        "scopeMetrics":[{
+          "scope":{"name":"x"},
+          "metrics":[
+            {"name":"empty.expo","exponentialHistogram":{}}
+          ]
+        }]
+      }]
+    }"#;
+
+    let req = parse_otel_metrics_message(&Bytes::from(json)).expect("parse ok");
+    let metric = &req.resource_metrics[0].scope_metrics[0].metrics[0];
+    assert!(
+        matches!(metric.data, Some(Data::ExponentialHistogram(_))),
+        "empty exponentialHistogram should yield an empty-data-points variant, not silent-drop"
+    );
+}


### PR DESCRIPTION
## Problem

The `opentelemetry-proto` Rust crate has several upstream deserialization gaps that cause OTLP/JSON metric payloads to silently drop data rather than returning errors:

1. **[upstream-1253]** Empty `value: {}` AnyValue objects fail to deserialize.
2. **[upstream-3328]** Several `fixed64`/`uint64`/`sfixed64` fields (`count`, `zeroCount`, `asInt`, `bucketCounts`, and timestamp fields) lack the `deserialize_string_to_u64` annotation, so the OTLP/JSON spec-canonical string encoding silently produces `data: None` instead of a parsed value.
3. **[upstream-unreported]** `ExponentialHistogram`, `ExponentialHistogramDataPoint`, `SummaryDataPoint`, `Buckets`, and `Exemplar` all lack `#[serde(default)]`, so any missing non-`Option` proto field hard-errors and trips the upstream silencing pattern.

The silencing pattern itself — `Metric.data` being `#[serde(flatten)] Option<Data>` on a `#[serde(default)]` struct — means any inner deserialization failure is swallowed and the metric is dropped with no log line and no error returned to the client.

## Changes

`patch_otel_json` is extended with three independently-removable workaround layers, each tagged with a `FIXME` referencing its upstream issue:

- **String→integer coercion** for `count`, `zeroCount`, `asInt`, and `bucketCounts` elements via `coerce_string_to_integer`, which tries `i64` first then `u64` to handle both signed and unsigned spec-valid values.
- **Timestamp coercion** for `timeUnixNano` and `startTimeUnixNano` descendants inside `exponentialHistogram` and `summary` variants via `coerce_unix_nano_descendants`.
- **Default injection** for all required-by-serde fields in `ExponentialHistogram`, `ExponentialHistogramDataPoint`, `SummaryDataPoint`, `Buckets`, and `Exemplar` via `fill_*_defaults` functions, preventing hard-errors on minimal but spec-valid payloads.

## How did you test this code?

A new integration test file `tests/metrics_test.rs` covers:

- Histogram with string-encoded `u64` fields alongside a sum counter (the primary regression case).
- Histogram with unquoted `u64` fields (baseline sanity check).
- Exponential histogram with string-encoded `u64` and timestamp fields.
- Summary with string-encoded `u64` fields.
- `NumberDataPoint.asInt` as a JSON string.
- `u64::MAX` round-trip via the `u64` fallback path in `coerce_string_to_integer`.
- Signed boundary values (`i64::MAX`, `i64::MIN`, `0`, `±1`) for `asInt`.
- Mixed string/number encoding in the same `bucketCounts` array.
- Minimal (field-sparse) exponential histogram and summary payloads that would previously silently drop.
- Empty `exponentialHistogram: {}` variant.

Two tests (`edge_negative_value_in_u64_field_should_error`, `edge_non_numeric_string_in_u64_field_should_error`) are marked `#[ignore]` because the upstream silencing pattern currently prevents them from returning errors. They should be un-ignored once the upstream structure changes.

## Publish to changelog?

No