### PR TITLE
fix(integrations): load all Slack channels in picker via pagination

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1461,12 +1461,13 @@ export class ApiRequest {
     public integrationSlackChannels(
         id: IntegrationType['id'],
         forceRefresh: boolean,
+        params?: { limit?: number; offset?: number },
         teamId?: TeamType['id']
     ): ApiRequest {
         return this.integrations(teamId)
             .addPathComponent(id)
             .addPathComponent('channels')
-            .withQueryString({ force_refresh: forceRefresh })
+            .withQueryString({ force_refresh: forceRefresh, ...params })
     }
 
     public integrationSlackChannelsById(
@@ -5799,9 +5800,10 @@ const api = {
         },
         async slackChannels(
             id: IntegrationType['id'],
-            forceRefresh: boolean
-        ): Promise<{ channels: SlackChannelType[]; lastRefreshedAt: string }> {
-            return await new ApiRequest().integrationSlackChannels(id, forceRefresh).get()
+            forceRefresh: boolean,
+            params?: { limit?: number; offset?: number }
+        ): Promise<{ channels: SlackChannelType[]; lastRefreshedAt: string; has_more?: boolean }> {
+            return await new ApiRequest().integrationSlackChannels(id, forceRefresh, params).get()
         },
         async slackChannelsById(
             id: IntegrationType['id'],

--- a/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
@@ -71,3 +71,60 @@ describe('slackIntegrationLogic — getChannelRefreshButtonDisabledReason', () =
         }
     })
 })
+
+describe('slackIntegrationLogic — loadAllSlackChannels pagination', () => {
+    let logic: ReturnType<typeof slackIntegrationLogic.build>
+    let forceRefreshByOffset: Record<string, string | null>
+
+    const channel = (id: string): { id: string; name: string; is_private: boolean; is_member: boolean } => ({
+        id,
+        name: id,
+        is_private: false,
+        is_member: true,
+    })
+
+    beforeEach(() => {
+        forceRefreshByOffset = {}
+        useMocks({
+            get: {
+                '/api/environments/:team_id/integrations/:id/channels': (req) => {
+                    const offset = Number(req.url.searchParams.get('offset') || 0)
+                    forceRefreshByOffset[offset] = req.url.searchParams.get('force_refresh')
+                    // Three pages of 200; the third is partial, so has_more flips false.
+                    if (offset === 0) {
+                        return [200, { channels: [channel('a')], lastRefreshedAt: '', has_more: true }]
+                    }
+                    if (offset === 200) {
+                        return [200, { channels: [channel('b')], lastRefreshedAt: '', has_more: true }]
+                    }
+                    return [200, { channels: [channel('zzz-sentry-alerts')], lastRefreshedAt: '', has_more: false }]
+                },
+            },
+        })
+        initKeaTests()
+        logic = slackIntegrationLogic({ id: 1 })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    it('walks every page and accumulates channels beyond the first', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadAllSlackChannels()
+        }).toFinishAllListeners()
+
+        expect(logic.values.slackChannels.map((c) => c.id)).toEqual(['a', 'b', 'zzz-sentry-alerts'])
+    })
+
+    it('only forces a refresh on the first page', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadAllSlackChannels(true)
+        }).toFinishAllListeners()
+
+        expect(forceRefreshByOffset['0']).toBe('true')
+        expect(forceRefreshByOffset['200']).toBe('false')
+        expect(forceRefreshByOffset['400']).toBe('false')
+    })
+})

--- a/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
@@ -127,4 +127,23 @@ describe('slackIntegrationLogic — loadAllSlackChannels pagination', () => {
         expect(forceRefreshByOffset['200']).toBe('false')
         expect(forceRefreshByOffset['400']).toBe('false')
     })
+
+    it('stops after the page cap if the endpoint never reports has_more false', async () => {
+        let requestCount = 0
+        useMocks({
+            get: {
+                '/api/environments/:team_id/integrations/:id/channels': () => {
+                    requestCount++
+                    return [200, { channels: [channel('a')], lastRefreshedAt: '', has_more: true }]
+                },
+            },
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.loadAllSlackChannels()
+        }).toFinishAllListeners()
+
+        // Bounded by SLACK_CHANNELS_MAX_PAGES (100) rather than looping forever.
+        expect(requestCount).toBe(100)
+    })
 })

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -14,6 +14,11 @@ export const SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS = 30
 // Matches the channels endpoint's max page size (SlackChannelsQuerySerializer.limit).
 const SLACK_CHANNELS_PAGE_SIZE = 200
 
