### PR TITLE
feat(metrics): extract trace and span IDs from OTel exemplars

### DIFF
--- a/rust/capture-logs/src/metric_record.rs
+++ b/rust/capture-logs/src/metric_record.rs
@@ -258,14 +258,15 @@ fn build_number_row(
     flags: u32,
 ) -> Result<(KafkaMetricRow, bool)> {
     // OTel exemplars attach trace context (and per-bucket trace context on histograms) to
-    // data points. V1 picks the first well-formed exemplar: a 16-byte trace_id is the spec
-    // length, so anything else (empty / truncated) is either "no trace context attached" or
-    // a malformed SDK payload — both should not pollute the trace_id column. Per-bucket
-    // attribution is lost in this representation; revisit when we add a multi-row exemplar
-    // shape or an array column.
+    // data points. V1 picks the first non-empty exemplar and runs it through the shared
+    // extract_trace_id / extract_span_id helpers, matching the log_record / trace_record
+    // precedent. Malformed-length IDs zero-fill to all-zeros via the helpers — consistent
+    // with how logs and traces treat malformed trace context today. Per-bucket attribution
+    // on histograms is lossy in this representation; revisit when we add a multi-row or
+    // array exemplar column.
     let (exemplar_trace_id, exemplar_span_id) = exemplars
         .iter()
-        .find(|e| e.trace_id.len() == 16)
+        .find(|e| !e.trace_id.is_empty())
         .map(|e| {
             (
                 BASE64_STANDARD.encode(extract_trace_id(&e.trace_id)),
@@ -574,13 +575,13 @@ mod tests {
     }
 
     #[test]
-    fn test_first_well_formed_exemplar_is_picked() {
-        // First exemplar has a malformed (8-byte) trace_id and should be skipped;
-        // second is well-formed and should win.
+    fn test_first_non_empty_exemplar_is_picked() {
+        // First exemplar has an empty trace_id (no context attached) and is skipped;
+        // second carries real bytes and wins. Matches "first non-empty wins" semantics.
         let other_trace = [9u8; 16];
         let other_span = [9u8; 8];
         let exemplars = vec![
-            make_exemplar(vec![0; 8], vec![0; 8]),
+            make_exemplar(vec![], vec![]),
             make_exemplar(other_trace.to_vec(), other_span.to_vec()),
         ];
         let row = build_test_row(&exemplars);
@@ -590,14 +591,16 @@ mod tests {
     }
 
     #[test]
-    fn test_exemplar_malformed_trace_id_is_skipped() {
-        // A 12-byte trace_id is not spec-conformant; skip rather than zero-pad,
-        // which would create a fake "all zeros" trace_id that collides across payloads.
+    fn test_exemplar_malformed_trace_id_zero_fills() {
+        // Matches log_record / trace_record precedent: a non-empty but malformed trace_id
+        // is run through extract_trace_id, which zero-fills wrong-length inputs to [0; 16].
+        // Documents (rather than fixes) the all-zeros-collision behavior — addressing it
+        // would mean changing the helper, which lives in log_record and is shared.
         let exemplar = make_exemplar(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], vec![]);
         let row = build_test_row(&[exemplar]);
 
-        assert_eq!(row.trace_id, "");
-        assert_eq!(row.span_id, "");
+        assert_eq!(row.trace_id, BASE64_STANDARD.encode([0u8; 16]));
+        assert_eq!(row.span_id, BASE64_STANDARD.encode([0u8; 8]));
     }
 
     #[test]

--- a/rust/capture-logs/src/metric_record.rs
+++ b/rust/capture-logs/src/metric_record.rs
@@ -258,15 +258,16 @@ fn build_number_row(
     flags: u32,
 ) -> Result<(KafkaMetricRow, bool)> {
     // OTel exemplars attach trace context (and per-bucket trace context on histograms) to
-    // data points. V1 picks the first non-empty exemplar and runs it through the shared
-    // extract_trace_id / extract_span_id helpers, matching the log_record / trace_record
-    // precedent. Malformed-length IDs zero-fill to all-zeros via the helpers — consistent
-    // with how logs and traces treat malformed trace context today. Per-bucket attribution
-    // on histograms is lossy in this representation; revisit when we add a multi-row or
-    // array exemplar column.
+    // data points. V1 picks the first exemplar with a spec-conformant 16-byte trace_id and
+    // runs it through the shared extract_trace_id / extract_span_id helpers (same encoding
+    // path as log_record / trace_record). Filtering by length up front avoids the case
+    // where a malformed exemplar earlier in the vec would shadow a valid one — exemplar
+    // selection is a metrics-specific concern with no precedent in logs/traces, which
+    // each carry a single trace_id field. Per-bucket attribution on histograms is lossy
+    // in this representation; revisit when we add a multi-row or array exemplar column.
     let (exemplar_trace_id, exemplar_span_id) = exemplars
         .iter()
-        .find(|e| !e.trace_id.is_empty())
+        .find(|e| e.trace_id.len() == 16)
         .map(|e| {
             (
                 BASE64_STANDARD.encode(extract_trace_id(&e.trace_id)),
@@ -575,9 +576,9 @@ mod tests {
     }
 
     #[test]
-    fn test_first_non_empty_exemplar_is_picked() {
+    fn test_first_well_formed_exemplar_is_picked() {
         // First exemplar has an empty trace_id (no context attached) and is skipped;
-        // second carries real bytes and wins. Matches "first non-empty wins" semantics.
+        // second carries spec-conformant 16-byte bytes and wins.
         let other_trace = [9u8; 16];
         let other_span = [9u8; 8];
         let exemplars = vec![
@@ -591,16 +592,31 @@ mod tests {
     }
 
     #[test]
-    fn test_exemplar_malformed_trace_id_zero_fills() {
-        // Matches log_record / trace_record precedent: a non-empty but malformed trace_id
-        // is run through extract_trace_id, which zero-fills wrong-length inputs to [0; 16].
-        // Documents (rather than fixes) the all-zeros-collision behavior — addressing it
-        // would mean changing the helper, which lives in log_record and is shared.
+    fn test_malformed_exemplar_before_valid_picks_valid() {
+        // A malformed (12-byte) trace_id must not shadow a later well-formed one. Without
+        // a length-based filter the malformed entry would be selected and zero-filled by
+        // extract_trace_id, silently overwriting real trace context. Regression guard.
+        let valid_trace = [7u8; 16];
+        let valid_span = [7u8; 8];
+        let exemplars = vec![
+            make_exemplar(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], vec![0; 8]),
+            make_exemplar(valid_trace.to_vec(), valid_span.to_vec()),
+        ];
+        let row = build_test_row(&exemplars);
+
+        assert_eq!(row.trace_id, BASE64_STANDARD.encode(valid_trace));
+        assert_eq!(row.span_id, BASE64_STANDARD.encode(valid_span));
+    }
+
+    #[test]
+    fn test_only_malformed_exemplar_yields_empty_ids() {
+        // When every exemplar in the vec is malformed, none pass the length filter and
+        // the row falls back to empty strings rather than producing an all-zeros sentinel.
         let exemplar = make_exemplar(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], vec![]);
         let row = build_test_row(&[exemplar]);
 
-        assert_eq!(row.trace_id, BASE64_STANDARD.encode([0u8; 16]));
-        assert_eq!(row.span_id, BASE64_STANDARD.encode([0u8; 8]));
+        assert_eq!(row.trace_id, "");
+        assert_eq!(row.span_id, "");
     }
 
     #[test]

--- a/rust/capture-logs/src/metric_record.rs
+++ b/rust/capture-logs/src/metric_record.rs
@@ -21,6 +21,8 @@ use serde_json::{json, Value as JsonValue};
 use tracing::debug;
 use uuid::Uuid;
 
+use crate::log_record::{extract_span_id, extract_trace_id};
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct KafkaMetricRow {
     pub uuid: String,
@@ -252,9 +254,25 @@ fn build_number_row(
     value: f64,
     histogram_bounds: Option<Vec<f64>>,
     histogram_counts: Option<Vec<i64>>,
-    _exemplars: &[opentelemetry_proto::tonic::metrics::v1::Exemplar],
+    exemplars: &[opentelemetry_proto::tonic::metrics::v1::Exemplar],
     flags: u32,
 ) -> Result<(KafkaMetricRow, bool)> {
+    // OTel exemplars attach trace context (and per-bucket trace context on histograms) to
+    // data points. V1 picks the first well-formed exemplar: a 16-byte trace_id is the spec
+    // length, so anything else (empty / truncated) is either "no trace context attached" or
+    // a malformed SDK payload — both should not pollute the trace_id column. Per-bucket
+    // attribution is lost in this representation; revisit when we add a multi-row exemplar
+    // shape or an array column.
+    let (exemplar_trace_id, exemplar_span_id) = exemplars
+        .iter()
+        .find(|e| e.trace_id.len() == 16)
+        .map(|e| {
+            (
+                BASE64_STANDARD.encode(extract_trace_id(&e.trace_id)),
+                BASE64_STANDARD.encode(extract_span_id(&e.span_id)),
+            )
+        })
+        .unwrap_or_default();
     let raw_timestamp = match time_unix_nano {
         0 => Utc::now(),
         _ => DateTime::<Utc>::from_timestamp_nanos(time_unix_nano.try_into()?),
@@ -283,8 +301,8 @@ fn build_number_row(
 
     let row = KafkaMetricRow {
         uuid: Uuid::now_v7().to_string(),
-        trace_id: String::new(),
-        span_id: String::new(),
+        trace_id: exemplar_trace_id,
+        span_id: exemplar_span_id,
         trace_flags: flags,
         timestamp,
         observed_timestamp,
@@ -497,5 +515,150 @@ mod tests {
         assert_eq!(temporality_str(1), "delta");
         assert_eq!(temporality_str(2), "cumulative");
         assert_eq!(temporality_str(0), "unspecified");
+    }
+
+    // --- Exemplar extraction ---
+
+    use opentelemetry_proto::tonic::metrics::v1::{
+        Exemplar, Gauge, Histogram, HistogramDataPoint, Metric, NumberDataPoint,
+    };
+
+    const VALID_TRACE_BYTES: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    const VALID_SPAN_BYTES: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    fn make_exemplar(trace_id: Vec<u8>, span_id: Vec<u8>) -> Exemplar {
+        Exemplar {
+            filtered_attributes: vec![],
+            time_unix_nano: 0,
+            value: None,
+            span_id,
+            trace_id,
+        }
+    }
+
+    fn build_test_row(exemplars: &[Exemplar]) -> KafkaMetricRow {
+        let (row, _) = build_number_row(
+            "test.metric",
+            "gauge",
+            "",
+            &HashMap::new(),
+            "test-service",
+            "test-scope@1.0",
+            1_700_000_000_000_000_000,
+            0,
+            &[],
+            1.0,
+            None,
+            None,
+            exemplars,
+            0,
+        )
+        .expect("build_number_row should succeed");
+        row
+    }
+
+    #[test]
+    fn test_exemplar_populates_trace_and_span_ids() {
+        let exemplar = make_exemplar(VALID_TRACE_BYTES.to_vec(), VALID_SPAN_BYTES.to_vec());
+        let row = build_test_row(&[exemplar]);
+
+        assert_eq!(row.trace_id, BASE64_STANDARD.encode(VALID_TRACE_BYTES));
+        assert_eq!(row.span_id, BASE64_STANDARD.encode(VALID_SPAN_BYTES));
+    }
+
+    #[test]
+    fn test_no_exemplar_yields_empty_ids() {
+        let row = build_test_row(&[]);
+        assert_eq!(row.trace_id, "");
+        assert_eq!(row.span_id, "");
+    }
+
+    #[test]
+    fn test_first_well_formed_exemplar_is_picked() {
+        // First exemplar has a malformed (8-byte) trace_id and should be skipped;
+        // second is well-formed and should win.
+        let other_trace = [9u8; 16];
+        let other_span = [9u8; 8];
+        let exemplars = vec![
+            make_exemplar(vec![0; 8], vec![0; 8]),
+            make_exemplar(other_trace.to_vec(), other_span.to_vec()),
+        ];
+        let row = build_test_row(&exemplars);
+
+        assert_eq!(row.trace_id, BASE64_STANDARD.encode(other_trace));
+        assert_eq!(row.span_id, BASE64_STANDARD.encode(other_span));
+    }
+
+    #[test]
+    fn test_exemplar_malformed_trace_id_is_skipped() {
+        // A 12-byte trace_id is not spec-conformant; skip rather than zero-pad,
+        // which would create a fake "all zeros" trace_id that collides across payloads.
+        let exemplar = make_exemplar(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], vec![]);
+        let row = build_test_row(&[exemplar]);
+
+        assert_eq!(row.trace_id, "");
+        assert_eq!(row.span_id, "");
+    }
+
+    #[test]
+    fn test_histogram_exemplar_flows_through_pipeline() {
+        // Exercises the histogram code path via the public flatten_metric API so a
+        // future refactor that splits the histogram path off build_number_row would
+        // surface here.
+        let exemplar = make_exemplar(VALID_TRACE_BYTES.to_vec(), VALID_SPAN_BYTES.to_vec());
+        let metric = Metric {
+            name: "test.histogram".to_string(),
+            description: String::new(),
+            unit: String::new(),
+            metadata: vec![],
+            data: Some(Data::Histogram(Histogram {
+                aggregation_temporality: 2,
+                data_points: vec![HistogramDataPoint {
+                    attributes: vec![],
+                    start_time_unix_nano: 1_700_000_000_000_000_000,
+                    time_unix_nano: 1_700_000_000_000_000_000,
+                    count: 1,
+                    sum: Some(1.0),
+                    bucket_counts: vec![1],
+                    explicit_bounds: vec![],
+                    exemplars: vec![exemplar],
+                    flags: 0,
+                    min: None,
+                    max: None,
+                }],
+            })),
+        };
+
+        let (rows, _) = flatten_metric(metric, None, None).expect("flatten_metric ok");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].trace_id, BASE64_STANDARD.encode(VALID_TRACE_BYTES));
+        assert_eq!(rows[0].span_id, BASE64_STANDARD.encode(VALID_SPAN_BYTES));
+    }
+
+    #[test]
+    fn test_gauge_with_no_exemplar_path_unchanged() {
+        // Regression guard: rows without exemplars must still set empty trace/span ids
+        // through the public flatten_metric path (the back-compat promise).
+        let metric = Metric {
+            name: "test.gauge".to_string(),
+            description: String::new(),
+            unit: String::new(),
+            metadata: vec![],
+            data: Some(Data::Gauge(Gauge {
+                data_points: vec![NumberDataPoint {
+                    attributes: vec![],
+                    start_time_unix_nano: 1_700_000_000_000_000_000,
+                    time_unix_nano: 1_700_000_000_000_000_000,
+                    exemplars: vec![],
+                    flags: 0,
+                    value: None,
+                }],
+            })),
+        };
+
+        let (rows, _) = flatten_metric(metric, None, None).expect("flatten_metric ok");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].trace_id, "");
+        assert_eq!(rows[0].span_id, "");
     }
 }


### PR DESCRIPTION
## Problem

Metrics rows in `posthog.metrics` had `trace_id` and `span_id` columns defined in both the Avro schema and the ClickHouse table, but they were always written as empty strings. The OTel proto carries exemplars (trace-context samples attached to metric data points) on `Gauge`, `Sum`, `Histogram`, and `ExponentialHistogram`, and the `flatten_metric` call sites in `rust/capture-logs/src/metric_record.rs` were already passing `&dp.exemplars` into `build_number_row` — but the argument was named `_exemplars` and silently dropped.

The result: no metric-to-trace correlation in ClickHouse, even when SDKs were emitting exemplars correctly. This blocks the "drill from a metric anomaly into the underlying traces" experience that the metrics alpha relies on.

This becomes more interesting now that #60261 (just merged) unblocked OTLP/JSON ingestion for histograms / expo histograms / summaries — those metric variants are the ones whose exemplars matter most (bucket-level trace links).

## Changes

Single file: `rust/capture-logs/src/metric_record.rs`.

- Import `extract_trace_id` / `extract_span_id` from `log_record.rs` (the same helpers `trace_record.rs` already uses).
- Rename `_exemplars` → `exemplars` in `build_number_row`.
- Pick the first exemplar with a spec-conformant 16-byte `trace_id` and base64-encode trace_id/span_id through the shared helpers.
- Wire the result into `KafkaMetricRow.trace_id` / `.span_id`, replacing `String::new()`.

The change is fully additive: data points without exemplars keep the existing empty-string behavior. No schema changes — the Avro and ClickHouse columns were already in place.

All four call sites (gauge, sum, histogram, exponential histogram) flow through the same `build_number_row`; summary data points don't carry exemplars in the OTel proto.

### V1 limitations (documented in the code comment)

- **Histogram per-bucket exemplar attribution is lossy.** OTel exemplars on a histogram are conceptually one-per-bucket — "show me a trace from the >100ms bucket." With a single `trace_id` column per row we lose which bucket the picked exemplar represents. Revisit when we add a multi-row or array-column representation for samples.
- **No exemplar timestamp.** Exemplars have their own `time_unix_nano` distinct from the data point's; we discard it. The data point's timestamp is the natural anchor for V1.
- **Malformed trace_id is skipped, not stored.** Selection requires a 16-byte trace_id. If no exemplar in the vec is well-formed, the row falls back to empty `trace_id`/`span_id` rather than producing the all-zeros base64 sentinel that the shared helper would emit for malformed input. The helper's zero-fill behavior is preserved (so cross-signal helper semantics are unchanged); this differs from `log_record` / `trace_record` only at the *selection* step, which is a metrics-specific concern (each log line / span carries a single `trace_id` field — there's no "pick one of many" decision in those pipelines).

## How did you test this code?

This was agent-authored. I ran the automated tests below; I did **not** manually exercise this against a live OTel exporter sending real exemplars on the local stack.

**Unit tests added (in `metric_record::tests`):**

| Test | What it covers |
|---|---|
| `test_exemplar_populates_trace_and_span_ids` | Happy path: one well-formed exemplar → base64 trace_id and span_id in the row |
| `test_no_exemplar_yields_empty_ids` | No exemplars → empty strings (back-compat) |
| `test_first_well_formed_exemplar_is_picked` | First exemplar has an empty trace_id (skipped), second is 16-byte (picked) |
| `test_malformed_exemplar_before_valid_picks_valid` | Regression guard: a malformed 12-byte trace_id must not shadow a later well-formed one |
| `test_only_malformed_exemplar_yields_empty_ids` | All exemplars malformed → empty strings (no all-zeros sentinel pollution) |
| `test_histogram_exemplar_flows_through_pipeline` | Histogram path coverage via the public `flatten_metric` API (canary against future refactors that split the histogram path off `build_number_row`) |
| `test_gauge_with_no_exemplar_path_unchanged` | End-to-end back-compat guard via `flatten_metric` |

**Verification commands run:**

```
cargo test --lib metric_record       # 14 passed (7 baseline + 7 new), 0 failed
cargo test --tests --lib             # all suites green (service_test, traces_test, datadog tests)
cargo fmt --check                    # clean
cargo clippy --lib --tests           # clean
```

**Manual validation suggested for the reviewer / next dev:** send an OTLP payload containing exemplars with trace context (Python or Node SDK with an active tracer + a histogram measurement) at `/v1/metrics`, then:

```sql
SELECT metric_name, trace_id, span_id
FROM posthog.metrics
WHERE trace_id != ''
  AND timestamp > now() - INTERVAL 10 MINUTE
```

## Publish to changelog?

No — internal plumbing for the metrics alpha; the user-facing surface lands with the Samples UI PR.

## Docs update

`skip-inkeep-docs` — no public docs change in this PR. Public docs will land with the UI.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) at Daniel's direction. Tools used: bash (cargo build/test/fmt/clippy), Read/Grep for codebase orientation, Edit for the diff, gh CLI for PR metadata.

**Decision log:**

1. **Filter strictness.** First pass used `find(|e| e.trace_id.len() == 16)` to skip malformed exemplars. Relaxed to `find(|e| !e.trace_id.is_empty())` mid-review to match `log_record` / `trace_record` precedent at the helper level. Greptile then surfaced that the relaxed filter lets a malformed exemplar shadow a well-formed one later in the vec, so the filter is now `len() == 16` again. The cross-signal-consistency goal is preserved at the *helper* level (zero-fill behavior unchanged); the strict filter is metrics-only because exemplar selection is metrics-only. Added `test_malformed_exemplar_before_valid_picks_valid` as the regression guard.
2. **"First well-formed" exemplar selection.** Considered keeping all exemplars in an array column (would preserve per-bucket attribution on histograms) but rejected for V1 — requires schema changes and downstream consumer changes. Pragmatic V1 picks one exemplar, accepts the per-bucket loss, and flags it explicitly so reviewers know it's known not oversight.
3. **No new helper.** The existing `extract_trace_id` / `extract_span_id` in `log_record.rs` were already `pub fn`s used by `trace_record.rs`. Reusing them across all three signals is the right move — if we ever want to change zero-fill behavior to skipping in logs/traces too, fix it once in the helper and all three pipelines benefit.
4. **Test placement.** Added new tests inside the existing `#[cfg(test)] mod tests` block in `metric_record.rs` rather than creating a separate integration test file, mirroring the convention in `log_record.rs` and `trace_record.rs`. Some tests need to call private `build_number_row` directly, which is only reachable from in-file tests.
5. **Parameterization (Greptile #2).** Declined for this PR. Sibling files (`log_record.rs` 9 tests, `trace_record.rs` 13 tests, this file 14 tests) all use plain `#[test] fn ...` with zero parameterized tests. `rstest` is available in the workspace but not used in capture-logs. Following local convention beats introducing a new test pattern in a single PR; happy to revisit as a follow-up across all three files if a maintainer prefers.
