### PR TITLE
feat(replay-vision): merge triggers into config tab

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -4,6 +4,7 @@ import { Field, Form } from 'kea-forms'
 import {
     LemonBanner,
     LemonButton,
+    LemonDivider,
     LemonInput,
     LemonSelect,
     LemonSwitch,
@@ -63,11 +64,6 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
             content: <ScannerObservationsTable scannerId={scannerId} tabId={tabId} />,
         },
         {
-            key: 'triggers',
-            label: 'Triggers',
-            content: <ScannerTriggers scannerId={scannerId} tabId={tabId} />,
-        },
-        {
             key: 'configuration',
             label: 'Configuration',
             content: (
@@ -125,6 +121,14 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
                             </div>
                         )}
                     </Field>
+
+                    <LemonDivider />
+
+                    <div>
+                        <h3 className="text-base font-semibold mb-1">Triggers</h3>
+                        <p className="text-sm text-muted m-0">Which completed recordings this scanner runs against.</p>
+                    </div>
+                    <ScannerTriggers scannerId={scannerId} tabId={tabId} />
                 </div>
             ),
         },

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -68,6 +68,13 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
             label: 'Configuration',
             content: (
                 <div className="space-y-6 max-w-3xl">
+                    <div>
+                        <h3 className="text-base font-semibold mb-1">Details</h3>
+                        <p className="text-sm text-muted m-0">
+                            What this scanner looks for and how it analyzes recordings.
+                        </p>
+                    </div>
+
                     <Field name="name" label="Name">
                         <LemonInput placeholder="e.g. Confused checkout flow" />
                     </Field>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -29,10 +29,6 @@ export function ScannerTriggers({ scannerId, tabId }: { scannerId: string; tabId
 
     return (
         <div className="space-y-6 max-w-3xl">
-            <div className="text-sm text-muted">
-                Sampling and filters control which completed recordings this scanner runs against.
-            </div>
-
             <Field name="sampling_rate" label="Sampling">
                 {({ value, onChange }) => {
                     const ratio = typeof value === 'number' ? value : 0

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -138,9 +138,9 @@ export const SCANNER_TYPE_OPTIONS: { value: ScannerType; label: string; descript
     },
 ]
 
-export type EditorTab = 'observations' | 'triggers' | 'configuration'
+export type EditorTab = 'observations' | 'configuration'
 
-export const ALL_EDITOR_TABS: EditorTab[] = ['observations', 'triggers', 'configuration']
+export const ALL_EDITOR_TABS: EditorTab[] = ['observations', 'configuration']
 
 export interface MonitorScannerConfig {
     prompt: string


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
triggers feel like they are still configuration, merging the tabs together since they are not big enough to be their own yet.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- merge triggers tab into config tab in replay vision
<img width="1099" height="1207" alt="Screenshot 2026-05-28 at 09 43 09" src="https://github.com/user-attachments/assets/7ee7fabf-b42b-4f97-aa16-b935fc269ab1" />

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
