### PR TITLE
feat(django): split personhog rpcs into batched calls

### DIFF
--- a/posthog/models/person/test/test_batched_personhog_helpers.py
+++ b/posthog/models/person/test/test_batched_personhog_helpers.py
@@ -2,67 +2,62 @@ from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
+from parameterized import parameterized
+
 from posthog.models.person.util import (
     _batched_get_distinct_ids_for_persons,
     _batched_get_persons_by_distinct_ids,
     _batched_get_persons_by_uuids,
     get_persons_mapped_by_distinct_id,
 )
-from posthog.personhog_client.fake_client import FakePersonHogClient, fake_personhog_client
+from posthog.personhog_client.fake_client import fake_personhog_client
 from posthog.personhog_client.proto.generated.personhog.types.v1 import person_pb2
 
 
 class TestBatchedGetPersonsByUuids(SimpleTestCase):
-    def test_single_batch(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
-        fake.add_person(team_id=1, person_id=2, uuid="uuid-2", distinct_ids=["d2"])
+    @parameterized.expand(
+        [
+            ("single_batch", 500, 2, 1),
+            ("multiple_batches", 2, 5, 3),
+        ]
+    )
+    def test_returns_all_persons(self, _name, batch_size, n_persons, expected_calls):
+        with patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", batch_size):
+            with fake_personhog_client() as fake:
+                for i in range(n_persons):
+                    fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}"])
 
-        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-1", "uuid-2"], "test")
+                result = _batched_get_persons_by_uuids(1, [f"uuid-{i}" for i in range(n_persons)], "test")
 
-        assert len(result) == 2
-        assert {p.uuid for p in result} == {"uuid-1", "uuid-2"}
-        fake.assert_called("get_persons_by_uuids", times=1)
+                assert len(result) == n_persons
+                assert {p.uuid for p in result} == {f"uuid-{i}" for i in range(n_persons)}
+                fake.assert_called("get_persons_by_uuids", times=expected_calls)
 
     def test_empty_input(self):
-        fake = FakePersonHogClient()
+        with fake_personhog_client():
+            result = _batched_get_persons_by_uuids(1, [], "test")
 
-        result = _batched_get_persons_by_uuids(fake, 1, [], "test")
-
-        assert result == []
-        fake.assert_not_called("get_persons_by_uuids")
+            assert result == []
 
     def test_filters_wrong_team(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
-        fake.add_person(team_id=999, person_id=2, uuid="uuid-2", distinct_ids=["d2"])
+        with fake_personhog_client() as fake:
+            fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
+            fake.add_person(team_id=999, person_id=2, uuid="uuid-2", distinct_ids=["d2"])
 
-        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-1", "uuid-2"], "test")
+            result = _batched_get_persons_by_uuids(1, ["uuid-1", "uuid-2"], "test")
 
-        assert len(result) == 1
-        assert result[0].uuid == "uuid-1"
+            assert len(result) == 1
+            assert result[0].uuid == "uuid-1"
 
     def test_filters_persons_with_no_id(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=0, uuid="uuid-zero", distinct_ids=["d0"])
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
+        with fake_personhog_client() as fake:
+            fake.add_person(team_id=1, person_id=0, uuid="uuid-zero", distinct_ids=["d0"])
+            fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
 
-        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-zero", "uuid-1"], "test")
+            result = _batched_get_persons_by_uuids(1, ["uuid-zero", "uuid-1"], "test")
 
-        assert len(result) == 1
-        assert result[0].uuid == "uuid-1"
-
-    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
-    def test_multiple_batches(self):
-        fake = FakePersonHogClient()
-        for i in range(5):
-            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}"])
-
-        result = _batched_get_persons_by_uuids(fake, 1, [f"uuid-{i}" for i in range(5)], "test")
-
-        assert len(result) == 5
-        assert {p.uuid for p in result} == {f"uuid-{i}" for i in range(5)}
-        fake.assert_called("get_persons_by_uuids", times=3)
+            assert len(result) == 1
+            assert result[0].uuid == "uuid-1"
 
     @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
     def test_team_mismatch_metric_across_batches(self):
@@ -77,8 +72,11 @@ class TestBatchedGetPersonsByUuids(SimpleTestCase):
             person_pb2.PersonsResponse(persons=[right_team_person_2, wrong_team_person_2]),
         ]
 
-        with patch("posthog.models.person.util.PERSONHOG_TEAM_MISMATCH_TOTAL") as mock_metric:
-            result = _batched_get_persons_by_uuids(mock_client, 1, ["uuid-0", "uuid-1", "uuid-2", "uuid-3"], "test_op")
+        with (
+            patch("posthog.models.person.util._get_client", return_value=mock_client),
+            patch("posthog.models.person.util.PERSONHOG_TEAM_MISMATCH_TOTAL") as mock_metric,
+        ):
+            result = _batched_get_persons_by_uuids(1, ["uuid-0", "uuid-1", "uuid-2", "uuid-3"], "test_op")
 
         assert len(result) == 2
         assert mock_metric.labels.call_count == 2
@@ -86,182 +84,163 @@ class TestBatchedGetPersonsByUuids(SimpleTestCase):
 
     @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
     def test_preserves_order_across_batches(self):
-        fake = FakePersonHogClient()
-        for i in range(4):
-            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}"])
+        with fake_personhog_client() as fake:
+            for i in range(4):
+                fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}"])
 
-        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-0", "uuid-1", "uuid-2", "uuid-3"], "test")
+            result = _batched_get_persons_by_uuids(1, ["uuid-0", "uuid-1", "uuid-2", "uuid-3"], "test")
 
