### PR TITLE
fix(hogli): trustworthy telemetry signals

### DIFF
--- a/tools/hogli-commands/hogli_commands/telemetry_commands.py
+++ b/tools/hogli-commands/hogli_commands/telemetry_commands.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import click
 from hogli import telemetry
 
@@ -20,15 +22,13 @@ def telemetry_off() -> None:
 
 @click.command(name="telemetry:status", help="Show current telemetry settings")
 def telemetry_status() -> None:
-    import os
-
     enabled = telemetry.is_enabled()
     config_path = telemetry.get_config_path()
 
     click.echo(f"Telemetry: {'enabled' if enabled else 'disabled'}")
 
     # Show which mechanism controls the state
-    if os.environ.get("CI"):
+    if telemetry.is_ci():
         click.echo("Controlled by: CI environment detected")
     elif os.environ.get("POSTHOG_TELEMETRY_OPT_OUT") == "1":
         click.echo("Controlled by: POSTHOG_TELEMETRY_OPT_OUT=1")

--- a/tools/hogli/src/hogli/cli.py
+++ b/tools/hogli/src/hogli/cli.py
@@ -192,8 +192,9 @@ def cli(ctx: click.Context) -> None:
             telemetry.show_first_run_notice_if_needed()
 
     # Fire early so long-running commands (e.g. hogli start) are always counted
-    # even if the process is killed without a clean exit.
-    if ctx.invoked_subcommand and ctx.invoked_subcommand != "telemetry:off":
+    # even if the process is killed without a clean exit. Gated identically to
+    # command_completed so the two events form matched pairs.
+    if _should_track(ctx.invoked_subcommand):
         telemetry.track(
             "command_started", {"command": ctx.invoked_subcommand, **_env_properties(ctx.invoked_subcommand)}
         )
@@ -512,13 +513,12 @@ _load_boot_modules()
 
 def _env_properties(command: str | None = None) -> dict[str, Any]:
     """Static environment properties shared across telemetry events."""
-    ci_env_vars = ("CI", "GITHUB_ACTIONS", "JENKINS_URL", "GITLAB_CI", "CIRCLECI", "BUILDKITE")
     props: dict[str, Any] = {
         "terminal_width": shutil.get_terminal_size().columns,
         "os": platform.system(),
         "arch": platform.machine(),
         "python_version": platform.python_version(),
-        "is_ci": any(os.environ.get(v) for v in ci_env_vars),
+        "is_ci": telemetry.is_ci(),
     }
     for hook in telemetry_property_hooks:
         try:
@@ -528,20 +528,45 @@ def _env_properties(command: str | None = None) -> dict[str, Any]:
     return props
 
 
+# Telemetry commands manage telemetry itself; tracking them would pollute the
+# dataset with self-referential noise, so they emit no command events.
+_TELEMETRY_META_COMMANDS = frozenset({"telemetry:on", "telemetry:off", "telemetry:status"})
+
+
+def _should_track(command: str | None) -> bool:
+    """Whether a subcommand should emit command_started / command_completed.
+
+    Requires a real subcommand (so bare ``hogli`` / ``--help`` don't fire a
+    completed event with no matching started event) and excludes the telemetry
+    management commands.
+    """
+    return bool(command) and command not in _TELEMETRY_META_COMMANDS
+
+
+def _outcome(exit_code: int) -> str:
+    """Classify an exit code so signal kills are distinct from real failures."""
+    if exit_code == 0:
+        return "success"
+    # Killed by a signal: negative (subprocess) or 128 + signum (e.g. 130 SIGINT).
+    if exit_code < 0 or exit_code >= 128:
+        return "interrupted"
+    return "error"
+
+
 def _fire_telemetry(ctx: click.Context, exit_code: int) -> None:
     """Send a command_completed telemetry event. Never raises."""
     command = ctx.invoked_subcommand
-    # Skip when CLI itself errors before reaching a subcommand (e.g. bad flag)
-    if command is None and exit_code != 0:
+    if not _should_track(command):
         return
     try:
         start_time: float = ctx.meta.get("hogli.start_time", 0.0)
         duration_s = _time.monotonic() - start_time
         props: dict[str, Any] = {
             "command": command,
-            "command_category": get_category_for_command(command) if command else None,
+            "command_category": get_category_for_command(command),
             "duration_s": round(duration_s, 3),
             "exit_code": exit_code,
+            "outcome": _outcome(exit_code),
             "has_extra_argv": ctx.meta.get("hogli.has_extra_argv", False),
             **_env_properties(command),
         }

