### PR TITLE
perf(insights): share same-entity aggregate in retention base query

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -429,24 +429,38 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
             min_timestamp_inner_expr = self.get_first_time_anchor_expr(self.start_event)
+            min_timestamp_expr = self.query_date_range.date_to_start_of_interval_hogql(min_timestamp_inner_expr)
 
-            start_event_timestamps = parse_expr(
-                """
-                    if(
-                        has(
-                            {start_event_timestamps} as _start_event_timestamps,
-                            {min_timestamp}
-                        ),
-                        _start_event_timestamps,
-                        []
-                    )
-                """,
-                {
-                    "start_event_timestamps": start_event_timestamps,
-                    # cast this to start of interval as well so we can compare with the timestamps fetched above
-                    "min_timestamp": self.query_date_range.date_to_start_of_interval_hogql(min_timestamp_inner_expr),
-                },
-            )
+            if shared_event_timestamps_alias is not None:
+                # When the source is the hoisted SELECT alias, reference it twice directly instead of
+                # using the inline `expr as _start_event_timestamps` rename. Aliasing a SELECT-level
+                # alias inside an expression is brittle in ClickHouse, and the alias is already a
+                # cheap repeated reference (no recomputation).
+                start_event_timestamps = parse_expr(
+                    "if(has({s}, {min_timestamp}), {s}, [])",
+                    {
+                        "s": ast.Field(chain=["_shared_event_timestamps"]),
+                        "min_timestamp": min_timestamp_expr,
+                    },
+                )
+            else:
+                start_event_timestamps = parse_expr(
+                    """
+                        if(
+                            has(
+                                {start_event_timestamps} as _start_event_timestamps,
+                                {min_timestamp}
+                            ),
+                            _start_event_timestamps,
+                            []
+                        )
+                    """,
+                    {
+                        "start_event_timestamps": start_event_timestamps,
+                        # cast this to start of interval as well so we can compare with the timestamps fetched above
+                        "min_timestamp": min_timestamp_expr,
+                    },
+                )
             # interval must be same as first interval of in which start event happened
         is_valid_start_interval = self._is_valid_start_interval_expr("_start_event_timestamps")
         retention_value_expr: ast.Expr | None

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -338,7 +338,18 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         event_filters = self._event_filters()
 
