### PR TITLE
feat(navigation): group logs, tracing, and error tracking under App monitoring

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1233,9 +1233,9 @@ snapshots:
     components-property-key-info--property-key-info--light:
         hash: v1.k794b7964.209b5c6ed30ec090249ca9036bb151b02765f23cf6eba2bb8417ac9297651bf6.FT9wC3m6u9L-NqbgWhg3YnEnnyhjjSzdHh740vfswDQ
     components-search--default--dark:
-        hash: v1.k794b7964.c30111430d8ea4d04c000cef06117cbfaddc35d878eabf460107e789d4c2e924.Ka1P3kDjRlH3ASfWAuc8YPXrw_kwFeB3X_4ytUd-Nzg
+        hash: v1.k794b7964.ef3f0cb1e2fadf78fd4b94b0d42d4c0d963bd63ad55cc0cd087f48417f022bb4.whCPtVL3sz11a7fr2xusJtdXgv1pU0cX8F0LBoeHxJI
     components-search--default--light:
-        hash: v1.k794b7964.5e6e91e6bae311ce2310a2192f3aaff14c143b1209da18aa0dd15b30ed378c23.we_dzaxMCPNMypRkaKFEQdAyzjTfZeI4dA-hl-fLBZo
+        hash: v1.k794b7964.aa78e91c7dc4d0fbe8ffee8a5db26c76399d443738ed1c5a68544382d0d41041.L3wA7NcXjTxTGZAS2i1QTRdxQBvWQ9dll4QwFT_nf44
     components-search--product-recents-and-starred--dark:
         hash: v1.k794b7964.22df1e775fc314a45651a47d2c84364561c276221a78ff7312412276b59a5b96.-d6xSe9GW0oteb2F2s7obniM1HUZ-IxQWK3YcIrnxeY
     components-search--product-recents-and-starred--light:
@@ -2081,9 +2081,9 @@ snapshots:
     layout-impersonation-reason-modal--upgrade-to-read-write--light:
         hash: v1.k794b7964.7686131e8d04113362f587050067e1daa76329becb2e33097cebc43792467919.B37QbmEEFysXtGrVVX0H_WUofFwz8yAI0cJah0GEK9s
     layout-project-tree-custom-products--all-products--dark:
-        hash: v1.k794b7964.1178f0f14d0044a1724ec2cfd03994b92c8b8004fd99db317c6328cd984d021f.6xgeV-EUayTdEm9kRByNN2yGtxKk-IPDabXKbzsn5iI
+        hash: v1.k794b7964.3fd06a251b707c03825ae76e4e1159e167417587566410dbe992ea6bbb0a4eae.CYo3HurcqZORSFbi-LiZ4IVQEdcCA38XWevGafUuXNQ
     layout-project-tree-custom-products--all-products--light:
-        hash: v1.k794b7964.e28cc2698276155ba5bb2f09c5f77fd37afea5daef4bb2de3402e31d93b2f4af.j9eTHa2cVPZnyP-xpQ37tBPIMTGc8QJOXmtbJRbJyR4
+        hash: v1.k794b7964.f7f10a40f8af7d59451968833271c19c51867a29957d35615b65f5982addddf3.uEKTL4Uxh4sNqWlv_8RSRcGEGOdO2ldUPynAFUJoC0Q
     layout-project-tree-custom-products--default--dark:
         hash: v1.k794b7964.0cfb3fc7184514a2e43715de235fb08c77d516acc35b1539f4f9c72c5e616684.BTCbowk4NNeKDyVajIr_6Qjut5httj64VO6TqfU8ITA
     layout-project-tree-custom-products--default--light:

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -13,7 +13,15 @@ import { iconForType } from './defaultTree'
 import { FolderState } from './types'
 
 // Hardcoded category order - categories not in this list will be sorted alphabetically after these
