### PR TITLE
chore(mcp): fix mcp ready_pattern for hono runtime

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -411,10 +411,10 @@ procs:
     mcp:
         shell: 'bin/start-mcp-server'
         capability: mcp_server
-        ready_pattern: 'Ready on *'
+        ready_pattern: 'Server started on'
         groups:
             layer: Product services
-            tech: Python
+            tech: Node
 
     mcp-ui-apps:
         shell: 'cd services/mcp && pnpm run build:ui-apps -- --watch'


### PR DESCRIPTION
## Problem

`bin/mprocs.yaml` ready_pattern for `mcp` was `Ready on *` — a leftover from the wrangler-era output. After the move to Hono, the server logs `[MCP] Server started on 0.0.0.0:8787`, so phrocs never marked the proc ready and kept it in starting/running limbo.

## Changes

- `ready_pattern: 'Ready on *'` → `'Server started on'`
- `tech: Python` → `Node` (Hono runtime)

## How did you test this code?

Agent-authored. No automated tests added — config-only change.

## Publish to changelog?

no

## 🤖 Agent context

PostHog Code agent. Located the mismatch by grepping the hono entrypoint for the actual ready log line and comparing to `bin/mprocs.yaml`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
