### PR TITLE
feat(insights): opt-in narrowing gate for first-time retention queries

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -21186,6 +21186,10 @@
                     "enum": ["enabled", "disabled", "optimized"],
                     "type": "string"
                 },
+                "retentionFirstTimeNarrowingPath": {
+                    "description": "Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Opt-in; only applied when start and return entities are identical.",
+                    "type": "boolean"
+                },
                 "s3TableUseInvalidColumns": {
                     "type": "boolean"
                 },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -21187,7 +21187,7 @@
                     "type": "string"
                 },
                 "retentionFirstTimeNarrowingPath": {
-                    "description": "Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Opt-in; only applied when start and return entities are identical.",
+                    "description": "Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Three-state: `true` forces on, `false` is a kill switch, unset falls back to a static gate that enables narrowing when the retention window is small relative to team age. Only applied when start and return entities are identical.",
                     "type": "boolean"
                 },
                 "s3TableUseInvalidColumns": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -21187,7 +21187,7 @@
                     "type": "string"
                 },
                 "retentionFirstTimeNarrowingPath": {
-                    "description": "Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Three-state: `true` forces on, `false` is a kill switch, unset falls back to a static gate that enables narrowing when the retention window is small relative to team age. Only applied when start and return entities are identical.",
+                    "description": "Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Three-state: `true` forces on, `false` is a kill switch, unset falls back to a static gate that enables narrowing when the retention window is small relative to team age.",
                     "type": "boolean"
                 },
                 "s3TableUseInvalidColumns": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -428,6 +428,8 @@ export interface HogQLQueryModifiers {
     sessionIdPushdown?: boolean
     /** Pre-filter raw_sessions aggregation by `session_id_v7 IN (cheap pre-aggregation that only materializes the columns referenced by the outer-WHERE session predicate)`. Useful when the breakdown/SELECT pulls in many session columns (e.g. `$channel_type`) but the filter only references one (e.g. `$entry_current_url`). */
     sessionPropertyPreAggregation?: boolean
+    /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Opt-in; only applied when start and return entities are identical. */
+    retentionFirstTimeNarrowingPath?: boolean
     dataWarehouseEventsModifiers?: DataWarehouseEventsModifier[]
     debug?: boolean
     timings?: boolean

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -428,7 +428,7 @@ export interface HogQLQueryModifiers {
     sessionIdPushdown?: boolean
     /** Pre-filter raw_sessions aggregation by `session_id_v7 IN (cheap pre-aggregation that only materializes the columns referenced by the outer-WHERE session predicate)`. Useful when the breakdown/SELECT pulls in many session columns (e.g. `$channel_type`) but the filter only references one (e.g. `$entry_current_url`). */
     sessionPropertyPreAggregation?: boolean
-    /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Three-state: `true` forces on, `false` is a kill switch, unset falls back to a static gate that enables narrowing when the retention window is small relative to team age. Only applied when start and return entities are identical. */
+    /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Three-state: `true` forces on, `false` is a kill switch, unset falls back to a static gate that enables narrowing when the retention window is small relative to team age. */
     retentionFirstTimeNarrowingPath?: boolean
     dataWarehouseEventsModifiers?: DataWarehouseEventsModifier[]
     debug?: boolean

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -428,7 +428,7 @@ export interface HogQLQueryModifiers {
     sessionIdPushdown?: boolean
     /** Pre-filter raw_sessions aggregation by `session_id_v7 IN (cheap pre-aggregation that only materializes the columns referenced by the outer-WHERE session predicate)`. Useful when the breakdown/SELECT pulls in many session columns (e.g. `$channel_type`) but the filter only references one (e.g. `$entry_current_url`). */
     sessionPropertyPreAggregation?: boolean
-    /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Opt-in; only applied when start and return entities are identical. */
+    /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Three-state: `true` forces on, `false` is a kill switch, unset falls back to a static gate that enables narrowing when the retention window is small relative to team age. Only applied when start and return entities are identical. */
     retentionFirstTimeNarrowingPath?: boolean
     dataWarehouseEventsModifiers?: DataWarehouseEventsModifier[]
     debug?: boolean

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -234,6 +234,36 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         )
 
     @cached_property
+    def _first_time_narrowing_static_gate(self) -> bool:
+        # Pattern A is a knockout when the cohort window is small relative to team lifetime
+        # (most actors' first qualifying event sits before date_from) and a regression when
+        # the window covers most of team history. As a cheap, conservative proxy for the
+        # narrowing ratio, gate on retention window <= team_age / 4.
+        if self.team.created_at is None:
+            return False
+        try:
+            window = self.query_date_range.date_to() - self.query_date_range.date_from()
+        except (TypeError, ValueError):
+            return False
+        team_age = datetime.now(tz=self.team.created_at.tzinfo) - self.team.created_at
+        return window * 4 <= team_age
+
+    @cached_property
+    def should_apply_first_time_narrowing(self) -> bool:
+        # Three-state resolution of the retentionFirstTimeNarrowingPath modifier:
+        #   True  → force on (bypass static gate, e.g. for opt-in benchmarking)
+        #   False → kill switch (never apply, even if static gate would trigger)
+        #   None  → fall back to the static gate so safe shapes get the win by default
+        if not (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
+            return False
+        if not self.start_and_return_entities_are_same:
+            return False
+        explicit = self.modifiers.retentionFirstTimeNarrowingPath
+        if explicit is not None:
+            return explicit
+        return self._first_time_narrowing_static_gate
+
+    @cached_property
     def aggregation_target_events_column(self) -> str:
         if self.group_type_index is not None:
             group_index = int(self.group_type_index)
@@ -418,14 +448,8 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
                 )
             )
 
-        # Pattern A narrowing gate: drop actors whose first qualifying start event sits outside the cohort window
-        # before the outer GROUP BY allocates per-actor aggregate state. Only safe when start and return are the
-        # same entity — for different entities the return side legitimately needs actors filtered out by the gate.
-        if (
-            self.modifiers.retentionFirstTimeNarrowingPath
-            and (is_first_occurrence_matching_filters or is_first_ever_occurrence)
-            and self.start_and_return_entities_are_same
-        ):
+        # Pattern A narrowing gate — see should_apply_first_time_narrowing for the resolution logic.
+        if self.should_apply_first_time_narrowing:
             events_where.append(
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.GlobalIn,

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -227,6 +227,13 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return entity_to_expr(self.return_event, self.team)
 
     @cached_property
+    def start_and_return_entities_are_same(self) -> bool:
+        identity_fields = {"id", "type", "table_name", "timestamp_field", "properties"}
+        return self.start_event.model_dump(mode="json", include=identity_fields) == self.return_event.model_dump(
+            mode="json", include=identity_fields
+        )
+
+    @cached_property
     def aggregation_target_events_column(self) -> str:
         if self.group_type_index is not None:
             group_index = int(self.group_type_index)
@@ -326,6 +333,24 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             ]
         )
 