--- a/tools/hogli/src/hogli/cli.py
+++ b/tools/hogli/src/hogli/cli.py
@@ -188,6 +188,9 @@ def cli(ctx: click.Context) -> None:
     in_git_hook = os.environ.get("GIT_DIR") is not None or os.environ.get("HUSKY") is not None
     if ctx.invoked_subcommand not in {"meta:check", "help"} and not in_git_hook:
         _auto_update_manifest()
+        # telemetry:on still shows the notice (it arms tracking by setting
+        # first_run_notice_shown); only off/status suppress it. This set is
+        # intentionally narrower than _TELEMETRY_META_COMMANDS below.
         if ctx.invoked_subcommand not in {"telemetry:off", "telemetry:status"}:
             telemetry.show_first_run_notice_if_needed()
 
@@ -547,8 +550,10 @@ def _outcome(exit_code: int) -> str:
     """Classify an exit code so signal kills are distinct from real failures."""
     if exit_code == 0:
         return "success"
-    # Killed by a signal: negative (subprocess) or 128 + signum (e.g. 130 SIGINT).
-    if exit_code < 0 or exit_code >= 128:
+    # Killed by a signal: a negative subprocess returncode, or the shell's
+    # 128 + signum convention (e.g. 130 SIGINT). Exactly 128 is excluded -- it's
+    # an application-error idiom (e.g. git's fatal errors), not a signal.
+    if exit_code < 0 or exit_code > 128:
         return "interrupted"
     return "error"
 

--- a/tools/hogli/src/hogli/telemetry.py
+++ b/tools/hogli/src/hogli/telemetry.py
@@ -9,7 +9,7 @@ Telemetry is **disabled** unless an API key is configured via the
 framework never emit events to PostHog's project by default.
 
 Opt-out precedence:
-    CI=* -> POSTHOG_TELEMETRY_OPT_OUT=1 -> DO_NOT_TRACK=1 -> config enabled: false -> no api_key
+    CI (any common provider) -> POSTHOG_TELEMETRY_OPT_OUT=1 -> DO_NOT_TRACK=1 -> config enabled: false -> no api_key
 
 Config file: ~/.config/posthog/hogli_telemetry.json
 """
@@ -32,6 +32,20 @@ import requests
 from hogli.manifest import get_manifest
 
 _DEFAULT_HOST = "https://us.i.posthog.com"
+
+# Environment variables set by common CI providers. Presence of any one means
+# we're in CI: telemetry is disabled, and (where enabled) the `is_ci` event
+# property is set from this same list so the gate and the label never diverge.
+# Depot CI runners are drop-in GitHub Actions runners and set CI/GITHUB_ACTIONS,
+# so they're already covered. Depot sandboxes expose no stable CI marker, and
+# DEPOT_TOKEN also lives on developer laptops, so gating on it would wrongly
+# suppress real local signal -- deliberately not listed here.
+_CI_ENV_VARS = ("CI", "GITHUB_ACTIONS", "JENKINS_URL", "GITLAB_CI", "CIRCLECI", "BUILDKITE")
+
+
+def is_ci() -> bool:
+    """True when any common CI provider's environment variable is present."""
+    return any(os.environ.get(v) for v in _CI_ENV_VARS)
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +114,7 @@ class TelemetryClient:
         return self._telemetry_config.get("api_key", "")
 
     def is_enabled(self) -> bool:
-        if os.environ.get("CI"):
+        if is_ci():
             return False
         if os.environ.get("POSTHOG_TELEMETRY_OPT_OUT") == "1":
             return False

--- a/tools/hogli/tests/test_telemetry.py
+++ b/tools/hogli/tests/test_telemetry.py
@@ -10,10 +10,12 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 from hogli import telemetry
-from hogli.cli import cli
+from hogli.cli import _outcome, _should_track, cli
 
 _TELEMETRY_ENV_VARS = (
-    "CI",
+    # Every CI marker the gate checks must be cleared, otherwise the suite
+    # running on GitHub Actions (GITHUB_ACTIONS=1) would see telemetry disabled.
+    *telemetry._CI_ENV_VARS,
     "POSTHOG_TELEMETRY_OPT_OUT",
     "DO_NOT_TRACK",
     "POSTHOG_TELEMETRY_HOST",
@@ -40,6 +42,9 @@ def test_is_enabled_by_default():
         ({"POSTHOG_TELEMETRY_OPT_OUT": "1"}, {}),
         ({"DO_NOT_TRACK": "1"}, {}),
         ({"CI": "true"}, {}),
+        ({"GITHUB_ACTIONS": "true"}, {}),
+        ({"BUILDKITE": "true"}, {}),
+        ({"GITLAB_CI": "true"}, {}),
         ({"POSTHOG_TELEMETRY_OPT_OUT": "1"}, {"enabled": True}),
     ],
 )
