### PR TITLE
chore(replay): Add copy button to session replay inspector

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
@@ -7,14 +7,17 @@ import {
     IconChevronDown,
     IconChevronRight,
     IconComment,
+    IconCopy,
     IconDashboard,
+    IconDownload,
+    IconEllipsis,
     IconGear,
     IconInfo,
     IconLive,
     IconStethoscope,
     IconTerminal,
 } from '@posthog/icons'
-import { LemonButton, LemonInput, SideAction, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonMenu, LemonMenuItems, SideAction, Tooltip } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { IconUnverifiedEvent } from 'lib/lemon-ui/icons'
@@ -284,8 +287,41 @@ export function PlayerInspectorControls(): JSX.Element {
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
     const { searchQuery, miniFiltersByKey } = useValues(miniFiltersLogic)
     const { setSearchQuery, setMiniFilter } = useActions(miniFiltersLogic)
+    const { displayGroups, logsHasMore } = useValues(playerInspectorLogic(logicProps))
+    const { copyVisibleInspectorRows, exportVisibleInspectorRowsJson } = useActions(playerInspectorLogic(logicProps))
 
     const mode = logicProps.mode ?? SessionRecordingPlayerMode.Standard
+    const isSharingMode = mode === SessionRecordingPlayerMode.Sharing
+    const hasVisibleRows = displayGroups.length > 0
+    const exportDisabledReason = hasVisibleRows ? undefined : 'There are no visible inspector rows to copy or export'
+    const exportTriggerTooltip = 'Copy or export the visible inspector rows'
+    const exportMenuItems: LemonMenuItems = [
+        logsHasMore && {
+            title: 'Backend logs are truncated — more logs are available',
+            items: [],
+            key: 'inspector-export-truncation-notice',
+        },
+        {
+            items: [
+                {
+                    label: 'Copy visible rows',
+                    icon: <IconCopy />,
+                    onClick: copyVisibleInspectorRows,
+                    disabledReason: exportDisabledReason,
+                    tooltip: 'Copy the currently visible rows as text',
+                    'data-attr': 'player-inspector-copy-visible-rows',
+                },
+                {
+                    label: 'Download JSON',
+                    icon: <IconDownload />,
+                    onClick: exportVisibleInspectorRowsJson,
+                    disabledReason: exportDisabledReason,
+                    tooltip: 'Download the visible rows as a JSON file',
+                    'data-attr': 'player-inspector-download-json',
+                },
+            ],
+        },
+    ]
 
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -299,14 +335,15 @@ export function PlayerInspectorControls(): JSX.Element {
     return (
         <div className="flex flex-col">
             <SettingsBar border="bottom" className="justify-end">
-                {mode !== SessionRecordingPlayerMode.Sharing && <EventsFilterSettingsButton />}
+                {!isSharingMode && <EventsFilterSettingsButton />}
                 <ConsoleFilterSettingsButton />
                 <NetworkFilterSettingsButton />
-                {featureFlags[FEATURE_FLAGS.SESSION_REPLAY_BACKEND_LOGS] &&
-                    mode !== SessionRecordingPlayerMode.Sharing && <LogsFilterSettingsButton />}
-                {mode !== SessionRecordingPlayerMode.Sharing && <CommentsFilterSettingsButton />}
+                {featureFlags[FEATURE_FLAGS.SESSION_REPLAY_BACKEND_LOGS] && !isSharingMode && (
+                    <LogsFilterSettingsButton />
+                )}
+                {!isSharingMode && <CommentsFilterSettingsButton />}
                 {(window.IMPERSONATED_SESSION || featureFlags[FEATURE_FLAGS.SESSION_REPLAY_DOCTOR]) &&
-                    mode !== SessionRecordingPlayerMode.Sharing && (
+                    !isSharingMode && (
                         <SettingsToggle
                             data-attr="player-inspector-doctor-toggle"
                             title="Doctor events help diagnose the health of a recording, and are used by PostHog support"
@@ -318,7 +355,7 @@ export function PlayerInspectorControls(): JSX.Element {
                     )}
             </SettingsBar>
 
-            <div className="flex px-2 py-1">
+            <div className="flex px-2 py-1 gap-1">
                 <LemonInput
                     data-attr="player-inspector-search-input"
                     size="xsmall"
@@ -334,6 +371,18 @@ export function PlayerInspectorControls(): JSX.Element {
                         </Tooltip>
                     }
                 />
+                {!isSharingMode ? (
+                    <LemonMenu items={exportMenuItems} buttonSize="xsmall" placement="bottom-end">
+                        <LemonButton
+                            size="xsmall"
+                            icon={<IconEllipsis />}
+                            tooltip={exportTriggerTooltip}
+                            disabledReason={exportDisabledReason}
+                            aria-label="Copy or export inspector rows"
+                            data-attr="player-inspector-copy-export-menu"
+                        />
+                    </LemonMenu>
+                ) : null}
             </div>
         </div>
     )

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -10,6 +10,7 @@ import {
     IconChat,
     IconCloud,
     IconCollapse,
+    IconCopy,
     IconCursor,
     IconDashboard,
     IconExpand,
@@ -39,16 +40,18 @@ import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
 
 import { ItemPerformanceEvent, ItemPerformanceEventDetail } from '../../../apm/playerInspector/ItemPerformanceEvent'
 import { IconWindow } from '../../icons'
-import { sessionRecordingPlayerLogic } from '../../sessionRecordingPlayerLogic'
+import { SessionRecordingPlayerMode, sessionRecordingPlayerLogic } from '../../sessionRecordingPlayerLogic'
 import {
     InspectorListItem,
     InspectorListItemConsole,
     InspectorListItemEvent,
+    InspectorListItemLog,
     playerInspectorLogic,
 } from '../playerInspectorLogic'
 import { ItemAppState, ItemAppStateDetail, ItemConsoleLog, ItemConsoleLogDetail } from './ItemConsoleLog'
 import { ItemDoctor, ItemDoctorDetail } from './ItemDoctor'
 import { ItemEvent, ItemEventDetail, ItemEventMenu } from './ItemEvent'
+import { ItemLog, ItemLogDetail } from './ItemLog'
 
 const PLAYER_INSPECTOR_LIST_ITEM_MARGIN = 1
 
@@ -178,6 +181,12 @@ function RowItemTitle({
                 <ItemPerformanceEvent item={item.data} finalTimestamp={finalTimestamp} />
             ) : item.type === 'console' ? (
                 <ItemConsoleLog item={item} groupCount={groupCount} />
+            ) : item.type === 'logs' ? (
+                <ItemLog
+                    item={item}
+                    groupCount={groupCount}
+                    groupedItems={groupedItems as InspectorListItemLog[] | undefined}
+                />
             ) : item.type === 'app-state' ? (
                 <ItemAppState item={item} />
             ) : item.type === 'events' ? (
@@ -221,10 +230,12 @@ function RowItemDetail({
     item,
     finalTimestamp,
     groupedItems,
+    sessionRecordingId,
 }: {
     item: InspectorListItem
     finalTimestamp: Dayjs | null
     groupedItems?: InspectorListItem[]
+    sessionRecordingId: string
 }): JSX.Element | null {
     return (
         <div>
@@ -236,6 +247,12 @@ function RowItemDetail({
                 <ItemConsoleLogDetail
                     item={item}
                     groupedItems={groupedItems as InspectorListItemConsole[] | undefined}
+                />
+            ) : item.type === 'logs' ? (
+                <ItemLogDetail
+                    item={item}
+                    groupedItems={groupedItems as InspectorListItemLog[] | undefined}
+                    sessionId={sessionRecordingId}
                 />
             ) : item.type === 'events' ? (
                 <ItemEventDetail item={item} groupedItems={groupedItems as InspectorListItemEvent[] | undefined} />
@@ -252,13 +269,13 @@ function RowItemDetail({
 const ListItemTitle = memo(function ListItemTitle({
     item,
     index,
-    hoverRef,
+    showCopyAction,
     groupCount,
     groupedItems,
 }: {
     item: InspectorListItem
     index: number
-    hoverRef: React.RefObject<HTMLDivElement>
+    showCopyAction: boolean
     groupCount?: number
     groupedItems?: InspectorListItem[]
 }) {
@@ -266,9 +283,11 @@ const ListItemTitle = memo(function ListItemTitle({
     const { seekToTime } = useActions(sessionRecordingPlayerLogic)
 
     const { end, expandedItems } = useValues(playerInspectorLogic(logicProps))
-    const { setItemExpanded } = useActions(playerInspectorLogic(logicProps))
+    const { copyInspectorRow, setItemExpanded } = useActions(playerInspectorLogic(logicProps))
 
     const isExpanded = expandedItems.includes(index)
+    const isSharingMode =
+        (logicProps.mode ?? SessionRecordingPlayerMode.Standard) === SessionRecordingPlayerMode.Sharing
 
     // NOTE: We offset by 1 second so that the playback starts just before the event occurs.
     // Ceiling second is used since this is what's displayed to the user.
@@ -284,7 +303,6 @@ const ListItemTitle = memo(function ListItemTitle({
         <div className="flex flex-row items-center w-full px-1">
             <div
                 className="flex flex-row flex-1 items-center overflow-hidden cursor-pointer"
-                ref={hoverRef}
                 onClick={() => seekToEvent()}
             >
                 {/*TODO this tooltip doesn't trigger whether its inside or outside of this hover container */}
@@ -340,6 +358,24 @@ const ListItemTitle = memo(function ListItemTitle({
                 </div>
             </div>
             {isExpanded && <RowItemMenu item={item} />}
+            {!isSharingMode ? (
+                <LemonButton
+                    icon={<IconCopy />}
+                    size="small"
+                    noPadding
+                    onClick={(event) => {
+                        event.stopPropagation()
+                        copyInspectorRow(index)
+                    }}
+                    tooltip="Copy inspector row"
+                    aria-label="Copy inspector row"
+                    data-attr="copy-inspector-row"
+                    className={clsx(
+                        'shrink-0 focus:opacity-100',
+                        showCopyAction || isExpanded ? 'opacity-100' : 'opacity-0'
+                    )}
+                />
+            ) : null}
             {!notExpandable.includes(item.type) && (
                 <LemonButton
                     icon={isExpanded ? <IconCollapse /> : <IconExpand />}
@@ -370,6 +406,7 @@ const ListItemDetail = memo(function ListItemDetail({
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
 
     const { end } = useValues(playerInspectorLogic(logicProps))
+    const { sessionRecordingId } = useValues(sessionRecordingPlayerLogic)
     const { setItemExpanded } = useActions(playerInspectorLogic(logicProps))
 
     return (
@@ -380,7 +417,12 @@ const ListItemDetail = memo(function ListItemDetail({
             )}
         >
             <div className="text-xs">
-                <RowItemDetail item={item} finalTimestamp={end} groupedItems={groupedItems} />
+                <RowItemDetail
+                    item={item}
+                    finalTimestamp={end}
+                    groupedItems={groupedItems}
+                    sessionRecordingId={sessionRecordingId}
+                />
                 <LemonDivider dashed />
 
                 <div
@@ -416,7 +458,7 @@ export const PlayerInspectorListItem = memo(function PlayerInspectorListItem({
     const isExpanded = expandedItems.includes(index)
 
     const onLayoutDebounced = useDebouncedCallback(onLayout ?? (() => {}), 500)
-    const { ref, width, height } = useResizeObserver({})
+    const { ref: resizeRef, width, height } = useResizeObserver({})
 
     const totalHeight = height ? height + PLAYER_INSPECTOR_LIST_ITEM_MARGIN : height
 
@@ -449,25 +491,26 @@ export const PlayerInspectorListItem = memo(function PlayerInspectorListItem({
 
     return (
         <div
-            ref={ref}
+            ref={resizeRef}
             className={clsx(
                 'ml-1 flex flex-col items-center',
                 isExpanded && 'border border-accent',
-                isExpanded && item.highlightColor && `border border-${item.highlightColor}-dark`,
-                isHovering && 'bg-surface-primary'
+                isExpanded && item.highlightColor && `border border-${item.highlightColor}-dark`
             )}
             // eslint-disable-next-line react/forbid-dom-props
             style={{
                 zIndex: isExpanded ? 1 : 0,
             }}
         >
-            <ListItemTitle
-                item={item}
-                index={index}
-                hoverRef={hoverRef}
-                groupCount={groupCount}
-                groupedItems={groupedItems}
-            />
+            <div ref={hoverRef} className={clsx('w-full', isHovering && 'bg-surface-primary')}>
+                <ListItemTitle
+                    item={item}
+                    index={index}
+                    showCopyAction={isHovering}
+                    groupCount={groupCount}
+                    groupedItems={groupedItems}
+                />
+            </div>
 
             {isExpanded ? <ListItemDetail item={item} index={index} groupedItems={groupedItems} /> : null}
         </div>

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorExport.test.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorExport.test.ts
@@ -1,0 +1,367 @@
+import { dayjs } from 'lib/dayjs'
+import { InspectorListItemPerformance } from 'scenes/session-recordings/apm/performanceEventDataLogic'
+
+import { SharedListMiniFilter } from './miniFiltersLogic'
+import {
+    buildInspectorExportDocument,
+    buildInspectorExportItem,
+    formatInspectorExportDocumentForClipboard,
+} from './playerInspectorExport'
+import {
+    DisplayGroup,
+    InspectorListBrowserVisibility,
+    InspectorListItem,
+    InspectorListItemAppState,
+    InspectorListItemComment,
+    InspectorListItemConsole,
+    InspectorListItemDoctor,
+    InspectorListItemEvent,
+    InspectorListItemInactivity,
+    InspectorListItemLog,
+    InspectorListItemNotebookComment,
+    InspectorListItemSummary,
+    InspectorListOfflineStatusChange,
+    InspectorListSessionChange,
+} from './playerInspectorLogic'
+
+const timestamp = dayjs('2024-01-01T00:00:05Z')
+
+function baseItem(overrides: Partial<InspectorListItem> = {}): Omit<InspectorListItemEvent, 'type' | 'data'> {
+    return {
+        timestamp,
+        timeInRecording: 5000,
+        search: 'search text',
+        key: 'base-key',
+        windowId: 1,
+        windowNumber: 1,
+        ...overrides,
+    }
+}
+
+function buildDocument(
+    items: InspectorListItem[],
+    displayGroups?: DisplayGroup[]
+): ReturnType<typeof buildInspectorExportDocument> {
+    const miniFilters: SharedListMiniFilter[] = [
+        { type: 'events', key: 'events-pageview', name: 'Pageview', enabled: true },
+        { type: 'console', key: 'console-error', name: 'Error', enabled: false },
+    ]
+
+    return buildInspectorExportDocument({
+        sessionRecordingId: 'recording-1',
+        exportedAt: '2024-01-01T00:00:10Z',
+        items,
+        displayGroups: displayGroups ?? items.map((_, index) => ({ indices: [index] })),
+        searchQuery: 'checkout',
+        miniFilters,
+        showOnlyMatching: true,
+        groupRepeatedItems: true,
+        trackedWindow: 1,
+        logsHasMore: true,
+    })
+}
+
+describe('playerInspectorExport', () => {
+    it.each([
+        [
+            'events',
+            {
+                ...baseItem(),
+                type: 'events',
+                data: {
+                    id: 'event-1',
+                    event: '$pageview',
+                    distinct_id: 'user-1',
+                    properties: { $current_url: 'https://example.com/pricing' },
+                    elements: [],
+                    timestamp: timestamp.toISOString(),
+                    fullyLoaded: true,
+                    playerTime: 0,
+                },
+            } satisfies InspectorListItemEvent,
+            { event: '$pageview', event_id: 'event-1', distinct_id: 'user-1' },
+        ],
+        [
+            'console',
+            {
+                ...baseItem(),
+                type: 'console',
+                data: {
+                    timestamp: timestamp.valueOf(),
+                    windowId: 1,
+                    level: 'error',
+                    content: 'Failed to fetch',
+                    lines: ['Failed to fetch'],
+                    trace: ['trace line'],
+                    count: 2,
+                },
+            } satisfies InspectorListItemConsole,
+            { level: 'error', content: 'Failed to fetch', repeat_count: 2 },
+        ],
+        [
+            'network',
+            {
+                ...baseItem(),
+                type: 'network',
+                data: {
+                    uuid: 'network-1',
+                    timestamp: timestamp.valueOf(),
+                    distinct_id: 'user-1',
+                    session_id: 'recording-1',
+                    window_id: 'window-1',
+                    pageview_id: 'pageview-1',
+                    current_url: 'https://example.com',
+                    entry_type: 'resource',
+                    name: 'https://example.com/api',
+                    method: 'POST',
+                    response_status: 500,
+                    duration: 321,
+                    request_body: '{"ok":false}',
+                },
+            } satisfies InspectorListItemPerformance,
+            { method: 'POST', response_status: 500, request_body: '{"ok":false}' },
+        ],
+        [
+            'comment',
+            {
+                ...baseItem(),
+                type: 'comment',
+                source: 'comment',
+                data: {
+                    id: 'comment-1',
+                    content: 'Needs investigation',
+                    rich_content: null,
+                    version: 1,
+                    created_at: timestamp.toISOString(),
+                    created_by: {
+                        id: 7,
+                        uuid: 'user-uuid',
+                        distinct_id: 'user-distinct',
+                        email: 'user@example.com',
+                        first_name: 'User',
+                        last_name: '',
+                    },
+                    scope: 'recording',
+                    item_context: null,
+                    is_task: false,
+                    completed_at: null,
+                    completed_by: null,
+                },
+            } satisfies InspectorListItemComment,
+            { source: 'comment', content: 'Needs investigation' },
+        ],
+        [
+            'notebook comment',
+            {
+                ...baseItem(),
+                type: 'comment',
+                source: 'notebook',
+                data: {
+                    id: 'notebook-comment-1',
+                    comment: 'Notebook note',
+                    notebookShortId: 'note-1',
+                    notebookTitle: 'Research',
+                    timeInRecording: 5000,
+                },
+            } satisfies InspectorListItemNotebookComment,
+            { source: 'notebook', comment: 'Notebook note', notebook_title: 'Research' },
+        ],
+        [
+            'doctor',
+            {
+                ...baseItem(),
+                type: 'doctor',
+                tag: 'session options',
+                data: { sampleRate: 1 },
+            } satisfies InspectorListItemDoctor,
+            { tag: 'session options', data: { sampleRate: 1 } },
+        ],
+        [
+            'inactivity',
+            {
+                ...baseItem(),
+                type: 'inactivity',
+                durationMs: 65000,
+            } satisfies InspectorListItemInactivity,
+            { duration_ms: 65000 },
+        ],
+        [
+            'session change',
+            {
+                ...baseItem(),
+                type: 'session-change',
+                tag: '$session_ending',
+                data: { nextSessionId: 'next-session' },
+            } satisfies InspectorListSessionChange,
+            { tag: '$session_ending', next_session_id: 'next-session' },
+        ],
+        [
+            'logs',
+            {
+                ...baseItem(),
+                type: 'logs',
+                data: {
+                    uuid: 'log-1',
+                    trace_id: 'trace-1',
+                    span_id: 'span-1',
+                    body: 'backend failed',
+                    attributes: { route: '/api' },
+                    timestamp: timestamp.toISOString(),
+                    observed_timestamp: timestamp.toISOString(),
+                    severity_text: 'error',
+                    severity_number: 17,
+                    level: 'error',
+                    resource_attributes: { service: 'web' },
+                    instrumentation_scope: 'django',
+                    event_name: 'log',
+                },
+            } satisfies InspectorListItemLog,
+            { level: 'error', body: 'backend failed', instrumentation_scope: 'django' },
+        ],
+        [
+            'app state',
+            {
+                ...baseItem(),
+                type: 'app-state',
+                action: 'cart updated',
+                stateEvent: { payload: { quantity: 2 } },
+            } satisfies InspectorListItemAppState,
+            { action: 'cart updated', state_event: { payload: { quantity: 2 } } },
+        ],
+        [
+            'offline status',
+            {
+                ...baseItem(),
+                type: 'offline-status',
+                offline: true,
+            } satisfies InspectorListOfflineStatusChange,
+            { offline: true },
+        ],
+        [
+            'browser visibility',
+            {
+                ...baseItem(),
+                type: 'browser-visibility',
+                status: 'hidden',
+            } satisfies InspectorListBrowserVisibility,
+            { status: 'hidden' },
+        ],
+        [
+            'summary',
+            {
+                ...baseItem(),
+                type: 'inspector-summary',
+                clickCount: 2,
+                keypressCount: 3,
+                errorCount: 1,
+            } satisfies InspectorListItemSummary,
+            { click_count: 2, keypress_count: 3, error_count: 1 },
+        ],
+    ])('exports visible fields for %s items', (_, item, expectedDetails) => {
+        const exportedItem = buildInspectorExportItem(item)
+
+        expect(exportedItem.timestamp).toBe('2024-01-01T00:00:05.000Z')
+        expect(exportedItem.time_in_recording_ms).toBe(5000)
+        expect(exportedItem.window_number).toBe(1)
+        expect(exportedItem.details).toMatchObject(expectedDetails)
+    })
+
+    it('builds a document from visible items and display groups', () => {
+        const firstItem: InspectorListItemConsole = {
+            ...baseItem({ key: 'console-1', search: 'Repeated failure' }),
+            type: 'console',
+            data: {
+                timestamp: timestamp.valueOf(),
+                windowId: 1,
+                level: 'error',
+                content: 'Repeated failure',
+                lines: ['Repeated failure'],
+                count: 1,
+            },
+        }
+        const secondItem: InspectorListItemConsole = {
+            ...firstItem,
+            key: 'console-2',
+            timeInRecording: 6000,
+            timestamp: timestamp.add(1, 'second'),
+        }
+        const hiddenUnfilteredItem: InspectorListItemDoctor = {
+            ...baseItem({ key: 'doctor-1' }),
+            type: 'doctor',
+            tag: 'hidden doctor event',
+        }
+
+        const document = buildDocument([firstItem, secondItem], [{ indices: [0, 1] }])
+
+        expect(document.rows).toHaveLength(1)
+        expect(document.row_count).toBe(1)
+        expect(document.item_count).toBe(2)
+        expect(document.truncated_logs).toBe(true)
+        expect(document.filter_context).toMatchObject({
+            search_query: 'checkout',
+            enabled_mini_filters: ['events-pageview'],
+            show_only_matching: true,
+            group_repeated_items: true,
+            tracked_window: 1,
+        })
+        expect(document.rows[0].group_count).toBe(2)
+        expect(document.rows[0].items?.map((item) => item.key)).toEqual(['console-1', 'console-2'])
+        expect(document.rows.map((row) => row.key)).not.toContain(hiddenUnfilteredItem.key)
+    })
+
+    it('formats clipboard text with grouped child rows and truncation note', () => {
+        const item: InspectorListItemConsole = {
+            ...baseItem({ key: 'console-1' }),
+            type: 'console',
+            data: {
+                timestamp: timestamp.valueOf(),
+                windowId: 1,
+                level: 'warn',
+                content: 'Retrying request',
+                lines: ['Retrying request'],
+                count: 1,
+            },
+        }
+
+        const document = buildDocument(
+            [item, { ...item, key: 'console-2', timeInRecording: 7000 }],
+            [{ indices: [0, 1] }]
+        )
+        const clipboardText = formatInspectorExportDocumentForClipboard(document)
+
+        expect(clipboardText).toContain('Session replay inspector for recording recording-1')
+        expect(clipboardText).toContain('1 rows, 2 items')
+        expect(clipboardText).toContain('Note: Backend logs are truncated')
+        expect(clipboardText).toContain('[00:05] console: Retrying request')
+        expect(clipboardText).toContain('  - [00:07] Retrying request')
+    })
+
+    it('handles an empty visible list', () => {
+        const document = buildDocument([])
+
+        expect(document.rows).toEqual([])
+        expect(document.row_count).toBe(0)
+        expect(document.item_count).toBe(0)
+    })
+
+    it('keeps window metadata in clipboard output when the window number is 0', () => {
+        const item: InspectorListItemConsole = {
+            ...baseItem({ key: 'console-1', windowNumber: 0 }),
+            type: 'console',
+            data: {
+                timestamp: timestamp.valueOf(),
+                windowId: 0,
+                level: 'warn',
+                content: 'Heartbeat',
+                lines: ['Heartbeat'],
+                count: 1,
+            },
+        }
+
+        const document = buildDocument([item])
+        const clipboardText = formatInspectorExportDocumentForClipboard(document)
+
+        expect(document.rows[0].window_number).toBe(0)
+        expect(clipboardText).toContain('window 0')
+    })
+})

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorExport.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorExport.ts
@@ -1,0 +1,346 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { dayjs } from 'lib/dayjs'
+import { eventToDescription, humanFriendlyDuration } from 'lib/utils'
+
+import { getCoreFilterDefinition } from '~/taxonomy/helpers'
+
+import type { SharedListMiniFilter } from './miniFiltersLogic'
+import type { DisplayGroup, InspectorListItem, InspectorListItemType } from './playerInspectorLogic'
+
+export interface InspectorExportItem {
+    key: string
+    type: InspectorListItemType
+    timestamp: string
+    time_in_recording_ms: number
+    label: string
+    search: string
+    window_id?: number
+    window_number?: number | '?'
+    highlight?: 'danger' | 'warning' | 'primary'
+    details: Record<string, unknown>
+}
+
+export interface InspectorExportRow extends InspectorExportItem {
+    group_count: number
+    items?: InspectorExportItem[]
+}
+
+export interface InspectorExportFilterContext {
+    search_query: string
+    enabled_mini_filters: string[]
+    show_only_matching: boolean
+    group_repeated_items: boolean
+    tracked_window: number | null
+}
+
+export interface InspectorExportDocument {
+    recording_id: string
+    exported_at: string
+    filter_context: InspectorExportFilterContext
+    truncated_logs: boolean
+    row_count: number
+    item_count: number
+    rows: InspectorExportRow[]
+}
+
+interface BuildInspectorExportDocumentParams {
+    sessionRecordingId: string
+    exportedAt: string
+    items: InspectorListItem[]
+    displayGroups: DisplayGroup[]
+    searchQuery: string
+    miniFilters: SharedListMiniFilter[]
+    showOnlyMatching: boolean
+    groupRepeatedItems: boolean
+    trackedWindow: number | null
+    logsHasMore: boolean
+}
+
+interface BuildInspectorExportRowParams {
+    items: InspectorListItem[]
+    displayGroup: DisplayGroup
+}
+
+function definedRecord(record: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined))
+}
+
+function formatTimestamp(item: InspectorListItem): string {
+    return item.timestamp.toISOString()
+}
+
+function formatTimeInRecording(milliseconds: number): string {
+    const totalSeconds = Math.max(Math.floor(milliseconds / 1000), 0)
+    const minutes = Math.floor(totalSeconds / 60)
+    const seconds = totalSeconds % 60
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}
+
+function eventLabel(item: Extract<InspectorListItem, { type: 'events' }>): string {
+    const eventName = item.data.event ?? 'Event'
+    const eventDisplayName = getCoreFilterDefinition(eventName, TaxonomicFilterGroupType.Events)?.label ?? eventName
+    const description = eventToDescription(item.data)
+    return [eventDisplayName, description].filter(Boolean).join(' ')
+}
+
+function itemLabel(item: InspectorListItem): string {
+    switch (item.type) {
+        case 'events':
+            return eventLabel(item)
+        case 'console':
+            return item.data.content
+        case 'network': {
+            const prefix = item.data.entry_type === 'navigation' ? 'Navigated to' : item.data.method
+            return [prefix, item.data.name].filter(Boolean).join(' ') || 'Network event'
+        }
+        case 'comment':
+            return item.source === 'notebook' ? item.data.comment : item.data.content || 'Comment'
+        case 'doctor':
+            return item.tag
+        case 'logs':
+            return `${item.data.level}: ${item.data.body}`
+        case 'app-state':
+            return item.action
+        case 'offline-status':
+            return item.offline ? 'Browser went offline' : 'Browser returned online'
+        case 'browser-visibility':
+            return `Window became ${item.status}`
+        case 'session-change':
+            return item.tag === '$session_starting' ? 'Previous session available' : 'Next session available'
+        case 'inactivity':
+            return `${humanFriendlyDuration(item.durationMs / 1000)} of inactivity`
+        case 'inspector-summary':
+            return `${item.clickCount ?? 0} clicks, ${item.keypressCount ?? 0} keystrokes, ${
+                item.errorCount ?? 0
+            } errors`
+    }
+}
+
+function itemDetails(item: InspectorListItem): Record<string, unknown> {
+    switch (item.type) {
+        case 'events':
+            return definedRecord({
+                event: item.data.event,
+                event_id: item.data.id,
+                distinct_id: item.data.distinct_id,
+                properties: item.data.properties,
+                fully_loaded: item.data.fullyLoaded,
+            })
+        case 'console':
+            return definedRecord({
+                level: item.data.level,
+                content: item.data.content,
+                lines: item.data.lines,
+                trace: item.data.trace,
+                repeat_count: item.data.count,
+            })
+        case 'network':
+            return definedRecord({
+                entry_type: item.data.entry_type,
+                initiator_type: item.data.initiator_type,
+                method: item.data.method,
+                name: item.data.name,
+                current_url: item.data.current_url,
+                response_status: item.data.response_status,
+                start_time: item.data.start_time ?? item.data.fetch_start,
+                duration: item.data.duration,
+                end_time: item.data.end_time,
+                transfer_size: item.data.transfer_size,
+                decoded_body_size: item.data.decoded_body_size,
+                encoded_body_size: item.data.encoded_body_size,
+                request_headers: item.data.request_headers,
+                response_headers: item.data.response_headers,
+                request_body: item.data.request_body,
+                response_body: item.data.response_body,
+            })
+        case 'comment':
+            return item.source === 'notebook'
+                ? definedRecord({
+                      source: item.source,
+                      comment: item.data.comment,
+                      notebook_short_id: item.data.notebookShortId,
+                      notebook_title: item.data.notebookTitle,
+                  })
+                : definedRecord({
+                      source: item.source,
+                      content: item.data.content,
+                      created_by: item.data.created_by
+                          ? {
+                                id: item.data.created_by.id,
+                                email: item.data.created_by.email,
+                                first_name: item.data.created_by.first_name,
+                                last_name: item.data.created_by.last_name,
+                            }
+                          : undefined,
+                  })
+        case 'doctor':
+            return definedRecord({ tag: item.tag, data: item.data })
+        case 'logs':
+            return definedRecord({
+                level: item.data.level,
+                severity_text: item.data.severity_text,
+                severity_number: item.data.severity_number,
+                body: item.data.body,
+                attributes: item.data.attributes,
+                resource_attributes: item.data.resource_attributes,
+                instrumentation_scope: item.data.instrumentation_scope,
+                trace_id: item.data.trace_id,
+                span_id: item.data.span_id,
+            })
+        case 'app-state':
+            return definedRecord({ action: item.action, state_event: item.stateEvent })
+        case 'offline-status':
+            return { offline: item.offline }
+        case 'browser-visibility':
+            return { status: item.status }
+        case 'session-change':
+            return definedRecord({
+                tag: item.tag,
+                previous_session_id: item.data.previousSessionId,
+                next_session_id: item.data.nextSessionId,
+                change_reason: item.data.changeReason,
+            })
+        case 'inactivity':
+            return { duration_ms: item.durationMs }
+        case 'inspector-summary':
+            return {
+                click_count: item.clickCount,
+                keypress_count: item.keypressCount,
+                error_count: item.errorCount,
+            }
+    }
+}
+
+export function buildInspectorExportItem(item: InspectorListItem): InspectorExportItem {
+    const exportItem: InspectorExportItem = {
+        key: item.key,
+        type: item.type,
+        timestamp: formatTimestamp(item),
+        time_in_recording_ms: item.timeInRecording,
+        label: itemLabel(item),
+        search: item.search,
+        details: itemDetails(item),
+    }
+
+    if (item.windowId !== undefined) {
+        exportItem.window_id = item.windowId
+    }
+    if (item.windowNumber !== undefined) {
+        exportItem.window_number = item.windowNumber
+    }
+    if (item.highlightColor !== undefined) {
+        exportItem.highlight = item.highlightColor
+    }
+
+    return exportItem
+}
+
+export function buildInspectorExportRow({
+    items,
+    displayGroup,
+}: BuildInspectorExportRowParams): InspectorExportRow | null {
+    const groupedItems = displayGroup.indices.map((index) => items[index]).filter((item) => !!item)
+    const firstItem = groupedItems[0]
+
+    if (!firstItem) {
+        return null
+    }
+
+    const row: InspectorExportRow = {
+        ...buildInspectorExportItem(firstItem),
+        group_count: groupedItems.length,
+    }
+
+    if (groupedItems.length > 1) {
+        row.items = groupedItems.map(buildInspectorExportItem)
+    }
+
+    return row
+}
+
+export function buildInspectorExportDocument({
+    sessionRecordingId,
+    exportedAt,
+    items,
+    displayGroups,
+    searchQuery,
+    miniFilters,
+    showOnlyMatching,
+    groupRepeatedItems,
+    trackedWindow,
+    logsHasMore,
+}: BuildInspectorExportDocumentParams): InspectorExportDocument {
+    const rows = displayGroups.flatMap((displayGroup) => {
+        const row = buildInspectorExportRow({ items, displayGroup })
+        return row ? [row] : []
+    })
+
+    return {
+        recording_id: sessionRecordingId,
+        exported_at: exportedAt,
+        filter_context: {
+            search_query: searchQuery,
+            enabled_mini_filters: miniFilters.filter((filter) => !!filter.enabled).map((filter) => filter.key),
+            show_only_matching: showOnlyMatching,
+            group_repeated_items: groupRepeatedItems,
+            tracked_window: trackedWindow,
+        },
+        truncated_logs: logsHasMore,
+        row_count: rows.length,
+        item_count: rows.reduce((count, row) => count + row.group_count, 0),
+        rows,
+    }
+}
+
+function formatInspectorExportRowForClipboard(row: InspectorExportRow): string {
+    const metadata = [
+        row.window_number != null ? `window ${row.window_number}` : null,
+        row.highlight ? row.highlight : null,
+        row.group_count > 1 ? `${row.group_count} items` : null,
+    ].filter(Boolean)
+
+    const title = `[${formatTimeInRecording(row.time_in_recording_ms)}] ${row.type}: ${row.label}`
+    const metadataText = metadata.length ? ` (${metadata.join(', ')})` : ''
+
+    if (!row.items?.length) {
+        return `${title}${metadataText}`
+    }
+
+    const childRows = row.items
+        .map((item) => `  - [${formatTimeInRecording(item.time_in_recording_ms)}] ${item.label}`)
+        .join('\n')
+
+    return `${title}${metadataText}\n${childRows}`
+}
+
+export function stringifyInspectorExportDocument(document: InspectorExportDocument): string {
+    const seen = new WeakSet<object>()
+    const replacer = (_key: string, value: unknown): unknown => {
+        if (typeof value === 'bigint') {
+            return value.toString()
+        }
+        if (typeof value === 'object' && value !== null) {
+            if (seen.has(value)) {
+                return '[Circular]'
+            }
+            seen.add(value)
+        }
+        return value
+    }
+    return JSON.stringify(document, replacer, 2)
+}
+
+export function formatInspectorExportDocumentForClipboard(document: InspectorExportDocument): string {
+    const exportedAt = dayjs(document.exported_at).format('YYYY-MM-DD HH:mm:ss')
+    const truncatedLogsLine = document.truncated_logs
+        ? '\nNote: Backend logs are truncated because more logs are available.'
+        : ''
+
+    return [
+        `Session replay inspector for recording ${document.recording_id}`,
+        `Exported at ${exportedAt}`,
+        `${document.row_count} rows, ${document.item_count} items${truncatedLogsLine}`,
+        '',
+        document.rows.map(formatInspectorExportRowForClipboard).join('\n'),
+    ].join('\n')
+}

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -10,12 +10,15 @@ import {
     pluginEvent,
 } from 'posthog-js/rrweb-types'
 
+import { lemonToast } from '@posthog/lemon-ui'
+
 import api from 'lib/api'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { Dayjs, dayjs } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { ceilMsToClosestSecond, eventToDescription, humanizeBytes, toParams } from 'lib/utils'
+import { ceilMsToClosestSecond, downloadFile, eventToDescription, humanizeBytes, toParams } from 'lib/utils'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { getText } from 'scenes/comments/Comment'
 import {
@@ -50,6 +53,11 @@ import {
     SessionRecordingPlayerLogicProps,
     sessionRecordingPlayerLogic,
 } from '../sessionRecordingPlayerLogic'
+import {
+    buildInspectorExportDocument,
+    formatInspectorExportDocumentForClipboard,
+    stringifyInspectorExportDocument,
+} from './playerInspectorExport'
 import type { playerInspectorLogicType } from './playerInspectorLogicType'
 import { playerInspectorLogsLogic } from './playerInspectorLogsLogic'
 
@@ -344,7 +352,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             miniFiltersLogic,
             ['setMiniFilter', 'setSearchQuery'],
             sessionRecordingEventUsageLogic,
-            ['reportRecordingInspectorItemExpanded'],
+            ['reportRecordingInspectorCopyExported', 'reportRecordingInspectorItemExpanded'],
             sessionRecordingDataCoordinatorLogic(props),
             ['loadFullEventData', 'setTrackedWindow', 'registerWindowId', 'loadEventsSuccess'],
             sessionRecordingPlayerLogic(props),
@@ -401,6 +409,9 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
         ],
     })),
     actions(() => ({
+        copyInspectorRow: (index: number) => ({ index }),
+        copyVisibleInspectorRows: true,
+        exportVisibleInspectorRowsJson: true,
         setItemExpanded: (index: number, expanded: boolean) => ({ index, expanded }),
         setSyncScrollPaused: (paused: boolean) => ({ paused }),
     })),
@@ -1443,7 +1454,118 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             (allItemsByItemType): boolean => allItemsByItemType['events']?.length > 0,
         ],
     })),
-    listeners(({ values, actions }) => ({
+    listeners(({ values, actions, props }) => ({
+        copyInspectorRow: async ({ index }) => {
+            const displayGroup = values.displayGroups[index]
+            if (!displayGroup) {
+                return
+            }
+
+            const document = buildInspectorExportDocument({
+                sessionRecordingId: props.sessionRecordingId,
+                exportedAt: dayjs().toISOString(),
+                items: values.items,
+                displayGroups: [displayGroup],
+                searchQuery: values.searchQuery,
+                miniFilters: values.miniFilters,
+                showOnlyMatching: values.showOnlyMatching,
+                groupRepeatedItems: values.groupRepeatedItems,
+                trackedWindow: values.trackedWindow,
+                logsHasMore: values.logsHasMore,
+            })
+
+            const copied = await copyToClipboard(formatInspectorExportDocumentForClipboard(document), 'inspector row')
+            if (!copied) {
+                return
+            }
+
+            actions.reportRecordingInspectorCopyExported({
+                action: 'copy_row',
+                format: 'text',
+                row_count: document.row_count,
+                item_count: document.item_count,
+                truncated_logs: document.truncated_logs,
+            })
+        },
+        copyVisibleInspectorRows: async () => {
+            if (!values.displayGroups.length) {
+                return
+            }
+
+            const document = buildInspectorExportDocument({
+                sessionRecordingId: props.sessionRecordingId,
+                exportedAt: dayjs().toISOString(),
+                items: values.items,
+                displayGroups: values.displayGroups,
+                searchQuery: values.searchQuery,
+                miniFilters: values.miniFilters,
+                showOnlyMatching: values.showOnlyMatching,
+                groupRepeatedItems: values.groupRepeatedItems,
+                trackedWindow: values.trackedWindow,
+                logsHasMore: values.logsHasMore,
+            })
+
+            const copied = await copyToClipboard(
+                formatInspectorExportDocumentForClipboard(document),
+                'visible inspector rows'
+            )
+            if (!copied) {
+                return
+            }
+
+            actions.reportRecordingInspectorCopyExported({
+                action: 'copy_visible_rows',
+                format: 'text',
+                row_count: document.row_count,
+                item_count: document.item_count,
+                truncated_logs: document.truncated_logs,
+            })
+        },
+        exportVisibleInspectorRowsJson: () => {
+            if (!values.displayGroups.length) {
+                return
+            }
+
+            const exportedAt = dayjs()
+            const document = buildInspectorExportDocument({
+                sessionRecordingId: props.sessionRecordingId,
+                exportedAt: exportedAt.toISOString(),
+                items: values.items,
+                displayGroups: values.displayGroups,
+                searchQuery: values.searchQuery,
+                miniFilters: values.miniFilters,
+                showOnlyMatching: values.showOnlyMatching,
+                groupRepeatedItems: values.groupRepeatedItems,
+                trackedWindow: values.trackedWindow,
+                logsHasMore: values.logsHasMore,
+            })
+            const filename = `replay-inspector-${props.sessionRecordingId}-${exportedAt.utc().format('YYYY-MM-DD-HHmmss')}Z.json`
+
+            try {
+                const file = new File([stringifyInspectorExportDocument(document)], filename, {
+                    type: 'application/json',
+                })
+                downloadFile(file)
+                actions.reportRecordingInspectorCopyExported({
+                    action: 'export_visible_rows_json',
+                    format: 'json',
+                    row_count: document.row_count,
+                    item_count: document.item_count,
+                    truncated_logs: document.truncated_logs,
+                })
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err)
+                lemonToast.error(`Could not export inspector rows: ${message}`)
+                actions.reportRecordingInspectorCopyExported({
+                    action: 'export_visible_rows_json',
+                    format: 'json',
+                    row_count: document.row_count,
+                    item_count: document.item_count,
+                    truncated_logs: document.truncated_logs,
+                    error: 'serialization_failed',
+                })
+            }
+        },
         setItemExpanded: ({ index, expanded }) => {
             if (expanded) {
                 const group = values.displayGroups[index]

--- a/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
@@ -36,6 +36,23 @@ interface RecordingViewedProps {
     snapshot_source: 'web' | 'mobile' | 'unknown'
 }
 
+type RecordingInspectorCopyExportAction = 'copy_row' | 'copy_visible_rows' | 'export_visible_rows_json'
+
+const RECORDING_INSPECTOR_COPY_EXPORT_EVENT_NAMES: Record<RecordingInspectorCopyExportAction, string> = {
+    copy_row: 'recording inspector row copied',
+    copy_visible_rows: 'recording inspector visible rows copied',
+    export_visible_rows_json: 'recording inspector visible rows exported',
+}
+
+export interface RecordingInspectorCopyExportProps {
+    action: RecordingInspectorCopyExportAction
+    format: 'text' | 'json'
+    row_count: number
+    item_count: number
+    truncated_logs: boolean
+    error?: 'serialization_failed'
+}
+
 export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLogicType>([
     path(['scenes', 'session-recordings', 'sessionRecordingEventUsageLogic']),
     connect(() => ({
@@ -63,6 +80,7 @@ export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLog
             minifilterKey,
             enabled,
         }),
+        reportRecordingInspectorCopyExported: (properties: RecordingInspectorCopyExportProps) => properties,
         reportNextRecordingTriggered: (automatic: boolean) => ({
             automatic,
         }),
@@ -145,6 +163,15 @@ export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLog
         },
         reportRecordingInspectorMiniFilterViewed: ({ minifilterKey, enabled }) => {
             posthog.capture('recording inspector minifilter selected', { tab: 'replay-4000', enabled, minifilterKey })
+        },
+        reportRecordingInspectorCopyExported: ({ action, format, row_count, item_count, truncated_logs, error }) => {
+            posthog.capture(RECORDING_INSPECTOR_COPY_EXPORT_EVENT_NAMES[action], {
+                format,
+                row_count,
+                item_count,
+                truncated_logs,
+                ...(error ? { error } : {}),
+            })
         },
         reportNextRecordingTriggered: ({ automatic }) => {
             posthog.capture('recording next recording triggered', { automatic })


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
When debugging problems / bugs, it's hard to export all of the logs for analysis. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a new copy / export button to the inspector logs

https://github.com/user-attachments/assets/616be92e-0f29-481d-af36-82bb97a639be


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
