### PR TITLE
fix(flags): persist false value in flag dependency conditions

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
@@ -119,21 +119,22 @@ describe('propertyFilterLogic', () => {
             expect(cb).not.toHaveBeenCalled()
         })
 
-        it('calls onChange when the value is the boolean false (e.g. flag dependency set to false)', async () => {
-            const filter = {
-                key: '911',
-                type: PropertyFilterType.Flag,
-                operator: PropertyOperator.FlagEvaluatesTo,
-                value: false,
-            } as AnyPropertyFilter
+        it.each<[string, AnyPropertyFilter, false | 0]>([
+            [
+                'boolean false (e.g. flag dependency set to false)',
+                {
+                    key: '911',
+                    type: PropertyFilterType.Flag,
+                    operator: PropertyOperator.FlagEvaluatesTo,
+                    value: false,
+                } as AnyPropertyFilter,
+                false,
+            ],
+            ['number 0', eventFilter('$browser', 0 as any, PropertyOperator.Exact), 0],
+        ])('calls onChange when the value is the falsy literal %s', async (_name, filter, expectedValue) => {
             const cb = await setFilterAndCheck(filter, false)
             expect(cb).toHaveBeenCalledTimes(1)
-            expect(cb.mock.calls[0][0][0]).toMatchObject({ value: false })
-        })
-
-        it('calls onChange when the value is the number 0', async () => {
-            const cb = await setFilterAndCheck(eventFilter('$browser', 0 as any, PropertyOperator.Exact), false)
-            expect(cb).toHaveBeenCalledTimes(1)
+            expect(cb.mock.calls[0][0][0]).toMatchObject({ value: expectedValue })
         })
     })
 

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
@@ -6,9 +6,9 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+import { AnyPropertyFilter, PropertyFilterType, PropertyFilterValue, PropertyOperator } from '~/types'
 
-const eventFilter = (key: string, value?: string, operator?: PropertyOperator): AnyPropertyFilter =>
+const eventFilter = (key: string, value?: PropertyFilterValue, operator?: PropertyOperator): AnyPropertyFilter =>
     ({
         key,
         type: PropertyFilterType.Event,
@@ -130,7 +130,7 @@ describe('propertyFilterLogic', () => {
                 } as AnyPropertyFilter,
                 false,
             ],
-            ['number 0', eventFilter('$browser', 0 as any, PropertyOperator.Exact), 0],
+            ['number 0', eventFilter('$browser', 0, PropertyOperator.Exact), 0],
         ])('calls onChange when the value is the falsy literal %s', async (_name, filter, expectedValue) => {
             const cb = await setFilterAndCheck(filter, false)
             expect(cb).toHaveBeenCalledTimes(1)

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
@@ -118,6 +118,23 @@ describe('propertyFilterLogic', () => {
             const cb = await setFilterAndCheck(filter, false)
             expect(cb).not.toHaveBeenCalled()
         })
+
+        it('calls onChange when the value is the boolean false (e.g. flag dependency set to false)', async () => {
+            const filter = {
+                key: '911',
+                type: PropertyFilterType.Flag,
+                operator: PropertyOperator.FlagEvaluatesTo,
+                value: false,
+            } as AnyPropertyFilter
+            const cb = await setFilterAndCheck(filter, false)
+            expect(cb).toHaveBeenCalledTimes(1)
+            expect(cb.mock.calls[0][0][0]).toMatchObject({ value: false })
+        })
+
+        it('calls onChange when the value is the number 0', async () => {
+            const cb = await setFilterAndCheck(eventFilter('$browser', 0 as any, PropertyOperator.Exact), false)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
     })
 
     describe('filter IDs are stable across mutations', () => {

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -118,11 +118,10 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>([
 
     listeners(({ actions, props, values }) => ({
         setFilter: async ({ property }) => {
-            const hasValue =
-                property?.value !== null &&
-                property?.value !== undefined &&
-                property?.value !== '' &&
-                !(Array.isArray(property.value) && property.value.length === 0)
+            const value = property?.value
+            const isEmpty =
+                value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)
+            const hasValue = !isEmpty
             const isComplete =
                 hasValue || ('operator' in property && property?.operator && isOperatorFlag(property.operator))
 

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -118,7 +118,11 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>([
 
     listeners(({ actions, props, values }) => ({
         setFilter: async ({ property }) => {
-            const hasValue = property?.value && !(Array.isArray(property.value) && property.value.length === 0)
+            const hasValue =
+                property?.value !== null &&
+                property?.value !== undefined &&
+                property?.value !== '' &&
+                !(Array.isArray(property.value) && property.value.length === 0)
             const isComplete =
                 hasValue || ('operator' in property && property?.operator && isOperatorFlag(property.operator))
 


### PR DESCRIPTION
## Problem

When editing a feature flag with a condition that depends on another flag, changing the dependency value from `true` to `false` did not persist. The API was never called with `false` — the UI silently kept the previous value.

## Changes

Fixed the truthy check in `propertyFilterLogic.setFilter` that gated `actions.update()`. `property.value && ...` short-circuited on `false` (and `0`), so the listener never propagated valid boolean/numeric values to the parent `onChange`. Replaced it with explicit null/undefined/empty-string/empty-array checks.

## How did you test this code?

I am an agent (PostHog Code). Verified via automated tests only:

- Added two regression tests in `propertyFilterLogic.test.ts` covering a flag dependency filter with `value: false` and a numeric filter with `value: 0`.
- Ran the full `propertyFilterLogic.test.ts` suite — 22/22 passing.
- Did not perform manual UI testing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7).

Investigation path:
- User reported the bug and confirmed via inspection that the API payload had `value: true` even after selecting `false` — so the regression was frontend-side, not the serializer.
- Traced the `flag` / `flag_evaluates_to` filter flow: `PropertyValue` → `OperatorValueSelect` → `propertyFilterLogic.setFilter`.
- Considered `isValidPropertyFilter` (`utils.ts`) as a possible suspect but ruled it out — `key` and `type` are truthy strings, so the filter survives the cleanup pass. The change-propagation gate in `setFilter` was the only place that silently dropped `false`.
- Kept the existing semantics for `undefined`/`null`/`""`/`[]` so unrelated flows (e.g. typing-in-progress) keep behaving the same.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
