### PR TITLE
chore(usage): speed up report tests

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1,6 +1,7 @@
 import gzip
 import json
 import base64
+from dataclasses import fields
 from datetime import datetime, timedelta
 from typing import Any
 from uuid import uuid4
@@ -47,6 +48,7 @@ from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 from posthog.tasks.usage_report import (
     OrgReport,
+    UsageReportCounters,
     _add_team_report_to_org_reports,
     _get_all_org_reports,
     _get_all_usage_data_as_team_rows,
@@ -77,6 +79,26 @@ from ee.clickhouse.materialized_columns.columns import materialize
 from ee.models.license import License
 
 logger = structlog.get_logger(__name__)
+
+
+def _usage_report_counters(**overrides: int | float) -> dict[str, int | float]:
+    counters: dict[str, int | float] = {field.name: 0 for field in fields(UsageReportCounters)}
+    counters.update(overrides)
+    return counters
+
+
+def _minimal_org_report(organization: Organization, team: Team) -> OrgReport:
+    team_report = UsageReportCounters(**_usage_report_counters(event_count_in_period=1))
+    return OrgReport(
+        date="2021-10-09",
+        organization_id=str(organization.id),
+        organization_name=organization.name,
+        organization_created_at=organization.created_at.isoformat(),
+        organization_user_count=0,
+        team_count=1,
+        teams={str(team.id): team_report},
+        **_usage_report_counters(event_count_in_period=1),
+    )
 
 
 def _setup_replay_data(team_id: int, include_mobile_replay: bool, include_zero_duration: bool = False) -> None:
@@ -182,8 +204,6 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesM
         sync_execute("TRUNCATE TABLE events")
         sync_execute("TRUNCATE TABLE person")
         sync_execute("TRUNCATE TABLE person_distinct_id")
-
-        materialize("events", "$exception_values")
 
         self.expected_properties: dict = {}
 
@@ -992,7 +1012,6 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesM
 class TestReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin):
     def setUp(self) -> None:
         super().setUp()
-        materialize("events", "$exception_values")
 
     @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
     def test_usage_report_replay(self) -> None:
@@ -1289,7 +1308,6 @@ class TestFeatureFlagsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickh
         self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
         self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
-        materialize("events", "$exception_values")
 
     @snapshot_clickhouse_queries
     @patch("posthog.tasks.usage_report.get_ph_client")
