### PR TITLE
chore(data-warehouse): test workflow.logger call shape in CDC-streaming skip branch

### DIFF
--- a/posthog/temporal/tests/external_data/test_external_data_job.py
+++ b/posthog/temporal/tests/external_data/test_external_data_job.py
@@ -13,6 +13,10 @@ import boto3
 import psycopg
 import pytest_asyncio
 from asgiref.sync import sync_to_async
+from temporalio import (
+    activity,
+    workflow as temporal_workflow,
+)
 from temporalio.common import RetryPolicy
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
@@ -899,3 +903,117 @@ async def test_run_postgres_job(
         folder_path = await sync_to_async(job_1.folder_path)()
         job_1_team_objects = minio_client.list_objects_v2(Bucket=BUCKET_NAME, Prefix=f"{folder_path}/posthog_test/")
         assert len(job_1_team_objects["Contents"]) == 3
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_external_data_job_workflow_completes_when_import_activity_signals_skip_post_import(team, **kwargs):
+    """Drive `ExternalDataJobWorkflow` through the CDC-streaming skip branch and assert it
+    exits cleanly. The branch logs through `workflow.logger`, which wraps stdlib `Logger` and
+    rejects unknown kwargs — a regression to direct kwargs (e.g. `schema_id="..."`) raises
+    TypeError, the workflow's catch-all flips status to FAILED, and the finally block calls
+    `update_external_data_job_model`. This was the prod failure mode for Postgres CDC syncs
+    after the snapshot → streaming transition.
+
+    The assertion: when `import_data_activity_sync` returns `consumer_manages_job_status=True`
+    + `skip_post_import_activities=True`, the workflow's finally block must skip the update
+    activity ([external_data_job.py:484-486](posthog/temporal/data_imports/external_data_job.py:484))
+    because the consumer owns the job's terminal status. So `update_external_data_job_model`
+    should never be called. If the log call inside the skip branch raises, the except path
+    flips status to FAILED and the update activity DOES get called — that's the regression.
+    """
+    new_source = await sync_to_async(ExternalDataSource.objects.create)(
+        source_id=uuid.uuid4(),
+        connection_id=uuid.uuid4(),
+        destination_id=uuid.uuid4(),
+        team=team,
+        status="running",
+        source_type="Stripe",
+        job_inputs={
+            "auth_method": {"selection": "api_key", "stripe_secret_key": "test-key"},
+            "stripe_account_id": "acct_id",
+        },
+    )
+    schema = await sync_to_async(ExternalDataSchema.objects.create)(
+        name=STRIPE_CUSTOMER_RESOURCE_NAME,
+        team_id=team.id,
+        source_id=new_source.pk,
+    )
+    inputs = ExternalDataWorkflowInputs(
+        team_id=team.id,
+        external_data_source_id=new_source.pk,
+        external_data_schema_id=schema.id,
+    )
+
+    # Stub `import_data_activity_sync` to return the CDCHandledExternally shape. Same registered
+    # name as the real activity so the worker dispatches to this one. The real activity would
+    # have marked the job Completed itself before returning this payload — we don't need to
+    # replicate that here, only the return signal that drives the workflow branch.
+    @activity.defn(name="import_data_activity_sync")
+    async def stub_skip_post_import(inputs: ImportDataActivityInputs) -> dict:
+        return {
+            "should_trigger_cdp_producer": False,
+            "consumer_manages_job_status": True,
+            "skip_post_import_activities": True,
+        }
+
+    # `consumer_manages_job_status=True` + COMPLETED status makes the workflow's finally block
+    # skip `update_external_data_job_model` ([external_data_job.py:484-486]) — so we don't
+    # need a real implementation, but we do need to register a stub by the same name so the
+    # worker can dispatch to it if the branch were to fall through to the failure path.
+    @activity.defn(name="update_external_data_job_model")
+    async def stub_update_external_data_job_model(inputs: UpdateExternalDataJobStatusInputs) -> None:
+        return None
+
+    # Spy on `workflow.logger`. The skip branch calls `workflow.logger.info(msg, ...)` — if
+    # any kwarg other than the stdlib-accepted ones (extra/exc_info/stack_info/stacklevel)
+    # shows up in the spy's call_args, the call would crash a real worker because
+    # `Logger._log` rejects unknown kwargs. We patch the module-level singleton with a Mock
+    # so the call always succeeds inside the workflow runtime (avoiding the replay/level
+    # short-circuit that hides the bug); we then check the recorded kwargs ourselves.
+    with mock.patch.object(temporal_workflow, "logger") as logger_spy:
+        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+            async with Worker(
+                activity_environment.client,
+                task_queue=settings.DATA_WAREHOUSE_TASK_QUEUE,
+                workflows=[ExternalDataJobWorkflow],
+                activities=[
+                    create_external_data_job_model_activity,
+                    stub_update_external_data_job_model,
+                    stub_skip_post_import,
+                    create_source_templates,
+                    calculate_table_size_activity,
+                    check_billing_limits_activity,
+                    sync_new_schemas_activity,
+                ],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+                activity_executor=ThreadPoolExecutor(max_workers=50),
+                max_concurrent_activities=50,
+                debug_mode=True,  # turn off sandbox so the workflow can see the patched logger
+            ):
+                await activity_environment.client.execute_workflow(
+                    ExternalDataJobWorkflow.run,
+                    inputs,
+                    id=str(uuid.uuid4()),
+                    task_queue=settings.DATA_WAREHOUSE_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                )
+
+    allowed_kwargs = {"extra", "exc_info", "stack_info", "stacklevel"}
+    bad_log_calls: list[tuple[str, dict]] = []
+    for log_method in ("debug", "info", "warning", "error", "exception", "critical", "log"):
+        method_mock = getattr(logger_spy, log_method)
+        for call in method_mock.call_args_list:
+            bad = {k: v for k, v in call.kwargs.items() if k not in allowed_kwargs}
+            if bad:
+                bad_log_calls.append((log_method, bad))
+
+    assert not bad_log_calls, (
+        "workflow.logger call in the CDC-streaming skip branch passes structured fields as "
+        "direct kwargs — stdlib Logger rejects these with TypeError in real workers. Wrap them "
+        f"in extra={{...}} instead. Offending calls: {bad_log_calls}"
+    )
+
+    # Belt-and-braces: confirm the spy was actually called, otherwise an over-eager refactor
+    # could remove the log line entirely and the kwarg check would silently pass.
+    assert logger_spy.info.called, "workflow.logger.info was not called — skip branch may not have been reached"


### PR DESCRIPTION
## Problem

The previous fix that landed on master ([posthog#60254](https://github.com/PostHog/posthog/pull/60254)) wrapped `workflow.logger.info/warning(..., schema_id=..., source_id=...)` calls in `ExternalDataJobWorkflow.run` with `extra={...}` because stdlib `Logger._log` raises `TypeError` on unknown kwargs. The actual prod regression — `Logger._log() got an unexpected keyword argument 'schema_id'` — wasn't caught by any existing test. The CDC-streaming skip branch (`if skip_post_import_activities:`) wasn't exercised end-to-end; the existing workflow test mocks `PipelineNonDLT.run` to return `{"should_trigger_cdp_producer": False}`, which doesn't set `skip_post_import_activities=True`.

## Changes

Drives the workflow through the skip branch by stubbing `import_data_activity_sync` (same registered name as the real activity) to return `{should_trigger_cdp_producer: False, consumer_manages_job_status: True, skip_post_import_activities: True}` — the exact payload the real `CDCHandledExternally` path returns. Spies on `temporalio.workflow.logger` and asserts the recorded `info()` kwargs only contain names stdlib `Logger._log` accepts (`extra`, `exc_info`, `stack_info`, `stacklevel`).

**Why a spy instead of catching the real TypeError end-to-end:** when run under `WorkflowEnvironment.start_time_skipping()`, the broken `workflow.logger.info(..., schema_id=...)` call doesn't propagate the TypeError. Temporal's `WorkflowLoggerAdapter.isEnabledFor` short-circuits the log when `is_replaying_history_events()` is True (default behavior) and when the underlying logger's level is too high (pytest defaults to WARNING). Both are tunable but unreliable across pytest's logging capture, so the cleanest approach is to patch the module-level logger singleton — the spy records the call shape the workflow code actually emits without needing the runtime to reproduce the TypeError.

## How did you test this code?

I'm an agent. Verified the test:
- Fails against the broken call (locally reverted the `extra={...}` fix back to direct kwargs) with `AssertionError: workflow.logger call ... Offending calls: [('info', {'schema_id': '...', 'source_id': '...'})]`.
- Passes against the fix on master.

Ran via `hogli test posthog/temporal/tests/external_data/test_external_data_job.py::test_external_data_job_workflow_completes_when_import_activity_signals_skip_post_import`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7). First attempt (AST scan of source) was rejected as too far removed from real behavior. The branch was retired and replaced by this runtime test. Two non-obvious things came out of building it: (1) the existing workflow test never reached the CDC-streaming skip path, so a kwargs regression had no signal at all; (2) inside the workflow runtime under `start_time_skipping()`, `workflow.logger.<level>` calls with unknown kwargs are silently dropped via the adapter's `isEnabledFor` short-circuit — even with `log_during_replay=True` and `logging.DEBUG` set, the TypeError did not propagate consistently. Patching the logger singleton is the reliable way to observe the call shape the workflow actually emits.