### PR TITLE
chore(code): add per-user option to ph code usage reset

### DIFF
--- a/services/llm-gateway/src/llm_gateway/cli/reset_posthog_code_usage.py
+++ b/services/llm-gateway/src/llm_gateway/cli/reset_posthog_code_usage.py
@@ -1,9 +1,10 @@
-"""Reset PostHog Code usage counters in Redis — all users by default, or a single user with --user-id."""
+"""Reset PostHog Code usage counters in Redis. Resets all users by default, or a single user with --user-id."""
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import re
 import sys
 
 import structlog
@@ -19,6 +20,8 @@ SCOPES = ("user_cost_burst", "user_cost_sustained")
 SCAN_COUNT = 500
 UNLINK_BATCH = 500
 
+_REDIS_GLOB_METACHARS = re.compile(r"([\\*?\[\]])")
+
 
 # Mirrors the cache key built by _UserCostThrottleBase._get_cache_key in
 # rate_limiting/cost_throttles.py (with the outer "ratelimit:" added by
@@ -26,9 +29,14 @@ UNLINK_BATCH = 500
 def _patterns_for(user_id: str | None) -> tuple[str, ...]:
     if user_id is None:
         return tuple(f"ratelimit:cost:user:{scope}:{POSTHOG_CODE_PRODUCT}:*" for scope in SCOPES)
+    # Escape glob metachars so a user_id like "10*" cannot expand the SCAN
+    # match and delete unrelated users' counters.
+    safe_id = _REDIS_GLOB_METACHARS.sub(r"\\\1", user_id)
+    # Two patterns per scope: the bare base key, plus its colon-suffixed
+    # variants. The trailing ':' prevents user "100" from matching user "1000".
     patterns: list[str] = []
     for scope in SCOPES:
-        base = f"ratelimit:cost:user:{scope}:{POSTHOG_CODE_PRODUCT}:{user_id}"
+        base = f"ratelimit:cost:user:{scope}:{POSTHOG_CODE_PRODUCT}:{safe_id}"
         patterns.append(base)
         patterns.append(f"{base}:*")
     return tuple(patterns)
@@ -60,6 +68,12 @@ async def _flush(redis: Redis, batch: list[str], *, dry_run: bool) -> int:
     return n
 
 
