### PR TITLE
feat(personhog): add caller tag support to Node.js client

### DIFF
--- a/nodejs/src/cdp/legacy-webhooks/utils.test.ts
+++ b/nodejs/src/cdp/legacy-webhooks/utils.test.ts
@@ -155,7 +155,12 @@ describe('addGroupPropertiesToPostIngestionEventsBatch', () => {
         )
 
         expect(mockGroupRepository.fetchGroupsByKeys).toHaveBeenCalledTimes(1)
-        expect(mockGroupRepository.fetchGroupsByKeys).toHaveBeenCalledWith([1], [0], ['acme'])
+        expect(mockGroupRepository.fetchGroupsByKeys).toHaveBeenCalledWith(
+            [1],
+            [0],
+            ['acme'],
+            'cdp/legacy-webhooks-group-enrichment'
+        )
 
         for (const event of result) {
             expect(event.groups?.company).toEqual({
@@ -384,7 +389,12 @@ describe('addGroupPropertiesToPostIngestionEventsBatch', () => {
         expect(result[0].groups?.company?.properties).toEqual({ name: 'Acme' })
         expect(result[1].groups?.organization?.properties).toEqual({ name: 'Globex' })
 
-        expect(mockGroupRepository.fetchGroupsByKeys).toHaveBeenCalledWith([1, 2], [0, 0], ['acme', 'globex'])
+        expect(mockGroupRepository.fetchGroupsByKeys).toHaveBeenCalledWith(
+            [1, 2],
+            [0, 0],
+            ['acme', 'globex'],
+            'cdp/legacy-webhooks-group-enrichment'
+        )
     })
 
     it('does not deduplicate when same group type index has different keys', async () => {
@@ -416,7 +426,12 @@ describe('addGroupPropertiesToPostIngestionEventsBatch', () => {
             mockGroupRepository as unknown as GroupRepository
         )
 
-        expect(mockGroupRepository.fetchGroupsByKeys).toHaveBeenCalledWith([1, 1], [0, 0], ['acme', 'globex'])
+        expect(mockGroupRepository.fetchGroupsByKeys).toHaveBeenCalledWith(
+            [1, 1],
+            [0, 0],
+            ['acme', 'globex'],
+            'cdp/legacy-webhooks-group-enrichment'
+        )
         expect(result[0].groups?.company?.properties).toEqual({ name: 'Acme' })
         expect(result[1].groups?.company?.properties).toEqual({ name: 'Globex' })
     })
@@ -454,7 +469,12 @@ describe('addGroupPropertiesToPostIngestionEventsBatch', () => {
             mockGroupRepository as unknown as GroupRepository
         )
 
-        expect(mockGroupRepository.fetchGroupsByKeys).toHaveBeenCalledWith([1, 2], [0, 0], ['acme', 'acme'])
+        expect(mockGroupRepository.fetchGroupsByKeys).toHaveBeenCalledWith(
+            [1, 2],
+            [0, 0],
+            ['acme', 'acme'],
+            'cdp/legacy-webhooks-group-enrichment'
+        )
         expect(result[0].groups?.company?.properties).toEqual({ name: 'Acme Team 1' })
         expect(result[1].groups?.company?.properties).toEqual({ name: 'Acme Team 2' })
     })

--- a/nodejs/src/cdp/legacy-webhooks/utils.ts
+++ b/nodejs/src/cdp/legacy-webhooks/utils.ts
@@ -29,7 +29,7 @@ export async function addGroupPropertiesToPostIngestionEvent(
                 event.teamId as TeamId,
                 columnIndex as GroupTypeIndex,
                 groupKey,
-                { useReadReplica: true }
+                { useReadReplica: true, callerTag: 'cdp/legacy-webhooks-group-enrichment' }
             )
 
             const groupProperties = group ? group.group_properties : {}
@@ -132,7 +132,12 @@ export async function addGroupPropertiesToPostIngestionEventsBatch(
 
     const groupResults =
         allTeamIds.length > 0
-            ? await groupRepository.fetchGroupsByKeys(allTeamIds, allGroupTypeIndexes, allGroupKeys)
+            ? await groupRepository.fetchGroupsByKeys(
+                  allTeamIds,
+                  allGroupTypeIndexes,
+                  allGroupKeys,
+                  'cdp/legacy-webhooks-group-enrichment'
+              )
             : []
 
     const groupPropertiesMap = new Map<GroupLookupKey, Record<string, any>>()

--- a/nodejs/src/cdp/services/managers/groups-manager-personhog.test.ts
+++ b/nodejs/src/cdp/services/managers/groups-manager-personhog.test.ts
@@ -213,12 +213,18 @@ describe('GroupsManagerService + PersonHogGroupRepository integration', () => {
             })
 
             if (rolloutPercentage === 100) {
-                expect(mockGrpc.groups.fetchGroupTypesByTeamIds).toHaveBeenCalledWith([TEAM_1])
+                expect(mockGrpc.groups.fetchGroupTypesByTeamIds).toHaveBeenCalledWith(
+                    [TEAM_1],
+                    'cdp/hogflow-group-type-resolution'
+                )
                 expect(mockGrpc.groups.fetchGroupsByKeys).toHaveBeenCalled()
                 expect(mockPostgres.fetchGroupTypesByTeamIds).not.toHaveBeenCalled()
                 expect(mockPostgres.fetchGroupsByKeys).not.toHaveBeenCalled()
             } else {
-                expect(mockPostgres.fetchGroupTypesByTeamIds).toHaveBeenCalledWith([TEAM_1])
+                expect(mockPostgres.fetchGroupTypesByTeamIds).toHaveBeenCalledWith(
+                    [TEAM_1],
+                    'cdp/hogflow-group-type-resolution'
+                )
                 expect(mockPostgres.fetchGroupsByKeys).toHaveBeenCalled()
                 expect(mockGrpc.groups.fetchGroupTypesByTeamIds).not.toHaveBeenCalled()
                 expect(mockGrpc.groups.fetchGroupsByKeys).not.toHaveBeenCalled()
@@ -340,7 +346,10 @@ describe('GroupsManagerService + PersonHogGroupRepository integration', () => {
 
             // UnknownType has no mapping → skipped entirely → empty groups
             expect(globals.groups).toEqual({})
-            expect(mockGrpc.groups.fetchGroupTypesByTeamIds).toHaveBeenCalledWith([TEAM_3])
+            expect(mockGrpc.groups.fetchGroupTypesByTeamIds).toHaveBeenCalledWith(
+                [TEAM_3],
+                'cdp/hogflow-group-type-resolution'
+            )
             // fetchGroupsByKeys should NOT be called since there are no valid group type mappings
             expect(mockGrpc.groups.fetchGroupsByKeys).not.toHaveBeenCalled()
         })

--- a/nodejs/src/cdp/services/managers/groups-manager.service.test.ts
+++ b/nodejs/src/cdp/services/managers/groups-manager.service.test.ts
@@ -233,8 +233,8 @@ describe('Groups Manager', () => {
         expect(mockFetchGroupTypesByTeamIds).toHaveBeenCalledTimes(1)
         expect(mockFetchGroupsByKeys).toHaveBeenCalledTimes(1)
 
-        expect(mockFetchGroupTypesByTeamIds).toHaveBeenCalledWith([1])
-        expect(mockFetchGroupsByKeys).toHaveBeenCalledWith([1], [1], ['id-2'])
+        expect(mockFetchGroupTypesByTeamIds).toHaveBeenCalledWith([1], 'cdp/hogflow-group-type-resolution')
+        expect(mockFetchGroupsByKeys).toHaveBeenCalledWith([1], [1], ['id-2'], 'cdp/hogflow-group-property-enrichment')
     })
 
     it.each([

--- a/nodejs/src/cdp/services/managers/groups-manager.service.ts
+++ b/nodejs/src/cdp/services/managers/groups-manager.service.ts
@@ -147,7 +147,10 @@ export class GroupsManagerService {
         }
 
         if (teamsToLoad.length > 0) {
-            const repoResult = await this.groupRepository.fetchGroupTypesByTeamIds(teamsToLoad)
+            const repoResult = await this.groupRepository.fetchGroupTypesByTeamIds(
+                teamsToLoad,
+                'cdp/hogflow-group-type-resolution'
+            )
             for (const teamId of teamsToLoad) {
                 const groupTypes = repoResult[String(teamId)] ?? []
                 const mapping: GroupTypeMapping = {}
@@ -170,7 +173,12 @@ export class GroupsManagerService {
         const groupIndexes = parsed.map((p) => p.groupTypeIndex) as GroupTypeIndex[]
         const groupKeys = parsed.map((p) => p.groupKey)
 
-        const rows = await this.groupRepository.fetchGroupsByKeys(teamIds, groupIndexes, groupKeys)
+        const rows = await this.groupRepository.fetchGroupsByKeys(
+            teamIds,
+            groupIndexes,
+            groupKeys,
+            'cdp/hogflow-group-property-enrichment'
+        )
 
         const result: Record<string, Record<string, any> | null | undefined> = {}
         for (const row of rows) {

--- a/nodejs/src/cdp/services/managers/persons-manager.service.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.ts
@@ -88,7 +88,9 @@ export class PersonsManagerService {
         logger.debug('[PersonManager]', 'Fetching persons', { teamPersons })
 
         const personRows = await this.personRepository.fetchPersonsByDistinctIds(
-            teamPersons.map(({ teamId, id }) => ({ teamId, distinctId: id }))
+            teamPersons.map(({ teamId, id }) => ({ teamId, distinctId: id })),
+            undefined,
+            'cdp/hogflow-person-enrichment'
         )
 
         // Map results back to the original keys
@@ -114,7 +116,9 @@ export class PersonsManagerService {
         logger.debug('[PersonManager]', 'Fetching persons', { teamPersons })
 
         const personRows = await this.personRepository.fetchPersonsByPersonIds(
-            teamPersons.map(({ teamId, id }) => ({ teamId, personId: id }))
+            teamPersons.map(({ teamId, id }) => ({ teamId, personId: id })),
+            undefined,
+            'cdp/hogflow-person-enrichment'
         )
 
         // Fetch one distinct_id per person so callers that need to identify the user

--- a/nodejs/src/ingestion/error-tracking/person-properties-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/person-properties-step.test.ts
@@ -102,7 +102,8 @@ describe('createFetchPersonBatchStep', () => {
                 { teamId: 123, distinctId: 'user-1' },
                 { teamId: 123, distinctId: 'user-2' },
             ],
-            true // useReadReplica
+            true, // useReadReplica
+            'error-tracking/person-properties'
         )
     })
 
@@ -204,7 +205,8 @@ describe('createFetchPersonBatchStep', () => {
         // Should only query for the event with distinct_id
         expect(mockPersonRepository.fetchPersonsByDistinctIds).toHaveBeenCalledWith(
             [{ teamId: 123, distinctId: 'user-123' }],
-            true
+            true,
+            'error-tracking/person-properties'
         )
     })
 

--- a/nodejs/src/ingestion/error-tracking/person-properties-step.ts
+++ b/nodejs/src/ingestion/error-tracking/person-properties-step.ts
@@ -41,7 +41,10 @@ export function createFetchPersonBatchStep<T extends PersonPropertiesInput>(
             .map((input) => ({ teamId: input.team.id, distinctId: input.event.distinct_id }))
 
         // Batch fetch all persons in a single query
-        const persons = lookups.length > 0 ? await personRepository.fetchPersonsByDistinctIds(lookups, true) : []
+        const persons =
+            lookups.length > 0
+                ? await personRepository.fetchPersonsByDistinctIds(lookups, true, 'error-tracking/person-properties')
+                : []
 
         // Build lookup map
         const personMap = new Map(persons.map((p) => [personKey(p.team_id, p.distinct_id), p as Person]))

--- a/nodejs/src/ingestion/personhog/client.ts
+++ b/nodejs/src/ingestion/personhog/client.ts
@@ -200,7 +200,9 @@ export class PersonHogClient {
         if (config.callerTag) {
             const callerTag = config.callerTag
             interceptors.push((next) => async (req) => {
-                req.header.set('x-caller-tag', callerTag)
+                if (!req.header.has('x-caller-tag')) {
+                    req.header.set('x-caller-tag', callerTag)
+                }
                 return await next(req)
             })
         }

--- a/nodejs/src/ingestion/personhog/client.ts
+++ b/nodejs/src/ingestion/personhog/client.ts
@@ -154,6 +154,11 @@ export interface PersonHogClientConfig {
      */
     idleConnectionTimeoutMs?: number
 
+    // -- Attribution --
+
+    /** Identifies the code path / feature area within this service (e.g., "ingestion/event-processing"). */
+    callerTag?: string
+
     // -- Observability --
 
     /**
@@ -189,6 +194,13 @@ export class PersonHogClient {
             const clientName = config.clientName
             interceptors.push((next) => async (req) => {
                 req.header.set('x-client-name', clientName)
+                return await next(req)
+            })
+        }
+        if (config.callerTag) {
+            const callerTag = config.callerTag
+            interceptors.push((next) => async (req) => {
+                req.header.set('x-caller-tag', callerTag)
                 return await next(req)
             })
         }

--- a/nodejs/src/ingestion/personhog/groups.ts
+++ b/nodejs/src/ingestion/personhog/groups.ts
@@ -39,14 +39,20 @@ function protoGroupToDomain(proto: ProtoGroup): DomainGroup {
 export class PersonHogGroupOperations {
     constructor(private client: Client<typeof PersonHogService>) {}
 
-    async fetchGroup(teamId: number, groupTypeIndex: number, groupKey: string): Promise<DomainGroup | undefined> {
+    async fetchGroup(
+        teamId: number,
+        groupTypeIndex: number,
+        groupKey: string,
+        callerTag?: string
+    ): Promise<DomainGroup | undefined> {
         const response = await this.client.getGroup(
             create(GetGroupRequestSchema, {
                 teamId: BigInt(teamId),
                 groupTypeIndex,
                 groupKey,
                 readOptions: eventualReadOptions(),
-            })
+            }),
+            callerTag ? { headers: { 'x-caller-tag': callerTag } } : undefined
         )
         return response.group ? protoGroupToDomain(response.group) : undefined
     }
@@ -54,7 +60,8 @@ export class PersonHogGroupOperations {
     async fetchGroupsByKeys(
         teamIds: number[],
         groupTypeIndexes: number[],
-        groupKeys: string[]
+        groupKeys: string[],
+        callerTag?: string
     ): Promise<
         {
             team_id: number
@@ -77,7 +84,8 @@ export class PersonHogGroupOperations {
                     })
                 ),
                 readOptions: eventualReadOptions(),
-            })
+            }),
+            callerTag ? { headers: { 'x-caller-tag': callerTag } } : undefined
         )
 
         const results: {
@@ -102,7 +110,8 @@ export class PersonHogGroupOperations {
     }
 
     async fetchGroupTypesByTeamIds(
-        teamIds: number[]
+        teamIds: number[],
+        callerTag?: string
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         if (teamIds.length === 0) {
             return {}
@@ -112,7 +121,8 @@ export class PersonHogGroupOperations {
             create(GetGroupTypeMappingsByTeamIdsRequestSchema, {
                 teamIds: teamIds.map(BigInt),
                 readOptions: eventualReadOptions(),
-            })
+            }),
+            callerTag ? { headers: { 'x-caller-tag': callerTag } } : undefined
         )
 
         const result: Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]> = {}
@@ -126,7 +136,8 @@ export class PersonHogGroupOperations {
     }
 
     async fetchGroupTypesByProjectIds(
-        projectIds: number[]
+        projectIds: number[],
+        callerTag?: string
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         if (projectIds.length === 0) {
             return {}
@@ -136,7 +147,8 @@ export class PersonHogGroupOperations {
             create(GetGroupTypeMappingsByProjectIdsRequestSchema, {
                 projectIds: projectIds.map(BigInt),
                 readOptions: eventualReadOptions(),
-            })
+            }),
+            callerTag ? { headers: { 'x-caller-tag': callerTag } } : undefined
         )
 
         const result: Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]> = {}

--- a/nodejs/src/ingestion/personhog/index.ts
+++ b/nodejs/src/ingestion/personhog/index.ts
@@ -21,6 +21,7 @@ export function createPersonHogClient(config: PersonHogConfig): PersonHogClient 
     return PersonHogClient.fromConfig({
         addr: config.PERSONHOG_ADDR,
         clientName: config.PLUGIN_SERVER_MODE ?? 'unknown',
+        callerTag: config.PLUGIN_SERVER_MODE ?? 'unknown',
         useTls: config.PERSONHOG_TLS,
         timeoutMs: config.PERSONHOG_TIMEOUT_MS,
         readMaxBytes: config.PERSONHOG_READ_MAX_BYTES,

--- a/nodejs/src/ingestion/personhog/index.ts
+++ b/nodejs/src/ingestion/personhog/index.ts
@@ -21,7 +21,6 @@ export function createPersonHogClient(config: PersonHogConfig): PersonHogClient 
     return PersonHogClient.fromConfig({
         addr: config.PERSONHOG_ADDR,
         clientName: config.PLUGIN_SERVER_MODE ?? 'unknown',
-        callerTag: config.PLUGIN_SERVER_MODE ?? 'unknown',
         useTls: config.PERSONHOG_TLS,
         timeoutMs: config.PERSONHOG_TIMEOUT_MS,
         readMaxBytes: config.PERSONHOG_READ_MAX_BYTES,

--- a/nodejs/src/ingestion/personhog/personhog-group-repository.test.ts
+++ b/nodejs/src/ingestion/personhog/personhog-group-repository.test.ts
@@ -236,7 +236,8 @@ describe('PersonHogGroupRepository', () => {
                     expect(mockPostgres.fetchGroupsByKeys).toHaveBeenCalledWith(
                         [TEAM_ID],
                         [GROUP_TYPE_INDEX],
-                        [GROUP_KEY]
+                        [GROUP_KEY],
+                        undefined
                     )
                     expect(handlers.getGroupsBatch).not.toHaveBeenCalled()
                 }
@@ -265,7 +266,7 @@ describe('PersonHogGroupRepository', () => {
                     expect(handlers.getGroupTypeMappingsByTeamIds).toHaveBeenCalled()
                     expect(mockPostgres.fetchGroupTypesByTeamIds).not.toHaveBeenCalled()
                 } else {
-                    expect(mockPostgres.fetchGroupTypesByTeamIds).toHaveBeenCalledWith([TEAM_ID])
+                    expect(mockPostgres.fetchGroupTypesByTeamIds).toHaveBeenCalledWith([TEAM_ID], undefined)
                     expect(handlers.getGroupTypeMappingsByTeamIds).not.toHaveBeenCalled()
                 }
             })
@@ -284,7 +285,7 @@ describe('PersonHogGroupRepository', () => {
                     expect(handlers.getGroupTypeMappingsByProjectIds).toHaveBeenCalled()
                     expect(mockPostgres.fetchGroupTypesByProjectIds).not.toHaveBeenCalled()
                 } else {
-                    expect(mockPostgres.fetchGroupTypesByProjectIds).toHaveBeenCalledWith([PROJECT_ID])
+                    expect(mockPostgres.fetchGroupTypesByProjectIds).toHaveBeenCalledWith([PROJECT_ID], undefined)
                     expect(handlers.getGroupTypeMappingsByProjectIds).not.toHaveBeenCalled()
                 }
             })

--- a/nodejs/src/ingestion/personhog/personhog-group-repository.ts
+++ b/nodejs/src/ingestion/personhog/personhog-group-repository.ts
@@ -22,7 +22,7 @@ export class PersonHogGroupRepository implements GroupRepository {
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
         groupKey: string,
-        options?: { forUpdate?: boolean; useReadReplica?: boolean }
+        options?: { forUpdate?: boolean; useReadReplica?: boolean; callerTag?: string }
     ): Promise<Group | undefined> {
         // Only route to gRPC for eventually-consistent replica reads (useReadReplica: true)
         // where no row-level lock is needed (forUpdate: false/unset).
@@ -38,7 +38,7 @@ export class PersonHogGroupRepository implements GroupRepository {
 
         try {
             return await timedGrpc(this.clientLabel, 'fetchGroup', () =>
-                this.grpcClient.groups.fetchGroup(teamId, groupTypeIndex, groupKey)
+                this.grpcClient.groups.fetchGroup(teamId, groupTypeIndex, groupKey, options?.callerTag)
             )
         } catch (error) {
             logger.warn('[PersonHog] gRPC fetchGroup failed, falling back to Postgres', {
@@ -55,7 +55,8 @@ export class PersonHogGroupRepository implements GroupRepository {
     async fetchGroupsByKeys(
         teamIds: TeamId[],
         groupTypeIndexes: GroupTypeIndex[],
-        groupKeys: string[]
+        groupKeys: string[],
+        callerTag?: string
     ): Promise<
         {
             team_id: TeamId
@@ -72,7 +73,7 @@ export class PersonHogGroupRepository implements GroupRepository {
 
         try {
             return await timedGrpc(this.clientLabel, 'fetchGroupsByKeys', () =>
-                this.grpcClient.groups.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys)
+                this.grpcClient.groups.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys, callerTag)
             )
         } catch (error) {
             logger.warn('[PersonHog] gRPC fetchGroupsByKeys failed, falling back to Postgres', {
@@ -86,7 +87,8 @@ export class PersonHogGroupRepository implements GroupRepository {
     }
 
     async fetchGroupTypesByTeamIds(
-        teamIds: TeamId[]
+        teamIds: TeamId[],
+        callerTag?: string
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         if (!shouldUseGrpcForTeams(this.rolloutTeamIds, teamIds, this.grpcPercentage)) {
             return timedPostgres(this.clientLabel, 'fetchGroupTypesByTeamIds', () =>
@@ -96,7 +98,7 @@ export class PersonHogGroupRepository implements GroupRepository {
 
         try {
             return await timedGrpc(this.clientLabel, 'fetchGroupTypesByTeamIds', () =>
-                this.grpcClient.groups.fetchGroupTypesByTeamIds(teamIds)
+                this.grpcClient.groups.fetchGroupTypesByTeamIds(teamIds, callerTag)
             )
         } catch (error) {
             logger.warn('[PersonHog] gRPC fetchGroupTypesByTeamIds failed, falling back to Postgres', {
@@ -110,7 +112,8 @@ export class PersonHogGroupRepository implements GroupRepository {
     }
 
     async fetchGroupTypesByProjectIds(
-        projectIds: ProjectId[]
+        projectIds: ProjectId[],
+        callerTag?: string
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         if (!shouldUseGrpc(this.grpcPercentage)) {
             return timedPostgres(this.clientLabel, 'fetchGroupTypesByProjectIds', () =>
@@ -120,7 +123,7 @@ export class PersonHogGroupRepository implements GroupRepository {
 
         try {
             return await timedGrpc(this.clientLabel, 'fetchGroupTypesByProjectIds', () =>
-                this.grpcClient.groups.fetchGroupTypesByProjectIds(projectIds)
+                this.grpcClient.groups.fetchGroupTypesByProjectIds(projectIds, callerTag)
             )
         } catch (error) {
             logger.warn('[PersonHog] gRPC fetchGroupTypesByProjectIds failed, falling back to Postgres', {

--- a/nodejs/src/ingestion/personhog/personhog-group-repository.ts
+++ b/nodejs/src/ingestion/personhog/personhog-group-repository.ts
@@ -67,7 +67,7 @@ export class PersonHogGroupRepository implements GroupRepository {
     > {
         if (!shouldUseGrpcForTeams(this.rolloutTeamIds, teamIds, this.grpcPercentage)) {
             return timedPostgres(this.clientLabel, 'fetchGroupsByKeys', () =>
-                this.postgres.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys)
+                this.postgres.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys, callerTag)
             )
         }
 
@@ -81,7 +81,7 @@ export class PersonHogGroupRepository implements GroupRepository {
                 error: String(error),
             })
             return timedPostgres(this.clientLabel, 'fetchGroupsByKeys', () =>
-                this.postgres.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys)
+                this.postgres.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys, callerTag)
             )
         }
     }
@@ -92,7 +92,7 @@ export class PersonHogGroupRepository implements GroupRepository {
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         if (!shouldUseGrpcForTeams(this.rolloutTeamIds, teamIds, this.grpcPercentage)) {
             return timedPostgres(this.clientLabel, 'fetchGroupTypesByTeamIds', () =>
-                this.postgres.fetchGroupTypesByTeamIds(teamIds)
+                this.postgres.fetchGroupTypesByTeamIds(teamIds, callerTag)
             )
         }
 
@@ -106,7 +106,7 @@ export class PersonHogGroupRepository implements GroupRepository {
                 error: String(error),
             })
             return timedPostgres(this.clientLabel, 'fetchGroupTypesByTeamIds', () =>
-                this.postgres.fetchGroupTypesByTeamIds(teamIds)
+                this.postgres.fetchGroupTypesByTeamIds(teamIds, callerTag)
             )
         }
     }
@@ -117,7 +117,7 @@ export class PersonHogGroupRepository implements GroupRepository {
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         if (!shouldUseGrpc(this.grpcPercentage)) {
             return timedPostgres(this.clientLabel, 'fetchGroupTypesByProjectIds', () =>
-                this.postgres.fetchGroupTypesByProjectIds(projectIds)
+                this.postgres.fetchGroupTypesByProjectIds(projectIds, callerTag)
             )
         }
 
@@ -131,7 +131,7 @@ export class PersonHogGroupRepository implements GroupRepository {
                 error: String(error),
             })
             return timedPostgres(this.clientLabel, 'fetchGroupTypesByProjectIds', () =>
-                this.postgres.fetchGroupTypesByProjectIds(projectIds)
+                this.postgres.fetchGroupTypesByProjectIds(projectIds, callerTag)
             )
         }
     }

--- a/nodejs/src/ingestion/personhog/personhog-person-repository.test.ts
+++ b/nodejs/src/ingestion/personhog/personhog-person-repository.test.ts
@@ -219,7 +219,8 @@ describe('PersonHogPersonRepository', () => {
                 } else {
                     expect(mockPostgres.fetchPersonsByDistinctIds).toHaveBeenCalledWith(
                         [{ teamId: TEAM_ID, distinctId: 'user-123' }],
-                        true
+                        true,
+                        undefined
                     )
                     expect(handlers.getPersonsByDistinctIds).not.toHaveBeenCalled()
                 }
@@ -256,7 +257,8 @@ describe('PersonHogPersonRepository', () => {
                 } else {
                     expect(mockPostgres.fetchPersonsByPersonIds).toHaveBeenCalledWith(
                         [{ teamId: TEAM_ID, personId: TEST_PERSON.uuid }],
-                        true
+                        true,
+                        undefined
                     )
                     expect(handlers.getPersonsByUuids).not.toHaveBeenCalled()
                 }

--- a/nodejs/src/ingestion/personhog/personhog-person-repository.ts
+++ b/nodejs/src/ingestion/personhog/personhog-person-repository.ts
@@ -36,7 +36,7 @@ export class PersonHogPersonRepository implements PersonRepository {
     async fetchPerson(
         teamId: Team['id'],
         distinctId: string,
-        options?: { forUpdate?: boolean; useReadReplica?: boolean }
+        options?: { forUpdate?: boolean; useReadReplica?: boolean; callerTag?: string }
     ): Promise<InternalPerson | undefined> {
         // Only route to gRPC for eventually-consistent replica reads
         if (
@@ -51,7 +51,7 @@ export class PersonHogPersonRepository implements PersonRepository {
 
         try {
             const results = await timedGrpc(this.clientLabel, 'fetchPerson', () =>
-                this.grpcClient.persons.fetchPersonsByDistinctIds([{ teamId, distinctId }])
+                this.grpcClient.persons.fetchPersonsByDistinctIds([{ teamId, distinctId }], options?.callerTag)
             )
             if (results.length === 0) {
                 return undefined
@@ -70,7 +70,8 @@ export class PersonHogPersonRepository implements PersonRepository {
 
     async fetchPersonsByDistinctIds(
         teamPersons: { teamId: TeamId; distinctId: string }[],
-        useReadReplica?: boolean
+        useReadReplica?: boolean,
+        callerTag?: string
     ): Promise<InternalPersonWithDistinctId[]> {
         // Default matches PostgresPersonRepository (useReadReplica=true)
         if (
@@ -84,7 +85,7 @@ export class PersonHogPersonRepository implements PersonRepository {
 
         try {
             return await timedGrpc(this.clientLabel, 'fetchPersonsByDistinctIds', () =>
-                this.grpcClient.persons.fetchPersonsByDistinctIds(teamPersons)
+                this.grpcClient.persons.fetchPersonsByDistinctIds(teamPersons, callerTag)
             )
         } catch (error) {
             logger.warn('[PersonHog] gRPC fetchPersonsByDistinctIds failed, falling back to Postgres', {
@@ -99,7 +100,8 @@ export class PersonHogPersonRepository implements PersonRepository {
 
     async fetchPersonsByPersonIds(
         teamPersons: { teamId: TeamId; personId: string }[],
-        useReadReplica?: boolean
+        useReadReplica?: boolean,
+        callerTag?: string
     ): Promise<InternalPerson[]> {
         // Default matches PostgresPersonRepository (useReadReplica=true)
         if (
@@ -113,7 +115,7 @@ export class PersonHogPersonRepository implements PersonRepository {
 
         try {
             return await timedGrpc(this.clientLabel, 'fetchPersonsByPersonIds', () =>
-                this.grpcClient.persons.fetchPersonsByPersonIds(teamPersons)
+                this.grpcClient.persons.fetchPersonsByPersonIds(teamPersons, callerTag)
             )
         } catch (error) {
             logger.warn('[PersonHog] gRPC fetchPersonsByPersonIds failed, falling back to Postgres', {

--- a/nodejs/src/ingestion/personhog/personhog-person-repository.ts
+++ b/nodejs/src/ingestion/personhog/personhog-person-repository.ts
@@ -79,7 +79,7 @@ export class PersonHogPersonRepository implements PersonRepository {
             !shouldUseGrpcForTeamItems(this.rolloutTeamIds, teamPersons, this.grpcPercentage)
         ) {
             return timedPostgres(this.clientLabel, 'fetchPersonsByDistinctIds', () =>
-                this.postgres.fetchPersonsByDistinctIds(teamPersons, useReadReplica)
+                this.postgres.fetchPersonsByDistinctIds(teamPersons, useReadReplica, callerTag)
             )
         }
 
@@ -93,7 +93,7 @@ export class PersonHogPersonRepository implements PersonRepository {
                 error: String(error),
             })
             return timedPostgres(this.clientLabel, 'fetchPersonsByDistinctIds', () =>
-                this.postgres.fetchPersonsByDistinctIds(teamPersons, useReadReplica)
+                this.postgres.fetchPersonsByDistinctIds(teamPersons, useReadReplica, callerTag)
             )
         }
     }
@@ -109,7 +109,7 @@ export class PersonHogPersonRepository implements PersonRepository {
             !shouldUseGrpcForTeamItems(this.rolloutTeamIds, teamPersons, this.grpcPercentage)
         ) {
             return timedPostgres(this.clientLabel, 'fetchPersonsByPersonIds', () =>
-                this.postgres.fetchPersonsByPersonIds(teamPersons, useReadReplica)
+                this.postgres.fetchPersonsByPersonIds(teamPersons, useReadReplica, callerTag)
             )
         }
 
@@ -123,7 +123,7 @@ export class PersonHogPersonRepository implements PersonRepository {
                 error: String(error),
             })
             return timedPostgres(this.clientLabel, 'fetchPersonsByPersonIds', () =>
-                this.postgres.fetchPersonsByPersonIds(teamPersons, useReadReplica)
+                this.postgres.fetchPersonsByPersonIds(teamPersons, useReadReplica, callerTag)
             )
         }
     }

--- a/nodejs/src/ingestion/personhog/persons.ts
+++ b/nodejs/src/ingestion/personhog/persons.ts
@@ -35,7 +35,8 @@ export class PersonHogPersonOperations {
     constructor(private client: Client<typeof PersonHogService>) {}
 
     async fetchPersonsByDistinctIds(
-        teamPersons: { teamId: number; distinctId: string }[]
+        teamPersons: { teamId: number; distinctId: string }[],
+        callerTag?: string
     ): Promise<InternalPersonWithDistinctId[]> {
         if (teamPersons.length === 0) {
             return []
@@ -53,7 +54,8 @@ export class PersonHogPersonOperations {
                         })
                     ),
                     readOptions: eventualReadOptions(),
-                })
+                }),
+                callerTag ? { headers: { 'x-caller-tag': callerTag } } : undefined
             )
 
             for (const result of response.results) {
@@ -87,7 +89,8 @@ export class PersonHogPersonOperations {
                 personIds: personIntIds.map((id) => BigInt(id)),
                 limitPerPerson: limitPerPerson != null ? BigInt(limitPerPerson) : undefined,
                 readOptions: eventualReadOptions(),
-            })
+            }),
+            callerTag ? { headers: { 'x-caller-tag': callerTag } } : undefined
         )
 
         const result: Record<string, string[]> = {}
@@ -97,7 +100,10 @@ export class PersonHogPersonOperations {
         return result
     }
 
-    async fetchPersonsByPersonIds(teamPersons: { teamId: number; personId: string }[]): Promise<InternalPerson[]> {
+    async fetchPersonsByPersonIds(
+        teamPersons: { teamId: number; personId: string }[],
+        callerTag?: string
+    ): Promise<InternalPerson[]> {
         if (teamPersons.length === 0) {
             return []
         }
@@ -119,7 +125,8 @@ export class PersonHogPersonOperations {
                             teamId: BigInt(teamId),
                             uuids: batch,
                             readOptions: eventualReadOptions(),
-                        })
+                        }),
+                        callerTag ? { headers: { 'x-caller-tag': callerTag } } : undefined
                     )
                     batchResults.push(...response.persons.map(protoPersonToDomain))
                 }

--- a/nodejs/src/ingestion/personhog/persons.ts
+++ b/nodejs/src/ingestion/personhog/persons.ts
@@ -77,7 +77,8 @@ export class PersonHogPersonOperations {
     async getDistinctIdsForPersons(
         teamId: number,
         personIntIds: string[],
-        limitPerPerson?: number
+        limitPerPerson?: number,
+        callerTag?: string
     ): Promise<Record<string, string[]>> {
         if (personIntIds.length === 0) {
             return {}

--- a/nodejs/src/worker/ingestion/group-type-manager.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.ts
@@ -26,7 +26,10 @@ export class GroupTypeManager {
                 const timeout = timeoutGuard(`Still running "fetchGroupTypes". Timeout warning after 30 sec!`)
                 try {
                     const projectIdNumbers = projectIds.map((id) => parseInt(id) as ProjectId)
-                    const groupTypesByProject = await this.groupRepository.fetchGroupTypesByProjectIds(projectIdNumbers)
+                    const groupTypesByProject = await this.groupRepository.fetchGroupTypesByProjectIds(
+                        projectIdNumbers,
+                        'ingestion/group-type-resolution'
+                    )
 
                     for (const [projectIdStr, groupTypes] of Object.entries(groupTypesByProject)) {
                         const groupTypeMapping: GroupTypeToColumnIndex = {}

--- a/nodejs/src/worker/ingestion/groups/batch-writing-group-store.ts
+++ b/nodejs/src/worker/ingestion/groups/batch-writing-group-store.ts
@@ -491,7 +491,8 @@ export class BatchWritingGroupStore implements GroupStore {
         const latestGroup = await this.groupRepository.fetchGroup(
             update.team_id,
             update.group_type_index,
-            update.group_key
+            update.group_key,
+            { callerTag: 'ingestion/group-update-conflict' }
         )
         if (latestGroup) {
             const propertiesUpdate = calculateUpdate(latestGroup.group_properties || {}, update.group_properties)

--- a/nodejs/src/worker/ingestion/groups/repositories/group-repository.interface.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/group-repository.interface.ts
@@ -17,13 +17,14 @@ export interface GroupRepository {
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
         groupKey: string,
-        options?: { forUpdate?: boolean; useReadReplica?: boolean }
+        options?: { forUpdate?: boolean; useReadReplica?: boolean; callerTag?: string }
     ): Promise<Group | undefined>
 
     fetchGroupsByKeys(
         teamIds: TeamId[],
         groupTypeIndexes: GroupTypeIndex[],
-        groupKeys: string[]
+        groupKeys: string[],
+        callerTag?: string
     ): Promise<
         {
             team_id: TeamId
@@ -68,11 +69,13 @@ export interface GroupRepository {
     // Group Type Methods
 
     fetchGroupTypesByProjectIds(
-        projectIds: ProjectId[]
+        projectIds: ProjectId[],
+        callerTag?: string
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
 
     fetchGroupTypesByTeamIds(
-        teamIds: TeamId[]
+        teamIds: TeamId[],
+        callerTag?: string
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
 
     insertGroupType(

--- a/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
@@ -41,7 +41,7 @@ export class PostgresGroupRepositoryTransaction implements GroupRepositoryTransa
             group_properties: Record<string, any>
         }[]
     > {
-        return await this.repository.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys, this.tx)
+        return await this.repository.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys, undefined, this.tx)
     }
 
     async insertGroup(
@@ -91,13 +91,13 @@ export class PostgresGroupRepositoryTransaction implements GroupRepositoryTransa
     async fetchGroupTypesByProjectIds(
         projectIds: ProjectId[]
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
-        return await this.repository.fetchGroupTypesByProjectIds(projectIds, this.tx)
+        return await this.repository.fetchGroupTypesByProjectIds(projectIds, undefined, this.tx)
     }
 
     async fetchGroupTypesByTeamIds(
         teamIds: TeamId[]
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
-        return await this.repository.fetchGroupTypesByTeamIds(teamIds, this.tx)
+        return await this.repository.fetchGroupTypesByTeamIds(teamIds, undefined, this.tx)
     }
 
     async insertGroupType(

--- a/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
@@ -22,6 +22,10 @@ import { RawPostgresGroupRepository } from './raw-postgres-group-repository.inte
 
 const MAX_GROUP_TYPES_PER_TEAM = 5
 
+function queryTag(base: string, callerTag?: string): string {
+    return callerTag ? `${base}:${callerTag}` : base
+}
+
 export class PostgresGroupRepository
     implements GroupRepository, RawPostgresGroupRepository, GroupRepositoryTransaction
 {
@@ -31,7 +35,7 @@ export class PostgresGroupRepository
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
         groupKey: string,
-        options: { forUpdate?: boolean; useReadReplica?: boolean } = {},
+        options: { forUpdate?: boolean; useReadReplica?: boolean; callerTag?: string } = {},
         tx?: TransactionClient
     ): Promise<Group | undefined> {
         if (options.forUpdate && options.useReadReplica) {
@@ -48,7 +52,7 @@ export class PostgresGroupRepository
             tx ?? (options.useReadReplica ? PostgresUse.PERSONS_READ : PostgresUse.PERSONS_WRITE),
             queryString,
             [teamId, groupTypeIndex, groupKey],
-            'fetchGroup'
+            queryTag('fetchGroup', options.callerTag)
         )
 
         if (selectResult.rows.length > 0) {
@@ -61,6 +65,7 @@ export class PostgresGroupRepository
         teamIds: TeamId[],
         groupTypeIndexes: GroupTypeIndex[],
         groupKeys: string[],
+        callerTag?: string,
         tx?: TransactionClient
     ): Promise<
         {
@@ -92,7 +97,7 @@ export class PostgresGroupRepository
               AND g.group_type_index = t.group_type_index
               AND g.group_key = t.group_key`,
             [teamIds, groupTypeIndexes, groupKeys],
-            'fetchGroupsByKeys'
+            queryTag('fetchGroupsByKeys', callerTag)
         )
 
         return rows.map((row) => {
@@ -235,6 +240,7 @@ export class PostgresGroupRepository
 
     async fetchGroupTypesByProjectIds(
         projectIds: ProjectId[],
+        callerTag?: string,
         tx?: TransactionClient
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         if (projectIds.length === 0) {
@@ -245,7 +251,7 @@ export class PostgresGroupRepository
             tx ?? PostgresUse.PERSONS_READ,
             `SELECT project_id, group_type, group_type_index FROM posthog_grouptypemapping WHERE project_id = ANY($1)`,
             [projectIds],
-            'fetchGroupTypesByProjectIds'
+            queryTag('fetchGroupTypesByProjectIds', callerTag)
         )
 
         const response: Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]> = {}
@@ -279,6 +285,7 @@ export class PostgresGroupRepository
 
     async fetchGroupTypesByTeamIds(
         teamIds: TeamId[],
+        callerTag?: string,
         tx?: TransactionClient
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         if (teamIds.length === 0) {
@@ -289,7 +296,7 @@ export class PostgresGroupRepository
             tx ?? PostgresUse.PERSONS_READ,
             `SELECT team_id, group_type, group_type_index FROM posthog_grouptypemapping WHERE team_id = ANY($1)`,
             [teamIds],
-            'fetchGroupTypesByTeamIds'
+            queryTag('fetchGroupTypesByTeamIds', callerTag)
         )
 
         const response: Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]> = {}

--- a/nodejs/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
@@ -25,6 +25,7 @@ export interface RawPostgresGroupRepository {
         teamIds: TeamId[],
         groupTypeIndexes: GroupTypeIndex[],
         groupKeys: string[],
+        callerTag?: string,
         tx?: TransactionClient
     ): Promise<
         {
@@ -73,11 +74,13 @@ export interface RawPostgresGroupRepository {
 
     fetchGroupTypesByProjectIds(
         projectIds: ProjectId[],
+        callerTag?: string,
         tx?: TransactionClient
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
 
     fetchGroupTypesByTeamIds(
         teamIds: TeamId[],
+        callerTag?: string,
         tx?: TransactionClient
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
 

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -665,7 +665,10 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                 try {
                     this.incrementDatabaseOperation('fetchForChecking', distinctId)
                     const start = performance.now()
-                    const person = await this.personRepository.fetchPerson(teamId, distinctId, { useReadReplica: true })
+                    const person = await this.personRepository.fetchPerson(teamId, distinctId, {
+                        useReadReplica: true,
+                        callerTag: 'ingestion/person-resolution',
+                    })
                     observeLatencyByVersion(person, start, 'fetchForChecking')
                     this.setCheckCachedPerson(teamId, distinctId, person ?? null)
                     return person ?? null
@@ -794,6 +797,7 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                     const start = performance.now()
                     const person = await this.personRepository.fetchPerson(teamId, distinctId, {
                         useReadReplica: false,
+                        callerTag: 'ingestion/person-update-conflict',
                     })
                     observeLatencyByVersion(person, start, 'fetchForUpdate')
                     if (person !== undefined) {
@@ -1482,7 +1486,9 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
 
         // Fetch latest person data to get current version and properties
         this.incrementDatabaseOperation('fetchPerson', personUpdate.distinct_id)
-        const latestPerson = await this.personRepository.fetchPerson(personUpdate.team_id, personUpdate.distinct_id)
+        const latestPerson = await this.personRepository.fetchPerson(personUpdate.team_id, personUpdate.distinct_id, {
+            callerTag: 'ingestion/person-version-conflict',
+        })
 
         if (latestPerson) {
             // Use fine-grained merge: start with latest properties from DB and apply our specific changes
@@ -1629,7 +1635,9 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
      * @returns updated PersonUpdate with new person ID if found, null if person no longer exists
      */
     private async refreshPersonIdAfterMerge(personUpdate: PersonUpdate): Promise<PersonUpdate | null> {
-        const currentPerson = await this.personRepository.fetchPerson(personUpdate.team_id, personUpdate.distinct_id)
+        const currentPerson = await this.personRepository.fetchPerson(personUpdate.team_id, personUpdate.distinct_id, {
+            callerTag: 'ingestion/person-merge-refresh',
+        })
 
         if (!currentPerson) {
             // Person truly doesn't exist anymore

--- a/nodejs/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/nodejs/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -38,17 +38,19 @@ export interface PersonRepository {
     fetchPerson(
         teamId: Team['id'],
         distinctId: string,
-        options?: { forUpdate?: boolean; useReadReplica?: boolean }
+        options?: { forUpdate?: boolean; useReadReplica?: boolean; callerTag?: string }
     ): Promise<InternalPerson | undefined>
 
     fetchPersonsByDistinctIds(
         teamPersons: { teamId: TeamId; distinctId: string }[],
-        useReadReplica?: boolean
+        useReadReplica?: boolean,
+        callerTag?: string
     ): Promise<InternalPersonWithDistinctId[]>
 
     fetchPersonsByPersonIds(
         teamPersons: { teamId: TeamId; personId: string }[],
-        useReadReplica?: boolean
+        useReadReplica?: boolean,
+        callerTag?: string
     ): Promise<InternalPerson[]>
 
     /**

--- a/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -44,6 +44,10 @@ import { RawPostgresPersonRepository } from './raw-postgres-person-repository'
 const DEFAULT_PERSON_PROPERTIES_TRIM_TARGET_BYTES = 512 * 1024
 const DEFAULT_PERSON_PROPERTIES_DB_CONSTRAINT_LIMIT_BYTES = 655360
 
+function queryTag(base: string, callerTag?: string): string {
+    return callerTag ? `${base}:${callerTag}` : base
+}
+
 export interface PostgresPersonRepositoryOptions {
     calculatePropertiesSize: number
     /** Limit used when comparing pg_column_size(properties) to decide whether to remediate */
@@ -221,7 +225,7 @@ export class PostgresPersonRepository
     async fetchPerson(
         teamId: number,
         distinctId: string,
-        options: { forUpdate?: boolean; useReadReplica?: boolean } = {}
+        options: { forUpdate?: boolean; useReadReplica?: boolean; callerTag?: string } = {}
     ): Promise<InternalPerson | undefined> {
         if (options.forUpdate && options.useReadReplica) {
             throw new Error("can't enable both forUpdate and useReadReplica in db::fetchPerson")
@@ -258,7 +262,7 @@ export class PostgresPersonRepository
             options.useReadReplica ? PostgresUse.PERSONS_READ : PostgresUse.PERSONS_WRITE,
             queryString,
             values,
-            'fetchPerson'
+            queryTag('fetchPerson', options.callerTag)
         )
 
         if (rows.length > 0) {
@@ -268,7 +272,8 @@ export class PostgresPersonRepository
 
     async fetchPersonsByDistinctIds(
         teamPersons: { teamId: TeamId; distinctId: string }[],
-        useReadReplica: boolean = true
+        useReadReplica: boolean = true,
+        callerTag?: string
     ): Promise<InternalPersonWithDistinctId[]> {
         if (teamPersons.length === 0) {
             return []
@@ -317,7 +322,7 @@ export class PostgresPersonRepository
             useReadReplica ? PostgresUse.PERSONS_READ : PostgresUse.PERSONS_WRITE,
             queryString,
             [teamIds, distinctIds],
-            'fetchPersonsByDistinctIds'
+            queryTag('fetchPersonsByDistinctIds', callerTag)
         )
 
         return rows.map((row) => ({
@@ -328,7 +333,8 @@ export class PostgresPersonRepository
 
     async fetchPersonsByPersonIds(
         teamPersons: { teamId: TeamId; personId: string }[],
-        useReadReplica: boolean = true
+        useReadReplica: boolean = true,
+        callerTag?: string
     ): Promise<InternalPerson[]> {
         if (teamPersons.length === 0) {
             return []
@@ -370,7 +376,7 @@ export class PostgresPersonRepository
             useReadReplica ? PostgresUse.PERSONS_READ : PostgresUse.PERSONS_WRITE,
             queryString,
             [teamIds, personIds],
-            'fetchPersonsByPersonIds'
+            queryTag('fetchPersonsByPersonIds', callerTag)
         )
 
         return rows.map(this.toPerson)

--- a/nodejs/tests/worker/ingestion/person-state-batch.test.ts
+++ b/nodejs/tests/worker/ingestion/person-state-batch.test.ts
@@ -3197,10 +3197,12 @@ describe('PersonState.processEvent()', () => {
 
             // Verify that fetchPerson was called for both users
             expect(personRepository.fetchPerson).toHaveBeenCalledWith(teamId, firstUserDistinctId, {
+                callerTag: 'ingestion/person-update-conflict',
                 useReadReplica: false,
             })
 
             expect(personRepository.fetchPerson).toHaveBeenCalledWith(teamId, secondUserDistinctId, {
+                callerTag: 'ingestion/person-update-conflict',
                 useReadReplica: false,
             })
 
@@ -3253,10 +3255,12 @@ describe('PersonState.processEvent()', () => {
 
             // Verify that fetchPerson was called for both users
             expect(personRepository.fetchPerson).toHaveBeenCalledWith(teamId, firstUserDistinctId, {
+                callerTag: 'ingestion/person-update-conflict',
                 useReadReplica: false,
             })
 
             expect(personRepository.fetchPerson).toHaveBeenCalledWith(teamId, secondUserDistinctId, {
+                callerTag: 'ingestion/person-update-conflict',
                 useReadReplica: false,
             })
 


### PR DESCRIPTION
## Problem

We need per-caller attribution on personhog gRPC requests to identify which code paths are generating high-latency/data-intensive requests. The `x-caller-tag` header (consumed by the router in PR #60361) provides this, but each client service needs to send it.

## Changes

- Adds `callerTag` optional config to `PersonHogClientConfig`
- Adds a gRPC interceptor that sets the `x-caller-tag` header on every request

## How did you test this code?

- existing unit tests