+    def _first_time_narrowing_subquery(self) -> ast.SelectQuery:
+        """
+        Inner subquery for the Pattern A narrowing gate. Returns the set of actor IDs
+        whose first qualifying start_entity event falls within the cohort date range —
+        i.e. the only actors who can possibly contribute to a first-time / first-ever
+        retention result. The outer query then applies `actor_id GLOBAL IN (this)` so
+        the wide GROUP BY only allocates state for in-cohort actors.
+        """
+        actor_id_field = ast.Field(chain=["events", self.aggregation_target_events_column])
+        min_timestamp = ast.Call(name="min", args=[ast.Field(chain=["events", "timestamp"])])
+        return ast.SelectQuery(
+            select=[actor_id_field],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=self.start_entity_expr,
+            group_by=[actor_id_field],
+            having=self.events_timestamp_filter(field=min_timestamp),
+        )
+
     @cached_property
     def query_date_range(self) -> QueryDateRangeWithIntervals:
         if self.is_custom_bracket_retention:
@@ -390,6 +415,22 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
                     # Sorting for consistent snapshots in tests
                     right=ast.Tuple(exprs=[ast.Constant(value=event) for event in sorted(unique_events)]),  # type: ignore
                     op=ast.CompareOperationOp.In,
+                )
+            )
+
+        # Pattern A narrowing gate: drop actors whose first qualifying start event sits outside the cohort window
+        # before the outer GROUP BY allocates per-actor aggregate state. Only safe when start and return are the
+        # same entity — for different entities the return side legitimately needs actors filtered out by the gate.
+        if (
+            self.modifiers.retentionFirstTimeNarrowingPath
+            and (is_first_occurrence_matching_filters or is_first_ever_occurrence)
+            and self.start_and_return_entities_are_same
+        ):
+            events_where.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GlobalIn,
+                    left=ast.Field(chain=["events", self.aggregation_target_events_column]),
+                    right=self._first_time_narrowing_subquery(),
                 )
             )
 

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -227,13 +227,6 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return entity_to_expr(self.return_event, self.team)
 
     @cached_property
