### PR TITLE
fix(eval): avoid mutating pytest keywords

### DIFF
--- a/ee/hogai/eval/sandboxed/conftest.py
+++ b/ee/hogai/eval/sandboxed/conftest.py
@@ -71,7 +71,6 @@ def pytest_collection_modifyitems(config, items):  # noqa: ARG001
             if own_markers is not None:
                 node.own_markers = [marker for marker in own_markers if marker.name != "django_db"]
             node = node.parent
-        item.keywords.pop("django_db", None)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Problem

Sandboxed eval collection strips `django_db` markers so pytest-django does not wrap each eval in per-test database handling. The hook also tried to delete `django_db` from `item.keywords`, but pytest's keyword mapping no longer supports deletion and raises `ValueError: cannot delete key in keywords dict` during collection.

## Changes

- Remove the unsupported `item.keywords.pop("django_db", None)` mutation.
- Keep the existing `own_markers` filtering, which is what pytest-django's `get_closest_marker("django_db")` checks.

## How did you test this code?

- Agent-authored.
- `.flox/cache/venv/bin/pytest ee/hogai/eval/sandboxed/experiments/eval_numbers_vs_sql.py --collect-only -q`
- `.flox/cache/venv/bin/ruff check ee/hogai/eval/sandboxed/conftest.py`

## Publish to changelog?

do not publish to changelog

## Docs update

Not needed.

## 🤖 Agent context

Codex applied a targeted pytest collection fix. The chosen approach keeps the existing marker removal because pytest-django checks markers via `get_closest_marker("django_db")`; the unsupported keyword deletion was redundant and caused collection to fail before evals could run.
