### PR TITLE
fix(agentic-provisioning): include team_id in new_user account_request events

### DIFF
--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -262,6 +262,24 @@ class TestAccountRequests(ProvisioningTestBase):
         assert res.json()["type"] == "oauth"
         assert "code" in res.json()["oauth"]
 
+    @patch("ee.api.agentic_provisioning.views._capture_provisioning_event")
+    def test_new_user_capture_includes_team_id(self, mock_capture_event):
+        payload = self._account_request_payload(email="capture@example.com")
+        res = self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
+        assert res.status_code == 200
+
+        user = User.objects.get(email="capture@example.com")
+        team = user.team
+        assert team is not None
+
+        new_user_calls = [
+            call for call in mock_capture_event.call_args_list if call.args[:2] == ("account_request", "new_user")
+        ]
+        assert len(new_user_calls) == 1
+        kwargs = new_user_calls[0].kwargs
+        assert kwargs["team_id"] == team.id
+        assert "partner_id" in kwargs
+
 
 @override_settings(STRIPE_SIGNING_SECRET=HMAC_SECRET)
 class TestPKCEPartnerExistingUserConsent(ProvisioningTestBase):

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -652,7 +652,13 @@ def _handle_new_user(
             status=500,
         )
 
-    _capture_provisioning_event("account_request", "new_user", region=region)
+    _capture_provisioning_event(
+        "account_request",
+        "new_user",
+        region=region,
+        team_id=team.id,
+        partner_id=str(partner.id) if partner else None,
+    )
 
     try:
         reset_token = password_reset_token_generator.make_token(user)


### PR DESCRIPTION
## Problem

The `_handle_new_user` path in `ee/api/agentic_provisioning/views.py` captured the `account_request` event with outcome `new_user` *before* passing the just-created `team_id` to `_capture_provisioning_event`. The helper falls back to a random UUID for `distinct_id` when `team_id` is missing, so these events could not be joined back to the team or user that was actually created — defeating the point of tracking onboarding outcomes.

Empirically, 182 `agentic_provisioning account_request` events with outcome `new_user` over the last 90 days all had `team_id` unset and a random `distinct_id`. We knew provisioning was being used but had no way to follow it through to the resulting team.

## Changes

- Pass `team_id=team.id` to the `new_user` `_capture_provisioning_event` call in `_handle_new_user`, right after `User.objects.bootstrap()` returns.
- Also pass `partner_id=str(partner.id) if partner else None`, matching the existing pattern used for rate-limit telemetry elsewhere in the file.

Early-exit error paths that fire before any team object exists (`missing_email`, `expired`, `missing_stripe_account`, `account_creation_disabled`, `creation_failed`, `race_condition_existing_user`) are intentionally left alone — there is no team to attribute to yet, and the helper's random-UUID fallback is the correct behavior there.

The `_capture_provisioning_event` helper itself is unchanged; only this one call site is updated.

## How did you test this code?

I'm an agent. Automated tests run:

- Added `test_new_user_capture_includes_team_id` in `ee/api/agentic_provisioning/test/test_account_requests.py`. It patches `_capture_provisioning_event`, runs the new-user provisioning flow, and asserts the `account_request` / `new_user` call receives `team_id` matching the newly-created team plus a `partner_id` kwarg.
- Ran the full `test_account_requests.py` suite locally — 32/32 pass.
- `ruff check` and `ruff format` clean.
- `python manage.py makemigrations --check --dry-run` reports no changes (pure code change, no migration drift).

No manual testing performed.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Agent: Claude Code (Opus 4.7, 1M context).

Scope discipline:

- The user flagged that several other `account_request` outcomes (`creation_failed`, `race_condition_existing_user`) also fire without `team_id`. Those fire *before* `bootstrap()` returns a team, so there is no `team.id` available — left them as-is per the helper's fallback semantics.
- The existing `_handle_existing_user` `existing_user` capture already passes `team_id`. Not touched.
- Out of scope per the user: credential-review-screen telemetry and other event types (`token_exchange`, `deep_link_created`). Separate PRs if needed.