### PR TITLE
perf(insights): skip redundant or(X, X) in retention WHERE for same-entity

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -290,7 +290,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         timestamp_field: ast.Expr,
     ) -> ast.Expr:
         property_aggregation_expr = self.runner.property_aggregation_expr_for_entity(entity)
-        if query_kind == "start" and not self._start_and_return_entities_are_same():
+        if query_kind == "start" and not self.runner.start_and_return_entities_are_same:
             property_aggregation_expr = ast.Constant(value=0.0)
 
         assert property_aggregation_expr
@@ -319,12 +319,6 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             return property_to_expr(entity.properties, self.team)
 
         return ast.Constant(value=True)
-
-    def _start_and_return_entities_are_same(self) -> bool:
-        identity_fields = {"id", "type", "table_name", "timestamp_field", "properties"}
-        return self.start_event.model_dump(mode="json", include=identity_fields) == self.return_event.model_dump(
-            mode="json", include=identity_fields
-        )
 
     # Original version of the fixed interval query.
     def build_base_query_legacy(
@@ -642,7 +636,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             # cohort count stays consistent with normal retention.
             # When they are the same event, start_data captures the interval-0 value and
             # return_data contributes only later intervals to avoid double-counting.
-            different_event_entities = not self._start_and_return_entities_are_same()
+            different_event_entities = not self.runner.start_and_return_entities_are_same
 
             if different_event_entities:
                 # Include return events in interval 0 (index 0 = same interval as cohort) only when

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -66,6 +66,12 @@ DEFAULT_ENTITY = RetentionEntity(
     }
 )
 
+# Fields that define "same entity" for the purposes of WHERE-clause and aggregate
+# de-duplication. Mirrors the inputs entity_to_expr consumes:
+# id+type → event/action selection; table_name+timestamp_field → DWH routing;
+# properties → AND-chain.
+_ENTITY_IDENTITY_FIELDS: frozenset[str] = frozenset({"id", "type", "table_name", "timestamp_field", "properties"})
+
 
 class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
     query: RetentionQuery
@@ -228,9 +234,8 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
 
     @cached_property
     def start_and_return_entities_are_same(self) -> bool:
-        identity_fields = {"id", "type", "table_name", "timestamp_field", "properties"}
-        return self.start_event.model_dump(mode="json", include=identity_fields) == self.return_event.model_dump(
-            mode="json", include=identity_fields
+        return all(
+            getattr(self.start_event, field) == getattr(self.return_event, field) for field in _ENTITY_IDENTITY_FIELDS
         )
 
     @cached_property
@@ -250,10 +255,12 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         # when start == return — ClickHouse does not fully CSE the WHERE-side
         # or(X, X) and the un-wrapped predicate is measurably faster.
         if not self.is_first_ever_occurrence:
-            if self.start_and_return_entities_are_same:
-                global_event_filters.append(self.start_entity_expr)
-            else:
-                global_event_filters.append(ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr]))
+            relevant_event_filter: ast.Expr = (
+                self.start_entity_expr
+                if self.start_and_return_entities_are_same
+                else ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr])
+            )
+            global_event_filters.append(relevant_event_filter)
 
         if self.group_type_index is not None:
             global_event_filters.append(

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -227,6 +227,13 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return entity_to_expr(self.return_event, self.team)
 
     @cached_property
+    def start_and_return_entities_are_same(self) -> bool:
+        identity_fields = {"id", "type", "table_name", "timestamp_field", "properties"}
+        return self.start_event.model_dump(mode="json", include=identity_fields) == self.return_event.model_dump(
+            mode="json", include=identity_fields
+        )
+
+    @cached_property
     def aggregation_target_events_column(self) -> str:
         if self.group_type_index is not None:
             group_index = int(self.group_type_index)
@@ -239,10 +246,14 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         global_event_filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence
         )
-        # Pre-filter events to only those we care about
-        is_relevant_event = ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr])
+        # Pre-filter events to only those we care about. Skip the or() wrapper
+        # when start == return — ClickHouse does not fully CSE the WHERE-side
+        # or(X, X) and the un-wrapped predicate is measurably faster.
         if not self.is_first_ever_occurrence:
-            global_event_filters.append(is_relevant_event)
+            if self.start_and_return_entities_are_same:
+                global_event_filters.append(self.start_entity_expr)
+            else:
+                global_event_filters.append(ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr]))
 
         if self.group_type_index is not None:
             global_event_filters.append(

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -12,7 +12,7 @@
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')), not(has([''], events.`$group_0`)))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -55,7 +55,7 @@
                arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
                arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
         FROM events
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')), not(has([''], events.`$group_0`)))
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)))
         GROUP BY actor_id
         HAVING ifNull(equals(start_interval_index, 0), 0)) AS actor_activity
      GROUP BY actor_activity.actor_id) AS source
@@ -88,7 +88,7 @@
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')), not(has([''], events.`$group_1`)))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'), not(has([''], events.`$group_1`)))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -120,7 +120,7 @@
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')), not(has([''], events.`$group_0`)))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -163,7 +163,7 @@
                arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
                arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
         FROM events
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')), not(has([''], events.`$group_0`)))
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)))
         GROUP BY actor_id
         HAVING ifNull(equals(start_interval_index, 0), 0)) AS actor_activity
      GROUP BY actor_activity.actor_id) AS source
