### PR TITLE
fix(workflows): require a sender on email steps

### DIFF
--- a/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
@@ -1,0 +1,162 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { HogFlow, HogFlowAction } from './hogflows/types'
+import { workflowLogic } from './workflowLogic'
+
+const WORKFLOW_ID = 'wf-email-validation-1'
+const EMAIL_NODE_ID = 'email_node'
+
+const makeEmailAction = (fromValue: any): Extract<HogFlowAction, { type: 'function_email' }> => ({
+    id: EMAIL_NODE_ID,
+    type: 'function_email',
+    name: 'Send email',
+    description: '',
+    created_at: 0,
+    updated_at: 0,
+    config: {
+        template_id: 'template-email',
+        inputs: {
+            email: {
+                value: {
+                    to: { email: 'recipient@example.com' },
+                    from: fromValue,
+                    subject: 'Hello',
+                    html: '<p>Hello</p>',
+                    text: 'Hello',
+                },
+                templating: 'liquid',
+            },
+        },
+    },
+})
+
+const makeWorkflow = (fromValue: any): HogFlow => ({
+    id: WORKFLOW_ID,
+    name: 'Email validation test',
+    actions: [
+        {
+            id: 'trigger_node',
+            type: 'trigger',
+            name: 'Trigger',
+            description: '',
+            created_at: 0,
+            updated_at: 0,
+            config: { type: 'event', filters: {} },
+        },
+        makeEmailAction(fromValue),
+        {
+            id: 'exit_node',
+            type: 'exit',
+            name: 'Exit',
+            description: '',
+            created_at: 0,
+            updated_at: 0,
+            config: { reason: 'Default exit' },
+        },
+    ],
+    edges: [
+        { from: 'trigger_node', to: EMAIL_NODE_ID, type: 'continue' },
+        { from: EMAIL_NODE_ID, to: 'exit_node', type: 'continue' },
+    ],
+    conversion: { window_minutes: null, filters: [] },
+    exit_condition: 'exit_only_at_end',
+    version: 1,
+    status: 'draft',
+    team_id: 1,
+    trigger: { type: 'event', filters: {} } as HogFlow['trigger'],
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+})
+
+// Never-resolving templates response keeps `hogFunctionTemplatesByIdLoading` true so the
+// function-action validation branch is skipped and the email-specific block in
+// `actionValidationErrorsById` is the only one that runs. That is the editor state we
+// care about — before the template fetch completes the user can already see (or miss)
+// inline errors on the step.
+const hangingTemplatesEndpoint = (): Promise<unknown> => new Promise(() => {})
+
+describe('workflowLogic email step "from" validation', () => {
+    let logic: ReturnType<typeof workflowLogic.build>
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('flags the step as invalid when "from" has an email but no integrationId (no sender picked)', async () => {
+        // The Zod schema for runtime email parameters
+        // (`CyclotronInvocationQueueParametersEmailSchema`) requires `from.integrationId`.
+        // The editor must reject this configuration before activation, even when a
+        // default/templated `from.email` is present.
+        useMocks({
+            get: {
+                '/api/environments/:team_id/hog_flows/:id/': makeWorkflow({ email: 'sender@example.com' }),
+                '/api/projects/:team_id/hog_function_templates/': hangingTemplatesEndpoint,
+            },
+        })
+        initKeaTests()
+        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
+
+        const result = logic.values.actionValidationErrorsById[EMAIL_NODE_ID]
+        expect(result).not.toBeNull()
+        expect(result?.valid).toBe(false)
+        expect(result?.errors.email).toBe('Choose who to send this email from')
+    })
+
+    it('flags the step as invalid when "from" is completely missing', async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/hog_flows/:id/': makeWorkflow(undefined),
+                '/api/projects/:team_id/hog_function_templates/': hangingTemplatesEndpoint,
+            },
+        })
+        initKeaTests()
+        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
+
+        const result = logic.values.actionValidationErrorsById[EMAIL_NODE_ID]
+        expect(result?.valid).toBe(false)
+        expect(result?.errors.email).toContain('Choose who to send this email from')
+    })
+
+    it('does not flag a "from" error when an integration sender has been picked', async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/hog_flows/:id/': makeWorkflow({
+                    email: 'sender@example.com',
+                    integrationId: 42,
+                }),
+                '/api/projects/:team_id/hog_function_templates/': hangingTemplatesEndpoint,
+            },
+        })
+        initKeaTests()
+        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
+
+        const result = logic.values.actionValidationErrorsById[EMAIL_NODE_ID]
+        // No email-block errors at all — every other required field (to, subject, html) is set.
+        expect(result?.errors.email).toBeUndefined()
+        expect(result?.valid).toBe(true)
+    })
+
+    it('propagates the step error into workflowHasActionErrors', async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/hog_flows/:id/': makeWorkflow({ email: 'sender@example.com' }),
+                '/api/projects/:team_id/hog_function_templates/': hangingTemplatesEndpoint,
+            },
+        })
+        initKeaTests()
+        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
+
+        expect(logic.values.workflowHasActionErrors).toBe(true)
+    })
+})

