### PR TITLE
fix(insights): move showAnnotationsConfig to avoid master conflict

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -105,12 +105,12 @@ export function InsightDisplayConfig(): JSX.Element {
         (smoothingOptions[interval]?.length ?? 0) > 0
     const showMultipleYAxesConfig = (isTrends || isStickiness) && !isNonTimeSeriesDisplay
     const showAlertThresholdLinesConfig = isTrends && !isNonTimeSeriesDisplay
-    const showAnnotationsConfig = (isTrends && !isNonTimeSeriesDisplay) || isTrendsFunnel
     const isLineGraph =
         display === ChartDisplayType.ActionsLineGraph ||
         display === ChartDisplayType.ActionsAreaGraph ||
         (!display && isTrendsQuery(querySource))
     const isLinearScale = !yAxisScaleType || yAxisScaleType === 'linear'
+    const showAnnotationsConfig = (isTrends && !isNonTimeSeriesDisplay) || isTrendsFunnel
 
     const { showValuesOnSeries, mightContainFractionalNumbers, showConfidenceIntervals, showMovingAverage } = useValues(
         trendsDataLogic(insightProps)


### PR DESCRIPTION
## Problem

PR #59708 is marked CONFLICTING against master. The single textual conflict was in `frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx`: the PR added `showAnnotationsConfig` immediately above the existing `isLineGraph` declaration, and master then refactored that exact `isLineGraph` block (introducing `isLineDisplay`, `isBarDisplay`, `isCumulativeLineDisplay`, `showAxisLabelsConfig`). Git sees both sides editing adjacent lines and bails.

The viz file relocations (`frontend/src/scenes/trends/viz/...` → `products/product_analytics/frontend/insights/...`) are not actually a problem here — git's rename detection handles them automatically when master is merged.

## Changes

Move the `showAnnotationsConfig` declaration down by four lines, past `isLineGraph` and `isLinearScale`. Functionally identical (the constant only depends on `isTrends`, `isNonTimeSeriesDisplay`, `isTrendsFunnel`, all defined above), but no longer touches the lines master changed.

Verified locally with `git merge-file` against `origin/master` and the merge-base: with this branch's content, the three-way merge of `InsightDisplayConfig.tsx` exits 0 with zero conflict markers. The merged result keeps both the PR's `showAnnotationsConfig` usages and master's new `isLineGraph` / `isLineDisplay` / `showAxisLabelsConfig` block.

## How did you test this code?

I'm an agent. I:
- Ran `git merge-file` in-memory against master and confirmed zero conflicts after the move.
- Inspected the merged file to confirm `showAnnotationsConfig` (line 234, 401), the new `isLineGraph = isLineDisplay && !isCumulativeLineDisplay`, and `showAxisLabelsConfig` are all present and consistent.
- Did not start a dev server or run frontend tests.

## Publish to changelog?

No — this is a merge-conflict fix.

## 🤖 Agent context

Authored by PostHog Code (Claude) on behalf of @mjwarren3. An earlier attempt (now-closed #60280) committed the full master merge into a fix branch, which produced a ~120k-line diff and triggered the CODEOWNERS-soft team tagging across the repo. This PR is the minimal alternative: one file, one line moved, surgical to the conflict.