### PR TITLE
chore(capture): cut steady-state operational warn noise

### DIFF
--- a/rust/capture/src/event_restrictions/repository.rs
+++ b/rust/capture/src/event_restrictions/repository.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use common_redis::{Client as RedisClient, CustomRedisError};
 use metrics::counter;
 use serde::Deserialize;
-use tracing::warn;
 
 use super::types::{Restriction, RestrictionFilters, RestrictionScope, RestrictionType};
 
@@ -156,7 +155,7 @@ impl EventRestrictionsRepository for RedisRestrictionsRepository {
         let key = self.build_key(restriction_type);
         let restriction_type_str = restriction_type.as_str();
 
-        let json_str = match self.redis.get(key.clone()).await {
+        let json_str = match self.redis.get(key).await {
             Ok(s) => s,
             Err(CustomRedisError::NotFound) => {
                 counter!(
@@ -174,7 +173,6 @@ impl EventRestrictionsRepository for RedisRestrictionsRepository {
                     "result" => "error"
                 )
                 .increment(1);
-                warn!(key = %key, error = %e, "Failed to fetch restrictions from Redis");
                 return Err(e);
             }
         };
@@ -196,7 +194,6 @@ impl EventRestrictionsRepository for RedisRestrictionsRepository {
                     "result" => "parse_error"
                 )
                 .increment(1);
-                warn!(key = %key, error = %e, "Failed to parse restrictions from Redis");
                 Err(CustomRedisError::ParseError(format!(
                     "Failed to parse JSON: {}",
                     e

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -11,7 +11,7 @@ use common_types::{CapturedEvent, RawEvent};
 use limiters::token_dropper::TokenDropper;
 use metrics::counter;
 use serde_json;
-use tracing::{error, instrument, warn, Span};
+use tracing::{debug, error, instrument, warn, Span};
 
 use limiters::overflow::OverflowLimiter;
 
@@ -240,7 +240,7 @@ pub async fn process_events(
                 continue;
             }
             Err(err) => {
-                error!("failed to create heatmap redirect: {err:#}");
+                warn!("failed to create heatmap redirect: {err:#}");
                 events.push(process_single_event(&raw, historical_cfg, context)?);
                 continue;
             }
@@ -343,7 +343,7 @@ pub async fn process_events(
                 "reason" => "global_rate_limit_token_distinctid",
             )
             .increment(limited_event_count);
-            warn!(
+            debug!(
                 token = context.token,
                 limited_event_count = limited_event_count,
                 distinct_id_count = limited_distinct_ids.len(),

--- a/rust/capture/src/extractors.rs
+++ b/rust/capture/src/extractors.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use axum::body::Body;
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::StreamExt;
-use tracing::warn;
 
 use crate::api::CaptureError;
 
@@ -40,12 +39,6 @@ pub async fn extract_body_with_timeout(
                         // Timeout waiting for next chunk
                         metrics::counter!(METRIC_BODY_READ_TIMEOUT, "path" => path.to_string())
                             .increment(1);
-                        warn!(
-                            path = path,
-                            bytes_received = buf.len(),
-                            timeout_ms = timeout.as_millis() as u64,
-                            "Body read timeout: client stopped sending data"
-                        );
                         return Err(CaptureError::BodyReadTimeout);
                     }
                 }

--- a/rust/capture/src/metrics_middleware.rs
+++ b/rust/capture/src/metrics_middleware.rs
@@ -93,38 +93,6 @@ where
                 } else {
                     UNMATCHED_PATH_LABEL.to_owned()
                 };
-                let client_ip = req
-                    .headers()
-                    .get("X-Forwarded-For")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|s| s.split(',').next())
-                    .map_or_else(|| "UNKNOWN".to_string(), |s| s.trim().to_string());
-                let request_id = req
-                    .headers()
-                    .get("X-REQUEST-ID")
-                    .and_then(|v| v.to_str().ok())
-                    .map_or_else(|| "UNKNOWN".to_string(), |s| s.to_string());
-                let content_type = req
-                    .headers()
-                    .get("Content-Type")
-                    .and_then(|v| v.to_str().ok())
-                    .map_or_else(|| "UNKNOWN".to_string(), |s| s.to_string());
-                let content_length = req
-                    .headers()
-                    .get("Content-Length")
-                    .and_then(|v| v.to_str().ok())
-                    .map_or_else(|| "UNKNOWN".to_string(), |s| s.to_string());
-                let user_agent = req
-                    .headers()
-                    .get("User-Agent")
-                    .and_then(|v| v.to_str().ok())
-                    .map_or_else(|| "UNKNOWN".to_string(), |s| s.to_string());
-                let envoy_ip = req
-                    .headers()
-                    .get("X-Envoy-External-Address")
-                    .and_then(|v| v.to_str().ok())
-                    .map_or_else(|| "UNKNOWN".to_string(), |s| s.to_string());
-
                 match tokio::time::timeout(timeout_duration, next.run(req)).await {
                     Ok(response) => {
                         let elapsed = start.elapsed();
@@ -156,21 +124,6 @@ where
                             tags.push(("threshold", "respected".to_string()));
                         }
                         metrics::counter!(METRIC_CAPTURE_REQUEST_TIMED_OUT, &tags).increment(1);
-
-                        tracing::warn!(
-                            method = method,
-                            path = path,
-                            request_id = request_id,
-                            client_ip = client_ip,
-                            envoy_ip = envoy_ip,
-                            content_type = content_type,
-                            content_length = content_length,
-                            user_agent = user_agent,
-                            timeout_threshold_seconds = request_timeout_seconds,
-                            threshold_exceeded = threshold_exceeded,
-                            elapsed_seconds = elapsed.as_secs_f64(),
-                            "Request timed out"
-                        );
 
                         // This should be a 408 Request Timeout, but we need to set it to
                         // a >500 status code to avoid breaking SDK integrations.

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -214,22 +214,18 @@ fn validate_events(context: &Context, batch: Batch) -> Result<Vec<WrappedEvent>,
     }
 
     if events.iter().any(|e| e.result != EventResult::Ok) {
-        observe_malformed_events(context, &events);
+        observe_malformed_events(&events);
     }
 
     Ok(events)
 }
 
-fn observe_malformed_events(context: &Context, events: &[WrappedEvent]) {
+fn observe_malformed_events(events: &[WrappedEvent]) {
     let mut malformed: HashMap<&'static str, u64> = HashMap::new();
-    let mut illegal_distinct_ids: HashSet<&str> = HashSet::new();
 
     for event in events.iter() {
         if let Some(tag) = event.details {
             *malformed.entry(tag).or_insert(0) += 1;
-            if tag == "invalid_distinct_id" {
-                illegal_distinct_ids.insert(&event.event.distinct_id);
-            }
         }
     }
 
@@ -237,22 +233,6 @@ fn observe_malformed_events(context: &Context, events: &[WrappedEvent]) {
         metrics::counter!(CAPTURE_V1_PARSED_EVENTS, "result" => "malformed", "error" => *error_tag)
             .increment(*count);
     }
-
-    let summary: String = malformed
-        .iter()
-        .map(|(tag, count)| format!("{tag}={count}"))
-        .collect::<Vec<_>>()
-        .join(", ");
-
-    let illegal_ids_csv: String = illegal_distinct_ids
-        .into_iter()
-        .collect::<Vec<_>>()
-        .join(", ");
-
-    crate::ctx_log!(Level::WARN, context,
-        illegal_distinct_ids = %illegal_ids_csv,
-        "malformed events: {summary}"
-    );
 }
 
 fn is_distinct_id_illegal(distinct_id: &str) -> bool {
@@ -484,7 +464,7 @@ async fn apply_token_distinct_id_limits(
         )
         .increment(limited_count as u64);
 
-        crate::ctx_log!(Level::WARN, context,
+        crate::ctx_log!(Level::DEBUG, context,
             limited_count = limited_count,
             distinct_ids = %preview,
             "events rate limited by distinct_id -- person processing disabled"


### PR DESCRIPTION
## Problem

Follow-up to #60244. After cleaning up per-request client-error noise in the analytics, AI, and replay paths, the next noise tier was the steady-state operational warnings — logs that don't fire per-request but fire continuously in normal operation:

- per-batch rate-limit logs (every batch with any rate-limited distinct_id)
- per-batch malformed-events summaries
- body-read and request timeouts
- event-restriction Redis fetch failures during background refresh

Each one has either an adjacent counter, a client-visible response, or a redundant caller-side log. The warn level was burying them in noise that already had a better surface.

## Changes

Five sites across the steady-state operational layer:

| File | Change | Why |
|---|---|---|
| `events/analytics.rs:243` | `error!` → `warn!` | code recovers (falls back to processing original event), so heatmap-redirect failure is a degraded path, not an error |
| `events/analytics.rs:346` | `warn!` → `debug!` | counter `capture_events_rate_limited_token_distinctid` already records volume; the token + distinct-id preview is rarely actionable at warn level |
| `v1/analytics/process.rs:252` | dropped entirely | same info already returned to the SDK via `BatchResponse { results: { uuid: { result: Drop, details: <tag> } } }` in the 200 body, **and** counted in `CAPTURE_V1_PARSED_EVENTS{result=malformed, error=<tag>}`. The log added only a per-batch summary string |
| `v1/analytics/process.rs:487` | `ctx_log!(WARN)` → `ctx_log!(DEBUG)` | v1 equivalent of the analytics rate-limit log; same rationale |
| `extractors.rs:43` | dropped | counter `capture_body_read_timeout_total{path}` covers volume; the `bytes_received` and `timeout_ms` fields add nothing operator-actionable beyond what the counter already conveys |
| `metrics_middleware.rs:160` | dropped | counter `capture_request_timed_out_total{method, path, threshold}` covers volume; per-request detail (request_id, IPs, user_agent) lives in tracing spans. Also removes the now-unused header extractions (47-line diff) |
| `event_restrictions/repository.rs:177, 199` | both dropped | caller in `event_restrictions/manager.rs:117` already logs every fetch failure with `restriction_type` and the propagated `CustomRedisError`. The `key` field these added is just `event_ingestion_restriction_dynamic_config:<restriction_type>` — no extra info |

### Intentional retentions

`event_restrictions/manager.rs:117` keeps its `warn!`. This is the right surface for Redis-down / corrupt-data conditions during the background refresh task. Background-task frequency means it doesn't flood; if a sustained outage ever makes it noisy, add per-restriction-type rate-limiting then.

### Code cleanup that fell out

- `v1/analytics/process.rs::observe_malformed_events`: lost the `context` parameter and the now-unused `illegal_distinct_ids` HashSet
- `metrics_middleware.rs`: lost six unused header extractions (client_ip, request_id, content_type, content_length, user_agent, envoy_ip) that were only fed to the dropped warn
- `event_restrictions/repository.rs`: dropped a `key.clone()` that was only needed to keep `key` alive for the warn, and the `tracing::warn` import
- `extractors.rs`: dropped the `tracing::warn` import

## How did you test this code?

I'm an agent. I ran:

- `cargo check -p capture` — clean after every commit
- `cargo fmt -p capture --check` — clean
- `cargo clippy -p capture --all-targets -- -D warnings` — clean
- `cargo test -p capture --lib` — 753 unit tests pass
- `cargo test -p capture --lib v1` — 444 v1 tests pass
- `cargo test -p capture --lib event_restrictions` — 43 event_restrictions tests pass

No manual traffic testing.

## Publish to changelog?

no

## Docs update

Not applicable.

## 🤖 Agent context

Continuation of the iterative log audit started in #60244. That PR cleaned up Category A (per-request client-error noise — ~50 sites). This PR handles Category B (steady-state operational warnings — 9 sites across 6 files).

Decisions per site were made iteratively in conversation against three principles:
1. Don't log per-batch what a counter already captures.
2. If the same info is already returned to the client in the response, the server-side log is redundant.
3. If a caller already logs the propagated error with sufficient context, the callee-level log is redundant.

The heatmap site is the one judgment call I'd flag for the reviewer: it's currently `error!` but the code recovers by falling back to processing the original event unchanged. Promoting to `warn!` (not dropping) preserves visibility into the degraded path without claiming it's an error.

Categories remaining for future PRs:
- **C** — rdkafka / sink callback noise (13 sites, needs rate-limiting helper)
- **D** — infra errors to consider sampling (12 sites)
- **G** — v1 `purposely chatty` INFO entries (2 sites marked TODO in the code)