+def _non_empty_user_id(value: str) -> str:
+    if not value:
+        raise argparse.ArgumentTypeError("--user-id cannot be empty")
+    return value
+
+
 async def _amain(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="reset-posthog-code-usage",
@@ -68,6 +82,7 @@ async def _amain(argv: list[str]) -> int:
     parser.add_argument("--dry-run", action="store_true", help="Count keys without deleting.")
     parser.add_argument(
         "--user-id",
+        type=_non_empty_user_id,
         help="Reset only the given user's counters (matches the end_user_id used in the cache key).",
     )
     args = parser.parse_args(argv)
@@ -81,7 +96,7 @@ async def _amain(argv: list[str]) -> int:
     deleted = await reset_usage(redis, dry_run=args.dry_run, user_id=args.user_id)
 
     mode = "DRY RUN" if args.dry_run else "EXECUTED"
-    scope = f"user {args.user_id}" if args.user_id else "all users"
+    scope = f"user {args.user_id}" if args.user_id is not None else "all users"
     print(f"[{mode}] reset posthog_code usage ({scope}): {deleted} keys")
     return 0
 

--- a/services/llm-gateway/src/llm_gateway/cli/reset_posthog_code_usage.py
+++ b/services/llm-gateway/src/llm_gateway/cli/reset_posthog_code_usage.py
@@ -1,4 +1,4 @@
-"""Reset PostHog Code usage counters for every user in Redis."""
+"""Reset PostHog Code usage counters in Redis — all users by default, or a single user with --user-id."""
 
 from __future__ import annotations
 
@@ -14,21 +14,29 @@ from llm_gateway.services.plan_resolver import POSTHOG_CODE_PRODUCT
 
 logger = structlog.get_logger(__name__)
 
-# Mirrors the cache key built by _UserCostThrottleBase._get_cache_key in
-# rate_limiting/cost_throttles.py (with the outer "ratelimit:" added by
-# redis_limiter). Update both ends if the key shape changes.
-PATTERNS = (
-    f"ratelimit:cost:user:user_cost_burst:{POSTHOG_CODE_PRODUCT}:*",
-    f"ratelimit:cost:user:user_cost_sustained:{POSTHOG_CODE_PRODUCT}:*",
-)
+SCOPES = ("user_cost_burst", "user_cost_sustained")
 
 SCAN_COUNT = 500
 UNLINK_BATCH = 500
 
 
-async def reset_usage(redis: Redis, *, dry_run: bool) -> int:
+# Mirrors the cache key built by _UserCostThrottleBase._get_cache_key in
+# rate_limiting/cost_throttles.py (with the outer "ratelimit:" added by
+# redis_limiter). Update both ends if the key shape changes.
+def _patterns_for(user_id: str | None) -> tuple[str, ...]:
+    if user_id is None:
+        return tuple(f"ratelimit:cost:user:{scope}:{POSTHOG_CODE_PRODUCT}:*" for scope in SCOPES)
+    patterns: list[str] = []
+    for scope in SCOPES:
+        base = f"ratelimit:cost:user:{scope}:{POSTHOG_CODE_PRODUCT}:{user_id}"
+        patterns.append(base)
+        patterns.append(f"{base}:*")
+    return tuple(patterns)
+
+
+async def reset_usage(redis: Redis, *, dry_run: bool, user_id: str | None = None) -> int:
     deleted = 0
-    for pattern in PATTERNS:
+    for pattern in _patterns_for(user_id):
         batch: list[str] = []
         cursor = 0
         while True:
@@ -55,9 +63,13 @@ async def _flush(redis: Redis, batch: list[str], *, dry_run: bool) -> int:
 async def _amain(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="reset-posthog-code-usage",
-        description="Reset PostHog Code usage counters in the LLM gateway Redis for every user.",
+        description="Reset PostHog Code usage counters in the LLM gateway Redis. Resets every user unless --user-id is given.",
     )
     parser.add_argument("--dry-run", action="store_true", help="Count keys without deleting.")
+    parser.add_argument(
+        "--user-id",
+        help="Reset only the given user's counters (matches the end_user_id used in the cache key).",
+    )
     args = parser.parse_args(argv)
 
     settings = get_settings()
@@ -66,10 +78,11 @@ async def _amain(argv: list[str]) -> int:
         return 1
 
     redis: Redis = Redis.from_url(settings.redis_url)
-    deleted = await reset_usage(redis, dry_run=args.dry_run)
+    deleted = await reset_usage(redis, dry_run=args.dry_run, user_id=args.user_id)
 
     mode = "DRY RUN" if args.dry_run else "EXECUTED"
-    print(f"[{mode}] reset posthog_code usage: {deleted} keys")
+    scope = f"user {args.user_id}" if args.user_id else "all users"
+    print(f"[{mode}] reset posthog_code usage ({scope}): {deleted} keys")
     return 0
 
 

--- a/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
+++ b/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
@@ -1,9 +1,10 @@
+import argparse
 from collections.abc import AsyncGenerator
 
 import pytest
 from fakeredis import aioredis as fakeredis
 
-from llm_gateway.cli.reset_posthog_code_usage import reset_usage
+from llm_gateway.cli.reset_posthog_code_usage import _non_empty_user_id, reset_usage
 
 
 @pytest.fixture
@@ -31,11 +32,14 @@ class TestResetUsage:
         for k in keys:
             assert await redis.get(k) is None
 
-    async def test_dry_run_counts_without_deleting(self, redis: fakeredis.FakeRedis) -> None:
+    @pytest.mark.parametrize("user_id", [None, "100"])
+    async def test_dry_run_counts_without_deleting(
+        self, redis: fakeredis.FakeRedis, user_id: str | None
+    ) -> None:
         await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
         await redis.set("ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0", "1.0")
 
-        deleted = await reset_usage(redis, dry_run=True)
+        deleted = await reset_usage(redis, dry_run=True, user_id=user_id)
 
         assert deleted == 2
         assert await redis.get("ratelimit:cost:user:user_cost_burst:posthog_code:100") is not None
@@ -70,7 +74,7 @@ class TestResetUsage:
             "ratelimit:cost:user:user_cost_burst:posthog_code:100:tm2",
             "ratelimit:cost:user:user_cost_sustained:posthog_code:100:tm2:period:1",
         ]