@@ -49,6 +54,13 @@ def test_is_disabled(monkeypatch: pytest.MonkeyPatch, telemetry_config: Path, en
     for key, value in env_vars.items():
         monkeypatch.setenv(key, value)
     assert telemetry.is_enabled() is False
+
+
+@pytest.mark.parametrize("ci_var", telemetry._CI_ENV_VARS)
+def test_is_ci_detects_each_provider(monkeypatch: pytest.MonkeyPatch, ci_var: str):
+    assert telemetry.is_ci() is False
+    monkeypatch.setenv(ci_var, "true")
+    assert telemetry.is_ci() is True
 
 
 def test_is_disabled_when_no_api_key_configured(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -192,5 +204,52 @@ class TestInvokeTelemetry:
             completed = next(e for e in batch if e["event"] == "command_completed")
             assert completed["properties"]["command"] == "quickstart"
             assert completed["properties"]["exit_code"] == 0
+            assert completed["properties"]["outcome"] == "success"
             assert "duration_s" in completed["properties"]
             assert "is_ci" in completed["properties"]
+
+    @pytest.mark.parametrize("command", ["telemetry:on", "telemetry:off", "telemetry:status"])
+    def test_management_commands_emit_no_events(
+        self, monkeypatch: pytest.MonkeyPatch, telemetry_config: Path, command: str
+    ):
+        telemetry_config.write_text(
+            json.dumps({"enabled": True, "anonymous_id": "test-id", "first_run_notice_shown": True})
+        )
+        monkeypatch.setenv("POSTHOG_TELEMETRY_HOST", "http://localhost")
+        monkeypatch.setenv("POSTHOG_TELEMETRY_API_KEY", "test-key")
+        with patch.object(telemetry._client, "_send_batch") as mock_send:
+            result = CliRunner().invoke(cli, [command])
+            assert result.exit_code == 0
+            mock_send.assert_not_called()
+
+
+class TestShouldTrack:
+    @pytest.mark.parametrize(
+        "command, expected",
+        [
+            ("test", True),
+            ("migrations:run", True),
+            (None, False),
+            ("telemetry:on", False),
+            ("telemetry:off", False),
+            ("telemetry:status", False),
+        ],
+    )
+    def test_should_track(self, command, expected):
+        assert _should_track(command) is expected
+
+
+class TestOutcome:
+    @pytest.mark.parametrize(
+        "exit_code, expected",
+        [
+            (0, "success"),
+            (1, "error"),
+            (2, "error"),
+            (130, "interrupted"),  # SIGINT (Ctrl-C)
+            (143, "interrupted"),  # SIGTERM
+            (-13, "interrupted"),  # subprocess killed by signal
+        ],
+    )
+    def test_outcome(self, exit_code, expected):
+        assert _outcome(exit_code) == expected

--- a/tools/hogli/tests/test_telemetry.py
+++ b/tools/hogli/tests/test_telemetry.py
@@ -246,6 +246,7 @@ class TestOutcome:
             (0, "success"),
             (1, "error"),
             (2, "error"),
+            (128, "error"),  # application-error idiom (e.g. git fatal), not a signal
             (130, "interrupted"),  # SIGINT (Ctrl-C)
             (143, "interrupted"),  # SIGTERM
             (-13, "interrupted"),  # subprocess killed by signal


### PR DESCRIPTION
## Problem

hogli telemetry is alive but noisy: the CI disable gate checks only `CI` while the `is_ci` label checks six providers (so CI runs leak in and inflate installs), bare `hogli` emits a `command_completed` with no matching `command_started`, the `telemetry:*` commands track themselves, and a non-zero `exit_code` can't tell a real failure from a Ctrl-C.

## Changes

- One source of truth for CI detection (`telemetry.is_ci()`) shared by the gate and the `is_ci` label. Depot CI runners set `CI`/`GITHUB_ACTIONS` so they're already covered; `DEPOT_TOKEN` intentionally not gated (also on dev laptops).
- Both events gated through a shared `_should_track()` (requires a subcommand, excludes `telemetry:on/off/status`) so they form matched pairs.
- New `outcome` property (`success`/`error`/`interrupted`) so signal kills read distinctly from failures.

## How did you test this code?

Agent-authored (Claude Code), automated tests only — no manual testing. 24 new tests; full hogli + hogli-commands suites pass (883). ruff and `ty` clean.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code; human author owns review/merge. Began as a check-in on whether the feature still produces useful data (queried the DevEx project via PostHog MCP, mapped the emit surface), which surfaced these fixes. CI logic kept in core `telemetry.py` per the framework boundary in `tools/hogli/CLAUDE.md`. Scoped out: `duration_s` is ~0 for umbrella commands (needs sub-step timing) and ephemeral identity churn — both noted for follow-up.