### PR TITLE
feat(personhog): add caller tag to property-defs-rs

### DIFF
--- a/rust/property-defs-rs/src/group_type_resolver.rs
+++ b/rust/property-defs-rs/src/group_type_resolver.rs
@@ -150,6 +150,10 @@ impl GroupTypeResolver {
         let metadata = request.metadata_mut();
         metadata.insert("x-client-name", "property-defs-rs".parse().unwrap());
         metadata.insert(
+            "x-caller-tag",
+            "property-defs/group-type-resolution".parse().unwrap(),
+        );
+        metadata.insert(
             "x-read-consistency",
             match consistency {
                 ConsistencyLevel::Strong => "strong",


### PR DESCRIPTION
## Problem

We need per-caller attribution on personhog gRPC requests to identify which code paths are generating heavy traffic. The `x-caller-tag` header (consumed by the router in PR #60361) provides this, but each client service needs to send it.

## Changes

Adds `x-caller-tag: property-defs/group-type-resolution` metadata header to the gRPC request in the property-defs-rs group type resolver. This is a single-line addition alongside the existing `x-client-name` header.

**Deploy target:** property-defs-rs

> **Note:** The router (PR #60361) must deploy first to consume this header. Until then, the header is harmlessly ignored.

## How did you test this code?

- Verified clippy passes with no warnings
- The change is a trivial metadata insertion following the exact same pattern as the existing `x-client-name` header on the adjacent line

## Publish to changelog?

No

## Docs update

N/A

## 🤖 Agent context

Cherry-picked from `nick/personhog-query-tagging` development branch. Part of a 4-PR series adding `x-caller-tag` attribution across the personhog stack:
1. PR #60361 — Router extraction (Rust) — **must deploy first**
2. **This PR** — property-defs-rs static tag
3. Node.js client caller tag
4. Django interceptor + middleware + manual tags