### PR TITLE
feat(capture): adjust illegal distinct ID handling in v1

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -400,7 +400,11 @@ jobs:
               uses: cargo-bins/cargo-binstall@5cbf019d8cb9b9d5b086218c41458ea35d817691 # main
 
             - name: Install cargo-shear
-              run: cargo binstall --no-confirm cargo-shear@1.1.12
+              # --force is required: Swatinem/rust-cache restores ~/.cargo/.crates2.json
+              # (which records cargo-shear as installed) but not the binary itself, so
+              # without --force binstall short-circuits ("already installed") and the
+              # next step fails with `error: no such command: shear`.
+              run: cargo binstall --no-confirm --force cargo-shear@1.1.12
 
             - name: Run cargo shear
               run: cargo shear

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -24,7 +24,9 @@ use crate::{
     prometheus::{report_clock_skew, report_dropped_events},
     router, sinks,
     utils::uuid_v7,
-    v0_request::{DataType, ProcessedEvent, ProcessedEventMetadata, ProcessingContext},
+    v0_request::{
+        DataType, OverflowReason, ProcessedEvent, ProcessedEventMetadata, ProcessingContext,
+    },
 };
 
 /// Property keys the heatmap pipeline reads from a redirected event. The
@@ -317,7 +319,9 @@ pub async fn process_events(
         debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "filtered by event_restrictions");
     }
 