-export const CATEGORY_ORDER = ['Analytics', 'AI engineering', 'Behavior', 'Features', 'Tools', 'Unreleased']
+export const CATEGORY_ORDER = [
+    'Analytics',
+    'AI engineering',
+    'Behavior',
+    'App monitoring',
+    'Features',
+    'Tools',
+    'Unreleased',
+]
 
 export function getCategoryOrder(category: string | undefined): number {
     if (!category) {

--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -65,7 +65,7 @@
         },
         {
             "path": "Error tracking",
-            "category": "Behavior",
+            "category": "App monitoring",
             "iconType": null,
             "type": "error_tracking",
             "intents": ["error_tracking"]
@@ -148,7 +148,7 @@
             "type": "llm_skills",
             "intents": ["llm_prompts"]
         },
-        { "path": "Logs", "category": "Behavior", "iconType": null, "type": null, "intents": ["logs"] },
+        { "path": "Logs", "category": "App monitoring", "iconType": null, "type": null, "intents": ["logs"] },
         {
             "path": "Marketing analytics",
             "category": "Analytics",
@@ -209,7 +209,13 @@
         },
         { "path": "Surveys", "category": "Behavior", "iconType": "survey", "type": "survey", "intents": ["surveys"] },
         { "path": "Toolbar", "category": "Tools", "iconType": "toolbar", "type": "toolbar", "intents": ["toolbar"] },
-        { "path": "Tracing", "category": "Unreleased", "iconType": "tracing", "type": null, "intents": ["tracing"] },
+        {
+            "path": "Tracing",
+            "category": "App monitoring",
+            "iconType": "tracing",
+            "type": null,
+            "intents": ["tracing"]
+        },
         {
             "path": "User research",
             "category": "Unreleased",

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1640,7 +1640,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     {
         path: 'Error tracking',
         intents: [ProductKey.ERROR_TRACKING],
-        category: ProductItemCategory.BEHAVIOR,
+        category: ProductItemCategory.APP_MONITORING,
         type: 'error_tracking',
         iconType: 'error_tracking' as FileSystemIconType,
         iconColor: [
@@ -1777,7 +1777,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     {
         path: 'Logs',
         intents: [ProductKey.LOGS],
-        category: ProductItemCategory.BEHAVIOR,
+        category: ProductItemCategory.APP_MONITORING,
         iconType: 'logs' as FileSystemIconType,
         iconColor: ['var(--color-product-logs-light)'] as FileSystemIconColor,
         href: urls.logs(),
@@ -2066,7 +2066,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     {
         path: 'Tracing',
         intents: [ProductKey.TRACING],
-        category: ProductItemCategory.UNRELEASED,
+        category: ProductItemCategory.APP_MONITORING,
         iconType: 'tracing',
         iconColor: ['var(--color-product-tracing-light)'] as FileSystemIconColor,
         href: urls.tracing(),

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -27634,6 +27634,7 @@
                 "Analytics",
                 "AI engineering",
                 "Behavior",
+                "App monitoring",
                 "Features",
                 "Tools",
                 "Schema",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -6441,6 +6441,7 @@ export enum ProductItemCategory {
     ANALYTICS = 'Analytics',
     AI_ENGINEERING = 'AI engineering',
     BEHAVIOR = 'Behavior',
+    APP_MONITORING = 'App monitoring',
     FEATURES = 'Features',
     TOOLS = 'Tools',
     SCHEMA = 'Schema',

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3905,6 +3905,7 @@ class ProductItemCategory(StrEnum):
     ANALYTICS = "Analytics"
     AI_ENGINEERING = "AI engineering"
     BEHAVIOR = "Behavior"
+    APP_MONITORING = "App monitoring"
     FEATURES = "Features"
     TOOLS = "Tools"
     SCHEMA = "Schema"

--- a/posthog/test/test_products.py
+++ b/posthog/test/test_products.py
@@ -35,7 +35,15 @@ class TestProducts(BaseTest):
         products_by_category = Products.get_products_by_category()
         categories = set(products_by_category.keys())
 
-        expected_categories = {"Analytics", "AI engineering", "Behavior", "Features", "Tools", "Unreleased"}
+        expected_categories = {
+            "Analytics",
+            "AI engineering",
+            "Behavior",
+            "App monitoring",
+            "Features",
+            "Tools",
+            "Unreleased",
+        }
         assert categories == expected_categories
 
     def test_get_products_by_category_each_category_has_list_of_strings(self):

--- a/products/error_tracking/manifest.tsx
+++ b/products/error_tracking/manifest.tsx
@@ -70,7 +70,7 @@ export const manifest: ProductManifest = {
         {
             path: 'Error tracking',
             intents: [ProductKey.ERROR_TRACKING],
-            category: ProductItemCategory.BEHAVIOR,
+            category: ProductItemCategory.APP_MONITORING,
             type: 'error_tracking',
             iconType: 'error_tracking' as FileSystemIconType,
             iconColor: [

--- a/products/logs/manifest.tsx
+++ b/products/logs/manifest.tsx
@@ -65,7 +65,7 @@ export const manifest: ProductManifest = {
         {
             path: 'Logs',
             intents: [ProductKey.LOGS],
-            category: ProductItemCategory.BEHAVIOR,
+            category: ProductItemCategory.APP_MONITORING,
             iconType: 'logs' as FileSystemIconType,
             iconColor: ['var(--color-product-logs-light)'] as FileSystemIconColor,
             href: urls.logs(),

--- a/products/tracing/manifest.tsx
+++ b/products/tracing/manifest.tsx
@@ -30,7 +30,7 @@ export const manifest: ProductManifest = {
         {
             path: 'Tracing',
             intents: [ProductKey.TRACING],
-            category: ProductItemCategory.UNRELEASED,
+            category: ProductItemCategory.APP_MONITORING,
             iconType: 'tracing',
             iconColor: ['var(--color-product-tracing-light)'] as FileSystemIconColor,
             href: urls.tracing(),


### PR DESCRIPTION
## Problem

Error tracking, Logs, and Tracing were grouped under `Behavior` or `Unreleased` in the project tree, which didn't accurately reflect their nature as app monitoring/observability tools. There was no dedicated category to group these products together.

## Changes  
  
![image.png](https://app.graphite.com/user-attachments/assets/64566eee-6609-4fb7-9cbc-2212654b6b0b.png)



Introduces a new `App monitoring` category and moves **Error tracking**, **Logs**, and **Tracing** into it. The `App monitoring` category is inserted between `Behavior` and `Features` in the hardcoded category order, ensuring consistent ordering in the project tree sidebar. Tracing is also promoted out of `Unreleased` as part of this change.

## How did you test this code?

Verified by inspecting the project tree to confirm Error tracking, Logs, and Tracing appear under the new `App monitoring` category in the correct position. Updated the expected categories in the backend test to include `App monitoring`.

## Publish to changelog?

No