### PR TITLE
perf(devex): skip django migrate walk on product test dbs

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -218,11 +218,23 @@ for route in product_routes:
     DATABASES[reader_alias].setdefault("OPTIONS", {})["connect_timeout"] = 3
 
     if TEST:
-        # Tell Django's test runner to create an independent test database and run
-        # migrations (via the router). Without this, test databases are created
-        # but left empty. Reader shares the writer's test database so reads inside
-        # a write transaction see uncommitted data.
-        DATABASES[writer_alias]["TEST"] = {"DEPENDENCIES": []}
+        # Skip the global migration-graph walk during test DB setup. Without
+        # `MIGRATE: False`, Django's `create_test_db` calls `migrate --database
+        # <alias>` with no app filter, which walks the full ~1300-migration
+        # graph for `state_forwards` on every alias — even though
+        # `ProductDBRouter.allow_migrate` gates DDL to just the owning product
+        # app. The state-machine walk runs regardless of the router and burns
+        # ~5 min per affected shard on a fresh test DB.
+        #
+        # `MIGRATE: False` makes `create_test_db` skip migrations and fall
+        # through to `run_syncdb=True`, which creates tables directly from the
+        # current model definitions for any app that `allow_migrate` permits.
+        # For Django-owned product DBs (`managed=True` models), that yields
+        # the same final-schema tables in milliseconds instead of minutes.
+        #
+        # Reader shares the writer's test database so reads inside a write
+        # transaction see uncommitted data.
+        DATABASES[writer_alias]["TEST"] = {"MIGRATE": False, "DEPENDENCIES": []}
         DATABASES[reader_alias]["TEST"] = {"MIRROR": writer_alias}
 
     if DISABLE_SERVER_SIDE_CURSORS:


### PR DESCRIPTION
## Problem

Mirror of #60167 but for product-routed databases instead of persons. Django's `create_test_db` walks the full migration graph (`state_forwards` for every migration) once per database alias, regardless of what `allow_migrate` returns. On a fresh test DB that walk runs ~300s of pure Python state-machine work per alias — same root cause that hit `persons_db_writer`.

Locally on a fresh test DB, `visual_review_db_writer` setup measured ~330s; PR #60167 already shaved off the persons portion, this trims off the visual-review portion. The CI win lands on whichever shard sets up `visual_review_db_writer` (the visual-review backend shard opts in via `PRODUCT_DATABASES`).

## Changes

One spot in `posthog/settings/data_stores.py` — set `TEST: {"MIGRATE": False}` on every product DB writer alias and `MIRROR` on the reader, matching the persons setup from #60167. Django then skips the global walk and falls through to `--run-syncdb`, which builds the schema directly from current model definitions for whichever apps `ProductDBRouter.allow_migrate` permits on that alias.

No conftest changes needed — for `managed=True` product models like `visual_review`, `--run-syncdb` reproduces the final schema in milliseconds.

## What this trade-off actually is

`MIGRATE: False` doesn't just skip the slow Python walk — it skips running migrations on the alias at all. Django then falls through to `--run-syncdb`, which materialises tables straight from the current `models.py` definitions instead of replaying migration history. For Django-managed models with no custom DDL this is fine (test DBs only need final schema, not history), but it means anything a migration does outside of `CreateModel` / `AddField` / etc. is invisible in tests.

In short: tests see whatever `models.py` declares, nothing more.

## Caveat — partitioned tables / views

`run-syncdb` builds tables from model meta only. Any migration that depends on `RunPython` / `RunSQL` for DDL (e.g. `PARTITION BY RANGE`, daily partitions, views) will *not* be reproduced in the test DB.

`warehouse_sources_queue/migrations/0001_initial.py` is such a case — it uses `RunPython` for `sourcebatch` / `sourcebatchstatus` partitioning plus `v_latest_source_batch_status`. **No test opts into `warehouse_sources_queue_db_writer` today** (the v3 pipeline tests build their own non-partitioned copies in the default test DB via `_ensure_sourcebatch_tables`), so this PR doesn't break anything in the current state, but it's a future trap.

When the first test that needs the real warehouse_sources_queue schema lands, the fix is either:

- Add a conftest fixture that runs `migrate warehouse_sources_queue --database=warehouse_sources_queue_db_writer` against the alias (per-app walk, ~ms not minutes), or
- Carry an opt-out flag in `products/db_routing.yaml` and keep migrating that one product's DB normally.

Worth noting because the next person reading `data_stores.py` shouldn't assume `MIGRATE: False` is safe for every product DB unconditionally.

## How did you test this code?

Agent-authored. Verified locally on a fresh test DB:

- `pytest products/visual_review/backend/tests/test_models.py -v --create-db` — 10/10 pass, total setup dropped from ~650s (with persons fix in place) to ~325s. The ~330s `visual_review_db_writer` portion is the elimination.
- Post-setup inspection of `test_posthog_visual_review`: all 6 `visual_review_*` tables present, no `django_migrations` table (expected per Django ticket #23273, fixed since 3.1).

CI will exercise the rest. The `Product tests (visual-review)` shard is the visible signal.

## Publish to changelog?

no

## 🤖 Agent context

Follow-up to #60167. Same root cause (full Django migration-graph walk on `create_test_db` regardless of `allow_migrate`), same fix shape, applied to the second class of separate-DB setup (product-routed via `ProductDBRouter`, schema owned by Django) rather than the persons case (routed via `PersonDBRouter`, schema owned by sqlx).

Initial draft also patched `conftest.py` to run an app-filtered migrate per product DB — removed after a `relation already exists` error proved that Django's `--run-syncdb` fallback already covers the `managed=True` case. The conftest path is still the right shape for products with non-syncdb-able DDL (warehouse_sources_queue, eventually) but isn't needed today.
