### PR TITLE
feat(web-analytics): Add focus mode to Web Analytics

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -500,6 +500,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_DRAG_TO_ZOOM: 'web-analytics-drag-to-zoom', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_EMPTY_ONBOARDING: 'web-analytics-empty-onboarding', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_FILTERS_V2: 'web-analytics-filters-v2', // owner: @jordanm-posthog #team-web-analytics
+    WEB_ANALYTICS_FOCUS_MODE: 'web-analytics-focus-mode', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_HEALTH_TAB: 'web_analytics_health_tab', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_INCLUDE_HOST: 'web-analytics-include-host', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_LIVE_CITY_BREAKDOWN: 'web-analytics-live-city-breakdown', // owner: @jordanm-posthog #team-web-analytics

--- a/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.tsx
+++ b/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.tsx
@@ -116,7 +116,7 @@ export function EventFilterScene(): JSX.Element {
                 }
             }
         },
-        [filterForm.filter_tree, updateTreeNode, setFilterFormValue]
+        [filterForm.filter_tree, updateTreeNode, setFilterFormValue, nodeIds]
     )
 
     const activeNode = activeId ? getNodeAtPath(filterForm.filter_tree, nodeIds.pathOf(activeId) ?? []) : null

--- a/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconSearch } from '@posthog/icons'
+import { IconGear, IconSearch, IconTarget, IconX } from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
@@ -31,12 +31,25 @@ const ANALYTICS_TILES = [
 ]
 
 export const WebAnalyticsMenu = (): JSX.Element => {
-    const { shouldFilterTestAccounts, useWebAnalyticsPrecompute, hiddenTiles, productTab } =
-        useValues(webAnalyticsLogic)
+    const {
+        hasSavedFocusMode,
+        hiddenTiles,
+        isFocusModeActive,
+        productTab,
+        shouldFilterTestAccounts,
+        showFocusMode,
+        useWebAnalyticsPrecompute,
+    } = useValues(webAnalyticsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const { setShouldFilterTestAccounts, setUseWebAnalyticsPrecompute, setTileVisibility } =
-        useActions(webAnalyticsLogic)
+    const {
+        enterFocusMode,
+        exitFocusMode,
+        openFocusModeModal,
+        setShouldFilterTestAccounts,
+        setUseWebAnalyticsPrecompute,
+        setTileVisibility,
+    } = useActions(webAnalyticsLogic)
 
     const showTileToggles = featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_TOGGLES]
     const availableTiles = productTab === ProductTab.ANALYTICS ? ANALYTICS_TILES : []
@@ -47,6 +60,24 @@ export const WebAnalyticsMenu = (): JSX.Element => {
                 <Link to={urls.sessionAttributionExplorer()} buttonProps={{ menuItem: true }}>
                     <IconSearch /> Session Attribution Explorer
                 </Link>
+                {showFocusMode && (
+                    <ButtonPrimitive menuItem onClick={openFocusModeModal}>
+                        <IconGear />
+                        Focus mode settings...
+                    </ButtonPrimitive>
+                )}
+                {showFocusMode &&
+                    (isFocusModeActive ? (
+                        <ButtonPrimitive menuItem onClick={exitFocusMode}>
+                            <IconX />
+                            Exit focus mode
+                        </ButtonPrimitive>
+                    ) : hasSavedFocusMode ? (
+                        <ButtonPrimitive menuItem onClick={enterFocusMode}>
+                            <IconTarget />
+                            Enter focus mode
+                        </ButtonPrimitive>
+                    ) : null)}
             </ScenePanelActionsSection>
             <ScenePanelDivider />
             <ScenePanelActionsSection>

--- a/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
@@ -1,6 +1,9 @@
+import { useValues } from 'kea'
+
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
+import { FocusModeModal } from 'scenes/web-analytics/focus-mode/FocusModeModal'
 import { WebAnalyticsDashboard } from 'scenes/web-analytics/WebAnalyticsDashboard'
 import { WebAnalyticsHeaderButtons } from 'scenes/web-analytics/WebAnalyticsHeaderButtons'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
@@ -21,6 +24,7 @@ export function WebAnalyticsScene(): JSX.Element {
             'Diagnose my reverse proxy setup',
         ],
     })
+    const { showFocusMode } = useValues(webAnalyticsLogic)
 
     return (
         <>
@@ -36,6 +40,7 @@ export function WebAnalyticsScene(): JSX.Element {
                 />
                 <WebAnalyticsDashboard />
             </SceneContent>
+            {showFocusMode && <FocusModeModal />}
         </>
     )
 }

