### PR TITLE
feat(onboarding): floating wizard progress panel during onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -5,6 +5,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 
 import { OnboardingFlowHost } from './OnboardingFlowHost'
 import { onboardingLogic } from './onboardingLogic'
+import { WizardProgressFab } from './sdks/OnboardingInstallStep/WizardProgressFab'
 
 export const scene: SceneExport = {
     component: Onboarding,
@@ -17,6 +18,10 @@ export const scene: SceneExport = {
  * - No `productKey` in the URL → render the product-selection landing page.
  * - With a `productKey` → hand off to {@link OnboardingFlowHost}, which renders the
  *   current step out of the data-driven flow built by `onboardingLogic.flow`.
+ *
+ * `WizardProgressFab` mounts at this scope so an in-flight wizard session
+ * survives step navigation — the install step renders the full panel,
+ * other steps see the FAB.
  */
 export function Onboarding(): JSX.Element | null {
     const { productKey } = useValues(onboardingLogic)
@@ -28,6 +33,7 @@ export function Onboarding(): JSX.Element | null {
     return (
         <div className="pt-4 pb-10">
             <OnboardingFlowHost />
+            <WizardProgressFab />
         </div>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.stories.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.stories.tsx
@@ -1,0 +1,148 @@
+import { Meta, StoryFn } from '@storybook/react'
+import { useMountedLogic } from 'kea'
+import { useEffect } from 'react'
+
+import { wizardSessionStreamLogic } from 'products/wizard/frontend/wizardSessionStreamLogic'
+
+import { WizardProgressFab } from './WizardProgressFab'
+import { wizardProgressTrackerLogic } from './wizardProgressTrackerLogic'
+
+const WORKFLOW_ID = 'posthog-integration'
+const SKILL_ID = 'laravel'
+
+if (typeof window !== 'undefined' && !(window as any).__wizardEventSourceStubbed) {
+    class StubEventSource {
+        readyState = 0
+        url = ''
+        withCredentials = false
+        onopen: ((ev: Event) => void) | null = null
+        onmessage: ((ev: MessageEvent) => void) | null = null
+        onerror: ((ev: Event) => void) | null = null
+        addEventListener(): void {}
+        removeEventListener(): void {}
+        dispatchEvent(): boolean {
+            return false
+        }
+        close(): void {}
+        static readonly CONNECTING = 0
+        static readonly OPEN = 1
+        static readonly CLOSED = 2
+    }
+    ;(window as any).EventSource = StubEventSource
+    ;(window as any).__wizardEventSourceStubbed = true
+}
+
+type WizardSessionFixture = {
+    session_id: string
+    team_id: number
+    workflow_id: string
+    skill_id: string
+    started_at: string
+    run_phase: 'idle' | 'running' | 'completed' | 'error'
+    tasks: Array<{
+        id: string
+        title: string
+        status: 'pending' | 'in_progress' | 'completed' | 'failed' | 'cancelled'
+    }>
+    event_plan: unknown | null
+    error: { type: string; message: string } | null
+    created_at: string
+    updated_at: string
+}
+
+function makeSession(overrides: Partial<WizardSessionFixture>): WizardSessionFixture {
+    const startedAt = new Date(Date.now() - 30_000).toISOString()
+    return {
+        session_id: `${WORKFLOW_ID}-${SKILL_ID}-${startedAt}`,
+        team_id: 1,
+        workflow_id: WORKFLOW_ID,
+        skill_id: SKILL_ID,
+        started_at: startedAt,
+        run_phase: 'running',
+        tasks: [],
+        event_plan: null,
+        error: null,
+        created_at: startedAt,
+        updated_at: new Date().toISOString(),
+        ...overrides,
+    }
+}
+
+function withSession(session: WizardSessionFixture | null): StoryFn {
+    return function StoryRender() {
+        useMountedLogic(wizardProgressTrackerLogic)
+        const streamLogic = wizardSessionStreamLogic({ workflowId: WORKFLOW_ID })
+        useMountedLogic(streamLogic)
+
+        useEffect(() => {
+            streamLogic.actions.connectionOpened()
+            if (session) {
+                streamLogic.actions.sessionUpdated(session as any)
+            }
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [])
+
+        return (
+            <SceneFrame>
+                <WizardProgressFab />
+            </SceneFrame>
+        )
+    }
+}
+
+const meta: Meta = {
+    title: 'Scenes-Other/Onboarding/Wizard Progress FAB',
+    component: WizardProgressFab,
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+    },
+}
+export default meta
+
+function SceneFrame({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+        <div className="min-h-screen bg-bg-light text-default px-6 py-10 relative">
+            <div className="max-w-4xl mx-auto">
+                <h1 className="text-2xl font-bold mb-1">Onboarding (some later step)</h1>
+                <p className="text-muted mb-8">
+                    The user has navigated away from the wizard install step. The FAB persists across the rest of the
+                    onboarding flow until the wizard finishes.
+                </p>
+            </div>
+            {children}
+        </div>
+    )
+}
+
+/** No session — FAB should render nothing. */
+export const Hidden: StoryFn = withSession(null)
+
+/** Wizard mid-run; pulsing dot, not dismissible. */
+export const Running: StoryFn = withSession(
+    makeSession({
+        run_phase: 'running',
+    })
+)
+
+/** Reconnecting state — same visual treatment as running. */
+export const Connecting: StoryFn = withSession(
+    makeSession({
+        run_phase: 'running',
+    })
+)
+
+/** Wizard finished cleanly; success colour + dismissible. */
+export const Completed: StoryFn = withSession(
+    makeSession({
+        run_phase: 'completed',
+    })
+)
+
+/** Wizard errored; brand-red FAB + dismissible. */
+export const Errored: StoryFn = withSession(
+    makeSession({
+        run_phase: 'error',
+        error: { type: 'TimeoutError', message: 'Anthropic API timed out' },
+    })
+)

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.stories.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryFn } from '@storybook/react'
 import { useMountedLogic } from 'kea'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
 
 import { wizardSessionStreamLogic } from 'products/wizard/frontend/wizardSessionStreamLogic'
 
@@ -32,6 +34,8 @@ if (typeof window !== 'undefined' && !(window as any).__wizardEventSourceStubbed
     ;(window as any).__wizardEventSourceStubbed = true
 }
 
+type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'failed' | 'canceled'
+
 type WizardSessionFixture = {
     session_id: string
     team_id: number
@@ -42,7 +46,7 @@ type WizardSessionFixture = {
     tasks: Array<{
         id: string
         title: string
-        status: 'pending' | 'in_progress' | 'completed' | 'failed' | 'cancelled'
+        status: TaskStatus
     }>
     event_plan: unknown | null
     error: { type: string; message: string } | null
@@ -50,8 +54,20 @@ type WizardSessionFixture = {
     updated_at: string
 }
 
+const SAMPLE_TASKS = [
+    { id: '1', title: 'Install posthog-node package' },
+    { id: '2', title: 'Set up PostHog environment variables' },
+    { id: '3', title: 'Create PostHog client module' },
+    { id: '4', title: 'Insert event tracking in API handlers' },
+    { id: '5', title: 'Wrapping up' },
+] as const
+
+function buildTasks(statuses: TaskStatus[]): WizardSessionFixture['tasks'] {
+    return SAMPLE_TASKS.map((t, i) => ({ ...t, status: statuses[i] ?? 'pending' }))
+}
+
 function makeSession(overrides: Partial<WizardSessionFixture>): WizardSessionFixture {
-    const startedAt = new Date(Date.now() - 30_000).toISOString()
+    const startedAt = new Date(Date.now() - 74_000).toISOString()
     return {
         session_id: `${WORKFLOW_ID}-${SKILL_ID}-${startedAt}`,
         team_id: 1,
@@ -96,6 +112,8 @@ const meta: Meta = {
     parameters: {
         layout: 'fullscreen',
         viewMode: 'story',
+        // FAB is flag-gated; storybook's useFeatureFlag treats any truthy value as "on".
+        featureFlags: [FEATURE_FLAGS.ONBOARDING_WIZARD_SYNC],
     },
 }
 export default meta
@@ -107,7 +125,7 @@ function SceneFrame({ children }: { children: React.ReactNode }): JSX.Element {
                 <h1 className="text-2xl font-bold mb-1">Onboarding (some later step)</h1>
                 <p className="text-muted mb-8">
                     The user has navigated away from the wizard install step. The FAB persists across the rest of the
-                    onboarding flow until the wizard finishes.
+                    onboarding flow until the wizard finishes. Click it to jump back to the full panel.
                 </p>
             </div>
             {children}
@@ -115,34 +133,151 @@ function SceneFrame({ children }: { children: React.ReactNode }): JSX.Element {
     )
 }
 
-/** No session — FAB should render nothing. */
+/** No session — FAB renders nothing. */
 export const Hidden: StoryFn = withSession(null)
 
-/** Wizard mid-run; pulsing dot, not dismissible. */
-export const Running: StoryFn = withSession(
+/** Wizard just kicked off, no tasks yet — ring spins (indeterminate). */
+export const Analyzing: StoryFn = withSession(
     makeSession({
         run_phase: 'running',
+        tasks: [],
     })
 )
 
-/** Reconnecting state — same visual treatment as running. */
-export const Connecting: StoryFn = withSession(
+/** Mid-run, ~40% done with a task currently running. */
+export const RunningEarly: StoryFn = withSession(
     makeSession({
         run_phase: 'running',
+        tasks: buildTasks(['completed', 'completed', 'in_progress', 'pending', 'pending']),
     })
 )
 
-/** Wizard finished cleanly; success colour + dismissible. */
+/** Late mid-run, ~80% done. Demonstrates the ring filling. */
+export const RunningLate: StoryFn = withSession(
+    makeSession({
+        run_phase: 'running',
+        tasks: buildTasks(['completed', 'completed', 'completed', 'completed', 'in_progress']),
+    })
+)
+
+/** Reconnecting state: live session mid-run, but the SSE transport just errored. */
+export const Connecting: StoryFn = function ConnectingStory() {
+    useMountedLogic(wizardProgressTrackerLogic)
+    const streamLogic = wizardSessionStreamLogic({ workflowId: WORKFLOW_ID })
+    useMountedLogic(streamLogic)
+
+    useEffect(() => {
+        streamLogic.actions.connectionOpened()
+        streamLogic.actions.sessionUpdated(
+            makeSession({
+                run_phase: 'running',
+                tasks: buildTasks(['completed', 'in_progress', 'pending', 'pending', 'pending']),
+            }) as any
+        )
+        const id = window.setTimeout(() => {
+            streamLogic.actions.connectionErrored('EventSource transport error — reconnecting')
+        }, 50)
+        return () => window.clearTimeout(id)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    return (
+        <SceneFrame>
+            <WizardProgressFab />
+        </SceneFrame>
+    )
+}
+
+/** Wizard finished cleanly; green ring + ✓ + dismiss available. */
 export const Completed: StoryFn = withSession(
     makeSession({
         run_phase: 'completed',
+        tasks: buildTasks(['completed', 'completed', 'completed', 'completed', 'completed']),
     })
 )
 
-/** Wizard errored; brand-red FAB + dismissible. */
+/** Wizard errored; red ring + ✗ + dismiss available. */
 export const Errored: StoryFn = withSession(
     makeSession({
         run_phase: 'error',
+        tasks: buildTasks(['completed', 'completed', 'failed', 'canceled', 'canceled']),
         error: { type: 'TimeoutError', message: 'Anthropic API timed out' },
     })
 )
+
+/**
+ * Auto-playing run that mirrors the real-world timeline. Watch the ring fill, the
+ * shimmer rainbow underneath, and the sub-line update with each task transition.
+ *
+ *   t=0s   session opens (Analyzing — indeterminate ring spin)
+ *   t=4s   task 1 in_progress
+ *   t=8s   task 1 ✓, task 2 in_progress
+ *   t=12s  task 2 ✓, task 3 in_progress
+ *   t=16s  task 3 ✓, task 4 in_progress
+ *   t=20s  task 4 ✓, task 5 in_progress
+ *   t=24s  task 5 ✓, run_phase = completed (green ring + dismiss visible)
+ */
+export const SimulatedRun: StoryFn = function SimulatedRunStory() {
+    useMountedLogic(wizardProgressTrackerLogic)
+    const streamLogic = wizardSessionStreamLogic({ workflowId: WORKFLOW_ID })
+    useMountedLogic(streamLogic)
+
+    const timersRef = useRef<number[]>([])
+
+    useEffect(() => {
+        const { actions } = streamLogic
+        const startedAt = new Date().toISOString()
+        const base: WizardSessionFixture = {
+            session_id: `${WORKFLOW_ID}-${SKILL_ID}-${startedAt}`,
+            team_id: 1,
+            workflow_id: WORKFLOW_ID,
+            skill_id: SKILL_ID,
+            started_at: startedAt,
+            run_phase: 'running',
+            tasks: [],
+            event_plan: null,
+            error: null,
+            created_at: startedAt,
+            updated_at: startedAt,
+        }
+
+        actions.connectionOpened()
+        actions.sessionUpdated(base as any)
+
+        const schedule: Array<{ atMs: number; tasks: TaskStatus[]; phase?: 'running' | 'completed' }> = [
+            { atMs: 4_000, tasks: ['in_progress', 'pending', 'pending', 'pending', 'pending'] },
+            { atMs: 8_000, tasks: ['completed', 'in_progress', 'pending', 'pending', 'pending'] },
+            { atMs: 12_000, tasks: ['completed', 'completed', 'in_progress', 'pending', 'pending'] },
+            { atMs: 16_000, tasks: ['completed', 'completed', 'completed', 'in_progress', 'pending'] },
+            { atMs: 20_000, tasks: ['completed', 'completed', 'completed', 'completed', 'in_progress'] },
+            {
+                atMs: 24_000,
+                tasks: ['completed', 'completed', 'completed', 'completed', 'completed'],
+                phase: 'completed',
+            },
+        ]
+
+        timersRef.current = schedule.map(({ atMs, tasks, phase }) =>
+            window.setTimeout(() => {
+                actions.sessionUpdated({
+                    ...base,
+                    run_phase: phase ?? 'running',
+                    tasks: buildTasks(tasks),
+                    updated_at: new Date().toISOString(),
+                } as any)
+            }, atMs)
+        )
+
+        return () => {
+            timersRef.current.forEach((id) => window.clearTimeout(id))
+            timersRef.current = []
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    return (
+        <SceneFrame>
+            <WizardProgressFab />
+        </SceneFrame>
+    )
+}

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.tsx
@@ -1,0 +1,114 @@
+import { useActions, useValues } from 'kea'
+
+import { IconCheck, IconX } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { wizardProgressTrackerLogic } from './wizardProgressTrackerLogic'
+
+/**
+ * Onboarding-scoped floating action button. Renders whenever a wizard session
+ * has been observed and the user has navigated away from the install step's
+ * full panel. Dismissible only after the run reaches a terminal phase.
+ *
+ * Mounts `wizardProgressTrackerLogic` at the scene root so SSE stays connected
+ * across step navigation.
+ */
+export function WizardProgressFab(): JSX.Element | null {
+    const { displayState, latestSession, elapsedSeconds, dismissed, panelMounted } =
+        useValues(wizardProgressTrackerLogic)
+    const { dismiss } = useActions(wizardProgressTrackerLogic)
+
+    if (dismissed || panelMounted || displayState === 'preTakeover') {
+        return null
+    }
+
+    const isTerminal = displayState === 'completed' || displayState === 'error'
+    const skill = latestSession?.skill_id
+
+    const headline =
+        displayState === 'completed'
+            ? "PostHog's wired in"
+            : displayState === 'error'
+              ? 'Wizard ran into trouble'
+              : displayState === 'connecting'
+                ? 'Reconnecting…'
+                : 'Wizard installing PostHog'
+
+    const sub =
+        displayState === 'completed' || displayState === 'error'
+            ? skill
+                ? `${skill}`
+                : null
+            : skill
+              ? `${skill} · ${formatElapsed(elapsedSeconds)}`
+              : formatElapsed(elapsedSeconds)
+
+    return (
+        <div className="fixed bottom-4 right-4 z-[60] font-mono">
+            <div
+                role="status"
+                aria-live="polite"
+                className={`flex items-center gap-3 pl-3 pr-2 py-2 rounded-full shadow-2xl shadow-black/30 border ${
+                    displayState === 'completed'
+                        ? 'bg-success text-white border-success'
+                        : displayState === 'error'
+                          ? 'bg-brand-red text-white border-brand-red'
+                          : 'bg-neutral-950 text-neutral-100 border-neutral-800'
+                }`}
+            >
+                <FabIcon displayState={displayState} />
+                <div className="flex flex-col leading-tight pr-1 min-w-0">
+                    <span className="text-xs uppercase tracking-wider opacity-80">{headline}</span>
+                    {sub ? <span className="text-[11px] tabular-nums truncate max-w-[180px]">{sub}</span> : null}
+                </div>
+                {isTerminal && (
+                    <LemonButton
+                        size="xsmall"
+                        icon={<IconX />}
+                        onClick={dismiss}
+                        aria-label="Dismiss"
+                        tooltip="Dismiss"
+                        className="opacity-80 hover:opacity-100"
+                    />
+                )}
+            </div>
+            <FabKeyframes />
+        </div>
+    )
+}
+
+function FabIcon({ displayState }: { displayState: string }): JSX.Element {
+    if (displayState === 'completed') {
+        return (
+            <span aria-hidden className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-white/20">
+                <IconCheck className="text-white" />
+            </span>
+        )
+    }
+    if (displayState === 'error') {
+        return (
+            <span aria-hidden className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-white/20">
+                <IconX className="text-white" />
+            </span>
+        )
+    }
+    return <span aria-hidden className="inline-block w-3 h-3 rounded-full bg-brand-red wizard-fab-pulse-dot shrink-0" />
+}
+
+function FabKeyframes(): JSX.Element {
+    return (
+        <style>{`
+            @keyframes wizard-fab-pulse-dot {
+                0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(245, 78, 0, 0.55); }
+                50% { opacity: 0.6; box-shadow: 0 0 0 5px rgba(245, 78, 0, 0); }
+            }
+            .wizard-fab-pulse-dot { animation: wizard-fab-pulse-dot 1.6s ease-in-out infinite; }
+        `}</style>
+    )
+}
+
+function formatElapsed(seconds: number): string {
+    const m = Math.floor(seconds / 60)
+    const s = seconds % 60
+    return `${m}:${s.toString().padStart(2, '0')}`
+}

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.tsx
@@ -1,75 +1,234 @@
 import { useActions, useValues } from 'kea'
 
-import { IconX } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { IconSparkles, IconX } from '@posthog/icons'
 
-import hogWelder from 'public/hedgehog/hog-welder.png'
-import starHog from 'public/hedgehog/star-hog.png'
-import warningHog from 'public/hedgehog/warning-hog.png'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
+import { OnboardingStepKey } from '~/types'
+
+import { onboardingLogic } from '../../onboardingLogic'
 import { type DisplayState, wizardProgressTrackerLogic } from './wizardProgressTrackerLogic'
 
+const RING_SIZE = 44
+const RING_STROKE = 4
+const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS
+
 /**
- * Onboarding-scoped floating widget. Persists across onboarding step navigation
- * while a wizard session is in flight, with a hog mascot + labelled status so
- * users understand what they're looking at. Dismissible only after a terminal phase.
+ * Persistent corner widget that surfaces an in-flight wizard run while the user
+ * navigates the rest of onboarding. Disappears when the install step is mounted
+ * (the full panel takes over) and again once the user dismisses a terminal run.
+ *
+ * Click anywhere on the card to jump back to the install step.
+ *
+ * Gated on the same flag as the takeover panel so control-arm users don't mount
+ * the sync logic (and open an SSE connection) at the scene level.
  */
 export function WizardProgressFab(): JSX.Element | null {
+    const isSyncEnabled = useFeatureFlag('ONBOARDING_WIZARD_SYNC', 'test')
+    if (!isSyncEnabled) {
+        return null
+    }
+    return <WizardProgressFabInner />
+}
+
+function WizardProgressFabInner(): JSX.Element | null {
     const { displayState, latestSession, elapsedSeconds, dismissed, panelMounted } =
         useValues(wizardProgressTrackerLogic)
     const { dismiss } = useActions(wizardProgressTrackerLogic)
+    const { setStepId } = useActions(onboardingLogic)
 
     if (dismissed || panelMounted || displayState === 'preTakeover') {
         return null
     }
 
+    const tasks = latestSession?.tasks ?? []
+    const totalCount = tasks.length
+    const completedCount = tasks.filter((t) => t.status === 'completed').length
+    const progressPct = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0
+    const currentTask = tasks.find((t) => t.status === 'in_progress')?.title
+
     const isTerminal = displayState === 'completed' || displayState === 'error'
-    const isRunning = !isTerminal
-    const skill = latestSession?.skill_id
-    const headline = headlineFor(displayState)
-    const sub = subFor(displayState, skill, elapsedSeconds)
-    const accent = accentColor(displayState)
-    const mascot = mascotFor(displayState)
+
+    const handleExpand = (): void => {
+        setStepId(OnboardingStepKey.INSTALL)
+    }
 
     return (
-        <div className="fixed bottom-5 right-5 z-[60]">
+        <div className="fixed bottom-5 right-5 z-[60] wizard-fab-slide-in">
             <FabKeyframes />
             <div
                 role="status"
                 aria-live="polite"
-                className="flex items-center gap-3 pl-2 pr-4 py-2 rounded-full bg-bg-light shadow-2xl shadow-black/20 border border-border min-w-[300px]"
-                style={{ borderColor: accent }}
+                className="relative w-[300px] bg-bg-light rounded-xl shadow-xl shadow-black/15 border border-border overflow-hidden"
             >
-                <span
-                    className={`relative flex-shrink-0 w-16 h-16 rounded-full flex items-center justify-center ${
-                        isRunning ? 'wizard-fab-glow' : ''
-                    }`}
-                    style={{ background: `${accent}1a` }}
+                <button
+                    type="button"
+                    onClick={handleExpand}
+                    className="w-full text-left flex items-center gap-3 px-3 py-3 hover:bg-bg-3000 transition-colors"
+                    aria-label="Return to the wizard install panel"
                 >
-                    <img
-                        src={mascot}
-                        alt=""
-                        draggable={false}
-                        className={`relative w-12 h-12 object-contain ${isRunning ? 'wizard-fab-mascot-bob' : ''}`}
+                    <ProgressRing
+                        progress={displayState === 'completed' ? 100 : progressPct}
+                        state={displayState}
+                        hasTasks={totalCount > 0}
                     />
-                </span>
-                <div className="flex flex-col leading-tight min-w-0 flex-1">
-                    <span className="text-[11px] font-semibold uppercase tracking-wider text-muted">Setup wizard</span>
-                    <span className="text-sm font-semibold text-default truncate" style={{ color: accent }}>
-                        {headline}
-                    </span>
-                    {sub ? <span className="text-xs text-muted tabular-nums truncate">{sub}</span> : null}
-                </div>
-                {isTerminal && (
-                    <LemonButton
-                        size="xsmall"
-                        icon={<IconX />}
-                        onClick={dismiss}
+                    <div className="flex-1 min-w-0 leading-tight">
+                        <div className="flex items-center gap-1 text-xs uppercase tracking-wider text-muted font-semibold">
+                            <IconSparkles className="text-sm wizard-fab-sparkle" aria-hidden />
+                            <span>Setup wizard</span>
+                        </div>
+                        <div className="text-sm font-semibold text-default truncate mt-0.5">
+                            {headlineFor(displayState)}
+                        </div>
+                        <div className="text-xs text-muted truncate mt-0.5 tabular-nums">
+                            {subLineFor(displayState, currentTask, elapsedSeconds)}
+                        </div>
+                    </div>
+                </button>
+                {isTerminal ? (
+                    <button
+                        type="button"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            dismiss()
+                        }}
                         aria-label="Dismiss"
-                        tooltip="Dismiss"
+                        className="absolute top-1.5 right-1.5 p-1 rounded-md text-muted hover:text-default hover:bg-bg-3000 transition-colors"
+                    >
+                        <IconX className="text-base" />
+                    </button>
+                ) : null}
+                <ProgressBar
+                    progress={displayState === 'completed' ? 100 : progressPct}
+                    state={displayState}
+                    hasTasks={totalCount > 0}
+                />
+            </div>
+        </div>
+    )
+}
+
+function ProgressRing({
+    progress,
+    state,
+    hasTasks,
+}: {
+    progress: number
+    state: DisplayState
+    hasTasks: boolean
+}): JSX.Element {
+    const accent = accentColor(state)
+    const isIndeterminate = state === 'connecting' || (state === 'running' && !hasTasks)
+    const dashOffset = RING_CIRCUMFERENCE * (1 - progress / 100)
+
+    return (
+        <div
+            className="relative shrink-0 flex items-center justify-center"
+            style={{ width: RING_SIZE, height: RING_SIZE }}
+        >
+            <svg width={RING_SIZE} height={RING_SIZE} viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}>
+                <circle
+                    cx={RING_SIZE / 2}
+                    cy={RING_SIZE / 2}
+                    r={RING_RADIUS}
+                    fill="none"
+                    stroke="currentColor"
+                    className="text-border"
+                    strokeWidth={RING_STROKE}
+                />
+                {isIndeterminate ? (
+                    <g className="wizard-fab-ring-spin" style={{ transformOrigin: '50% 50%' }}>
+                        <circle
+                            cx={RING_SIZE / 2}
+                            cy={RING_SIZE / 2}
+                            r={RING_RADIUS}
+                            fill="none"
+                            stroke={accent}
+                            strokeWidth={RING_STROKE}
+                            strokeLinecap="round"
+                            strokeDasharray={`${RING_CIRCUMFERENCE * 0.25} ${RING_CIRCUMFERENCE}`}
+                            transform={`rotate(-90 ${RING_SIZE / 2} ${RING_SIZE / 2})`}
+                        />
+                    </g>
+                ) : (
+                    <circle
+                        cx={RING_SIZE / 2}
+                        cy={RING_SIZE / 2}
+                        r={RING_RADIUS}
+                        fill="none"
+                        stroke={accent}
+                        strokeWidth={RING_STROKE}
+                        strokeLinecap="round"
+                        strokeDasharray={RING_CIRCUMFERENCE}
+                        strokeDashoffset={dashOffset}
+                        transform={`rotate(-90 ${RING_SIZE / 2} ${RING_SIZE / 2})`}
+                        style={{ transition: 'stroke-dashoffset 600ms ease-out' }}
                     />
                 )}
-            </div>
+            </svg>
+            <span className="absolute inset-0 flex items-center justify-center text-[11px] font-semibold tabular-nums">
+                <RingCenter state={state} progress={progress} hasTasks={hasTasks} accent={accent} />
+            </span>
+        </div>
+    )
+}
+
+function RingCenter({
+    state,
+    progress,
+    hasTasks,
+    accent,
+}: {
+    state: DisplayState
+    progress: number
+    hasTasks: boolean
+    accent: string
+}): JSX.Element {
+    if (state === 'completed') {
+        return (
+            <span style={{ color: accent }} aria-hidden>
+                ✓
+            </span>
+        )
+    }
+    if (state === 'error') {
+        return (
+            <span style={{ color: accent }} aria-hidden>
+                ✗
+            </span>
+        )
+    }
+    if (state === 'connecting' || !hasTasks) {
+        return <span aria-hidden />
+    }
+    return <span style={{ color: accent }}>{`${progress}%`}</span>
+}
+
+function ProgressBar({
+    progress,
+    state,
+    hasTasks,
+}: {
+    progress: number
+    state: DisplayState
+    hasTasks: boolean
+}): JSX.Element | null {
+    if (!hasTasks && state !== 'completed') {
+        return null
+    }
+    const isTerminal = state === 'completed' || state === 'error'
+    return (
+        <div className="h-1 bg-bg-3000 relative" aria-hidden>
+            <div
+                className={`absolute inset-y-0 left-0 transition-[width] duration-500 ${
+                    isTerminal ? '' : 'wizard-fab-shimmer'
+                }`}
+                style={{
+                    width: `${progress}%`,
+                    ...(isTerminal ? { background: accentColor(state) } : {}),
+                }}
+            />
         </div>
     )
 }
@@ -77,9 +236,9 @@ export function WizardProgressFab(): JSX.Element | null {
 function headlineFor(state: DisplayState): string {
     switch (state) {
         case 'completed':
-            return "PostHog's wired in"
+            return 'PostHog is set up'
         case 'error':
-            return 'Hit a snag'
+            return 'Wizard hit a snag'
         case 'connecting':
             return 'Reconnecting…'
         default:
@@ -87,62 +246,82 @@ function headlineFor(state: DisplayState): string {
     }
 }
 
-function subFor(state: DisplayState, skill: string | undefined, elapsedSeconds: number): string | null {
+function subLineFor(state: DisplayState, currentTask: string | undefined, elapsedSeconds: number): string {
     if (state === 'completed') {
-        return skill ? `${skill} · all set` : 'all set'
+        return 'tap to see what was set up'
     }
     if (state === 'error') {
-        return skill ? `${skill} · open the panel to retry` : 'open the panel to retry'
+        return 'tap to open and retry'
+    }
+    if (state === 'connecting') {
+        return 'restoring connection to the wizard'
     }
     const elapsed = formatElapsed(elapsedSeconds)
-    return skill ? `${skill} · ${elapsed}` : elapsed
-}
-
-function mascotFor(state: DisplayState): string {
-    switch (state) {
-        case 'completed':
-            return starHog
-        case 'error':
-            return warningHog
-        default:
-            return hogWelder
+    if (currentTask) {
+        return `${currentTask} · ${elapsed}`
     }
+    return `running for ${elapsed}`
 }
 
 function accentColor(state: DisplayState): string {
-    switch (state) {
-        case 'completed':
-            return 'rgb(16, 185, 129)' // emerald-500
-        case 'error':
-            return 'rgb(245, 78, 0)' // brand-red
-        default:
-            return 'rgb(245, 78, 0)' // brand-red
+    if (state === 'completed') {
+        return 'rgb(16, 185, 129)' // emerald-500
     }
-}
-
-function FabKeyframes(): JSX.Element {
-    return (
-        <style>{`
-            @keyframes wizard-fab-mascot-bob {
-                0%, 100% { transform: translateY(0) rotate(-2deg); }
-                50%      { transform: translateY(-3px) rotate(2deg); }
-            }
-            .wizard-fab-mascot-bob {
-                animation: wizard-fab-mascot-bob 1.6s ease-in-out infinite;
-            }
-            @keyframes wizard-fab-glow {
-                0%, 100% { box-shadow: 0 0 0 0 rgba(245, 78, 0, 0.45); }
-                50%      { box-shadow: 0 0 0 8px rgba(245, 78, 0, 0); }
-            }
-            .wizard-fab-glow {
-                animation: wizard-fab-glow 2.2s ease-in-out infinite;
-            }
-        `}</style>
-    )
+    return 'rgb(245, 78, 0)' // brand-red — used for running, connecting, and error
 }
 
 function formatElapsed(seconds: number): string {
     const m = Math.floor(seconds / 60)
     const s = seconds % 60
     return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+function FabKeyframes(): JSX.Element {
+    return (
+        <style>{`
+            @keyframes wizard-fab-slide-in {
+                from { opacity: 0; transform: translateY(12px); }
+                to   { opacity: 1; transform: translateY(0); }
+            }
+            .wizard-fab-slide-in {
+                animation: wizard-fab-slide-in 320ms ease-out both;
+            }
+            @keyframes wizard-fab-ring-spin {
+                to { transform: rotate(360deg); }
+            }
+            .wizard-fab-ring-spin {
+                animation: wizard-fab-ring-spin 1.2s linear infinite;
+                transform-box: fill-box;
+            }
+            /* Soft wizard-rainbow shimmer on the running progress bar — saturated
+               enough to read as "magical", muted enough not to fight the headline. */
+            @keyframes wizard-fab-shimmer {
+                0%   { background-position: 0% 50%; }
+                100% { background-position: 200% 50%; }
+            }
+            .wizard-fab-shimmer {
+                background-image: linear-gradient(
+                    90deg,
+                    #f54e00 0%,
+                    #ff8a3d 20%,
+                    #ffc83d 40%,
+                    #66d19e 60%,
+                    #5b9dff 80%,
+                    #b285ff 100%
+                );
+                background-size: 200% 100%;
+                animation: wizard-fab-shimmer 5s linear infinite;
+            }
+            @keyframes wizard-fab-sparkle {
+                0%, 60%, 100% { opacity: 1; transform: scale(1) rotate(0deg); }
+                70%           { opacity: 0.4; transform: scale(0.85) rotate(-8deg); }
+                85%           { opacity: 1; transform: scale(1.1) rotate(8deg); }
+            }
+            .wizard-fab-sparkle {
+                color: #b285ff;
+                animation: wizard-fab-sparkle 3.4s ease-in-out infinite;
+                transform-origin: center;
+            }
+        `}</style>
+    )
 }

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressFab.tsx
@@ -1,17 +1,18 @@
 import { useActions, useValues } from 'kea'
 
-import { IconCheck, IconX } from '@posthog/icons'
+import { IconX } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
-import { wizardProgressTrackerLogic } from './wizardProgressTrackerLogic'
+import hogWelder from 'public/hedgehog/hog-welder.png'
+import starHog from 'public/hedgehog/star-hog.png'
+import warningHog from 'public/hedgehog/warning-hog.png'
+
+import { type DisplayState, wizardProgressTrackerLogic } from './wizardProgressTrackerLogic'
 
 /**
- * Onboarding-scoped floating action button. Renders whenever a wizard session
- * has been observed and the user has navigated away from the install step's
- * full panel. Dismissible only after the run reaches a terminal phase.
- *
- * Mounts `wizardProgressTrackerLogic` at the scene root so SSE stays connected
- * across step navigation.
+ * Onboarding-scoped floating widget. Persists across onboarding step navigation
+ * while a wizard session is in flight, with a hog mascot + labelled status so
+ * users understand what they're looking at. Dismissible only after a terminal phase.
  */
 export function WizardProgressFab(): JSX.Element | null {
     const { displayState, latestSession, elapsedSeconds, dismissed, panelMounted } =
@@ -23,43 +24,41 @@ export function WizardProgressFab(): JSX.Element | null {
     }
 
     const isTerminal = displayState === 'completed' || displayState === 'error'
+    const isRunning = !isTerminal
     const skill = latestSession?.skill_id
-
-    const headline =
-        displayState === 'completed'
-            ? "PostHog's wired in"
-            : displayState === 'error'
-              ? 'Wizard ran into trouble'
-              : displayState === 'connecting'
-                ? 'Reconnecting…'
-                : 'Wizard installing PostHog'
-
-    const sub =
-        displayState === 'completed' || displayState === 'error'
-            ? skill
-                ? `${skill}`
-                : null
-            : skill
-              ? `${skill} · ${formatElapsed(elapsedSeconds)}`
-              : formatElapsed(elapsedSeconds)
+    const headline = headlineFor(displayState)
+    const sub = subFor(displayState, skill, elapsedSeconds)
+    const accent = accentColor(displayState)
+    const mascot = mascotFor(displayState)
 
     return (
-        <div className="fixed bottom-4 right-4 z-[60] font-mono">
+        <div className="fixed bottom-5 right-5 z-[60]">
+            <FabKeyframes />
             <div
                 role="status"
                 aria-live="polite"
-                className={`flex items-center gap-3 pl-3 pr-2 py-2 rounded-full shadow-2xl shadow-black/30 border ${
-                    displayState === 'completed'
-                        ? 'bg-success text-white border-success'
-                        : displayState === 'error'
-                          ? 'bg-brand-red text-white border-brand-red'
-                          : 'bg-neutral-950 text-neutral-100 border-neutral-800'
-                }`}
+                className="flex items-center gap-3 pl-2 pr-4 py-2 rounded-full bg-bg-light shadow-2xl shadow-black/20 border border-border min-w-[300px]"
+                style={{ borderColor: accent }}
             >
-                <FabIcon displayState={displayState} />
-                <div className="flex flex-col leading-tight pr-1 min-w-0">
-                    <span className="text-xs uppercase tracking-wider opacity-80">{headline}</span>
-                    {sub ? <span className="text-[11px] tabular-nums truncate max-w-[180px]">{sub}</span> : null}
+                <span
+                    className={`relative flex-shrink-0 w-16 h-16 rounded-full flex items-center justify-center ${
+                        isRunning ? 'wizard-fab-glow' : ''
+                    }`}
+                    style={{ background: `${accent}1a` }}
+                >
+                    <img
+                        src={mascot}
+                        alt=""
+                        draggable={false}
+                        className={`relative w-12 h-12 object-contain ${isRunning ? 'wizard-fab-mascot-bob' : ''}`}
+                    />
+                </span>
+                <div className="flex flex-col leading-tight min-w-0 flex-1">
+                    <span className="text-[11px] font-semibold uppercase tracking-wider text-muted">Setup wizard</span>
+                    <span className="text-sm font-semibold text-default truncate" style={{ color: accent }}>
+                        {headline}
+                    </span>
+                    {sub ? <span className="text-xs text-muted tabular-nums truncate">{sub}</span> : null}
                 </div>
                 {isTerminal && (
                     <LemonButton
@@ -68,41 +67,76 @@ export function WizardProgressFab(): JSX.Element | null {
                         onClick={dismiss}
                         aria-label="Dismiss"
                         tooltip="Dismiss"
-                        className="opacity-80 hover:opacity-100"
                     />
                 )}
             </div>
-            <FabKeyframes />
         </div>
     )
 }
 
-function FabIcon({ displayState }: { displayState: string }): JSX.Element {
-    if (displayState === 'completed') {
-        return (
-            <span aria-hidden className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-white/20">
-                <IconCheck className="text-white" />
-            </span>
-        )
+function headlineFor(state: DisplayState): string {
+    switch (state) {
+        case 'completed':
+            return "PostHog's wired in"
+        case 'error':
+            return 'Hit a snag'
+        case 'connecting':
+            return 'Reconnecting…'
+        default:
+            return 'Installing PostHog'
     }
-    if (displayState === 'error') {
-        return (
-            <span aria-hidden className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-white/20">
-                <IconX className="text-white" />
-            </span>
-        )
+}
+
+function subFor(state: DisplayState, skill: string | undefined, elapsedSeconds: number): string | null {
+    if (state === 'completed') {
+        return skill ? `${skill} · all set` : 'all set'
     }
-    return <span aria-hidden className="inline-block w-3 h-3 rounded-full bg-brand-red wizard-fab-pulse-dot shrink-0" />
+    if (state === 'error') {
+        return skill ? `${skill} · open the panel to retry` : 'open the panel to retry'
+    }
+    const elapsed = formatElapsed(elapsedSeconds)
+    return skill ? `${skill} · ${elapsed}` : elapsed
+}
+
+function mascotFor(state: DisplayState): string {
+    switch (state) {
+        case 'completed':
+            return starHog
+        case 'error':
+            return warningHog
+        default:
+            return hogWelder
+    }
+}
+
+function accentColor(state: DisplayState): string {
+    switch (state) {
+        case 'completed':
+            return 'rgb(16, 185, 129)' // emerald-500
+        case 'error':
+            return 'rgb(245, 78, 0)' // brand-red
+        default:
+            return 'rgb(245, 78, 0)' // brand-red
+    }
 }
 
 function FabKeyframes(): JSX.Element {
     return (
         <style>{`
-            @keyframes wizard-fab-pulse-dot {
-                0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(245, 78, 0, 0.55); }
-                50% { opacity: 0.6; box-shadow: 0 0 0 5px rgba(245, 78, 0, 0); }
+            @keyframes wizard-fab-mascot-bob {
+                0%, 100% { transform: translateY(0) rotate(-2deg); }
+                50%      { transform: translateY(-3px) rotate(2deg); }
             }
-            .wizard-fab-pulse-dot { animation: wizard-fab-pulse-dot 1.6s ease-in-out infinite; }
+            .wizard-fab-mascot-bob {
+                animation: wizard-fab-mascot-bob 1.6s ease-in-out infinite;
+            }
+            @keyframes wizard-fab-glow {
+                0%, 100% { box-shadow: 0 0 0 0 rgba(245, 78, 0, 0.45); }
+                50%      { box-shadow: 0 0 0 8px rgba(245, 78, 0, 0); }
+            }
+            .wizard-fab-glow {
+                animation: wizard-fab-glow 2.2s ease-in-out infinite;
+            }
         `}</style>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressTracker.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardProgressTracker.tsx
@@ -1,4 +1,5 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
 
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner'
@@ -15,6 +16,12 @@ import { type ActivityEntry, type DisplayState, wizardProgressTrackerLogic } fro
  */
 export function WizardProgressTracker({ onManualSetup }: { onManualSetup?: () => void } = {}): JSX.Element | null {
     const { displayState } = useValues(wizardProgressTrackerLogic)
+    const { setPanelMounted } = useActions(wizardProgressTrackerLogic)
+
+    useEffect(() => {
+        setPanelMounted(true)
+        return () => setPanelMounted(false)
+    }, [setPanelMounted])
 
     if (displayState === 'preTakeover') {
         return null

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/wizardProgressTrackerLogic.ts
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/wizardProgressTrackerLogic.ts
@@ -48,6 +48,8 @@ export const wizardProgressTrackerLogic = kea<wizardProgressTrackerLogicType>([
         appendActivity: (text: string) => ({ text, at: Date.now() }),
         tick: (now: number) => ({ now }),
         taskStarted: (taskId: string, at: number) => ({ taskId, at }),
+        dismiss: true,
+        setPanelMounted: (mounted: boolean) => ({ mounted }),
     }),
     reducers({
         activityLog: [
@@ -71,6 +73,18 @@ export const wizardProgressTrackerLogic = kea<wizardProgressTrackerLogicType>([
             {} as Record<string, number>,
             {
                 taskStarted: (state, { taskId, at }) => ({ ...state, [taskId]: at }),
+            },
+        ],
+        dismissed: [
+            false,
+            {
+                dismiss: () => true,
+            },
+        ],
+        panelMounted: [
+            false,
+            {
+                setPanelMounted: (_, { mounted }) => mounted,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

PR #59304 introduces the live wizard takeover panel on the install step, but when the user navigates forward in onboarding (Configure → Verify → …) the wizard's run is invisible. There's no way to know it's still working, how far along it is, or what happened when it finishes — they only find out by going back. That kills the value of the live tracker for anyone who doesn't sit on the install step.

This PR adds a corner widget (`WizardProgressFab`) that persists across the rest of the onboarding flow until the run completes, and lets the user jump back to the full panel at any time.

## Changes

[Screen Recording 2026-05-27 at 18.51.45.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a1e263e2-377c-497e-ad94-f9c0d00f272a.mov" />](https://app.graphite.com/user-attachments/video/a1e263e2-377c-497e-ad94-f9c0d00f272a.mov)



- **`WizardProgressFab.tsx`** — 300×~80px card pinned to the bottom-right, mounted at the `Onboarding` scene level so it survives step navigation.
    - **Left: 44px SVG progress ring** (`strokeDasharray` / `strokeDashoffset`) — fills brand-red as tasks complete with the percentage rendered in the center. Indeterminate spin while connecting or before tasks arrive.
    - **Right stack**: an `IconSparkles` + `SETUP WIZARD` label, a state-specific headline, and a sub-line with the current task name and elapsed time.
    - **Whole card clickable** — dispatches `onboardingLogic.setStepId(OnboardingStepKey.INSTALL)` to return the user to the full tracker.
    - **Dismiss X** appears only on `completed` / `error`. While running there's no way to dismiss — the run stays visible until it ends.
    - **Bottom: 4px progress bar** with a soft wizard-rainbow shimmer (`brand-red → orange → yellow → mint → blue → lilac`, 5s loop) only while running. Terminal states collapse to a solid accent color.
- **`wizardProgressTrackerLogic.ts`** — adds `dismiss` + `setPanelMounted` actions and `dismissed` + `panelMounted` reducers.
    - `panelMounted` is toggled by the `WizardProgressTracker` panel mounting / unmounting, so the FAB and the panel never render at the same time (the panel takes priority).
    - `dismissed` is the user's escape hatch on terminal runs — kept in-memory only, so a refresh restores the FAB if the session is still in scope.
- **`Onboarding.tsx`** — renders `<WizardProgressFab />` next to the flow host.
- **Flag-gating** — the outer `WizardProgressFab` short-circuits unless `useFeatureFlag('ONBOARDING_WIZARD_SYNC', 'test')` is on, so control-arm users don't mount the sync logic (and don't open an SSE connection) at the scene level.
- **Storybook** — `WizardProgressFab.stories.tsx` covers Hidden / Analyzing / RunningEarly / RunningLate / Connecting (live transport-error simulation) / Completed / Errored / SimulatedRun (24s auto-play through every state).

## How did you test this code?

I'm an agent. I did not manually verify this in a running browser — please pull the branch and confirm the visuals in Storybook and on the install step before merging.

Automated checks I ran locally:

- `pnpm exec oxlint src/scenes/onboarding/sdks/OnboardingInstallStep/` — 0 warnings, 0 errors
- `pnpm exec oxfmt --check` on the touched directory — clean
- `pnpm exec tsc --noEmit` — zero errors in the FAB, stories, logic, and `Onboarding.tsx`. Pre-existing unrelated TS2307 errors in `products/customer_analytics`, `products/growth`, `products/replay_vision`, and `experiments` kea-typegen artifacts are not on this branch.
- `kea-typegen write` — `dismiss` / `dismissed` / `setPanelMounted` / `panelMounted` all picked up in the generated logic type file.

Visual review (Storybook) suggested:

- Navigate to `Scenes-Other / Onboarding / Wizard Progress FAB`.
- Walk the static states (Analyzing → RunningEarly → RunningLate → Connecting → Completed → Errored) to see the ring + shimmer + headline transitions.
- Run `SimulatedRun` to watch the 24s timeline from session-open through completion in one go.

## Publish to changelog?

No — this ships behind the `onboarding-wizard-sync` test arm. Will be in the rollout changelog if/when the flag flips to 100%.

## Docs update

No docs change needed.

## 🤖 Agent context

Co-authored with Claude Code (Opus 4.7) in a long-running session. Two design iterations:

1. **First pass (rejected)**: hog-mascot pill — `hog-welder` / `star-hog` / `warning-hog` swapped by state, ~300px pill with bobbing animation and pulsing glow ring. I pushed back on the bob and the rotating halo midway through, and rejected the original mascot-cycling slideshow. The committed-but-rejected design at `b4dee98` is what we replaced.
2. **Second pass (this PR)**: I asked the agent to research Mobbin for corner-anchored long-running-task widgets and pick a direction. It surfaced the WeTransfer "transferring" card (circular % ring + headline + cancel) and the Vercel deployment card as the dominant convention. The current design lifts the ring + headline + sub-line layout from that pattern, swaps the hog/glow for a subtle wizard signature (sparkles icon + rainbow shimmer bar), and makes the whole card clickable to return to the panel.

Other decisions:

- The dismiss is only available on terminal states. Mid-run dismiss would orphan a still-running CLI — the FAB is the only visible signal of it once the user has moved on.
- The flag is checked in an outer wrapper component (`WizardProgressFab` → `WizardProgressFabInner`) so the kea logic and its SSE connection only mount for the test arm. Control-arm users render `null` and pay nothing.
- The rainbow gradient stops at five hues with soft saturations — saturated enough to read as "magical / wizard", muted enough that it doesn't fight the headline at a glance.

References:

- Mobbin pattern matches: [WeTransfer transferring card](https://mobbin.com/screens/4bea6e4a-6a12-46ec-8cb2-469bd2c644f0), [Vercel deployment](https://mobbin.com/screens/bb63ac69-2477-4795-91c3-d0f9fb0bb1e3), [Manus task progress](https://mobbin.com/screens/0ea4aede-c4e6-454a-a3aa-70712b584330).