### PR TITLE
feat(personhog): add caller tag attribution to Django client

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import os
 import time
 import errno
+import contextvars
 
 from django.dispatch import receiver
 
@@ -194,6 +197,20 @@ def on_worker_process_shutdown(**kwargs) -> None:
         multiprocess.mark_process_dead(os.getpid())
 
 
+# -- personhog caller-tag for Celery tasks --
+
+_caller_tag_tokens: dict[str, contextvars.Token[str]] = {}
+
+
+def _celery_caller_tag(task_name: str) -> str:
+    """Derive a personhog caller tag from a Celery task name.
+
+    "posthog.tasks.calculate_cohort.calculate_cohort_ch" → "celery/calculate_cohort_ch"
+    """
+    short = task_name.rsplit(".", 1)[-1] if "." in task_name else task_name
+    return f"celery/{short}"
+
+
 # Set up clickhouse query instrumentation
 @task_prerun.connect
 def prerun_signal_handler(task_id, task, **kwargs):
@@ -201,6 +218,7 @@ def prerun_signal_handler(task_id, task, **kwargs):
 
     from posthog.clickhouse.client.connection import Workload, set_default_clickhouse_workload_type
     from posthog.clickhouse.query_tagging import tag_queries
+    from posthog.personhog_client.interceptor import set_caller_tag
 
     statsd.incr("celery_tasks_metrics.pre_run", tags={"name": task.name})
     tag_queries(kind="celery", id=task.name)
@@ -208,17 +226,24 @@ def prerun_signal_handler(task_id, task, **kwargs):
 
     task_timings[task_id] = time.time()
 
+    _caller_tag_tokens[task_id] = set_caller_tag(_celery_caller_tag(task.name))
+
     CELERY_TASK_PRE_RUN_COUNTER.labels(task_name=task.name).inc()
 
 
 @task_postrun.connect
 def postrun_signal_handler(task_id, task, **kwargs):
     from posthog.clickhouse.query_tagging import reset_query_tags
+    from posthog.personhog_client.interceptor import _caller_tag
 
     if task_id in task_timings:
         start_time = task_timings.pop(task_id, None)
         if start_time:
             CELERY_TASK_DURATION_HISTOGRAM.labels(task_name=task.name).observe(time.time() - start_time)
+
+    token = _caller_tag_tokens.pop(task_id, None)
+    if token is not None:
+        _caller_tag.reset(token)
 
     reset_query_tags()
 

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -54,12 +54,16 @@ def delete_bulky_postgres_data(team_ids: list[int]):
         _delete_cohort_members_for_teams(team_ids, cohort_ids)
 
     _raw_delete(FeatureFlagHashKeyOverride.objects.filter(team_id__in=team_ids))  # nosemgrep: no-direct-persons-db-orm
-    _delete_groups_for_teams(team_ids)
-    _delete_group_type_mappings_for_teams(team_ids)
 
-    # Delete Person + PersonDistinctId via personhog RPC (handles both tables).
-    # Falls back to ORM batch deletion when personhog is not available.
-    _delete_persons_for_teams(team_ids)
+    from posthog.personhog_client.interceptor import personhog_caller_tag
+
+    with personhog_caller_tag("admin/team-delete"):
+        _delete_groups_for_teams(team_ids)
+        _delete_group_type_mappings_for_teams(team_ids)
+
+        # Delete Person + PersonDistinctId via personhog RPC (handles both tables).
+        # Falls back to ORM batch deletion when personhog is not available.
+        _delete_persons_for_teams(team_ids)
 
     _raw_delete(InsightCachingState.objects.filter(team_id__in=team_ids))
 

--- a/posthog/personhog_client/client.py
+++ b/posthog/personhog_client/client.py
@@ -10,7 +10,12 @@ import grpc
 import structlog
 from prometheus_client import Counter, Enum, Histogram
 