--- a/frontend/src/scenes/web-analytics/WebAnalyticsSceneMenuBar.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsSceneMenuBar.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconBolt, IconSearch } from '@posthog/icons'
+import { IconBolt, IconGear, IconSearch, IconTarget, IconX } from '@posthog/icons'
 import { Badge, Tooltip, TooltipContent, TooltipTrigger } from '@posthog/quill'
 
 import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
@@ -85,8 +85,10 @@ export function WebAnalyticsSceneMenuBar(): JSX.Element | null {
 }
 
 function WebAnalyticsSceneMenuBarInner(): JSX.Element {
-    const { shouldFilterTestAccounts, hiddenTiles, productTab } = useValues(webAnalyticsLogic)
-    const { setShouldFilterTestAccounts, setTileVisibility } = useActions(webAnalyticsLogic)
+    const { hasSavedFocusMode, hiddenTiles, isFocusModeActive, productTab, shouldFilterTestAccounts, showFocusMode } =
+        useValues(webAnalyticsLogic)
+    const { enterFocusMode, exitFocusMode, openFocusModeModal, setShouldFilterTestAccounts, setTileVisibility } =
+        useActions(webAnalyticsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { projectTreeRefEntry } = useValues(projectTreeDataLogic)
     const { currentTeam } = useValues(teamLogic)
@@ -144,6 +146,28 @@ function WebAnalyticsSceneMenuBarInner(): JSX.Element {
                     <IconSearch />
                     Session Attribution Explorer
                 </SceneMenuBarItem>
+                {showFocusMode && (
+                    <SceneMenuBarItem
+                        onClick={openFocusModeModal}
+                        data-attr="web-analytics-menubar-focus-mode-settings"
+                        opensFloatingUi
+                    >
+                        <IconGear />
+                        Focus mode settings
+                    </SceneMenuBarItem>
+                )}
+                {showFocusMode &&
+                    (isFocusModeActive ? (
+                        <SceneMenuBarItem onClick={exitFocusMode} data-attr="web-analytics-menubar-exit-focus-mode">
+                            <IconX />
+                            Exit focus mode
+                        </SceneMenuBarItem>
+                    ) : hasSavedFocusMode ? (
+                        <SceneMenuBarItem onClick={enterFocusMode} data-attr="web-analytics-menubar-enter-focus-mode">
+                            <IconTarget />
+                            Enter focus mode
+                        </SceneMenuBarItem>
+                    ) : null)}
                 <SceneMenuBarSeparator />
                 <SceneMenuBarCheckboxItem
                     checked={shouldFilterTestAccounts}
@@ -158,7 +182,7 @@ function WebAnalyticsSceneMenuBarInner(): JSX.Element {
                             <SceneMenuBarCheckboxItem
                                 key={tileId}
                                 checked={!hiddenTiles.includes(tileId)}
-                                onCheckedChange={(checked) => setTileVisibility(tileId, !checked)}
+                                onCheckedChange={(checked) => setTileVisibility(tileId, checked)}
                                 data-attr={`web-analytics-menubar-tile-${tileId}`}
                             >
                                 {TILE_LABELS[tileId]}

--- a/frontend/src/scenes/web-analytics/focus-mode/FocusModeModal.tsx
+++ b/frontend/src/scenes/web-analytics/focus-mode/FocusModeModal.tsx
@@ -1,0 +1,82 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { cn } from 'lib/utils/css-classes'
+import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
+
+import { CONCERN_ICONS, CONCERN_LABELS, CONCERN_ORDER, WebAnalyticsConcern } from './types'
+
+export function FocusModeModal(): JSX.Element {
+    const { focusModeModalOpen, focusModeDraftConcerns } = useValues(webAnalyticsLogic)
+    const { closeFocusModeModal, toggleFocusModeConcern, applyFocusMode } = useActions(webAnalyticsLogic)
+    const canApply = focusModeDraftConcerns.length > 0
+
+    return (
+        <LemonModal
+            isOpen={focusModeModalOpen}
+            onClose={closeFocusModeModal}
+            title="Focus mode"
+            description="Choose the areas you want to keep visible."
+            footer={
+                <div className="flex justify-end w-full gap-2">
+                    <LemonButton type="secondary" onClick={closeFocusModeModal}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={applyFocusMode}
+                        disabledReason={canApply ? undefined : 'Choose at least one area'}
+                        data-attr="focus-mode-apply"
+                    >
+                        Save and apply
+                    </LemonButton>
+                </div>
+            }
+        >
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                {CONCERN_ORDER.map((concern) => (
+                    <SelectableConcern
+                        key={concern}
+                        concern={concern}
+                        selected={focusModeDraftConcerns.includes(concern)}
+                        onClick={() => toggleFocusModeConcern(concern)}
+                    />
+                ))}
+            </div>
+        </LemonModal>
+    )
+}
+
+interface SelectableConcernProps {
+    concern: WebAnalyticsConcern
+    selected: boolean
+    onClick: () => void
+}
+
+function SelectableConcern({ concern, selected, onClick }: SelectableConcernProps): JSX.Element {
+    const Icon = CONCERN_ICONS[concern]
+
+    return (
+        <button
+            type="button"
+            aria-pressed={selected}
+            aria-label={CONCERN_LABELS[concern]}
+            onClick={onClick}
+            data-attr={`focus-mode-concern-${concern}`}
+            className={cn(
+                'group relative flex min-h-24 flex-col items-center gap-2 rounded border-2 p-3 text-center transition-colors',
+                'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+                selected
+                    ? 'border-accent bg-accent-highlight-secondary'
+                    : 'border-border-primary bg-surface-primary hover:border-accent/40 hover:bg-surface-secondary'
+            )}
+        >
+            <Icon
+                fontSize={32}
+                className={cn('shrink-0', selected ? 'text-accent' : 'text-secondary group-hover:text-primary')}
+            />
+            <div className="text-sm font-semibold leading-tight">{CONCERN_LABELS[concern]}</div>
+        </button>
+    )
+}

--- a/frontend/src/scenes/web-analytics/focus-mode/focusModeMapping.test.ts
+++ b/frontend/src/scenes/web-analytics/focus-mode/focusModeMapping.test.ts
@@ -1,0 +1,57 @@
+import { TileId } from 'scenes/web-analytics/common'
+
+import { FOCUS_MODE_TILE_IDS, getHiddenTilesForFocusConcerns, getTilesForFocusConcerns } from './focusModeMapping'
+import { WebAnalyticsConcern } from './types'
+
+describe('getTilesForFocusConcerns', () => {
+    it('always includes OVERVIEW as the headline tile', () => {
+        expect(getTilesForFocusConcerns([])).toContain(TileId.OVERVIEW)
+    })
+
+    it('maps traffic concern to OVERVIEW and GRAPHS', () => {
+        const result = getTilesForFocusConcerns([WebAnalyticsConcern.TRAFFIC])
+        expect(result).toEqual(new Set([TileId.OVERVIEW, TileId.GRAPHS]))
+    })
+
+    it('maps engagement concern to ACTIVE_HOURS and REPLAY', () => {
+        const result = getTilesForFocusConcerns([WebAnalyticsConcern.ENGAGEMENT])
+        expect(result).toEqual(new Set([TileId.OVERVIEW, TileId.ACTIVE_HOURS, TileId.REPLAY]))
+    })
+
+    it('maps errors concern to ERROR_TRACKING and FRUSTRATING_PAGES', () => {
+        const result = getTilesForFocusConcerns([WebAnalyticsConcern.ERRORS])
+        expect(result).toEqual(new Set([TileId.OVERVIEW, TileId.ERROR_TRACKING, TileId.FRUSTRATING_PAGES]))
+    })
+
+    it('unions multiple concerns without duplicates', () => {
+        const result = getTilesForFocusConcerns([
+            WebAnalyticsConcern.TRAFFIC,
+            WebAnalyticsConcern.SOURCES,
+            WebAnalyticsConcern.PATHS,
+        ])
+        expect(result).toEqual(new Set([TileId.OVERVIEW, TileId.GRAPHS, TileId.SOURCES, TileId.PATHS]))
+    })
+
+    it('returns hidden focus tiles for the selected concerns', () => {
+        expect(getHiddenTilesForFocusConcerns([WebAnalyticsConcern.RETENTION])).toEqual(
+            FOCUS_MODE_TILE_IDS.filter((tileId) => ![TileId.OVERVIEW, TileId.RETENTION].includes(tileId))
+        )
+    })
+
+    it('lists the analytics tiles focus mode can hide', () => {
+        expect(FOCUS_MODE_TILE_IDS).toEqual([
+            TileId.OVERVIEW,
+            TileId.GRAPHS,
+            TileId.PATHS,
+            TileId.SOURCES,
+            TileId.DEVICES,
+            TileId.GEOGRAPHY,
+            TileId.ACTIVE_HOURS,
+            TileId.RETENTION,
+            TileId.GOALS,
+            TileId.REPLAY,
+            TileId.ERROR_TRACKING,
+            TileId.FRUSTRATING_PAGES,
+        ])
+    })
+})

--- a/frontend/src/scenes/web-analytics/focus-mode/focusModeMapping.ts
+++ b/frontend/src/scenes/web-analytics/focus-mode/focusModeMapping.ts
@@ -1,0 +1,45 @@
+import { TileId } from 'scenes/web-analytics/common'
+
+import { WebAnalyticsConcern } from './types'
+
+const CONCERN_TILES: Record<WebAnalyticsConcern, TileId[]> = {
+    [WebAnalyticsConcern.TRAFFIC]: [TileId.OVERVIEW, TileId.GRAPHS],
+    [WebAnalyticsConcern.SOURCES]: [TileId.SOURCES],
+    [WebAnalyticsConcern.PATHS]: [TileId.PATHS],
+    [WebAnalyticsConcern.GEOGRAPHY]: [TileId.GEOGRAPHY],
+    [WebAnalyticsConcern.DEVICES]: [TileId.DEVICES],
+    [WebAnalyticsConcern.RETENTION]: [TileId.RETENTION],
+    [WebAnalyticsConcern.GOALS_CONVERSIONS]: [TileId.GOALS],
+    [WebAnalyticsConcern.ENGAGEMENT]: [TileId.ACTIVE_HOURS, TileId.REPLAY],
+    [WebAnalyticsConcern.ERRORS]: [TileId.ERROR_TRACKING, TileId.FRUSTRATING_PAGES],
+}
+
+export const FOCUS_MODE_TILE_IDS: TileId[] = [
+    TileId.OVERVIEW,
+    TileId.GRAPHS,
+    TileId.PATHS,
+    TileId.SOURCES,
+    TileId.DEVICES,
+    TileId.GEOGRAPHY,
+    TileId.ACTIVE_HOURS,
+    TileId.RETENTION,
+    TileId.GOALS,
+    TileId.REPLAY,
+    TileId.ERROR_TRACKING,
+    TileId.FRUSTRATING_PAGES,
+]
+
+export const getTilesForFocusConcerns = (concerns: WebAnalyticsConcern[]): Set<TileId> => {
+    const tiles = new Set<TileId>([TileId.OVERVIEW])
+    for (const concern of concerns) {
+        for (const tileId of CONCERN_TILES[concern]) {
+            tiles.add(tileId)
+        }
+    }
+    return tiles
+}
+
+export const getHiddenTilesForFocusConcerns = (concerns: WebAnalyticsConcern[]): TileId[] => {
+    const visibleTiles = getTilesForFocusConcerns(concerns)
+    return FOCUS_MODE_TILE_IDS.filter((tileId) => !visibleTiles.has(tileId))
+}

--- a/frontend/src/scenes/web-analytics/focus-mode/focusModeMapping.ts
+++ b/frontend/src/scenes/web-analytics/focus-mode/focusModeMapping.ts
@@ -43,3 +43,10 @@ export const getHiddenTilesForFocusConcerns = (concerns: WebAnalyticsConcern[]):
     const visibleTiles = getTilesForFocusConcerns(concerns)
     return FOCUS_MODE_TILE_IDS.filter((tileId) => !visibleTiles.has(tileId))
 }
+
+export const computeFocusHiddenTiles = (currentHiddenTiles: TileId[], concerns: WebAnalyticsConcern[]): TileId[] => {
+    const focusModeTileSet = new Set<TileId>(FOCUS_MODE_TILE_IDS)
+    const nonFocusHiddenTiles = currentHiddenTiles.filter((tileId) => !focusModeTileSet.has(tileId))
+    const focusHiddenTiles = getHiddenTilesForFocusConcerns(concerns)
+    return [...nonFocusHiddenTiles, ...focusHiddenTiles]
+}

--- a/frontend/src/scenes/web-analytics/focus-mode/types.ts
+++ b/frontend/src/scenes/web-analytics/focus-mode/types.ts
@@ -1,0 +1,61 @@
+import {
+    IconComponent,
+    IconGlobe,
+    IconLaptop,
+    IconPlay,
+    IconProps,
+    IconRetention,
+    IconShare,
+    IconTarget,
+    IconTrends,
+    IconUserPaths,
+    IconWarning,
+} from '@posthog/icons'
+
+export enum WebAnalyticsConcern {
+    TRAFFIC = 'traffic',
+    SOURCES = 'sources',
+    PATHS = 'paths',
+    GEOGRAPHY = 'geography',
+    DEVICES = 'devices',
+    RETENTION = 'retention',
+    GOALS_CONVERSIONS = 'goals_conversions',
+    ENGAGEMENT = 'engagement',
+    ERRORS = 'errors',
+}
+
+export const CONCERN_LABELS: Record<WebAnalyticsConcern, string> = {
+    [WebAnalyticsConcern.TRAFFIC]: 'Traffic & visitors',
+    [WebAnalyticsConcern.SOURCES]: 'Where visitors come from',
+    [WebAnalyticsConcern.PATHS]: 'Pages they land on and leave from',
+    [WebAnalyticsConcern.GEOGRAPHY]: 'Where in the world',
+    [WebAnalyticsConcern.DEVICES]: 'Devices and browsers',
+    [WebAnalyticsConcern.RETENTION]: 'Whether they come back',
+    [WebAnalyticsConcern.GOALS_CONVERSIONS]: 'Goals & conversions',
+    [WebAnalyticsConcern.ENGAGEMENT]: 'Engagement & session replay',
+    [WebAnalyticsConcern.ERRORS]: 'Errors & frustration',
+}
+
+export const CONCERN_ORDER: WebAnalyticsConcern[] = [
+    WebAnalyticsConcern.TRAFFIC,
+    WebAnalyticsConcern.SOURCES,
+    WebAnalyticsConcern.PATHS,
+    WebAnalyticsConcern.GEOGRAPHY,
+    WebAnalyticsConcern.DEVICES,
+    WebAnalyticsConcern.RETENTION,
+    WebAnalyticsConcern.GOALS_CONVERSIONS,
+    WebAnalyticsConcern.ENGAGEMENT,
+    WebAnalyticsConcern.ERRORS,
+]
+
+export const CONCERN_ICONS: Record<WebAnalyticsConcern, IconComponent<IconProps>> = {
+    [WebAnalyticsConcern.TRAFFIC]: IconTrends,
+    [WebAnalyticsConcern.SOURCES]: IconShare,
+    [WebAnalyticsConcern.PATHS]: IconUserPaths,
+    [WebAnalyticsConcern.GEOGRAPHY]: IconGlobe,
+    [WebAnalyticsConcern.DEVICES]: IconLaptop,
+    [WebAnalyticsConcern.RETENTION]: IconRetention,
+    [WebAnalyticsConcern.GOALS_CONVERSIONS]: IconTarget,
+    [WebAnalyticsConcern.ENGAGEMENT]: IconPlay,
+    [WebAnalyticsConcern.ERRORS]: IconWarning,
+}

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.test.ts
@@ -97,6 +97,23 @@ describe('webAnalyticsLogic focus mode', () => {
         })
     })
 
+    it('exits focus mode and preserves manually-hidden non-focus tiles', async () => {
+        enableFocusMode()
+        logic.actions.setTileVisibility(TileId.WEB_VITALS, false)
+        logic.actions.openFocusModeModal()
+        logic.actions.toggleFocusModeConcern(WebAnalyticsConcern.RETENTION)
+        logic.actions.applyFocusMode()
+
+        await expectLogic(logic, () => {
+            logic.actions.exitFocusMode()
+        }).toMatchValues({
+            focusModeConcerns: [WebAnalyticsConcern.RETENTION],
+            focusModeEnabled: false,
+            hiddenTiles: [TileId.WEB_VITALS],
+            isFocusModeActive: false,
+        })
+    })
+
     it('re-enters focus mode using saved concerns', async () => {
         enableFocusMode()
         logic.actions.setFocusModeConcerns([WebAnalyticsConcern.RETENTION])

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.test.ts
@@ -1,0 +1,132 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import { ProductTab, TileId } from './common'
+import { FOCUS_MODE_TILE_IDS } from './focus-mode/focusModeMapping'
+import { WebAnalyticsConcern } from './focus-mode/types'
+import { webAnalyticsLogic } from './webAnalyticsLogic'
+
+describe('webAnalyticsLogic focus mode', () => {
+    let logic: ReturnType<typeof webAnalyticsLogic.build>
+
+    const enableFocusMode = (): void => {
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.WEB_ANALYTICS_FOCUS_MODE], {
+            [FEATURE_FLAGS.WEB_ANALYTICS_FOCUS_MODE]: true,
+        })
+    }
+
+    beforeEach(() => {
+        localStorage.clear()
+        initKeaTests()
+        jest.spyOn(api.propertyDefinitions, 'list').mockResolvedValue({ results: [] } as any)
+        jest.spyOn(api.hogFunctions, 'list').mockResolvedValue({ results: [] } as any)
+        featureFlagLogic.mount()
+        logic = webAnalyticsLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        jest.restoreAllMocks()
+    })
+
+    it('applies selected concerns by updating hiddenTiles', async () => {
+        enableFocusMode()
+        logic.actions.openFocusModeModal()
+        logic.actions.toggleFocusModeConcern(WebAnalyticsConcern.RETENTION)
+
+        await expectLogic(logic, () => {
+            logic.actions.applyFocusMode()
+        }).toMatchValues({
+            focusModeConcerns: [WebAnalyticsConcern.RETENTION],
+            focusModeEnabled: true,
+            focusModeModalOpen: false,
+            hiddenTiles: FOCUS_MODE_TILE_IDS.filter((tileId) => ![TileId.OVERVIEW, TileId.RETENTION].includes(tileId)),
+            isFocusModeActive: true,
+        })
+    })
+
+    it('does not apply focus mode with an empty selection', async () => {
+        enableFocusMode()
+        logic.actions.setTileVisibility(TileId.GRAPHS, false)
+        logic.actions.openFocusModeModal()
+
+        await expectLogic(logic, () => {
+            logic.actions.applyFocusMode()
+        }).toMatchValues({
+            focusModeConcerns: [],
+            focusModeEnabled: false,
+            focusModeModalOpen: true,
+            hiddenTiles: [TileId.GRAPHS],
+            isFocusModeActive: false,
+        })
+    })
+
+    it('uses saved concerns when reopening focus mode settings', async () => {
+        enableFocusMode()
+        logic.actions.openFocusModeModal()
+        logic.actions.toggleFocusModeConcern(WebAnalyticsConcern.RETENTION)
+        logic.actions.applyFocusMode()
+
+        await expectLogic(logic, () => {
+            logic.actions.openFocusModeModal()
+        }).toMatchValues({
+            focusModeDraftConcerns: [WebAnalyticsConcern.RETENTION],
+            focusModeModalOpen: true,
+        })
+    })
+
+    it('exits focus mode without clearing saved concerns', async () => {
+        enableFocusMode()
+        logic.actions.openFocusModeModal()
+        logic.actions.toggleFocusModeConcern(WebAnalyticsConcern.RETENTION)
+        logic.actions.applyFocusMode()
+
+        await expectLogic(logic, () => {
+            logic.actions.exitFocusMode()
+        }).toMatchValues({
+            focusModeConcerns: [WebAnalyticsConcern.RETENTION],
+            focusModeEnabled: false,
+            hiddenTiles: [],
+            isFocusModeActive: false,
+        })
+    })
+
+    it('re-enters focus mode using saved concerns', async () => {
+        enableFocusMode()
+        logic.actions.setFocusModeConcerns([WebAnalyticsConcern.RETENTION])
+
+        await expectLogic(logic, () => {
+            logic.actions.enterFocusMode()
+        }).toMatchValues({
+            focusModeConcerns: [WebAnalyticsConcern.RETENTION],
+            focusModeEnabled: true,
+            hiddenTiles: FOCUS_MODE_TILE_IDS.filter((tileId) => ![TileId.OVERVIEW, TileId.RETENTION].includes(tileId)),
+            isFocusModeActive: true,
+        })
+    })
+
+    it('resetTileVisibility restores all tiles', async () => {
+        logic.actions.setFocusModeEnabled(true)
+        logic.actions.setTileVisibility(TileId.GRAPHS, false)
+
+        await expectLogic(logic, () => {
+            logic.actions.resetTileVisibility()
+        }).toMatchValues({
+            focusModeEnabled: false,
+            hiddenTiles: [],
+        })
+    })
+
+    it('hides focus mode when the feature flag is off', async () => {
+        await expectLogic(logic).toMatchValues({
+            productTab: ProductTab.ANALYTICS,
+            showFocusMode: false,
+        })
+    })
+})

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -118,6 +118,8 @@ import {
     convertCurrentURLFilter,
     hasURLSearchParams,
 } from './constants'
+import { FOCUS_MODE_TILE_IDS, getHiddenTilesForFocusConcerns } from './focus-mode/focusModeMapping'
+import { WebAnalyticsConcern } from './focus-mode/types'
 import { webAnalyticsHealthLogic } from './health'
 import { IncludeHostToggle } from './IncludeHostToggle'
 import { getDashboardItemId, getNewInsightUrlFactory } from './insightsUtils'
@@ -230,7 +232,17 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         setWebVitalsTab: (tab: WebVitalsMetric) => ({ tab }),
         setTileVisualization: (tileId: TileId, visualization: TileVisualizationOption) => ({ tileId, visualization }),
         setTileVisibility: (tileId: TileId, visible: boolean) => ({ tileId, visible }),
+        setHiddenTiles: (hiddenTiles: TileId[]) => ({ hiddenTiles }),
         resetTileVisibility: () => true,
+        openFocusModeModal: true,
+        closeFocusModeModal: true,
+        setFocusModeConcerns: (concerns: WebAnalyticsConcern[]) => ({ concerns }),
+        setFocusModeDraftConcerns: (concerns: WebAnalyticsConcern[]) => ({ concerns }),
+        setFocusModeEnabled: (enabled: boolean) => ({ enabled }),
+        toggleFocusModeConcern: (concern: WebAnalyticsConcern) => ({ concern }),
+        enterFocusMode: true,
+        exitFocusMode: true,
+        applyFocusMode: true,
         zoomIntoPeriod: (dateFrom: string, dateTo: string) => ({ dateFrom, dateTo }),
         resetZoom: true,
         setPreZoomDateFilter: (
@@ -508,7 +520,40 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         }
                         return state.includes(tileId) ? state : [...state, tileId]
                     },
