### PR TITLE
chore(health): remove duplicate sdk doctor from unified health menu

### DIFF
--- a/frontend/src/lib/components/HealthMenu/HealthMenu.tsx
+++ b/frontend/src/lib/components/HealthMenu/HealthMenu.tsx
@@ -159,21 +159,12 @@ const UnifiedHealthMenu = ({ iconOnly = false }: { iconOnly?: boolean }): JSX.El
         useValues(healthMenuLogic)
     const { setHealthMenuOpen } = useActions(healthMenuLogic)
     const { triggerBadgeContent, triggerBadgeStatus, totalIssues } = useValues(unifiedHealthMenuLogic)
-    const { needsAttention, needsUpdatingCount, sdkHealth } = useValues(sdkDoctorLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const pipelineStatusEnabled = !!featureFlags[FEATURE_FLAGS.PIPELINE_STATUS_PAGE]
 
-    const sdkDoctorTooltip = needsAttention
-        ? 'Needs attention'
-        : needsUpdatingCount > 0
-          ? 'Outdated SDKs found'
-          : 'SDK health is good'
-
-    const hasSdkIssues = needsAttention || needsUpdatingCount > 0
-    const combinedBadgeContent =
-        postHogStatusBadgeContent === '!' || triggerBadgeContent === '!' || hasSdkIssues ? '!' : '✓'
+    const combinedBadgeContent = postHogStatusBadgeContent === '!' || triggerBadgeContent === '!' ? '!' : '✓'
     const combinedBadgeStatus: 'danger' | 'warning' | 'success' =
-        postHogStatusBadgeStatus === 'danger' || triggerBadgeStatus === 'danger' || hasSdkIssues
+        postHogStatusBadgeStatus === 'danger' || triggerBadgeStatus === 'danger'
             ? 'danger'
             : postHogStatusBadgeStatus === 'warning' || triggerBadgeStatus === 'warning'
               ? 'warning'
@@ -230,24 +221,6 @@ const UnifiedHealthMenu = ({ iconOnly = false }: { iconOnly?: boolean }): JSX.El
                             <IconStethoscope className="size-5" />
                         </IconWithBadge>
                         Health issues
-                    </Link>
-                )}
-            />
-            <Menu.Item
-                render={(props) => (
-                    <Link
-                        {...props}
-                        to={urls.sdkDoctor()}
-                        buttonProps={{ menuItem: true }}
-                        tooltip={sdkDoctorTooltip}
-                        tooltipPlacement="right"
-                        tooltipCloseDelayMs={0}
-                        data-attr="health-menu-sdk-doctor-button"
-                    >
-                        <IconWithBadge size="xsmall" content={needsUpdatingCount > 0 ? '!' : '✓'} status={sdkHealth}>
-                            <IconCode className="size-5" />
-                        </IconWithBadge>
-                        SDK Doctor
                     </Link>
                 )}
             />


### PR DESCRIPTION
## Problem

In the bottom-left "Health" menu, the unified variant (behind `UNIFIED_HEALTH_PAGE`) listed both "Health issues" and "SDK Doctor". The SDK Doctor entry is redundant — the unified Health Issues page already includes the `sdk` category and surfaces `sdk_outdated` issues, so users were seeing the same information in two adjacent menu rows.

## Changes

- Removed the "SDK Doctor" `Menu.Item` from `UnifiedHealthMenu` in `frontend/src/lib/components/HealthMenu/HealthMenu.tsx`.
- Dropped the now-redundant `hasSdkIssues` contribution to the combined trigger badge in the unified menu — SDK badge state was being double-counted because `unifiedHealthMenuLogic.totalIssues` already includes SDK issues.
- Kept `LegacyHealthMenu` (no `Health issues` entry there) untouched, and kept the SDK Doctor scene/route in place so it can still be linked to directly.

Menu order after the change: PostHog status → Health issues → Pipeline status (gated) → Ingestion warnings.

## How did you test this code?

I'm an agent. I did not perform manual testing — no browser/UI verification was done. Local `tsc` reports only environmental errors (missing `node_modules`); no new type errors are introduced by the change. There were no existing tests, stories, or snapshots referencing the removed `health-menu-sdk-doctor-button` in the unified menu.

## Publish to changelog?

no

## Docs update

No docs reference the unified Health menu's SDK Doctor row.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) in an agent session.

- Located the menu in `frontend/src/lib/components/HealthMenu/HealthMenu.tsx` and confirmed the duplication only exists in `UnifiedHealthMenu` (the legacy menu does not have a "Health issues" entry, so it stays as-is).
- Verified `frontend/src/scenes/health/healthCategories.tsx` exposes `sdk` as a category with `sdk_outdated` mapped into it, so removing the menu item does not hide SDK health from users.
- Cleaned up the badge derivation so the trigger pip is not driven by SDK state from two places.