-    def start_and_return_entities_are_same(self) -> bool:
-        identity_fields = {"id", "type", "table_name", "timestamp_field", "properties"}
-        return self.start_event.model_dump(mode="json", include=identity_fields) == self.return_event.model_dump(
-            mode="json", include=identity_fields
-        )
-
-    @cached_property
     def _first_time_narrowing_static_gate(self) -> bool:
         # Pattern A is a knockout when the cohort window is small relative to team lifetime
         # (most actors' first qualifying event sits before date_from) and a regression when
@@ -254,9 +247,10 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         #   True  → force on (bypass static gate, e.g. for opt-in benchmarking)
         #   False → kill switch (never apply, even if static gate would trigger)
         #   None  → fall back to the static gate so safe shapes get the win by default
+        # First-time / first-ever is the only precondition. Different entities are fine —
+        # narrowing filters by actor, not by event, and for first-time semantics the outer
+        # query already drops actors whose first start event sits outside the cohort window.
         if not (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
-            return False
-        if not self.start_and_return_entities_are_same:
             return False
         explicit = self.modifiers.retentionFirstTimeNarrowingPath
         if explicit is not None:

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -5500,7 +5500,7 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
 
     @parameterized.expand(
         [
-            # Explicit True forces narrowing on for first-time/first-ever same-entity queries.
+            # Explicit True forces narrowing on for any first-time / first-ever query.
             ("force_on_first_time_same_entity", True, "retention_first_time", "$pageview", "$pageview", True),
             (
                 "force_on_first_ever_same_entity",
@@ -5510,9 +5510,11 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
                 "$pageview",
                 True,
             ),
-            # Explicit True still respects the preconditions (must be first-time, same entity).
+            # Different entities are fine — narrowing filters by actor, the outer first-time wrapper
+            # already drops actors whose first start event sits outside the cohort window.
+            ("force_on_first_time_different_entity", True, "retention_first_time", "$pageview", "$screen", True),
+            # Recurring retention has no first-time wrapper, so narrowing would be unsafe.
             ("force_on_recurring_skipped", True, "retention_recurring", "$pageview", "$pageview", False),
-            ("force_on_different_entity_skipped", True, "retention_first_time", "$pageview", "$screen", False),
             # Explicit False is a kill switch — never apply, regardless of preconditions or gate.
             ("kill_switch_first_time_same_entity", False, "retention_first_time", "$pageview", "$pageview", False),
         ]

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from dateutil.relativedelta import relativedelta
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
@@ -5467,24 +5468,13 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
         # event property access should be present, not person property access
         self.assertIn("properties", sql)
 
-    @parameterized.expand(
-        [
-            ("modifier_off", False, "retention_first_time", "$pageview", "$pageview", False),
-            ("first_time_same_entity", True, "retention_first_time", "$pageview", "$pageview", True),
-            ("first_ever_same_entity", True, "retention_first_ever_occurrence", "$pageview", "$pageview", True),
-            ("recurring_same_entity_not_applied", True, "retention_recurring", "$pageview", "$pageview", False),
-            ("first_time_different_entity_not_applied", True, "retention_first_time", "$pageview", "$screen", False),
-        ]
-    )
-    def test_retention_first_time_narrowing_modifier(
+    def _render_retention_sql(
         self,
-        _name: str,
-        modifier_on: bool,
+        modifier: bool | None,
         retention_type: str,
         target_event: str,
         return_event: str,
-        expect_global_in: bool,
-    ) -> None:
+    ) -> str:
         from posthog.hogql.context import HogQLContext
         from posthog.hogql.modifiers import create_default_modifiers_for_team
         from posthog.hogql.printer import prepare_and_print_ast
@@ -5497,7 +5487,7 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
                 "returningEntity": {"id": return_event, "type": "events"},
             },
         )