-        assert [p.uuid for p in result] == ["uuid-0", "uuid-1", "uuid-2", "uuid-3"]
+            assert [p.uuid for p in result] == ["uuid-0", "uuid-1", "uuid-2", "uuid-3"]
 
     def test_missing_uuids_excluded(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
+        with fake_personhog_client() as fake:
+            fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
 
-        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-1", "uuid-missing"], "test")
+            result = _batched_get_persons_by_uuids(1, ["uuid-1", "uuid-missing"], "test")
 
-        assert len(result) == 1
-        assert result[0].uuid == "uuid-1"
+            assert len(result) == 1
+            assert result[0].uuid == "uuid-1"
 
 
 class TestBatchedGetPersonsByDistinctIds(SimpleTestCase):
-    def test_single_batch(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["did-1"])
-        fake.add_person(team_id=1, person_id=2, uuid="uuid-2", distinct_ids=["did-2"])
+    @parameterized.expand(
+        [
+            ("single_batch", 500, 2, 1),
+            ("multiple_batches", 2, 5, 3),
+        ]
+    )
+    def test_returns_all_persons(self, _name, batch_size, n_persons, expected_calls):
+        with patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", batch_size):
+            with fake_personhog_client() as fake:
+                for i in range(n_persons):
+                    fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"did-{i}"])
 
-        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2"], "test")
+                result = _batched_get_persons_by_distinct_ids(1, [f"did-{i}" for i in range(n_persons)], "test")
 
-        assert len(result) == 2
-        assert {r.distinct_id for r in result} == {"did-1", "did-2"}
-        fake.assert_called("get_persons_by_distinct_ids_in_team", times=1)
+                assert len(result) == n_persons
+                assert {r.distinct_id for r in result} == {f"did-{i}" for i in range(n_persons)}
+                fake.assert_called("get_persons_by_distinct_ids_in_team", times=expected_calls)
 
     def test_empty_input(self):
-        fake = FakePersonHogClient()
+        with fake_personhog_client():
+            result = _batched_get_persons_by_distinct_ids(1, [], "test")
 
-        result = _batched_get_persons_by_distinct_ids(fake, 1, [], "test")
+            assert result == []
 
-        assert result == []
-        fake.assert_not_called("get_persons_by_distinct_ids_in_team")
+    @parameterized.expand(
+        [
+            ("single_batch", 500, 2, 1),
+            ("across_batches", 2, 3, 1),
+        ]
+    )
+    def test_deduplicates_same_person(self, _name, batch_size, n_distinct_ids, expected_result_count):
+        with patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", batch_size):
+            with fake_personhog_client() as fake:
+                dids = [f"did-{i}" for i in range(n_distinct_ids)]
+                fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=dids)
 
-    def test_deduplicates_same_person_across_distinct_ids(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2"])
+                result = _batched_get_persons_by_distinct_ids(1, dids, "test")
 
-        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2"], "test")
+                assert len(result) == expected_result_count
+                assert result[0].person.id == 42
 
-        assert len(result) == 1
-        assert result[0].person.id == 42
+    @parameterized.expand(
+        [
+            ("single_batch", 500, 2),
+            ("across_batches", 2, 3),
+        ]
+    )
+    def test_no_dedup_returns_all_entries(self, _name, batch_size, n_distinct_ids):
+        with patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", batch_size):
+            with fake_personhog_client() as fake:
+                dids = [f"did-{i}" for i in range(n_distinct_ids)]
+                fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=dids)
 
-    def test_no_dedup_returns_all_entries(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2"])
+                result = _batched_get_persons_by_distinct_ids(1, dids, "test", deduplicate_by_person=False)
 
-        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2"], "test", deduplicate_by_person=False)
-
-        assert len(result) == 2
-        assert {r.distinct_id for r in result} == {"did-1", "did-2"}
-        assert all(r.person.id == 42 for r in result)
-
-    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
-    def test_deduplicates_across_batches(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2", "did-3"])
-
-        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2", "did-3"], "test")
-
-        assert len(result) == 1
-        assert result[0].person.id == 42
-        fake.assert_called("get_persons_by_distinct_ids_in_team", times=2)
-
-    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
-    def test_no_dedup_across_batches(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2", "did-3"])
-
-        result = _batched_get_persons_by_distinct_ids(
-            fake, 1, ["did-1", "did-2", "did-3"], "test", deduplicate_by_person=False
-        )
-
-        assert len(result) == 3
-        assert {r.distinct_id for r in result} == {"did-1", "did-2", "did-3"}
+                assert len(result) == n_distinct_ids
+                assert {r.distinct_id for r in result} == set(dids)
+                assert all(r.person.id == 42 for r in result)
 
     def test_filters_wrong_team(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["did-1"])
-        fake.add_person(team_id=999, person_id=2, uuid="uuid-2", distinct_ids=["did-2"])
+        with fake_personhog_client() as fake:
+            fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["did-1"])
+            fake.add_person(team_id=999, person_id=2, uuid="uuid-2", distinct_ids=["did-2"])
 
-        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2"], "test")
+            result = _batched_get_persons_by_distinct_ids(1, ["did-1", "did-2"], "test")
 
-        assert len(result) == 1
-        assert result[0].person.uuid == "uuid-1"
-
-    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
-    def test_multiple_batches_multiple_persons(self):
-        fake = FakePersonHogClient()
-        for i in range(5):
-            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"did-{i}"])
-
-        result = _batched_get_persons_by_distinct_ids(fake, 1, [f"did-{i}" for i in range(5)], "test")
-
-        assert len(result) == 5
-        fake.assert_called("get_persons_by_distinct_ids_in_team", times=3)
+            assert len(result) == 1
+            assert result[0].person.uuid == "uuid-1"
 
     def test_missing_distinct_ids_excluded(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["did-1"])
+        with fake_personhog_client() as fake:
+            fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["did-1"])
 
-        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-missing"], "test")
+            result = _batched_get_persons_by_distinct_ids(1, ["did-1", "did-missing"], "test")
 
-        assert len(result) == 1
+            assert len(result) == 1
 
 
 class TestBatchedGetDistinctIdsForPersons(SimpleTestCase):
-    def test_single_batch(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1a", "d1b"])
-        fake.add_person(team_id=1, person_id=2, uuid="uuid-2", distinct_ids=["d2a"])
+    @parameterized.expand(
+        [
+            ("single_batch", 500, 2, 1),
+            ("multiple_batches", 2, 5, 3),
+        ]
+    )
+    def test_returns_all_distinct_ids(self, _name, batch_size, n_persons, expected_calls):
+        with patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", batch_size):
+            with fake_personhog_client() as fake:
+                for i in range(n_persons):
+                    fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}"])
 