@@ -196,7 +196,7 @@
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 7), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM events
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')), not(has([''], events.`$group_1`)))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('2020-07-26 00:00:00.000000', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'), not(has([''], events.`$group_1`)))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -235,7 +235,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -282,10 +282,10 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
         GROUP BY actor_id
         HAVING isNotNull(t_0)) AS actors_with_t0 ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), actors_with_t0.actor_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')), greaterOrEquals(events.timestamp, actors_with_t0.t_0))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'), greaterOrEquals(events.timestamp, actors_with_t0.t_0))
      GROUP BY actors_with_t0.actor_id,
               actors_with_t0.t_0) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -324,7 +324,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -371,10 +371,10 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
         GROUP BY actor_id
         HAVING isNotNull(t_0)) AS actors_with_t0 ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), actors_with_t0.actor_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')), greaterOrEquals(events.timestamp, actors_with_t0.t_0))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'), greaterOrEquals(events.timestamp, actors_with_t0.t_0))
      GROUP BY actors_with_t0.actor_id,
               actors_with_t0.t_0) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -413,7 +413,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -461,7 +461,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC')), toIntervalMonth(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC')), toIntervalMonth(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -555,7 +555,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -764,7 +764,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -803,7 +803,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'US/Pacific')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'US/Pacific'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'US/Pacific')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'US/Pacific'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -842,7 +842,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-07 00:00:00', 'UTC')), 0)), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -881,7 +881,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-08 00:00:00', 'UTC')), 3)), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfWeek(assumeNotNull(toDateTime('2020-06-08 00:00:00', 'UTC')), 3)), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), equals(events.event, '$pageview'))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/test_retention_first_time_anchor.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_first_time_anchor.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
 
 from unittest import TestCase
@@ -11,6 +12,7 @@ from posthog.schema import RetentionEntity
 from posthog.hogql import ast
 
 from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RetentionFixedIntervalBaseQueryBuilder
+from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
 
 
 def _walk_ast(node: Any, visit: Callable[[Any], None]) -> None:
@@ -197,3 +199,114 @@ class TestFirstTimeAnchorExpr(TestCase):
                 self.assertIsInstance(pred, ast.Constant)
                 assert isinstance(pred, ast.Constant)  # narrow for mypy
                 self.assertTrue(pred.value)
+
+
+# Pull the underlying function out of the cached_property descriptor so we can call it
+# against a lightweight stub instead of building a full RetentionQueryRunner.
+# Note: posthog's cached_property is `property(lru_cache(...)(func))`; .fget.__wrapped__ unwraps both.
+_start_and_return_entities_are_same = RetentionQueryRunner.start_and_return_entities_are_same.fget.__wrapped__  # type: ignore[attr-defined,union-attr]
+
+
+class TestStartAndReturnEntitiesAreSame(TestCase):
+    @parameterized.expand(
+        [
+            (
+                "identical_events_entity",
+                RetentionEntity(id="$pageview", type="events"),
+                RetentionEntity(id="$pageview", type="events"),
+                True,
+            ),
+            (
+                "different_id",
+                RetentionEntity(id="$pageview", type="events"),
+                RetentionEntity(id="$screen", type="events"),
+                False,
+            ),
+            (
+                "different_type",
+                RetentionEntity(id="1", type="events"),
+                RetentionEntity(id="1", type="actions"),
+                False,
+            ),
+            (
+                "differing_properties",
+                RetentionEntity(
+                    id="$pageview",
+                    type="events",
+                    properties=[{"key": "browser", "value": "Chrome", "operator": "exact", "type": "event"}],
+                ),
+                RetentionEntity(id="$pageview", type="events", properties=[]),
+                False,
+            ),
+            (
+                "different_property_order",
+                # Order-sensitive — list equality is element-wise, so reordering counts as different.
+                # Documenting current behaviour so a future change doesn't silently widen this.
+                RetentionEntity(
+                    id="$pageview",
+                    type="events",
+                    properties=[
+                        {"key": "browser", "value": "Chrome", "operator": "exact", "type": "event"},
+                        {"key": "os", "value": "Mac", "operator": "exact", "type": "event"},
+                    ],
+                ),
+                RetentionEntity(
+                    id="$pageview",
+                    type="events",
+                    properties=[
+                        {"key": "os", "value": "Mac", "operator": "exact", "type": "event"},
+                        {"key": "browser", "value": "Chrome", "operator": "exact", "type": "event"},
+                    ],
+                ),
+                False,
+            ),
+            (
+                "dwh_same_table_and_timestamp_differing_aggregation_target",
+                # aggregation_target_field is intentionally NOT in the identity set — the WHERE
+                # predicate doesn't depend on it. Pinning the current behaviour so a future
+                # widening of the field set is a conscious choice.
+                RetentionEntity(
+                    type="data_warehouse",
+                    table_name="warehouse_activity",
+                    timestamp_field="occurred_at",
+                    aggregation_target_field="person_id",
+                    id="warehouse_activity",
+                ),
+                RetentionEntity(
+                    type="data_warehouse",
+                    table_name="warehouse_activity",
+                    timestamp_field="occurred_at",
+                    aggregation_target_field="account_id",
+                    id="warehouse_activity",
+                ),
+                True,
+            ),
+            (
+                "dwh_different_table_name",
+                RetentionEntity(
+                    type="data_warehouse",
+                    table_name="a",
+                    timestamp_field="ts",
+                    aggregation_target_field="person_id",
+                    id="a",
+                ),
+                RetentionEntity(
+                    type="data_warehouse",
+                    table_name="b",
+                    timestamp_field="ts",
+                    aggregation_target_field="person_id",
+                    id="b",
+                ),
+                False,
+            ),
+        ]
+    )
+    def test_start_and_return_entities_are_same(
+        self,
+        _name: str,
+        start_event: RetentionEntity,
+        return_event: RetentionEntity,
+        expected: bool,
+    ) -> None:
+        stub = SimpleNamespace(start_event=start_event, return_event=return_event)
+        self.assertEqual(_start_and_return_entities_are_same(stub), expected)


