### PR TITLE
fix(mcp): match phrocs ready_pattern to actual server log line

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -411,7 +411,7 @@ procs:
     mcp:
         shell: 'bin/start-mcp-server'
         capability: mcp_server
-        ready_pattern: 'Ready on *'
+        ready_pattern: '\[MCP\] Server started on'
         groups:
             layer: Product services
             tech: Python


### PR DESCRIPTION
## Problem

The `mcp` proc in `bin/mprocs.yaml` was permanently stuck in the "booting" state in the phrocs TUI, even though the Hono MCP server was up and serving traffic. The status icon never flipped to ready.

Root cause: the configured `ready_pattern` was `Ready on *`, but the server actually logs `[MCP] Server started on <host>:<port>` (see `services/mcp/src/hono/index.ts`). Phrocs compiles `ready_pattern` as a Go regex, so the old value parsed as "Ready o" followed by zero-or-more "n" — a valid regex, just one that never matches any real log line.

## Changes

- Update `ready_pattern` for the `mcp` proc to `\[MCP\] Server started on`, with the brackets escaped so the regex anchors on the literal startup log line.

Sibling procs are unaffected:
- `mcp-ui-apps` already matches its own log (`Initial build complete` in `services/mcp/scripts/build-ui-apps.ts`).
- `mcp-inspector` pattern (`MCP Inspector`) is unchanged.

## How did you test this code?

I'm an agent. I did not start phrocs to observe the icon. I verified statically that:
- The MCP server's startup log is emitted from `services/mcp/src/hono/index.ts:58` as `[MCP] Server started on ${HOST}:${info.port}`.
- Phrocs compiles `ready_pattern` via `regexp.Compile` in `tools/phrocs/internal/process/proc.go:165`, so escaped square brackets are needed for a literal match.
- No other process in `bin/mprocs.yaml` shares this pattern, so this is a scoped change.

No automated tests were added — this is a single-line config fix to a YAML field consumed only at runtime.

## Publish to changelog?

no

## 🤖 Agent context

Agent-authored via Claude Code. The user reported that the MCP process in phrocs was stuck on the "booting" indicator despite the server working. I traced the discrepancy from `bin/mprocs.yaml` → `bin/start-mcp-server` → `services/mcp/scripts/dev-hono.ts` → `services/mcp/src/hono/index.ts`, found the mismatch between the configured regex and the actual log line, and confirmed via `tools/phrocs/internal/process/proc.go` that the field is treated as a Go regex.

Considered alternatives:
- Changing the server log line to literally print `Ready on ...` — rejected; the existing `[MCP] Server started on ...` format is consistent with other logs in the same file and is more informative.
- Using a looser pattern like `Server started on` — rejected in favor of the bracketed form so the match is anchored to MCP's own log namespace.

Out of scope but worth a follow-up: the `mcp` proc's `groups.tech` is labeled `Python`, but the server is a Node/Hono process.