### PR TITLE
feat(clickhouse): materialize lc_source in query_log_archive

### DIFF
--- a/posthog/clickhouse/migrations/0267_add_lc_source_to_query_log_archive.py
+++ b/posthog/clickhouse/migrations/0267_add_lc_source_to_query_log_archive.py
@@ -1,0 +1,55 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.query_log_archive import (
+    DIST_QUERY_LOG_ARCHIVE_MV,
+    MV_SELECT_SQL,
+    QUERY_LOG_ARCHIVE_ADD_SOURCE_COLUMN_SQL,
+    QUERY_LOG_ARCHIVE_DATA_TABLE,
+    SHARDED_QUERY_LOG_ARCHIVE_MV,
+    SHARDED_QUERY_LOG_ARCHIVE_TABLE,
+    SHARDED_QUERY_LOG_ARCHIVE_WRITABLE_TABLE,
+    SHARDED_WRITABLE_QUERY_LOG_ARCHIVE_TABLE_SQL,
+)
+
+operations = [
+    # Add column to the sharded data table
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_ADD_SOURCE_COLUMN_SQL(SHARDED_QUERY_LOG_ARCHIVE_TABLE),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    # Recreate writable distributed table (creates with new schema if not exists)
+    run_sql_with_exceptions(
+        SHARDED_WRITABLE_QUERY_LOG_ARCHIVE_TABLE_SQL(),
+        node_roles=[NodeRole.ENDPOINTS],
+    ),
+    # Add column to the writable distributed table (if it already existed)
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_ADD_SOURCE_COLUMN_SQL(SHARDED_QUERY_LOG_ARCHIVE_WRITABLE_TABLE),
+        node_roles=[NodeRole.ENDPOINTS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # Add column to the distributed read table
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_ADD_SOURCE_COLUMN_SQL(QUERY_LOG_ARCHIVE_DATA_TABLE),
+        node_roles=[NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # Update the MV on data nodes
+    run_sql_with_exceptions(
+        f"ALTER TABLE {SHARDED_QUERY_LOG_ARCHIVE_MV} MODIFY QUERY\n{MV_SELECT_SQL}",
+        node_roles=[NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # Update the MV on endpoints nodes
+    run_sql_with_exceptions(
+        f"ALTER TABLE {DIST_QUERY_LOG_ARCHIVE_MV} MODIFY QUERY\n{MV_SELECT_SQL}",
+        node_roles=[NodeRole.ENDPOINTS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0266_recreate_session_replay_features
+0267_add_lc_source_to_query_log_archive

--- a/posthog/clickhouse/query_log_archive.py
+++ b/posthog/clickhouse/query_log_archive.py
@@ -189,6 +189,7 @@ CREATE TABLE IF NOT EXISTS {table_name} (
     lc_kind LowCardinality(String),
     lc_id String,
     lc_route_id String,
+    lc_source LowCardinality(String),
 
     lc_access_method LowCardinality(String),
     lc_api_key_label String,
@@ -314,6 +315,7 @@ SELECT
     JSONExtractString(log_comment, 'kind') as lc_kind,
     JSONExtractString(log_comment, 'id') as lc_id,
     JSONExtractString(log_comment, 'route_id') as lc_route_id,
+    JSONExtractString(log_comment, 'source') as lc_source,
 
     JSONExtractString(log_comment, 'access_method') as lc_access_method,
     JSONExtractString(log_comment, 'api_key_label') as lc_api_key_label,
@@ -482,6 +484,14 @@ def QUERY_LOG_ARCHIVE_ADD_MODIFIERS_COLUMN_SQL(table=QUERY_LOG_ARCHIVE_DATA_TABL
     return f"""
     ALTER TABLE {table}
         ADD COLUMN IF NOT EXISTS lc_modifiers String AFTER lc_dagster__owner
+    """
+
+
+# V11 - adding lc_source (request provenance: web, api, mcp, posthog_ai, posthog_code, ...)
+def QUERY_LOG_ARCHIVE_ADD_SOURCE_COLUMN_SQL(table=QUERY_LOG_ARCHIVE_DATA_TABLE):
+    return f"""
+    ALTER TABLE {table}
+        ADD COLUMN IF NOT EXISTS lc_source LowCardinality(String) AFTER lc_route_id
     """
 
 

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -3819,6 +3819,7 @@
       lc_kind LowCardinality(String),
       lc_id String,
       lc_route_id String,
+      lc_source LowCardinality(String),
   
       lc_access_method LowCardinality(String),
       lc_api_key_label String,
@@ -3940,6 +3941,7 @@
       JSONExtractString(log_comment, 'kind') as lc_kind,
       JSONExtractString(log_comment, 'id') as lc_id,
       JSONExtractString(log_comment, 'route_id') as lc_route_id,
+      JSONExtractString(log_comment, 'source') as lc_source,
   
       JSONExtractString(log_comment, 'access_method') as lc_access_method,
       JSONExtractString(log_comment, 'api_key_label') as lc_api_key_label,
@@ -8428,6 +8430,7 @@
       lc_kind LowCardinality(String),
       lc_id String,
       lc_route_id String,
+      lc_source LowCardinality(String),
   
       lc_access_method LowCardinality(String),
       lc_api_key_label String,


### PR DESCRIPTION
## Problem

When analyzing ClickHouse query performance from `query_log_archive`, there is no typed column for a query's **request provenance**. The `source` tag (`web`, `api`, `mcp`, `posthog_ai`, `posthog_code`, `terraform`, `wizard`, ...) already exists in `QueryTags` and is written into `log_comment`, but the archive never materialized it, so attributing queries by origin (notably AI/agent traffic via the assistant and the MCP server) required brittle `JSONExtract(log_comment, 'source')` parsing and was not available on the typed schema.

## Changes

- Add an `lc_source LowCardinality(String)` column to `query_log_archive` (the sharded data table, the writable distributed table, and the distributed read table).
- Extract it in the feeding materialized view: `JSONExtractString(log_comment, 'source') as lc_source`.
- Migration `0267_add_lc_source_to_query_log_archive`, mirroring the existing add-column pattern (`0208`): `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` across the table set, then `MODIFY QUERY` on the MVs on both DATA and ENDPOINTS nodes.

The tag is already populated upstream, so this is a pure materialization: forward-only (existing rows keep the empty default; new rows get the value). No `QueryTags` / Python tagging changes.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run locally:

- `python -m pytest posthog/clickhouse/test/test_schema.py --snapshot-update` — 271 passed, 3 snapshots updated (the two table CREATEs and the MV `SELECT`), diff is exactly the three `lc_source` lines.
- `ruff check` / `ruff format --check` clean; pre-commit `ty check` passed.
- Confirmed `log_comment.source` is populated in production US `system.query_log` (values `api`, `web`, `mcp`, plus empty for background work) before materializing it.

I did not apply the migration to a cluster.

## Publish to changelog?

no

## Docs update

n/a (internal observability schema).

## 🤖 Agent context

- Authored with Claude Code (Opus 4.7), while building a query-performance analysis skill and looking for a reliable way to identify AI-written queries in `query_log_archive`.
- Decision: `lc_product`/`lc_feature` already exist and partly identify AI traffic, but the dedicated `log_comment.source` tag (`EventSource` enum, including `mcp` / `posthog_ai` / `posthog_code`) is the cleaner provenance signal. `ai_query_source` was considered and rejected, it records the LLM-analytics events-table resolver choice, not authorship.
- Scope kept minimal: materialize the existing tag only; no new tag and no changes to where tags are set. The MCP metadata fields (`mcp_client_name`, etc.) were left unmaterialized for now.
- Agent-authored, human-reviewed: please review before merging; do not self-merge. If `max_migration.txt` has advanced past `0266` on master, this needs a rebase + renumber.