@@ -1550,7 +1568,6 @@ class TestSurveysUsageReport(ClickhouseDestroyTablesMixin, TestCase, ClickhouseT
         self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
         self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
-        materialize("events", "$exception_values")
 
     @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
@@ -1727,7 +1744,6 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
         self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
         self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
-        materialize("events", "$exception_values")
 
     @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
@@ -2324,7 +2340,6 @@ class TestDWHStorageUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhou
         self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
         self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
-        materialize("events", "$exception_values")
 
     @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
@@ -2514,7 +2529,6 @@ class TestHogFunctionUsageReports(ClickhouseDestroyTablesMixin, TestCase, Clickh
         self.org_1 = Organization.objects.create(name="Org 1")
         self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
-        materialize("events", "$exception_values")
 
     @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
@@ -2745,7 +2759,6 @@ class TestErrorTrackingUsageReport(ClickhouseDestroyTablesMixin, TestCase, Click
         self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
         self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
-        materialize("events", "$exception_values")
 
     @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
@@ -2827,7 +2840,6 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
     def _setup_teams(self) -> None:
         self.org_1 = Organization.objects.create(name="Org 1")
         self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
-        materialize("events", "$exception_values")
         materialize("events", "region")
 
     @patch("posthog.tasks.usage_report.get_ph_client")
@@ -3795,7 +3807,8 @@ class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         compressed_bytes = gzip.compress(json_data.encode("utf-8"))
         compressed_b64 = base64.b64encode(compressed_bytes).decode("ascii")
 
-        send_all_org_usage_reports(dry_run=False)
+        with patch("posthog.tasks.usage_report._get_all_org_reports", return_value=all_reports):
+            send_all_org_usage_reports(dry_run=False)
         license = License.objects.first()
         assert license
 
@@ -3849,7 +3862,8 @@ class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
             compressed_bytes = gzip.compress(json_data.encode("utf-8"))
             compressed_b64 = base64.b64encode(compressed_bytes).decode("ascii")
 
-            send_all_org_usage_reports(dry_run=False)
+            with patch("posthog.tasks.usage_report._get_all_org_reports", return_value=all_reports):
+                send_all_org_usage_reports(dry_run=False)
             license = License.objects.first()
             assert license
 
@@ -4005,7 +4019,7 @@ class TestSendUsageNoLicense(APIBaseTest):
 
 
 @freeze_time("2021-10-10T23:01:00Z")
-class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
+class TestOrganizationFiltering(LicensedTestMixin, APIBaseTest):
     """Test organization_ids filtering for send_all_org_usage_reports"""
 
     def setUp(self) -> None:
@@ -4018,28 +4032,16 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
         self.org3 = Organization.objects.create(name="Org 3")
         self.team3 = Team.objects.create(organization=self.org3)
 
-        # Create events for all orgs
-        _create_event(
-            event="$pageview",
-            team=self.team,
-            distinct_id=1,
-            timestamp="2021-10-09T12:01:01Z",
-        )
-        _create_event(
-            event="$pageview",
-            team=self.team2,
-            distinct_id=1,
-            timestamp="2021-10-09T14:01:01Z",
-        )
-        _create_event(
-            event="$pageview",
-            team=self.team3,
-            distinct_id=1,
-            timestamp="2021-10-09T16:01:01Z",
-        )
-        flush_persons_and_events()
-        TEST_clear_instance_license_cache()
-        materialize("events", "$exception_values")
+    def _org_reports(self) -> dict[str, OrgReport]:
+        return {
+            str(self.organization.id): _minimal_org_report(self.organization, self.team),
+            str(self.org2.id): _minimal_org_report(self.org2, self.team2),
+            str(self.org3.id): _minimal_org_report(self.org3, self.team3),
+        }
+
+    def _send_usage_reports(self, organization_ids: list[str] | None = None) -> None:
+        with patch("posthog.tasks.usage_report._get_all_org_reports", return_value=self._org_reports()):
+            send_all_org_usage_reports(dry_run=False, organization_ids=organization_ids)
 
     @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("ee.sqs.SQSProducer.get_sqs_producer")
@@ -4049,7 +4051,7 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
         mock_producer = MagicMock()
         mock_get_sqs_producer.return_value = mock_producer
 
-        send_all_org_usage_reports(dry_run=False, organization_ids=[str(self.organization.id)])
+        self._send_usage_reports(organization_ids=[str(self.organization.id)])
 
         # Should only send one message (for org1)
         assert mock_producer.send_message.call_count == 1
@@ -4082,7 +4084,7 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
         mock_get_sqs_producer.return_value = mock_producer
 
         org_ids = [str(self.organization.id), str(self.org2.id)]
-        send_all_org_usage_reports(dry_run=False, organization_ids=org_ids)
+        self._send_usage_reports(organization_ids=org_ids)
 
         # Should send two messages
         assert mock_producer.send_message.call_count == 2
@@ -4116,7 +4118,7 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
 
         fake_org_id = str(uuid4())
 
-        send_all_org_usage_reports(dry_run=False, organization_ids=[fake_org_id])
+        self._send_usage_reports(organization_ids=[fake_org_id])
 
         # Should not send any messages
         mock_producer.send_message.assert_not_called()
@@ -4150,7 +4152,7 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
             fake_org_id2,
         ]
 
-        send_all_org_usage_reports(dry_run=False, organization_ids=org_ids)
+        self._send_usage_reports(organization_ids=org_ids)
 
         # Should send two messages (for the 2 existing orgs)
         assert mock_producer.send_message.call_count == 2
@@ -4184,7 +4186,7 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
         mock_producer = MagicMock()
         mock_get_sqs_producer.return_value = mock_producer
 
-        send_all_org_usage_reports(dry_run=False)
+        self._send_usage_reports()
 
         # Should send three messages (one for each org)
         assert mock_producer.send_message.call_count == 3

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -22,7 +22,7 @@ from posthog.test.base import (
 )
 from unittest.mock import MagicMock, Mock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.utils.timezone import now
 
 import structlog
@@ -50,6 +50,7 @@ from posthog.tasks.usage_report import (
     OrgReport,
     UsageReportCounters,
     _add_team_report_to_org_reports,
+    _execute_split_query,
     _get_all_org_reports,
     _get_all_usage_data_as_team_rows,
     _get_full_org_usage_report,
@@ -57,7 +58,9 @@ from posthog.tasks.usage_report import (
     _get_team_report,
     _get_teams_for_usage_reports,
     capture_event,
+    get_all_event_metrics_in_period,
     get_instance_metadata,
+    get_teams_with_billable_event_count_in_period,
     send_all_org_usage_reports,
 )
 from posthog.test.fixtures import create_app_metric2
@@ -3694,6 +3697,36 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
         self.assertEqual(result[0][1], 240)
 
 
+class TestUsageReportCaptureEvent(SimpleTestCase):
+    def test_capture_event_called_with_string_timestamp(self) -> None:
+        mock_client = MagicMock()
+
+        capture_event(
+            pha_client=mock_client,
+            name="test event",
+            organization_id="organization-id",
+            distinct_id="distinct-id",
+            properties={"prop1": "val1"},
+            timestamp="2021-10-10T23:01:00.00Z",
+        )
+
+        assert mock_client.capture.call_args[1]["timestamp"] == datetime(2021, 10, 10, 23, 1, tzinfo=tzutc())
+
+    @patch("posthog.tasks.report_utils.is_cloud", return_value=True)
+    def test_capture_event_skips_group_identify_without_group_properties(self, _mock_is_cloud: MagicMock) -> None:
+        mock_client = MagicMock()
+
+        capture_event(
+            pha_client=mock_client,
+            name="test event",
+            organization_id="organization-id",
+            distinct_id="distinct-id",
+            properties={"prop1": "val1"},
+        )
+
+        mock_client.group_identify.assert_not_called()
+
+
 class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
     def setUp(self) -> None:
         super().setUp()
@@ -3907,34 +3940,6 @@ class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
     #             mock_client.return_value = mock_posthog
     #             send_all_org_usage_reports(dry_run=False)
     #     assert mock_capture_exception.call_count == 1
-
-    @patch("posthog.tasks.usage_report.get_ph_client")
-    def test_capture_event_called_with_string_timestamp(self, mock_client: MagicMock) -> None:
-        organization = Organization.objects.create()
-        mock_posthog = MagicMock()
-        mock_client.return_value = mock_posthog
-        capture_event(
-            pha_client=mock_client,
-            name="test event",
-            organization_id=organization.id,
-            properties={"prop1": "val1"},
-            timestamp="2021-10-10T23:01:00.00Z",
-        )
-        assert mock_client.capture.call_args[1]["timestamp"] == datetime(2021, 10, 10, 23, 1, tzinfo=tzutc())
-
-    @patch("posthog.tasks.report_utils.is_cloud", return_value=True)
-    def test_capture_event_skips_group_identify_without_group_properties(self, mock_is_cloud: MagicMock) -> None:
-        organization = Organization.objects.create()
-        mock_client = MagicMock()
-
-        capture_event(
-            pha_client=mock_client,
-            name="test event",
-            organization_id=str(organization.id),
-            properties={"prop1": "val1"},
-        )
-
-        mock_client.group_identify.assert_not_called()
 
 
 class TestSendNoUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
@@ -4202,6 +4207,113 @@ class TestOrganizationFiltering(LicensedTestMixin, APIBaseTest):
         assert properties["total_orgs"] == 3
 
 
+class TestQuerySplittingHelpers(SimpleTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.team_id = 1
+        self.begin = datetime(2023, 1, 1, 0, 0)
+        self.end = datetime(2023, 1, 2, 0, 0)
+
+    @patch("posthog.tasks.usage_report.sync_execute")
+    def test_execute_split_query_splits_correctly(self, mock_sync_execute: MagicMock) -> None:
+        mock_sync_execute.side_effect = [
+            [(self.team_id, 5)],
+            [(self.team_id, 5)],
+        ]
+
+        query_template = """
+            SELECT team_id, count(1) as count
+            FROM events
+            WHERE timestamp BETWEEN %(begin)s AND %(end)s
+            GROUP BY team_id
+        """
+
+        result = _execute_split_query(
+            begin=self.begin,
+            end=self.end,
+            query_template=query_template,
+            params={},
+            num_splits=2,
+        )
+
+        self.assertEqual(mock_sync_execute.call_count, 2)
+
+        first_call_args = mock_sync_execute.call_args_list[0][0]
+        first_call_kwargs = mock_sync_execute.call_args_list[0].kwargs
+        self.assertEqual(first_call_args[1]["begin"], self.begin)
+        self.assertEqual(first_call_kwargs["ch_user"], ClickHouseUser.BILLING)
+        mid_point = self.begin + (self.end - self.begin) / 2
+        self.assertEqual(first_call_args[1]["end"], mid_point)
+
+        second_call_args = mock_sync_execute.call_args_list[1][0]
+        second_call_kwargs = mock_sync_execute.call_args_list[1].kwargs
+        self.assertEqual(second_call_args[1]["begin"], mid_point)
+        self.assertEqual(second_call_kwargs["ch_user"], ClickHouseUser.BILLING)
+        self.assertEqual(second_call_args[1]["end"], self.end)
+
+        self.assertEqual(result, [(self.team_id, 10)])
+
+    @patch("posthog.tasks.usage_report.sync_execute")
+    def test_execute_split_query_with_custom_combiner(self, mock_sync_execute: MagicMock) -> None:
+        mock_sync_execute.side_effect = [
+            [(self.team_id, "web_events", 3)],
+            [
+                (self.team_id, "web_events", 2),
+                (self.team_id, "mobile_events", 1),
+            ],
+        ]
+
+        def custom_combiner(results_list: list[list[tuple[int, str, int]]]) -> dict[str, list[tuple[int, int]]]:
+            metrics: dict[str, dict[int, int]] = {
+                "web_events": {},
+                "mobile_events": {},
+            }
+
+            for results in results_list:
+                for team_id, metric, count in results:
+                    if team_id in metrics[metric]:
+                        metrics[metric][team_id] += count
+                    else:
+                        metrics[metric][team_id] = count
+
+            return {metric: list(team_counts.items()) for metric, team_counts in metrics.items()}
+
+        query_template = """
+            SELECT team_id, 'web_events' as metric, count(1) as count
+            FROM events
+            WHERE timestamp BETWEEN %(begin)s AND %(end)s
+            GROUP BY team_id, metric
+        """
+
+        result = _execute_split_query(
+            begin=self.begin,
+            end=self.end,
+            query_template=query_template,
+            params={},
+            num_splits=2,
+            combine_results_func=custom_combiner,
+        )
+
+        self.assertEqual(result["web_events"], [(self.team_id, 5)])
+        self.assertEqual(result["mobile_events"], [(self.team_id, 1)])
+
+    @patch("posthog.tasks.usage_report._execute_split_query")
+    def test_split_query_with_different_num_splits(self, mock_execute_split_query: MagicMock) -> None:
+        mock_execute_split_query.return_value = [(self.team_id, 10)]
+
+        get_teams_with_billable_event_count_in_period(self.begin, self.end)
+        with patch("posthog.tasks.usage_report.get_property_string_expr", return_value=("properties['$lib']", None)):
+            get_all_event_metrics_in_period(self.begin, self.end)
+
+        self.assertEqual(mock_execute_split_query.call_count, 2)
+
+        first_call_kwargs = mock_execute_split_query.call_args_list[0][1]
+        self.assertEqual(first_call_kwargs["num_splits"], 12)
+
+        second_call_kwargs = mock_execute_split_query.call_args_list[1][1]
+        self.assertEqual(second_call_kwargs["num_splits"], 12)
+
+
 class TestQuerySplitting(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -4351,108 +4463,8 @@ class TestQuerySplitting(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, Test
 
         flush_persons_and_events()
 
-    @patch("posthog.tasks.usage_report.sync_execute")
-    def test_execute_split_query_splits_correctly(self, mock_sync_execute: MagicMock) -> None:
-        """Test that _execute_split_query correctly splits the time period and combines results."""
-        # Mock the sync_execute to return test data
-        mock_sync_execute.side_effect = [
-            [(self.team.id, 5)],  # First split returns 5 events
-            [(self.team.id, 5)],  # Second split returns 5 events
-        ]
-
-        # Test with 2 splits
-        query_template = """
-            SELECT team_id, count(1) as count
-            FROM events
-            WHERE timestamp BETWEEN %(begin)s AND %(end)s
-            GROUP BY team_id
-        """
-
-        from posthog.tasks.usage_report import _execute_split_query
-
-        result = _execute_split_query(
-            begin=self.begin,
-            end=self.end,
-            query_template=query_template,
-            params={},
-            num_splits=2,
-        )
-
-        # Verify sync_execute was called twice with different time ranges
-        self.assertEqual(mock_sync_execute.call_count, 2)
-
-        # First call should use the first half of the time range
-        first_call_args = mock_sync_execute.call_args_list[0][0]
-        first_call_kwargs = mock_sync_execute.call_args_list[0].kwargs
-        self.assertEqual(first_call_args[1]["begin"], self.begin)
-        self.assertEqual(first_call_kwargs["ch_user"], ClickHouseUser.BILLING)
-        mid_point = self.begin + (self.end - self.begin) / 2
-        self.assertEqual(first_call_args[1]["end"], mid_point)
-
-        # Second call should use the second half of the time range
-        second_call_args = mock_sync_execute.call_args_list[1][0]
-        second_call_kwargs = mock_sync_execute.call_args_list[1].kwargs
-        self.assertEqual(second_call_args[1]["begin"], mid_point)
-        self.assertEqual(second_call_kwargs["ch_user"], ClickHouseUser.BILLING)
-        self.assertEqual(second_call_args[1]["end"], self.end)
-
-        # Result should combine both splits (5 + 5 = 10)
-        self.assertEqual(result, [(self.team.id, 10)])
-
-    @patch("posthog.tasks.usage_report.sync_execute")
-    def test_execute_split_query_with_custom_combiner(self, mock_sync_execute: MagicMock) -> None:
-        """Test that _execute_split_query works with a custom result combiner function."""
-        # Mock the sync_execute to return test data for event metrics
-        mock_sync_execute.side_effect = [
-            [(self.team.id, "web_events", 3)],  # First split
-            [
-                (self.team.id, "web_events", 2),
-                (self.team.id, "mobile_events", 1),
-            ],  # Second split
-        ]
-
-        # Define a custom combiner function similar to what we use in get_all_event_metrics_in_period
-        def custom_combiner(results_list: list) -> dict[str, list[tuple[int, int]]]:
-            metrics: dict[str, dict[int, int]] = {
-                "web_events": {},
-                "mobile_events": {},
-            }
-
-            for results in results_list:
-                for team_id, metric, count in results:
-                    if team_id in metrics[metric]:
-                        metrics[metric][team_id] += count
-                    else:
-                        metrics[metric][team_id] = count
-
-            return {metric: list(team_counts.items()) for metric, team_counts in metrics.items()}
-
-        query_template = """
-            SELECT team_id, 'web_events' as metric, count(1) as count
-            FROM events
-            WHERE timestamp BETWEEN %(begin)s AND %(end)s
-            GROUP BY team_id, metric
-        """
-
-        from posthog.tasks.usage_report import _execute_split_query
-
-        result = _execute_split_query(
-            begin=self.begin,
-            end=self.end,
-            query_template=query_template,
-            params={},
-            num_splits=2,
-            combine_results_func=custom_combiner,
-        )
-
-        # Verify the custom combiner worked correctly
-        self.assertEqual(result["web_events"], [(self.team.id, 5)])
-        self.assertEqual(result["mobile_events"], [(self.team.id, 1)])
-
     def test_get_teams_with_billable_event_count_in_period(self) -> None:
         """Test that get_teams_with_billable_event_count_in_period returns correct results after splitting and excludes AI events."""
-        from posthog.tasks.usage_report import get_teams_with_billable_event_count_in_period
-
         # Run the function with our test data
         result = get_teams_with_billable_event_count_in_period(self.begin, self.end)
 
@@ -4482,31 +4494,6 @@ class TestQuerySplitting(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, Test
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0][0], self.team.id)
         self.assertEqual(result[0][1], 5)
-
-    @patch("posthog.tasks.usage_report._execute_split_query")
-    def test_split_query_with_different_num_splits(self, mock_execute_split_query: MagicMock) -> None:
-        """Test that functions call _execute_split_query with the correct number of splits."""
-        mock_execute_split_query.return_value = [(self.team.id, 10)]
-
-        from posthog.tasks.usage_report import (
-            get_all_event_metrics_in_period,
-            get_teams_with_billable_event_count_in_period,
-        )
-
-        # Call the functions
-        get_teams_with_billable_event_count_in_period(self.begin, self.end)
-        get_all_event_metrics_in_period(self.begin, self.end)
-
-        # Verify the calls
-        self.assertEqual(mock_execute_split_query.call_count, 2)
-
-        # First call (get_teams_with_billable_event_count_in_period) should use 12 splits
-        first_call_kwargs = mock_execute_split_query.call_args_list[0][1]
-        self.assertEqual(first_call_kwargs["num_splits"], 12)
-
-        # Second call (get_all_event_metrics_in_period) should use 12 splits
-        second_call_kwargs = mock_execute_split_query.call_args_list[1][1]
-        self.assertEqual(second_call_kwargs["num_splits"], 12)
 
     def test_ai_events_not_double_counted(self) -> None:
         """Test that AI events are excluded from billable event counts and counted separately."""


### PR DESCRIPTION
## Problem

`posthog/tasks/test/test_usage_report.py` repeats expensive usage-report setup across tests, including unused event materialization and full report generation for tests that only assert delivery fanout or filtering behavior.

## Changes

Removes standalone `$exception_values` materialization from usage-report tests where the production report code does not read that property. Reuses precomputed org reports in send-usage tests, and replaces full report generation in organization-filtering tests with lightweight `OrgReport` fixtures that still exercise filtering, queue fanout, and telemetry assertions.

## How did you test this code?

Agent validation:

- `ruff check posthog/tasks/test/test_usage_report.py --fix`
- `ruff format posthog/tasks/test/test_usage_report.py`
- `python -c "import ast, pathlib; ast.parse(pathlib.Path('posthog/tasks/test/test_usage_report.py').read_text())"`
- `git diff --check`

Attempted `hogli test posthog/tasks/test/test_usage_report.py::TestOrganizationFiltering`, but local Postgres was not available (`127.0.0.1:5432 connection refused`), so runtime validation is expected from CI.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update. Test-only change.

## 🤖 Agent context

Authored by Codex in a dedicated worktree. The optimization keeps full report coverage where tests assert report values, but avoids full ClickHouse usage queries in tests that only validate `send_all_org_usage_reports` filtering behavior.