-        start_event_timestamps = parse_expr(
+        # When the start and return entities are identical, the start-side and return-side
+        # `groupUniqArrayIf` aggregates are byte-identical over the same filter. Hoist them
+        # to a single alias so ClickHouse aggregates the events table once instead of twice.
+        # Excludes the property-aggregation path (computes 3-tuples, not bare timestamps) and
+        # the minimum_occurrences>1 path (return side needs groupArrayIf with duplicates).
+        can_share_event_aggregate = (
+            self._start_and_return_entities_are_same()
+            and not self.has_property_aggregation
+            and self.minimum_occurrences == 1
+        )
+
+        base_event_timestamps_expr = parse_expr(
             """
             arraySort(
                 groupUniqArrayIf(
@@ -354,6 +365,16 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 "filter_timestamp": self.events_timestamp_filter(),
             },
         )
+
+        shared_event_timestamps_alias: ast.Alias | None = None
+        if can_share_event_aggregate:
+            shared_event_timestamps_alias = ast.Alias(
+                alias="_shared_event_timestamps",
+                expr=base_event_timestamps_expr,
+            )
+            start_event_timestamps: ast.Expr = ast.Field(chain=["_shared_event_timestamps"])
+        else:
+            start_event_timestamps = base_event_timestamps_expr
 
         minimum_occurrences_aliases = self._get_minimum_occurrences_aliases(
             minimum_occurrences=self.minimum_occurrences,
@@ -394,6 +415,10 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             # Reference the pre-computed aliases rather than inlining the expressions again
             return_event_timestamps = parse_expr("arrayMap(x -> x.1, _return_event_data)")
             return_event_values = (start_event_data, return_event_data)
+        elif shared_event_timestamps_alias is not None:
+            # Reuse the hoisted aggregate computed for the start side.
+            return_event_timestamps = ast.Field(chain=["_shared_event_timestamps"])
+            return_event_values = None
         else:
             return_event_timestamps = self._get_return_event_timestamps_expr(
                 minimum_occurrences=self.minimum_occurrences,
@@ -429,13 +454,21 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         select_fields: list[ast.Expr] = [
             ast.Alias(alias="actor_id", expr=ast.Field(chain=["events", self.aggregation_target_events_column])),
-            # start events between date_from and date_to (represented by start of interval)
-            # when TARGET_FIRST_TIME, also adds filter for start (target) event performed for first time
-            ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps),
-            # get all intervals between date_from and date_to (represented by start of interval)
-            self._date_range_alias(),
-            *minimum_occurrences_aliases,
         ]
+        # When start and return share an aggregate, the alias must precede any column that
+        # references `_shared_event_timestamps` (start_event_timestamps below).
+        if shared_event_timestamps_alias is not None:
+            select_fields.append(shared_event_timestamps_alias)
+        select_fields.extend(
+            [
+                # start events between date_from and date_to (represented by start of interval)
+                # when TARGET_FIRST_TIME, also adds filter for start (target) event performed for first time
+                ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps),
+                # get all intervals between date_from and date_to (represented by start of interval)
+                self._date_range_alias(),
+                *minimum_occurrences_aliases,
+            ]
+        )
 
         # When using aggregation mode, add the grouped data arrays as named aliases BEFORE columns that reference them.
         # This ensures ClickHouse uses the pre-aggregated arrays rather than re-executing the groupArrayIf inside

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
 RETENTION_FIXED_INTERVAL_BASE_QUERY_DWH_VARIANT_FLAG = "retention-fixed-interval-base-query-dwh-variant"
 
+SHARED_EVENT_TIMESTAMPS_ALIAS = "_shared_event_timestamps"
+
 
 def retention_fixed_interval_base_query_use_dwh_variant(team: "Team") -> bool:
     return bool(
@@ -341,14 +343,9 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         # When the start and return entities are identical, the start-side and return-side
         # `groupUniqArrayIf` aggregates are byte-identical over the same filter. Hoist them
         # to a single alias so ClickHouse aggregates the events table once instead of twice.
-        # Excludes the property-aggregation path (computes 3-tuples, not bare timestamps) and
-        # the minimum_occurrences>1 path (return side needs groupArrayIf with duplicates).
-        can_share_event_aggregate = (
-            self._start_and_return_entities_are_same()
-            and not self.has_property_aggregation
-            and self.minimum_occurrences == 1
-        )
-
+        # Excludes the property-aggregation path (return side emits 3-tuples, not bare
+        # timestamps) and minimum_occurrences>1 (return side filters
+        # return_event_counts_by_interval, not the same aggregate as the start side).
         base_event_timestamps_expr = parse_expr(
             """
             arraySort(
@@ -367,12 +364,18 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         )
 
         shared_event_timestamps_alias: ast.Alias | None = None
-        if can_share_event_aggregate:
+        shared_event_timestamps_ref: ast.Field | None = None
+        if (
+            self._start_and_return_entities_are_same()
+            and not self.has_property_aggregation
+            and self.minimum_occurrences == 1
+        ):
             shared_event_timestamps_alias = ast.Alias(
-                alias="_shared_event_timestamps",
+                alias=SHARED_EVENT_TIMESTAMPS_ALIAS,
                 expr=base_event_timestamps_expr,
             )
-            start_event_timestamps: ast.Expr = ast.Field(chain=["_shared_event_timestamps"])
+            shared_event_timestamps_ref = ast.Field(chain=[SHARED_EVENT_TIMESTAMPS_ALIAS])
+            start_event_timestamps: ast.Expr = shared_event_timestamps_ref
         else:
             start_event_timestamps = base_event_timestamps_expr
 
@@ -415,9 +418,8 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             # Reference the pre-computed aliases rather than inlining the expressions again
             return_event_timestamps = parse_expr("arrayMap(x -> x.1, _return_event_data)")
             return_event_values = (start_event_data, return_event_data)
-        elif shared_event_timestamps_alias is not None:
-            # Reuse the hoisted aggregate computed for the start side.
-            return_event_timestamps = ast.Field(chain=["_shared_event_timestamps"])
+        elif shared_event_timestamps_ref is not None:
+            return_event_timestamps = shared_event_timestamps_ref
             return_event_values = None
         else:
             return_event_timestamps = self._get_return_event_timestamps_expr(
@@ -431,7 +433,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             min_timestamp_inner_expr = self.get_first_time_anchor_expr(self.start_event)
             min_timestamp_expr = self.query_date_range.date_to_start_of_interval_hogql(min_timestamp_inner_expr)
 
-            if shared_event_timestamps_alias is not None:
+            if shared_event_timestamps_ref is not None:
                 # When the source is the hoisted SELECT alias, reference it twice directly instead of
                 # using the inline `expr as _start_event_timestamps` rename. Aliasing a SELECT-level
                 # alias inside an expression is brittle in ClickHouse, and the alias is already a
@@ -439,7 +441,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 start_event_timestamps = parse_expr(
                     "if(has({s}, {min_timestamp}), {s}, [])",
                     {
-                        "s": ast.Field(chain=["_shared_event_timestamps"]),
+                        "s": shared_event_timestamps_ref,
                         "min_timestamp": min_timestamp_expr,
                     },
                 )
@@ -457,32 +459,24 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                     """,
                     {
                         "start_event_timestamps": start_event_timestamps,
-                        # cast this to start of interval as well so we can compare with the timestamps fetched above
                         "min_timestamp": min_timestamp_expr,
                     },
                 )
-            # interval must be same as first interval of in which start event happened
         is_valid_start_interval = self._is_valid_start_interval_expr("_start_event_timestamps")
         retention_value_expr: ast.Expr | None
         intervals_from_base_expr, retention_value_expr = self._get_intervals_from_base_exprs()
 
+        # `shared_event_timestamps_alias` (when set) must precede the columns that reference it.
         select_fields: list[ast.Expr] = [
             ast.Alias(alias="actor_id", expr=ast.Field(chain=["events", self.aggregation_target_events_column])),
+            *([shared_event_timestamps_alias] if shared_event_timestamps_alias is not None else []),
+            # start events between date_from and date_to (represented by start of interval)
+            # when TARGET_FIRST_TIME, also adds filter for start (target) event performed for first time
+            ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps),
+            # get all intervals between date_from and date_to (represented by start of interval)
+            self._date_range_alias(),
+            *minimum_occurrences_aliases,
         ]
-        # When start and return share an aggregate, the alias must precede any column that
-        # references `_shared_event_timestamps` (start_event_timestamps below).
-        if shared_event_timestamps_alias is not None:
-            select_fields.append(shared_event_timestamps_alias)
-        select_fields.extend(
-            [
-                # start events between date_from and date_to (represented by start of interval)
-                # when TARGET_FIRST_TIME, also adds filter for start (target) event performed for first time
-                ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps),
-                # get all intervals between date_from and date_to (represented by start of interval)
-                self._date_range_alias(),
-                *minimum_occurrences_aliases,
-            ]
-        )
 
         # When using aggregation mode, add the grouped data arrays as named aliases BEFORE columns that reference them.
         # This ensures ClickHouse uses the pre-aggregated arrays rather than re-executing the groupArrayIf inside

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -6,9 +6,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT events.`$group_0` AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0), toIntervalWeek(x)), range(0, 7)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -49,9 +50,10 @@
             actor_activity.actor_id AS key
      FROM
        (SELECT events.`$group_0` AS actor_id,
-               arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS start_event_timestamps,
+               arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS _shared_event_timestamps,
+               _shared_event_timestamps AS start_event_timestamps,
                arrayMap(x -> plus(toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0), toIntervalWeek(x)), range(0, 7)) AS date_range,
-               arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps,
+               _shared_event_timestamps AS return_event_timestamps,
                arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
                arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
         FROM events
@@ -82,9 +84,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT events.`$group_1` AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0), toIntervalWeek(x)), range(0, 7)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -114,9 +117,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT events.`$group_0` AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0), toIntervalWeek(x)), range(0, 7)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -157,9 +161,10 @@
             actor_activity.actor_id AS key
      FROM
        (SELECT events.`$group_0` AS actor_id,
-               arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS start_event_timestamps,
+               arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS _shared_event_timestamps,
+               _shared_event_timestamps AS start_event_timestamps,
                arrayMap(x -> plus(toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0), toIntervalWeek(x)), range(0, 7)) AS date_range,
-               arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps,
+               _shared_event_timestamps AS return_event_timestamps,
                arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
                arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
         FROM events
@@ -190,9 +195,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT events.`$group_1` AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0), toIntervalWeek(x)), range(0, 7)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -222,9 +228,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 11)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 3), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -311,9 +318,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 11)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 3), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -400,9 +408,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 11)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 11), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -448,9 +457,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfMonth(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC')), toIntervalMonth(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfMonth(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC')), toIntervalMonth(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC')), toIntervalMonth(1)), toIntervalMonth(x)), range(0, 11)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfMonth(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC')), toIntervalMonth(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 11), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -751,9 +761,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 11)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 11), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -790,9 +801,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'US/Pacific')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'US/Pacific'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'US/Pacific')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'US/Pacific'), toDateTime64('explicit_redacted_timestamp', 6, 'US/Pacific')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'US/Pacific')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'US/Pacific'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'US/Pacific')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'US/Pacific'), toDateTime64('explicit_redacted_timestamp', 6, 'US/Pacific')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'US/Pacific')), toIntervalDay(1)), toIntervalDay(x)), range(0, 11)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'US/Pacific')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'US/Pacific'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'US/Pacific')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'US/Pacific'), toDateTime64('explicit_redacted_timestamp', 6, 'US/Pacific')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 11), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -829,9 +841,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0), toIntervalWeek(x)), range(0, 7)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
@@ -868,9 +881,10 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 3), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-08 00:00:00', 'UTC')), 3)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS start_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 3), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-08 00:00:00', 'UTC')), 3)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _shared_event_timestamps,
+            _shared_event_timestamps AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfWeek(assumeNotNull(toDateTime('2020-06-08 00:00:00', 'UTC')), 3), toIntervalWeek(x)), range(0, 7)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 3), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(toDateTime('2020-06-08 00:00:00', 'UTC')), 3)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            _shared_event_timestamps AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events


### PR DESCRIPTION
## Problem

Fixed-interval retention queries were aggregating the events table twice when the start and return entities are the same. The `start_event_timestamps` and `return_event_timestamps` columns each held a byte-identical `groupUniqArrayIf(...)` over the same filter. ClickHouse's analyzer CSEs these reliably for simple shapes but stops doing so once a `GROUP BY` with breakdown cardinality multiplies the per-group aggregate state — that's where the duplication starts to cost real memory and wall time.

This is the dominant production shape: telemetry from the past 7 days shows ~94% of executed retention queries use the same event or action for both target and return, with no property aggregation and `minimum_occurrences = 1`. Main-query p50 sits at ~1.5s and p99 at ~7.8s today.

## Changes

In `RetentionFixedIntervalBaseQueryBuilder.build_base_query_legacy`, when the entities are identical and we're not on the property-aggregation or `minimum_occurrences > 1` path, hoist a single `_shared_event_timestamps` alias and reference it from both `start_event_timestamps` and `return_event_timestamps`. For first-time / first-ever retention the wrap on the start side still applies; the return side reuses the unwrapped shared aggregate (matching today's semantic that return events aren't filtered by first-occurrence).

Excluded paths, all intentional:

- Property aggregation — computes 3-tuples, distinct optimization opportunity
- `minimum_occurrences > 1` — return side uses `groupArrayIf` with duplicates, not `groupUniqArrayIf`
- DWH variant (`build_base_query_dwh`) — separate structure with UNION ALL of sub-selects

## How did you test this code?

### Production benchmark — team 2, alternating runs against prod-us via metabase

Captured production query: 95s, 8-day range, **`properties_group_custom['enabled']` breakdown**, 11 negative `mat_*` filters, same-entity `$pageview`. The breakdown is the load-bearing shape characteristic.

|              | BEFORE      | AFTER       | Δ                |
|--------------|------------:|------------:|-----------------:|
| n            | 6           | 6           |                  |
| min ms       | 5583        | 5713        | ~equal           |
| median ms    | 6044        | 5817        | −3.8%            |
| mean ms      | 6256        | 5908        | −5.6%            |
| **avg memory** | **13.21 GiB** | **11.74 GiB** | **−11% (−1.47 GiB)** |
| avg read     | 5.91 TiB    | 5.91 TiB    | identical        |

Memory is the headline result and the most trustworthy: same query plan → same hash-table size, so it's reproducible across runs. The wall-time delta is real-directional but n=6 isn't enough to anchor a tight percentage. Runs hit warm cache (5–8s vs 88–95s in prod), so absolute numbers don't reflect cold-start cost — the delta is what matters.

### Synthetic range sweep — team 2, no breakdown

|              | 1 day | 7 day | 30 day | 31d first-occurrence |
|--------------|------:|------:|-------:|---------------------:|
| n per form   | 8     | 15    | 8      | 9                    |
| median Δ     | −4.5% | −7.7% | **−24.1%** | −2.1%            |
| mean Δ       | −7%   | +3%   | **−52.7%** | −11.4%           |
| memory       | ~equal | ~equal | **−23%** | ~equal          |
| read bytes   | identical | identical | identical | identical    |

Effect scales with date range and per-actor state cost — clear at 30-day, marginal at 1-day.

### Where the PR is a no-op

Team 49640 (31s production, 40-event `or(...)` filter, no breakdown, 8-day): no measurable difference across 6 runs/form. ClickHouse's analyzer fully CSEs simple same-entity aggregates without help — the optimization only becomes load-bearing once breakdown cardinality or long-range per-actor state multiplies the aggregate cost. PR #60384 covers the duplicate-WHERE-predicate cost on this exact shape.

### Where it's near-OOM insurance

Team 70894 (122-day "any event" retention, 32 GiB / 26s in production): couldn't directly benchmark — both BEFORE and AFTER hit the Metabase session's 37 GiB cap. Indirect evidence (the ~11% memory drop on team 2's breakdown case) suggests this is the difference between fitting and OOMing at the next scale bump.

### Methodology / reproducibility

- Pulled production SQL from `system.query_log`, built BEFORE (as-is) and AFTER (hoisted alias) variants
- Verified byte-identical output (modulo ≤1 row drift from live ingestion)
- 6–15 alternating runs per form with `use_query_cache=0`, unique markers
- Pulled `query_duration_ms`, `memory_usage`, `read_bytes` from `system.query_log`

### Caveats

- Warm-cache numbers are 5–10× faster than cold production. Relative deltas hold; absolute numbers don't reflect cold-start cost.
- Small n (6–15 per form): memory and read deltas are reproducible, wall-time deltas are directional with noticeable run-to-run variance.
- Cross-team validation of the breakdown effect was only confirmed on team 2.
- Snapshot regeneration should be reviewed before merge: `hogli test posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py --snapshot-update`. Same-entity queries swap to the shared-alias form; mixed-entity queries are byte-identical.

## Publish to changelog?

no

## 🤖 Agent context

Author: Claude Code (Opus 4.7) at the user's direction.

Investigation flow:
1. Read the retention runner and base-query builders to map the current strategy and where the work happens.
2. Queried the project's own analytics via the PostHog MCP to characterize executed retention queries: distribution of period / retention type / breakdown / sampling / same-entity, and p50/p90/p99 latency for the main query, actor drill-down, and events drill-down.
3. Ranked improvement opportunities by frequency × cost. Same-entity aggregate sharing topped the list because it covers ~94% of executions with a localized change.
4. Benchmarked against captured production queries (see above) to validate per-shape impact.

Rejected (for this PR) alternatives:
- Drill-down rework (actor / events queries currently re-execute the full base query) — bigger latency cut per click but larger blast radius; worth a follow-up PR.
- Pushing the `start_interval_index_filter` from HAVING into WHERE — clean win but only for drill-downs.
- First-ever-occurrence lookback cap — rare in production (<1%) and needs product input on the cap value.

Findings & methodology are in `.planning/pr-60285-share-same-entity-aggregate-benchmark.md` on a parallel branch (not part of this PR).
