### PR TITLE
fix(error-tracking): only show MCP hint during onboarding

### DIFF
--- a/products/error_tracking/frontend/components/SetupPrompt/SetupPrompt.tsx
+++ b/products/error_tracking/frontend/components/SetupPrompt/SetupPrompt.tsx
@@ -85,6 +85,7 @@ const IngestionStatusCheck = ({ className }: { className?: string }): JSX.Elemen
             isEmpty={true}
             productKey={ProductKey.ERROR_TRACKING}
             className={className}
+            mcpSurfaceKey="error_tracking.assign"
             customHog={WarningHog}
             actionElementOverride={
                 <div className="flex flex-col items-start gap-4">

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react'
 
 import { Tooltip } from '@posthog/lemon-ui'
 
-import { MCPUseCaseCard } from 'lib/components/MCPHint/MCPUseCaseCard'
 import { humanFriendlyLargeNumber } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 
@@ -164,20 +163,7 @@ export function IssuesList(): JSX.Element {
             <div data-attr="error-tracking-issue-row">
                 <Query query={query} context={context} />
             </div>
-            <IssuesListMCPHint />
         </BindLogic>
-    )
-}
-
-const IssuesListMCPHint = (): JSX.Element | null => {
-    const { results, responseLoading } = useValues(issuesDataNodeLogic)
-    if (responseLoading || results.length > 0) {
-        return null
-    }
-    return (
-        <div className="mt-4 flex justify-center">
-            <MCPUseCaseCard surfaceKey="error_tracking.assign" className="max-w-140" />
-        </div>
     )
 }
 


### PR DESCRIPTION
## Problem

The "Or using PostHog code" MCP card on the Error tracking page was rendered any time the issues list returned zero rows — including when a user had filtered or searched their way to an empty result set. It was meant to appear only during the product onboarding empty state.

## Changes

- Drop the always-on `IssuesListMCPHint` block (and its `MCPUseCaseCard` import) in `IssuesList.tsx` that rendered below the issues query whenever `results.length === 0`.
- Pass `mcpSurfaceKey="error_tracking.assign"` to the `ProductIntroduction` used by `SetupPrompt`'s `IngestionStatusCheck`, so the MCP card still surfaces, but only in the onboarding empty state.

## How did you test this code?

I'm an agent — no manual UI testing was performed. No new automated tests were added; this is a render-location move with no logic change. A human reviewer should sanity-check the onboarding empty state and a filtered-to-zero issues list.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (PostHog Code).
- The user pointed out the MCP card was visible on the Error tracking page outside the onboarding flow. The card already had a first-class home inside `ProductIntroduction` via the `mcpSurfaceKey` prop, so the fix was to remove the standalone render in `IssuesList` and feed the surface key into the existing onboarding component rather than introduce a new gate.