### PR TITLE
chore(endpoints): extract endpoint_version into lc_endpoint_version

### DIFF
--- a/posthog/clickhouse/migrations/0269_query_log_archive_endpoint_version.py
+++ b/posthog/clickhouse/migrations/0269_query_log_archive_endpoint_version.py
@@ -1,0 +1,49 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.query_log_archive import (
+    DIST_QUERY_LOG_ARCHIVE_MV,
+    MV_SELECT_SQL,
+    QUERY_LOG_ARCHIVE_ADD_ENDPOINT_VERSION_COLUMN_SQL,
+    QUERY_LOG_ARCHIVE_DATA_TABLE,
+    SHARDED_QUERY_LOG_ARCHIVE_MV,
+    SHARDED_QUERY_LOG_ARCHIVE_TABLE,
+    SHARDED_QUERY_LOG_ARCHIVE_WRITABLE_TABLE,
+    SHARDED_WRITABLE_QUERY_LOG_ARCHIVE_TABLE_SQL,
+)
+
+operations = [
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_ADD_ENDPOINT_VERSION_COLUMN_SQL(SHARDED_QUERY_LOG_ARCHIVE_TABLE),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        SHARDED_WRITABLE_QUERY_LOG_ARCHIVE_TABLE_SQL(),
+        node_roles=[NodeRole.ENDPOINTS],
+    ),
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_ADD_ENDPOINT_VERSION_COLUMN_SQL(SHARDED_QUERY_LOG_ARCHIVE_WRITABLE_TABLE),
+        node_roles=[NodeRole.ENDPOINTS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_ADD_ENDPOINT_VERSION_COLUMN_SQL(QUERY_LOG_ARCHIVE_DATA_TABLE),
+        node_roles=[NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    run_sql_with_exceptions(
+        f"ALTER TABLE {SHARDED_QUERY_LOG_ARCHIVE_MV} MODIFY QUERY\n{MV_SELECT_SQL}",
+        node_roles=[NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    run_sql_with_exceptions(
+        f"ALTER TABLE {DIST_QUERY_LOG_ARCHIVE_MV} MODIFY QUERY\n{MV_SELECT_SQL}",
+        node_roles=[NodeRole.ENDPOINTS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0268_property_values_kafka_num_consumers
+0269_query_log_archive_endpoint_version

--- a/posthog/clickhouse/query_log_archive.py
+++ b/posthog/clickhouse/query_log_archive.py
@@ -221,6 +221,7 @@ CREATE TABLE IF NOT EXISTS {table_name} (
     lc_person_on_events_mode LowCardinality(String),
     lc_service_name String,
     lc_workload LowCardinality(String),
+    lc_endpoint_version Int64,
 
     lc_query__kind LowCardinality(String),
     lc_query__query String,
@@ -346,6 +347,7 @@ SELECT
     JSONExtractString(log_comment, 'person_on_events_mode') as lc_person_on_events_mode,
     JSONExtractString(log_comment, 'service_name') as lc_service_name,
     JSONExtractString(log_comment, 'workload') as lc_workload,
+    JSONExtractInt(log_comment, 'endpoint_version') as lc_endpoint_version,
 
     -- for entries with 'query' tag, some queries have source, we should use this
     if(JSONHas(log_comment, 'query', 'source'),
@@ -482,6 +484,14 @@ def QUERY_LOG_ARCHIVE_ADD_MODIFIERS_COLUMN_SQL(table=QUERY_LOG_ARCHIVE_DATA_TABL
     return f"""
     ALTER TABLE {table}
         ADD COLUMN IF NOT EXISTS lc_modifiers String AFTER lc_dagster__owner
+    """
+
+
+# V11 - adding lc_endpoint_version to track per-version Endpoints usage
+def QUERY_LOG_ARCHIVE_ADD_ENDPOINT_VERSION_COLUMN_SQL(table=QUERY_LOG_ARCHIVE_DATA_TABLE):
+    return f"""
+    ALTER TABLE {table}
+        ADD COLUMN IF NOT EXISTS lc_endpoint_version Int64 AFTER lc_workload
     """
 
 

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -3853,6 +3853,7 @@
       lc_person_on_events_mode LowCardinality(String),
       lc_service_name String,
       lc_workload LowCardinality(String),
+      lc_endpoint_version Int64,
   
       lc_query__kind LowCardinality(String),
       lc_query__query String,
@@ -3974,6 +3975,7 @@
       JSONExtractString(log_comment, 'person_on_events_mode') as lc_person_on_events_mode,
       JSONExtractString(log_comment, 'service_name') as lc_service_name,
       JSONExtractString(log_comment, 'workload') as lc_workload,
+      JSONExtractInt(log_comment, 'endpoint_version') as lc_endpoint_version,
   
       -- for entries with 'query' tag, some queries have source, we should use this
       if(JSONHas(log_comment, 'query', 'source'),
@@ -8462,6 +8464,7 @@
       lc_person_on_events_mode LowCardinality(String),
       lc_service_name String,
       lc_workload LowCardinality(String),
+      lc_endpoint_version Int64,
   
       lc_query__kind LowCardinality(String),
       lc_query__query String,

--- a/posthog/hogql/database/schema/query_log_archive.py
+++ b/posthog/hogql/database/schema/query_log_archive.py
@@ -35,6 +35,7 @@ QUERY_LOG_ARCHIVE_FIELDS: dict[str, FieldOrTable] = {
     "is_personal_api_key_request": BooleanDatabaseField(name="is_personal_api_key_request", nullable=False),
     "api_key_label": StringDatabaseField(name="lc_api_key_label", nullable=False),
     "api_key_mask": StringDatabaseField(name="lc_api_key_mask", nullable=False),
+    "endpoint_version": IntegerDatabaseField(name="lc_endpoint_version", nullable=False),
     "cpu_microseconds": IntegerDatabaseField(name="ProfileEvents_OSCPUVirtualTimeMicroseconds", nullable=False),
     "RealTimeMicroseconds": IntegerDatabaseField(name="ProfileEvents_RealTimeMicroseconds", nullable=False),
     "S3ListObjects": IntegerDatabaseField(name="ProfileEvents_S3ListObjects", nullable=False),
@@ -137,6 +138,7 @@ class RawQueryLogArchiveTable(Table):
         "lc_api_key_label": StringDatabaseField(name="lc_api_key_label", nullable=False),
         "lc_api_key_mask": StringDatabaseField(name="lc_api_key_mask", nullable=False),
         "lc_query__kind": StringDatabaseField(name="lc_query__kind", nullable=False),
+        "lc_endpoint_version": IntegerDatabaseField(name="lc_endpoint_version", nullable=False),
         "ProfileEvents_OSCPUVirtualTimeMicroseconds": IntegerDatabaseField(
             name="ProfileEvents_OSCPUVirtualTimeMicroseconds", nullable=False
         ),

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -2271,6 +2271,16 @@
                   "table": null,
                   "type": "string"
               },
+              "endpoint_version": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "endpoint_version",
+                  "id": null,
+                  "name": "endpoint_version",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
               "cpu_microseconds": {
                   "chain": null,
                   "fields": null,
@@ -10251,6 +10261,16 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
+              },
+              "endpoint_version": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "endpoint_version",
+                  "id": null,
+                  "name": "endpoint_version",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
               },
               "cpu_microseconds": {
                   "chain": null,


### PR DESCRIPTION
## Problem

Endpoints needs per-version usage signal so audits can tell which materialised versions are actually being called. The `endpoint_version` tag is set upstream today but dropped at insertion — `query_log_archive` extracts each tag into a dedicated `lc_*` column and `lc_endpoint_version` did not exist.

## Changes

- Adds `lc_endpoint_version Int64` to `query_log_archive` (data table + writable distributed) via migration `0267`.
- Extends `MV_SELECT_SQL` to extract `endpoint_version` from `log_comment`.
- Exposes `endpoint_version` on the HogQL `query_log` table.

## How did you test this code?

Migration imports cleanly and lints. End-to-end verification (apply migration, tag a query, read back via HogQL) is deferred until I have the local dev stack up — flagged in the agent session.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs — internal infra, no user-facing surface.

## 🤖 Agent context

Claude (Opus 4.7), bottom of a 4-PR stack building per-version endpoint audit + skills. Surfaced during planning that the original plan ("path 1: JSONExtract from log_comment") was impossible because the table doesn't store raw `log_comment`; a materialised column was the only real path. Followed the precedent at `0193_add_lc_is_impersonated`.