-        result = _batched_get_distinct_ids_for_persons(fake, 1, [1, 2])
+                result = _batched_get_distinct_ids_for_persons(1, list(range(1, n_persons + 1)))
 
-        assert result == {1: ["d1a", "d1b"], 2: ["d2a"]}
-        fake.assert_called("get_distinct_ids_for_persons", times=1)
+                assert len(result) == n_persons
+                for i in range(n_persons):
+                    assert result[i + 1] == [f"d{i}"]
+                fake.assert_called("get_distinct_ids_for_persons", times=expected_calls)
 
     def test_empty_input(self):
-        fake = FakePersonHogClient()
+        with fake_personhog_client():
+            result = _batched_get_distinct_ids_for_persons(1, [])
 
-        result = _batched_get_distinct_ids_for_persons(fake, 1, [])
+            assert result == {}
 
-        assert result == {}
-        fake.assert_not_called("get_distinct_ids_for_persons")
+    @parameterized.expand(
+        [
+            ("single_batch", 500, 1),
+            ("across_batches", 2, 3),
+        ]
+    )
+    def test_limit_per_person(self, _name, batch_size, n_persons):
+        with patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", batch_size):
+            with fake_personhog_client() as fake:
+                for i in range(n_persons):
+                    fake.add_person(
+                        team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}a", f"d{i}b", f"d{i}c"]
+                    )
 
