### PR TITLE
chore(ci): time backend setup

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -459,13 +459,32 @@ jobs:
               # No-op on cache miss; pytest --reuse-db falls back to a full migrate.
               if: ${{ github.event_name == 'pull_request' }}
               run: |
+                  # Temporary timing instrumentation for backend setup analysis.
+                  timing_now_ms() { date +%s%3N; }
+                  timing_emit() {
+                      local label="$1"
+                      local started_ms="$2"
+                      local status="${3:-ok}"
+                      local finished_ms
+                      finished_ms=$(timing_now_ms)
+                      echo "backend_setup_timing label=${label} status=${status} ms=$((finished_ms - started_ms))"
+                  }
+
+                  prime_started_ms=$(timing_now_ms)
                   if [ ! -f schema.sql.gz ]; then
                       echo "::notice::Schema cache miss — pytest --reuse-db will run full migrations"
+                      timing_emit schema_cache_check "$prime_started_ms" miss
                       exit 0
                   fi
+
+                  timing_emit schema_cache_check "$prime_started_ms" hit
+                  prepare_started_ms=$(timing_now_ms)
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  ./bin/hogli db:restore-test-db
+                  timing_emit schema_file_prepare "$prepare_started_ms"
+
+                  BACKEND_SETUP_TIMING=1 ./bin/hogli db:restore-test-db
+                  timing_emit prime_test_posthog_total "$prime_started_ms"
 
             - name: Register Temporal search attributes
               run: |
@@ -1645,13 +1664,32 @@ jobs:
               # No-op on cache miss; pytest --reuse-db falls back to a full migrate.
               if: ${{ github.event_name == 'pull_request' }}
               run: |
+                  # Temporary timing instrumentation for backend setup analysis.
+                  timing_now_ms() { date +%s%3N; }
+                  timing_emit() {
+                      local label="$1"
+                      local started_ms="$2"
+                      local status="${3:-ok}"
+                      local finished_ms
+                      finished_ms=$(timing_now_ms)
+                      echo "backend_setup_timing label=${label} status=${status} ms=$((finished_ms - started_ms))"
+                  }
+
+                  prime_started_ms=$(timing_now_ms)
                   if [ ! -f schema.sql.gz ]; then
                       echo "::notice::Schema cache miss — pytest --reuse-db will run full migrations"
+                      timing_emit schema_cache_check "$prime_started_ms" miss
                       exit 0
                   fi
+
+                  timing_emit schema_cache_check "$prime_started_ms" hit
+                  prepare_started_ms=$(timing_now_ms)
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  ./bin/hogli db:restore-test-db
+                  timing_emit schema_file_prepare "$prepare_started_ms"
+
+                  BACKEND_SETUP_TIMING=1 ./bin/hogli db:restore-test-db
+                  timing_emit prime_test_posthog_total "$prime_started_ms"
 
             - name: Determine if --snapshot-update should be on
               # UPDATE mode: human commits - update snapshots

--- a/tools/hogli-commands/hogli_commands/db_schema.py
+++ b/tools/hogli-commands/hogli_commands/db_schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import gzip
+import time
 import shutil
 import zipfile
 import tempfile
@@ -87,6 +88,14 @@ def _run(command: list[str], *, env: Mapping[str, str] | None = None) -> None:
         env={**os.environ, **dict(env or {})},
         check=True,
     )
+
+
+def _emit_backend_setup_timing(label: str, started_at: float) -> None:
+    if os.environ.get("BACKEND_SETUP_TIMING") != "1":
+        return
+
+    elapsed_ms = int((time.monotonic() - started_at) * 1000)
+    click.echo(f"backend_setup_timing label={label} status=ok ms={elapsed_ms}")
 
 
 def _validate_db_identifier(target_db: str) -> str:
@@ -172,21 +181,30 @@ def restore_schema_dump(
     schema_path: Path = LOCAL_SCHEMA_PATH,
     ensure_defaults: bool = True,
 ) -> None:
+    total_start = time.monotonic()
     target_db = _validate_db_identifier(target_db)
     resolved_schema_path = _resolve_repo_path(schema_path)
     if not resolved_schema_path.is_file():
         raise SchemaRestoreError(f"no schema at {schema_path}; run db:download-schema first")
 
+    validate_start = time.monotonic()
     _validate_gzip(resolved_schema_path)
+    _emit_backend_setup_timing("schema_gzip_validate", validate_start)
 
     if recreate:
+        recreate_start = time.monotonic()
         _recreate_database(target_db)
+        _emit_backend_setup_timing("postgres_recreate_database", recreate_start)
 
     try:
+        restore_start = time.monotonic()
         _run_psql_with_gzip_input(resolved_schema_path, target_db)
+        _emit_backend_setup_timing("postgres_restore_schema", restore_start)
 
         if ensure_defaults:
+            defaults_start = time.monotonic()
             _ensure_migration_defaults(target_db)
+            _emit_backend_setup_timing("ensure_migration_defaults", defaults_start)
     except Exception as exc:
         if recreate:
             try:
@@ -198,6 +216,7 @@ def restore_schema_dump(
         raise
 
     click.echo(f"Restored {target_db} from {schema_path}")
+    _emit_backend_setup_timing("restore_test_db_total", total_start)
 
 
 def _github_token() -> str | None:


### PR DESCRIPTION
## Problem

Backend CI repeats common setup across many jobs, and the schema prime step does not expose enough detail to separate cache hit/miss, schema file preparation, database restore, and migration-default work.

## Changes

Adds temporary `backend_setup_timing` log lines around the `Prime test_posthog from cached schema` steps in product and Django test jobs. Also adds an env-gated `BACKEND_SETUP_TIMING=1` path inside `hogli db:restore-test-db` to break down gzip validation, Postgres database recreation, schema restore, and `ensure_migration_defaults`.

## How did you test this code?

Agent validation:

- `./bin/hogli lint:workflows`
- `ruff check tools/hogli-commands/hogli_commands/db_schema.py --fix`
- `ruff format tools/hogli-commands/hogli_commands/db_schema.py`
- `python -c "import ast, pathlib; ast.parse(pathlib.Path('tools/hogli-commands/hogli_commands/db_schema.py').read_text())"`
- `git diff --check`

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update. Temporary CI instrumentation only.

## 🤖 Agent context

Authored by Codex in a dedicated worktree. The instrumentation is env-gated in `hogli` and enabled only from Backend CI so normal local schema restore output is unchanged.