-        modifiers = HogQLQueryModifiers(retentionFirstTimeNarrowingPath=modifier_on or None)
+        modifiers = HogQLQueryModifiers(retentionFirstTimeNarrowingPath=modifier)
         runner = RetentionQueryRunner(query=query, team=self.team, modifiers=modifiers)
         base_query = runner._base_query()
         context = HogQLContext(
@@ -5506,11 +5496,59 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
             modifiers=create_default_modifiers_for_team(self.team),
         )
         sql, _ = prepare_and_print_ast(base_query, context, "clickhouse", pretty=True)
+        return sql
 
+    @parameterized.expand(
+        [
+            # Explicit True forces narrowing on for first-time/first-ever same-entity queries.
+            ("force_on_first_time_same_entity", True, "retention_first_time", "$pageview", "$pageview", True),
+            (
+                "force_on_first_ever_same_entity",
+                True,
+                "retention_first_ever_occurrence",
+                "$pageview",
+                "$pageview",
+                True,
+            ),
+            # Explicit True still respects the preconditions (must be first-time, same entity).
+            ("force_on_recurring_skipped", True, "retention_recurring", "$pageview", "$pageview", False),
+            ("force_on_different_entity_skipped", True, "retention_first_time", "$pageview", "$screen", False),
+            # Explicit False is a kill switch — never apply, regardless of preconditions or gate.
+            ("kill_switch_first_time_same_entity", False, "retention_first_time", "$pageview", "$pageview", False),
+        ]
+    )
+    def test_retention_first_time_narrowing_explicit_modifier(
+        self,
+        _name: str,
+        modifier: bool,
+        retention_type: str,
+        target_event: str,
+        return_event: str,
+        expect_global_in: bool,
+    ) -> None:
+        sql = self._render_retention_sql(modifier, retention_type, target_event, return_event)
         if expect_global_in:
             self.assertIn("globalIn(", sql)
         else:
             self.assertNotIn("globalIn(", sql)