+                    setHiddenTiles: (_, { hiddenTiles }) => hiddenTiles,
                     resetTileVisibility: () => [],
+                },
+            ],
+            focusModeModalOpen: [
+                false,
+                {
+                    openFocusModeModal: () => true,
+                    closeFocusModeModal: () => false,
+                    setProductTab: (state, { tab }) => (tab === ProductTab.ANALYTICS ? state : false),
+                },
+            ],
+            focusModeConcerns: [
+                [] as WebAnalyticsConcern[],
+                persistConfig,
+                {
+                    setFocusModeConcerns: (_, { concerns }) => concerns,
+                },
+            ],
+            focusModeEnabled: [
+                false,
+                persistConfig,
+                {
+                    setFocusModeEnabled: (_, { enabled }) => enabled,
+                    resetTileVisibility: () => false,
+                },
+            ],
+            focusModeDraftConcerns: [
+                [] as WebAnalyticsConcern[],
+                {
+                    setFocusModeDraftConcerns: (_, { concerns }) => concerns,
+                    closeFocusModeModal: () => [],
+                    toggleFocusModeConcern: (state, { concern }) =>
+                        state.includes(concern) ? state.filter((item) => item !== concern) : [...state, concern],
                 },
             ],
         }
@@ -923,6 +968,20 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         ],
     }),
     selectors(({ actions }) => ({
+        showFocusMode: [
+            (s) => [s.featureFlags, s.productTab],
+            (featureFlags, productTab: ProductTab): boolean =>
+                !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_FOCUS_MODE] && productTab === ProductTab.ANALYTICS,
+        ],
+        hasSavedFocusMode: [
+            (s) => [s.focusModeConcerns],
+            (focusModeConcerns: WebAnalyticsConcern[]): boolean => focusModeConcerns.length > 0,
+        ],
+        isFocusModeActive: [
+            (s) => [s.showFocusMode, s.focusModeEnabled, s.focusModeConcerns],
+            (showFocusMode: boolean, focusModeEnabled: boolean, focusModeConcerns: WebAnalyticsConcern[]): boolean =>
+                showFocusMode && focusModeEnabled && focusModeConcerns.length > 0,
+        ],
         tiles: [
             (s) => [
                 s.productTab,
@@ -2765,6 +2824,35 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 if (tab === ProductTab.BOT_ANALYTICS && values.dateFilter.dateFrom === INITIAL_DATE_FROM) {
                     actions.setDates('-1d', null)
                 }
+            },
+            openFocusModeModal: () => {
+                actions.setFocusModeDraftConcerns(values.focusModeConcerns)
+            },
+            enterFocusMode: () => {
+                if (!values.showFocusMode || values.focusModeConcerns.length === 0) {
+                    return
+                }
+                const focusModeTileSet = new Set<TileId>(FOCUS_MODE_TILE_IDS)
+                const nonFocusHiddenTiles = values.hiddenTiles.filter((tileId) => !focusModeTileSet.has(tileId))
+                const focusHiddenTiles = getHiddenTilesForFocusConcerns(values.focusModeConcerns)
+                actions.setHiddenTiles([...nonFocusHiddenTiles, ...focusHiddenTiles])
+                actions.setFocusModeEnabled(true)
+            },
+            exitFocusMode: () => {
+                actions.resetTileVisibility()
+                actions.setFocusModeEnabled(false)
+            },
+            applyFocusMode: () => {
+                if (!values.showFocusMode || values.focusModeDraftConcerns.length === 0) {
+                    return
+                }
+                actions.setFocusModeConcerns(values.focusModeDraftConcerns)
+                const focusModeTileSet = new Set<TileId>(FOCUS_MODE_TILE_IDS)
+                const nonFocusHiddenTiles = values.hiddenTiles.filter((tileId) => !focusModeTileSet.has(tileId))
+                const focusHiddenTiles = getHiddenTilesForFocusConcerns(values.focusModeDraftConcerns)
+                actions.setHiddenTiles([...nonFocusHiddenTiles, ...focusHiddenTiles])
+                actions.setFocusModeEnabled(true)
+                actions.closeFocusModeModal()
             },
             setGraphsTab: ({ tab }) => {
                 checkGraphsTabIsCompatibleWithConversionGoal(tab, values.conversionGoal)

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -118,7 +118,7 @@ import {
     convertCurrentURLFilter,
     hasURLSearchParams,
 } from './constants'
-import { FOCUS_MODE_TILE_IDS, getHiddenTilesForFocusConcerns } from './focus-mode/focusModeMapping'
+import { FOCUS_MODE_TILE_IDS, computeFocusHiddenTiles } from './focus-mode/focusModeMapping'
 import { WebAnalyticsConcern } from './focus-mode/types'
 import { webAnalyticsHealthLogic } from './health'
 import { IncludeHostToggle } from './IncludeHostToggle'
@@ -2832,14 +2832,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 if (!values.showFocusMode || values.focusModeConcerns.length === 0) {
                     return
                 }
-                const focusModeTileSet = new Set<TileId>(FOCUS_MODE_TILE_IDS)
-                const nonFocusHiddenTiles = values.hiddenTiles.filter((tileId) => !focusModeTileSet.has(tileId))
-                const focusHiddenTiles = getHiddenTilesForFocusConcerns(values.focusModeConcerns)
-                actions.setHiddenTiles([...nonFocusHiddenTiles, ...focusHiddenTiles])
+                actions.setHiddenTiles(computeFocusHiddenTiles(values.hiddenTiles, values.focusModeConcerns))
                 actions.setFocusModeEnabled(true)
             },
             exitFocusMode: () => {
-                actions.resetTileVisibility()
+                const focusModeTileSet = new Set<TileId>(FOCUS_MODE_TILE_IDS)
+                actions.setHiddenTiles(values.hiddenTiles.filter((tileId) => !focusModeTileSet.has(tileId)))
                 actions.setFocusModeEnabled(false)
             },
             applyFocusMode: () => {
@@ -2847,10 +2845,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     return
                 }
                 actions.setFocusModeConcerns(values.focusModeDraftConcerns)
-                const focusModeTileSet = new Set<TileId>(FOCUS_MODE_TILE_IDS)
-                const nonFocusHiddenTiles = values.hiddenTiles.filter((tileId) => !focusModeTileSet.has(tileId))
-                const focusHiddenTiles = getHiddenTilesForFocusConcerns(values.focusModeDraftConcerns)
-                actions.setHiddenTiles([...nonFocusHiddenTiles, ...focusHiddenTiles])
+                actions.setHiddenTiles(computeFocusHiddenTiles(values.hiddenTiles, values.focusModeDraftConcerns))
                 actions.setFocusModeEnabled(true)
                 actions.closeFocusModeModal()
             },


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
Users are overwhelmed with the Web Analytics dashboard
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a new focused mode that wraps the existing visible tiles work. This is PR one of a larger work item that will include the focused mode as a part of onboarding

https://github.com/user-attachments/assets/23af4ba4-5345-4acc-8cef-ba894722714f




<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
