### PR TITLE
fix(cdp): handle undefined event properties in filter global conversion

### DIFF
--- a/nodejs/src/cdp/utils/hog-function-filtering.test.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.test.ts
@@ -102,6 +102,27 @@ describe('hog-function-filtering', () => {
                 }
             `)
         })
+        it('should handle undefined event properties', () => {
+            const globals: Pick<HogFunctionInvocationGlobals, 'event' | 'person' | 'groups' | 'variables'> = {
+                event: {
+                    uuid: 'event_uuid',
+                    event: 'test_event',
+                    distinct_id: 'user_123',
+                    properties: undefined as any,
+                    elements_chain: '',
+                    timestamp: '2025-01-01T00:00:00.000Z',
+                    url: 'http://example.com/event',
+                },
+                person: null as any,
+                groups: {},
+            }
+
+            const response = convertToHogFunctionFilterGlobal(globals)
+
+            expect(response.event).toBe('test_event')
+            expect(response.elements_chain).toBe('')
+            expect(response.properties).toBeUndefined()
+        })
     })
     describe('convertClickhouseRawEventToFilterGlobals', () => {
         it('should convert RawClickHouseEvent to HogFunctionFilterGlobals with basic event data', () => {

--- a/nodejs/src/cdp/utils/hog-function-filtering.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.ts
@@ -225,7 +225,8 @@ export function convertClickhouseRawEventToFilterGlobals(event: RawClickHouseEve
 export function convertToHogFunctionFilterGlobal(
     globals: Pick<HogFunctionInvocationGlobals, 'event' | 'person' | 'groups' | 'variables'>
 ): HogFunctionFilterGlobals {
-    const elementsChain = globals.event.elements_chain ?? globals.event.properties['$elements_chain']
+    const elementsChain =
+        globals.event.elements_chain ?? (globals.event.properties && globals.event.properties['$elements_chain'])
 
     const response: HogFunctionFilterGlobals = {
         event: globals.event.event,


### PR DESCRIPTION
## Problem

Testing any CDP/Hog function via the "Test" button in the PostHog UI fails with a 500 error. This affects both internal and external users — 11 occurrences across 4 users since the error first appeared on 2025-03-16.

The root cause is in `convertToHogFunctionFilterGlobal()` in the CDP API, which crashes with `TypeError: Cannot read properties of undefined (reading '$elements_chain')` when `globals.event.properties` is undefined during test invocations.

## Changes

- Add a guard for `globals.event.properties` being undefined before accessing `$elements_chain` in `convertToHogFunctionFilterGlobal()`
- Add a test case covering the undefined properties scenario

## How did you test this code?

I'm an agent. I ran the existing test suite for `hog-function-filtering.test.ts` (12 tests, all passing) which includes a new test for the undefined properties case that previously would have crashed.

## Publish to changelog?

No

## 🤖 Agent context

- **Agent**: Claude Code (Opus 4.6)
- **Investigation**: used PostHog error tracking and logs (via MCP tools) to trace the error from the client-side `MCPToolError` (issue `019cf830-90ce-7c72-901f-2f0845f6817c`) through Django's forwarded 500, into the CDP API's stderr logs where the actual `TypeError: Cannot read properties of undefined (reading '$elements_chain')` stacktrace was found
- **Root cause**: `convertToHogFunctionFilterGlobal()` at line 228 of `hog-function-filtering.ts` assumes `globals.event.properties` is always defined, but during test invocations the event globals can have `properties` as `undefined`
- **Fix**: added a truthiness check (`properties && properties[...]`) before the bracket access — optional chaining (`?.`) would have been cleaner but the repo's prettier version doesn't support `ChainExpression` in the nodejs package's formatter pipeline