-    // Apply per-(token, distinct_id) global rate limiting -- skip person processing for high-volume distinct_ids
+    // Apply per-(token, distinct_id) global rate limiting -- skip person
+    // processing for high-volume distinct_ids and reroute AnalyticsMain events
+    // to overflow to spread the hot key across partitions.
     if let Some(ref limiter) = global_rate_limiter {
         let mut limited_distinct_ids: HashSet<&str> = HashSet::new();
         let mut limited_event_count: u64 = 0;
@@ -327,6 +331,15 @@ pub async fn process_events(
                     .to_cache_key();
             if limiter.is_limited(&cache_key, 1).await.is_some() {
                 event.metadata.skip_person_processing = true;
+                // Reroute to overflow via ForceLimited (null key + force-disable
+                // header at the sink). Gated to AnalyticsMain: the sink's
+                // AnalyticsHistorical arm never overflows, and only AnalyticsMain
+                // acts on overflow_reason. Leaving force_overflow untouched keeps
+                // stamp_overflow_reason (which runs next) free to evaluate the
+                // overflow limiter without the event_restriction short-circuit.
+                if event.metadata.data_type == DataType::AnalyticsMain {
+                    event.metadata.overflow_reason = Some(OverflowReason::ForceLimited);
+                }
                 limited_distinct_ids.insert(&event.event.distinct_id);
                 limited_event_count += 1;
             }
@@ -1550,14 +1563,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_overflow_stamp_global_rate_limiter_and_overflow_interplay() {
-        // Both limiters fire on the same event: global RL sets
-        // skip_person_processing=true on (token, distinct_id) overage, and the
-        // OverflowLimiter stamps RateLimited{preserve_locality: true} on the
-        // second event because burst=1. The pipeline must OR the two effects
-        // into the same metadata record; the sink then routes to the overflow
-        // topic, keeps the partition key, and writes the skip-person header.
-        // Pre-refactor these were split across pipeline + sink; this test
-        // pins the end-to-end metadata contract.
+        // Both limiters interact on AnalyticsMain events. The global RL now does
+        // two things on a (token, distinct_id) overage: sets
+        // skip_person_processing=true AND stamps overflow_reason=ForceLimited
+        // (rerouting the hot key to overflow). stamp_overflow_reason then runs:
+        // event[0] is within the overflow limiter's burst (NotLimited), so the
+        // global RL's ForceLimited stamp survives; event[1] exceeds burst=1 so
+        // the overflow limiter overwrites it with RateLimited{preserve_locality:
+        // true}. Either way both land on the overflow topic with the skip-person
+        // header. This pins the end-to-end metadata contract.
 
         let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
             .unwrap()
@@ -1596,15 +1610,17 @@ mod tests {
         let captured = sink.get_events();
         assert_eq!(captured.len(), 2);
 
-        // event[0]: global RL fires (distinct_id limited) -> skip_person_processing.
-        // Overflow limiter's first token is within burst so no overflow_reason.
+        // event[0]: global RL fires (distinct_id limited) -> skip_person_processing
+        // AND overflow_reason=ForceLimited. The overflow limiter's first token is
+        // within burst (NotLimited), so the global RL's ForceLimited stamp stands.
         assert!(
             captured[0].metadata.skip_person_processing,
             "event[0]: global RL should set skip_person_processing"
         );
         assert_eq!(
-            captured[0].metadata.overflow_reason, None,
-            "event[0]: burst=1 means first event is NOT overflow"
+            captured[0].metadata.overflow_reason,
+            Some(OverflowReason::ForceLimited),
+            "event[0]: global RL reroutes the hot key to overflow via ForceLimited"
         );
 
         // event[1]: BOTH stamps fire. skip_person_processing from global RL,
@@ -1620,6 +1636,100 @@ mod tests {
             }),
             "event[1]: overflow limiter should stamp RateLimited{{preserve_locality: true}}"
         );
+    }
+
+    #[tokio::test]
+    async fn global_rate_limit_reroutes_analytics_main_to_overflow() {
+        // A globally rate-limited AnalyticsMain event is rerouted to overflow via
+        // ForceLimited even when no OverflowLimiter is configured -- the global RL
+        // loop stamps the reason directly and stamp_overflow_reason leaves it
+        // intact (no limiter to consult).
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        // historical_migration defaults to false -> AnalyticsMain.
+        let context = create_test_context(now, None);
+        let events = vec![create_test_event(
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        let global_limiter = Arc::new(GlobalRateLimiter::mock_limiting(&["test_token:test_user"]));
+
+        process_events(
+            sink.clone(),
+            dropper,
+            None,
+            historical_cfg,
+            Some(global_limiter),
+            None, // no overflow limiter -- isolate global RL behavior
+            events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].metadata.data_type, DataType::AnalyticsMain);
+        assert!(captured[0].metadata.skip_person_processing);
+        assert_eq!(
+            captured[0].metadata.overflow_reason,
+            Some(OverflowReason::ForceLimited),
+            "globally limited AnalyticsMain should be rerouted to overflow"
+        );
+    }
+
+    #[tokio::test]
+    async fn global_rate_limit_does_not_overflow_historical_events() {
+        // Invariant: a globally rate-limited AnalyticsHistorical event gets person
+        // processing disabled but is NOT rerouted to overflow -- it stays on the
+        // historical lane (matches the sink's AnalyticsHistorical arm, which never
+        // overflows).
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut context = create_test_context(now, None);
+        context.historical_migration = true; // classifies events as AnalyticsHistorical
+        let events = vec![create_test_event(
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        let global_limiter = Arc::new(GlobalRateLimiter::mock_limiting(&["test_token:test_user"]));
+
+        process_events(
+            sink.clone(),
+            dropper,
+            None,
+            historical_cfg,
+            Some(global_limiter),
+            None, // no overflow limiter -- isolate global RL behavior
+            events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].metadata.data_type,
+            DataType::AnalyticsHistorical
+        );
+        // Person processing disabled...
+        assert!(captured[0].metadata.skip_person_processing);
+        // ...but NOT rerouted to overflow.
+        assert_eq!(captured[0].metadata.overflow_reason, None);
+        assert!(!captured[0].metadata.force_overflow);
     }
 
     // ============ end-to-end pipeline -> real KafkaSinkBase tests ============

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -319,9 +319,8 @@ pub async fn process_events(
         debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "filtered by event_restrictions");
     }
 
-    // Apply per-(token, distinct_id) global rate limiting -- skip person
-    // processing for high-volume distinct_ids and reroute AnalyticsMain events
-    // to overflow to spread the hot key across partitions.
+    // Per-(token, distinct_id) global rate limiting: skip person processing for
+    // hot distinct_ids and reroute AnalyticsMain events to overflow.
     if let Some(ref limiter) = global_rate_limiter {
         let mut limited_distinct_ids: HashSet<&str> = HashSet::new();
         let mut limited_event_count: u64 = 0;
@@ -331,12 +330,8 @@ pub async fn process_events(
                     .to_cache_key();
             if limiter.is_limited(&cache_key, 1).await.is_some() {
                 event.metadata.skip_person_processing = true;
-                // Reroute to overflow via ForceLimited (null key + force-disable
-                // header at the sink). Gated to AnalyticsMain: the sink's
-                // AnalyticsHistorical arm never overflows, and only AnalyticsMain
-                // acts on overflow_reason. Leaving force_overflow untouched keeps
-                // stamp_overflow_reason (which runs next) free to evaluate the
-                // overflow limiter without the event_restriction short-circuit.
+                // Reroute the hot key to overflow. AnalyticsMain only: historical
+                // never overflows and only AnalyticsMain acts on overflow_reason.
                 if event.metadata.data_type == DataType::AnalyticsMain {
                     event.metadata.overflow_reason = Some(OverflowReason::ForceLimited);
                 }
@@ -1563,15 +1558,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_overflow_stamp_global_rate_limiter_and_overflow_interplay() {
-        // Both limiters interact on AnalyticsMain events. The global RL now does
-        // two things on a (token, distinct_id) overage: sets
-        // skip_person_processing=true AND stamps overflow_reason=ForceLimited
-        // (rerouting the hot key to overflow). stamp_overflow_reason then runs:
-        // event[0] is within the overflow limiter's burst (NotLimited), so the
-        // global RL's ForceLimited stamp survives; event[1] exceeds burst=1 so
-        // the overflow limiter overwrites it with RateLimited{preserve_locality:
-        // true}. Either way both land on the overflow topic with the skip-person
-        // header. This pins the end-to-end metadata contract.
+        // Global RL stamps skip_person_processing + ForceLimited on both events;
+        // the overflow limiter (burst=1) then overwrites event[1] with
+        // RateLimited. Either way both reach overflow with the skip-person header.
 
         let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
             .unwrap()
@@ -1610,9 +1599,8 @@ mod tests {
         let captured = sink.get_events();
         assert_eq!(captured.len(), 2);
 
-        // event[0]: global RL fires (distinct_id limited) -> skip_person_processing
-        // AND overflow_reason=ForceLimited. The overflow limiter's first token is
-        // within burst (NotLimited), so the global RL's ForceLimited stamp stands.
+        // event[0]: global RL stamps skip_person_processing + ForceLimited; within
+        // the overflow limiter's burst, so the ForceLimited stamp survives.
         assert!(
             captured[0].metadata.skip_person_processing,
             "event[0]: global RL should set skip_person_processing"
@@ -1641,9 +1629,7 @@ mod tests {
     #[tokio::test]
     async fn global_rate_limit_reroutes_analytics_main_to_overflow() {
         // A globally rate-limited AnalyticsMain event is rerouted to overflow via
-        // ForceLimited even when no OverflowLimiter is configured -- the global RL
-        // loop stamps the reason directly and stamp_overflow_reason leaves it
-        // intact (no limiter to consult).
+        // ForceLimited even with no OverflowLimiter configured.
         let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
@@ -1687,9 +1673,7 @@ mod tests {
     #[tokio::test]
     async fn global_rate_limit_does_not_overflow_historical_events() {
         // Invariant: a globally rate-limited AnalyticsHistorical event gets person
-        // processing disabled but is NOT rerouted to overflow -- it stays on the
-        // historical lane (matches the sink's AnalyticsHistorical arm, which never
-        // overflows).
+        // processing disabled but is never rerouted to overflow.
         let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
             .unwrap()
             .with_timezone(&Utc);

--- a/rust/capture/src/v1/analytics/constants.rs
+++ b/rust/capture/src/v1/analytics/constants.rs
@@ -52,7 +52,7 @@ pub(crate) const CAPTURE_V1_RATE_LIMITER: &str = "capture_v1_rate_limiter";
 pub(super) const CAPTURE_V1_ILLEGAL_DISTINCT_ID: &str = "capture_v1_illegal_distinct_id";
 
 /// Detail tag for events flagged by the per-token:distinct_id rate limiter.
-/// Matches the OpenAPI BatchEntryStatusError example for `result: limited`.
+/// Matches the OpenAPI BatchEntryStatusError example for `result: warning`.
 pub(super) const DETAIL_PERSON_PROCESSING_DISABLED: &str = "person_processing_disabled";
 
 /// Detail tag for events dropped by the event restriction service.

--- a/rust/capture/src/v1/analytics/constants.rs
+++ b/rust/capture/src/v1/analytics/constants.rs
@@ -48,6 +48,9 @@ pub(super) const CAPTURE_V1_OVERFLOW_ROUTED: &str = "capture_v1_events_rerouted_
 /// Counter/gauge key for the per-token global rate limiter.
 pub(crate) const CAPTURE_V1_RATE_LIMITER: &str = "capture_v1_rate_limiter";
 
+/// Counter for events with an illegal distinct_id (person processing disabled).
+pub(super) const CAPTURE_V1_ILLEGAL_DISTINCT_ID: &str = "capture_v1_illegal_distinct_id";
+
 /// Detail tag for events flagged by the per-token:distinct_id rate limiter.
 /// Matches the OpenAPI BatchEntryStatusError example for `result: limited`.
 pub(super) const DETAIL_PERSON_PROCESSING_DISABLED: &str = "person_processing_disabled";

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -5,10 +5,10 @@ use uuid::Uuid;
 
 use super::constants::{
     CAPTURE_V1_DISTINCT_ID_MAX_SIZE, CAPTURE_V1_EVENTS_DROPPED,
-    CAPTURE_V1_EVENTS_REROUTED_HISTORICAL, CAPTURE_V1_MAX_EVENT_NAME_LENGTH,
-    CAPTURE_V1_OVERFLOW_ROUTED, CAPTURE_V1_PARSED_EVENTS, CAPTURE_V1_RATE_LIMITER,
-    DETAIL_EVENT_RESTRICTION_DROP, DETAIL_PERSON_PROCESSING_DISABLED, FUTURE_EVENT_HOURS_CUTOFF_MS,
-    ILLEGAL_DISTINCT_IDS,
+    CAPTURE_V1_EVENTS_REROUTED_HISTORICAL, CAPTURE_V1_ILLEGAL_DISTINCT_ID,
+    CAPTURE_V1_MAX_EVENT_NAME_LENGTH, CAPTURE_V1_OVERFLOW_ROUTED, CAPTURE_V1_PARSED_EVENTS,
+    CAPTURE_V1_RATE_LIMITER, DETAIL_EVENT_RESTRICTION_DROP, DETAIL_PERSON_PROCESSING_DISABLED,
+    FUTURE_EVENT_HOURS_CUTOFF_MS, ILLEGAL_DISTINCT_IDS,
 };
 use super::response::BatchResponse;
 use super::types::{Batch, Event, EventResult, WrappedEvent};
@@ -171,6 +171,7 @@ fn validate_batch(batch: &Batch) -> Result<(), Error> {
 fn validate_events(context: &Context, batch: Batch) -> Result<Vec<WrappedEvent>, Error> {
     let mut events: Vec<WrappedEvent> = Vec::with_capacity(batch.batch.len());
     let mut seen: HashSet<Uuid> = HashSet::with_capacity(batch.batch.len());
+    let mut illegal_distinct_id_count: u64 = 0;
 
     for event in batch.batch.into_iter() {
         let uuid_str = event.uuid();
@@ -189,14 +190,22 @@ fn validate_events(context: &Context, batch: Batch) -> Result<Vec<WrappedEvent>,
             Ok(raw_ts) => {
                 metrics::counter!(CAPTURE_V1_PARSED_EVENTS, "result" => "valid").increment(1);
                 let adjusted = normalize_timestamp(context, &event, raw_ts);
+                let illegal = is_distinct_id_illegal(&event.distinct_id);
+                if illegal {
+                    illegal_distinct_id_count += 1;
+                }
                 events.push(WrappedEvent {
                     event,
                     uuid,
                     adjusted_timestamp: Some(adjusted),
                     result: EventResult::Ok,
-                    details: None,
+                    details: if illegal {
+                        Some(DETAIL_PERSON_PROCESSING_DISABLED)
+                    } else {
+                        None
+                    },
                     destination,
-                    force_disable_person_processing: false,
+                    force_disable_person_processing: illegal,
                 });
             }
             Err(err) => {
@@ -213,6 +222,16 @@ fn validate_events(context: &Context, batch: Batch) -> Result<Vec<WrappedEvent>,
         }
     }
 
+    if illegal_distinct_id_count > 0 {
+        metrics::counter!(CAPTURE_V1_ILLEGAL_DISTINCT_ID).increment(illegal_distinct_id_count);
+        crate::ctx_log!(
+            Level::INFO,
+            context,
+            count = illegal_distinct_id_count,
+            "events with illegal distinct_id -- person processing disabled"
+        );
+    }
+
     if events.iter().any(|e| e.result != EventResult::Ok) {
         observe_malformed_events(context, &events);
     }
@@ -222,13 +241,11 @@ fn validate_events(context: &Context, batch: Batch) -> Result<Vec<WrappedEvent>,
 
 fn observe_malformed_events(context: &Context, events: &[WrappedEvent]) {
     let mut malformed: HashMap<&'static str, u64> = HashMap::new();
-    let mut illegal_distinct_ids: HashSet<&str> = HashSet::new();
 
     for event in events.iter() {
-        if let Some(tag) = event.details {
-            *malformed.entry(tag).or_insert(0) += 1;
-            if tag == "invalid_distinct_id" {
-                illegal_distinct_ids.insert(&event.event.distinct_id);
+        if event.result != EventResult::Ok {
+            if let Some(tag) = event.details {
+                *malformed.entry(tag).or_insert(0) += 1;
             }
         }
     }
@@ -244,15 +261,7 @@ fn observe_malformed_events(context: &Context, events: &[WrappedEvent]) {
         .collect::<Vec<_>>()
         .join(", ");
 
-    let illegal_ids_csv: String = illegal_distinct_ids
-        .into_iter()
-        .collect::<Vec<_>>()
-        .join(", ");
-
-    crate::ctx_log!(Level::WARN, context,
-        illegal_distinct_ids = %illegal_ids_csv,
-        "malformed events: {summary}"
-    );
+    crate::ctx_log!(Level::WARN, context, "malformed events: {summary}");
 }
 
 fn is_distinct_id_illegal(distinct_id: &str) -> bool {
@@ -277,9 +286,6 @@ fn validate_event(event: &Event) -> Result<DateTime<Utc>, Error> {
     }
     if event.distinct_id.len() > CAPTURE_V1_DISTINCT_ID_MAX_SIZE {
         return Err(Error::DistinctIdTooLarge);
-    }
-    if is_distinct_id_illegal(&event.distinct_id) {
-        return Err(Error::InvalidDistinctId(event.distinct_id.clone()));
     }
 
     let ts = DateTime::parse_from_rfc3339(&event.timestamp)
@@ -442,7 +448,7 @@ async fn apply_token_distinct_id_limits(
     let mut allowed_count: u64 = 0;
 
     for event in events.iter_mut() {
-        if event.result != EventResult::Ok {
+        if event.result != EventResult::Ok || event.force_disable_person_processing {
             continue;
         }
         let cache_key =
@@ -618,7 +624,7 @@ mod tests {
     }
 
     #[test]
-    fn event_illegal_distinct_ids_rejected() {
+    fn event_illegal_distinct_ids_pass_validation() {
         let illegal_ids = [
             "anonymous",
             "ANONYMOUS",
@@ -641,8 +647,8 @@ mod tests {
             let mut event = valid_event();
             event.distinct_id = id.to_string();
             assert!(
-                matches!(validate_event(&event), Err(Error::InvalidDistinctId(_))),
-                "expected InvalidDistinctId for distinct_id={id:?}"
+                validate_event(&event).is_ok(),
+                "expected Ok for illegal distinct_id={id:?} (flagging happens in validate_events)"
             );
         }
     }
@@ -749,6 +755,39 @@ mod tests {
             assert_eq!(ev.result, EventResult::Drop);
             assert_eq!(ev.details, Some("dropped_performance_event"));
         }
+    }
+
+    #[test]
+    fn validate_events_illegal_distinct_id_flags_person_processing_disabled() {
+        let ctx = test_utils::test_context();
+        let mut illegal_event = valid_event();
+        illegal_event.distinct_id = "null".to_string();
+        let legal_event = valid_event();
+        let batch = valid_batch(vec![illegal_event, legal_event]);
+        let events = validate_events(&ctx, batch).unwrap();
+        assert_eq!(events.len(), 2);
+
+        let flagged = &events[0];
+        assert_eq!(flagged.result, EventResult::Ok);
+        assert!(flagged.force_disable_person_processing);
+        assert_eq!(flagged.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
+        assert_ne!(flagged.destination, Destination::Drop);
+
+        let normal = &events[1];
+        assert_eq!(normal.result, EventResult::Ok);
+        assert!(!normal.force_disable_person_processing);
+        assert!(normal.details.is_none());
+    }
+
+    #[test]
+    fn validate_events_illegal_distinct_id_still_publishable() {
+        let ctx = test_utils::test_context();
+        let mut illegal_event = valid_event();
+        illegal_event.distinct_id = "anonymous".to_string();
+        let batch = valid_batch(vec![illegal_event]);
+        let events = validate_events(&ctx, batch).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].should_publish());
     }
 
     // --- validate_events ---
@@ -1452,6 +1491,32 @@ mod tests {
         assert_eq!(limited.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
     }
 
+    #[tokio::test]
+    async fn td_limits_skips_events_already_flagged_force_disable_pp() {
+        let limiter = mock_limiter(vec!["phc_tok:user-1"]);
+        let ctx = td_context();
+        let mut events = vec![
+            wrapped_event("$pageview", "user-1"),
+            wrapped_event("$identify", "user-2"),
+        ];
+        // Simulate illegal distinct_id flagging from validate_events
+        events[0].force_disable_person_processing = true;
+        events[0].details = Some(DETAIL_PERSON_PROCESSING_DISABLED);
+
+        apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
+
+        // Already-flagged event not re-evaluated: result stays Ok, details unchanged
+        let flagged = find_by_did(&events, "user-1");
+        assert_eq!(flagged.result, EventResult::Ok);
+        assert!(flagged.force_disable_person_processing);
+        assert_eq!(flagged.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
+        // Unflagged event passes (not in limiter's limited keys)
+        let normal = find_by_did(&events, "user-2");
+        assert_eq!(normal.result, EventResult::Ok);
+        assert!(!normal.force_disable_person_processing);
+        assert!(normal.details.is_none());
+    }
+
     // --- apply_historical_rerouting ---
 
     #[test]
@@ -2076,7 +2141,7 @@ mod tests {
     fn merge_pre_drop_not_mutated_even_if_result_present() {
         let mut events = vec![wrapped_event("$pageview", "user-1")];
         events[0].result = EventResult::Drop;
-        events[0].details = Some("invalid_distinct_id");
+        events[0].details = Some("missing_event_name");
 
         // Should be unreachable in practice (dropped events aren't published
         // so they won't have a SinkResult), but even if a result exists for
@@ -2087,7 +2152,7 @@ mod tests {
         merge_sink_results(&mut events, &results);
 
         assert_eq!(events[0].result, EventResult::Drop);
-        assert_eq!(events[0].details, Some("invalid_distinct_id"));
+        assert_eq!(events[0].details, Some("missing_event_name"));
     }
 
     #[tokio::test]

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -115,7 +115,7 @@ pub async fn process_batch(
 ///
 /// Events that were not published (`should_publish() == false`) are untouched.
 /// Published events receive updated `result` and `details` based on the sink outcome:
-/// - `Outcome::Success` → keep existing result (Ok or Limited)
+/// - `Outcome::Success` → keep existing result (Ok or Warning)
 /// - `Outcome::RetriableError` | `Outcome::Timeout` → `EventResult::Retry`
 /// - `Outcome::FatalError` → `EventResult::Drop`
 pub fn merge_sink_results(events: &mut [WrappedEvent], sink_results: &[Box<dyn SinkResult>]) {
@@ -135,7 +135,7 @@ pub fn merge_sink_results(events: &mut [WrappedEvent], sink_results: &[Box<dyn S
 
         match result.outcome() {
             Outcome::Success => {
-                // Leave event.result as-is (Ok or Limited from upstream processing)
+                // Leave event.result as-is (Ok or Warning from upstream processing)
             }
             Outcome::RetriableError | Outcome::Timeout => {
                 event.result = EventResult::Retry;
@@ -423,7 +423,11 @@ async fn apply_restrictions(
         }
 
         // Priority: overflow < custom topic < DLQ (DLQ wins, applied last)
-        if applied.force_overflow() {
+        // Overflow only applies to AnalyticsMain: AnalyticsHistorical must never
+        // overflow (legacy sink invariant). Today this stage runs before
+        // historical rerouting so the destination is always AnalyticsMain here;
+        // the explicit guard makes the invariant ordering-independent.
+        if applied.force_overflow() && event.destination == Destination::AnalyticsMain {
             event.destination = Destination::Overflow;
         }
         if let Some(topic) = applied.redirect_to_topic() {
@@ -455,10 +459,18 @@ async fn apply_token_distinct_id_limits(
             GlobalRateLimitKey::TokenDistinctId(&context.api_token, &event.event.distinct_id)
                 .to_cache_key();
         if limiter.is_limited(&cache_key, 1).await.is_some() {
-            event.result = EventResult::Limited;
+            event.result = EventResult::Warning;
             // Disables person processing -- sink will null partition key for Main/Overflow.
             event.force_disable_person_processing = true;
             event.details = Some(DETAIL_PERSON_PROCESSING_DISABLED);
+            // Reroute to overflow to spread a hot token:distinct_id across
+            // partitions. Gated to AnalyticsMain only: this stage runs after
+            // historical rerouting, and AnalyticsHistorical must never overflow
+            // (matches the legacy sink invariant). Other lanes (exceptions,
+            // heatmaps, etc.) keep their own destination.
+            if event.destination == Destination::AnalyticsMain {
+                event.destination = Destination::Overflow;
+            }
             limited_distinct_ids.insert(event.event.distinct_id.as_str());
         } else {
             allowed_count += 1;
@@ -759,35 +771,43 @@ mod tests {
 
     #[test]
     fn validate_events_illegal_distinct_id_flags_person_processing_disabled() {
-        let ctx = test_utils::test_context();
-        let mut illegal_event = valid_event();
-        illegal_event.distinct_id = "null".to_string();
-        let legal_event = valid_event();
-        let batch = valid_batch(vec![illegal_event, legal_event]);
-        let events = validate_events(&ctx, batch).unwrap();
-        assert_eq!(events.len(), 2);
+        for id in ILLEGAL_DISTINCT_IDS {
+            let ctx = test_utils::test_context();
+            let mut illegal_event = valid_event();
+            illegal_event.distinct_id = id.to_string();
+            let legal_event = valid_event();
+            let batch = valid_batch(vec![illegal_event, legal_event]);
+            let events = validate_events(&ctx, batch).unwrap();
+            assert_eq!(events.len(), 2, "id={id:?}");
 
-        let flagged = &events[0];
-        assert_eq!(flagged.result, EventResult::Ok);
-        assert!(flagged.force_disable_person_processing);
-        assert_eq!(flagged.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
-        assert_ne!(flagged.destination, Destination::Drop);
+            let flagged = &events[0];
+            assert_eq!(flagged.result, EventResult::Ok, "id={id:?}");
+            assert!(flagged.force_disable_person_processing, "id={id:?}");
+            assert_eq!(
+                flagged.details,
+                Some(DETAIL_PERSON_PROCESSING_DISABLED),
+                "id={id:?}"
+            );
+            assert_ne!(flagged.destination, Destination::Drop, "id={id:?}");
 
-        let normal = &events[1];
-        assert_eq!(normal.result, EventResult::Ok);
-        assert!(!normal.force_disable_person_processing);
-        assert!(normal.details.is_none());
+            let normal = &events[1];
+            assert_eq!(normal.result, EventResult::Ok, "id={id:?}");
+            assert!(!normal.force_disable_person_processing, "id={id:?}");
+            assert!(normal.details.is_none(), "id={id:?}");
+        }
     }
 
     #[test]
     fn validate_events_illegal_distinct_id_still_publishable() {
-        let ctx = test_utils::test_context();
-        let mut illegal_event = valid_event();
-        illegal_event.distinct_id = "anonymous".to_string();
-        let batch = valid_batch(vec![illegal_event]);
-        let events = validate_events(&ctx, batch).unwrap();
-        assert_eq!(events.len(), 1);
-        assert!(events[0].should_publish());
+        for id in ILLEGAL_DISTINCT_IDS {
+            let ctx = test_utils::test_context();
+            let mut illegal_event = valid_event();
+            illegal_event.distinct_id = id.to_string();
+            let batch = valid_batch(vec![illegal_event]);
+            let events = validate_events(&ctx, batch).unwrap();
+            assert_eq!(events.len(), 1, "id={id:?}");
+            assert!(events[0].should_publish(), "id={id:?}");
+        }
     }
 
     // --- validate_events ---
@@ -1414,8 +1434,9 @@ mod tests {
         assert_eq!(ok_ev.destination, Destination::AnalyticsMain);
         assert!(ok_ev.details.is_none());
         let limited_ev = find_by_did(&events, "user-2");
-        assert_eq!(limited_ev.result, EventResult::Limited);
-        assert_eq!(limited_ev.destination, Destination::AnalyticsMain);
+        assert_eq!(limited_ev.result, EventResult::Warning);
+        // AnalyticsMain event over the limit is rerouted to overflow.
+        assert_eq!(limited_ev.destination, Destination::Overflow);
         assert!(limited_ev.force_disable_person_processing);
         assert_eq!(limited_ev.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
     }
@@ -1447,11 +1468,11 @@ mod tests {
         apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
 
         for ev in &events {
-            assert_eq!(ev.result, EventResult::Limited, "should be Limited");
+            assert_eq!(ev.result, EventResult::Warning, "should be Warning");
             assert_eq!(
                 ev.destination,
-                Destination::AnalyticsMain,
-                "should stay on main topic"
+                Destination::Overflow,
+                "should be rerouted to overflow"
             );
             assert!(
                 ev.force_disable_person_processing,
@@ -1483,10 +1504,10 @@ mod tests {
         let dropped = find_by_did(&events, "user-1");
         assert_eq!(dropped.result, EventResult::Drop);
         assert_eq!(dropped.destination, Destination::Drop);
-        // Other event rate-limited (person processing disabled, stays on main topic)
+        // Other event rate-limited (person processing disabled, rerouted to overflow)
         let limited = find_by_did(&events, "user-2");
-        assert_eq!(limited.result, EventResult::Limited);
-        assert_eq!(limited.destination, Destination::AnalyticsMain);
+        assert_eq!(limited.result, EventResult::Warning);
+        assert_eq!(limited.destination, Destination::Overflow);
         assert!(limited.force_disable_person_processing);
         assert_eq!(limited.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
     }
@@ -1515,6 +1536,31 @@ mod tests {
         assert_eq!(normal.result, EventResult::Ok);
         assert!(!normal.force_disable_person_processing);
         assert!(normal.details.is_none());
+    }
+
+    #[tokio::test]
+    async fn td_limits_historical_event_not_rerouted_to_overflow() {
+        // Invariant: AnalyticsHistorical must never be rerouted to Overflow.
+        // A globally rate-limited historical event still gets person processing
+        // disabled, but stays on the historical lane (matches the legacy sink,
+        // where the AnalyticsHistorical arm never overflows).
+        let limiter = mock_limiter(vec!["phc_tok:user-1"]);
+        let ctx = td_context();
+        let mut events =
+            vec![wrapped_event("$pageview", "user-1")
+                .with_destination(Destination::AnalyticsHistorical)];
+
+        apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
+
+        let ev = find_by_did(&events, "user-1");
+        assert_eq!(ev.result, EventResult::Warning);
+        assert_eq!(
+            ev.destination,
+            Destination::AnalyticsHistorical,
+            "historical events must not be rerouted to overflow"
+        );
+        assert!(ev.force_disable_person_processing);
+        assert_eq!(ev.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
     }
 
     // --- apply_historical_rerouting ---
@@ -1805,14 +1851,19 @@ mod tests {
             ],
         );
         assert!(!events[0].force_disable_person_processing);
+        assert_eq!(events[0].destination, Destination::AnalyticsMain);
         assert!(events[1].force_disable_person_processing);
-        assert_eq!(events[1].result, EventResult::Limited);
+        assert_eq!(events[1].result, EventResult::Warning);
+        assert_eq!(events[1].destination, Destination::Overflow);
         assert_eq!(events[1].details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
         assert!(!events[2].force_disable_person_processing);
+        assert_eq!(events[2].destination, Destination::AnalyticsMain);
         assert!(events[3].force_disable_person_processing);
-        assert_eq!(events[3].result, EventResult::Limited);
+        assert_eq!(events[3].result, EventResult::Warning);
+        assert_eq!(events[3].destination, Destination::Overflow);
         assert_eq!(events[3].details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
         assert!(!events[4].force_disable_person_processing);
+        assert_eq!(events[4].destination, Destination::AnalyticsMain);
     }
 
     #[tokio::test]
@@ -2041,15 +2092,15 @@ mod tests {
     }
 
     #[test]
-    fn merge_preserves_limited_result_on_success() {
+    fn merge_preserves_warning_result_on_success() {
         let mut events = vec![wrapped_event("$pageview", "user-1")];
-        events[0].result = EventResult::Limited;
+        events[0].result = EventResult::Warning;
         events[0].details = Some("person_processing_disabled");
 
         let results: Vec<Box<dyn SinkResult>> = vec![MockSinkResult::success(events[0].uuid)];
         merge_sink_results(&mut events, &results);
 
-        assert_eq!(events[0].result, EventResult::Limited);
+        assert_eq!(events[0].result, EventResult::Warning);
         assert_eq!(events[0].details, Some("person_processing_disabled"));
     }
 
@@ -2267,7 +2318,7 @@ mod tests {
             wrapped_event("$pageview", "user-2")
                 .with_result(EventResult::Drop, Some("billing_limit_exceeded")),
             wrapped_event("$pageview", "user-3")
-                .with_result(EventResult::Limited, Some("person_processing_disabled")),
+                .with_result(EventResult::Warning, Some("person_processing_disabled")),
         ];
 
         let event_refs: Vec<&(dyn crate::v1::sinks::event::Event + Send + Sync)> = events
@@ -2279,7 +2330,7 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(event_refs.len(), 2); // only Ok + Limited are published
+        assert_eq!(event_refs.len(), 2); // only Ok + Warning are published
 
         let sink_results = router
             .publish_batch(router.default_sink(), &ctx, &event_refs)
@@ -2294,7 +2345,7 @@ mod tests {
         assert_eq!(resp.entries()[0].1.result, EventResult::Ok);
         assert_eq!(resp.entries()[1].1.result, EventResult::Drop);
         assert_eq!(resp.entries()[1].1.details, Some("billing_limit_exceeded"));
-        assert_eq!(resp.entries()[2].1.result, EventResult::Limited);
+        assert_eq!(resp.entries()[2].1.result, EventResult::Warning);
         assert_eq!(
             resp.entries()[2].1.details,
             Some("person_processing_disabled")

--- a/rust/capture/src/v1/analytics/response.rs
+++ b/rust/capture/src/v1/analytics/response.rs
@@ -197,15 +197,15 @@ mod tests {
     }
 
     #[test]
-    fn batch_entry_status_serialize_limited_with_details() {
+    fn batch_entry_status_serialize_warning_with_details() {
         let status = BatchEntryStatus {
-            result: EventResult::Limited,
+            result: EventResult::Warning,
             details: Some("person_processing_disabled"),
         };
         let json = serde_json::to_string(&status).unwrap();
         assert_eq!(
             json,
-            r#"{"result":"limited","details":"person_processing_disabled"}"#
+            r#"{"result":"warning","details":"person_processing_disabled"}"#
         );
     }
 
@@ -232,7 +232,7 @@ mod tests {
         let events = vec![
             make_wrapped(EventResult::Ok, None),
             make_wrapped(EventResult::Drop, Some("billing_limit_exceeded")),
-            make_wrapped(EventResult::Limited, Some("person_processing_disabled")),
+            make_wrapped(EventResult::Warning, Some("person_processing_disabled")),
             make_wrapped(EventResult::Retry, Some("not_persisted")),
         ];
         let resp = BatchResponse::build(&ctx, &events);
@@ -240,7 +240,7 @@ mod tests {
         assert_eq!(resp.entries().len(), 4);
         assert_eq!(resp.entries()[0].1.result, EventResult::Ok);
         assert_eq!(resp.entries()[1].1.result, EventResult::Drop);
-        assert_eq!(resp.entries()[2].1.result, EventResult::Limited);
+        assert_eq!(resp.entries()[2].1.result, EventResult::Warning);
         assert_eq!(resp.entries()[3].1.result, EventResult::Retry);
     }
 
@@ -250,7 +250,7 @@ mod tests {
         let events = vec![
             make_wrapped(EventResult::Ok, None),
             make_wrapped(EventResult::Drop, Some("billing")),
-            make_wrapped(EventResult::Limited, Some("pp_disabled")),
+            make_wrapped(EventResult::Warning, Some("pp_disabled")),
         ];
         let resp = BatchResponse::build(&ctx, &events);
         assert!(!resp.has_retry);

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -31,7 +31,7 @@ fn empty_raw_object() -> Box<RawValue> {
 }
 
 /// Per-event outcome in the batch response.
-/// Ok: captured successfully. Drop: rejected (billing/validation). Limited: accepted
+/// Ok: captured successfully. Drop: rejected (billing/validation). Warning: accepted
 /// with person processing disabled (do not resubmit). Retry: not persisted, safe to resubmit.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -39,7 +39,7 @@ pub enum EventResult {
     #[default]
     Ok,
     Drop,
-    Limited,
+    Warning,
     Retry,
 }
 
@@ -107,9 +107,9 @@ impl SinkEvent for WrappedEvent {
         self.uuid
     }
 
-    // Publish Ok and Limited events; skip Drop, Retry, and anything routed to Destination::Drop.
+    // Publish Ok and Warning events; skip Drop, Retry, and anything routed to Destination::Drop.
     fn should_publish(&self) -> bool {
-        (self.result == EventResult::Ok || self.result == EventResult::Limited)
+        (self.result == EventResult::Ok || self.result == EventResult::Warning)
             && self.destination != Destination::Drop
     }
 
@@ -702,9 +702,9 @@ mod tests {
     #[case::ok_main(EventResult::Ok, Destination::AnalyticsMain)]
     #[case::ok_historical(EventResult::Ok, Destination::AnalyticsHistorical)]
     #[case::ok_overflow(EventResult::Ok, Destination::Overflow)]
-    #[case::limited_main(EventResult::Limited, Destination::AnalyticsMain)]
-    #[case::limited_historical(EventResult::Limited, Destination::AnalyticsHistorical)]
-    #[case::limited_overflow(EventResult::Limited, Destination::Overflow)]
+    #[case::warning_main(EventResult::Warning, Destination::AnalyticsMain)]
+    #[case::warning_historical(EventResult::Warning, Destination::AnalyticsHistorical)]
+    #[case::warning_overflow(EventResult::Warning, Destination::Overflow)]
     fn should_publish_true(#[case] result: EventResult, #[case] dest: Destination) {
         let mut ev = ok_wrapped("$pageview", "user-1");
         ev.result = result;
@@ -716,7 +716,7 @@ mod tests {
     #[case::drop_main(EventResult::Drop, Destination::AnalyticsMain)]
     #[case::retry_main(EventResult::Retry, Destination::AnalyticsMain)]
     #[case::ok_dest_drop(EventResult::Ok, Destination::Drop)]
-    #[case::limited_dest_drop(EventResult::Limited, Destination::Drop)]
+    #[case::warning_dest_drop(EventResult::Warning, Destination::Drop)]
     #[case::drop_dest_drop(EventResult::Drop, Destination::Drop)]
     #[case::retry_dest_drop(EventResult::Retry, Destination::Drop)]
     fn should_publish_false(#[case] result: EventResult, #[case] dest: Destination) {
@@ -1565,7 +1565,7 @@ mod tests {
     fn round_trip_spread_destinations() {
         let ctx = serialize_ctx();
         for ev in &realistic_spread_destinations() {
-            if (ev.result == EventResult::Ok || ev.result == EventResult::Limited)
+            if (ev.result == EventResult::Ok || ev.result == EventResult::Warning)
                 && ev.adjusted_timestamp.is_some()
             {
                 assert_round_trip(ev, &ctx);

--- a/rust/capture/src/v1/error.rs
+++ b/rust/capture/src/v1/error.rs
@@ -52,8 +52,6 @@ pub enum Error {
     MissingDistinctId,
     #[error("distinct_id exceeds maximum size")]
     DistinctIdTooLarge,
-    #[error("distinct_id is a known illegal value: {0}")]
-    InvalidDistinctId(String),
     #[error("event submitted without a uuid")]
     MissingEventUuid,
     #[error("event uuid is not valid: {0}")]
@@ -120,7 +118,6 @@ impl Error {
             Self::EventNameTooLong => "event_name_too_long",
             Self::MissingDistinctId => "missing_distinct_id",
             Self::DistinctIdTooLarge => "distinct_id_too_large",
-            Self::InvalidDistinctId(_) => "invalid_distinct_id",
             Self::MissingEventUuid => "missing_event_uuid",
             Self::InvalidEventUuid(_) => "invalid_event_uuid",
             Self::DuplicateEventUuid(_) => "duplicate_event_uuid",
@@ -178,7 +175,6 @@ impl Error {
             | Self::EventNameTooLong
             | Self::MissingDistinctId
             | Self::DistinctIdTooLarge
-            | Self::InvalidDistinctId(_)
             | Self::MissingEventUuid
             | Self::InvalidEventUuid(_)
             | Self::DuplicateEventUuid(_)
@@ -236,7 +232,6 @@ impl Error {
             | Self::EventNameTooLong
             | Self::MissingDistinctId
             | Self::DistinctIdTooLarge
-            | Self::InvalidDistinctId(_)
             | Self::MissingEventUuid
             | Self::InvalidEventUuid(_)
             | Self::DuplicateEventUuid(_)

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -270,7 +270,7 @@ pub fn realistic_batch() -> Vec<WrappedEvent> {
 }
 
 /// 6-event batch with `user-pos-{0..5}` distinct_ids and per-slot state:
-/// 0=Ok/Main, 1=Drop, 2=Ok/Main, 3=Limited, 4=Ok/Overflow, 5=Ok/Historical.
+/// 0=Ok/Main, 1=Drop, 2=Ok/Main, 3=Warning, 4=Ok/Overflow, 5=Ok/Historical.
 pub fn realistic_ordered_mixed_batch() -> Vec<WrappedEvent> {
     let pageview_ok = realistic_pageview("user-pos-0");
 
@@ -283,10 +283,10 @@ pub fn realistic_ordered_mixed_batch() -> Vec<WrappedEvent> {
 
     let identify_ok = realistic_identify("user-pos-2");
 
-    let mut exception_limited = realistic_custom("user-pos-3", "$exception");
-    exception_limited.result = EventResult::Limited;
-    exception_limited.destination = Destination::Drop;
-    exception_limited.details = Some("exceptions_over_quota");
+    let mut exception_warning = realistic_custom("user-pos-3", "$exception");
+    exception_warning.result = EventResult::Warning;
+    exception_warning.destination = Destination::Drop;
+    exception_warning.details = Some("exceptions_over_quota");
 
     let click_overflow =
         realistic_custom("user-pos-4", "button_clicked").with_destination(Destination::Overflow);
@@ -298,7 +298,7 @@ pub fn realistic_ordered_mixed_batch() -> Vec<WrappedEvent> {
         pageview_ok,
         malformed,
         identify_ok,
-        exception_limited,
+        exception_warning,
         click_overflow,
         pageview_historical,
     ]

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -346,7 +346,7 @@ pub fn realistic_spread_destinations() -> Vec<WrappedEvent> {
     let custom = realistic_pageview("user-dest-4")
         .with_destination(Destination::Custom("custom_topic".to_string()));
     let dropped = realistic_pageview("user-dest-5")
-        .with_result(EventResult::Drop, Some("invalid_distinct_id"))
+        .with_result(EventResult::Drop, Some("missing_event_name"))
         .with_destination(Destination::Drop);
     vec![main, historical, overflow, dlq, custom, dropped]
 }


### PR DESCRIPTION
## Problem
Right now, the capture v1 request handler drops events with [known illegal distinct IDs from an allowlist](https://github.com/PostHog/posthog/blob/master/rust/capture/src/v1/analytics/constants.rs#L72-L101). Given recent changes to the global rate limiter on distinct IDs, we should consider a similar approach: mark these to disable person processing (via Kafka header on event publish) instead.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Adjust "illegal" distinct ID handling in v1 processing pipeline
* Related test/util adjustments
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (test updates etc.)
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
Eli planned, Claude coded
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
