### PR TITLE
feat(property-vals): add two-stage aggregation to collapse pod amplification

### DIFF
--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -21,22 +21,22 @@ pub struct Config {
     pub consumer: ConsumerConfig,
 
     /// Final destination read by ClickHouse via the kafka_property_values
-    /// table engine. The collapser writes here.
+    /// table engine. The merger writes here.
     #[envconfig(default = "clickhouse_property_values")]
     pub output_topic: String,
 
     /// Intermediate topic for the two-stage aggregation shuffle. The
     /// events/groups workers produce here (keyed by full tuple); the
-    /// collapser consumes here and re-aggregates to merge cross-pod
+    /// merger consumes here and re-aggregates to merge cross-pod
     /// duplicates before forwarding to `output_topic`.
     #[envconfig(default = "property_vals_intermediate")]
     pub intermediate_topic: String,
 
-    /// Consumer group for the collapser (intermediate -> output). Distinct
+    /// Consumer group for the merger (intermediate -> output). Distinct
     /// from the events/groups consumer groups so partition assignment is
     /// independent.
-    #[envconfig(default = "clickhouse-property-vals-rs-collapser")]
-    pub collapser_consumer_group: String,
+    #[envconfig(default = "clickhouse-property-vals-rs-merger")]
+    pub merger_consumer_group: String,
 
     #[envconfig(default = "30")]
     pub flush_interval_secs: u64,

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -21,22 +21,22 @@ pub struct Config {
     pub consumer: ConsumerConfig,
 
     /// Final destination read by ClickHouse via the kafka_property_values
-    /// table engine. Stage 2's producer writes here.
+    /// table engine. The collapser writes here.
     #[envconfig(default = "clickhouse_property_values")]
     pub output_topic: String,
 
-    /// Intermediate topic for the two-stage aggregation shuffle. Stage 1's
-    /// producer writes here (keyed by full tuple); stage 2's consumer reads
-    /// here and re-aggregates to collapse cross-pod duplicates before
-    /// forwarding to `output_topic`.
+    /// Intermediate topic for the two-stage aggregation shuffle. The
+    /// events/groups workers produce here (keyed by full tuple); the
+    /// collapser consumes here and re-aggregates to merge cross-pod
+    /// duplicates before forwarding to `output_topic`.
     #[envconfig(default = "property_vals_intermediate")]
     pub intermediate_topic: String,
 
-    /// Consumer group for stage 2 (intermediate -> output). Distinct from
-    /// the stage-1 consumer groups (events/groups) so partition assignment
-    /// is independent.
-    #[envconfig(default = "clickhouse-property-vals-rs-stage2")]
-    pub stage2_consumer_group: String,
+    /// Consumer group for the collapser (intermediate -> output). Distinct
+    /// from the events/groups consumer groups so partition assignment is
+    /// independent.
+    #[envconfig(default = "clickhouse-property-vals-rs-collapser")]
+    pub collapser_consumer_group: String,
 
     #[envconfig(default = "30")]
     pub flush_interval_secs: u64,

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -20,8 +20,23 @@ pub struct Config {
     #[envconfig(nested = true)]
     pub consumer: ConsumerConfig,
 
+    /// Final destination read by ClickHouse via the kafka_property_values
+    /// table engine. Stage 2's producer writes here.
     #[envconfig(default = "clickhouse_property_values")]
     pub output_topic: String,
+
+    /// Intermediate topic for the two-stage aggregation shuffle. Stage 1's
+    /// producer writes here (keyed by full tuple); stage 2's consumer reads
+    /// here and re-aggregates to collapse cross-pod duplicates before
+    /// forwarding to `output_topic`.
+    #[envconfig(default = "property_vals_intermediate")]
+    pub intermediate_topic: String,
+
+    /// Consumer group for stage 2 (intermediate -> output). Distinct from
+    /// the stage-1 consumer groups (events/groups) so partition assignment
+    /// is independent.
+    #[envconfig(default = "clickhouse-property-vals-rs-stage2")]
+    pub stage2_consumer_group: String,
 
     #[envconfig(default = "30")]
     pub flush_interval_secs: u64,

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -20,21 +20,12 @@ pub struct Config {
     #[envconfig(nested = true)]
     pub consumer: ConsumerConfig,
 
-    /// Final destination read by ClickHouse via the kafka_property_values
-    /// table engine. The merger writes here.
     #[envconfig(default = "clickhouse_property_values")]
     pub output_topic: String,
 
-    /// Intermediate topic for the two-stage aggregation shuffle. The
-    /// events/groups workers produce here (keyed by full tuple); the
-    /// merger consumes here and re-aggregates to merge cross-pod
-    /// duplicates before forwarding to `output_topic`.
     #[envconfig(default = "property_vals_intermediate")]
     pub intermediate_topic: String,
 
-    /// Consumer group for the merger (intermediate -> output). Distinct
-    /// from the events/groups consumer groups so partition assignment is
-    /// independent.
     #[envconfig(default = "clickhouse-property-vals-rs-merger")]
     pub merger_consumer_group: String,
 

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -414,18 +414,9 @@ mod tests {
         assert!(extract_tuple(&empty_value).is_empty());
     }
 
-    /// Stage-1's wire format (producer.rs::Outgoing) must round-trip into
-    /// `PropertyValueMessage` so stage 2 can deserialize what stage 1 produced.
     #[test]
     fn property_value_message_round_trips_producer_wire_format() {
-        #[derive(serde::Serialize)]
-        struct Outgoing<'a> {
-            team_id: i64,
-            property_type: PropertyType,
-            property_key: &'a str,
-            property_value: &'a str,
-            property_count: u64,
-        }
+        use crate::producer::Outgoing;
         for (pt, expected) in [
             (PropertyType::Event, "event"),
             (PropertyType::Person, "person"),

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -7,33 +7,31 @@ pub const MAX_PROPERTY_KEY_LEN: usize = 400;
 pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
 
 pub fn fan_out(event: &Event, excluded: &ExcludedPropertyKeys) -> Vec<(TupleKey, u64)> {
-    let mut out = Vec::new();
-
+    let mut tuples = Vec::new();
     if let Some(raw) = &event.properties {
-        emit_from_blob(event.team_id, PropertyType::Event, raw, excluded, &mut out);
+        emit_from_blob(event.team_id, PropertyType::Event, raw, excluded, &mut tuples);
     }
     if let Some(raw) = &event.person_properties {
-        emit_from_blob(event.team_id, PropertyType::Person, raw, excluded, &mut out);
+        emit_from_blob(event.team_id, PropertyType::Person, raw, excluded, &mut tuples);
     }
-
-    out
+    tuples.into_iter().map(|t| (t, 1)).collect()
 }
 
 pub fn fan_out_group(
     event: &GroupIdentify,
     excluded: &ExcludedPropertyKeys,
 ) -> Vec<(TupleKey, u64)> {
-    let mut out = Vec::new();
+    let mut tuples = Vec::new();
     if let Some(raw) = &event.group_properties {
         emit_from_blob(
             event.team_id,
             PropertyType::Group(event.group_type_index),
             raw,
             excluded,
-            &mut out,
+            &mut tuples,
         );
     }
-    out
+    tuples.into_iter().map(|t| (t, 1)).collect()
 }
 
 pub fn extract_tuple(msg: &PropertyValueMessage) -> Vec<(TupleKey, u64)> {
@@ -56,7 +54,7 @@ fn emit_from_blob(
     property_type: PropertyType,
     raw: &str,
     excluded: &ExcludedPropertyKeys,
-    out: &mut Vec<(TupleKey, u64)>,
+    out: &mut Vec<TupleKey>,
 ) {
     let parsed: Value = match serde_json::from_str(raw) {
         Ok(v) => v,
@@ -86,15 +84,12 @@ fn emit_from_blob(
             continue;
         }
 
-        out.push((
-            TupleKey {
-                team_id,
-                property_type,
-                property_key: key.clone(),
-                property_value,
-            },
-            1,
-        ));
+        out.push(TupleKey {
+            team_id,
+            property_type,
+            property_key: key.clone(),
+            property_value,
+        });
     }
 }
 

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -36,11 +36,7 @@ pub fn fan_out_group(
     out
 }
 
-/// Stage-2 input adapter. Each intermediate-topic message represents one
-/// already-aggregated `(team, type, key, value)` tuple with its per-pod count;
-/// emit it 1:1 into the stage-2 aggregator so it can be summed with sibling
-/// emissions of the same tuple from other stage-1 pods.
-pub fn fan_in(msg: &PropertyValueMessage) -> Vec<(TupleKey, u64)> {
+pub fn extract_tuple(msg: &PropertyValueMessage) -> Vec<(TupleKey, u64)> {
     if msg.property_key.is_empty() || msg.property_value.is_empty() {
         return Vec::new();
     }
@@ -383,9 +379,9 @@ mod tests {
     }
 
     #[test]
-    fn fan_in_emits_single_tuple_with_message_count() {
+    fn extract_tuple_emits_single_tuple_with_message_count() {
         let msg = pv_message(2, PropertyType::Event, "$browser", "Chrome", 42);
-        let out = fan_in(&msg);
+        let out = extract_tuple(&msg);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].0.team_id, 2);
         assert_eq!(out[0].0.property_type, PropertyType::Event);
@@ -395,27 +391,27 @@ mod tests {
     }
 
     #[test]
-    fn fan_in_carries_property_count_for_person_type() {
+    fn extract_tuple_carries_property_count_for_person_type() {
         let msg = pv_message(7, PropertyType::Person, "email", "a@b.com", 5);
-        let out = fan_in(&msg);
+        let out = extract_tuple(&msg);
         assert_eq!(out[0].0.property_type, PropertyType::Person);
         assert_eq!(out[0].1, 5);
     }
 
     #[test]
-    fn fan_in_carries_property_count_for_group_type() {
+    fn extract_tuple_carries_property_count_for_group_type() {
         let msg = pv_message(7, PropertyType::Group(3), "plan", "enterprise", 11);
-        let out = fan_in(&msg);
+        let out = extract_tuple(&msg);
         assert_eq!(out[0].0.property_type, PropertyType::Group(3));
         assert_eq!(out[0].1, 11);
     }
 
     #[test]
-    fn fan_in_drops_empty_key_or_value() {
+    fn extract_tuple_drops_empty_key_or_value() {
         let empty_key = pv_message(2, PropertyType::Event, "", "Chrome", 1);
-        assert!(fan_in(&empty_key).is_empty());
+        assert!(extract_tuple(&empty_key).is_empty());
         let empty_value = pv_message(2, PropertyType::Event, "$browser", "", 1);
-        assert!(fan_in(&empty_value).is_empty());
+        assert!(extract_tuple(&empty_value).is_empty());
     }
 
     /// Stage-1's wire format (producer.rs::Outgoing) must round-trip into

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
 use crate::config::ExcludedPropertyKeys;
-use crate::types::{Event, GroupIdentify, PropertyType, TupleKey};
+use crate::types::{Event, GroupIdentify, PropertyType, PropertyValueMessage, TupleKey};
 
 pub const MAX_PROPERTY_KEY_LEN: usize = 400;
 pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
 
-pub fn fan_out(event: &Event, excluded: &ExcludedPropertyKeys) -> Vec<TupleKey> {
+pub fn fan_out(event: &Event, excluded: &ExcludedPropertyKeys) -> Vec<(TupleKey, u64)> {
     let mut out = Vec::new();
 
     if let Some(raw) = &event.properties {
@@ -19,7 +19,10 @@ pub fn fan_out(event: &Event, excluded: &ExcludedPropertyKeys) -> Vec<TupleKey> 
     out
 }
 
-pub fn fan_out_group(event: &GroupIdentify, excluded: &ExcludedPropertyKeys) -> Vec<TupleKey> {
+pub fn fan_out_group(
+    event: &GroupIdentify,
+    excluded: &ExcludedPropertyKeys,
+) -> Vec<(TupleKey, u64)> {
     let mut out = Vec::new();
     if let Some(raw) = &event.group_properties {
         emit_from_blob(
@@ -33,12 +36,31 @@ pub fn fan_out_group(event: &GroupIdentify, excluded: &ExcludedPropertyKeys) -> 
     out
 }
 
+/// Stage-2 input adapter. Each intermediate-topic message represents one
+/// already-aggregated `(team, type, key, value)` tuple with its per-pod count;
+/// emit it 1:1 into the stage-2 aggregator so it can be summed with sibling
+/// emissions of the same tuple from other stage-1 pods.
+pub fn fan_in(msg: &PropertyValueMessage) -> Vec<(TupleKey, u64)> {
+    if msg.property_key.is_empty() || msg.property_value.is_empty() {
+        return Vec::new();
+    }
+    vec![(
+        TupleKey {
+            team_id: msg.team_id,
+            property_type: msg.property_type,
+            property_key: msg.property_key.clone(),
+            property_value: msg.property_value.clone(),
+        },
+        msg.property_count,
+    )]
+}
+
 fn emit_from_blob(
     team_id: i64,
     property_type: PropertyType,
     raw: &str,
     excluded: &ExcludedPropertyKeys,
-    out: &mut Vec<TupleKey>,
+    out: &mut Vec<(TupleKey, u64)>,
 ) {
     let parsed: Value = match serde_json::from_str(raw) {
         Ok(v) => v,
@@ -68,12 +90,15 @@ fn emit_from_blob(
             continue;
         }
 
-        out.push(TupleKey {
-            team_id,
-            property_type,
-            property_key: key.clone(),
-            property_value,
-        });
+        out.push((
+            TupleKey {
+                team_id,
+                property_type,
+                property_key: key.clone(),
+                property_value,
+            },
+            1,
+        ));
     }
 }
 
@@ -156,26 +181,27 @@ mod tests {
         keys.join(",").parse().unwrap()
     }
 
-    fn check_tuple_invariants(t: &TupleKey, expected_team: i64) {
+    fn check_tuple_invariants(t: &TupleKey, count: u64, expected_team: i64) {
         assert_eq!(t.team_id, expected_team);
         assert!(!t.property_key.is_empty());
         assert!(!t.property_value.is_empty());
         assert!(t.property_key.chars().count() <= MAX_PROPERTY_KEY_LEN);
         assert!(t.property_value.chars().count() <= MAX_PROPERTY_VALUE_LEN);
+        assert_eq!(count, 1, "stage-1 fan-out always emits count=1");
     }
 
     proptest! {
         #[test]
         fn fan_out_outputs_obey_caps_and_team(e in arb_event()) {
-            for t in fan_out(&e, &none()) {
-                check_tuple_invariants(&t, e.team_id);
+            for (t, n) in fan_out(&e, &none()) {
+                check_tuple_invariants(&t, n, e.team_id);
             }
         }
 
         #[test]
         fn fan_out_group_outputs_obey_caps_and_team(g in arb_group_identify()) {
-            for t in fan_out_group(&g, &none()) {
-                check_tuple_invariants(&t, g.team_id);
+            for (t, n) in fan_out_group(&g, &none()) {
+                check_tuple_invariants(&t, n, g.team_id);
             }
         }
 
@@ -191,7 +217,7 @@ mod tests {
 
         #[test]
         fn fan_out_group_property_type_matches_index(g in arb_group_identify()) {
-            for t in fan_out_group(&g, &none()) {
+            for (t, _) in fan_out_group(&g, &none()) {
                 prop_assert_eq!(t.property_type, PropertyType::Group(g.group_type_index));
             }
         }
@@ -201,9 +227,10 @@ mod tests {
     fn event_property_produces_event_type_tuple() {
         let tuples = fan_out(&event(r#"{"$browser":"Chrome"}"#), &none());
         assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].property_type, PropertyType::Event);
-        assert_eq!(tuples[0].property_key, "$browser");
-        assert_eq!(tuples[0].property_value, "Chrome");
+        assert_eq!(tuples[0].0.property_type, PropertyType::Event);
+        assert_eq!(tuples[0].0.property_key, "$browser");
+        assert_eq!(tuples[0].0.property_value, "Chrome");
+        assert_eq!(tuples[0].1, 1);
     }
 
     #[test]
@@ -227,23 +254,23 @@ mod tests {
         };
         let tuples = fan_out(&ev, &none());
         assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].property_type, PropertyType::Person);
-        assert_eq!(tuples[0].property_key, "email");
-        assert_eq!(tuples[0].property_value, "foo@bar.com");
+        assert_eq!(tuples[0].0.property_type, PropertyType::Person);
+        assert_eq!(tuples[0].0.property_key, "email");
+        assert_eq!(tuples[0].0.property_value, "foo@bar.com");
     }
 
     #[test]
     fn bool_value_coerces_to_string() {
         let tuples = fan_out(&event(r#"{"a_bool":true}"#), &none());
         assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].property_value, "true");
+        assert_eq!(tuples[0].0.property_value, "true");
     }
 
     #[test]
     fn number_value_coerces_to_string() {
         let tuples = fan_out(&event(r#"{"a_number":42}"#), &none());
         assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].property_value, "42");
+        assert_eq!(tuples[0].0.property_value, "42");
     }
 
     #[test]
@@ -262,16 +289,16 @@ mod tests {
     fn group_identify_index_0_emits_group_type() {
         let tuples = fan_out_group(&group_identify(0, r#"{"plan":"enterprise"}"#), &none());
         assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].property_type, PropertyType::Group(0));
-        assert_eq!(tuples[0].property_key, "plan");
-        assert_eq!(tuples[0].property_value, "enterprise");
+        assert_eq!(tuples[0].0.property_type, PropertyType::Group(0));
+        assert_eq!(tuples[0].0.property_key, "plan");
+        assert_eq!(tuples[0].0.property_value, "enterprise");
     }
 
     #[test]
     fn group_identify_emits_group_type_matching_index() {
         let tuples = fan_out_group(&group_identify(4, r#"{"region":"us-east"}"#), &none());
         assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].property_type, PropertyType::Group(4));
+        assert_eq!(tuples[0].0.property_type, PropertyType::Group(4));
     }
 
     #[test]
@@ -297,8 +324,8 @@ mod tests {
         let exclusions = excluded(&["$insert_id", "distinct_id", "$session_id"]);
         let tuples = fan_out(&event(blob), &exclusions);
         assert_eq!(tuples.len(), 1, "only $browser should survive exclusion");
-        assert_eq!(tuples[0].property_key, "$browser");
-        assert_eq!(tuples[0].property_value, "Chrome");
+        assert_eq!(tuples[0].0.property_key, "$browser");
+        assert_eq!(tuples[0].0.property_value, "Chrome");
     }
 
     #[test]
@@ -312,7 +339,10 @@ mod tests {
         };
         let tuples = fan_out(&ev, &excluded(&["$session_id"]));
         assert_eq!(tuples.len(), 2);
-        let keys: Vec<&str> = tuples.iter().map(|t| t.property_key.as_str()).collect();
+        let keys: Vec<&str> = tuples
+            .iter()
+            .map(|(t, _)| t.property_key.as_str())
+            .collect();
         assert!(keys.contains(&"email"));
         assert!(keys.contains(&"plan"));
         assert!(!keys.contains(&"$session_id"));
@@ -323,7 +353,7 @@ mod tests {
         let g = group_identify(0, r#"{"plan":"enterprise","internal_id":"g-42"}"#);
         let tuples = fan_out_group(&g, &excluded(&["internal_id"]));
         assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].property_key, "plan");
+        assert_eq!(tuples[0].0.property_key, "plan");
     }
 
     #[test]
@@ -334,5 +364,96 @@ mod tests {
         let with_parsed_empty = fan_out(&event(blob), &parsed_empty);
         assert_eq!(with_default.len(), 2);
         assert_eq!(with_default, with_parsed_empty);
+    }
+
+    fn pv_message(
+        team_id: i64,
+        property_type: PropertyType,
+        key: &str,
+        value: &str,
+        count: u64,
+    ) -> PropertyValueMessage {
+        PropertyValueMessage {
+            team_id,
+            property_type,
+            property_key: key.to_string(),
+            property_value: value.to_string(),
+            property_count: count,
+        }
+    }
+
+    #[test]
+    fn fan_in_emits_single_tuple_with_message_count() {
+        let msg = pv_message(2, PropertyType::Event, "$browser", "Chrome", 42);
+        let out = fan_in(&msg);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0.team_id, 2);
+        assert_eq!(out[0].0.property_type, PropertyType::Event);
+        assert_eq!(out[0].0.property_key, "$browser");
+        assert_eq!(out[0].0.property_value, "Chrome");
+        assert_eq!(out[0].1, 42, "count must round-trip from the message");
+    }
+
+    #[test]
+    fn fan_in_carries_property_count_for_person_type() {
+        let msg = pv_message(7, PropertyType::Person, "email", "a@b.com", 5);
+        let out = fan_in(&msg);
+        assert_eq!(out[0].0.property_type, PropertyType::Person);
+        assert_eq!(out[0].1, 5);
+    }
+
+    #[test]
+    fn fan_in_carries_property_count_for_group_type() {
+        let msg = pv_message(7, PropertyType::Group(3), "plan", "enterprise", 11);
+        let out = fan_in(&msg);
+        assert_eq!(out[0].0.property_type, PropertyType::Group(3));
+        assert_eq!(out[0].1, 11);
+    }
+
+    #[test]
+    fn fan_in_drops_empty_key_or_value() {
+        let empty_key = pv_message(2, PropertyType::Event, "", "Chrome", 1);
+        assert!(fan_in(&empty_key).is_empty());
+        let empty_value = pv_message(2, PropertyType::Event, "$browser", "", 1);
+        assert!(fan_in(&empty_value).is_empty());
+    }
+
+    /// Stage-1's wire format (producer.rs::Outgoing) must round-trip into
+    /// `PropertyValueMessage` so stage 2 can deserialize what stage 1 produced.
+    #[test]
+    fn property_value_message_round_trips_producer_wire_format() {
+        #[derive(serde::Serialize)]
+        struct Outgoing<'a> {
+            team_id: i64,
+            property_type: PropertyType,
+            property_key: &'a str,
+            property_value: &'a str,
+            property_count: u64,
+        }
+        for (pt, expected) in [
+            (PropertyType::Event, "event"),
+            (PropertyType::Person, "person"),
+            (PropertyType::Group(0), "group_0"),
+            (PropertyType::Group(7), "group_7"),
+        ] {
+            let outgoing = Outgoing {
+                team_id: 2,
+                property_type: pt,
+                property_key: "$browser",
+                property_value: "Chrome",
+                property_count: 99,
+            };
+            let serialized = serde_json::to_string(&outgoing).unwrap();
+            assert!(
+                serialized.contains(&format!(r#""property_type":"{expected}""#)),
+                "expected {expected} in {serialized}"
+            );
+            let parsed: PropertyValueMessage = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(parsed.team_id, 2);
+            assert_eq!(parsed.property_type, pt);
+            assert_eq!(parsed.property_key, "$browser");
+            assert_eq!(parsed.property_value, "Chrome");
+            assert_eq!(parsed.property_count, 99);
+        }
     }
 }

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -7,31 +7,33 @@ pub const MAX_PROPERTY_KEY_LEN: usize = 400;
 pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
 
 pub fn fan_out(event: &Event, excluded: &ExcludedPropertyKeys) -> Vec<(TupleKey, u64)> {
-    let mut tuples = Vec::new();
+    let mut out = Vec::new();
+
     if let Some(raw) = &event.properties {
-        emit_from_blob(event.team_id, PropertyType::Event, raw, excluded, &mut tuples);
+        emit_from_blob(event.team_id, PropertyType::Event, raw, excluded, &mut out);
     }
     if let Some(raw) = &event.person_properties {
-        emit_from_blob(event.team_id, PropertyType::Person, raw, excluded, &mut tuples);
+        emit_from_blob(event.team_id, PropertyType::Person, raw, excluded, &mut out);
     }
-    tuples.into_iter().map(|t| (t, 1)).collect()
+
+    out
 }
 
 pub fn fan_out_group(
     event: &GroupIdentify,
     excluded: &ExcludedPropertyKeys,
 ) -> Vec<(TupleKey, u64)> {
-    let mut tuples = Vec::new();
+    let mut out = Vec::new();
     if let Some(raw) = &event.group_properties {
         emit_from_blob(
             event.team_id,
             PropertyType::Group(event.group_type_index),
             raw,
             excluded,
-            &mut tuples,
+            &mut out,
         );
     }
-    tuples.into_iter().map(|t| (t, 1)).collect()
+    out
 }
 
 pub fn extract_tuple(msg: &PropertyValueMessage) -> Vec<(TupleKey, u64)> {
@@ -54,7 +56,7 @@ fn emit_from_blob(
     property_type: PropertyType,
     raw: &str,
     excluded: &ExcludedPropertyKeys,
-    out: &mut Vec<TupleKey>,
+    out: &mut Vec<(TupleKey, u64)>,
 ) {
     let parsed: Value = match serde_json::from_str(raw) {
         Ok(v) => v,
@@ -84,12 +86,15 @@ fn emit_from_blob(
             continue;
         }
 
-        out.push(TupleKey {
-            team_id,
-            property_type,
-            property_key: key.clone(),
-            property_value,
-        });
+        out.push((
+            TupleKey {
+                team_id,
+                property_type,
+                property_key: key.clone(),
+                property_value,
+            },
+            1,
+        ));
     }
 }
 

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -118,8 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut merger_consumer_config = config.consumer.clone();
     merger_consumer_config.kafka_consumer_topic = config.intermediate_topic.clone();
     merger_consumer_config.kafka_consumer_group = config.merger_consumer_group.clone();
-    let merger_consumer =
-        SingleTopicConsumer::new(config.kafka.clone(), merger_consumer_config)?;
+    let merger_consumer = SingleTopicConsumer::new(config.kafka.clone(), merger_consumer_config)?;
     let merger_producer = AggregatedProducer::new(
         &config.kafka,
         merger_handle.clone(),

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -94,8 +94,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let produce_timeout = Duration::from_secs(config.kafka_produce_timeout_secs);
 
-    // Events worker — consumes raw events, fans out to per-pod aggregates,
-    // produces to the intermediate topic.
     let events_consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone())?;
     let events_producer = AggregatedProducer::new(
         &config.kafka,
@@ -105,8 +103,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    // Groups worker — consumes group-identify events, fans out, produces
-    // to the intermediate topic (same destination as the events worker).
     let mut groups_consumer_config = config.consumer.clone();
     groups_consumer_config.kafka_consumer_topic = config.groups_kafka_consumer_topic.clone();
     groups_consumer_config.kafka_consumer_group = config.groups_kafka_consumer_group.clone();
@@ -119,9 +115,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    // Merger — consumes the intermediate topic and merges the per-pod
-    // emissions the events/groups workers produced for the same tuple, then
-    // forwards to the final output topic that ClickHouse reads.
     let mut merger_consumer_config = config.consumer.clone();
     merger_consumer_config.kafka_consumer_topic = config.intermediate_topic.clone();
     merger_consumer_config.kafka_consumer_group = config.merger_consumer_group.clone();

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -151,7 +151,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         events_producer,
         events_handle.clone(),
         move |e: &Event| fan_out(e, &excluded_events),
-        false,
     ));
     tokio::spawn(worker_loop::<GroupIdentify, _, _>(
         shared_config.clone(),
@@ -159,19 +158,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         groups_producer,
         groups_handle.clone(),
         move |g: &GroupIdentify| fan_out_group(g, &excluded_groups),
-        false,
     ));
-    // Merger bypasses the team filter: every record on the intermediate
-    // topic already passed the events/groups workers' filter, and re-applying
-    // would silently drop partial aggregates if rollout_percentage shrinks
-    // between deploys, breaking sum-conservation.
     tokio::spawn(worker_loop::<PropertyValueMessage, _, _>(
         shared_config.clone(),
         merger_consumer,
         merger_producer,
         merger_handle.clone(),
         |m: &PropertyValueMessage| extract_tuple(m),
-        true,
     ));
     drop(events_handle);
     drop(groups_handle);

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -66,8 +66,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_liveness_deadline(Duration::from_secs(60))
             .with_stall_threshold(3),
     );
-    let stage2_handle = manager.register(
-        "stage2-worker",
+    let collapser_handle = manager.register(
+        "collapser-worker",
         ComponentOptions::new()
             .with_graceful_shutdown(Duration::from_secs(30))
             .with_liveness_deadline(Duration::from_secs(60))
@@ -86,7 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         groups_topic = %config.groups_kafka_consumer_topic,
         groups_consumer_group = %config.groups_kafka_consumer_group,
         intermediate_topic = %config.intermediate_topic,
-        stage2_consumer_group = %config.stage2_consumer_group,
+        collapser_consumer_group = %config.collapser_consumer_group,
         output_topic = %config.output_topic,
         flush_interval_secs = config.flush_interval_secs,
         "config loaded"
@@ -94,7 +94,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let produce_timeout = Duration::from_secs(config.kafka_produce_timeout_secs);
 
-    // Stage 1 (events) — consumes raw events, fans out to per-pod aggregates,
+    // Events worker — consumes raw events, fans out to per-pod aggregates,
     // produces to the intermediate topic.
     let events_consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone())?;
     let events_producer = AggregatedProducer::new(
@@ -105,8 +105,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    // Stage 1 (groups) — consumes group-identify events, fans out, produces
-    // to the intermediate topic (same destination as the events stage).
+    // Groups worker — consumes group-identify events, fans out, produces
+    // to the intermediate topic (same destination as the events worker).
     let mut groups_consumer_config = config.consumer.clone();
     groups_consumer_config.kafka_consumer_topic = config.groups_kafka_consumer_topic.clone();
     groups_consumer_config.kafka_consumer_group = config.groups_kafka_consumer_group.clone();
@@ -119,16 +119,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    // Stage 2 — consumes the intermediate topic and collapses the per-pod
-    // emissions stage 1 produced for the same tuple, then forwards to the
-    // final output topic that ClickHouse reads.
-    let mut stage2_consumer_config = config.consumer.clone();
-    stage2_consumer_config.kafka_consumer_topic = config.intermediate_topic.clone();
-    stage2_consumer_config.kafka_consumer_group = config.stage2_consumer_group.clone();
-    let stage2_consumer = SingleTopicConsumer::new(config.kafka.clone(), stage2_consumer_config)?;
-    let stage2_producer = AggregatedProducer::new(
+    // Collapser — consumes the intermediate topic and merges the per-pod
+    // emissions the events/groups workers produced for the same tuple, then
+    // forwards to the final output topic that ClickHouse reads.
+    let mut collapser_consumer_config = config.consumer.clone();
+    collapser_consumer_config.kafka_consumer_topic = config.intermediate_topic.clone();
+    collapser_consumer_config.kafka_consumer_group = config.collapser_consumer_group.clone();
+    let collapser_consumer =
+        SingleTopicConsumer::new(config.kafka.clone(), collapser_consumer_config)?;
+    let collapser_producer = AggregatedProducer::new(
         &config.kafka,
-        stage2_handle.clone(),
+        collapser_handle.clone(),
         config.output_topic.clone(),
         produce_timeout,
     )
@@ -167,21 +168,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         move |g: &GroupIdentify| fan_out_group(g, &excluded_groups),
         false,
     ));
-    // Stage 2 bypasses the team filter: every record on the intermediate topic
-    // already passed the stage-1 filter, and re-applying would silently drop
-    // partial aggregates if rollout_percentage shrinks between deploys, breaking
-    // sum-conservation.
+    // Collapser bypasses the team filter: every record on the intermediate
+    // topic already passed the events/groups workers' filter, and re-applying
+    // would silently drop partial aggregates if rollout_percentage shrinks
+    // between deploys, breaking sum-conservation.
     tokio::spawn(worker_loop::<PropertyValueMessage, _, _>(
         shared_config.clone(),
-        stage2_consumer,
-        stage2_producer,
-        stage2_handle.clone(),
+        collapser_consumer,
+        collapser_producer,
+        collapser_handle.clone(),
         |m: &PropertyValueMessage| extract_tuple(m),
         true,
     ));
     drop(events_handle);
     drop(groups_handle);
-    drop(stage2_handle);
+    drop(collapser_handle);
 
     let app = Router::new()
         .route("/", get(index))

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -66,8 +66,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_liveness_deadline(Duration::from_secs(60))
             .with_stall_threshold(3),
     );
-    let collapser_handle = manager.register(
-        "collapser-worker",
+    let merger_handle = manager.register(
+        "merger-worker",
         ComponentOptions::new()
             .with_graceful_shutdown(Duration::from_secs(30))
             .with_liveness_deadline(Duration::from_secs(60))
@@ -86,7 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         groups_topic = %config.groups_kafka_consumer_topic,
         groups_consumer_group = %config.groups_kafka_consumer_group,
         intermediate_topic = %config.intermediate_topic,
-        collapser_consumer_group = %config.collapser_consumer_group,
+        merger_consumer_group = %config.merger_consumer_group,
         output_topic = %config.output_topic,
         flush_interval_secs = config.flush_interval_secs,
         "config loaded"
@@ -119,17 +119,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    // Collapser — consumes the intermediate topic and merges the per-pod
+    // Merger — consumes the intermediate topic and merges the per-pod
     // emissions the events/groups workers produced for the same tuple, then
     // forwards to the final output topic that ClickHouse reads.
-    let mut collapser_consumer_config = config.consumer.clone();
-    collapser_consumer_config.kafka_consumer_topic = config.intermediate_topic.clone();
-    collapser_consumer_config.kafka_consumer_group = config.collapser_consumer_group.clone();
-    let collapser_consumer =
-        SingleTopicConsumer::new(config.kafka.clone(), collapser_consumer_config)?;
-    let collapser_producer = AggregatedProducer::new(
+    let mut merger_consumer_config = config.consumer.clone();
+    merger_consumer_config.kafka_consumer_topic = config.intermediate_topic.clone();
+    merger_consumer_config.kafka_consumer_group = config.merger_consumer_group.clone();
+    let merger_consumer =
+        SingleTopicConsumer::new(config.kafka.clone(), merger_consumer_config)?;
+    let merger_producer = AggregatedProducer::new(
         &config.kafka,
-        collapser_handle.clone(),
+        merger_handle.clone(),
         config.output_topic.clone(),
         produce_timeout,
     )
@@ -168,21 +168,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         move |g: &GroupIdentify| fan_out_group(g, &excluded_groups),
         false,
     ));
-    // Collapser bypasses the team filter: every record on the intermediate
+    // Merger bypasses the team filter: every record on the intermediate
     // topic already passed the events/groups workers' filter, and re-applying
     // would silently drop partial aggregates if rollout_percentage shrinks
     // between deploys, breaking sum-conservation.
     tokio::spawn(worker_loop::<PropertyValueMessage, _, _>(
         shared_config.clone(),
-        collapser_consumer,
-        collapser_producer,
-        collapser_handle.clone(),
+        merger_consumer,
+        merger_producer,
+        merger_handle.clone(),
         |m: &PropertyValueMessage| extract_tuple(m),
         true,
     ));
     drop(events_handle);
     drop(groups_handle);
-    drop(collapser_handle);
+    drop(merger_handle);
 
     let app = Router::new()
         .route("/", get(index))

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -6,9 +6,9 @@ use common_kafka::kafka_consumer::SingleTopicConsumer;
 use lifecycle::{ComponentOptions, Manager};
 use property_vals_rs::{
     config::Config,
-    fan_out::{fan_out, fan_out_group},
+    fan_out::{fan_in, fan_out, fan_out_group},
     producer::AggregatedProducer,
-    types::{Event, GroupIdentify},
+    types::{Event, GroupIdentify, PropertyValueMessage},
     worker::worker_loop,
 };
 use serve_metrics::setup_metrics_routes;
@@ -66,6 +66,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_liveness_deadline(Duration::from_secs(60))
             .with_stall_threshold(3),
     );
+    let stage2_handle = manager.register(
+        "stage2-worker",
+        ComponentOptions::new()
+            .with_graceful_shutdown(Duration::from_secs(30))
+            .with_liveness_deadline(Duration::from_secs(60))
+            .with_stall_threshold(3),
+    );
 
     let metrics_handle =
         manager.register("metrics", ComponentOptions::new().is_observability(true));
@@ -78,6 +85,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         events_consumer_group = %config.consumer.kafka_consumer_group,
         groups_topic = %config.groups_kafka_consumer_topic,
         groups_consumer_group = %config.groups_kafka_consumer_group,
+        intermediate_topic = %config.intermediate_topic,
+        stage2_consumer_group = %config.stage2_consumer_group,
         output_topic = %config.output_topic,
         flush_interval_secs = config.flush_interval_secs,
         "config loaded"
@@ -85,15 +94,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let produce_timeout = Duration::from_secs(config.kafka_produce_timeout_secs);
 
+    // Stage 1 (events) — consumes raw events, fans out to per-pod aggregates,
+    // produces to the intermediate topic.
     let events_consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone())?;
     let events_producer = AggregatedProducer::new(
         &config.kafka,
         events_handle.clone(),
-        config.output_topic.clone(),
+        config.intermediate_topic.clone(),
         produce_timeout,
     )
     .await?;
 
+    // Stage 1 (groups) — consumes group-identify events, fans out, produces
+    // to the intermediate topic (same destination as the events stage).
     let mut groups_consumer_config = config.consumer.clone();
     groups_consumer_config.kafka_consumer_topic = config.groups_kafka_consumer_topic.clone();
     groups_consumer_config.kafka_consumer_group = config.groups_kafka_consumer_group.clone();
@@ -101,6 +114,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let groups_producer = AggregatedProducer::new(
         &config.kafka,
         groups_handle.clone(),
+        config.intermediate_topic.clone(),
+        produce_timeout,
+    )
+    .await?;
+
+    // Stage 2 — consumes the intermediate topic and collapses the per-pod
+    // emissions stage 1 produced for the same tuple, then forwards to the
+    // final output topic that ClickHouse reads.
+    let mut stage2_consumer_config = config.consumer.clone();
+    stage2_consumer_config.kafka_consumer_topic = config.intermediate_topic.clone();
+    stage2_consumer_config.kafka_consumer_group = config.stage2_consumer_group.clone();
+    let stage2_consumer = SingleTopicConsumer::new(config.kafka.clone(), stage2_consumer_config)?;
+    let stage2_producer = AggregatedProducer::new(
+        &config.kafka,
+        stage2_handle.clone(),
         config.output_topic.clone(),
         produce_timeout,
     )
@@ -114,6 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Subscribed to topic: {}",
         config.groups_kafka_consumer_topic
     );
+    info!("Subscribed to topic: {}", config.intermediate_topic);
 
     let shared_config = Arc::new(config.clone());
 
@@ -128,6 +157,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         events_producer,
         events_handle.clone(),
         move |e: &Event| fan_out(e, &excluded_events),
+        false,
     ));
     tokio::spawn(worker_loop::<GroupIdentify, _, _>(
         shared_config.clone(),
@@ -135,9 +165,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         groups_producer,
         groups_handle.clone(),
         move |g: &GroupIdentify| fan_out_group(g, &excluded_groups),
+        false,
+    ));
+    // Stage 2 bypasses the team filter: every record on the intermediate topic
+    // already passed the stage-1 filter, and re-applying would silently drop
+    // partial aggregates if rollout_percentage shrinks between deploys, breaking
+    // sum-conservation.
+    tokio::spawn(worker_loop::<PropertyValueMessage, _, _>(
+        shared_config.clone(),
+        stage2_consumer,
+        stage2_producer,
+        stage2_handle.clone(),
+        |m: &PropertyValueMessage| fan_in(m),
+        true,
     ));
     drop(events_handle);
     drop(groups_handle);
+    drop(stage2_handle);
 
     let app = Router::new()
         .route("/", get(index))

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -6,7 +6,7 @@ use common_kafka::kafka_consumer::SingleTopicConsumer;
 use lifecycle::{ComponentOptions, Manager};
 use property_vals_rs::{
     config::Config,
-    fan_out::{fan_in, fan_out, fan_out_group},
+    fan_out::{extract_tuple, fan_out, fan_out_group},
     producer::AggregatedProducer,
     types::{Event, GroupIdentify, PropertyValueMessage},
     worker::worker_loop,
@@ -176,7 +176,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         stage2_consumer,
         stage2_producer,
         stage2_handle.clone(),
-        |m: &PropertyValueMessage| fan_in(m),
+        |m: &PropertyValueMessage| extract_tuple(m),
         true,
     ));
     drop(events_handle);

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -84,10 +84,22 @@ impl Producer for AggregatedProducer {
             })
             .collect();
 
+        // Full-tuple partition key. Same (team, type, key, value) tuple from any
+        // pod always lands on the same partition, so the stage-2 aggregator on
+        // the consuming side can collapse the per-pod duplicates that stage-1
+        // emits across replicas.
         let send_fut = send_keyed_iter_to_kafka(
             &self.inner,
             &self.output_topic,
-            |m| Some(format!("{}:{}", m.team_id, m.property_key)),
+            |m| {
+                Some(format!(
+                    "{}:{}:{}:{}",
+                    m.team_id,
+                    m.property_type.as_kafka_key_segment(),
+                    m.property_key,
+                    m.property_value,
+                ))
+            },
             messages,
         );
 

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -84,10 +84,10 @@ impl Producer for AggregatedProducer {
             })
             .collect();
 
-        // Full-tuple partition key. Same (team, type, key, value) tuple from any
-        // pod always lands on the same partition, so the stage-2 aggregator on
-        // the consuming side can collapse the per-pod duplicates that stage-1
-        // emits across replicas.
+        // Full-tuple partition key. The same (team, type, key, value) tuple
+        // from any pod always lands on the same partition, so the merger on
+        // the consuming side can merge the per-pod duplicates that the
+        // events/groups workers emit across replicas.
         let send_fut = send_keyed_iter_to_kafka(
             &self.inner,
             &self.output_topic,

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -13,12 +13,12 @@ use tracing::warn;
 use crate::types::{PropertyType, TupleKey};
 
 #[derive(serde::Serialize)]
-struct Outgoing<'a> {
-    team_id: i64,
-    property_type: PropertyType,
-    property_key: &'a str,
-    property_value: &'a str,
-    property_count: u64,
+pub(crate) struct Outgoing<'a> {
+    pub team_id: i64,
+    pub property_type: PropertyType,
+    pub property_key: &'a str,
+    pub property_value: &'a str,
+    pub property_count: u64,
 }
 
 #[derive(Debug, Error)]

--- a/rust/property-vals-rs/src/types.rs
+++ b/rust/property-vals-rs/src/types.rs
@@ -62,11 +62,7 @@ impl PropertyType {
 
 impl Serialize for PropertyType {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            PropertyType::Event => serializer.serialize_str("event"),
-            PropertyType::Person => serializer.serialize_str("person"),
-            PropertyType::Group(n) => serializer.serialize_str(&format!("group_{n}")),
-        }
+        serializer.serialize_str(&self.as_kafka_key_segment())
     }
 }
 

--- a/rust/property-vals-rs/src/types.rs
+++ b/rust/property-vals-rs/src/types.rs
@@ -1,3 +1,4 @@
+use serde::de::{self, Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 
 pub trait IngestableEvent: serde::de::DeserializeOwned + Send + Sync + 'static {
@@ -49,6 +50,16 @@ pub enum PropertyType {
     Group(u8),
 }
 
+impl PropertyType {
+    pub fn as_kafka_key_segment(&self) -> String {
+        match self {
+            PropertyType::Event => "event".to_string(),
+            PropertyType::Person => "person".to_string(),
+            PropertyType::Group(n) => format!("group_{n}"),
+        }
+    }
+}
+
 impl Serialize for PropertyType {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
@@ -56,5 +67,42 @@ impl Serialize for PropertyType {
             PropertyType::Person => serializer.serialize_str("person"),
             PropertyType::Group(n) => serializer.serialize_str(&format!("group_{n}")),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for PropertyType {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s: &str = Deserialize::deserialize(deserializer)?;
+        match s {
+            "event" => Ok(PropertyType::Event),
+            "person" => Ok(PropertyType::Person),
+            other => {
+                let n: u8 = other
+                    .strip_prefix("group_")
+                    .ok_or_else(|| de::Error::custom(format!("invalid property_type: {other}")))?
+                    .parse()
+                    .map_err(|_| {
+                        de::Error::custom(format!("invalid group property_type: {other}"))
+                    })?;
+                Ok(PropertyType::Group(n))
+            }
+        }
+    }
+}
+
+/// Wire format of records on the intermediate topic. Mirrors `Outgoing` in
+/// `producer.rs` so a stage-1 produce round-trips to a stage-2 consume.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PropertyValueMessage {
+    pub team_id: i64,
+    pub property_type: PropertyType,
+    pub property_key: String,
+    pub property_value: String,
+    pub property_count: u64,
+}
+
+impl IngestableEvent for PropertyValueMessage {
+    fn team_id(&self) -> i64 {
+        self.team_id
     }
 }

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -24,10 +24,11 @@ pub async fn worker_loop<E, P, F>(
     producer: P,
     handle: lifecycle::Handle,
     fan_out_fn: F,
+    bypass_team_filter: bool,
 ) where
     E: IngestableEvent,
     P: Producer,
-    F: Fn(&E) -> Vec<TupleKey>,
+    F: Fn(&E) -> Vec<(TupleKey, u64)>,
 {
     let _guard = handle.process_scope();
 
@@ -61,11 +62,11 @@ pub async fn worker_loop<E, P, F>(
                     Ok((event, offset)) => {
                         metrics::counter!(EVENTS_RECEIVED).increment(1);
 
-                        if config.should_process(event.team_id()) {
+                        if bypass_team_filter || config.should_process(event.team_id()) {
                             let tuples = fan_out_fn(&event);
                             metrics::counter!(TUPLES_AGGREGATED).increment(tuples.len() as u64);
-                            for t in tuples {
-                                aggregator.add(t, 1);
+                            for (t, count) in tuples {
+                                aggregator.add(t, count);
                             }
                         } else {
                             metrics::counter!(EVENTS_FILTERED).increment(1);

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -24,7 +24,6 @@ pub async fn worker_loop<E, P, F>(
     producer: P,
     handle: lifecycle::Handle,
     fan_out_fn: F,
-    bypass_team_filter: bool,
 ) where
     E: IngestableEvent,
     P: Producer,
@@ -62,7 +61,7 @@ pub async fn worker_loop<E, P, F>(
                     Ok((event, offset)) => {
                         metrics::counter!(EVENTS_RECEIVED).increment(1);
 
-                        if bypass_team_filter || config.should_process(event.team_id()) {
+                        if config.should_process(event.team_id()) {
                             let tuples = fan_out_fn(&event);
                             metrics::counter!(TUPLES_AGGREGATED).increment(tuples.len() as u64);
                             for (t, count) in tuples {


### PR DESCRIPTION
## Problem

property-vals-rs aggregates `(team, type, key, value)` tuples in each pod's local HashMap and flushes to `clickhouse_property_values` every 30s. The input topic `team_event_partitioned_events_json` keys by `team_id-event-random(0..6)`, which spreads a single team's events across most of the 128 partitions. With N pods, the same low-cardinality tuple like `(team=2, $browser, Chrome)` lives in N different pods' HashMaps, so each pod emits a record for it at flush. ClickHouse ends up consuming N records for what should be one logical update per window.

When I collasped the number of replicas in prod from 12 to 1, the records-per-event ratio from 0.17 to 0.092, a ~46% reduction. That portion of `clickhouse_property_values` traffic is entirely cross-pod duplication, not unique data.

## Changes

Add a second aggregation pass so duplicates collapse before they reach `clickhouse_property_values`.

```mermaid
flowchart TB
      E[team_event_partitioned_events_json<br/>128 partitions, keyed team-event-random]

      subgraph POD1["pod 1"]
        S1_1["events/groups worker<br/>fan-out + local HashMap"]
        S2_1["merger<br/>merge cross-pod copies"]
      end
      subgraph POD2["pod 2"]
        S1_2["events/groups worker"]
        S2_2["merger"]
      end
      subgraph PODN["pod ...N"]
        S1_N["events/groups worker"]
        S2_N["merger"]
      end

      INT["property_vals_intermediate<br/>NEW, 64 partitions<br/>keyed hash team:type:key:value"]
      OUT["clickhouse_property_values<br/>1 record per tuple per window"]
      CH[(ClickHouse<br/>kafka_property_values MV<br/>AggregatingMergeTree sum)]

      E --> S1_1 & S1_2 & S1_N
      S1_1 & S1_2 & S1_N -->|partial aggregates<br/>routed by tuple hash| INT
      INT -->|each partition owned<br/>by one merger pod| S2_1 & S2_2 & S2_N
      S2_1 & S2_2 & S2_N -->|collapsed| OUT
      OUT --> CH

      style INT fill:#90EE90,stroke:#006400,color:#000
      style S1_1 fill:#FFE4B5,color:#000
      style S1_2 fill:#FFE4B5,color:#000
      style S1_N fill:#FFE4B5,color:#000
      style S2_1 fill:#FFB6C1,color:#000
      style S2_2 fill:#FFB6C1,color:#000
      style S2_N fill:#FFB6C1,color:#000
```

The events and groups workers are existing. Their only behavior change is the destination topic and the partition key. The merger is a new consumer group in the same binary; each pod owns a partition slice and re-aggregates the per-pod copies the events/groups workers produced for the same tuple before forwarding to the final output topic.

Implementation notes:

- `fan_out`/`fan_out_group` now return `Vec<(TupleKey, u64)>`. The events/groups workers still emit count=1 per tuple; the wider signature lets the same `worker_loop` handle the merger, where the count comes from the input message.
- New `PropertyValueMessage` type for the merger's input. A round-trip test pins the schema to the producer's wire format so future drift fails loudly instead of silently dropping records.
- Producer partition key changes from `team:key` to `team:type:key:value` so the same tuple always lands on the same intermediate partition.
- Defaults: `INTERMEDIATE_TOPIC=property_vals_intermediate`, `MERGER_CONSUMER_GROUP=clickhouse-property-vals-rs-merger`.

## How did you test this code?

I'm an agent and have not run the binary or the prod stack manually.

- All 42 unit + property tests in `property-vals-rs` pass locally: `cargo test -p property-vals-rs`
- `cargo clippy -p property-vals-rs --no-deps --all-targets` is clean
- `cargo fmt -p property-vals-rs` is a no-op
- A new wire-format round-trip test pins `PropertyValueMessage` deserialization against the producer's `Outgoing` serialization to catch silent schema drift in either direction.

## Publish to changelog?

no

## 🤖 Agent context

Co-authored with Claude. Earlier in the same session we measured the 46%/54% split between pod-amplification cost and unique-singleton cost by scaling property-vals-rs from 12 pods to 1 and comparing the `flush_tuples_sum / events_received` ratio. That experiment is what motivated investing in the two-pass architecture as opposed to alternatives like an MV-side `GROUP BY` (which only helps if the CH-side bottleneck is INSERT/merge, not consume — and the data showed `DelayedInserts=0`, `RejectedInserts=0`, idle merge pool, while `KafkaRowsRead` was plateaued at ~62k/replica during the lag spike).

Considered and rejected:
- MV-level GROUP BY on `kafka_property_values`: only helps stages 4–5 of the CH pipeline; the bottleneck data showed stages 1–2 (consume + parse) were where the ceiling lived.
- Upstream re-partition (key the input topic by team_id alone): would create hot partitions for team 2.
- In-process consistent-hash routing via gRPC: lower latency but rebuilds Kafka's partition-assignment/rebalance/durability machinery in user code. Not worth the complexity given Kafka topics are cheap.

A singleton emission gate (drop tuples with count=1 at flush time) is a complementary follow-up — it addresses the other ~54% of the cost, which is unique high-cardinality identifiers that don't aggregate.
