### PR TITLE
chore: merge team-flags-platform into team-feature-flags

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -75,15 +75,10 @@ posthog/tasks/exports/** @PostHog/team-analytics-platform
 # Revenue Analytics - owned by @rafaeelaudibert and @PostHog/team-web-analytics
 products/revenue_analytics/\*\* @rafaeelaudibert @PostHog/team-web-analytics
 
-# Feature Flags (the `/flags` endpoint, flag matching, CRUD, and tests) - owned by @PostHog/team-feature-flags
+# Feature Flags (Rust evaluator + remaining monolith tests) - owned by @PostHog/team-feature-flags
+# Note: the Django models and API moved to products/feature_flags/ (covered by products/feature_flags/product.yaml).
 rust/feature-flags/ @PostHog/team-feature-flags
-posthog/models/feature_flag/ @PostHog/team-feature-flags
-posthog/api/feature_flag.py @PostHog/team-feature-flags
-posthog/api/test/test_feature_flag_dependency_deletion.py @PostHog/team-feature-flags
-posthog/api/test/test_feature_flag_utils.py @PostHog/team-feature-flags
-posthog/api/test/test_feature_flag.py @PostHog/team-feature-flags
 posthog/test/test_feature_flag_analytics.py @PostHog/team-feature-flags
-posthog/test/test_feature_flag.py @PostHog/team-feature-flags
 
 # Cohorts - owned by @PostHog/team-feature-flags
 posthog/api/cohort.py @PostHog/team-feature-flags

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -75,18 +75,15 @@ posthog/tasks/exports/** @PostHog/team-analytics-platform
 # Revenue Analytics - owned by @rafaeelaudibert and @PostHog/team-web-analytics
 products/revenue_analytics/\*\* @rafaeelaudibert @PostHog/team-web-analytics
 
-# Feature Flags platform (the `/flags` endpoint + associated utils) - owned by @PostHog/team-flags-platform
-rust/feature-flags/ @PostHog/team-flags-platform
-posthog/models/feature_flag/flag_matching.py @PostHog/team-flags-platform
-
-# Feature Flags CRUD operations - owned by @PostHog/team-feature-flags and @PostHog/team-flags-platform
-posthog/models/feature_flag/ @PostHog/team-feature-flags @PostHog/team-flags-platform
-posthog/api/feature_flag.py @PostHog/team-feature-flags @PostHog/team-flags-platform
-posthog/api/test/test_feature_flag_dependency_deletion.py @PostHog/team-feature-flags @PostHog/team-flags-platform
-posthog/api/test/test_feature_flag_utils.py @PostHog/team-feature-flags @PostHog/team-flags-platform
-posthog/api/test/test_feature_flag.py @PostHog/team-feature-flags @PostHog/team-flags-platform
-posthog/test/test_feature_flag_analytics.py @PostHog/team-feature-flags @PostHog/team-flags-platform
-posthog/test/test_feature_flag.py @PostHog/team-feature-flags @PostHog/team-flags-platform
+# Feature Flags (the `/flags` endpoint, flag matching, CRUD, and tests) - owned by @PostHog/team-feature-flags
+rust/feature-flags/ @PostHog/team-feature-flags
+posthog/models/feature_flag/ @PostHog/team-feature-flags
+posthog/api/feature_flag.py @PostHog/team-feature-flags
+posthog/api/test/test_feature_flag_dependency_deletion.py @PostHog/team-feature-flags
+posthog/api/test/test_feature_flag_utils.py @PostHog/team-feature-flags
+posthog/api/test/test_feature_flag.py @PostHog/team-feature-flags
+posthog/test/test_feature_flag_analytics.py @PostHog/team-feature-flags
+posthog/test/test_feature_flag.py @PostHog/team-feature-flags
 
 # Cohorts - owned by @PostHog/team-feature-flags
 posthog/api/cohort.py @PostHog/team-feature-flags

--- a/.github/workflows/canary-flags-enable.yml
+++ b/.github/workflows/canary-flags-enable.yml
@@ -12,7 +12,7 @@ name: Enable Feature Flags PR Canary
 # Requirements:
 # - PR must be approved (no outstanding change requests)
 # - PR author must be a PostHog org member
-# - For /pr-canary and workflow_dispatch: actor must be in team-feature-flags or team-flags-platform
+# - For /pr-canary and workflow_dispatch: actor must be in team-feature-flags
 
 concurrency:
     group: canary-flags-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id }}
@@ -121,7 +121,7 @@ jobs:
                                   '| `weight` | `1`–`10` or `auto` | `auto` |',
                                   '| `env` | `dev`, `prod-us`, `prod-eu` | `dev` |',
                                   '',
-                                  '**Requirements:** PR must be approved. You must be in `team-feature-flags` or `team-flags-platform`.',
+                                  '**Requirements:** PR must be approved. You must be in `team-feature-flags`.',
                                   '',
                                   'The canary auto-disables after 48h or when the PR is closed/merged.',
                               ].join('\n')
@@ -132,7 +132,7 @@ jobs:
 
                       // Check team membership
                       const actor = process.env.ACTOR;
-                      const allowedTeams = ['team-feature-flags', 'team-flags-platform'];
+                      const allowedTeams = ['team-feature-flags'];
                       let isMember = false;
 
                       for (const team of allowedTeams) {
@@ -163,7 +163,7 @@ jobs:
                               owner: context.repo.owner,
                               repo: context.repo.repo,
                               issue_number: prNumber,
-                              body: `@${actor} you must be a member of \`team-feature-flags\` or \`team-flags-platform\` to use \`/pr-canary\`.`
+                              body: `@${actor} you must be a member of \`team-feature-flags\` to use \`/pr-canary\`.`
                           });
                           core.setFailed('Not a member of an authorized team');
                           return;
@@ -531,7 +531,7 @@ jobs:
                       }
 
                       // Label added manually — verify the user is on an allowed team
-                      const allowedTeams = ['team-feature-flags', 'team-flags-platform'];
+                      const allowedTeams = ['team-feature-flags'];
                       for (const team of allowedTeams) {
                           try {
                               await github.rest.teams.getMembershipForUserInOrg({
@@ -551,7 +551,7 @@ jobs:
 
                       core.setFailed(
                           `canary-flags label was added by ${labeler} who is not a member of ` +
-                          `team-feature-flags or team-flags-platform. ` +
+                          `team-feature-flags. ` +
                           `Use /pr-canary to enable canary deployments.`
                       );
 
@@ -597,7 +597,7 @@ jobs:
                   github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       const actor = process.env.ACTOR;
-                      const allowedTeams = ['team-feature-flags', 'team-flags-platform'];
+                      const allowedTeams = ['team-feature-flags'];
 
                       for (const team of allowedTeams) {
                           try {
@@ -621,8 +621,8 @@ jobs:
                           }
                       }
                       core.setFailed(
-                          `${actor} is not a member of team-feature-flags or team-flags-platform. ` +
-                          `Only members of these teams can trigger canary deployments.`
+                          `${actor} is not a member of team-feature-flags. ` +
+                          `Only members of this team can trigger canary deployments.`
                       );
 
             - name: Validate canary inputs


### PR DESCRIPTION
## Problem

The `team-flags-platform` GitHub team is being merged into `team-feature-flags`. References to `team-flags-platform` in this repo need to point at the consolidated team so code ownership and canary deployment authorization keep working after the team is removed.

## Changes

- `.github/CODEOWNERS-soft`: collapse the separate "platform" and "CRUD" ownership blocks into a single block owned by `@PostHog/team-feature-flags`. All feature flag paths (`rust/feature-flags/`, `posthog/models/feature_flag/`, `posthog/api/feature_flag.py`, and the related tests) are now owned by one team.
- `.github/workflows/canary-flags-enable.yml`: drop `team-flags-platform` from every `allowedTeams` check, comment, help message, and error string in the `/pr-canary` and workflow_dispatch authorization paths.

No code paths or behavior change beyond authorization membership.

## How did you test this code?

I'm an agent. No tests were run. The changes are configuration-only (CODEOWNERS entries and string/array constants in a workflow). Reviewers should verify:

- The CODEOWNERS-soft consolidation still covers every path that was previously listed.
- The three `allowedTeams` arrays in the workflow and their accompanying user-facing messages all match.

## Publish to changelog?

no