### PR TITLE
fix(diff-editor): detach models before disposing CodeEditor diff mode

### DIFF
--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -274,6 +274,10 @@ export function CodeEditor({
     const disposeEditor = (): void => {
         try {
             if (diffEditorRef.current) {
+                // Detach models from the DiffEditorWidget before disposing,
+                // so Monaco's onWillDispose listeners don't fire against
+                // models that are about to be torn down.
+                diffEditorRef.current.setModel(null)
                 diffEditorRef.current.dispose()
             } else {
                 editorRef.current?.dispose()
@@ -538,6 +542,8 @@ export function CodeEditor({
                 theme={isDarkModeOn ? 'vs-dark' : 'vs-light'}
                 original={originalValue}
                 modified={value}
+                keepCurrentOriginalModel
+                keepCurrentModifiedModel
                 options={{
                     ...editorOptions,
                     renderSideBySide: false,


### PR DESCRIPTION
## Problem

Users see a "TextModel got disposed before DiffEditorWidget model got reset" error when navigating away from pages that render a Monaco diff editor via `CodeEditor` (e.g. the Hog Functions history tab). This is a Monaco lifecycle error where text models are disposed while the `DiffEditorWidget` still holds references to them.

The root cause is in the `@monaco-editor/react` library's `DiffEditor` cleanup function, which disposes models *before* the editor widget — the wrong order. We already fixed this exact pattern in our custom `MonacoDiffEditor.tsx` (commit `77194bec49d`), but `CodeEditor.tsx` uses the library's `DiffEditor` component directly and was still vulnerable.

## Changes

Two changes to `CodeEditor.tsx`:

- **`disposeEditor()`**: call `diffEditorRef.current.setModel(null)` before `dispose()` to detach models from the `DiffEditorWidget` first, preventing Monaco's `onWillDispose` listeners from firing against models that are about to be torn down.
- **`keepCurrentOriginalModel` / `keepCurrentModifiedModel`**: pass these props to the `@monaco-editor/react` `DiffEditor` to prevent the library from disposing models during its own cleanup (we already handle model disposal ourselves via `disposeTrackedModels()`).

## How did you test this code?

This PR was authored by an agent (Claude Code). No manual testing was performed.

The fix mirrors the established pattern in `MonacoDiffEditor.tsx` (commit `77194bec49d`) which resolved the same error for that component. TypeScript compilation passes with no errors.

To verify manually: open a Hog Function with AI-suggested code changes (so the diff editor renders), then navigate away — the console error should no longer appear.

## 🤖 Agent context

- **Agent**: Claude Code (Opus)
- **Flow**: User reported the error with a link to an error tracking issue and PostHog AI chat session. Investigation used PostHog MCP tools to retrieve the resolved stack trace from error tracking, which revealed the actual `$current_url` was a Hog Functions page (not the AI chat page as initially suspected). Traced the stack through `@monaco-editor/react`'s `DiffEditor.disposeEditor` → Monaco's `textModel.dispose` → `diffEditorWidget.onWillDispose` listener. The fix follows the same pattern already applied in `MonacoDiffEditor.tsx`.