--- a/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
@@ -124,6 +124,26 @@ describe('workflowLogic email step "from" validation', () => {
         expect(result?.errors.email).toContain('Choose who to send this email from')
     })
 
+    it('flags the step as invalid when integrationId is set but from.email is missing', async () => {
+        // Runtime schema requires both `from.email` and `from.integrationId`. The pre-fix
+        // validator already rejected missing `from.email`; the editor must keep doing so even
+        // though the new code path also requires `from.integrationId`.
+        useMocks({
+            get: {
+                '/api/environments/:team_id/hog_flows/:id/': makeWorkflow({ integrationId: 42 }),
+                '/api/projects/:team_id/hog_function_templates/': hangingTemplatesEndpoint,
+            },
+        })
+        initKeaTests()
+        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
+
+        const result = logic.values.actionValidationErrorsById[EMAIL_NODE_ID]
+        expect(result?.valid).toBe(false)
+        expect(result?.errors.email).toContain('Choose who to send this email from')
+    })
+
     it('does not flag a "from" error when an integration sender has been picked', async () => {
         useMocks({
             get: {

--- a/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
@@ -71,11 +71,8 @@ const makeWorkflow = (fromValue: any): HogFlow => ({
     updated_at: '2026-05-01T00:00:00.000Z',
 })
 
-// Never-resolving templates response keeps `hogFunctionTemplatesByIdLoading` true so the
-// function-action validation branch is skipped and the email-specific block in
-// `actionValidationErrorsById` is the only one that runs. That is the editor state we
-// care about — before the template fetch completes the user can already see (or miss)
-// inline errors on the step.
+// Hangs the templates fetch so `hogFunctionTemplatesByIdLoading` stays true and the
+// function-action branch in `actionValidationErrorsById` doesn't clobber the email block.
 const hangingTemplatesEndpoint = (): Promise<unknown> => new Promise(() => {})
 
 describe('workflowLogic email step "from" validation', () => {
@@ -86,10 +83,6 @@ describe('workflowLogic email step "from" validation', () => {
     })
 
     it('flags the step as invalid when "from" has an email but no integrationId (no sender picked)', async () => {
-        // The Zod schema for runtime email parameters
-        // (`CyclotronInvocationQueueParametersEmailSchema`) requires `from.integrationId`.
-        // The editor must reject this configuration before activation, even when a
-        // default/templated `from.email` is present.
         useMocks({
             get: {
                 '/api/environments/:team_id/hog_flows/:id/': makeWorkflow({ email: 'sender@example.com' }),
@@ -125,9 +118,6 @@ describe('workflowLogic email step "from" validation', () => {
     })
 
     it('flags the step as invalid when integrationId is set but from.email is missing', async () => {
-        // Runtime schema requires both `from.email` and `from.integrationId`. The pre-fix
-        // validator already rejected missing `from.email`; the editor must keep doing so even
-        // though the new code path also requires `from.integrationId`.
         useMocks({
             get: {
                 '/api/environments/:team_id/hog_flows/:id/': makeWorkflow({ integrationId: 42 }),
@@ -160,7 +150,6 @@ describe('workflowLogic email step "from" validation', () => {
         await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 
         const result = logic.values.actionValidationErrorsById[EMAIL_NODE_ID]
-        // No email-block errors at all — every other required field (to, subject, html) is set.
         expect(result?.errors.email).toBeUndefined()
         expect(result?.valid).toBe(true)
     })

--- a/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
@@ -75,6 +75,29 @@ const makeWorkflow = (fromValue: any): HogFlow => ({
 // function-action branch in `actionValidationErrorsById` doesn't clobber the email block.
 const hangingTemplatesEndpoint = (): Promise<unknown> => new Promise(() => {})
 
+// Matches the production template-email definition closely enough for validation:
+// a single required `native_email` input. Used to reproduce the loaded-templates state.
+const loadedTemplatesResponse = {
+    results: [
+        {
+            id: 'template-email',
+            name: 'Email',
+            type: 'destination',
+            status: 'hidden',
+            free: false,
+            inputs_schema: [
+                {
+                    type: 'native_email',
+                    key: 'email',
+                    label: 'Email message',
+                    required: true,
+                },
+            ],
+        },
+    ],
+    count: 1,
+}
+
 describe('workflowLogic email step "from" validation', () => {
     let logic: ReturnType<typeof workflowLogic.build>
 
@@ -152,6 +175,23 @@ describe('workflowLogic email step "from" validation', () => {
         const result = logic.values.actionValidationErrorsById[EMAIL_NODE_ID]
         expect(result?.errors.email).toBeUndefined()
         expect(result?.valid).toBe(true)
+    })
+
+    it('keeps the email-block error after templates load (function-action branch must not clobber it)', async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/hog_flows/:id/': makeWorkflow({ email: 'sender@example.com' }),
+                '/api/projects/:team_id/hog_function_templates/': loadedTemplatesResponse,
+            },
+        })
+        initKeaTests()
+        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess', 'loadHogFunctionTemplatesByIdSuccess'])
+
+        const result = logic.values.actionValidationErrorsById[EMAIL_NODE_ID]
+        expect(result?.valid).toBe(false)
+        expect(result?.errors.email).toBe('Choose who to send this email from')
     })
 
     it('propagates the step error into workflowHasActionErrors', async () => {

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -503,6 +503,7 @@ export const workflowLogic = kea<workflowLogicType>([
                             if (!template) {
                                 result.valid = false
                                 result.errors = {
+                                    ...result.errors,
                                     // This is a special case for the template_id field which might need to go to a generic error message
                                     _template_id: 'Template not found',
                                 }
@@ -511,8 +512,10 @@ export const workflowLogic = kea<workflowLogicType>([
                                     action.config.inputs,
                                     template.inputs_schema ?? []
                                 )
-                                result.valid = configValidation.valid
-                                result.errors = configValidation.errors
+                                // Merge so the type-specific block above (e.g. function_email's
+                                // stricter `from` check) is not clobbered by the generic validator.
+                                result.valid = result.valid && configValidation.valid
+                                result.errors = { ...configValidation.errors, ...result.errors }
                             }
                         }
 

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -474,8 +474,8 @@ export const workflowLogic = kea<workflowLogicType>([
                                 subject: !emailValue?.subject
                                     ? 'Subject is required'
                                     : getTemplatingError(emailValue?.subject, emailTemplating),
-                                from: !emailValue?.from?.email
-                                    ? 'From is required'
+                                from: !emailValue?.from?.integrationId
+                                    ? 'Choose who to send this email from'
                                     : getTemplatingError(emailValue?.from?.email, emailTemplating),
                                 to: !emailValue?.to?.email
                                     ? 'To is required'

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -474,9 +474,10 @@ export const workflowLogic = kea<workflowLogicType>([
                                 subject: !emailValue?.subject
                                     ? 'Subject is required'
                                     : getTemplatingError(emailValue?.subject, emailTemplating),
-                                from: !emailValue?.from?.integrationId
-                                    ? 'Choose who to send this email from'
-                                    : getTemplatingError(emailValue?.from?.email, emailTemplating),
+                                from:
+                                    !emailValue?.from?.integrationId || !emailValue?.from?.email
+                                        ? 'Choose who to send this email from'
+                                        : getTemplatingError(emailValue?.from?.email, emailTemplating),
                                 to: !emailValue?.to?.email
                                     ? 'To is required'
                                     : getTemplatingError(emailValue?.to?.email, emailTemplating),


### PR DESCRIPTION
## Problem

  You could save and activate a workflow with a Send email step that had no sender picked. The editor said the step
  was valid; the email then failed at runtime with a raw Zod error in the logs.

  Two bugs combined:

  1. **Wrong field checked.** The editor validated `from.email`, but the runtime schema requires `from.integrationId`
  (and `from.email`).
  2. **Errors were swallowed.** Even when the email-specific validator did flag a problem, a generic validator ran
  afterward and reassigned `result.valid` / `result.errors`, wiping the earlier finding once templates loaded.

  ## Changes

<img width="2682" height="1846" alt="2026-05-28 11 52 09" src="https://github.com/user-attachments/assets/9a8d2c3e-fbcb-4edd-a6df-aff139df74a6" />


  - Require both `integrationId` and `email` on email-step senders, matching the runtime schema.
  - Merge action-validation results instead of overwriting, so type-specific errors survive the generic pass.

  Draft saves are still allowed; only activation is gated.

  ## How did you test this code?

  Agent-authored. Added `workflowLogic.emailValidation.test.ts` (6 cases). All pass; the swallowed-error regression
  was confirmed to fail without the merge fix.

  ## Publish to changelog?

  no

  ## Docs update

  No docs change.

  ## 🤖 Agent context

  Authored by Claude (Opus 4.7) via Claude Code. The original fix only swapped one field for another and tests
  sidestepped the overwrite by hanging the templates fetch. Reviewer feedback surfaced both follow-ups: require both
  fields, and stop the generic validator from clobbering the email-specific result.