### PR TITLE
chore(ci): report product test durations

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -479,9 +479,11 @@ jobs:
               env:
                   # --reuse-db: keep the test database between sequential product runs to avoid
                   # ClickHouse drop/create race conditions with ReplicatedMergeTree ZK metadata.
+                  # Temporary timing instrumentation: expose slow product backend test bodies in PR logs.
                   # On master, also collect timing data for pytest-split sharding.
                   PYTEST_ADDOPTS: >-
                       --reuse-db
+                      --durations=100 --durations-min=1.0
                       ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && '--snapshot-update --snapshot-warn-unused' || '' }}
                       ${{ github.ref == 'refs/heads/master' && '--store-durations --durations-path ../../.test_durations' || '' }}
               run: pnpm turbo run backend:test ${{ matrix.filters }} --concurrency=1 --output-logs=full --force --log-order=stream ${{ matrix.pytest_args }}


### PR DESCRIPTION
## Problem

Product backend CI shards can spend significant time inside pytest bodies without printing the slowest tests. This temporary draft PR adds duration reporting so the slowest product backend tests are visible in PR logs.

## Changes

Adds `--durations=100 --durations-min=1.0` to the product backend pytest options used by Backend CI. The change is timing-only and leaves test behavior unchanged.

## How did you test this code?

Agent validation:

- `./bin/hogli lint:workflows`
- `git diff --check`

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update. Temporary CI instrumentation only.

## 🤖 Agent context

Authored by Codex in a dedicated worktree. The goal is to expose per-test timing for product backend shards so follow-up optimization work can target measured slow tests.