-    def test_limit_per_person(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1", "d2", "d3"])
+                result = _batched_get_distinct_ids_for_persons(1, list(range(1, n_persons + 1)), limit_per_person=1)
 
-        result = _batched_get_distinct_ids_for_persons(fake, 1, [1], limit_per_person=2)
-
-        assert len(result[1]) == 2
+                assert all(len(dids) == 1 for dids in result.values())
 
     def test_limit_per_person_none_returns_all(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1", "d2", "d3"])
+        with fake_personhog_client() as fake:
+            fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1", "d2", "d3"])
 
-        result = _batched_get_distinct_ids_for_persons(fake, 1, [1])
+            result = _batched_get_distinct_ids_for_persons(1, [1])
 
-        assert len(result[1]) == 3
-
-    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
-    def test_multiple_batches(self):
-        fake = FakePersonHogClient()
-        for i in range(5):
-            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}"])
-
-        result = _batched_get_distinct_ids_for_persons(fake, 1, [1, 2, 3, 4, 5])
-
-        assert len(result) == 5
-        for i in range(5):
-            assert result[i + 1] == [f"d{i}"]
-        fake.assert_called("get_distinct_ids_for_persons", times=3)
-
-    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
-    def test_limit_per_person_applied_to_each_batch(self):
-        fake = FakePersonHogClient()
-        for i in range(3):
-            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}a", f"d{i}b", f"d{i}c"])
-
-        result = _batched_get_distinct_ids_for_persons(fake, 1, [1, 2, 3], limit_per_person=1)
-
-        assert all(len(dids) == 1 for dids in result.values())
+            assert len(result[1]) == 3
 
     def test_missing_person_gets_empty_list(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
+        with fake_personhog_client() as fake:
+            fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
 
-        result = _batched_get_distinct_ids_for_persons(fake, 1, [1, 999])
+            result = _batched_get_distinct_ids_for_persons(1, [1, 999])
 
-        assert result[1] == ["d1"]
-        assert result[999] == []
+            assert result[1] == ["d1"]
+            assert result[999] == []
 
 
 class TestGetPersonsMappedByDistinctIdDedup(SimpleTestCase):
@@ -283,14 +262,14 @@ class TestGetPersonsMappedByDistinctIdDedup(SimpleTestCase):
 
     @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
     def test_multiple_distinct_ids_same_person_across_batches(self):
-        fake = FakePersonHogClient()
-        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2", "did-3"])
+        with fake_personhog_client() as fake:
+            fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2", "did-3"])
 
-        results = _batched_get_persons_by_distinct_ids(
-            fake, 1, ["did-1", "did-2", "did-3"], "test", deduplicate_by_person=False
-        )
+            results = _batched_get_persons_by_distinct_ids(
+                1, ["did-1", "did-2", "did-3"], "test", deduplicate_by_person=False
+            )
 
-        assert len(results) == 3
-        assert {r.distinct_id for r in results} == {"did-1", "did-2", "did-3"}
-        assert all(r.person.id == 42 for r in results)
-        fake.assert_called("get_persons_by_distinct_ids_in_team", times=2)
+            assert len(results) == 3
+            assert {r.distinct_id for r in results} == {"did-1", "did-2", "did-3"}
+            assert all(r.person.id == 42 for r in results)
+            fake.assert_called("get_persons_by_distinct_ids_in_team", times=2)

--- a/posthog/models/person/test/test_batched_personhog_helpers.py
+++ b/posthog/models/person/test/test_batched_personhog_helpers.py
@@ -1,0 +1,296 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from posthog.models.person.util import (
+    _batched_get_distinct_ids_for_persons,
+    _batched_get_persons_by_distinct_ids,
+    _batched_get_persons_by_uuids,
+    get_persons_mapped_by_distinct_id,
+)
+from posthog.personhog_client.fake_client import FakePersonHogClient, fake_personhog_client
+from posthog.personhog_client.proto.generated.personhog.types.v1 import person_pb2
+
+
+class TestBatchedGetPersonsByUuids(SimpleTestCase):
+    def test_single_batch(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
+        fake.add_person(team_id=1, person_id=2, uuid="uuid-2", distinct_ids=["d2"])
+
+        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-1", "uuid-2"], "test")
+
+        assert len(result) == 2
+        assert {p.uuid for p in result} == {"uuid-1", "uuid-2"}
+        fake.assert_called("get_persons_by_uuids", times=1)
+
+    def test_empty_input(self):
+        fake = FakePersonHogClient()
+
+        result = _batched_get_persons_by_uuids(fake, 1, [], "test")
+
+        assert result == []
+        fake.assert_not_called("get_persons_by_uuids")
+
+    def test_filters_wrong_team(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
+        fake.add_person(team_id=999, person_id=2, uuid="uuid-2", distinct_ids=["d2"])
+
+        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-1", "uuid-2"], "test")
+
+        assert len(result) == 1
+        assert result[0].uuid == "uuid-1"
+
+    def test_filters_persons_with_no_id(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=0, uuid="uuid-zero", distinct_ids=["d0"])
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
+
+        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-zero", "uuid-1"], "test")
+
+        assert len(result) == 1
+        assert result[0].uuid == "uuid-1"
+
+    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
+    def test_multiple_batches(self):
+        fake = FakePersonHogClient()
+        for i in range(5):
+            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}"])
+
+        result = _batched_get_persons_by_uuids(fake, 1, [f"uuid-{i}" for i in range(5)], "test")
+
+        assert len(result) == 5
+        assert {p.uuid for p in result} == {f"uuid-{i}" for i in range(5)}
+        fake.assert_called("get_persons_by_uuids", times=3)
+
+    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
+    def test_team_mismatch_metric_across_batches(self):
+        wrong_team_person = person_pb2.Person(id=2, uuid="uuid-1", team_id=999)
+        right_team_person_1 = person_pb2.Person(id=1, uuid="uuid-0", team_id=1)
+        right_team_person_2 = person_pb2.Person(id=3, uuid="uuid-2", team_id=1)
+        wrong_team_person_2 = person_pb2.Person(id=4, uuid="uuid-3", team_id=888)
+
+        mock_client = MagicMock()
+        mock_client.get_persons_by_uuids.side_effect = [
+            person_pb2.PersonsResponse(persons=[right_team_person_1, wrong_team_person]),
+            person_pb2.PersonsResponse(persons=[right_team_person_2, wrong_team_person_2]),
+        ]
+
+        with patch("posthog.models.person.util.PERSONHOG_TEAM_MISMATCH_TOTAL") as mock_metric:
+            result = _batched_get_persons_by_uuids(mock_client, 1, ["uuid-0", "uuid-1", "uuid-2", "uuid-3"], "test_op")
+
+        assert len(result) == 2
+        assert mock_metric.labels.call_count == 2
+        mock_metric.labels.assert_any_call(operation="test_op", client_name="posthog-django")
+
+    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
+    def test_preserves_order_across_batches(self):
+        fake = FakePersonHogClient()
+        for i in range(4):
+            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}"])
+
+        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-0", "uuid-1", "uuid-2", "uuid-3"], "test")
+
+        assert [p.uuid for p in result] == ["uuid-0", "uuid-1", "uuid-2", "uuid-3"]
+
+    def test_missing_uuids_excluded(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
+
+        result = _batched_get_persons_by_uuids(fake, 1, ["uuid-1", "uuid-missing"], "test")
+
+        assert len(result) == 1
+        assert result[0].uuid == "uuid-1"
+
+
+class TestBatchedGetPersonsByDistinctIds(SimpleTestCase):
+    def test_single_batch(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["did-1"])
+        fake.add_person(team_id=1, person_id=2, uuid="uuid-2", distinct_ids=["did-2"])
+
+        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2"], "test")
+
+        assert len(result) == 2
+        assert {r.distinct_id for r in result} == {"did-1", "did-2"}
+        fake.assert_called("get_persons_by_distinct_ids_in_team", times=1)
+
+    def test_empty_input(self):
+        fake = FakePersonHogClient()
+
+        result = _batched_get_persons_by_distinct_ids(fake, 1, [], "test")
+
+        assert result == []
+        fake.assert_not_called("get_persons_by_distinct_ids_in_team")
+
+    def test_deduplicates_same_person_across_distinct_ids(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2"])
+
+        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2"], "test")
+
+        assert len(result) == 1
+        assert result[0].person.id == 42
+
+    def test_no_dedup_returns_all_entries(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2"])
+
+        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2"], "test", deduplicate_by_person=False)
+
+        assert len(result) == 2
+        assert {r.distinct_id for r in result} == {"did-1", "did-2"}
+        assert all(r.person.id == 42 for r in result)
+
+    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
+    def test_deduplicates_across_batches(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2", "did-3"])
+
+        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2", "did-3"], "test")
+
+        assert len(result) == 1
+        assert result[0].person.id == 42
+        fake.assert_called("get_persons_by_distinct_ids_in_team", times=2)
+
+    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
+    def test_no_dedup_across_batches(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2", "did-3"])
+
+        result = _batched_get_persons_by_distinct_ids(
+            fake, 1, ["did-1", "did-2", "did-3"], "test", deduplicate_by_person=False
+        )
+
+        assert len(result) == 3
+        assert {r.distinct_id for r in result} == {"did-1", "did-2", "did-3"}
+
+    def test_filters_wrong_team(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["did-1"])
+        fake.add_person(team_id=999, person_id=2, uuid="uuid-2", distinct_ids=["did-2"])
+
+        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-2"], "test")
+
+        assert len(result) == 1
+        assert result[0].person.uuid == "uuid-1"
+
+    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
+    def test_multiple_batches_multiple_persons(self):
+        fake = FakePersonHogClient()
+        for i in range(5):
+            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"did-{i}"])
+
+        result = _batched_get_persons_by_distinct_ids(fake, 1, [f"did-{i}" for i in range(5)], "test")
+
+        assert len(result) == 5
+        fake.assert_called("get_persons_by_distinct_ids_in_team", times=3)
+
+    def test_missing_distinct_ids_excluded(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["did-1"])
+
+        result = _batched_get_persons_by_distinct_ids(fake, 1, ["did-1", "did-missing"], "test")
+
+        assert len(result) == 1
+
+
+class TestBatchedGetDistinctIdsForPersons(SimpleTestCase):
+    def test_single_batch(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1a", "d1b"])
+        fake.add_person(team_id=1, person_id=2, uuid="uuid-2", distinct_ids=["d2a"])
+
+        result = _batched_get_distinct_ids_for_persons(fake, 1, [1, 2])
+
+        assert result == {1: ["d1a", "d1b"], 2: ["d2a"]}
+        fake.assert_called("get_distinct_ids_for_persons", times=1)
+
+    def test_empty_input(self):
+        fake = FakePersonHogClient()
+
+        result = _batched_get_distinct_ids_for_persons(fake, 1, [])
+
+        assert result == {}
+        fake.assert_not_called("get_distinct_ids_for_persons")
+
+    def test_limit_per_person(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1", "d2", "d3"])
+
+        result = _batched_get_distinct_ids_for_persons(fake, 1, [1], limit_per_person=2)
+
+        assert len(result[1]) == 2
+
+    def test_limit_per_person_none_returns_all(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1", "d2", "d3"])
+
+        result = _batched_get_distinct_ids_for_persons(fake, 1, [1])
+
+        assert len(result[1]) == 3
+
+    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
+    def test_multiple_batches(self):
+        fake = FakePersonHogClient()
+        for i in range(5):
+            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}"])
+
+        result = _batched_get_distinct_ids_for_persons(fake, 1, [1, 2, 3, 4, 5])
+
+        assert len(result) == 5
+        for i in range(5):
+            assert result[i + 1] == [f"d{i}"]
+        fake.assert_called("get_distinct_ids_for_persons", times=3)
+
+    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
+    def test_limit_per_person_applied_to_each_batch(self):
+        fake = FakePersonHogClient()
+        for i in range(3):
+            fake.add_person(team_id=1, person_id=i + 1, uuid=f"uuid-{i}", distinct_ids=[f"d{i}a", f"d{i}b", f"d{i}c"])
+
+        result = _batched_get_distinct_ids_for_persons(fake, 1, [1, 2, 3], limit_per_person=1)
+
+        assert all(len(dids) == 1 for dids in result.values())
+
+    def test_missing_person_gets_empty_list(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=1, uuid="uuid-1", distinct_ids=["d1"])
+
+        result = _batched_get_distinct_ids_for_persons(fake, 1, [1, 999])
+
+        assert result[1] == ["d1"]
+        assert result[999] == []
+
+
+class TestGetPersonsMappedByDistinctIdDedup(SimpleTestCase):
+    def test_multiple_distinct_ids_same_person_all_present(self):
+        with fake_personhog_client() as fake:
+            fake.add_person(
+                team_id=1, person_id=42, uuid="550e8400-e29b-41d4-a716-446655440042", distinct_ids=["did-1", "did-2"]
+            )
+
+            result = get_persons_mapped_by_distinct_id(1, ["did-1", "did-2"])
+
+            assert len(result) == 2
+            assert "did-1" in result
+            assert "did-2" in result
+            assert result["did-1"].id == 42
+            assert result["did-2"].id == 42
+            assert result["did-1"].distinct_ids == ["did-1"]
+            assert result["did-2"].distinct_ids == ["did-2"]
+
+    @patch("posthog.models.person.util.PERSONHOG_BATCH_SIZE", 2)
+    def test_multiple_distinct_ids_same_person_across_batches(self):
+        fake = FakePersonHogClient()
+        fake.add_person(team_id=1, person_id=42, uuid="uuid-42", distinct_ids=["did-1", "did-2", "did-3"])
+
+        results = _batched_get_persons_by_distinct_ids(
+            fake, 1, ["did-1", "did-2", "did-3"], "test", deduplicate_by_person=False
+        )
+
+        assert len(results) == 3
+        assert {r.distinct_id for r in results} == {"did-1", "did-2", "did-3"}
+        assert all(r.person.id == 42 for r in results)
+        fake.assert_called("get_persons_by_distinct_ids_in_team", times=2)

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import json
 import datetime
 from collections.abc import Callable
 from contextlib import ExitStack
-from typing import Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Optional, TypeVar, Union, cast
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
@@ -47,6 +49,88 @@ from posthog.personhog_client.proto import (
 from posthog.settings import TEST
 
 logger = structlog.get_logger(__name__)
+
+PERSONHOG_BATCH_SIZE = 1000
+
+
+if TYPE_CHECKING:
+    from posthog.personhog_client.client import PersonHogClient
+    from posthog.personhog_client.proto.generated.personhog.types.v1 import person_pb2
+
+
+def _batched_get_persons_by_uuids(
+    client: PersonHogClient,
+    team_id: int,
+    uuids: list[str],
+    operation: str,
+) -> list[person_pb2.Person]:
+    valid_persons: list[person_pb2.Person] = []
+    for i in range(0, len(uuids), PERSONHOG_BATCH_SIZE):
+        batch = uuids[i : i + PERSONHOG_BATCH_SIZE]
+        resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=batch))
+
+        present_persons = [p for p in resp.persons if p.id]
+        batch_valid = [p for p in present_persons if p.team_id == team_id]
+
+        mismatched = len(present_persons) - len(batch_valid)
+        if mismatched:
+            PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation=operation, client_name=get_client_name()).inc(mismatched)
+            logger.warning("personhog_team_mismatch", operation=operation, team_id=team_id, dropped=mismatched)
+
+        valid_persons.extend(batch_valid)
+
+    return valid_persons
+
+
+def _batched_get_persons_by_distinct_ids(
+    client: PersonHogClient,
+    team_id: int,
+    distinct_ids: list[str],
+    operation: str,
+) -> list[person_pb2.PersonWithDistinctIds]:
+    seen_person_ids: set[int] = set()
+    valid_results: list[person_pb2.PersonWithDistinctIds] = []
+
+    for i in range(0, len(distinct_ids), PERSONHOG_BATCH_SIZE):
+        batch = distinct_ids[i : i + PERSONHOG_BATCH_SIZE]
+        resp = client.get_persons_by_distinct_ids_in_team(
+            GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=batch)
+        )
+
+        present_results = [r for r in resp.results if r.person and r.person.id]
+        batch_valid = [r for r in present_results if r.person.team_id == team_id]
+
+        mismatched = len(present_results) - len(batch_valid)
+        if mismatched:
+            PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation=operation, client_name=get_client_name()).inc(mismatched)
+            logger.warning("personhog_team_mismatch", operation=operation, team_id=team_id, dropped=mismatched)
+
+        # Deduplicate across batches — same person can appear for different distinct_ids
+        for r in batch_valid:
+            if r.person.id not in seen_person_ids:
+                seen_person_ids.add(r.person.id)
+                valid_results.append(r)
+
+    return valid_results
+
+
+def _batched_get_distinct_ids_for_persons(
+    client: PersonHogClient,
+    team_id: int,
+    person_ids: list[int],
+    limit_per_person: int | None = None,
+) -> dict[int, list[str]]:
+    distinct_ids_by_person: dict[int, list[str]] = {}
+    for i in range(0, len(person_ids), PERSONHOG_BATCH_SIZE):
+        batch_ids = person_ids[i : i + PERSONHOG_BATCH_SIZE]
+        did_request = GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=batch_ids)
+        if limit_per_person is not None:
+            did_request.limit_per_person = limit_per_person
+        did_resp = client.get_distinct_ids_for_persons(did_request)
+        for pd in did_resp.person_distinct_ids:
+            distinct_ids_by_person[pd.person_id] = [d.distinct_id for d in pd.distinct_ids]
+    return distinct_ids_by_person
+
 
 if TEST:
     # :KLUDGE: Hooks are kept around for tests. All other code goes through plugin-server or the other methods explicitly
@@ -223,44 +307,15 @@ def _fetch_persons_by_distinct_ids_via_personhog(
     if client is None:
         raise RuntimeError("personhog client not configured")
 
-    resp = client.get_persons_by_distinct_ids_in_team(
-        GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=distinct_ids)
-    )
-
-    present_results = [r for r in resp.results if r.person and r.person.id]
-    valid_results = [r for r in present_results if r.person.team_id == team_id]
-
-    mismatched = len(present_results) - len(valid_results)
-    if mismatched:
-        PERSONHOG_TEAM_MISMATCH_TOTAL.labels(
-            operation="get_persons_by_distinct_ids", client_name=get_client_name()
-        ).inc(mismatched)
-        logger.warning(
-            "personhog_team_mismatch", operation="get_persons_by_distinct_ids", team_id=team_id, dropped=mismatched
-        )
-
-    # The RPC returns one result per distinct_id, so the same person can
-    # appear multiple times.  Deduplicate by person_id to return unique persons.
-    seen_person_ids: set[int] = set()
-    unique_results = []
-    for r in valid_results:
-        if r.person.id not in seen_person_ids:
-            seen_person_ids.add(r.person.id)
-            unique_results.append(r)
-    valid_results = unique_results
+    valid_results = _batched_get_persons_by_distinct_ids(client, team_id, distinct_ids, "get_persons_by_distinct_ids")
 
     person_ids = [r.person.id for r in valid_results]
     if not person_ids:
         return []
 
-    did_request = GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
-    if distinct_id_limit is not None:
-        did_request.limit_per_person = distinct_id_limit
-    distinct_ids_resp = client.get_distinct_ids_for_persons(did_request)
-
-    distinct_ids_by_person: dict[int, list[str]] = {}
-    for pd in distinct_ids_resp.person_distinct_ids:
-        distinct_ids_by_person[pd.person_id] = [d.distinct_id for d in pd.distinct_ids]
+    distinct_ids_by_person = _batched_get_distinct_ids_for_persons(
+        client, team_id, person_ids, limit_per_person=distinct_id_limit
+    )
 
     return [
         proto_person_to_model(r.person, distinct_ids=distinct_ids_by_person.get(r.person.id, [])) for r in valid_results
@@ -380,25 +435,9 @@ def get_persons_mapped_by_distinct_id(
         if client is None:
             raise RuntimeError("personhog client not configured")
 
-        resp = client.get_persons_by_distinct_ids_in_team(
-            GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=distinct_ids)
+        valid_results = _batched_get_persons_by_distinct_ids(
+            client, team_id, distinct_ids, "get_persons_mapped_by_distinct_id"
         )
-
-        present_results = [r for r in resp.results if r.person and r.person.id]
-        valid_results = [r for r in present_results if r.person.team_id == team_id]
-
-        mismatched = len(present_results) - len(valid_results)
-        if mismatched:
-            PERSONHOG_TEAM_MISMATCH_TOTAL.labels(
-                operation="get_persons_mapped_by_distinct_id", client_name=get_client_name()
-            ).inc(mismatched)
-            logger.warning(
-                "personhog_team_mismatch",
-                operation="get_persons_mapped_by_distinct_id",
-                team_id=team_id,
-                dropped=mismatched,
-            )
-
         return {r.distinct_id: proto_person_to_model(r.person, distinct_ids=[r.distinct_id]) for r in valid_results}
 
     return _personhog_routed(
@@ -416,29 +455,13 @@ def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> lis
     if client is None:
         raise RuntimeError("personhog client not configured")
 
-    resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
-
-    present_persons = [p for p in resp.persons if p.id]
-    valid_persons = [p for p in present_persons if p.team_id == team_id]
-
-    mismatched = len(present_persons) - len(valid_persons)
-    if mismatched:
-        PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation="get_persons_by_uuids", client_name=get_client_name()).inc(
-            mismatched
-        )
-        logger.warning("personhog_team_mismatch", operation="get_persons_by_uuids", team_id=team_id, dropped=mismatched)
+    valid_persons = _batched_get_persons_by_uuids(client, team_id, uuids, "get_persons_by_uuids")
 
     person_ids = [p.id for p in valid_persons]
     if not person_ids:
         return []
 
-    distinct_ids_resp = client.get_distinct_ids_for_persons(
-        GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
-    )
-
-    distinct_ids_by_person: dict[int, list[str]] = {}
-    for pd in distinct_ids_resp.person_distinct_ids:
-        distinct_ids_by_person[pd.person_id] = [d.distinct_id for d in pd.distinct_ids]
+    distinct_ids_by_person = _batched_get_distinct_ids_for_persons(client, team_id, person_ids)
 
     return [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in valid_persons]
 
@@ -576,20 +599,8 @@ def _validate_uuids_via_personhog(team_id: int, uuids: list[str]) -> list[str]:
     if client is None:
         raise RuntimeError("personhog client not configured")
 
-    resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
-    valid = [p for p in resp.persons if p.team_id == team_id]
-    mismatched = len(resp.persons) - len(valid)
-    if mismatched:
-        PERSONHOG_TEAM_MISMATCH_TOTAL.labels(
-            operation="validate_person_uuids_exist", client_name=get_client_name()
-        ).inc(mismatched)
-        logger.warning(
-            "personhog_team_mismatch",
-            operation="validate_person_uuids_exist",
-            team_id=team_id,
-            dropped=mismatched,
-        )
-    return [p.uuid for p in valid]
+    valid_persons = _batched_get_persons_by_uuids(client, team_id, uuids, "validate_person_uuids_exist")
+    return [p.uuid for p in valid_persons]
 
 
 def validate_person_uuids_exist(team_id: int, uuids: list[str]) -> list[str]:

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -50,7 +50,7 @@ from posthog.settings import TEST
 
 logger = structlog.get_logger(__name__)
 
-PERSONHOG_BATCH_SIZE = 1000
+PERSONHOG_BATCH_SIZE = 500
 
 
 if TYPE_CHECKING:
@@ -87,6 +87,7 @@ def _batched_get_persons_by_distinct_ids(
     team_id: int,
     distinct_ids: list[str],
     operation: str,
+    deduplicate_by_person: bool = True,
 ) -> list[person_pb2.PersonWithDistinctIds]:
     seen_person_ids: set[int] = set()
     valid_results: list[person_pb2.PersonWithDistinctIds] = []
@@ -105,11 +106,13 @@ def _batched_get_persons_by_distinct_ids(
             PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation=operation, client_name=get_client_name()).inc(mismatched)
             logger.warning("personhog_team_mismatch", operation=operation, team_id=team_id, dropped=mismatched)
 
-        # Deduplicate across batches — same person can appear for different distinct_ids
-        for r in batch_valid:
-            if r.person.id not in seen_person_ids:
-                seen_person_ids.add(r.person.id)
-                valid_results.append(r)
+        if deduplicate_by_person:
+            for r in batch_valid:
+                if r.person.id not in seen_person_ids:
+                    seen_person_ids.add(r.person.id)
+                    valid_results.append(r)
+        else:
+            valid_results.extend(batch_valid)
 
     return valid_results
 
@@ -436,7 +439,7 @@ def get_persons_mapped_by_distinct_id(
             raise RuntimeError("personhog client not configured")
 
         valid_results = _batched_get_persons_by_distinct_ids(
-            client, team_id, distinct_ids, "get_persons_mapped_by_distinct_id"
+            client, team_id, distinct_ids, "get_persons_mapped_by_distinct_id", deduplicate_by_person=False
         )
         return {r.distinct_id: proto_person_to_model(r.person, distinct_ids=[r.distinct_id]) for r in valid_results}
 

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -54,16 +54,24 @@ PERSONHOG_BATCH_SIZE = 500
 
 
 if TYPE_CHECKING:
-    from posthog.personhog_client.client import PersonHogClient
     from posthog.personhog_client.proto.generated.personhog.types.v1 import person_pb2
 
 
+def _get_client():
+    from posthog.personhog_client.client import get_personhog_client
+
+    client = get_personhog_client()
+    if client is None:
+        raise RuntimeError("personhog client not configured")
+    return client
+
+
 def _batched_get_persons_by_uuids(
-    client: PersonHogClient,
     team_id: int,
     uuids: list[str],
     operation: str,
 ) -> list[person_pb2.Person]:
+    client = _get_client()
     valid_persons: list[person_pb2.Person] = []
     for i in range(0, len(uuids), PERSONHOG_BATCH_SIZE):
         batch = uuids[i : i + PERSONHOG_BATCH_SIZE]
@@ -83,12 +91,12 @@ def _batched_get_persons_by_uuids(
 
 
 def _batched_get_persons_by_distinct_ids(
-    client: PersonHogClient,
     team_id: int,
     distinct_ids: list[str],
     operation: str,
     deduplicate_by_person: bool = True,
 ) -> list[person_pb2.PersonWithDistinctIds]:
+    client = _get_client()
     seen_person_ids: set[int] = set()
     valid_results: list[person_pb2.PersonWithDistinctIds] = []
 
@@ -118,11 +126,11 @@ def _batched_get_persons_by_distinct_ids(
 
 
 def _batched_get_distinct_ids_for_persons(
-    client: PersonHogClient,
     team_id: int,
     person_ids: list[int],
     limit_per_person: int | None = None,
 ) -> dict[int, list[str]]:
+    client = _get_client()
     distinct_ids_by_person: dict[int, list[str]] = {}
     for i in range(0, len(person_ids), PERSONHOG_BATCH_SIZE):
         batch_ids = person_ids[i : i + PERSONHOG_BATCH_SIZE]
@@ -304,20 +312,14 @@ def create_person_distinct_id(
 def _fetch_persons_by_distinct_ids_via_personhog(
     team_id: int, distinct_ids: list[str], *, distinct_id_limit: int | None = None
 ) -> list[Person]:
-    from posthog.personhog_client.client import get_personhog_client
-
-    client = get_personhog_client()
-    if client is None:
-        raise RuntimeError("personhog client not configured")
-
-    valid_results = _batched_get_persons_by_distinct_ids(client, team_id, distinct_ids, "get_persons_by_distinct_ids")
+    valid_results = _batched_get_persons_by_distinct_ids(team_id, distinct_ids, "get_persons_by_distinct_ids")
 
     person_ids = [r.person.id for r in valid_results]
     if not person_ids:
         return []
 
     distinct_ids_by_person = _batched_get_distinct_ids_for_persons(
-        client, team_id, person_ids, limit_per_person=distinct_id_limit
+        team_id, person_ids, limit_per_person=distinct_id_limit
     )
 
     return [
@@ -432,14 +434,8 @@ def get_persons_mapped_by_distinct_id(
         return result
 
     def personhog_fn() -> dict[str, Person]:
-        from posthog.personhog_client.client import get_personhog_client
-
-        client = get_personhog_client()
-        if client is None:
-            raise RuntimeError("personhog client not configured")
-
         valid_results = _batched_get_persons_by_distinct_ids(
-            client, team_id, distinct_ids, "get_persons_mapped_by_distinct_id", deduplicate_by_person=False
+            team_id, distinct_ids, "get_persons_mapped_by_distinct_id", deduplicate_by_person=False
         )
         return {r.distinct_id: proto_person_to_model(r.person, distinct_ids=[r.distinct_id]) for r in valid_results}
 
@@ -452,19 +448,13 @@ def get_persons_mapped_by_distinct_id(
 
 
 def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> list[Person]:
-    from posthog.personhog_client.client import get_personhog_client
-
-    client = get_personhog_client()
-    if client is None:
-        raise RuntimeError("personhog client not configured")
-
-    valid_persons = _batched_get_persons_by_uuids(client, team_id, uuids, "get_persons_by_uuids")
+    valid_persons = _batched_get_persons_by_uuids(team_id, uuids, "get_persons_by_uuids")
 
     person_ids = [p.id for p in valid_persons]
     if not person_ids:
         return []
 
-    distinct_ids_by_person = _batched_get_distinct_ids_for_persons(client, team_id, person_ids)
+    distinct_ids_by_person = _batched_get_distinct_ids_for_persons(team_id, person_ids)
 
     return [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in valid_persons]
 
@@ -596,13 +586,9 @@ def get_person_by_pk_or_uuid(team_id: int, key: str) -> Optional[Person]:
 
 
 def _validate_uuids_via_personhog(team_id: int, uuids: list[str]) -> list[str]:
-    from posthog.personhog_client.client import get_personhog_client
-
-    client = get_personhog_client()
-    if client is None:
-        raise RuntimeError("personhog client not configured")
-
-    valid_persons = _batched_get_persons_by_uuids(client, team_id, uuids, "validate_person_uuids_exist")
+    # _batched_get_persons_by_uuids also filters out persons with id == 0 (server "not found" sentinel),
+    # which the previous single-RPC implementation did not do. This is intentionally more correct.
+    valid_persons = _batched_get_persons_by_uuids(team_id, uuids, "validate_person_uuids_exist")
     return [p.uuid for p in valid_persons]
 
 

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -19,15 +19,10 @@ from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.group import Group
 from posthog.models.person import Person
 from posthog.models.person.person import READ_DB_FOR_PERSONS
+from posthog.models.person.util import _batched_get_distinct_ids_for_persons, _batched_get_persons_by_uuids
 from posthog.personhog_client.client import get_personhog_client
 from posthog.personhog_client.converters import proto_person_to_model
-from posthog.personhog_client.metrics import (
-    PERSONHOG_ROUTING_ERRORS_TOTAL,
-    PERSONHOG_ROUTING_TOTAL,
-    PERSONHOG_TEAM_MISMATCH_TOTAL,
-    get_client_name,
-)
-from posthog.personhog_client.proto import GetDistinctIdsForPersonsRequest, GetPersonsByUuidsRequest
+from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
 from posthog.queries.insight import insight_sync_execute
 
 logger = structlog.get_logger(__name__)
@@ -273,27 +268,15 @@ def _fetch_people_via_personhog(
         raise RuntimeError("personhog client not configured")
 
     uuids = [str(pid) for pid in people_ids]
-    resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
-
-    present_persons = [p for p in resp.persons if p.id]
-    valid_persons = [p for p in present_persons if p.team_id == team_id]
-
-    mismatched = len(present_persons) - len(valid_persons)
-    if mismatched:
-        PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation="get_people", client_name=get_client_name()).inc(mismatched)
-        logger.warning("personhog_team_mismatch", operation="get_people", team_id=team_id, dropped=mismatched)
+    valid_persons = _batched_get_persons_by_uuids(client, team_id, uuids, "get_people")
 
     person_ids = [p.id for p in valid_persons]
     if not person_ids:
         return []
 
-    request = GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
-    if distinct_id_limit is not None:
-        request.limit_per_person = distinct_id_limit
-    distinct_ids_resp = client.get_distinct_ids_for_persons(request)
-    distinct_ids_by_person: dict[int, list[str]] = {}
-    for pd in distinct_ids_resp.person_distinct_ids:
-        distinct_ids_by_person[pd.person_id] = [d.distinct_id for d in pd.distinct_ids]
+    distinct_ids_by_person = _batched_get_distinct_ids_for_persons(
+        client, team_id, person_ids, limit_per_person=distinct_id_limit
+    )
 
     persons = [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in valid_persons]
     persons.sort(key=lambda p: (-(p.created_at.timestamp() if p.created_at else 0), str(p.uuid)))

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -20,7 +20,6 @@ from posthog.models.group import Group
 from posthog.models.person import Person
 from posthog.models.person.person import READ_DB_FOR_PERSONS
 from posthog.models.person.util import _batched_get_distinct_ids_for_persons, _batched_get_persons_by_uuids
-from posthog.personhog_client.client import get_personhog_client
 from posthog.personhog_client.converters import proto_person_to_model
 from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
 from posthog.queries.insight import insight_sync_execute
@@ -263,19 +262,15 @@ def get_groups(
 def _fetch_people_via_personhog(
     team_id: int, people_ids: list[Any], distinct_id_limit: int | None = 1000
 ) -> list[Person]:
-    client = get_personhog_client()
-    if client is None:
-        raise RuntimeError("personhog client not configured")
-
     uuids = [str(pid) for pid in people_ids]
-    valid_persons = _batched_get_persons_by_uuids(client, team_id, uuids, "get_people")
+    valid_persons = _batched_get_persons_by_uuids(team_id, uuids, "get_people")
 
     person_ids = [p.id for p in valid_persons]
     if not person_ids:
         return []
 
     distinct_ids_by_person = _batched_get_distinct_ids_for_persons(
-        client, team_id, person_ids, limit_per_person=distinct_id_limit
+        team_id, person_ids, limit_per_person=distinct_id_limit
     )
 
     persons = [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in valid_persons]


### PR DESCRIPTION
## Problem

Django's personhog gRPC call sites send unbounded request payloads. If a caller passes thousands of UUIDs or distinct IDs, the entire list goes in a single RPC.

## Changes

Adds shared helpers that chunks RPCs into batches of 500:

- batches `GetPersonsByUuuids`
- batches `GetPersonsByDistinctIdsInTeam`
- batches `GetDistinctIdsForPersons`

Error Handling --

If any batch RPC failes, the exception propagates out to the healper and we fall back to ORM path

## How did you test this code?

- new unit tests in the `test_batched_personhog_helpers.py` file
- existing unit tests pass