+// Safety bound on the pagination loop. The backend caps list_channels at 10k public +
+// 10k private channels, so 100 pages covers any real workspace; the cap only guards
+// against a runaway loop if the endpoint ever returns has_more incorrectly.
+const SLACK_CHANNELS_MAX_PAGES = 100
+
 export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
     props({} as { id: number }),
     key((props) => props.id),
@@ -37,7 +42,7 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
                     const channels: SlackChannelType[] = []
                     let offset = 0
                     let lastRefreshedAt = ''
-                    for (;;) {
+                    for (let page = 0; page < SLACK_CHANNELS_MAX_PAGES; page++) {
                         const res = await api.integrations.slackChannels(props.id, forceRefresh && offset === 0, {
                             limit: SLACK_CHANNELS_PAGE_SIZE,
                             offset,

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -11,6 +11,9 @@ import type { slackIntegrationLogicType } from './slackIntegrationLogicType'
 
 export const SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS = 30
 
+// Matches the channels endpoint's max page size (SlackChannelsQuerySerializer.limit).
+const SLACK_CHANNELS_PAGE_SIZE = 200
+
 export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
     props({} as { id: number }),
     key((props) => props.id),
@@ -28,7 +31,25 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
             null as { channels: SlackChannelType[]; lastRefreshedAt: string } | null,
             {
                 loadAllSlackChannels: async ({ forceRefresh }) => {
-                    return await api.integrations.slackChannels(props.id, forceRefresh)
+                    // The channels endpoint is paginated, so walk every page to build the full
+                    // channel list for client-side filtering. Only force a refresh on the first
+                    // page — later pages read the cache that first page populated.
+                    const channels: SlackChannelType[] = []
+                    let offset = 0
+                    let lastRefreshedAt = ''
+                    for (;;) {
+                        const res = await api.integrations.slackChannels(props.id, forceRefresh && offset === 0, {
+                            limit: SLACK_CHANNELS_PAGE_SIZE,
+                            offset,
+                        })
+                        channels.push(...res.channels)
+                        lastRefreshedAt = res.lastRefreshedAt
+                        if (!res.has_more) {
+                            break
+                        }
+                        offset += SLACK_CHANNELS_PAGE_SIZE
+                    }
+                    return { channels, lastRefreshedAt }
                 },
             },
         ],


### PR DESCRIPTION
## Problem

The shared Slack channel picker stopped showing most channels in workspaces with many channels. Users could only select channels that sort within the first 50 alphabetically; anything later was missing from the dropdown and couldn't be found via search.

This is a regression from #58774, which made the `integrations/:id/channels/` endpoint paginated with a default `limit` of 50. That PR wired the new server-side search/pagination into the signals/inbox flow, but the shared `slackIntegrationLogic` was left requesting a single unpaginated page, so it silently began receiving only the first 50 channels (the list is sorted alphabetically in `SlackIntegration.list_channels`). The picker filters client-side, so channels never returned by the API can't be selected.

This affects every surface that uses the shared `SlackChannelPicker`: CDP/Hog function Slack destinations, logs alerts, and insight/subscription alerts.

## Changes

`slackIntegrationLogic.loadAllSlackChannels` now walks every page of the channels endpoint via `has_more`, rebuilding the full channel list for client-side filtering. This restores the pre-#58774 behavior against the now-paginated API and mirrors the existing `githubIntegrationLogic` pagination pattern. It only sends `force_refresh=true` on the first page, so later pages read the cache the first page populated rather than re-hitting Slack mid-walk.

`api.integrations.slackChannels` and the `integrationSlackChannels` request builder gain optional `limit`/`offset` params and surface `has_more` in the response type. No backend changes — the endpoint already supports this.

## How did you test this code?

Manual testing not completed. I'm not sure the best way to test this with a very large number of Slack channels 🤔 

Automated tests added and run:

- `frontend/src/lib/integrations/slackIntegrationLogic.test.ts` — asserts `loadAllSlackChannels` accumulates channels across pages (including one that only appears on the last page) and that `force_refresh` is sent only on the first page. Full file passes (5/5) via `hogli test`.
- oxfmt + oxlint clean on changed files.

Suggested manual check before merge: in a workspace with >50 channels, open a Slack channel picker (CDP destination, logs alert, or insight alert) and confirm a channel that sorts alphabetically late (e.g. `#sentry-alerts`) appears and is selectable, and that "Refresh channels" still works.

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7), investigating a support report that a customer couldn't select an existing Slack channel in an alert despite the bot having access, and that it had worked the previous week.