### PR DESCRIPTION
## Problem

Retention's `global_event_filters` always appends `or(start_entity, return_entity)` to the WHERE clause as a pre-filter on the events scan. When start and return entities are identical (the common case — most production retention queries are same-entity, including all of $pageview retention), this collapses to literal `or(X, X)` wrapping the same predicate.

PR #60285 verified that ClickHouse fully CSEs identical *aggregate-internal* filters. But this WHERE-side wrapper is not fully CSE'd by the analyzer, so we pay measurable wall time evaluating the duplicated predicate.

## Changes

When `start_event` and `return_event` are structurally identical (compared on the same identity fields as the existing builder check — `id`, `type`, `table_name`, `timestamp_field`, `properties`), append only the single entity predicate to WHERE instead of the `Or([X, X])` wrapper.

The same-entity check moves from a private builder method to a runner `@cached_property` (`start_and_return_entities_are_same`) so it's reused from both the new WHERE-clause branch and the existing call sites (property-aggregation interval-0 marker, different-event combined-data path). Two call sites in `retention_base_query_fixed.py` updated to use the runner property; the duplicate method is removed.

## How did you test this code?

I'm an agent — listing only what I actually ran:

- Full `posthog/hogql_queries/insights/retention/test/` suite. After updating snapshots, the same 12 pre-existing failures appear on this branch as on master baseline (verified by stashing the diff and rerunning). My change adds zero new failures. Snapshot diffs are byte-identical except every `or(equals(event, X), equals(event, X))` becomes `equals(event, X)`.
- `ruff check` and `ruff format --check` pass on the modified files.
- `bin/hogli lint:python:fix`, `bin/hogli format:python`, and `uv run ty check` all clean (pre-commit hooks).

### Production benchmark — team 49640, alternating runs against prod-us via metabase

Captured production query: 31s, 40-event `or(...)` filter, 8-day range, no breakdown, recurring same-entity ($pageview-style):

|              | BEFORE      | AFTER       | Δ              |
|--------------|------------:|------------:|---------------:|
| n            | 8           | 8           |                |
| min ms       | 8985        | 8651        | −4%            |
| median ms    | 12482       | 10022       | −20%           |
| mean ms      | 16653       | 15428       | −7%            |
| avg memory   | 6.34 GiB    | 6.30 GiB    | ~equal         |
| avg read     | 14.59 GiB   | 14.59 GiB   | identical      |

Memory and read bytes are unchanged — purely a CPU/analyzer win. Run-to-run wall-time variance is high (8s–33s spread across runs of the same form, both before and after) which is inherent to the prod cluster; the median and mean deltas trend consistently in the same direction across all 8 alternating runs but should be read as directional, not as anchored percentages.

Sanity-checked semantic equivalence: BEFORE and AFTER produced byte-identical result sets on the team 49640 production query (modulo a 4-event drift from live ingestion past `date_to`).

## Publish to changelog?

no

## 🤖 Agent context

Co-authored with Claude Opus 4.7 (1M context) in Claude Code. Same exploration session as PR #60285.

Shaping decisions worth flagging for review:

- **Property placement.** Considered moving the same-entity check to `RetentionBaseQueryBuilder` (the abstract base) so both builders inherit it. Decided against because `global_event_filters` runs on the runner before any builder is instantiated — a builder method would create an awkward call ordering. Kept it on the runner.
- **Comment scope.** Default per repo conventions is "no comments" — the one I kept explains the non-obvious *why* (ClickHouse's selective CSE behavior) which a future reader couldn't get from the code alone. Trimmed from a longer draft.
- **Rejected adjacent wins.** Also benchmarked collapsing the triple `minIf` in `is_first_ever_occurrence` (team 202755) — wash result, ClickHouse already CSEs that one. Not included in this PR.

Findings & methodology are in `.planning/retention-perf-explorations.md` on a parallel branch (not part of this PR).
