### PR TITLE
fix(mcp): keep mode for a session id

### DIFF
--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -41,6 +41,7 @@ function buildBaseProperties(
               }
             : {}),
         mcp_runtime: 'hono',
+        mcp_vendor_client: props.mcpVendorClient,
     }
     return { properties, groups }
 }

--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -1,19 +1,19 @@
 import { MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { getPostHogClient } from '@/lib/posthog'
 import { buildMCPAnalyticsGroups, buildMCPContextProperties, type MCPAnalyticsContext } from '@/lib/posthog/analytics'
-import type { RequestProperties } from '@/lib/request-properties'
 
+import { buildMCPSessionAnalyticsProperties } from './mcp-context'
 import type { ResolvedState } from './request-state-resolver'
 
 function buildBaseProperties(
     state: ResolvedState,
-    props: RequestProperties,
     analyticsContext: MCPAnalyticsContext | undefined
 ): {
     properties: Record<string, unknown>
     groups: Record<string, string>
 } {
     const groups = analyticsContext ? buildMCPAnalyticsGroups(analyticsContext) : {}
+    const requestContext = state.requestContext
 
     const properties: Record<string, unknown> = {
         $ai_product: 'mcp',
@@ -21,16 +21,16 @@ function buildBaseProperties(
         $mcp_server_name: MCP_SERVER_NAME,
         $mcp_server_version: MCP_SERVER_VERSION,
         $mcp_version: state.version,
-        $mcp_client_name: props.mcpClientName,
-        $mcp_client_version: props.mcpClientVersion,
-        $mcp_client_user_agent: props.clientUserAgent,
-        $mcp_protocol_version: props.mcpProtocolVersion,
-        $mcp_transport: props.transport,
-        $mcp_session_id: props.mcpSessionId,
-        $mcp_conversation_id: props.mcpConversationId,
-        $mcp_consumer: props.mcpConsumer,
-        $mcp_mode: props.mode,
-        $mcp_region: props.region,
+        $mcp_client_name: requestContext.mcpClientName,
+        $mcp_client_version: requestContext.mcpClientVersion,
+        $mcp_client_user_agent: requestContext.clientUserAgent,
+        $mcp_protocol_version: requestContext.mcpProtocolVersion,
+        $mcp_transport: requestContext.transport,
+        $mcp_session_id: requestContext.mcpSessionId,
+        $mcp_conversation_id: requestContext.mcpConversationId,
+        $mcp_consumer: requestContext.mcpConsumer,
+        $mcp_mode: requestContext.mode,
+        $mcp_region: requestContext.region,
         ...(analyticsContext
             ? {
                   $mcp_organization_id: analyticsContext.organizationId,
@@ -41,18 +41,24 @@ function buildBaseProperties(
               }
             : {}),
         mcp_runtime: 'hono',
-        mcp_vendor_client: props.mcpVendorClient,
+        mcp_vendor_client: requestContext.mcpVendorClient,
+        ...buildMCPSessionAnalyticsProperties(state.sessionContext),
     }
     return { properties, groups }
 }
 
-export async function trackInitEvent(props: RequestProperties, state: ResolvedState): Promise<void> {
+export async function trackInitEvent(state: ResolvedState): Promise<void> {
     try {
         const analyticsContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
-        const initDurationMs = props.requestStartTime ? Date.now() - props.requestStartTime : undefined
-        const sessionUuid = props.sessionId ? await state.reqCtx.getSessionUuid(props.sessionId) : undefined
+        const requestContext = state.requestContext
+        const initDurationMs = requestContext.requestStartTime
+            ? Date.now() - requestContext.requestStartTime
+            : undefined
+        const sessionUuid = requestContext.sessionId
+            ? await state.reqCtx.getSessionUuid(requestContext.sessionId)
+            : undefined
 
-        const { properties, groups } = buildBaseProperties(state, props, analyticsContext)
+        const { properties, groups } = buildBaseProperties(state, analyticsContext)
 
         getPostHogClient().capture({
             distinctId: state.distinctId,
@@ -63,10 +69,10 @@ export async function trackInitEvent(props: RequestProperties, state: ResolvedSt
                 $mcp_duration_ms: initDurationMs ?? 0,
                 $mcp_is_error: false,
                 tool_count: state.allTools.length,
-                has_organization_id: !!props.organizationId,
-                has_project_id: !!props.projectId,
-                read_only: !!props.readOnly,
-                via_sse_redirect: !!props.viaSseRedirect,
+                has_organization_id: !!requestContext.organizationId,
+                has_project_id: !!requestContext.projectId,
+                read_only: !!requestContext.readOnly,
+                via_sse_redirect: !!requestContext.viaSseRedirect,
                 ...(sessionUuid ? { $session_id: sessionUuid } : {}),
             },
         })
@@ -79,15 +85,17 @@ export async function trackToolCall(
     toolName: string,
     durationMs: number,
     isError: boolean,
-    props: RequestProperties,
     state: ResolvedState,
     extraProperties?: Record<string, unknown>
 ): Promise<void> {
     try {
         const analyticsContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
-        const sessionUuid = props.sessionId ? await state.reqCtx.getSessionUuid(props.sessionId) : undefined
+        const requestContext = state.requestContext
+        const sessionUuid = requestContext.sessionId
+            ? await state.reqCtx.getSessionUuid(requestContext.sessionId)
+            : undefined
 
-        const { properties, groups } = buildBaseProperties(state, props, analyticsContext)
+        const { properties, groups } = buildBaseProperties(state, analyticsContext)
 
         getPostHogClient().capture({
             distinctId: state.distinctId,

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -188,9 +188,9 @@ class McpDispatcher {
                 case Method.Initialize:
                     return jsonRpcResult(id, await this.handleInitialize(params, props, state!))
                 case Method.ToolsList:
-                    return jsonRpcResult(id, await this.toolExecutor.handleToolsList(state!, props))
+                    return jsonRpcResult(id, await this.toolExecutor.handleToolsList(state!))
                 case Method.ToolsCall:
-                    return jsonRpcResult(id, await this.toolExecutor.handleToolCall(params, props, state!))
+                    return jsonRpcResult(id, await this.toolExecutor.handleToolCall(params, state!))
                 case Method.ResourcesList:
                     return jsonRpcResult(id, this.resourceCatalog.getResourcesList())
                 case Method.ResourcesRead:

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -227,7 +227,7 @@ class McpDispatcher {
             initDurationSeconds.observe(props.requestStartTime ? (Date.now() - props.requestStartTime) / 1000 : 0)
             initTotal.inc({ status: 'success' })
 
-            void trackInitEvent(props, state)
+            void trackInitEvent(state)
 
             return {
                 protocolVersion,

--- a/services/mcp/src/hono/instructions.ts
+++ b/services/mcp/src/hono/instructions.ts
@@ -1,3 +1,5 @@
+import type { Tool as McpTool } from '@modelcontextprotocol/sdk/types.js'
+
 import { hasScope } from '@/lib/api'
 import type { QueryToolInfo } from '@/lib/instructions'
 import { type InstructionsContext, InstructionsFormatter } from '@/lib/instructions-formatter'
@@ -5,8 +7,6 @@ import type { RequestProperties } from '@/lib/request-properties'
 import { formatPrompt } from '@/lib/utils'
 import EXECUTE_SQL_PROMPT from '@/templates/execute-sql-prompt.md'
 import { getToolDefinition } from '@/tools/toolDefinitions'
-
-import type { Tool as McpTool } from '@modelcontextprotocol/sdk/types.js'
 
 import type { ResolvedState } from './request-state-resolver'
 
@@ -69,7 +69,7 @@ export class InstructionsBuilder {
         }
     }
 
-    buildExecToolEntry(state: ResolvedState, _props: RequestProperties): McpTool {
+    buildExecToolEntry(state: ResolvedState): McpTool {
         const supportsInstructions = state.clientProfile.capabilities.supportsInstructions
         const ctx = this.buildContext(state)
         const commandReference = this.formatter.buildExecCommandReference(ctx, {

--- a/services/mcp/src/hono/mcp-context.ts
+++ b/services/mcp/src/hono/mcp-context.ts
@@ -1,30 +1,34 @@
 import type { RequestProperties } from '@/lib/request-properties'
 import type { McpMode } from '@/lib/utils'
 
-export type MCPClientContext = Pick<
+export interface MCPClientContext extends Pick<
     RequestProperties,
     'mcpClientName' | 'mcpClientVersion' | 'mcpProtocolVersion' | 'mcpConsumer' | 'mcpVendorClient'
->
+> {}
 
-export type MCPRequestContext = MCPClientContext &
-    Pick<
-        RequestProperties,
-        | 'sessionId'
-        | 'organizationId'
-        | 'projectId'
-        | 'readOnly'
-        | 'viaSseRedirect'
-        | 'requestStartTime'
-        | 'clientUserAgent'
-        | 'transport'
-        | 'mcpSessionId'
-        | 'mcpConversationId'
-        | 'region'
-    > & {
-        mode?: McpMode | undefined
-    }
+export interface MCPRequestContext
+    extends
+        MCPClientContext,
+        Pick<
+            RequestProperties,
+            | 'sessionId'
+            | 'organizationId'
+            | 'projectId'
+            | 'readOnly'
+            | 'viaSseRedirect'
+            | 'requestStartTime'
+            | 'clientUserAgent'
+            | 'transport'
+            | 'mcpSessionId'
+            | 'mcpConversationId'
+            | 'region'
+        > {
+    mode?: McpMode | undefined
+}
 
-export type MCPSessionContext = MCPClientContext
+// Identical shape to MCPClientContext but tracked separately to mark values
+// pinned to the MCP session id rather than the live request.
+export interface MCPSessionContext extends MCPClientContext {}
 
 export function buildMCPRequestContext(props: RequestProperties): MCPRequestContext {
     return {

--- a/services/mcp/src/hono/mcp-context.ts
+++ b/services/mcp/src/hono/mcp-context.ts
@@ -4,9 +4,7 @@ import type { McpMode } from '@/lib/utils'
 export type MCPClientContext = Pick<
     RequestProperties,
     'mcpClientName' | 'mcpClientVersion' | 'mcpProtocolVersion' | 'mcpConsumer' | 'mcpVendorClient'
-> & {
-    mode?: McpMode | undefined
-}
+>
 
 export type MCPRequestContext = MCPClientContext &
     Pick<
@@ -22,7 +20,9 @@ export type MCPRequestContext = MCPClientContext &
         | 'mcpSessionId'
         | 'mcpConversationId'
         | 'region'
-    >
+    > & {
+        mode?: McpMode | undefined
+    }
 
 export type MCPSessionContext = MCPClientContext
 
@@ -58,7 +58,6 @@ export function buildMCPSessionAnalyticsProperties(sessionContext: MCPSessionCon
         mcp_session_client_version: sessionContext.mcpClientVersion,
         mcp_session_protocol_version: sessionContext.mcpProtocolVersion,
         mcp_session_consumer: sessionContext.mcpConsumer,
-        mcp_session_mode: sessionContext.mode,
         mcp_session_vendor_client: sessionContext.mcpVendorClient,
     }
 }

--- a/services/mcp/src/hono/mcp-context.ts
+++ b/services/mcp/src/hono/mcp-context.ts
@@ -1,0 +1,71 @@
+import type { RequestProperties } from '@/lib/request-properties'
+import type { McpMode } from '@/lib/utils'
+
+export type MCPClientContext = Pick<
+    RequestProperties,
+    'mcpClientName' | 'mcpClientVersion' | 'mcpProtocolVersion' | 'mcpConsumer' | 'mcpVendorClient'
+> & {
+    mode?: McpMode | undefined
+}
+
+export type MCPRequestContext = MCPClientContext &
+    Pick<
+        RequestProperties,
+        | 'sessionId'
+        | 'organizationId'
+        | 'projectId'
+        | 'readOnly'
+        | 'viaSseRedirect'
+        | 'requestStartTime'
+        | 'clientUserAgent'
+        | 'transport'
+        | 'mcpSessionId'
+        | 'mcpConversationId'
+        | 'region'
+    >
+
+export type MCPSessionContext = MCPClientContext
+
+export function buildMCPRequestContext(props: RequestProperties): MCPRequestContext {
+    return {
+        sessionId: props.sessionId,
+        organizationId: props.organizationId,
+        projectId: props.projectId,
+        readOnly: props.readOnly,
+        viaSseRedirect: props.viaSseRedirect,
+        requestStartTime: props.requestStartTime,
+        clientUserAgent: props.clientUserAgent,
+        mcpClientName: props.mcpClientName,
+        mcpClientVersion: props.mcpClientVersion,
+        mcpProtocolVersion: props.mcpProtocolVersion,
+        transport: props.transport,
+        mcpSessionId: props.mcpSessionId,
+        mcpConversationId: props.mcpConversationId,
+        mcpConsumer: props.mcpConsumer,
+        mode: props.mode,
+        region: props.region,
+        mcpVendorClient: props.mcpVendorClient,
+    }
+}
+
+export function buildMCPSessionAnalyticsProperties(sessionContext: MCPSessionContext | null): Record<string, unknown> {
+    if (!sessionContext) {
+        return {}
+    }
+
+    return {
+        mcp_session_client_name: sessionContext.mcpClientName,
+        mcp_session_client_version: sessionContext.mcpClientVersion,
+        mcp_session_protocol_version: sessionContext.mcpProtocolVersion,
+        mcp_session_consumer: sessionContext.mcpConsumer,
+        mcp_session_mode: sessionContext.mode,
+        mcp_session_vendor_client: sessionContext.mcpVendorClient,
+    }
+}
+
+export function getEffectiveMCPClientContext(
+    requestContext: MCPRequestContext,
+    sessionContext: MCPSessionContext | null
+): MCPClientContext {
+    return sessionContext ?? requestContext
+}

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -1,21 +1,23 @@
 import { ApiClient } from '@/api/client'
 import { MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { wrapError } from '@/lib/errors'
-import { hash } from '@/lib/utils'
+import { getPostHogClient } from '@/lib/posthog'
 import {
     AnalyticsEvent,
     buildMCPAnalyticsGroups,
     buildMCPContextProperties,
     type MCPAnalyticsContext,
 } from '@/lib/posthog/analytics'
-import { getPostHogClient } from '@/lib/posthog'
 import type { RequestProperties } from '@/lib/request-properties'
 import { SessionManager } from '@/lib/SessionManager'
 import { StateManager } from '@/lib/StateManager'
+import { hash } from '@/lib/utils'
 import type { Context, Env, State } from '@/tools/types'
 
 import { RedisCache, type RedisLike } from './cache/RedisCache'
 import { getCustomApiBaseUrl } from './constants'
+
+export const SESSION_CACHE_TTL_SECONDS = 14 * 24 * 60 * 60
 
 export class RequestContext {
     private tokenCacheInstance: RedisCache<State> | undefined
@@ -49,7 +51,12 @@ export class RequestContext {
             throw new Error('Session ID is required to use the session cache')
         }
         if (!this.sessionCacheInstance) {
-            this.sessionCacheInstance = new RedisCache<State>(hash(this.props.mcpSessionId), this.redis, 'session')
+            this.sessionCacheInstance = new RedisCache<State>(
+                hash(this.props.mcpSessionId),
+                this.redis,
+                'session',
+                SESSION_CACHE_TTL_SECONDS
+            )
         }
         return this.sessionCacheInstance
     }

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -36,11 +36,16 @@ export class RequestContext {
     private requestContext: MCPRequestContext
     private sessionContext: MCPSessionContext | null = null
 
-    constructor(redis: RedisLike, env: Env, props: RequestProperties) {
+    constructor(
+        redis: RedisLike,
+        env: Env,
+        props: RequestProperties,
+        requestContext: MCPRequestContext = buildMCPRequestContext(props)
+    ) {
         this.redis = redis
         this.env = env
         this.props = props
-        this.requestContext = buildMCPRequestContext(props)
+        this.requestContext = requestContext
     }
 
     get tokenCache(): RedisCache<State> {

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -16,8 +16,12 @@ import type { Context, Env, State } from '@/tools/types'
 
 import { RedisCache, type RedisLike } from './cache/RedisCache'
 import { getCustomApiBaseUrl } from './constants'
-
-export const SESSION_CACHE_TTL_SECONDS = 14 * 24 * 60 * 60
+import {
+    buildMCPRequestContext,
+    buildMCPSessionAnalyticsProperties,
+    type MCPRequestContext,
+    type MCPSessionContext,
+} from './mcp-context'
 
 export class RequestContext {
     private tokenCacheInstance: RedisCache<State> | undefined
@@ -29,11 +33,14 @@ export class RequestContext {
     private readonly redis: RedisLike
     private readonly env: Env
     private readonly props: RequestProperties
+    private requestContext: MCPRequestContext
+    private sessionContext: MCPSessionContext | null = null
 
     constructor(redis: RedisLike, env: Env, props: RequestProperties) {
         this.redis = redis
         this.env = env
         this.props = props
+        this.requestContext = buildMCPRequestContext(props)
     }
 
     get tokenCache(): RedisCache<State> {
@@ -51,12 +58,7 @@ export class RequestContext {
             throw new Error('Session ID is required to use the session cache')
         }
         if (!this.sessionCacheInstance) {
-            this.sessionCacheInstance = new RedisCache<State>(
-                hash(this.props.mcpSessionId),
-                this.redis,
-                'session',
-                SESSION_CACHE_TTL_SECONDS
-            )
+            this.sessionCacheInstance = new RedisCache<State>(hash(this.props.mcpSessionId), this.redis, 'session')
         }
         return this.sessionCacheInstance
     }
@@ -147,9 +149,14 @@ export class RequestContext {
         const trackEvent: Context['trackEvent'] = async (event, properties = {}) => {
             const analyticsContext = await this.getAnalyticsContextSafe(partialContext)
             const distinctId = await this.getDistinctId()
-            await this.trackEvent(event, properties, analyticsContext, undefined, distinctId, this.props)
+            await this.trackEvent(event, properties, analyticsContext, undefined, distinctId)
         }
         return { ...partialContext, trackEvent }
+    }
+
+    setMcpContexts(requestContext: MCPRequestContext, sessionContext: MCPSessionContext | null): void {
+        this.requestContext = requestContext
+        this.sessionContext = sessionContext
     }
 
     async getAnalyticsContextSafe(context: Pick<Context, 'stateManager'>): Promise<MCPAnalyticsContext | undefined> {
@@ -181,28 +188,31 @@ export class RequestContext {
         }
 
         const distinctId = await this.getDistinctId()
-        await this.trackEvent(event, {}, resolvedContext, previousContext, distinctId, this.props)
+        await this.trackEvent(event, {}, resolvedContext, previousContext, distinctId)
     }
 
-    buildClientProperties(props?: RequestProperties): Record<string, unknown> {
-        const p = props ?? this.props
+    buildClientProperties(
+        requestContext: MCPRequestContext = this.requestContext,
+        sessionContext: MCPSessionContext | null = this.sessionContext
+    ): Record<string, unknown> {
         return {
             $ai_product: 'mcp',
             $mcp_source: MCP_ANALYTICS_SOURCE,
             $mcp_server_name: MCP_SERVER_NAME,
             $mcp_server_version: MCP_SERVER_VERSION,
-            $mcp_client_name: p.mcpClientName,
-            $mcp_client_version: p.mcpClientVersion,
-            $mcp_client_user_agent: p.clientUserAgent,
-            $mcp_protocol_version: p.mcpProtocolVersion,
-            $mcp_transport: p.transport,
-            $mcp_session_id: p.mcpSessionId,
-            $mcp_conversation_id: p.mcpConversationId,
-            $mcp_consumer: p.mcpConsumer,
-            $mcp_mode: p.mode,
-            $mcp_region: p.region,
+            $mcp_client_name: requestContext.mcpClientName,
+            $mcp_client_version: requestContext.mcpClientVersion,
+            $mcp_client_user_agent: requestContext.clientUserAgent,
+            $mcp_protocol_version: requestContext.mcpProtocolVersion,
+            $mcp_transport: requestContext.transport,
+            $mcp_session_id: requestContext.mcpSessionId,
+            $mcp_conversation_id: requestContext.mcpConversationId,
+            $mcp_consumer: requestContext.mcpConsumer,
+            $mcp_mode: requestContext.mode,
+            $mcp_region: requestContext.region,
             mcp_runtime: 'hono',
-            mcp_vendor_client: p.mcpVendorClient,
+            mcp_vendor_client: requestContext.mcpVendorClient,
+            ...buildMCPSessionAnalyticsProperties(sessionContext),
         }
     }
 
@@ -211,12 +221,10 @@ export class RequestContext {
         properties: Record<string, unknown>,
         analyticsContext?: MCPAnalyticsContext,
         previousContext?: MCPAnalyticsContext,
-        distinctId?: string,
-        props?: RequestProperties
+        distinctId?: string
     ): Promise<void> {
         try {
             const resolvedDistinctId = distinctId ?? (await this.getDistinctId())
-            const resolvedProps = props ?? this.props
             const clientName = await this.tokenCache.get('clientName')
             const contextProperties = analyticsContext ? buildMCPContextProperties(analyticsContext) : {}
             const previousContextProperties = previousContext
@@ -229,9 +237,9 @@ export class RequestContext {
                 event,
                 ...(Object.keys(groups).length > 0 ? { groups } : {}),
                 properties: {
-                    ...this.buildClientProperties(resolvedProps),
-                    ...(resolvedProps.sessionId
-                        ? { $session_id: await this.getSessionUuid(resolvedProps.sessionId) }
+                    ...this.buildClientProperties(),
+                    ...(this.requestContext.sessionId
+                        ? { $session_id: await this.getSessionUuid(this.requestContext.sessionId) }
                         : {}),
                     ...(clientName ? { $mcp_oauth_client_name: clientName } : {}),
                     ...contextProperties,

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -202,6 +202,7 @@ export class RequestContext {
             $mcp_mode: p.mode,
             $mcp_region: p.region,
             mcp_runtime: 'hono',
+            mcp_vendor_client: p.mcpVendorClient,
         }
     }
 

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -123,6 +123,7 @@ export class RequestStateResolver {
             clientVersion: mcpClientVersion,
             consumer: props.mcpConsumer,
             oauthClientName,
+            vendorClient: props.mcpVendorClient,
         })
 
         const {

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -4,9 +4,15 @@ import { evaluateFeatureFlags, type FlagGroups } from '@/lib/posthog/flags'
 import type { RequestProperties } from '@/lib/request-properties'
 import type { McpMode } from '@/lib/utils'
 import { getRequiredFeatureFlags } from '@/tools/toolDefinitions'
-import type { Context, Tool, Env, ZodObjectAny } from '@/tools/types'
+import type { Context, Tool, Env, State, ZodObjectAny } from '@/tools/types'
 
 import type { RedisLike } from './cache/RedisCache'
+import {
+    buildMCPRequestContext,
+    getEffectiveMCPClientContext,
+    type MCPRequestContext,
+    type MCPSessionContext,
+} from './mcp-context'
 import { RequestContext } from './request-context'
 import type { ToolCatalog } from './tool-catalog'
 
@@ -20,6 +26,8 @@ export interface ResolvedState {
     toolFeatureFlags: Record<string, boolean> | undefined
     apiKeyScopes: string[]
     clientProfile: MCPClientProfile
+    requestContext: MCPRequestContext
+    sessionContext: MCPSessionContext | null
     allTools: Tool<ZodObjectAny>[]
     distinctId: string
 }
@@ -60,6 +68,10 @@ export class RequestStateResolver {
 
     async resolve(props: RequestProperties): Promise<ResolvedState> {
         const reqCtx = new RequestContext(this.redis, this.env, props)
+        const requestContext = buildMCPRequestContext(props)
+        const sessionContext = await this.resolveSessionContext(reqCtx, requestContext)
+        const clientContext = getEffectiveMCPClientContext(requestContext, sessionContext)
+
         const context = await reqCtx.getContext()
 
         const { features, tools, version: clientVersion, organizationId, projectId, readOnly } = props
@@ -68,14 +80,6 @@ export class RequestStateResolver {
             ...(organizationId ? { orgId: organizationId } : {}),
             ...(projectId ? { projectId } : {}),
         })
-
-        if (props.mcpSessionId) {
-            await reqCtx.sessionCache.setMany({
-                ...(props.mcpClientName ? { mcpClientName: props.mcpClientName } : {}),
-                ...(props.mcpClientVersion ? { mcpClientVersion: props.mcpClientVersion } : {}),
-                ...(props.mcpProtocolVersion ? { mcpProtocolVersion: props.mcpProtocolVersion } : {}),
-            })
-        }
 
         let cachedProjectId = projectId || (await reqCtx.tokenCache.get('projectId'))
         if (!cachedProjectId) {
@@ -101,42 +105,29 @@ export class RequestStateResolver {
 
         const oauthClientName = (await reqCtx.tokenCache.get('clientName')) || undefined
 
-        let mcpClientName = props.mcpClientName
-        let mcpClientVersion = props.mcpClientVersion
-        let mcpProtocolVersion = props.mcpProtocolVersion
-        if (props.mcpSessionId && (!mcpClientName || !mcpClientVersion || !mcpProtocolVersion)) {
-            const [cachedName, cachedVersion, cachedProto] = await Promise.all([
-                mcpClientName ? undefined : reqCtx.sessionCache.get('mcpClientName'),
-                mcpClientVersion ? undefined : reqCtx.sessionCache.get('mcpClientVersion'),
-                mcpProtocolVersion ? undefined : reqCtx.sessionCache.get('mcpProtocolVersion'),
-            ])
-            mcpClientName = mcpClientName || cachedName || undefined
-            mcpClientVersion = mcpClientVersion || cachedVersion || undefined
-            mcpProtocolVersion = mcpProtocolVersion || cachedProto || undefined
-        }
-
-        props.mcpClientName = mcpClientName
-        props.mcpClientVersion = mcpClientVersion
-        props.mcpProtocolVersion = mcpProtocolVersion
         const clientProfile = new MCPClientProfile({
-            clientName: mcpClientName,
-            clientVersion: mcpClientVersion,
-            consumer: props.mcpConsumer,
+            clientName: clientContext.mcpClientName,
+            clientVersion: clientContext.mcpClientVersion,
+            consumer: clientContext.mcpConsumer,
             oauthClientName,
-            vendorClient: props.mcpVendorClient,
+            vendorClient: clientContext.mcpVendorClient,
         })
 
         const {
             mode: resolvedMode,
             useSingleExec,
             version,
-        } = await this.resolveSessionModeAndVersion({
-            reqCtx,
-            props,
+        } = this.resolveSessionModeAndVersion({
+            explicitMode: requestContext.mode,
             clientProfile,
             flagVersion,
             clientVersion,
         })
+        requestContext.mode = resolvedMode
+        if (sessionContext) {
+            sessionContext.mode = resolvedMode
+        }
+        reqCtx.setMcpContexts(requestContext, sessionContext)
         props.mode = resolvedMode
 
         const apiKeyScopes = _apiKey?.scopes ?? []
@@ -170,8 +161,58 @@ export class RequestStateResolver {
             toolFeatureFlags,
             apiKeyScopes,
             clientProfile,
+            requestContext,
+            sessionContext,
             allTools,
             distinctId,
+        }
+    }
+
+    private async resolveSessionContext(
+        reqCtx: RequestContext,
+        requestContext: MCPRequestContext
+    ): Promise<MCPSessionContext | null> {
+        if (!requestContext.mcpSessionId) {
+            return null
+        }
+
+        const [cachedName, cachedVersion, cachedProtocol, cachedConsumer, cachedVendor] = await Promise.all([
+            reqCtx.sessionCache.get('mcpClientName'),
+            reqCtx.sessionCache.get('mcpClientVersion'),
+            reqCtx.sessionCache.get('mcpProtocolVersion'),
+            reqCtx.sessionCache.get('mcpConsumer'),
+            reqCtx.sessionCache.get('mcpVendorClient'),
+        ])
+
+        const cacheUpdates: Partial<
+            Pick<State, 'mcpClientName' | 'mcpClientVersion' | 'mcpProtocolVersion' | 'mcpConsumer' | 'mcpVendorClient'>
+        > = {}
+        if (!cachedName && requestContext.mcpClientName) {
+            cacheUpdates.mcpClientName = requestContext.mcpClientName
+        }
+        if (!cachedVersion && requestContext.mcpClientVersion) {
+            cacheUpdates.mcpClientVersion = requestContext.mcpClientVersion
+        }
+        if (!cachedProtocol && requestContext.mcpProtocolVersion) {
+            cacheUpdates.mcpProtocolVersion = requestContext.mcpProtocolVersion
+        }
+        if (!cachedConsumer && requestContext.mcpConsumer) {
+            cacheUpdates.mcpConsumer = requestContext.mcpConsumer
+        }
+        if (!cachedVendor && requestContext.mcpVendorClient) {
+            cacheUpdates.mcpVendorClient = requestContext.mcpVendorClient
+        }
+
+        if (Object.keys(cacheUpdates).length > 0) {
+            await reqCtx.sessionCache.setMany(cacheUpdates)
+        }
+
+        return {
+            mcpClientName: cachedName || requestContext.mcpClientName || undefined,
+            mcpClientVersion: cachedVersion || requestContext.mcpClientVersion || undefined,
+            mcpProtocolVersion: cachedProtocol || requestContext.mcpProtocolVersion || undefined,
+            mcpConsumer: cachedConsumer || requestContext.mcpConsumer || undefined,
+            mcpVendorClient: cachedVendor || requestContext.mcpVendorClient || undefined,
         }
     }
 
@@ -191,15 +232,13 @@ export class RequestStateResolver {
         }
     }
 
-    private async resolveSessionModeAndVersion(args: {
-        reqCtx: RequestContext
-        props: RequestProperties
+    private resolveSessionModeAndVersion(args: {
+        explicitMode: McpMode | undefined
         clientProfile: MCPClientProfile
         flagVersion: number | undefined
         clientVersion: number | undefined
-    }): Promise<{ mode: McpMode; useSingleExec: boolean; version: number }> {
-        const { reqCtx, props, clientProfile, flagVersion, clientVersion } = args
-        const explicitMode = props.mode
+    }): { mode: McpMode; useSingleExec: boolean; version: number } {
+        const { explicitMode, clientProfile, flagVersion, clientVersion } = args
         const candidate = resolveModeAndVersion({
             mode: explicitMode,
             clientProfile,
@@ -212,23 +251,6 @@ export class RequestStateResolver {
             return { mode: explicitMode, useSingleExec: candidate.useSingleExec, version: candidate.version }
         }
 
-        let resolvedMode = candidateMode
-        if (props.mcpSessionId) {
-            const cachedMode = await reqCtx.sessionCache.get('mcpMode')
-            if (cachedMode) {
-                resolvedMode = cachedMode
-            } else {
-                await reqCtx.sessionCache.set('mcpMode', candidateMode)
-            }
-        }
-
-        const { useSingleExec, version } = resolveModeAndVersion({
-            mode: resolvedMode,
-            clientProfile,
-            flagVersion,
-            clientVersion,
-        })
-
-        return { mode: resolvedMode, useSingleExec, version }
+        return { mode: candidateMode, useSingleExec: candidate.useSingleExec, version: candidate.version }
     }
 }

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -39,7 +39,7 @@ export function resolveModeAndVersion(args: {
     clientProfile: MCPClientProfile
     flagVersion: number | undefined
     clientVersion: number | undefined
-}): { useSingleExec: boolean; version: number } {
+}): { mode: McpMode; useSingleExec: boolean; version: number } {
     const { mode, clientProfile, flagVersion, clientVersion } = args
     const useSingleExec =
         mode === 'cli' ||
@@ -48,12 +48,21 @@ export function resolveModeAndVersion(args: {
                 clientProfile.isPostHogCodeConsumer() ||
                 clientProfile.isVibeCodingClient()))
     const version = useSingleExec ? 2 : (flagVersion ?? clientVersion ?? 1)
-    return { useSingleExec, version }
+    return { mode: mode ?? (useSingleExec ? 'cli' : 'tools'), useSingleExec, version }
 }
 
 // ─── Resolver ───
 
 const SYSTEM_FLAGS = ['mcp-version-2'] as const
+const SESSION_CONTEXT_KEYS = [
+    'mcpClientName',
+    'mcpClientVersion',
+    'mcpProtocolVersion',
+    'mcpConsumer',
+    'mcpVendorClient',
+] as const
+type SessionContextKey = (typeof SESSION_CONTEXT_KEYS)[number]
+type SessionContextCache = Pick<State, SessionContextKey>
 
 export class RequestStateResolver {
     private readonly catalog: ToolCatalog
@@ -67,8 +76,8 @@ export class RequestStateResolver {
     }
 
     async resolve(props: RequestProperties): Promise<ResolvedState> {
-        const reqCtx = new RequestContext(this.redis, this.env, props)
         const requestContext = buildMCPRequestContext(props)
+        const reqCtx = new RequestContext(this.redis, this.env, props, requestContext)
         const sessionContext = await this.resolveSessionContext(reqCtx, requestContext)
         const clientContext = getEffectiveMCPClientContext(requestContext, sessionContext)
 
@@ -117,16 +126,13 @@ export class RequestStateResolver {
             mode: resolvedMode,
             useSingleExec,
             version,
-        } = this.resolveSessionModeAndVersion({
-            explicitMode: requestContext.mode,
+        } = resolveModeAndVersion({
+            mode: requestContext.mode,
             clientProfile,
             flagVersion,
             clientVersion,
         })
         requestContext.mode = resolvedMode
-        if (sessionContext) {
-            sessionContext.mode = resolvedMode
-        }
         reqCtx.setMcpContexts(requestContext, sessionContext)
         props.mode = resolvedMode
 
@@ -176,44 +182,25 @@ export class RequestStateResolver {
             return null
         }
 
-        const [cachedName, cachedVersion, cachedProtocol, cachedConsumer, cachedVendor] = await Promise.all([
-            reqCtx.sessionCache.get('mcpClientName'),
-            reqCtx.sessionCache.get('mcpClientVersion'),
-            reqCtx.sessionCache.get('mcpProtocolVersion'),
-            reqCtx.sessionCache.get('mcpConsumer'),
-            reqCtx.sessionCache.get('mcpVendorClient'),
-        ])
+        const cachedEntries = await Promise.all(
+            SESSION_CONTEXT_KEYS.map(async (key) => [key, await reqCtx.sessionCache.get(key)] as const)
+        )
+        const cachedContext = Object.fromEntries(cachedEntries) as Partial<SessionContextCache>
 
-        const cacheUpdates: Partial<
-            Pick<State, 'mcpClientName' | 'mcpClientVersion' | 'mcpProtocolVersion' | 'mcpConsumer' | 'mcpVendorClient'>
-        > = {}
-        if (!cachedName && requestContext.mcpClientName) {
-            cacheUpdates.mcpClientName = requestContext.mcpClientName
-        }
-        if (!cachedVersion && requestContext.mcpClientVersion) {
-            cacheUpdates.mcpClientVersion = requestContext.mcpClientVersion
-        }
-        if (!cachedProtocol && requestContext.mcpProtocolVersion) {
-            cacheUpdates.mcpProtocolVersion = requestContext.mcpProtocolVersion
-        }
-        if (!cachedConsumer && requestContext.mcpConsumer) {
-            cacheUpdates.mcpConsumer = requestContext.mcpConsumer
-        }
-        if (!cachedVendor && requestContext.mcpVendorClient) {
-            cacheUpdates.mcpVendorClient = requestContext.mcpVendorClient
+        const cacheUpdates: Partial<SessionContextCache> = {}
+        for (const key of SESSION_CONTEXT_KEYS) {
+            if (!cachedContext[key] && requestContext[key]) {
+                cacheUpdates[key] = requestContext[key]
+            }
         }
 
         if (Object.keys(cacheUpdates).length > 0) {
             await reqCtx.sessionCache.setMany(cacheUpdates)
         }
 
-        return {
-            mcpClientName: cachedName || requestContext.mcpClientName || undefined,
-            mcpClientVersion: cachedVersion || requestContext.mcpClientVersion || undefined,
-            mcpProtocolVersion: cachedProtocol || requestContext.mcpProtocolVersion || undefined,
-            mcpConsumer: cachedConsumer || requestContext.mcpConsumer || undefined,
-            mcpVendorClient: cachedVendor || requestContext.mcpVendorClient || undefined,
-        }
+        return Object.fromEntries(
+            SESSION_CONTEXT_KEYS.map((key) => [key, cachedContext[key] || requestContext[key] || undefined])
+        ) as MCPSessionContext
     }
 
     private async resolveAllFlags(
@@ -230,27 +217,5 @@ export class RequestStateResolver {
         } catch {
             return {}
         }
-    }
-
-    private resolveSessionModeAndVersion(args: {
-        explicitMode: McpMode | undefined
-        clientProfile: MCPClientProfile
-        flagVersion: number | undefined
-        clientVersion: number | undefined
-    }): { mode: McpMode; useSingleExec: boolean; version: number } {
-        const { explicitMode, clientProfile, flagVersion, clientVersion } = args
-        const candidate = resolveModeAndVersion({
-            mode: explicitMode,
-            clientProfile,
-            flagVersion,
-            clientVersion,
-        })
-        const candidateMode: McpMode = candidate.useSingleExec ? 'cli' : 'tools'
-
-        if (explicitMode) {
-            return { mode: explicitMode, useSingleExec: candidate.useSingleExec, version: candidate.version }
-        }
-
-        return { mode: candidateMode, useSingleExec: candidate.useSingleExec, version: candidate.version }
     }
 }

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -62,7 +62,7 @@ export class RequestStateResolver {
         const reqCtx = new RequestContext(this.redis, this.env, props)
         const context = await reqCtx.getContext()
 
-        const { features, tools, version: clientVersion, organizationId, projectId, readOnly, mode } = props
+        const { features, tools, version: clientVersion, organizationId, projectId, readOnly } = props
 
         await reqCtx.tokenCache.setMany({
             ...(organizationId ? { orgId: organizationId } : {}),
@@ -125,16 +125,18 @@ export class RequestStateResolver {
             oauthClientName,
         })
 
-        const { useSingleExec, version } = resolveModeAndVersion({
-            mode,
+        const {
+            mode: resolvedMode,
+            useSingleExec,
+            version,
+        } = await this.resolveSessionModeAndVersion({
+            reqCtx,
+            props,
             clientProfile,
             flagVersion,
             clientVersion,
         })
-
-        if (!props.mode) {
-            props.mode = useSingleExec ? 'cli' : 'tools'
-        }
+        props.mode = resolvedMode
 
         const apiKeyScopes = _apiKey?.scopes ?? []
         const apiKeyScopedTeams = _apiKey?.scoped_teams ?? []
@@ -186,5 +188,46 @@ export class RequestStateResolver {
         } catch {
             return {}
         }
+    }
+
+    private async resolveSessionModeAndVersion(args: {
+        reqCtx: RequestContext
+        props: RequestProperties
+        clientProfile: MCPClientProfile
+        flagVersion: number | undefined
+        clientVersion: number | undefined
+    }): Promise<{ mode: McpMode; useSingleExec: boolean; version: number }> {
+        const { reqCtx, props, clientProfile, flagVersion, clientVersion } = args
+        const explicitMode = props.mode
+        const candidate = resolveModeAndVersion({
+            mode: explicitMode,
+            clientProfile,
+            flagVersion,
+            clientVersion,
+        })
+        const candidateMode: McpMode = candidate.useSingleExec ? 'cli' : 'tools'
+
+        if (explicitMode) {
+            return { mode: explicitMode, useSingleExec: candidate.useSingleExec, version: candidate.version }
+        }
+
+        let resolvedMode = candidateMode
+        if (props.mcpSessionId) {
+            const cachedMode = await reqCtx.sessionCache.get('mcpMode')
+            if (cachedMode) {
+                resolvedMode = cachedMode
+            } else {
+                await reqCtx.sessionCache.set('mcpMode', candidateMode)
+            }
+        }
+
+        const { useSingleExec, version } = resolveModeAndVersion({
+            mode: resolvedMode,
+            clientProfile,
+            flagVersion,
+            clientVersion,
+        })
+
+        return { mode: resolvedMode, useSingleExec, version }
     }
 }

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -71,7 +71,7 @@ export class ToolExecutor {
             return { content: [{ type: 'text', text: 'Missing tool name' }], isError: true }
         }
 
-        if (state.useSingleExec && toolName === 'exec') {
+        if (toolName === 'exec') {
             return this.callExecTool(params, props, state)
         }
 

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -1,6 +1,7 @@
 import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
 
 import { buildToolResultPayload, isToolCallPayload } from '@/lib/build-tool-result'
+import { isCodingAgentClient } from '@/lib/client-detection'
 import {
     handleToolError,
     MissingOrganizationContextError,
@@ -17,6 +18,7 @@ import type { Context, ZodObjectAny } from '@/tools/types'
 
 import { trackToolCall } from './analytics'
 import type { InstructionsBuilder } from './instructions'
+import { getEffectiveMCPClientContext } from './mcp-context'
 import { toolCallDurationSeconds, toolCallsTotal, toolErrorsTotal } from './metrics'
 import type { ResolvedState } from './request-state-resolver'
 import type { ToolCatalog } from './tool-catalog'
@@ -63,7 +65,7 @@ export class ToolExecutor {
 
     async handleToolCall(
         params: Record<string, unknown> | undefined,
-        props: RequestProperties,
+        _props: RequestProperties,
         state: ResolvedState
     ): Promise<unknown> {
         const toolName = params?.name as string
@@ -72,7 +74,7 @@ export class ToolExecutor {
         }
 
         if (toolName === 'exec') {
-            return this.callExecTool(params, props, state)
+            return this.callExecTool(params, state)
         }
 
         if (!state.allTools.some((t) => t.name === toolName)) {
@@ -94,7 +96,6 @@ export class ToolExecutor {
                 _meta: preBuilt.base._meta,
             },
             params,
-            props,
             state
         )
     }
@@ -102,7 +103,6 @@ export class ToolExecutor {
     private async callTool(
         tool: ResolvedTool,
         params: Record<string, unknown> | undefined,
-        props: RequestProperties,
         state: ResolvedState
     ): Promise<unknown> {
         const toolArgs = (params?.arguments ?? {}) as Record<string, unknown>
@@ -130,7 +130,7 @@ export class ToolExecutor {
             toolCallsTotal.inc({ tool: tool.name, status: 'success' })
             stop({ status: 'success' })
 
-            void trackToolCall(tool.name, Date.now() - startMs, false, props, state)
+            void trackToolCall(tool.name, Date.now() - startMs, false, state)
 
             if (isToolCallPayload(handlerResult)) {
                 return handlerResult
@@ -145,7 +145,7 @@ export class ToolExecutor {
                 toolMeta: tool._meta,
                 toolName: tool.name,
                 params: validation.data,
-                clientName: props.mcpClientName,
+                suppressStructuredContentForFormattedResults: isCodingAgentClient(state.clientProfile.clientName),
                 distinctId,
             })
         } catch (error: unknown) {
@@ -153,20 +153,16 @@ export class ToolExecutor {
             stop({ status: 'error' })
             classifyToolError(error, tool.name)
 
-            void trackToolCall(tool.name, Date.now() - startMs, true, props, state)
+            void trackToolCall(tool.name, Date.now() - startMs, true, state)
 
-            const sessionUuid = await state.reqCtx.getSessionUuid(props.sessionId)
+            const sessionUuid = await state.reqCtx.getSessionUuid(state.requestContext.sessionId)
             return handleToolError(error, tool.name, state.distinctId, sessionUuid)
         }
     }
 
-    private async callExecTool(
-        params: Record<string, unknown> | undefined,
-        props: RequestProperties,
-        state: ResolvedState
-    ): Promise<unknown> {
+    private async callExecTool(params: Record<string, unknown> | undefined, state: ResolvedState): Promise<unknown> {
         const execMetrics: ExecMetricState = { innerToolName: undefined }
-        const resolved = this.resolveExecTool(state, props, execMetrics)
+        const resolved = this.resolveExecTool(state, execMetrics)
 
         const toolArgs = (params?.arguments ?? {}) as Record<string, unknown>
         const validation = resolved.schema.safeParse(toolArgs)
@@ -180,7 +176,7 @@ export class ToolExecutor {
         try {
             const handlerResult = await resolved.handler(state.context, validation.data)
 
-            void trackToolCall('exec', Date.now() - startMs, false, props, state)
+            void trackToolCall('exec', Date.now() - startMs, false, state)
 
             if (isToolCallPayload(handlerResult)) {
                 return handlerResult
@@ -191,7 +187,7 @@ export class ToolExecutor {
                 toolMeta: resolved._meta,
                 toolName: 'exec',
                 params: validation.data,
-                clientName: props.mcpClientName,
+                suppressStructuredContentForFormattedResults: isCodingAgentClient(state.clientProfile.clientName),
                 distinctId: undefined,
             })
         } catch (error: unknown) {
@@ -201,18 +197,14 @@ export class ToolExecutor {
             }
             classifyToolError(error, metricTool)
 
-            void trackToolCall('exec', Date.now() - startMs, true, props, state)
+            void trackToolCall('exec', Date.now() - startMs, true, state)
 
-            const sessionUuid = await state.reqCtx.getSessionUuid(props.sessionId)
+            const sessionUuid = await state.reqCtx.getSessionUuid(state.requestContext.sessionId)
             return handleToolError(error, 'exec', state.distinctId, sessionUuid)
         }
     }
 
-    private resolveExecTool(
-        state: ResolvedState,
-        props: RequestProperties,
-        execMetrics: ExecMetricState
-    ): ResolvedTool {
+    private resolveExecTool(state: ResolvedState, execMetrics: ExecMetricState): ResolvedTool {
         const commandReference = this.instructionsBuilder.buildExecCommandReference(state)
 
         const trackInnerCall: ExecInnerCallTracker = (toolName, properties) => {
@@ -228,18 +220,18 @@ export class ToolExecutor {
                     { tool_name: toolName, ...properties },
                     freshContext,
                     undefined,
-                    state.distinctId,
-                    props
+                    state.distinctId
                 )
             })().catch(() => {})
         }
+        const clientContext = getEffectiveMCPClientContext(state.requestContext, state.sessionContext)
 
         const execTool = createExecTool(
             state.allTools,
             state.context,
             this.instructionsBuilder.buildExecToolDescription(),
             commandReference,
-            props.mcpConsumer,
+            clientContext.mcpConsumer,
             trackInnerCall
         )
 

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -1,7 +1,6 @@
 import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
 
 import { buildToolResultPayload, isToolCallPayload } from '@/lib/build-tool-result'
-import { isCodingAgentClient } from '@/lib/client-detection'
 import {
     handleToolError,
     MissingOrganizationContextError,
@@ -12,7 +11,6 @@ import {
     findRecoverableApiError,
 } from '@/lib/errors'
 import { AnalyticsEvent } from '@/lib/posthog/analytics'
-import type { RequestProperties } from '@/lib/request-properties'
 import { createExecTool, type ExecInnerCallTracker } from '@/tools/exec'
 import type { Context, ZodObjectAny } from '@/tools/types'
 
@@ -43,9 +41,9 @@ export class ToolExecutor {
         this.instructionsBuilder = instructionsBuilder
     }
 
-    async handleToolsList(state: ResolvedState, props: RequestProperties): Promise<ListToolsResult> {
+    async handleToolsList(state: ResolvedState): Promise<ListToolsResult> {
         if (state.useSingleExec) {
-            return { tools: [this.instructionsBuilder.buildExecToolEntry(state, props)] }
+            return { tools: [this.instructionsBuilder.buildExecToolEntry(state)] }
         }
 
         const nameSet = new Set(state.allTools.map((t) => t.name))
@@ -63,11 +61,7 @@ export class ToolExecutor {
         return { tools: filteredTools }
     }
 
-    async handleToolCall(
-        params: Record<string, unknown> | undefined,
-        _props: RequestProperties,
-        state: ResolvedState
-    ): Promise<unknown> {
+    async handleToolCall(params: Record<string, unknown> | undefined, state: ResolvedState): Promise<unknown> {
         const toolName = params?.name as string
         if (!toolName) {
             return { content: [{ type: 'text', text: 'Missing tool name' }], isError: true }
@@ -145,7 +139,7 @@ export class ToolExecutor {
                 toolMeta: tool._meta,
                 toolName: tool.name,
                 params: validation.data,
-                suppressStructuredContentForFormattedResults: isCodingAgentClient(state.clientProfile.clientName),
+                suppressStructuredContentForFormattedResults: state.clientProfile.isCodingAgent(),
                 distinctId,
             })
         } catch (error: unknown) {
@@ -187,7 +181,7 @@ export class ToolExecutor {
                 toolMeta: resolved._meta,
                 toolName: 'exec',
                 params: validation.data,
-                suppressStructuredContentForFormattedResults: isCodingAgentClient(state.clientProfile.clientName),
+                suppressStructuredContentForFormattedResults: state.clientProfile.isCodingAgent(),
                 distinctId: undefined,
             })
         } catch (error: unknown) {

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -381,7 +381,7 @@ const handleRequest = async (
 
     // Explicit selection between tool-based and CLI-based MCP. Falls back to the
     // flag + client-detection logic in `MCP.init()` when unset. See `parseMcpMode`.
-    const mode = parseMcpMode(request.headers.get('x-posthog-mcp-mode') || url.searchParams.get('mode'))
+    const mode = parseMcpMode(url.searchParams.get('mode')) || parseMcpMode(request.headers.get('x-posthog-mcp-mode'))
 
     const extraContextProps = { features, tools, region: regionParam, version, readOnly, mode }
     Object.assign(ctx.props, extraContextProps)

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -344,6 +344,13 @@ const handleRequest = async (
     // the same `requestProperties.mcpConversationId` slot.
     const mcpConversationId = sanitizeHeaderValue(request.headers.get('mcp-conversation-id') || undefined)
 
+    // Anthropic-set per-request identifier for the inner upstream client (e.g.
+    // `ClaudeCode`, `ClaudeAI`, `Cowork`). Distinct from `mcpClientName` (the
+    // MCP `initialize` body's `clientInfo.name`) because Claude pools MCP
+    // transports — the same `mcpSessionId` can carry requests from multiple
+    // upstream products, and only this header tracks the live one.
+    const mcpVendorClient = sanitizeHeaderValue(request.headers.get('x-anthropic-client') || undefined)
+
     Object.assign(ctx.props, {
         apiToken: token,
         userHash: hash(token),
@@ -357,6 +364,7 @@ const handleRequest = async (
         mcpClientName: clientInfo.clientName,
         mcpClientVersion: clientInfo.clientVersion,
         mcpProtocolVersion: clientInfo.protocolVersion,
+        mcpVendorClient,
         requestStartTime: Date.now(),
     })
 

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -389,7 +389,7 @@ const handleRequest = async (
 
     // Explicit selection between tool-based and CLI-based MCP. Falls back to the
     // flag + client-detection logic in `MCP.init()` when unset. See `parseMcpMode`.
-    const mode = parseMcpMode(url.searchParams.get('mode')) || parseMcpMode(request.headers.get('x-posthog-mcp-mode'))
+    const mode = parseMcpMode(request.headers.get('x-posthog-mcp-mode') || url.searchParams.get('mode'))
 
     const extraContextProps = { features, tools, region: regionParam, version, readOnly, mode }
     Object.assign(ctx.props, extraContextProps)

--- a/services/mcp/src/lib/build-tool-result.ts
+++ b/services/mcp/src/lib/build-tool-result.ts
@@ -1,6 +1,5 @@
 import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 
-import { isCodingAgentClient } from '@/lib/client-detection'
 import { formatResponse } from '@/lib/response'
 import { POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY, POSTHOG_META_KEY } from '@/tools/types'
 import type { AnalyticsMetadata, WithAnalytics } from '@/ui-apps/types'
@@ -19,8 +18,8 @@ export interface BuildToolResultOptions {
     toolName: string
     /** The input params passed to the tool (used to read `output_format=json` escape hatch). */
     params: unknown
-    /** The MCP `clientInfo.name` captured during `initialize`. */
-    clientName: string | undefined
+    /** Whether formatted-result text should win over structuredContent for this client profile. */
+    suppressStructuredContentForFormattedResults?: boolean | undefined
     /** PostHog distinctId for analytics metadata (only read when a UI resource is present). */
     distinctId?: string | undefined
     /**
@@ -74,14 +73,22 @@ export function markExecPayload(payload: ToolResultPayload): ToolResultPayload {
  * 1. When the handler returns a primitive string, we pass it through to `formatResponse`
  *    unchanged. Earlier, object-rest on a string exploded it into a character-indexed
  *    dict ({"0":"{","1":"\""...}).
- * 2. When `formattedResults` is present AND the client is a coding-agent
- *    (e.g. Claude Code) AND the caller didn't opt into JSON via `output_format=json`,
- *    we drop `structuredContent`. Coding agents surface `structuredContent` to the model
- *    in preference to `content[].text`, so keeping it would hide the formatted table
+ * 2. When `formattedResults` is present AND the resolved client profile needs formatted
+ *    text to win AND the caller didn't opt into JSON via `output_format=json`, we drop
+ *    `structuredContent`. Coding agents surface `structuredContent` to the model in
+ *    preference to `content[].text`, so keeping it would hide the formatted table
  *    behind raw JSON.
  */
 export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResultPayload {
-    const { handlerResult, toolMeta, toolName, params, clientName, distinctId, includeUiResponseMeta } = opts
+    const {
+        handlerResult,
+        toolMeta,
+        toolName,
+        params,
+        suppressStructuredContentForFormattedResults,
+        distinctId,
+        includeUiResponseMeta,
+    } = opts
 
     const isStringResult = typeof handlerResult === 'string'
     const formattedResults: string | undefined = isStringResult
@@ -124,7 +131,7 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
     const text = formattedResults ?? (useJson ? JSON.stringify(rawResult) : formatResponse(rawResult))
 
     const suppressStructuredContent =
-        formattedResults !== undefined && !callerWantsJson && isCodingAgentClient(clientName)
+        formattedResults !== undefined && !callerWantsJson && !!suppressStructuredContentForFormattedResults
 
     const payload: ToolResultPayload = {
         content: [{ type: 'text', text }],

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -105,6 +105,10 @@ type MCPClientProfileInput = {
     clientVersion?: string | undefined
     consumer?: string | undefined
     oauthClientName?: string | undefined
+    // Per-request `x-anthropic-client` value (e.g. `ClaudeCode`, `ClaudeAI`).
+    // Anthropic pools MCP transports across products, so the live inner client
+    // can disagree with the session-pinned `clientName` from `initialize`.
+    vendorClient?: string | undefined
 }
 
 export class MCPClientProfile {
@@ -112,6 +116,7 @@ export class MCPClientProfile {
     readonly clientVersion: string | undefined
     readonly consumer: string | undefined
     readonly oauthClientName: string | undefined
+    readonly vendorClient: string | undefined
 
     private _capabilities: ClientCapabilities | undefined
 
@@ -120,10 +125,11 @@ export class MCPClientProfile {
         this.clientVersion = input.clientVersion
         this.consumer = input.consumer
         this.oauthClientName = input.oauthClientName
+        this.vendorClient = input.vendorClient
     }
 
     isCodingAgent(): boolean {
-        return matchesAnyFragment(this.clientName, CODING_AGENT_CLIENT_NAME_FRAGMENTS)
+        return matchesAnyFragment(this.vendorClient ?? this.clientName, CODING_AGENT_CLIENT_NAME_FRAGMENTS)
     }
 
     isPostHogCodeConsumer(): boolean {

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -8,12 +8,11 @@
  *
  * The `MCPClientProfile` class owns all per-client behavior decisions:
  *
- * - `isCodingAgent()` matches coding agents that surface `structuredContent`
- *   to the model in preference to `content[].text`. Used to drop
- *   `structuredContent` when a `formatted_results` override is set, otherwise
- *   Claude Code (and friends) show raw JSON instead of the formatted table.
- *   Cursor is deliberately excluded — it reads text for the model and renders
- *   `structuredContent` in UI, so it does not need the workaround.
+ * - `isCodingAgent()` matches coding agents that should default to single-exec
+ *   mode and drop `structuredContent` when a `formatted_results` override is
+ *   set. Cursor is deliberately excluded — it reads text for the model and
+ *   renders `structuredContent` in UI, so it does not need single-exec mode or
+ *   the formatted-results workaround.
  *
  * - `isPostHogCodeConsumer()` matches the `x-posthog-mcp-consumer` header
  *   sent by the PostHog Code Tasks wrapper.

--- a/services/mcp/src/lib/posthog/analytics.ts
+++ b/services/mcp/src/lib/posthog/analytics.ts
@@ -57,6 +57,9 @@ export type IdentityProvider = {
     getMcpClientName: () => Promise<string | undefined>
     getMcpClientVersion: () => Promise<string | undefined>
     getMcpProtocolVersion: () => Promise<string | undefined>
+    // Per-request `x-anthropic-client` value. Distinct from `mcpClientName`:
+    // tracks the live inner client on pooled MCP transports.
+    getMcpVendorClient: () => Promise<string | undefined>
     getRegion: () => Promise<string | undefined>
     getAnalyticsContext: () => Promise<MCPAnalyticsContext | undefined>
     getClientUserAgent: () => Promise<string | undefined>
@@ -146,6 +149,7 @@ export async function buildEventProperties(identity: IdentityProvider): Promise<
         mcpClientName,
         mcpClientVersion,
         mcpProtocolVersion,
+        mcpVendorClient,
         mcpRegion,
         analyticsContext,
         oauthClientName,
@@ -161,6 +165,7 @@ export async function buildEventProperties(identity: IdentityProvider): Promise<
         identity.getMcpClientName(),
         identity.getMcpClientVersion(),
         identity.getMcpProtocolVersion(),
+        identity.getMcpVendorClient(),
         identity.getRegion(),
         identity.getAnalyticsContext(),
         identity.getOAuthClientName(),
@@ -183,6 +188,7 @@ export async function buildEventProperties(identity: IdentityProvider): Promise<
         $mcp_client_user_agent: clientUserAgent,
         $mcp_client_name: mcpClientName,
         $mcp_client_version: mcpClientVersion,
+        mcp_vendor_client: mcpVendorClient,
         $mcp_protocol_version: mcpProtocolVersion,
         $mcp_region: mcpRegion,
         $mcp_organization_id: analyticsContext?.organizationId,

--- a/services/mcp/src/lib/request-properties.ts
+++ b/services/mcp/src/lib/request-properties.ts
@@ -20,6 +20,7 @@ export type RequestProperties = {
     mcpClientName?: string | undefined
     mcpClientVersion?: string | undefined
     mcpProtocolVersion?: string | undefined
+    mcpVendorClient?: string | undefined
     readOnly?: boolean | undefined
     mode?: McpMode | undefined
     transport?: Transport | undefined
@@ -76,6 +77,7 @@ export function parseRequestProperties(
         mcpClientName: clientInfo.clientName,
         mcpClientVersion: clientInfo.clientVersion,
         mcpProtocolVersion: clientInfo.protocolVersion,
+        mcpVendorClient: sanitizeHeaderValue(header(request, 'x-anthropic-client')),
         mode: parseMcpMode(params.get('mode')) || parseMcpMode(header(request, 'x-posthog-mcp-mode')),
         transport,
         requestStartTime: Date.now(),

--- a/services/mcp/src/lib/request-properties.ts
+++ b/services/mcp/src/lib/request-properties.ts
@@ -76,7 +76,7 @@ export function parseRequestProperties(
         mcpClientName: clientInfo.clientName,
         mcpClientVersion: clientInfo.clientVersion,
         mcpProtocolVersion: clientInfo.protocolVersion,
-        mode: parseMcpMode(header(request, 'x-posthog-mcp-mode') || params.get('mode')),
+        mode: parseMcpMode(params.get('mode')) || parseMcpMode(header(request, 'x-posthog-mcp-mode')),
         transport,
         requestStartTime: Date.now(),
     }

--- a/services/mcp/src/lib/request-properties.ts
+++ b/services/mcp/src/lib/request-properties.ts
@@ -78,7 +78,7 @@ export function parseRequestProperties(
         mcpClientVersion: clientInfo.clientVersion,
         mcpProtocolVersion: clientInfo.protocolVersion,
         mcpVendorClient: sanitizeHeaderValue(header(request, 'x-anthropic-client')),
-        mode: parseMcpMode(params.get('mode')) || parseMcpMode(header(request, 'x-posthog-mcp-mode')),
+        mode: parseMcpMode(header(request, 'x-posthog-mcp-mode') || params.get('mode')),
         transport,
         requestStartTime: Date.now(),
     }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -75,6 +75,10 @@ export type RequestProperties = {
     mcpClientName?: string
     mcpClientVersion?: string
     mcpProtocolVersion?: string
+    // Per-request `x-anthropic-client` value. Identifies the live inner client
+    // on pooled MCP transports — distinct from `mcpClientName` (session-pinned
+    // from the initialize body's `clientInfo.name`).
+    mcpVendorClient?: string
     readOnly?: boolean
     mode?: McpMode
     transport?: 'streamable-http' | 'sse'
@@ -393,6 +397,9 @@ export class MCP extends McpAgent<Env> {
                     ...(this.mcpClientName ? { mcp_client_name: this.mcpClientName } : {}),
                     ...(this.mcpClientVersion ? { mcp_client_version: this.mcpClientVersion } : {}),
                     ...(this.mcpProtocolVersion ? { mcp_protocol_version: this.mcpProtocolVersion } : {}),
+                    ...(this.requestProperties.mcpVendorClient
+                        ? { mcp_vendor_client: this.requestProperties.mcpVendorClient }
+                        : {}),
                     ...(this.requestProperties.mcpConsumer ? { mcp_consumer: this.requestProperties.mcpConsumer } : {}),
                     ...(this.requestProperties.transport ? { mcp_transport: this.requestProperties.transport } : {}),
                     ...(this.requestProperties.mcpSessionId
@@ -621,6 +628,7 @@ export class MCP extends McpAgent<Env> {
             clientVersion: this.mcpClientVersion,
             consumer: this.requestProperties.mcpConsumer,
             oauthClientName,
+            vendorClient: this.requestProperties.mcpVendorClient,
         })
 
         const { useSingleExec, version } = this.resolveModeAndVersion({
@@ -785,6 +793,7 @@ export class MCP extends McpAgent<Env> {
             getMcpClientName: async () => this.mcpClientName,
             getMcpClientVersion: async () => this.mcpClientVersion,
             getMcpProtocolVersion: async () => this.mcpProtocolVersion,
+            getMcpVendorClient: async () => this.requestProperties.mcpVendorClient,
             // Prefer the cached region (set on init after detection) so we don't miss it
             // when the inbound request didn't include the `region` hint.
             getRegion: async () => (await this.cache.get('region')) ?? this.requestProperties.region,

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -8,7 +8,7 @@ import { ApiClient } from '@/api/client'
 import { hasScope } from '@/lib/api'
 import { buildToolResultPayload, isToolCallPayload } from '@/lib/build-tool-result'
 import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
-import { MCPClientProfile, isCodingAgentClient } from '@/lib/client-detection'
+import { MCPClientProfile } from '@/lib/client-detection'
 import {
     getCustomApiBaseUrl,
     MCP_SERVER_NAME,
@@ -503,7 +503,10 @@ export class MCP extends McpAgent<Env> {
                     toolMeta: tool._meta,
                     toolName: tool.name,
                     params,
-                    suppressStructuredContentForFormattedResults: isCodingAgentClient(this.mcpClientName),
+                    suppressStructuredContentForFormattedResults: new MCPClientProfile({
+                        clientName: this.mcpClientName,
+                        vendorClient: this.requestProperties.mcpVendorClient,
+                    }).isCodingAgent(),
                     distinctId,
                 })
             } catch (error: any) {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -102,6 +102,7 @@ export class MCP extends McpAgent<Env> {
         mcpClientName: undefined,
         mcpClientVersion: undefined,
         mcpProtocolVersion: undefined,
+        mcpMode: undefined,
     }
 
     _cache: DurableObjectCache<State> | undefined

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -8,7 +8,7 @@ import { ApiClient } from '@/api/client'
 import { hasScope } from '@/lib/api'
 import { buildToolResultPayload, isToolCallPayload } from '@/lib/build-tool-result'
 import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
-import { MCPClientProfile } from '@/lib/client-detection'
+import { MCPClientProfile, isCodingAgentClient } from '@/lib/client-detection'
 import {
     getCustomApiBaseUrl,
     MCP_SERVER_NAME,
@@ -106,7 +106,8 @@ export class MCP extends McpAgent<Env> {
         mcpClientName: undefined,
         mcpClientVersion: undefined,
         mcpProtocolVersion: undefined,
-        mcpMode: undefined,
+        mcpConsumer: undefined,
+        mcpVendorClient: undefined,
     }
 
     _cache: DurableObjectCache<State> | undefined
@@ -502,7 +503,7 @@ export class MCP extends McpAgent<Env> {
                     toolMeta: tool._meta,
                     toolName: tool.name,
                     params,
-                    clientName: this.mcpClientName,
+                    suppressStructuredContentForFormattedResults: isCodingAgentClient(this.mcpClientName),
                     distinctId,
                 })
             } catch (error: any) {

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -310,9 +310,9 @@ export function createExecTool(
                                 toolName: tool.name,
                                 params: useJson ? { ...input, output_format: 'json' } : input,
                                 // Consumer is the UI-apps host; keep `structuredContent` for the UI.
-                                // Passing `undefined` bypasses the coding-agent suppression in
+                                // Passing `false` bypasses coding-agent suppression in
                                 // `buildToolResultPayload` because this path explicitly wants it.
-                                clientName: undefined,
+                                suppressStructuredContentForFormattedResults: false,
                                 distinctId,
                                 includeUiResponseMeta: true,
                             })

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -7,6 +7,7 @@ import type { AnalyticsEvent } from '@/lib/posthog/analytics'
 import type { SessionManager } from '@/lib/SessionManager'
 import type { StateManager } from '@/lib/StateManager'
 import type { PrefixedString } from '@/lib/types'
+import type { McpMode } from '@/lib/utils'
 import type { ApiRedactedPersonalApiKey, ApiUser } from '@/schema/api'
 
 export type CloudRegion = 'us' | 'eu'
@@ -29,6 +30,7 @@ export type State = {
     mcpClientName: string | undefined
     mcpClientVersion: string | undefined
     mcpProtocolVersion: string | undefined
+    mcpMode: McpMode | undefined
 } & Record<PrefixedString<'session'>, SessionState> &
     Record<PrefixedString<'groupTypes'>, GroupType[] | undefined> &
     Record<PrefixedString<'groupTypesFetchedAt'>, number | undefined> &

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -7,7 +7,6 @@ import type { AnalyticsEvent } from '@/lib/posthog/analytics'
 import type { SessionManager } from '@/lib/SessionManager'
 import type { StateManager } from '@/lib/StateManager'
 import type { PrefixedString } from '@/lib/types'
-import type { McpMode } from '@/lib/utils'
 import type { ApiRedactedPersonalApiKey, ApiUser } from '@/schema/api'
 
 export type CloudRegion = 'us' | 'eu'
@@ -30,7 +29,8 @@ export type State = {
     mcpClientName: string | undefined
     mcpClientVersion: string | undefined
     mcpProtocolVersion: string | undefined
-    mcpMode: McpMode | undefined
+    mcpConsumer: string | undefined
+    mcpVendorClient: string | undefined
 } & Record<PrefixedString<'session'>, SessionState> &
     Record<PrefixedString<'groupTypes'>, GroupType[] | undefined> &
     Record<PrefixedString<'groupTypesFetchedAt'>, number | undefined> &

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockCapture } = vi.hoisted(() => ({
+    mockCapture: vi.fn(),
+}))
+
+vi.mock('@/lib/posthog', () => ({
+    getPostHogClient: vi.fn(() => ({
+        capture: mockCapture,
+    })),
+}))
+
+import { trackInitEvent, trackToolCall } from '@/hono/analytics'
+import type { ResolvedState } from '@/hono/request-state-resolver'
+
+function makeState(overrides: Partial<ResolvedState> = {}): ResolvedState {
+    return {
+        reqCtx: {
+            getAnalyticsContextSafe: vi.fn(async () => undefined),
+            getSessionUuid: vi.fn(async () => 'session-uuid'),
+        } as any,
+        context: {
+            stateManager: {},
+        } as any,
+        version: 2,
+        useSingleExec: true,
+        toolFeatureFlags: undefined,
+        apiKeyScopes: [],
+        clientProfile: {} as any,
+        requestContext: {
+            sessionId: 'sess-1',
+            organizationId: 'org-request',
+            projectId: 'project-request',
+            readOnly: true,
+            viaSseRedirect: true,
+            requestStartTime: Date.now(),
+            clientUserAgent: 'request-agent/1.0',
+            mcpClientName: 'Claude Desktop',
+            mcpClientVersion: '2.0',
+            mcpProtocolVersion: '2025-03-26',
+            transport: 'streamable-http',
+            mcpSessionId: 'mcp-session-request',
+            mcpConversationId: 'conversation-request',
+            mcpConsumer: 'request-consumer',
+            mode: 'cli',
+            region: 'us',
+            mcpVendorClient: 'ClaudeAI',
+        },
+        sessionContext: {
+            mcpClientName: 'claude-code',
+            mcpClientVersion: '1.0',
+            mcpProtocolVersion: '2025-03-26',
+            mcpConsumer: 'session-consumer',
+            mode: 'cli',
+            mcpVendorClient: 'ClaudeCode',
+        },
+        allTools: [],
+        distinctId: 'distinct-id',
+        ...overrides,
+    }
+}
+
+describe('Hono MCP analytics contexts', () => {
+    beforeEach(() => {
+        mockCapture.mockClear()
+    })
+
+    it('emits request properties on $mcp fields and session properties on mcp_session fields', async () => {
+        await trackInitEvent(makeState())
+
+        expect(mockCapture).toHaveBeenCalledTimes(1)
+        expect(mockCapture.mock.calls[0]![0].properties).toMatchObject({
+            $mcp_client_name: 'Claude Desktop',
+            $mcp_client_version: '2.0',
+            $mcp_client_user_agent: 'request-agent/1.0',
+            $mcp_protocol_version: '2025-03-26',
+            $mcp_transport: 'streamable-http',
+            $mcp_session_id: 'mcp-session-request',
+            $mcp_conversation_id: 'conversation-request',
+            $mcp_consumer: 'request-consumer',
+            $mcp_mode: 'cli',
+            $mcp_region: 'us',
+            mcp_vendor_client: 'ClaudeAI',
+            mcp_session_client_name: 'claude-code',
+            mcp_session_client_version: '1.0',
+            mcp_session_protocol_version: '2025-03-26',
+            mcp_session_consumer: 'session-consumer',
+            mcp_session_mode: 'cli',
+            mcp_session_vendor_client: 'ClaudeCode',
+        })
+    })
+
+    it('omits session properties when there is no MCP session context', async () => {
+        await trackToolCall('user-get', 12, false, makeState({ sessionContext: null }))
+
+        const properties = mockCapture.mock.calls[0]![0].properties
+        expect(properties.$mcp_client_name).toBe('Claude Desktop')
+        expect(properties.mcp_session_client_name).toBeUndefined()
+        expect(properties.mcp_session_vendor_client).toBeUndefined()
+        expect(properties.mcp_session_mode).toBeUndefined()
+    })
+})

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -51,7 +51,6 @@ function makeState(overrides: Partial<ResolvedState> = {}): ResolvedState {
             mcpClientVersion: '1.0',
             mcpProtocolVersion: '2025-03-26',
             mcpConsumer: 'session-consumer',
-            mode: 'cli',
             mcpVendorClient: 'ClaudeCode',
         },
         allTools: [],
@@ -85,7 +84,6 @@ describe('Hono MCP analytics contexts', () => {
             mcp_session_client_version: '1.0',
             mcp_session_protocol_version: '2025-03-26',
             mcp_session_consumer: 'session-consumer',
-            mcp_session_mode: 'cli',
             mcp_session_vendor_client: 'ClaudeCode',
         })
     })
@@ -97,6 +95,5 @@ describe('Hono MCP analytics contexts', () => {
         expect(properties.$mcp_client_name).toBe('Claude Desktop')
         expect(properties.mcp_session_client_name).toBeUndefined()
         expect(properties.mcp_session_vendor_client).toBeUndefined()
-        expect(properties.mcp_session_mode).toBeUndefined()
     })
 })

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/api/client', () => ({
 }))
 
 import type { RedisLike } from '@/hono/cache/RedisCache'
-import { RequestContext } from '@/hono/request-context'
+import { RequestContext, SESSION_CACHE_TTL_SECONDS } from '@/hono/request-context'
 import type { RequestProperties } from '@/lib/request-properties'
 
 import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
@@ -32,6 +32,16 @@ function fakeRedis(): RedisLike {
             return n
         },
         scan: async () => ['0', [...store.keys()]],
+        ...makeRedisRateLimitStubs(),
+    }
+}
+
+function spyRedis(): RedisLike {
+    return {
+        get: vi.fn(async () => null),
+        set: vi.fn(async () => 'OK'),
+        del: vi.fn(async () => 0),
+        scan: vi.fn(async () => ['0', []] as [string, string[]]),
         ...makeRedisRateLimitStubs(),
     }
 }
@@ -185,6 +195,34 @@ describe('RequestContext', () => {
         it('returns the same cache instance on repeated access', () => {
             const ctx = new RequestContext(fakeRedis(), env, makeProps())
             expect(ctx.cache).toBe(ctx.cache)
+        })
+
+        it('uses a 14 day TTL for MCP session cache entries', async () => {
+            const redis = spyRedis()
+            const ctx = new RequestContext(redis, env, makeProps({ mcpSessionId: 'mcp-session-1' }))
+
+            await ctx.sessionCache.set('mcpMode', 'cli')
+
+            expect(redis.set).toHaveBeenCalledWith(
+                expect.stringMatching(/^mcp:session:/),
+                JSON.stringify('cli'),
+                'EX',
+                SESSION_CACHE_TTL_SECONDS
+            )
+        })
+
+        it('keeps token cache entries on the default 7 day TTL', async () => {
+            const redis = spyRedis()
+            const ctx = new RequestContext(redis, env, makeProps())
+
+            await ctx.tokenCache.set('distinctId', 'user-123')
+
+            expect(redis.set).toHaveBeenCalledWith(
+                'mcp:token:test-user:distinctId',
+                JSON.stringify('user-123'),
+                'EX',
+                7 * 24 * 60 * 60
+            )
         })
     })
 })

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -189,7 +189,6 @@ describe('RequestContext', () => {
                     mcpProtocolVersion: '2025-03-26',
                     mcpConsumer: 'session-consumer',
                     mcpVendorClient: 'ClaudeCode',
-                    mode: 'cli',
                 }
             )
 
@@ -203,7 +202,6 @@ describe('RequestContext', () => {
                 mcp_session_client_version: '1.0',
                 mcp_session_consumer: 'session-consumer',
                 mcp_session_vendor_client: 'ClaudeCode',
-                mcp_session_mode: 'cli',
             })
         })
 

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/api/client', () => ({
 }))
 
 import type { RedisLike } from '@/hono/cache/RedisCache'
-import { RequestContext, SESSION_CACHE_TTL_SECONDS } from '@/hono/request-context'
+import { RequestContext } from '@/hono/request-context'
 import type { RequestProperties } from '@/lib/request-properties'
 
 import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
@@ -159,6 +159,54 @@ describe('RequestContext', () => {
             })
         })
 
+        it('adds stable session properties without replacing request properties', () => {
+            const ctx = new RequestContext(
+                fakeRedis(),
+                env,
+                makeProps({
+                    mcpClientName: 'Claude Desktop',
+                    mcpClientVersion: '2.0',
+                    mcpProtocolVersion: '2025-03-26',
+                    mcpConsumer: 'request-consumer',
+                    mcpVendorClient: 'ClaudeAI',
+                    transport: 'streamable-http',
+                })
+            )
+            ctx.setMcpContexts(
+                {
+                    sessionId: 'sess-1',
+                    mcpClientName: 'Claude Desktop',
+                    mcpClientVersion: '2.0',
+                    mcpProtocolVersion: '2025-03-26',
+                    mcpConsumer: 'request-consumer',
+                    mcpVendorClient: 'ClaudeAI',
+                    transport: 'streamable-http',
+                    mode: 'cli',
+                },
+                {
+                    mcpClientName: 'claude-code',
+                    mcpClientVersion: '1.0',
+                    mcpProtocolVersion: '2025-03-26',
+                    mcpConsumer: 'session-consumer',
+                    mcpVendorClient: 'ClaudeCode',
+                    mode: 'cli',
+                }
+            )
+
+            const result = ctx.buildClientProperties()
+            expect(result).toMatchObject({
+                $mcp_client_name: 'Claude Desktop',
+                $mcp_client_version: '2.0',
+                $mcp_consumer: 'request-consumer',
+                mcp_vendor_client: 'ClaudeAI',
+                mcp_session_client_name: 'claude-code',
+                mcp_session_client_version: '1.0',
+                mcp_session_consumer: 'session-consumer',
+                mcp_session_vendor_client: 'ClaudeCode',
+                mcp_session_mode: 'cli',
+            })
+        })
+
         it('omits undefined properties', () => {
             const ctx = new RequestContext(
                 fakeRedis(),
@@ -197,17 +245,17 @@ describe('RequestContext', () => {
             expect(ctx.cache).toBe(ctx.cache)
         })
 
-        it('uses a 14 day TTL for MCP session cache entries', async () => {
+        it('keeps MCP session cache entries on the default 7 day TTL', async () => {
             const redis = spyRedis()
             const ctx = new RequestContext(redis, env, makeProps({ mcpSessionId: 'mcp-session-1' }))
 
-            await ctx.sessionCache.set('mcpMode', 'cli')
+            await ctx.sessionCache.set('mcpClientName', 'claude-code')
 
             expect(redis.set).toHaveBeenCalledWith(
                 expect.stringMatching(/^mcp:session:/),
-                JSON.stringify('cli'),
+                JSON.stringify('claude-code'),
                 'EX',
-                SESSION_CACHE_TTL_SECONDS
+                7 * 24 * 60 * 60
             )
         })
 

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -114,7 +114,6 @@ describe('RequestStateResolver MCP client contexts', () => {
             mcpClientName: 'claude-code',
             mcpClientVersion: '1.0',
             mcpProtocolVersion: '2025-03-26',
-            mode: 'cli',
         })
         expect(mockSessionStore.get('mcpClientName')).toBe('claude-code')
         expect(mockSessionStore.get('mcpClientVersion')).toBe('1.0')
@@ -129,7 +128,6 @@ describe('RequestStateResolver MCP client contexts', () => {
         expect(result.useSingleExec).toBe(false)
         expect(props.mode).toBe('tools')
         expect(result.requestContext.mode).toBe('tools')
-        expect(result.sessionContext?.mode).toBe('tools')
         expect(mockSessionStore.get('mcpMode')).toBeUndefined()
     })
 

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -142,4 +142,25 @@ describe('RequestStateResolver MCP mode pinning', () => {
         expect(props.mode).toBe('cli')
         expect(mockSessionStore.get('mcpMode')).toBeUndefined()
     })
+
+    it('keeps the cached mode even when the vendor client would resolve to a different mode', async () => {
+        // First request inits a non-coding-agent pool (Claude Desktop) and pins mode='tools'.
+        await makeResolver().resolve(
+            makeProps({
+                mcpClientName: 'Anthropic/ClaudeAI',
+                mcpVendorClient: undefined,
+            })
+        )
+        expect(mockSessionStore.get('mcpMode')).toBe('tools')
+
+        // Same pooled session id, now carrying a Claude Code inner request.
+        // Cache must win — mode stays 'tools'.
+        const pooled = makeProps({
+            mcpClientName: 'Anthropic/ClaudeAI',
+            mcpVendorClient: 'ClaudeCode',
+        })
+        const result = await makeResolver().resolve(pooled)
+        expect(result.useSingleExec).toBe(false)
+        expect(pooled.mode).toBe('tools')
+    })
 })

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSessionStore, mockTokenStore } = vi.hoisted(() => ({
+    mockSessionStore: new Map<string, unknown>(),
+    mockTokenStore: new Map<string, unknown>(),
+}))
+
+vi.mock('@/lib/posthog/flags', () => ({
+    evaluateFeatureFlags: vi.fn(async () => ({})),
+}))
+
+vi.mock('@/hono/request-context', () => {
+    type MockCache = {
+        get: (key: string) => Promise<unknown>
+        set: (key: string, value: unknown) => Promise<void>
+        setMany: (entries: Record<string, unknown>) => Promise<void>
+        delete: (key: string) => Promise<void>
+        clear: () => Promise<void>
+    }
+
+    const makeCache = (store: Map<string, unknown>): MockCache => ({
+        get: vi.fn(async (key: string) => store.get(key)),
+        set: vi.fn(async (key: string, value: unknown) => {
+            store.set(key, value)
+        }),
+        setMany: vi.fn(async (entries: Record<string, unknown>) => {
+            for (const [key, value] of Object.entries(entries)) {
+                if (value !== undefined) {
+                    store.set(key, value)
+                }
+            }
+        }),
+        delete: vi.fn(async (key: string) => {
+            store.delete(key)
+        }),
+        clear: vi.fn(async () => {
+            store.clear()
+        }),
+    })
+
+    return {
+        RequestContext: vi.fn().mockImplementation((_redis, _env, props: { mcpSessionId?: string } = {}) => {
+            const sessionCache = makeCache(mockSessionStore)
+            return {
+                tokenCache: makeCache(mockTokenStore),
+                get sessionCache() {
+                    if (!props.mcpSessionId) {
+                        throw new Error('Session ID is required to use the session cache')
+                    }
+                    return sessionCache
+                },
+                getContext: vi.fn(async () => ({
+                    stateManager: {
+                        setDefaultOrganizationAndProject: vi.fn(async () => {}),
+                        getApiKey: vi.fn(async () => ({ scopes: ['*'], scoped_teams: [] })),
+                        getAiConsentGiven: vi.fn(async () => undefined),
+                    },
+                })),
+                getAnalyticsContextSafe: vi.fn(async () => undefined),
+                getDistinctId: vi.fn(async () => 'distinct-id'),
+            }
+        }),
+    }
+})
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+import { RequestStateResolver } from '@/hono/request-state-resolver'
+import type { RequestProperties } from '@/lib/request-properties'
+import type { Env } from '@/tools/types'
+
+function makeProps(overrides: Partial<RequestProperties> = {}): RequestProperties {
+    return {
+        apiToken: 'phx_test',
+        userHash: 'test-user',
+        mcpSessionId: 'mcp-session-1',
+        mcpClientName: 'claude-code',
+        mcpClientVersion: '1.0',
+        mcpProtocolVersion: '2025-03-26',
+        projectId: '1',
+        requestStartTime: Date.now(),
+        transport: 'streamable-http',
+        version: 1,
+        ...overrides,
+    }
+}
+
+function makeResolver(): RequestStateResolver {
+    const catalog = {
+        getFilteredTools: vi.fn(() => []),
+    }
+    return new RequestStateResolver(catalog as any, {} as RedisLike, {} as Env)
+}
+
+describe('RequestStateResolver MCP mode pinning', () => {
+    beforeEach(() => {
+        mockSessionStore.clear()
+        mockTokenStore.clear()
+    })
+
+    it('stores the resolved mode for a new MCP session', async () => {
+        const props = makeProps()
+        const result = await makeResolver().resolve(props)
+
+        expect(result.useSingleExec).toBe(true)
+        expect(props.mode).toBe('cli')
+        expect(mockSessionStore.get('mcpMode')).toBe('cli')
+    })
+
+    it('does not store mode for a new MCP session when the mode was explicit', async () => {
+        const props = makeProps({ mode: 'tools' })
+        const result = await makeResolver().resolve(props)
+
+        expect(result.useSingleExec).toBe(false)
+        expect(props.mode).toBe('tools')
+        expect(mockSessionStore.get('mcpMode')).toBeUndefined()
+    })
+
+    it('uses cached session mode when client detection would resolve differently', async () => {
+        await makeResolver().resolve(makeProps())
+
+        const props = makeProps({ mcpClientName: 'Claude Desktop' })
+        const result = await makeResolver().resolve(props)
+
+        expect(result.useSingleExec).toBe(true)
+        expect(props.mode).toBe('cli')
+    })
+
+    it('uses explicit mode when an existing MCP session cached a different mode', async () => {
+        await makeResolver().resolve(makeProps())
+
+        const props = makeProps({ mode: 'tools' })
+        const result = await makeResolver().resolve(props)
+
+        expect(result.useSingleExec).toBe(false)
+        expect(props.mode).toBe('tools')
+    })
+
+    it('does not pin mode without an MCP session ID', async () => {
+        const props = makeProps({ mcpSessionId: undefined })
+        await makeResolver().resolve(props)
+
+        expect(props.mode).toBe('cli')
+        expect(mockSessionStore.get('mcpMode')).toBeUndefined()
+    })
+})

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -58,6 +58,7 @@ vi.mock('@/hono/request-context', () => {
                 })),
                 getAnalyticsContextSafe: vi.fn(async () => undefined),
                 getDistinctId: vi.fn(async () => 'distinct-id'),
+                setMcpContexts: vi.fn(),
             }
         }),
     }
@@ -91,19 +92,34 @@ function makeResolver(): RequestStateResolver {
     return new RequestStateResolver(catalog as any, {} as RedisLike, {} as Env)
 }
 
-describe('RequestStateResolver MCP mode pinning', () => {
+describe('RequestStateResolver MCP client contexts', () => {
     beforeEach(() => {
         mockSessionStore.clear()
         mockTokenStore.clear()
     })
 
-    it('stores the resolved mode for a new MCP session', async () => {
+    it('stores client props, but not resolved mode, for a new MCP session', async () => {
         const props = makeProps()
         const result = await makeResolver().resolve(props)
 
         expect(result.useSingleExec).toBe(true)
         expect(props.mode).toBe('cli')
-        expect(mockSessionStore.get('mcpMode')).toBe('cli')
+        expect(result.requestContext).toMatchObject({
+            mcpClientName: 'claude-code',
+            mcpClientVersion: '1.0',
+            mcpProtocolVersion: '2025-03-26',
+            mode: 'cli',
+        })
+        expect(result.sessionContext).toMatchObject({
+            mcpClientName: 'claude-code',
+            mcpClientVersion: '1.0',
+            mcpProtocolVersion: '2025-03-26',
+            mode: 'cli',
+        })
+        expect(mockSessionStore.get('mcpClientName')).toBe('claude-code')
+        expect(mockSessionStore.get('mcpClientVersion')).toBe('1.0')
+        expect(mockSessionStore.get('mcpProtocolVersion')).toBe('2025-03-26')
+        expect(mockSessionStore.get('mcpMode')).toBeUndefined()
     })
 
     it('does not store mode for a new MCP session when the mode was explicit', async () => {
@@ -112,10 +128,12 @@ describe('RequestStateResolver MCP mode pinning', () => {
 
         expect(result.useSingleExec).toBe(false)
         expect(props.mode).toBe('tools')
+        expect(result.requestContext.mode).toBe('tools')
+        expect(result.sessionContext?.mode).toBe('tools')
         expect(mockSessionStore.get('mcpMode')).toBeUndefined()
     })
 
-    it('uses cached session mode when client detection would resolve differently', async () => {
+    it('uses cached session client props when request client detection would resolve differently', async () => {
         await makeResolver().resolve(makeProps())
 
         const props = makeProps({ mcpClientName: 'Claude Desktop' })
@@ -123,9 +141,27 @@ describe('RequestStateResolver MCP mode pinning', () => {
 
         expect(result.useSingleExec).toBe(true)
         expect(props.mode).toBe('cli')
+        expect(props.mcpClientName).toBe('Claude Desktop')
+        expect(result.requestContext.mcpClientName).toBe('Claude Desktop')
+        expect(result.sessionContext?.mcpClientName).toBe('claude-code')
+        expect(result.clientProfile.clientName).toBe('claude-code')
+        expect(result.clientProfile.isCodingAgent()).toBe(true)
     })
 
-    it('uses explicit mode when an existing MCP session cached a different mode', async () => {
+    it('uses cached session client props for instruction capabilities without overwriting request props', async () => {
+        await makeResolver().resolve(makeProps({ mcpClientName: 'codex' }))
+
+        const props = makeProps({ mcpClientName: 'Claude Desktop' })
+        const result = await makeResolver().resolve(props)
+
+        expect(props.mcpClientName).toBe('Claude Desktop')
+        expect(result.requestContext.mcpClientName).toBe('Claude Desktop')
+        expect(result.sessionContext?.mcpClientName).toBe('codex')
+        expect(result.clientProfile.clientName).toBe('codex')
+        expect(result.clientProfile.capabilities.supportsInstructions).toBe(false)
+    })
+
+    it('uses explicit mode when cached session client props would resolve differently', async () => {
         await makeResolver().resolve(makeProps())
 
         const props = makeProps({ mode: 'tools' })
@@ -137,30 +173,78 @@ describe('RequestStateResolver MCP mode pinning', () => {
 
     it('does not pin mode without an MCP session ID', async () => {
         const props = makeProps({ mcpSessionId: undefined })
-        await makeResolver().resolve(props)
+        const result = await makeResolver().resolve(props)
 
         expect(props.mode).toBe('cli')
+        expect(result.sessionContext).toBeNull()
+        expect(result.requestContext.mcpClientName).toBe('claude-code')
         expect(mockSessionStore.get('mcpMode')).toBeUndefined()
     })
 
-    it('keeps the cached mode even when the vendor client would resolve to a different mode', async () => {
-        // First request inits a non-coding-agent pool (Claude Desktop) and pins mode='tools'.
+    it('uses cached vendor client when the live vendor header would resolve differently', async () => {
+        await makeResolver().resolve(
+            makeProps({
+                mcpClientName: 'Anthropic/ClaudeAI',
+                mcpVendorClient: 'ClaudeCode',
+            })
+        )
+        expect(mockSessionStore.get('mcpVendorClient')).toBe('ClaudeCode')
+
+        const pooled = makeProps({
+            mcpClientName: 'Anthropic/ClaudeAI',
+            mcpVendorClient: 'ClaudeAI',
+        })
+        const result = await makeResolver().resolve(pooled)
+
+        expect(result.useSingleExec).toBe(true)
+        expect(pooled.mode).toBe('cli')
+        expect(pooled.mcpVendorClient).toBe('ClaudeAI')
+        expect(result.requestContext.mcpVendorClient).toBe('ClaudeAI')
+        expect(result.sessionContext?.mcpVendorClient).toBe('ClaudeCode')
+        expect(result.clientProfile.vendorClient).toBe('ClaudeCode')
+    })
+
+    it('captures vendor client from a later request when initialize omitted the header', async () => {
         await makeResolver().resolve(
             makeProps({
                 mcpClientName: 'Anthropic/ClaudeAI',
                 mcpVendorClient: undefined,
             })
         )
-        expect(mockSessionStore.get('mcpMode')).toBe('tools')
+        expect(mockSessionStore.get('mcpVendorClient')).toBeUndefined()
 
-        // Same pooled session id, now carrying a Claude Code inner request.
-        // Cache must win — mode stays 'tools'.
         const pooled = makeProps({
             mcpClientName: 'Anthropic/ClaudeAI',
             mcpVendorClient: 'ClaudeCode',
         })
         const result = await makeResolver().resolve(pooled)
-        expect(result.useSingleExec).toBe(false)
-        expect(pooled.mode).toBe('tools')
+
+        expect(result.useSingleExec).toBe(true)
+        expect(pooled.mode).toBe('cli')
+        expect(result.requestContext.mcpVendorClient).toBe('ClaudeCode')
+        expect(result.sessionContext?.mcpVendorClient).toBe('ClaudeCode')
+        expect(mockSessionStore.get('mcpVendorClient')).toBe('ClaudeCode')
+    })
+
+    it('captures consumer from a later request when initialize omitted the header', async () => {
+        await makeResolver().resolve(
+            makeProps({
+                mcpClientName: 'Claude Desktop',
+                mcpConsumer: undefined,
+            })
+        )
+        expect(mockSessionStore.get('mcpConsumer')).toBeUndefined()
+
+        const posthogCode = makeProps({
+            mcpClientName: 'Claude Desktop',
+            mcpConsumer: 'posthog-code',
+        })
+        const result = await makeResolver().resolve(posthogCode)
+
+        expect(result.useSingleExec).toBe(true)
+        expect(posthogCode.mode).toBe('cli')
+        expect(result.requestContext.mcpConsumer).toBe('posthog-code')
+        expect(result.sessionContext?.mcpConsumer).toBe('posthog-code')
+        expect(mockSessionStore.get('mcpConsumer')).toBe('posthog-code')
     })
 })

--- a/services/mcp/tests/hono/session-mode-pool.test.ts
+++ b/services/mcp/tests/hono/session-mode-pool.test.ts
@@ -1,9 +1,10 @@
 // Verifies the connection-pooling scenario observed in production: Anthropic
 // reuses a single `Mcp-Session-Id` across multiple inner clients (Claude
 // Code, Claude.ai, Cowork) and differentiates them via the per-request
-// `x-anthropic-client` header. The server pins `mcpMode` (and the matching
-// `version`) in the session cache at `initialize`; a later `tools/call`
-// carrying a different vendor must NOT flip the resolved mode/version.
+// `x-anthropic-client` header. The server caches the initial raw session
+// identity hints and derives mode from those cached-first hints; a later
+// `tools/call` carrying a different vendor must NOT flip the resolved
+// mode/version.
 //
 // To probe the resolved mode DIRECTLY via a `tools/call` (the user flow
 // under test) we exploit tools that are gated by `mcpVersion` in the catalog.
@@ -128,8 +129,8 @@ describe('Resolved mode is preserved across pooled-transport vendor flips', () =
         // Without reading the vendor header, the resolver picks tools mode at
         // init (because `Anthropic/ClaudeAI` doesn't match any coding-agent
         // fragment) and the SDK gets the full multi-tool roster. With vendor
-        // reading + mode pinning, the resolver picks cli mode at init and the
-        // SDK gets the wrapped `[exec]` roster.
+        // reading + cached session hints, the resolver picks cli mode at init
+        // and the SDK gets the wrapped `[exec]` roster.
         const transportA = new StreamableHTTPClientTransport(new URL('/mcp', BASE_URL), {
             fetch: fetchViaApp,
             requestInit: {
@@ -152,12 +153,12 @@ describe('Resolved mode is preserved across pooled-transport vendor flips', () =
         expect(cachedTools.tools[0]!.name).toBe('exec')
 
         // headers_2 — pool member with a non-coding-agent vendor. If the
-        // resolver re-derives mode from the live profile, `vendorClient='ClaudeAI'`
+        // resolver re-derives mode from the live request, `vendorClient='ClaudeAI'`
         // + cached `clientName='Anthropic/ClaudeAI'` both miss the coding-agent
-        // fragments → resolves to tools mode (v1) → the v2-only tool falls out
-        // of `state.allTools` and the dispatcher returns "not found". With mode
-        // pinned to cli at init, the request stays at v2 and the v2-only tool
-        // dispatches.
+        // fragments -> resolves to tools mode (v1) -> the v2-only tool falls out
+        // of `state.allTools` and the dispatcher returns "not found". With the
+        // initial vendor hint cached, the request stays at v2 and the v2-only
+        // tool dispatches.
         const probe = await callToolOnSession(sessionId!, 'ClaudeAI', V2_ONLY_TOOL)
         expect(firstText(probe)).not.toMatch(new RegExp(`Tool ${V2_ONLY_TOOL} not found`, 'i'))
 

--- a/services/mcp/tests/hono/session-mode-pool.test.ts
+++ b/services/mcp/tests/hono/session-mode-pool.test.ts
@@ -1,9 +1,26 @@
 // Verifies the connection-pooling scenario observed in production: Anthropic
 // reuses a single `Mcp-Session-Id` across multiple inner clients (Claude
 // Code, Claude.ai, Cowork) and differentiates them via the per-request
-// `x-anthropic-client` header. The server pins `mcpMode` in the session cache
-// at `initialize` and must not flip mode mid-session when the live vendor
-// changes. Observable signal: the tool roster size returned by `tools/list`.
+// `x-anthropic-client` header. The server pins `mcpMode` (and the matching
+// `version`) in the session cache at `initialize`; a later `tools/call`
+// carrying a different vendor must NOT flip the resolved mode/version.
+//
+// To probe the resolved mode DIRECTLY via a `tools/call` (the user flow
+// under test) we exploit tools that are gated by `mcpVersion` in the catalog.
+// The state resolver filters `state.allTools` by the resolved `version`
+// (`tool-catalog.ts:161-163`), and `handleToolCall` returns the guard
+// "Tool <name> not found" (`tool-executor.ts:78-80`) when the requested
+// tool is absent from `state.allTools`.
+//
+// cli mode pins `version=2`. A v2-only tool (e.g. `query-session-recordings-list`)
+// is present iff this request resolved to v2; a v1-only tool
+// (e.g. `accounts-list`) is absent iff this request resolved to v2.
+//
+// If cli mode survives the vendor flip on the pooled session, calling the
+// v2-only tool dispatches (any non-"not found" response) and calling the
+// v1-only tool returns the missing-tool guard. If mode flipped to v1, both
+// outcomes reverse. That's a direct observable for "the resolved mode at
+// headers_2 equals the resolved mode at headers_1".
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { setupServer } from 'msw/node'
@@ -47,6 +64,10 @@ let app: ReturnType<typeof createApp>['app']
 const TOKEN = 'phx_session_mode_pool_test'
 const BASE_URL = new URL('http://hono.test')
 
+// Tools chosen as version-specific probes (see file header for rationale).
+const V1_ONLY_TOOL = 'accounts-list'
+const V2_ONLY_TOOL = 'query-session-recordings-list'
+
 beforeAll(async () => {
     process.env.TEST = '1'
     process.env.MCP_APPS_BASE_URL = 'https://apps.test'
@@ -67,11 +88,11 @@ const fetchViaApp: typeof fetch = async (input, init) => {
 
 type ConnectableTransport = Parameters<Client['connect']>[0]
 
-interface ToolListResponse {
-    result?: { tools?: Array<{ name: string }> }
+interface ToolCallResponse {
+    result?: { content?: Array<{ type: string; text: string }>; isError?: boolean }
 }
 
-async function postToolsListOnSession(sessionId: string, vendorClient: string): Promise<ToolListResponse> {
+async function callToolOnSession(sessionId: string, vendorClient: string, toolName: string): Promise<ToolCallResponse> {
     const res = await fetchViaApp(new URL('/mcp', BASE_URL), {
         method: 'POST',
         headers: {
@@ -81,16 +102,34 @@ async function postToolsListOnSession(sessionId: string, vendorClient: string): 
             'Mcp-Session-Id': sessionId,
             'x-anthropic-client': vendorClient,
         },
-        body: JSON.stringify({ jsonrpc: '2.0', id: 'pool-tools-list', method: 'tools/list' }),
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 'pool-tools-call',
+            method: 'tools/call',
+            params: { name: toolName, arguments: {} },
+        }),
     })
     expect(res.status).toBe(200)
-    return (await res.json()) as ToolListResponse
+    return (await res.json()) as ToolCallResponse
 }
 
-describe('Session mode survives a pooled-transport vendor flip', () => {
-    it('keeps cli mode (1 tool) when a non-coding-agent reuses the session id', async () => {
-        // Client A — Claude Code: clientInfo.name=claude-code + x-anthropic-client=ClaudeCode.
-        // The server should pin mcpMode='cli' in the session cache during initialize.
+function firstText(resp: ToolCallResponse): string {
+    return resp.result?.content?.[0]?.text ?? ''
+}
+
+describe('Resolved mode is preserved across pooled-transport vendor flips', () => {
+    it('cli init via x-anthropic-client survives a non-coding-agent vendor on the same session', async () => {
+        // headers_1 — clientInfo.name is the new Claude Desktop-style vendor-prefixed
+        // shape (NOT a coding-agent fragment), while the per-request vendor header
+        // identifies the inner client as Claude Code. This is the production-pool
+        // scenario where the body identifies the transport-owner and the header
+        // identifies the live consumer.
+        //
+        // Without reading the vendor header, the resolver picks tools mode at
+        // init (because `Anthropic/ClaudeAI` doesn't match any coding-agent
+        // fragment) and the SDK gets the full multi-tool roster. With vendor
+        // reading + mode pinning, the resolver picks cli mode at init and the
+        // SDK gets the wrapped `[exec]` roster.
         const transportA = new StreamableHTTPClientTransport(new URL('/mcp', BASE_URL), {
             fetch: fetchViaApp,
             requestInit: {
@@ -100,50 +139,33 @@ describe('Session mode survives a pooled-transport vendor flip', () => {
                 },
             },
         })
-        const clientA = new Client({ name: 'claude-code', version: '1.0.0' }, { capabilities: {} })
-        await clientA.connect(transportA as ConnectableTransport)
-
-        const sessionId = transportA.sessionId
-        expect(sessionId).toBeTruthy()
-
-        const a = await clientA.listTools()
-        expect(a.tools).toHaveLength(1)
-        expect(a.tools[0]!.name).toBe('exec')
-
-        // Client B — emulates Claude.ai / Cowork carrying a tools/list on the same
-        // pooled session id. Raw JSON-RPC because there is no second initialize:
-        // the pool member piggybacks on A's existing transport from the server's POV.
-        const pool = await postToolsListOnSession(sessionId!, 'ClaudeAI')
-        expect(pool.result?.tools).toHaveLength(1)
-        expect(pool.result!.tools![0]!.name).toBe('exec')
-
-        await clientA.close()
-    })
-
-    it('keeps tools mode (>1 tools) when a coding-agent reuses a Desktop-pooled session id', async () => {
-        // Client A — Claude Desktop: clientInfo.name='Anthropic/ClaudeAI' (the new
-        // vendor-prefixed shape) and no x-anthropic-client on initialize, mirroring
-        // the production logs. mcpMode should pin to 'tools'.
-        const transportA = new StreamableHTTPClientTransport(new URL('/mcp', BASE_URL), {
-            fetch: fetchViaApp,
-            requestInit: { headers: { Authorization: `Bearer ${TOKEN}` } },
-        })
         const clientA = new Client({ name: 'Anthropic/ClaudeAI', version: '1.0.0' }, { capabilities: {} })
         await clientA.connect(transportA as ConnectableTransport)
 
         const sessionId = transportA.sessionId
         expect(sessionId).toBeTruthy()
 
-        const a = await clientA.listTools()
-        expect(a.tools.length).toBeGreaterThan(1)
-        const baselineCount = a.tools.length
+        // Client caches the tools payload at init. cli mode collapses the wire
+        // roster to a single `exec`.
+        const cachedTools = await clientA.listTools()
+        expect(cachedTools.tools).toHaveLength(1)
+        expect(cachedTools.tools[0]!.name).toBe('exec')
 
-        // Client B — emulates a ClaudeCode-flavored inner request landing on the
-        // Desktop pool. Without session-mode pinning, this would resolve as
-        // coding-agent and collapse the roster to just `exec`.
-        const pool = await postToolsListOnSession(sessionId!, 'ClaudeCode')
-        expect(pool.result?.tools).toBeTruthy()
-        expect(pool.result!.tools!.length).toBe(baselineCount)
+        // headers_2 — pool member with a non-coding-agent vendor. If the
+        // resolver re-derives mode from the live profile, `vendorClient='ClaudeAI'`
+        // + cached `clientName='Anthropic/ClaudeAI'` both miss the coding-agent
+        // fragments → resolves to tools mode (v1) → the v2-only tool falls out
+        // of `state.allTools` and the dispatcher returns "not found". With mode
+        // pinned to cli at init, the request stays at v2 and the v2-only tool
+        // dispatches.
+        const probe = await callToolOnSession(sessionId!, 'ClaudeAI', V2_ONLY_TOOL)
+        expect(firstText(probe)).not.toMatch(new RegExp(`Tool ${V2_ONLY_TOOL} not found`, 'i'))
+
+        // Symmetric negative probe: a v1-only tool must STILL be absent under
+        // the preserved cli/v2 mode.
+        const negative = await callToolOnSession(sessionId!, 'ClaudeAI', V1_ONLY_TOOL)
+        expect(negative.result?.isError).toBe(true)
+        expect(firstText(negative)).toMatch(new RegExp(`Tool ${V1_ONLY_TOOL} not found`, 'i'))
 
         await clientA.close()
     })

--- a/services/mcp/tests/hono/session-mode-pool.test.ts
+++ b/services/mcp/tests/hono/session-mode-pool.test.ts
@@ -1,0 +1,150 @@
+// Verifies the connection-pooling scenario observed in production: Anthropic
+// reuses a single `Mcp-Session-Id` across multiple inner clients (Claude
+// Code, Claude.ai, Cowork) and differentiates them via the per-request
+// `x-anthropic-client` header. The server pins `mcpMode` in the session cache
+// at `initialize` and must not flip mode mid-session when the live vendor
+// changes. Observable signal: the tool roster size returned by `tools/list`.
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { setupServer } from 'msw/node'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { createApp } from '@/hono/app'
+import type { RedisLike } from '@/hono/cache/RedisCache'
+
+import { contextMillHandler, handlers } from '../workers/fixtures/handlers'
+import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
+
+const mswServer = setupServer(...handlers, contextMillHandler)
+
+function createInMemoryRedis(): RedisLike & { ping(): Promise<string> } {
+    const store = new Map<string, string>()
+    return {
+        get: async (key) => store.get(key) ?? null,
+        set: async (key, value) => {
+            store.set(key, String(value))
+            return 'OK'
+        },
+        del: async (...keys) => {
+            let removed = 0
+            for (const key of keys) {
+                if (store.delete(key)) {
+                    removed++
+                }
+            }
+            return removed
+        },
+        scan: async (cursor) => {
+            const cur = String(cursor)
+            return [cur === '0' ? 'next' : '0', cur === '0' ? Array.from(store.keys()) : []] as [string, string[]]
+        },
+        ...makeRedisRateLimitStubs(),
+        ping: async () => 'PONG',
+    }
+}
+
+let app: ReturnType<typeof createApp>['app']
+const TOKEN = 'phx_session_mode_pool_test'
+const BASE_URL = new URL('http://hono.test')
+
+beforeAll(async () => {
+    process.env.TEST = '1'
+    process.env.MCP_APPS_BASE_URL = 'https://apps.test'
+    mswServer.listen({ onUnhandledRequest: 'bypass' })
+    const created = createApp(createInMemoryRedis())
+    app = created.app
+    await created.warmup()
+})
+
+afterAll(() => {
+    mswServer.close()
+})
+
+const fetchViaApp: typeof fetch = async (input, init) => {
+    const url = input instanceof URL ? input : new URL(typeof input === 'string' ? input : input.url)
+    return app.request(url.pathname + url.search, init ?? {})
+}
+
+type ConnectableTransport = Parameters<Client['connect']>[0]
+
+interface ToolListResponse {
+    result?: { tools?: Array<{ name: string }> }
+}
+
+async function postToolsListOnSession(sessionId: string, vendorClient: string): Promise<ToolListResponse> {
+    const res = await fetchViaApp(new URL('/mcp', BASE_URL), {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${TOKEN}`,
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+            'Mcp-Session-Id': sessionId,
+            'x-anthropic-client': vendorClient,
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 'pool-tools-list', method: 'tools/list' }),
+    })
+    expect(res.status).toBe(200)
+    return (await res.json()) as ToolListResponse
+}
+
+describe('Session mode survives a pooled-transport vendor flip', () => {
+    it('keeps cli mode (1 tool) when a non-coding-agent reuses the session id', async () => {
+        // Client A — Claude Code: clientInfo.name=claude-code + x-anthropic-client=ClaudeCode.
+        // The server should pin mcpMode='cli' in the session cache during initialize.
+        const transportA = new StreamableHTTPClientTransport(new URL('/mcp', BASE_URL), {
+            fetch: fetchViaApp,
+            requestInit: {
+                headers: {
+                    Authorization: `Bearer ${TOKEN}`,
+                    'x-anthropic-client': 'ClaudeCode',
+                },
+            },
+        })
+        const clientA = new Client({ name: 'claude-code', version: '1.0.0' }, { capabilities: {} })
+        await clientA.connect(transportA as ConnectableTransport)
+
+        const sessionId = transportA.sessionId
+        expect(sessionId).toBeTruthy()
+
+        const a = await clientA.listTools()
+        expect(a.tools).toHaveLength(1)
+        expect(a.tools[0]!.name).toBe('exec')
+
+        // Client B — emulates Claude.ai / Cowork carrying a tools/list on the same
+        // pooled session id. Raw JSON-RPC because there is no second initialize:
+        // the pool member piggybacks on A's existing transport from the server's POV.
+        const pool = await postToolsListOnSession(sessionId!, 'ClaudeAI')
+        expect(pool.result?.tools).toHaveLength(1)
+        expect(pool.result!.tools![0]!.name).toBe('exec')
+
+        await clientA.close()
+    })
+
+    it('keeps tools mode (>1 tools) when a coding-agent reuses a Desktop-pooled session id', async () => {
+        // Client A — Claude Desktop: clientInfo.name='Anthropic/ClaudeAI' (the new
+        // vendor-prefixed shape) and no x-anthropic-client on initialize, mirroring
+        // the production logs. mcpMode should pin to 'tools'.
+        const transportA = new StreamableHTTPClientTransport(new URL('/mcp', BASE_URL), {
+            fetch: fetchViaApp,
+            requestInit: { headers: { Authorization: `Bearer ${TOKEN}` } },
+        })
+        const clientA = new Client({ name: 'Anthropic/ClaudeAI', version: '1.0.0' }, { capabilities: {} })
+        await clientA.connect(transportA as ConnectableTransport)
+
+        const sessionId = transportA.sessionId
+        expect(sessionId).toBeTruthy()
+
+        const a = await clientA.listTools()
+        expect(a.tools.length).toBeGreaterThan(1)
+        const baselineCount = a.tools.length
+
+        // Client B — emulates a ClaudeCode-flavored inner request landing on the
+        // Desktop pool. Without session-mode pinning, this would resolve as
+        // coding-agent and collapse the roster to just `exec`.
+        const pool = await postToolsListOnSession(sessionId!, 'ClaudeCode')
+        expect(pool.result?.tools).toBeTruthy()
+        expect(pool.result!.tools!.length).toBe(baselineCount)
+
+        await clientA.close()
+    })
+})

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -40,21 +40,6 @@ import { InstructionsBuilder } from '@/hono/instructions'
 import type { ResolvedState } from '@/hono/request-state-resolver'
 import { ToolCatalog } from '@/hono/tool-catalog'
 import { ToolExecutor } from '@/hono/tool-executor'
-import type { RequestProperties } from '@/lib/request-properties'
-
-function makeProps(overrides: Partial<RequestProperties> = {}): RequestProperties {
-    return {
-        userHash: 'test-user',
-        apiToken: 'phx_test',
-        sessionId: 'sess-1',
-        mcpClientName: 'test',
-        mcpClientVersion: '1.0',
-        mcpProtocolVersion: '2025-03-26',
-        transport: 'streamable-http',
-        requestStartTime: Date.now(),
-        ...overrides,
-    }
-}
 
 function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> = {}): ResolvedState {
     return {
@@ -80,6 +65,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         apiKeyScopes: [],
         clientProfile: {
             capabilities: { supportsInstructions: true },
+            isCodingAgent: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',
@@ -135,11 +121,7 @@ describe('ToolExecutor metrics', () => {
         it('records success counter and duration timer', async () => {
             vi.spyOn(catalog, 'getToolByName').mockReturnValue(makeFakeTool('my-tool') as any)
 
-            await executor.handleToolCall(
-                { name: 'my-tool', arguments: {} },
-                makeProps(),
-                makeState([{ name: 'my-tool' }])
-            )
+            await executor.handleToolCall({ name: 'my-tool', arguments: {} }, makeState([{ name: 'my-tool' }]))
 
             expect(mockToolDurationStartTimer).toHaveBeenCalledWith({ tool: 'my-tool' })
             expect(mockToolCallsInc).toHaveBeenCalledWith({ tool: 'my-tool', status: 'success' })
@@ -153,11 +135,7 @@ describe('ToolExecutor metrics', () => {
                 }) as any
             )
 
-            await executor.handleToolCall(
-                { name: 'fail-tool', arguments: {} },
-                makeProps(),
-                makeState([{ name: 'fail-tool' }])
-            )
+            await executor.handleToolCall({ name: 'fail-tool', arguments: {} }, makeState([{ name: 'fail-tool' }]))
 
             expect(mockToolCallsInc).toHaveBeenCalledWith({ tool: 'fail-tool', status: 'error' })
             expect(mockToolErrorsInc).toHaveBeenCalledWith({ tool: 'fail-tool', error_type: 'internal' })
@@ -170,18 +148,14 @@ describe('ToolExecutor metrics', () => {
                 base: { schema: z.object({ required_field: z.string() }), handler: vi.fn(), _meta: undefined },
             } as any)
 
-            await executor.handleToolCall(
-                { name: 'strict-tool', arguments: {} },
-                makeProps(),
-                makeState([{ name: 'strict-tool' }])
-            )
+            await executor.handleToolCall({ name: 'strict-tool', arguments: {} }, makeState([{ name: 'strict-tool' }]))
 
             expect(mockToolCallsInc).toHaveBeenCalledWith({ tool: 'strict-tool', status: 'validation_error' })
             expect(mockToolDurationStartTimer).not.toHaveBeenCalled()
         })
 
         it('records error for unknown tool', async () => {
-            await executor.handleToolCall({ name: 'nonexistent', arguments: {} }, makeProps(), makeState([]))
+            await executor.handleToolCall({ name: 'nonexistent', arguments: {} }, makeState([]))
 
             expect(mockToolCallsInc).toHaveBeenCalledWith({ tool: 'nonexistent', status: 'error' })
         })
@@ -196,7 +170,7 @@ describe('ToolExecutor metrics', () => {
         }
 
         it('emits no exec-labelled counter or timer on success', async () => {
-            await executor.handleToolCall({ name: 'exec', arguments: { command: 'tools' } }, makeProps(), execState())
+            await executor.handleToolCall({ name: 'exec', arguments: { command: 'tools' } }, execState())
 
             expect(callsFor(mockToolCallsInc, 'exec')).toHaveLength(0)
             expect(callsFor(mockToolDurationStartTimer, 'exec')).toHaveLength(0)
@@ -205,7 +179,6 @@ describe('ToolExecutor metrics', () => {
         it('emits inner tool name for counter and duration on inner tool call', async () => {
             await executor.handleToolCall(
                 { name: 'exec', arguments: { command: 'call docs-search {"query": "test"}' } },
-                makeProps(),
                 execState()
             )
 
@@ -222,7 +195,6 @@ describe('ToolExecutor metrics', () => {
         it('classifies inner tool errors under the inner tool name, not exec', async () => {
             await executor.handleToolCall(
                 { name: 'exec', arguments: { command: 'call docs-search {"query": "test"}' } },
-                makeProps(),
                 execState()
             )
 
@@ -237,7 +209,6 @@ describe('ToolExecutor metrics', () => {
         it('emits exec-level error for framework failures before inner dispatch', async () => {
             await executor.handleToolCall(
                 { name: 'exec', arguments: { command: 'call nonexistent-tool-xyz {}' } },
-                makeProps(),
                 execState()
             )
 

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -36,10 +36,10 @@ vi.mock('@/resources', () => ({
 
 import { z } from 'zod'
 
+import { InstructionsBuilder } from '@/hono/instructions'
 import type { ResolvedState } from '@/hono/request-state-resolver'
 import { ToolCatalog } from '@/hono/tool-catalog'
 import { ToolExecutor } from '@/hono/tool-executor'
-import { InstructionsBuilder } from '@/hono/instructions'
 import type { RequestProperties } from '@/lib/request-properties'
 
 function makeProps(overrides: Partial<RequestProperties> = {}): RequestProperties {
@@ -78,7 +78,17 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         useSingleExec: false,
         toolFeatureFlags: undefined,
         apiKeyScopes: [],
-        clientProfile: { capabilities: { supportsInstructions: true } } as any,
+        clientProfile: {
+            capabilities: { supportsInstructions: true },
+        } as any,
+        requestContext: {
+            sessionId: 'sess-1',
+            mcpClientName: 'test',
+            mcpClientVersion: '1.0',
+            mcpProtocolVersion: '2025-03-26',
+            transport: 'streamable-http',
+        },
+        sessionContext: null,
         allTools: tools as any,
         distinctId: 'test-distinct-id',
         ...overrides,

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -53,7 +53,17 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         useSingleExec: false,
         toolFeatureFlags: undefined,
         apiKeyScopes: [],
-        clientProfile: { capabilities: { supportsInstructions: true } } as any,
+        clientProfile: {
+            capabilities: { supportsInstructions: true },
+        } as any,
+        requestContext: {
+            sessionId: 'sess-1',
+            mcpClientName: 'test',
+            mcpClientVersion: '1.0',
+            mcpProtocolVersion: '2025-03-26',
+            transport: 'streamable-http',
+        },
+        sessionContext: null,
         allTools: tools as any,
         distinctId: 'test-distinct-id',
         ...overrides,

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -15,22 +15,6 @@ import { InstructionsBuilder } from '@/hono/instructions'
 import type { ResolvedState } from '@/hono/request-state-resolver'
 import { ToolCatalog } from '@/hono/tool-catalog'
 import { ToolExecutor } from '@/hono/tool-executor'
-import type { RequestProperties } from '@/lib/request-properties'
-import type {} from '@/tools/types'
-
-function makeProps(overrides: Partial<RequestProperties> = {}): RequestProperties {
-    return {
-        userHash: 'test-user',
-        apiToken: 'phx_test',
-        sessionId: 'sess-1',
-        mcpClientName: 'test',
-        mcpClientVersion: '1.0',
-        mcpProtocolVersion: '2025-03-26',
-        transport: 'streamable-http',
-        requestStartTime: Date.now(),
-        ...overrides,
-    }
-}
 
 function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> = {}): ResolvedState {
     return {
@@ -55,6 +39,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         apiKeyScopes: [],
         clientProfile: {
             capabilities: { supportsInstructions: true },
+            isCodingAgent: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',
@@ -82,7 +67,7 @@ describe('ToolExecutor', () => {
 
     describe('handleToolCall', () => {
         it('returns error when tool name is missing', async () => {
-            const result = (await executor.handleToolCall({}, makeProps(), makeState([]))) as any
+            const result = (await executor.handleToolCall({}, makeState([]))) as any
             expect(result.isError).toBe(true)
             expect(result.content[0].text).toContain('Missing tool name')
         })
@@ -90,7 +75,6 @@ describe('ToolExecutor', () => {
         it('returns error when tool does not exist', async () => {
             const result = (await executor.handleToolCall(
                 { name: 'nonexistent-tool', arguments: {} },
-                makeProps(),
                 makeState([])
             )) as any
             expect(result.isError).toBe(true)
@@ -102,11 +86,7 @@ describe('ToolExecutor', () => {
             const entries = catalog.getPreBuiltEntries()
             const tool = entries[0]!
 
-            const result = (await executor.handleToolCall(
-                { name: tool.name, arguments: {} },
-                makeProps(),
-                makeState([])
-            )) as any
+            const result = (await executor.handleToolCall({ name: tool.name, arguments: {} }, makeState([]))) as any
             expect(result.isError).toBe(true)
             expect(result.content[0].text).toContain('not found')
         })
@@ -119,7 +99,6 @@ describe('ToolExecutor', () => {
 
             const result = (await executor.handleToolCall(
                 { name: knownTool.name, arguments: { __invalid_field_xyz: 'bad' } },
-                makeProps(),
                 makeState([{ name: knownTool.name }])
             )) as any
 
@@ -135,7 +114,6 @@ describe('ToolExecutor', () => {
 
             const result = (await executor.handleToolCall(
                 { name: 'user-get', arguments: {} },
-                makeProps(),
                 makeState([{ name: 'user-get' }])
             )) as any
 
@@ -150,7 +128,6 @@ describe('ToolExecutor', () => {
 
             const result = (await executor.handleToolCall(
                 { name: 'exec', arguments: { command: 'tools' } },
-                makeProps({ mode: 'tools' }),
                 makeState(filteredTools, { useSingleExec: false, version: 2 })
             )) as any
 
@@ -167,14 +144,14 @@ describe('ToolExecutor', () => {
             const allEntries = catalog.getPreBuiltEntries()
             const subset = allEntries.slice(0, 3)
 
-            const result = await executor.handleToolsList(makeState(subset.map((e) => ({ name: e.name }))), makeProps())
+            const result = await executor.handleToolsList(makeState(subset.map((e) => ({ name: e.name }))))
 
             expect(result.tools).toHaveLength(3)
             expect(result.tools.map((t) => t.name)).toEqual(subset.map((e) => e.name))
         })
 
         it('returns empty list when allTools is empty', async () => {
-            const result = await executor.handleToolsList(makeState([]), makeProps())
+            const result = await executor.handleToolsList(makeState([]))
             expect(result.tools).toEqual([])
         })
 
@@ -187,7 +164,7 @@ describe('ToolExecutor', () => {
                 { useSingleExec: true, version: 2 }
             )
 
-            const result = await executor.handleToolsList(state, makeProps())
+            const result = await executor.handleToolsList(state)
             expect(result.tools).toHaveLength(1)
             expect(result.tools[0]!.name).toBe('exec')
         })

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -11,11 +11,11 @@ vi.mock('@/resources', () => ({
     getPromptsFromManifest: vi.fn().mockResolvedValue([]),
 }))
 
-import type { RequestProperties } from '@/lib/request-properties'
+import { InstructionsBuilder } from '@/hono/instructions'
 import type { ResolvedState } from '@/hono/request-state-resolver'
 import { ToolCatalog } from '@/hono/tool-catalog'
 import { ToolExecutor } from '@/hono/tool-executor'
-import { InstructionsBuilder } from '@/hono/instructions'
+import type { RequestProperties } from '@/lib/request-properties'
 import type {} from '@/tools/types'
 
 function makeProps(overrides: Partial<RequestProperties> = {}): RequestProperties {
@@ -131,6 +131,24 @@ describe('ToolExecutor', () => {
 
             expect(result).not.toBeNull()
             expect(result.content).not.toBeNull()
+        })
+
+        it('accepts cached exec calls even when the current session is in tools mode', async () => {
+            const filteredTools = catalog
+                .getFilteredTools({ version: 2, scopes: ['*'] })
+                .filter((tool) => tool.name === 'execute-sql' || tool.name === 'organization-get')
+
+            const result = (await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'tools' } },
+                makeProps({ mode: 'tools' }),
+                makeState(filteredTools, { useSingleExec: false, version: 2 })
+            )) as any
+
+            expect(result.isError).toBeFalsy()
+            const text = result.content?.[0]?.text ?? ''
+            expect(text).toContain('execute-sql')
+            expect(text).toContain('organization-get')
+            expect(text).not.toContain('feature-flag-get-all')
         })
     })
 

--- a/services/mcp/tests/unit/build-tool-result.test.ts
+++ b/services/mcp/tests/unit/build-tool-result.test.ts
@@ -54,7 +54,7 @@ describe('buildToolResultPayload — query-trends for Claude Code', () => {
             toolMeta: queryTrendsToolMeta,
             toolName: 'query-trends',
             params: { series: [{ event: '$pageview', kind: 'EventsNode' }] },
-            clientName: 'claude-code',
+            suppressStructuredContentForFormattedResults: true,
             distinctId: 'test-distinct-id',
         })
 
@@ -65,40 +65,13 @@ describe('buildToolResultPayload — query-trends for Claude Code', () => {
         expect(payload).not.toHaveProperty('structuredContent')
     })
 
-    it.each([
-        ['claude-code'],
-        ['Claude Code'], // whitespace variant — normalizer strips it
-        ['claude-code-cli'],
-        ['claude-code/1.2.3'],
-        ['cline'],
-        ['cline-bot'],
-        ['continue'],
-        ['codex'],
-        ['windsurf'],
-        ['zed'],
-        ['aider'],
-        ['github.copilot'],
-    ])('suppresses structuredContent for coding agent %s', (clientName) => {
+    it('keeps structuredContent when suppression is false', () => {
         const payload = buildToolResultPayload({
             handlerResult: queryTrendsHandlerResult(),
             toolMeta: queryTrendsToolMeta,
             toolName: 'query-trends',
             params: {},
-            clientName,
-            distinctId: 'd',
-        })
-
-        expect(payload.content[0]!.text).toBe(FORMATTED_TABLE)
-        expect(payload).not.toHaveProperty('structuredContent')
-    })
-
-    it('keeps structuredContent for Cursor (it reads text for the model, structured for UI)', () => {
-        const payload = buildToolResultPayload({
-            handlerResult: queryTrendsHandlerResult(),
-            toolMeta: queryTrendsToolMeta,
-            toolName: 'query-trends',
-            params: {},
-            clientName: 'cursor',
+            suppressStructuredContentForFormattedResults: false,
             distinctId: 'test-distinct-id',
         })
 
@@ -112,22 +85,18 @@ describe('buildToolResultPayload — query-trends for Claude Code', () => {
         expect(payload.structuredContent).not.toHaveProperty(POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY)
     })
 
-    it.each([['Claude Desktop'], ['claude-desktop'], ['mcp-inspector'], [undefined]])(
-        'keeps structuredContent for non-coding client %s',
-        (clientName) => {
-            const payload = buildToolResultPayload({
-                handlerResult: queryTrendsHandlerResult(),
-                toolMeta: queryTrendsToolMeta,
-                toolName: 'query-trends',
-                params: {},
-                clientName,
-                distinctId: 'd',
-            })
+    it('keeps structuredContent when suppression is omitted', () => {
+        const payload = buildToolResultPayload({
+            handlerResult: queryTrendsHandlerResult(),
+            toolMeta: queryTrendsToolMeta,
+            toolName: 'query-trends',
+            params: {},
+            distinctId: 'd',
+        })
 
-            expect(payload.content[0]!.text).toBe(FORMATTED_TABLE)
-            expect(payload.structuredContent).not.toBeUndefined()
-        }
-    )
+        expect(payload.content[0]!.text).toBe(FORMATTED_TABLE)
+        expect(payload.structuredContent).not.toBeUndefined()
+    })
 
     it('keeps structuredContent when caller explicitly passes output_format=json (even on claude-code)', () => {
         const payload = buildToolResultPayload({
@@ -135,7 +104,7 @@ describe('buildToolResultPayload — query-trends for Claude Code', () => {
             toolMeta: queryTrendsToolMeta,
             toolName: 'query-trends',
             params: { output_format: 'json' },
-            clientName: 'claude-code',
+            suppressStructuredContentForFormattedResults: true,
             distinctId: 'd',
         })
 
@@ -158,7 +127,7 @@ describe('buildToolResultPayload — query-trends for Claude Code', () => {
             toolMeta: queryTrendsToolMeta,
             toolName: 'query-trends',
             params: {},
-            clientName: 'claude-code',
+            suppressStructuredContentForFormattedResults: true,
             distinctId: 'd',
         })
 
@@ -174,7 +143,7 @@ describe('buildToolResultPayload — query-trends for Claude Code', () => {
             toolMeta: queryTrendsToolMeta,
             toolName: 'query-trends',
             params: {},
-            clientName: 'claude-desktop',
+            suppressStructuredContentForFormattedResults: false,
             distinctId: 'user-abc-123',
         })
 
@@ -194,7 +163,7 @@ describe('buildToolResultPayload — query-trends for Claude Code', () => {
             toolMeta: undefined,
             toolName: 'whatever',
             params: {},
-            clientName: 'cursor',
+            suppressStructuredContentForFormattedResults: false,
             distinctId: 'd',
         })
 
@@ -214,7 +183,7 @@ describe('buildToolResultPayload — non-query use cases', () => {
             toolMeta: undefined,
             toolName: 'execute-sql',
             params: {},
-            clientName: 'claude-code',
+            suppressStructuredContentForFormattedResults: true,
             distinctId: undefined,
         })
 
@@ -231,7 +200,7 @@ describe('buildToolResultPayload — non-query use cases', () => {
             toolMeta: { [POSTHOG_META_KEY]: { outputFormat: 'json' } },
             toolName: 'query-llm-traces-list',
             params: {},
-            clientName: 'claude-code',
+            suppressStructuredContentForFormattedResults: true,
             distinctId: undefined,
         })
 

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -149,14 +149,27 @@ describe('isVibeCodingClient', () => {
 
 describe('MCPClientProfile', () => {
     describe('isCodingAgent()', () => {
-        it.each([['claude-code'], ['Codex CLI'], ['cline'], ['zed-editor'], ['GitHub Copilot Chat']])(
-            'returns true for %s',
-            (clientName) => {
-                expect(new MCPClientProfile({ clientName }).isCodingAgent()).toBe(true)
-            }
-        )
+        it.each([
+            ['claude-code'],
+            ['Claude Code'],
+            ['claude-code-cli'],
+            ['claude-code/1.2.3'],
+            ['cline'],
+            ['cline-bot'],
+            ['continue'],
+            ['codex'],
+            ['Codex CLI'],
+            ['windsurf'],
+            ['zed'],
+            ['zed-editor'],
+            ['aider'],
+            ['github.copilot'],
+            ['GitHub Copilot Chat'],
+        ])('returns true for %s', (clientName) => {
+            expect(new MCPClientProfile({ clientName }).isCodingAgent()).toBe(true)
+        })
 
-        it.each([['Claude Desktop'], ['cursor'], ['mcp-inspector'], [''], ['   ']])(
+        it.each([['Claude Desktop'], ['claude-desktop'], ['cursor'], ['mcp-inspector'], [''], ['   ']])(
             'returns false for %s',
             (clientName) => {
                 expect(new MCPClientProfile({ clientName }).isCodingAgent()).toBe(false)

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -166,6 +166,32 @@ describe('MCPClientProfile', () => {
         it('returns false when clientName is undefined', () => {
             expect(new MCPClientProfile({}).isCodingAgent()).toBe(false)
         })
+
+        describe('vendorClient precedence', () => {
+            it('prefers vendorClient over clientName for detection', () => {
+                // Claude pools MCP transports: the initialize body says
+                // `Anthropic/ClaudeAI` (the pool owner) but the live inner
+                // client is `ClaudeCode` (a coding agent). The header wins.
+                expect(
+                    new MCPClientProfile({
+                        clientName: 'Anthropic/ClaudeAI',
+                        vendorClient: 'ClaudeCode',
+                    }).isCodingAgent()
+                ).toBe(true)
+            })
+
+            it('falls back to clientName when vendorClient is missing', () => {
+                expect(new MCPClientProfile({ clientName: 'claude-code' }).isCodingAgent()).toBe(true)
+            })
+
+            it('treats coding-agent clientName as non-coding when vendorClient says otherwise', () => {
+                // Inverse case: if a pool of coding-agent clients somehow
+                // carries a non-coding request, the live header rules.
+                expect(
+                    new MCPClientProfile({ clientName: 'claude-code', vendorClient: 'ClaudeAI' }).isCodingAgent()
+                ).toBe(false)
+            })
+        })
     })
 
     describe('isPostHogCodeConsumer()', () => {
@@ -251,11 +277,13 @@ describe('MCPClientProfile', () => {
             clientVersion: '1.2.3',
             consumer: POSTHOG_CODE_CONSUMER,
             oauthClientName: 'Lovable',
+            vendorClient: 'ClaudeCode',
         })
         expect(profile.clientName).toBe('claude-code')
         expect(profile.clientVersion).toBe('1.2.3')
         expect(profile.consumer).toBe(POSTHOG_CODE_CONSUMER)
         expect(profile.oauthClientName).toBe('Lovable')
+        expect(profile.vendorClient).toBe('ClaudeCode')
     })
 })
 

--- a/services/mcp/tests/unit/posthog/analytics.test.ts
+++ b/services/mcp/tests/unit/posthog/analytics.test.ts
@@ -76,6 +76,7 @@ describe('initMcpAnalytics', () => {
             getMcpClientName: vi.fn().mockResolvedValue('claude-code'),
             getMcpClientVersion: vi.fn().mockResolvedValue('1.2.3'),
             getMcpProtocolVersion: vi.fn().mockResolvedValue('2024-11-05'),
+            getMcpVendorClient: vi.fn().mockResolvedValue('ClaudeCode'),
             getRegion: vi.fn().mockResolvedValue('us'),
             getAnalyticsContext: vi.fn().mockResolvedValue({
                 organizationId: 'org-789',
@@ -227,6 +228,7 @@ describe('initMcpAnalytics', () => {
             $mcp_client_user_agent: 'test-agent/1.0',
             $mcp_client_name: 'claude-code',
             $mcp_client_version: '1.2.3',
+            mcp_vendor_client: 'ClaudeCode',
             $mcp_protocol_version: '2024-11-05',
             $mcp_region: 'us',
             $mcp_organization_id: 'org-789',

--- a/services/mcp/tests/unit/protocol-types.test.ts
+++ b/services/mcp/tests/unit/protocol-types.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { MCPClientProfile } from '@/lib/client-detection'
 import { resolveModeAndVersion } from '@/hono/request-state-resolver'
+import { MCPClientProfile } from '@/lib/client-detection'
 
 describe('resolveModeAndVersion', () => {
     function profile(overrides: Partial<ConstructorParameters<typeof MCPClientProfile>[0]> = {}): MCPClientProfile {
@@ -16,11 +16,12 @@ describe('resolveModeAndVersion', () => {
     }
 
     it('defaults to version 1, no single exec', () => {
-        expect(resolveModeAndVersion(base)).toEqual({ useSingleExec: false, version: 1 })
+        expect(resolveModeAndVersion(base)).toEqual({ mode: 'tools', useSingleExec: false, version: 1 })
     })
 
     it('explicit mode=cli forces single exec and version 2', () => {
         expect(resolveModeAndVersion({ ...base, mode: 'cli' })).toEqual({
+            mode: 'cli',
             useSingleExec: true,
             version: 2,
         })
@@ -40,7 +41,7 @@ describe('resolveModeAndVersion', () => {
             ...base,
             clientProfile: profile({ clientName: 'claude-code' }),
         })
-        expect(result).toEqual({ useSingleExec: true, version: 2 })
+        expect(result).toEqual({ mode: 'cli', useSingleExec: true, version: 2 })
     })
 
     it('non-coding agent does NOT activate single exec', () => {
@@ -61,12 +62,12 @@ describe('resolveModeAndVersion', () => {
 
     it('uses flagVersion when not in single exec mode', () => {
         const result = resolveModeAndVersion({ ...base, flagVersion: 2 })
-        expect(result).toEqual({ useSingleExec: false, version: 2 })
+        expect(result).toEqual({ mode: 'tools', useSingleExec: false, version: 2 })
     })
 
     it('clientVersion overrides default when no flagVersion', () => {
         const result = resolveModeAndVersion({ ...base, clientVersion: 2 })
-        expect(result).toEqual({ useSingleExec: false, version: 2 })
+        expect(result).toEqual({ mode: 'tools', useSingleExec: false, version: 2 })
     })
 
     it('flagVersion takes precedence over clientVersion', () => {
@@ -76,6 +77,6 @@ describe('resolveModeAndVersion', () => {
 
     it('single exec always forces version 2 regardless of flagVersion', () => {
         const result = resolveModeAndVersion({ ...base, mode: 'cli', flagVersion: 1 })
-        expect(result).toEqual({ useSingleExec: true, version: 2 })
+        expect(result).toEqual({ mode: 'cli', useSingleExec: true, version: 2 })
     })
 })

--- a/services/mcp/tests/unit/url-routing.test.ts
+++ b/services/mcp/tests/unit/url-routing.test.ts
@@ -205,15 +205,9 @@ describe('URL Routing', () => {
                 expected: undefined,
             },
             {
-                description: 'query param takes precedence over header',
+                description: 'header takes precedence over query param',
                 headers: { 'x-posthog-mcp-mode': 'cli' },
                 params: '?mode=tools',
-                expected: 'tools' as const,
-            },
-            {
-                description: 'invalid query param falls back to header',
-                headers: { 'x-posthog-mcp-mode': 'cli' },
-                params: '?mode=banana',
                 expected: 'cli' as const,
             },
         ]
@@ -223,13 +217,13 @@ describe('URL Routing', () => {
             const headerValue = headers['x-posthog-mcp-mode'] ?? null
             const queryValue = url.searchParams.get('mode')
 
-            // Mirrors the merge order in `src/index.ts` — a valid query param wins over the header.
-            expect(parseMcpMode(queryValue) || parseMcpMode(headerValue)).toBe(expected)
+            // Mirrors the merge order in `src/index.ts` — header wins over query param.
+            expect(parseMcpMode(headerValue || queryValue)).toBe(expected)
         })
     })
 
     describe('shared request property mode parsing', () => {
-        it('uses URL mode before header mode', () => {
+        it('uses header mode before URL mode', () => {
             const request = new Request('https://example.com/mcp?mode=tools', {
                 headers: {
                     Authorization: 'Bearer phx_test',
@@ -237,7 +231,7 @@ describe('URL Routing', () => {
                 },
             })
 
-            expect(parseRequestProperties(request, {}).mode).toBe('tools')
+            expect(parseRequestProperties(request, {}).mode).toBe('cli')
         })
     })
 

--- a/services/mcp/tests/unit/url-routing.test.ts
+++ b/services/mcp/tests/unit/url-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { parseRequestProperties } from '@/lib/request-properties'
 import { parseMcpMode, sanitizeHeaderValue } from '@/lib/utils'
 
 function parseIdFromRequest(
@@ -204,9 +205,15 @@ describe('URL Routing', () => {
                 expected: undefined,
             },
             {
-                description: 'header takes precedence over query param',
+                description: 'query param takes precedence over header',
                 headers: { 'x-posthog-mcp-mode': 'cli' },
                 params: '?mode=tools',
+                expected: 'tools' as const,
+            },
+            {
+                description: 'invalid query param falls back to header',
+                headers: { 'x-posthog-mcp-mode': 'cli' },
+                params: '?mode=banana',
                 expected: 'cli' as const,
             },
         ]
@@ -216,8 +223,21 @@ describe('URL Routing', () => {
             const headerValue = headers['x-posthog-mcp-mode'] ?? null
             const queryValue = url.searchParams.get('mode')
 
-            // Mirrors the merge order in `src/index.ts` — header wins over query param.
-            expect(parseMcpMode(headerValue || queryValue)).toBe(expected)
+            // Mirrors the merge order in `src/index.ts` — a valid query param wins over the header.
+            expect(parseMcpMode(queryValue) || parseMcpMode(headerValue)).toBe(expected)
+        })
+    })
+
+    describe('shared request property mode parsing', () => {
+        it('uses URL mode before header mode', () => {
+            const request = new Request('https://example.com/mcp?mode=tools', {
+                headers: {
+                    Authorization: 'Bearer phx_test',
+                    'x-posthog-mcp-mode': 'cli',
+                },
+            })
+
+            expect(parseRequestProperties(request, {}).mode).toBe('tools')
         })
     })
 

--- a/services/mcp/tests/unit/url-routing.test.ts
+++ b/services/mcp/tests/unit/url-routing.test.ts
@@ -241,6 +241,25 @@ describe('URL Routing', () => {
         })
     })
 
+    describe('mcpVendorClient parsing', () => {
+        it('captures x-anthropic-client into mcpVendorClient', () => {
+            const request = new Request('https://example.com/mcp', {
+                headers: {
+                    Authorization: 'Bearer phx_test',
+                    'x-anthropic-client': 'ClaudeCode',
+                },
+            })
+            expect(parseRequestProperties(request, {}).mcpVendorClient).toBe('ClaudeCode')
+        })
+
+        it('returns undefined when x-anthropic-client is missing', () => {
+            const request = new Request('https://example.com/mcp', {
+                headers: { Authorization: 'Bearer phx_test' },
+            })
+            expect(parseRequestProperties(request, {}).mcpVendorClient).toBeUndefined()
+        })
+    })
+
     describe('MCP consumer parsing', () => {
         const consumerTests = [
             {


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Claude now pools the MCP connection, so it breaks the MCP mode when you switch from Claude Code to Claude – it is kept as the CLI mode, but it is supposed to be the tools mode.

## Changes

- If the mode is auto-resolved, cache it for the session id.
- If the session is not set, resolve on the fly.
- If the mode is explicitly passed, use it.
- Allow to query exec despite the mode, so if the mode switches to tools, the agent will still be able to use the exec tool.

## How did you test this code?

Manual testing

## Publish to changelog?

No

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