+
+    def test_retention_first_time_narrowing_static_gate_satisfied(self) -> None:
+        # Modifier unset + retention window much smaller than team age → static gate triggers
+        # narrowing automatically. Team needs to be old enough that `window * 4 <= team_age`
+        # holds for the -7d retention window in `_render_retention_sql` (~11 days incl. lookahead).
+        self.team.created_at = datetime.now(tz=ZoneInfo("UTC")) - relativedelta(years=2)
+        self.team.save()
+
+        sql = self._render_retention_sql(None, "retention_first_time", "$pageview", "$pageview")
+        self.assertIn("globalIn(", sql)
+
+    def test_retention_first_time_narrowing_static_gate_not_satisfied(self) -> None:
+        # Modifier unset + team younger than 4× retention window → gate fails, narrowing skipped.
+        self.team.created_at = datetime.now(tz=ZoneInfo("UTC")) - timedelta(days=1)
+        self.team.save()
+
+        sql = self._render_retention_sql(None, "retention_first_time", "$pageview", "$pageview")
+        self.assertNotIn("globalIn(", sql)
 
 
 class TestClickhouseRetentionGroupAggregation(

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import HogQLQueryModifiers, InCohortVia, RetentionQuery
@@ -5465,6 +5466,51 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
         self.assertNotIn("events__events", sql)
         # event property access should be present, not person property access
         self.assertIn("properties", sql)
+
+    @parameterized.expand(
+        [
+            ("modifier_off", False, "retention_first_time", "$pageview", "$pageview", False),
+            ("first_time_same_entity", True, "retention_first_time", "$pageview", "$pageview", True),
+            ("first_ever_same_entity", True, "retention_first_ever_occurrence", "$pageview", "$pageview", True),
+            ("recurring_same_entity_not_applied", True, "retention_recurring", "$pageview", "$pageview", False),
+            ("first_time_different_entity_not_applied", True, "retention_first_time", "$pageview", "$screen", False),
+        ]
+    )
+    def test_retention_first_time_narrowing_modifier(
+        self,
+        _name: str,
+        modifier_on: bool,
+        retention_type: str,
+        target_event: str,
+        return_event: str,
+        expect_global_in: bool,
+    ) -> None:
+        from posthog.hogql.context import HogQLContext
+        from posthog.hogql.modifiers import create_default_modifiers_for_team
+        from posthog.hogql.printer import prepare_and_print_ast
+
+        query = RetentionQuery(
+            dateRange={"date_from": "-7d"},
+            retentionFilter={
+                "retentionType": retention_type,
+                "targetEntity": {"id": target_event, "type": "events"},
+                "returningEntity": {"id": return_event, "type": "events"},
+            },
+        )
+        modifiers = HogQLQueryModifiers(retentionFirstTimeNarrowingPath=modifier_on or None)
+        runner = RetentionQueryRunner(query=query, team=self.team, modifiers=modifiers)
+        base_query = runner._base_query()
+        context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            modifiers=create_default_modifiers_for_team(self.team),
+        )
+        sql, _ = prepare_and_print_ast(base_query, context, "clickhouse", pretty=True)
+
+        if expect_global_in:
+            self.assertIn("globalIn(", sql)
+        else:
+            self.assertNotIn("globalIn(", sql)
 
 
 class TestClickhouseRetentionGroupAggregation(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7428,6 +7428,15 @@ class HogQLQueryModifiers(BaseModel):
     personsJoinMode: PersonsJoinMode | None = None
     personsOnEventsMode: PersonsOnEventsMode | None = None
     propertyGroupsMode: PropertyGroupsMode | None = None
+    retentionFirstTimeNarrowingPath: bool | None = Field(
+        default=None,
+        description=(
+            "Narrow first-time / first-ever retention queries with a `person_id GLOBAL"
+            " IN (cheap inner subquery)` predicate that keeps only actors whose first"
+            " qualifying start event falls in the cohort date range. Opt-in; only"
+            " applied when start and return entities are identical."
+        ),
+    )
     s3TableUseInvalidColumns: bool | None = None
     sessionIdPushdown: bool | None = Field(
         default=None,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7436,7 +7436,7 @@ class HogQLQueryModifiers(BaseModel):
             " qualifying start event falls in the cohort date range. Three-state:"
             " `true` forces on, `false` is a kill switch, unset falls back to a static"
             " gate that enables narrowing when the retention window is small relative"
-            " to team age. Only applied when start and return entities are identical."
+            " to team age."
         ),
     )
     s3TableUseInvalidColumns: bool | None = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7433,8 +7433,10 @@ class HogQLQueryModifiers(BaseModel):
         description=(
             "Narrow first-time / first-ever retention queries with a `person_id GLOBAL"
             " IN (cheap inner subquery)` predicate that keeps only actors whose first"
-            " qualifying start event falls in the cohort date range. Opt-in; only"
-            " applied when start and return entities are identical."
+            " qualifying start event falls in the cohort date range. Three-state:"
+            " `true` forces on, `false` is a kill switch, unset falls back to a static"
+            " gate that enables narrowing when the retention window is small relative"
+            " to team age. Only applied when start and return entities are identical."
         ),
     )
     s3TableUseInvalidColumns: bool | None = None

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -438,6 +438,8 @@ export interface HogQLQueryModifiersApi {
     personsJoinMode?: PersonsJoinModeApi | null
     personsOnEventsMode?: PersonsOnEventsModeApi | null
     propertyGroupsMode?: PropertyGroupsModeApi | null
+    /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Opt-in; only applied when start and return entities are identical. */
+    retentionFirstTimeNarrowingPath?: boolean | null
     s3TableUseInvalidColumns?: boolean | null
     /** Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter. */
     sessionIdPushdown?: boolean | null

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -438,7 +438,7 @@ export interface HogQLQueryModifiersApi {
     personsJoinMode?: PersonsJoinModeApi | null
     personsOnEventsMode?: PersonsOnEventsModeApi | null
     propertyGroupsMode?: PropertyGroupsModeApi | null
-    /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Opt-in; only applied when start and return entities are identical. */
+    /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Three-state: `true` forces on, `false` is a kill switch, unset falls back to a static gate that enables narrowing when the retention window is small relative to team age. */
     retentionFirstTimeNarrowingPath?: boolean | null
     s3TableUseInvalidColumns?: boolean | null
     /** Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1587,7 +1587,7 @@ export namespace Schemas {
       personsJoinMode?: PersonsJoinMode | null;
       personsOnEventsMode?: PersonsOnEventsMode | null;
       propertyGroupsMode?: PropertyGroupsMode | null;
-      /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Opt-in; only applied when start and return entities are identical. */
+      /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Three-state: `true` forces on, `false` is a kill switch, unset falls back to a static gate that enables narrowing when the retention window is small relative to team age. */
       retentionFirstTimeNarrowingPath?: boolean | null;
       s3TableUseInvalidColumns?: boolean | null;
       /** Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1587,6 +1587,8 @@ export namespace Schemas {
       personsJoinMode?: PersonsJoinMode | null;
       personsOnEventsMode?: PersonsOnEventsMode | null;
       propertyGroupsMode?: PropertyGroupsMode | null;
+      /** Narrow first-time / first-ever retention queries with a `person_id GLOBAL IN (cheap inner subquery)` predicate that keeps only actors whose first qualifying start event falls in the cohort date range. Opt-in; only applied when start and return entities are identical. */
+      retentionFirstTimeNarrowingPath?: boolean | null;
       s3TableUseInvalidColumns?: boolean | null;
       /** Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter. */
       sessionIdPushdown?: boolean | null;


### PR DESCRIPTION
## Problem

First-time and first-ever retention queries scan the actor's full event history because there's no `events_timestamp_filter` on the WHERE clause (this is required — the outer query needs to identify each actor's first qualifying event, which may sit before `date_from`). The outer GROUP BY then allocates per-actor aggregate state for *every* historically-active actor, including the long tail whose first qualifying event sits outside the cohort window and who will be dropped by the start anchor anyway.

For shapes where the cohort window is narrow relative to team lifetime — a 2-week retention chart on a multi-year team is the common case — the GROUP BY is allocating state for ~100x more actors than actually contribute to the result. Memory pressure shows up first; wall time follows because the hash table no longer fits in CPU cache.

Production telemetry shows ~96% of slow-retention runtime is first-time queries, so this is the right corner to attack.

## Changes

Add a HogQL modifier `retentionFirstTimeNarrowingPath` with three-state resolution:

- `true` → force narrowing on (bypass the static gate, e.g. for opt-in benchmarking on a team where we want to override the heuristic)
- `false` → kill switch (never apply, regardless of preconditions or gate)
- unset / `null` (the default) → fall back to a **static gate** that enables narrowing automatically when the retention window is small relative to team age

When narrowing applies, the runner appends a `person_id GLOBAL IN (cheap inner subquery)` predicate to `events_where_clause`. The inner subquery groups events by `person_id` (or `$group_N` for group retention), filters to the start entity, and keeps only actors whose `min(timestamp)` for that entity falls in `[date_from, date_to)`.

### Precondition

The optimization only applies to **first-time / first-ever retention** (`retentionType ∈ {RETENTION_FIRST_TIME, RETENTION_FIRST_EVER_OCCURRENCE}`). Recurring retention already has `events_timestamp_filter` in WHERE, so the wide GROUP BY problem doesn't apply — and the narrowing would be incorrect (the cohort isn't defined by a single first event).

The narrowing is safe for **both same-entity and different-entity** queries. The predicate filters by actor, not by event type, and the outer first-time wrapper already drops actors whose first start event sits outside the cohort window — so the inner subquery just does that filtering earlier and cheaper.

### Static gate

The gate is `retention_window * 4 <= (now - team.created_at)`. It catches the shape where the optimization is a knockout:

| Workload shape | Gate verdict | Pattern A result |
|---|---|---|
| Mem-bound first-time, narrow window vs team age (team 5092: 2w on a multi-year team, $screen → $pageview) | **applies** | **−47% duration, −99% memory** |
| Mem-bound first-time, wide window covering team lifetime (team 202755: 43w on ~1yr team) | **skipped** | (would have been +161% regression) |
| Read-bound first-time, fits in memory (team 2 31d on multi-year team) | applies | +21% duration |

It's conservative on purpose. The team-2 31d case still triggers the gate and pays a small (~+21%) cost from memory savings that aren't load-bearing for that shape — but the modifier can be set to `false` per-team if a regression shows up in real traffic. Tuning the ratio (currently `× 4`) is a follow-up once we have post-merge data.

### Why `GLOBAL IN`

Plain `IN (subquery)` runs the inner once per shard/replica, multiplying scan cost. Exploration runs against `clusterAllReplicas` showed +1000% read bytes with `IN` vs the right shape with `GLOBAL IN` — the latter broadcasts the inner result set once.

## How did you test this code?

I'm an agent. Listing what I actually ran:

- 7 new tests in `TestRetention`:
  - 5 parameterized cases for explicit modifier `True`/`False` covering both first-time and first-ever, same-entity and different-entity, plus recurring (excluded) and the kill-switch case
  - 1 case for `None` + static gate satisfied (team aged 2 years, narrowing applied)
  - 1 case for `None` + gate not satisfied (team 1 day old, narrowing skipped)
- Full `posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py` suite: 12 pre-existing failures on this branch match the 12 pre-existing failures on master baseline (verified by `git stash` + rerun). My changes add **zero** new failures.
  - The static gate naturally doesn't trigger for existing tests because their teams are created at test setup with `created_at ≈ now`, so `team_age ≈ 0` and the gate fails. No snapshot changes.
- `ruff check` and `ruff format --check` pass.
- Pre-commit hooks (`lint:python:fix`, `format:python`, `uv run ty check`) all clean.

I did **not** run a production benchmark for this PR. Prior benchmarking in the same area showed that ClickHouse cluster noise at small samples (n=6–8) was larger than the deltas we wanted to claim. The right validation path here is to merge and watch the real-traffic deltas on retention queries that hit the gate post-deploy, then tune the gate ratio or set `false` per-team if any regression shows up.

Underlying benchmarks for the three workload shapes in the gate table above are in `.planning/retention-perf-explorations.md` on a parallel branch (not part of this PR).

## Publish to changelog?

no

## 🤖 Agent context

Co-authored with Claude Opus 4.7 (1M context) in Claude Code. Same exploration session as PRs #60285 and #60384.

Scope shape:

- **In:** modifier + static gate (three-state resolution) + tests.
- **Out (deferred to follow-ups):** per-team feature flag wiring, telemetry / rollout dashboards, gate-ratio tuning based on production data, DWH retention support.

Decisions worth flagging:

- **Three-state modifier vs. plain boolean.** First version of this PR was a plain boolean defaulting to off with no automatic enablement — machinery without a customer. Three-state makes the modifier a kill switch + force-on knob layered on top of an automatic decision, which is the actually-useful rollout posture.
- **No same-entity restriction.** Earlier drafts of this PR copy-pasted a same-entity precondition from PRs #60285 and #60384. For those PRs, same-entity is structurally required (you can only dedupe identical things). For Pattern A, the narrowing filters by actor and the first-time wrapper handles the rest — so the precondition was over-cautious and would have silently excluded the original motivating shape (team 5092 was different-entity). Removed.
- **Gate is `window × 4 <= team_age`.** Conservative on purpose. The exploration doc's starting ratio. Tunable post-merge.
- **Cohort window = `date_to - date_from`.** Includes the lookahead, so it's slightly larger than the "true" cohort interval. Conservative direction (fewer false-positives from the gate).
- **Subquery construction in HogQL AST, not raw SQL.** Keeps the person_id override join automatic (HogQL adds it) and lets the existing `events_timestamp_filter` helper supply the date predicate so the cohort window stays consistent with the outer query.

Findings & methodology for the underlying benchmarks are in `.planning/retention-perf-explorations.md` on a parallel branch (not part of this PR).