-from posthog.personhog_client.interceptor import ClientNameInterceptor, ConsistencyHeaderInterceptor, MetricsInterceptor
+from posthog.personhog_client.interceptor import (
+    CallerTagInterceptor,
+    ClientNameInterceptor,
+    ConsistencyHeaderInterceptor,
+    MetricsInterceptor,
+)
 from posthog.personhog_client.proto import (
     CheckCohortMembershipRequest,
     CohortMembershipResponse,
@@ -170,6 +175,7 @@ class PersonHogClient:
         self._channel = grpc.intercept_channel(
             channel,
             ClientNameInterceptor(client_name),
+            CallerTagInterceptor(),
             ConsistencyHeaderInterceptor(),
             MetricsInterceptor(client_name),
         )

--- a/posthog/personhog_client/interceptor.py
+++ b/posthog/personhog_client/interceptor.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import time
+import contextvars
 from collections import namedtuple
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
 from typing import Any
 
 import grpc
@@ -20,17 +22,41 @@ class _MutableClientCallDetails(_ClientCallDetails, grpc.ClientCallDetails):
     pass
 
 
+# ── Caller-tag context propagation ───────────────────────────────────
+
+_caller_tag: contextvars.ContextVar[str] = contextvars.ContextVar("personhog_caller_tag", default="unknown")
+
+
+@contextmanager
+def personhog_caller_tag(tag: str) -> Generator[None, None, None]:
+    token = _caller_tag.set(tag)
+    try:
+        yield
+    finally:
+        _caller_tag.reset(token)
+
+
+def set_caller_tag(tag: str) -> contextvars.Token[str]:
+    return _caller_tag.set(tag)
+
+
+def get_caller_tag() -> str:
+    return _caller_tag.get()
+
+
+# ── Prometheus metrics ───────────────────────────────────────────────
+
 PERSONHOG_DJANGO_REQUEST_DURATION = Histogram(
     "personhog_django_grpc_request_duration_seconds",
     "gRPC request duration from a Django personhog client to the personhog service",
-    labelnames=["method", "client_name"],
+    labelnames=["method", "client_name", "caller_tag"],
     buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
 )
 
 PERSONHOG_DJANGO_REQUEST_COUNT = Counter(
     "personhog_django_grpc_requests_total",
     "Total gRPC requests from a Django personhog client to the personhog service",
-    labelnames=["method", "status", "client_name"],
+    labelnames=["method", "status", "client_name", "caller_tag"],
 )
 
 PERSONHOG_DJANGO_TIMEOUT_TOTAL = Counter(
@@ -75,6 +101,20 @@ class ClientNameInterceptor(grpc.UnaryUnaryClientInterceptor):
         return continuation(new_details, request)
 
 
+class CallerTagInterceptor(grpc.UnaryUnaryClientInterceptor):
+    """Injects x-caller-tag gRPC metadata header from the contextvars-based caller tag."""
+
+    def intercept_unary_unary(
+        self,
+        continuation: Any,
+        client_call_details: grpc.ClientCallDetails,
+        request: Any,
+    ) -> Any:
+        tag = _caller_tag.get()
+        new_details = _with_metadata(client_call_details, [("x-caller-tag", tag)])
+        return continuation(new_details, request)
+
+
 class ConsistencyHeaderInterceptor(grpc.UnaryUnaryClientInterceptor):
     """Sets x-read-consistency gRPC metadata header based on the request's read_options field.
 
@@ -109,24 +149,29 @@ class MetricsInterceptor(grpc.UnaryUnaryClientInterceptor):
         request: Any,
     ) -> Any:
         method = _method_name(client_call_details)
+        caller_tag = _caller_tag.get()
         start = time.monotonic()
         try:
             response = continuation(client_call_details, request)
             # grpc-python returns a future-like object; .code() is None on success
             code = response.code()
             status = code.name if code else "OK"
-            PERSONHOG_DJANGO_REQUEST_COUNT.labels(method=method, status=status, client_name=self._client_name).inc()
+            PERSONHOG_DJANGO_REQUEST_COUNT.labels(
+                method=method, status=status, client_name=self._client_name, caller_tag=caller_tag
+            ).inc()
             if code == grpc.StatusCode.DEADLINE_EXCEEDED:
                 PERSONHOG_DJANGO_TIMEOUT_TOTAL.labels(method=method, client_name=self._client_name).inc()
             return response
         except grpc.RpcError as exc:
             code = exc.code()
             status = code.name if code else "UNKNOWN"
-            PERSONHOG_DJANGO_REQUEST_COUNT.labels(method=method, status=status, client_name=self._client_name).inc()
+            PERSONHOG_DJANGO_REQUEST_COUNT.labels(
+                method=method, status=status, client_name=self._client_name, caller_tag=caller_tag
+            ).inc()
             if code == grpc.StatusCode.DEADLINE_EXCEEDED:
                 PERSONHOG_DJANGO_TIMEOUT_TOTAL.labels(method=method, client_name=self._client_name).inc()
             raise
         finally:
-            PERSONHOG_DJANGO_REQUEST_DURATION.labels(method=method, client_name=self._client_name).observe(
-                time.monotonic() - start
-            )
+            PERSONHOG_DJANGO_REQUEST_DURATION.labels(
+                method=method, client_name=self._client_name, caller_tag=caller_tag
+            ).observe(time.monotonic() - start)

--- a/posthog/personhog_client/middleware.py
+++ b/posthog/personhog_client/middleware.py
@@ -1,6 +1,9 @@
 from django.http import HttpRequest, HttpResponse
+from django.urls import resolve
+from django.urls.exceptions import Resolver404
 
 from posthog.personhog_client.gate import pin_personhog_decision, unpin_personhog_decision
+from posthog.personhog_client.interceptor import set_caller_tag
 
 
 class PersonHogGateMiddleware:
@@ -20,3 +23,70 @@ class PersonHogGateMiddleware:
             return self.get_response(request)
         finally:
             unpin_personhog_decision()
+
+
+# DRF view_name prefix → caller tag.
+# view_name is "{basename}-{action}", e.g. "persons-list", "project_cohorts-detail".
+# Checked with startswith so "persons-list" matches prefix "persons".
+_VIEW_NAME_TO_CALLER_TAG: dict[str, str] = {
+    "persons": "api/persons",
+    "environment_persons": "api/persons",
+    "project_feature_flags": "api/feature-flags",
+    "feature_flag": "api/feature-flags",
+    "organization_feature_flags": "api/feature-flags",
+    "project_cohorts": "api/cohorts",
+    "cohort": "api/cohorts",
+    "environment_groups": "api/groups",
+    "project_groups_types": "api/group-types",
+    "project_groups_metrics": "api/group-types",
+    "project_insights": "api/insights",
+    "environment_insights": "api/insights",
+    "project_dashboards": "api/dashboards",
+    "environment_exports": "api/exports",
+    "project_experiments": "api/experiments",
+    "environment_events": "api/events",
+    "event": "api/events",
+    "project_session_recordings": "api/session-recordings",
+    "environment_session_recordings": "api/session-recordings",
+    "project_query": "api/query",
+    "environment_query": "api/query",
+}
+
+
+def _resolve_caller_tag(request: HttpRequest) -> str:
+    try:
+        route = resolve(request.path)
+    except Resolver404:
+        return "web/unresolved"
+
+    view_name = route.view_name or ""
+
+    for prefix, tag in _VIEW_NAME_TO_CALLER_TAG.items():
+        if view_name.startswith(prefix):
+            return tag
+
+    if "api/" in request.path:
+        return "api/other"
+
+    return "web/other"
+
+
+class PersonHogCallerTagMiddleware:
+    """Derive an x-caller-tag from the resolved Django URL name.
+
+    Sets the caller_tag ContextVar so that downstream personhog gRPC calls
+    carry the tag via CallerTagInterceptor.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        tag = _resolve_caller_tag(request)
+        token = set_caller_tag(tag)
+        try:
+            return self.get_response(request)
+        finally:
+            from posthog.personhog_client.interceptor import _caller_tag
+
+            _caller_tag.reset(token)

--- a/posthog/personhog_client/test_interceptor.py
+++ b/posthog/personhog_client/test_interceptor.py
@@ -6,10 +6,14 @@ import grpc
 from parameterized import parameterized
 
 from posthog.personhog_client.interceptor import (
+    CallerTagInterceptor,
     ClientNameInterceptor,
     ConsistencyHeaderInterceptor,
     _MutableClientCallDetails,
     _with_metadata,
+    get_caller_tag,
+    personhog_caller_tag,
+    set_caller_tag,
 )
 from posthog.personhog_client.proto import (
     CONSISTENCY_LEVEL_EVENTUAL,
@@ -141,3 +145,60 @@ class TestConsistencyHeaderInterceptor(BaseTest):
         self.assertEqual(len(captured_details), 1)
         metadata = dict(captured_details[0].metadata)
         self.assertEqual(metadata["x-read-consistency"], expected)
+
+
+class TestCallerTagInterceptor(BaseTest):
+    def test_injects_default_unknown_tag(self) -> None:
+        interceptor = CallerTagInterceptor()
+        original_details = _make_call_details()
+        captured_details: list[grpc.ClientCallDetails] = []
+
+        def mock_continuation(details: grpc.ClientCallDetails, request: object) -> str:
+            captured_details.append(details)
+            return "ok"
+
+        result = interceptor.intercept_unary_unary(mock_continuation, original_details, request=b"")
+
+        self.assertEqual(result, "ok")
+        metadata = dict(captured_details[0].metadata)
+        self.assertEqual(metadata["x-caller-tag"], "unknown")
+
+    def test_injects_tag_from_context(self) -> None:
+        interceptor = CallerTagInterceptor()
+        original_details = _make_call_details()
+        captured_details: list[grpc.ClientCallDetails] = []
+
+        def mock_continuation(details: grpc.ClientCallDetails, request: object) -> str:
+            captured_details.append(details)
+            return "ok"
+
+        with personhog_caller_tag("api/feature-flags"):
+            interceptor.intercept_unary_unary(mock_continuation, original_details, request=b"")
+
+        metadata = dict(captured_details[0].metadata)
+        self.assertEqual(metadata["x-caller-tag"], "api/feature-flags")
+
+
+class TestCallerTagContextManager(BaseTest):
+    def test_default_is_unknown(self) -> None:
+        self.assertEqual(get_caller_tag(), "unknown")
+
+    def test_context_manager_sets_and_resets(self) -> None:
+        self.assertEqual(get_caller_tag(), "unknown")
+        with personhog_caller_tag("celery/cohort-calculation"):
+            self.assertEqual(get_caller_tag(), "celery/cohort-calculation")
+        self.assertEqual(get_caller_tag(), "unknown")
+
+    def test_nesting(self) -> None:
+        with personhog_caller_tag("outer"):
+            self.assertEqual(get_caller_tag(), "outer")
+            with personhog_caller_tag("inner"):
+                self.assertEqual(get_caller_tag(), "inner")
+            self.assertEqual(get_caller_tag(), "outer")
+
+    def test_set_caller_tag_function(self) -> None:
+        token = set_caller_tag("manual-tag")
+        self.assertEqual(get_caller_tag(), "manual-tag")
+        from posthog.personhog_client.interceptor import _caller_tag
+
+        _caller_tag.reset(token)

--- a/posthog/personhog_client/test_middleware.py
+++ b/posthog/personhog_client/test_middleware.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.personhog_client.interceptor import get_caller_tag
+from posthog.personhog_client.middleware import PersonHogCallerTagMiddleware, _resolve_caller_tag
+
+
+class TestResolveCallerTag(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("persons_list", "/api/environments/1/persons/", "api/persons"),
+            ("legacy_persons", "/api/person/", "api/persons"),
+            ("cohorts_list", "/api/projects/1/cohorts/", "api/cohorts"),
+            ("legacy_cohort", "/api/cohort/", "api/cohorts"),
+            ("feature_flags", "/api/projects/1/feature_flags/", "api/feature-flags"),
+            ("groups", "/api/environments/1/groups/", "api/groups"),
+            ("insights", "/api/projects/1/insights/", "api/insights"),
+            ("dashboards", "/api/projects/1/dashboards/", "api/dashboards"),
+            ("events", "/api/environments/1/events/", "api/events"),
+            ("query", "/api/projects/1/query/", "api/query"),
+        ]
+    )
+    def test_known_routes(self, _name: str, path: str, expected_tag: str) -> None:
+        factory = RequestFactory()
+        request = factory.get(path)
+        self.assertEqual(_resolve_caller_tag(request), expected_tag)
+
+    def test_unmapped_api_route_falls_back(self) -> None:
+        factory = RequestFactory()
+        request = factory.get("/api/projects/1/annotations/")
+        self.assertEqual(_resolve_caller_tag(request), "api/other")
+
+    def test_non_api_route_falls_back(self) -> None:
+        factory = RequestFactory()
+        request = factory.get("/")
+        self.assertEqual(_resolve_caller_tag(request), "web/other")
+
+    def test_spa_catchall_path(self) -> None:
+        factory = RequestFactory()
+        request = factory.get("/this/path/does/not/exist/ever/")
+        self.assertEqual(_resolve_caller_tag(request), "web/other")
+
+
+class TestPersonHogCallerTagMiddleware(SimpleTestCase):
+    def test_sets_and_resets_caller_tag(self) -> None:
+        factory = RequestFactory()
+        request = factory.get("/api/projects/1/cohorts/")
+        observed_tags: list[str] = []
+
+        def fake_response(req):
+            observed_tags.append(get_caller_tag())
+            return HttpResponse("ok")
+
+        middleware = PersonHogCallerTagMiddleware(fake_response)
+        middleware(request)
+
+        self.assertEqual(observed_tags, ["api/cohorts"])
+        self.assertEqual(get_caller_tag(), "unknown")
+
+    def test_resets_on_exception(self) -> None:
+        factory = RequestFactory()
+        request = factory.get("/api/projects/1/feature_flags/")
+
+        def exploding_response(req):
+            raise ValueError("boom")
+
+        middleware = PersonHogCallerTagMiddleware(exploding_response)
+
+        with self.assertRaises(ValueError):
+            middleware(request)
+
+        self.assertEqual(get_caller_tag(), "unknown")

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -254,8 +254,10 @@ def get_groups(
 ) -> tuple[list[Group], list[SerializedGroup]]:
     """Get groups from raw SQL results in data model and dict formats"""
     from posthog.models.group.util import get_groups_by_identifiers
+    from posthog.personhog_client.interceptor import personhog_caller_tag
 
-    groups = get_groups_by_identifiers(team_id, group_type_index, [str(gid) for gid in group_ids])
+    with personhog_caller_tag("insights/actor-query"):
+        groups = get_groups_by_identifiers(team_id, group_type_index, [str(gid) for gid in group_ids])
     return groups, serialize_groups(groups, value_per_actor_id)
 
 
@@ -286,10 +288,12 @@ def get_people(
 ) -> tuple[Union[QuerySet[Person], list[Person]], list[SerializedPerson]]:
     """Get people from raw SQL results in data model and dict formats"""
     from posthog.personhog_client.gate import use_personhog
+    from posthog.personhog_client.interceptor import personhog_caller_tag
 
     if use_personhog():
         try:
-            persons = _fetch_people_via_personhog(team.pk, people_ids, distinct_id_limit)
+            with personhog_caller_tag("insights/actor-query"):
+                persons = _fetch_people_via_personhog(team.pk, people_ids, distinct_id_limit)
             PERSONHOG_ROUTING_TOTAL.labels(
                 operation="get_people", source="personhog", client_name=get_client_name()
             ).inc()

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -79,6 +79,7 @@ from posthog.models.comment import Comment
 from posthog.models.person.util import get_persons_mapped_by_distinct_id
 from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.models.utils import hash_key_value
+from posthog.personhog_client.interceptor import personhog_caller_tag
 from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
@@ -2047,7 +2048,8 @@ def list_recordings_from_query(
 
     with timer("load_persons"), tracer.start_as_current_span("load_persons"):
         distinct_ids = sorted([x.distinct_id for x in recordings if x.distinct_id])
-        distinct_id_to_person = get_persons_mapped_by_distinct_id(team.pk, distinct_ids)
+        with personhog_caller_tag("session-recordings/persons"):
+            distinct_id_to_person = get_persons_mapped_by_distinct_id(team.pk, distinct_ids)
 
     with timer("process_persons"), tracer.start_as_current_span("process_persons"):
         for recording in recordings:

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -126,6 +126,7 @@ MIDDLEWARE = [
     "posthog.middleware.per_request_logging_context_middleware",
     "django_structlog.middlewares.RequestMiddleware",
     "posthog.personhog_client.middleware.PersonHogGateMiddleware",
+    "posthog.personhog_client.middleware.PersonHogCallerTagMiddleware",
     "posthog.middleware.Fix204Middleware",
     "django.middleware.security.SecurityMiddleware",
     "posthog.middleware.OAuthCoopMiddleware",

--- a/posthog/test/test_celery.py
+++ b/posthog/test/test_celery.py
@@ -1,7 +1,22 @@
 from unittest import TestCase
 from unittest.mock import patch
 
+from parameterized import parameterized
+
+from posthog.celery import _celery_caller_tag
 from posthog.tasks.tasks import clickhouse_errors_count
+
+
+class TestCeleryCallerTag(TestCase):
+    @parameterized.expand(
+        [
+            ("dotted_task", "posthog.tasks.calculate_cohort.calculate_cohort_ch", "celery/calculate_cohort_ch"),
+            ("simple_name", "my_task", "celery/my_task"),
+            ("deeply_nested", "a.b.c.d.run", "celery/run"),
+        ]
+    )
+    def test_derives_tag_from_task_name(self, _name: str, task_name: str, expected: str) -> None:
+        self.assertEqual(_celery_caller_tag(task_name), expected)
 
 
 class TestCeleryMetrics(TestCase):

--- a/products/feature_flags/backend/local_evaluation.py
+++ b/products/feature_flags/backend/local_evaluation.py
@@ -580,8 +580,11 @@ def _get_flags_response_for_local_evaluation_batch(
     # Bulk load group type mappings for all projects
     gtm_by_project: dict[int, dict[str, str]] = defaultdict(dict)
     from posthog.models.group_type_mapping import get_group_types_for_projects
+    from posthog.personhog_client.interceptor import personhog_caller_tag
 
-    for pid, mappings in get_group_types_for_projects(list(project_ids)).items():
+    with personhog_caller_tag("feature-flags/local-evaluation"):
+        project_mappings = get_group_types_for_projects(list(project_ids))
+    for pid, mappings in project_mappings.items():
         for m in mappings:
             gtm_by_project[pid][str(m["group_type_index"])] = m["group_type"]
 


### PR DESCRIPTION
## Problem

We need per-caller attribution on personhog gRPC requests to trace heavy queries back to specific Django views, Celery tasks, and code paths. The `x-caller-tag` header (consumed by the router in PR #60361) provides this on the server side — this PR sends it from the Django/Python side.

## Changes

Four commits, each building on the previous:

**1. CallerTagInterceptor** — Core machinery: `_caller_tag` ContextVar (default `"unknown"`), `CallerTagInterceptor` gRPC interceptor, `personhog_caller_tag()` context manager, `set_caller_tag()`/`get_caller_tag()` helpers. Adds `caller_tag` label to client-side `PERSONHOG_DJANGO_REQUEST_DURATION` and `PERSONHOG_DJANGO_REQUEST_COUNT` metrics. 6 new tests.

**2. Django middleware auto-tagging** — `PersonHogCallerTagMiddleware` derives a caller tag from the resolved Django URL name (e.g., `persons-list` → `api/persons`, `project_cohorts-detail` → `api/cohorts`). Maps ~20 known view prefixes; unmapped API routes → `api/other`, non-API → `web/other`. 15 new tests.

**3. Celery task auto-tagging** — `task_prerun` signal handler derives tags from task names (e.g., `posthog.tasks.calculate_cohort.calculate_cohort_ch` → `celery/calculate_cohort_ch`). Resets in `task_postrun`. 3 parameterized tests.

**4. Manual tags at known-heavy paths** — Wraps specific call sites with `personhog_caller_tag()` for finer attribution:
- `insights/actor-query` — `get_people()` and `get_groups()` in actor queries
- `session-recordings/persons` — person lookup in recording list API
- `feature-flags/local-evaluation` — group type mapping bulk load
- `admin/team-delete` — bulk person/group/mapping deletion

**Deploy target:** posthog-web, posthog-worker

> **Note:** The router (PR #60361) must deploy first to consume this header. Until then, the header is harmlessly ignored by the router but client-side metrics still get the `caller_tag` label.

## How did you test this code?

- All ruff checks pass (lint + format)
- 24 new tests total across interceptor, middleware, and celery modules

## Publish to changelog?

No

## Docs update

N/A

## 🤖 Agent context

Cherry-picked from `nick/personhog-query-tagging` development branch (4 commits). Part of a 4-PR series adding `x-caller-tag` attribution across the personhog stack:
1. PR #60361 — Router extraction (Rust) — **must deploy first**
2. PR #60367 — property-defs-rs static tag
3. PR #60368 — Node.js client caller tag
4. **This PR** — Django interceptor + middleware + manual tags