### PR TITLE
fix(llma): respect dark mode in skill version compare diff

### DIFF
--- a/products/llm_analytics/frontend/skills/LLMSkillScene.tsx
+++ b/products/llm_analytics/frontend/skills/LLMSkillScene.tsx
@@ -17,6 +17,7 @@ import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
@@ -406,6 +407,7 @@ function SkillViewDetails(): JSX.Element {
 function SkillDiffView(): JSX.Element {
     const { skill, compareSkill, compareSkillLoading, compareVersion, compareVersionOptions } = useValues(llmSkillLogic)
     const { setCompareVersion } = useActions(llmSkillLogic)
+    const { isDarkModeOn } = useValues(themeLogic)
 
     if (!skill || !isSkill(skill)) {
         return <></>
@@ -453,6 +455,7 @@ function SkillDiffView(): JSX.Element {
                             value={modified}
                             modified={modified}
                             language="markdown"
+                            theme={isDarkModeOn ? 'vs-dark' : 'vs-light'}
                             options={{
                                 readOnly: true,
                                 renderSideBySide: true,


### PR DESCRIPTION
## Problem

On the LLM skill detail page (prompt management), clicking **Compare versions** opens a side-by-side diff between two versions. The diff is rendered with Monaco's built-in diff editor via `MonacoDiffEditor`, but `SkillDiffView` never passed a `theme`. As a result, the editor fell back to Monaco's default light theme even when the surrounding PostHog UI was in dark mode, producing a jarring bright panel inside an otherwise dark page.

## Changes

- In `SkillDiffView` (`products/llm_analytics/frontend/skills/LLMSkillScene.tsx`), read `isDarkModeOn` from `themeLogic` and pass `theme={isDarkModeOn ? 'vs-dark' : 'vs-light'}` to `<MonacoDiffEditor>`.
- This mirrors the pattern already used by `frontend/src/lib/monaco/CodeEditor.tsx`, and uses the `theme` prop that `MonacoDiffEditor` already accepts and forwards to `monaco.editor.setTheme(...)`.

No new dependency, no styling overrides — just wiring the existing theme selector into the existing prop.

## How did you test this code?

I'm an agent — no manual UI verification was performed. Suggested manual check for the reviewer:

1. Open an LLM skill with at least two versions.
2. Click **Compare versions** and pick an older version.
3. Toggle dark / light mode (or change the system theme with "Sync with system" on).
4. Confirm the diff editor swaps between `vs-light` and `vs-dark` alongside the rest of the UI.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). The reporter pointed out that the Compare diff on the skill detail page didn't respect dark mode. Exploration confirmed that `MonacoDiffEditor` already supports a `theme` prop (it just calls `monaco.editor.setTheme`) and that `CodeEditor` was already reading `isDarkModeOn` from `themeLogic` to drive the same prop — the skill diff view was the only caller missing this wiring. No alternative approaches considered: the fix is purely "use the existing prop the same way the rest of the codebase already does".