-        # Other users — including one whose id is a prefix of the target's id (1 vs 100)
+        # Other users, including one whose id is a prefix of the target's id (1 vs 100)
         # and one whose id starts with the target's id (1000 vs 100).
         other_keys = [
             "ratelimit:cost:user:user_cost_burst:posthog_code:1",
@@ -90,13 +94,24 @@ class TestResetUsage:
         for k in other_keys:
             assert await redis.get(k) is not None
 
-    async def test_user_id_dry_run_counts_without_deleting(self, redis: fakeredis.FakeRedis) -> None:
-        await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
-        await redis.set("ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0", "1.0")
-        await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:200", "1.0")
+    async def test_user_id_glob_metachars_do_not_expand_match(self, redis: fakeredis.FakeRedis) -> None:
+        # A user_id like "10*" must be treated as a literal id, not a glob that
+        # would match every user starting with "10".
+        survivors = [
+            "ratelimit:cost:user:user_cost_burst:posthog_code:100",
+            "ratelimit:cost:user:user_cost_burst:posthog_code:1000",
+            "ratelimit:cost:user:user_cost_burst:posthog_code:10abc",
+            "ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0",
+        ]
+        for k in survivors:
+            await redis.set(k, "1.0")
 
-        deleted = await reset_usage(redis, dry_run=True, user_id="100")
+        deleted = await reset_usage(redis, dry_run=False, user_id="10*")
 
-        assert deleted == 2
-        assert await redis.get("ratelimit:cost:user:user_cost_burst:posthog_code:100") is not None
-        assert await redis.get("ratelimit:cost:user:user_cost_burst:posthog_code:200") is not None
+        assert deleted == 0
+        for k in survivors:
+            assert await redis.get(k) is not None
+
+    def test_non_empty_user_id_rejects_empty_string(self) -> None:
+        with pytest.raises(argparse.ArgumentTypeError):
+            _non_empty_user_id("")

--- a/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
+++ b/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
@@ -33,9 +33,7 @@ class TestResetUsage:
             assert await redis.get(k) is None
 
     @pytest.mark.parametrize("user_id", [None, "100"])
-    async def test_dry_run_counts_without_deleting(
-        self, redis: fakeredis.FakeRedis, user_id: str | None
-    ) -> None:
+    async def test_dry_run_counts_without_deleting(self, redis: fakeredis.FakeRedis, user_id: str | None) -> None:
         await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
         await redis.set("ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0", "1.0")
 

--- a/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
+++ b/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
@@ -62,3 +62,41 @@ class TestResetUsage:
         assert deleted == 1
         for k in survivors:
             assert await redis.get(k) is not None
+
+    async def test_user_id_resets_only_that_user(self, redis: fakeredis.FakeRedis) -> None:
+        target_keys = [
+            "ratelimit:cost:user:user_cost_burst:posthog_code:100",
+            "ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0",
+            "ratelimit:cost:user:user_cost_burst:posthog_code:100:tm2",
+            "ratelimit:cost:user:user_cost_sustained:posthog_code:100:tm2:period:1",
+        ]
+        # Other users — including one whose id is a prefix of the target's id (1 vs 100)
+        # and one whose id starts with the target's id (1000 vs 100).
+        other_keys = [
+            "ratelimit:cost:user:user_cost_burst:posthog_code:1",
+            "ratelimit:cost:user:user_cost_sustained:posthog_code:1:period:0",
+            "ratelimit:cost:user:user_cost_burst:posthog_code:1000",
+            "ratelimit:cost:user:user_cost_sustained:posthog_code:1000:period:0",
+            "ratelimit:cost:user:user_cost_burst:posthog_code:200",
+        ]
+        for k in target_keys + other_keys:
+            await redis.set(k, "1.0")
+
+        deleted = await reset_usage(redis, dry_run=False, user_id="100")
+
+        assert deleted == len(target_keys)
+        for k in target_keys:
+            assert await redis.get(k) is None
+        for k in other_keys:
+            assert await redis.get(k) is not None
+
+    async def test_user_id_dry_run_counts_without_deleting(self, redis: fakeredis.FakeRedis) -> None:
+        await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
+        await redis.set("ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0", "1.0")
+        await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:200", "1.0")
+
+        deleted = await reset_usage(redis, dry_run=True, user_id="100")
+
+        assert deleted == 2
+        assert await redis.get("ratelimit:cost:user:user_cost_burst:posthog_code:100") is not None
+        assert await redis.get("ratelimit:cost:user:user_cost_burst:posthog_code:200") is not None


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

`reset_posthog_code_usage` only work for ALL users, need the ability to do this per-user

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds `--user-id` argument to the command

usage:

```
reset-posthog-code-usage --dry-run --user-id <the-user-id>
```

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

tested against local stack

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->