### PR TITLE
feat(hog-charts): add Legend primitive and ChartLegendLayout

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -528,6 +528,38 @@ snapshots:
         hash: v1.k794b7964.c154af270a078cbbb060543de422c6f2f2a2ae2134ffb797be0fb07f4e9c77bf.0gi1GO81ELv-U16NxXdiJF3VbtVBZaYK81G92hf8g_k
     components-hogcharts-boxplot--with-gaps--light:
         hash: v1.k794b7964.17739e468a4911b2bdfe16f13059a9b832e87386e3339ffb3a51c1c38ecfe821.9zttDtobDMs7E45HWOOxGwbEKOCRWDa2BqtMW8GSXcQ
+    components-hogcharts-legend--horizontal--dark:
+        hash: v1.k794b7964.5d39636c62e9f666902a6eba9478531a5326385494ae1a754ab1c133f546b3e1.knlLoncURwS3ntN36nlVwLODHi5eZonBGOOwIvLx5I8
+    components-hogcharts-legend--horizontal--light:
+        hash: v1.k794b7964.82d79f7e0a07c188f597a89fbc0a479e1b9605d007ba6f5fb71087a312fc0764.ENVTf91ekYBrR2zzMYiFkilFzL5adW_itJFXc3eZo-w
+    components-hogcharts-legend--interactive--dark:
+        hash: v1.k794b7964.5d39636c62e9f666902a6eba9478531a5326385494ae1a754ab1c133f546b3e1.yN8df5f_O9LA7ppecXLLDnoTO9CbnJT8QhazW0m0xkU
+    components-hogcharts-legend--interactive--light:
+        hash: v1.k794b7964.82d79f7e0a07c188f597a89fbc0a479e1b9605d007ba6f5fb71087a312fc0764.kFDhmb2BkonZoo3bR5snWR-aN_yY6R2-utLZ5ify3_E
+    components-hogcharts-legend--layout-bottom--dark:
+        hash: v1.k794b7964.6f34c5c79807ea26a631024458558c84093ab248138fbb7cba4d24deccda210d.xJ098X5I0o1k6yvWtmYXYJGlgsrbw5TpIN8C-osCojY
+    components-hogcharts-legend--layout-bottom--light:
+        hash: v1.k794b7964.ebb34148784fd49f208e59207fcfc3aa1476aeddd0af0cc3987543af514e6f0c.ygBJg6yMPl8-arZKotkxgO5XzM4AkWb_HsYkcTOkqes
+    components-hogcharts-legend--layout-left--dark:
+        hash: v1.k794b7964.e5ffa84c0c4612544185166fd7127e091f743d0a4e80e610021e9898cf68c16c.RWP2gB5lEXOaZJk2wYPvfCzAeDRDCBd59flzROZBj_E
+    components-hogcharts-legend--layout-left--light:
+        hash: v1.k794b7964.88db7c4f4fab4b0fee6b0be8b1508c91798270e69c17b507e046fc530dd2fafd.Yn1GAbiBehr5i16TVhPR01gSC2GpOfBnmo5LHnmCWqs
+    components-hogcharts-legend--layout-right--dark:
+        hash: v1.k794b7964.501db0b97c4d897a816cf08afba0f837a54be6f3533dd253b8410f34c57528d5.iT0_3sNr9zqZPacv3XSvc7iFxAhpejg9l26-8ek1wCA
+    components-hogcharts-legend--layout-right--light:
+        hash: v1.k794b7964.81902d1fc7bc428f1455585a08aa7667b409fe0edbf56f269ad38b56e21c53e0.nXCrZLvGoncvjvDYQ0Iq7VmbmorY7jNA6e1qCirbzbQ
+    components-hogcharts-legend--layout-top--dark:
+        hash: v1.k794b7964.07957a22916e5a09eedba69d385c07646d97d3d9483b3fc8d56ae0fae6eea448.4uZJgPeHOc567hzQaIzohLOCyS3dXMJOKB-boXjbYVA
+    components-hogcharts-legend--layout-top--light:
+        hash: v1.k794b7964.efd2345115e956ad9a0c4267248d90c40aade934d5dd896e10fad79f2afb425d.1JqrR7X4fPy38s0mKd20fHKfgLjrdwSNa05lG5GPcHA
+    components-hogcharts-legend--many-items-wraps--dark:
+        hash: v1.k794b7964.f6c2b82b8d93c25d9c21b9afc1d914d041138d25836485cf2d76a577d55a37c5.Ut_YYVfVrtgFs0gV16xnW-pxSADhDhx9tsfA_XEPirQ
+    components-hogcharts-legend--many-items-wraps--light:
+        hash: v1.k794b7964.376cc3f2d00b32edd65a5bc74b43ad4a22bb5d5befc0d7be5e10767717bf792f.cBQPCb5144l7YdeI5UPYc8saSV_mQiXEvGnOmA0xGuw
+    components-hogcharts-legend--vertical--dark:
+        hash: v1.k794b7964.8f9cdc0ce4c1529c1f95cf226b16fb3d28ebdf2a2eed7f57bb8b1e086fa54edf.iKnCYMI4351HMtNeZht7XjoxmFkbF8N0eIX9b8rIOQc
+    components-hogcharts-legend--vertical--light:
+        hash: v1.k794b7964.613d93ab14bd635185a8f3f5eabfaa884a3a8f7b418cdbdec94478b2bc3da2d2.poxwlxr4MP5HbhAC8JKzXCBFxGSJwc8uUXs26xUUcHU
     components-hogcharts-linechart--combined-overlays--dark:
         hash: v1.k794b7964.38753d5c6bab2f9d1be492d0e191aca21265953e220c0f37714913c89d7caf42.0wzgqeeUqe_bxIfIbS861HknzpuGVzxC664U1GTe9S8
     components-hogcharts-linechart--combined-overlays--light:

--- a/frontend/src/lib/hog-charts/components/Legend/ChartLegendLayout.test.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/ChartLegendLayout.test.tsx
@@ -1,0 +1,92 @@
+import { render } from '@testing-library/react'
+
+import { ChartLegendLayout } from './ChartLegendLayout'
+
+function setup(props: Parameters<typeof ChartLegendLayout>[0]): {
+    root: HTMLElement
+    legend: HTMLElement | null
+    chart: HTMLElement
+} {
+    const { container } = render(<ChartLegendLayout {...props} />)
+    const root = container.firstChild as HTMLElement
+    const legend = root.querySelector<HTMLElement>('[data-attr="hog-charts-legend-slot"]')
+    const chart = root.querySelector<HTMLElement>('[data-attr="hog-charts-chart-slot"]')!
+    return { root, legend, chart }
+}
+
+const LEGEND = <div data-attr="my-legend">legend</div>
+const CHART = <div data-attr="my-chart">chart</div>
+
+describe('ChartLegendLayout', () => {
+    it("default position 'top' puts the legend before the chart in column flex", () => {
+        const { root, legend, chart } = setup({ legend: LEGEND, children: CHART })
+        expect(root.className).toContain('flex-col')
+        expect(legend).not.toBeNull()
+        expect(root.children[0]).toBe(legend)
+        expect(root.children[1]).toBe(chart)
+    })
+
+    it("position 'bottom' puts the legend after the chart in column flex", () => {
+        const { root, legend, chart } = setup({ legend: LEGEND, position: 'bottom', children: CHART })
+        expect(root.className).toContain('flex-col')
+        expect(root.children[0]).toBe(chart)
+        expect(root.children[1]).toBe(legend)
+    })
+
+    it("position 'left' puts the legend before the chart in row flex", () => {
+        const { root, legend, chart } = setup({ legend: LEGEND, position: 'left', children: CHART })
+        expect(root.className).toContain('flex-row')
+        expect(root.children[0]).toBe(legend)
+        expect(root.children[1]).toBe(chart)
+    })
+
+    it("position 'right' puts the legend after the chart in row flex", () => {
+        const { root, legend, chart } = setup({ legend: LEGEND, position: 'right', children: CHART })
+        expect(root.className).toContain('flex-row')
+        expect(root.children[0]).toBe(chart)
+        expect(root.children[1]).toBe(legend)
+    })
+
+    it.each([
+        ['start', 'items-start'],
+        ['center', 'items-center'],
+        ['end', 'items-end'],
+    ] as const)('align=%s applies %s', (align, expected) => {
+        const { root } = setup({ legend: LEGEND, align, children: CHART })
+        expect(root.className).toContain(expected)
+    })
+
+    it('passes the gap prop through as an inline gap style value', () => {
+        const { root } = setup({ legend: LEGEND, gap: 24, children: CHART })
+        expect(root.style.gap).toBe('24px')
+    })
+
+    it('defaults gap to 8 pixels when not provided', () => {
+        const { root } = setup({ legend: LEGEND, children: CHART })
+        expect(root.style.gap).toBe('8px')
+    })
+
+    it('omits the legend slot but still renders children when legend is null', () => {
+        const { root, legend, chart } = setup({ legend: null, children: CHART })
+        expect(legend).toBeNull()
+        expect(root.children).toHaveLength(1)
+        expect(root.children[0]).toBe(chart)
+    })
+
+    it('omits the legend slot when legend is undefined', () => {
+        const { legend, chart } = setup({ legend: undefined, children: CHART })
+        expect(legend).toBeNull()
+        expect(chart.textContent).toBe('chart')
+    })
+
+    it('omits the legend slot when legend is false', () => {
+        const { legend, chart } = setup({ legend: false, children: CHART })
+        expect(legend).toBeNull()
+        expect(chart.textContent).toBe('chart')
+    })
+
+    it.each(['top', 'bottom', 'left', 'right'] as const)('children render unchanged at position=%s', (position) => {
+        const { chart } = setup({ legend: LEGEND, position, children: CHART })
+        expect(chart.textContent).toBe('chart')
+    })
+})

--- a/frontend/src/lib/hog-charts/components/Legend/ChartLegendLayout.test.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/ChartLegendLayout.test.tsx
@@ -2,91 +2,34 @@ import { render } from '@testing-library/react'
 
 import { ChartLegendLayout } from './ChartLegendLayout'
 
-function setup(props: Parameters<typeof ChartLegendLayout>[0]): {
-    root: HTMLElement
-    legend: HTMLElement | null
-    chart: HTMLElement
-} {
-    const { container } = render(<ChartLegendLayout {...props} />)
-    const root = container.firstChild as HTMLElement
-    const legend = root.querySelector<HTMLElement>('[data-attr="hog-charts-legend-slot"]')
-    const chart = root.querySelector<HTMLElement>('[data-attr="hog-charts-chart-slot"]')!
-    return { root, legend, chart }
+const LEGEND = <div data-attr="legend">L</div>
+const CHART = <div data-attr="chart">C</div>
+
+function root(props: Parameters<typeof ChartLegendLayout>[0]): HTMLElement {
+    return render(<ChartLegendLayout {...props} />).container.firstChild as HTMLElement
 }
 
-const LEGEND = <div data-attr="my-legend">legend</div>
-const CHART = <div data-attr="my-chart">chart</div>
-
 describe('ChartLegendLayout', () => {
-    it("default position 'top' puts the legend before the chart in column flex", () => {
-        const { root, legend, chart } = setup({ legend: LEGEND, children: CHART })
-        expect(root.className).toContain('flex-col')
-        expect(legend).not.toBeNull()
-        expect(root.children[0]).toBe(legend)
-        expect(root.children[1]).toBe(chart)
-    })
-
-    it("position 'bottom' puts the legend after the chart in column flex", () => {
-        const { root, legend, chart } = setup({ legend: LEGEND, position: 'bottom', children: CHART })
-        expect(root.className).toContain('flex-col')
-        expect(root.children[0]).toBe(chart)
-        expect(root.children[1]).toBe(legend)
-    })
-
-    it("position 'left' puts the legend before the chart in row flex", () => {
-        const { root, legend, chart } = setup({ legend: LEGEND, position: 'left', children: CHART })
-        expect(root.className).toContain('flex-row')
-        expect(root.children[0]).toBe(legend)
-        expect(root.children[1]).toBe(chart)
-    })
-
-    it("position 'right' puts the legend after the chart in row flex", () => {
-        const { root, legend, chart } = setup({ legend: LEGEND, position: 'right', children: CHART })
-        expect(root.className).toContain('flex-row')
-        expect(root.children[0]).toBe(chart)
-        expect(root.children[1]).toBe(legend)
-    })
-
     it.each([
-        ['start', 'items-start'],
-        ['center', 'items-center'],
-        ['end', 'items-end'],
-    ] as const)('align=%s applies %s', (align, expected) => {
-        const { root } = setup({ legend: LEGEND, align, children: CHART })
-        expect(root.className).toContain(expected)
+        ['top', 'flex-col', 0],
+        ['bottom', 'flex-col', 1],
+        ['left', 'flex-row', 0],
+        ['right', 'flex-row', 1],
+    ] as const)('position=%s uses %s with legend at child index %s', (position, flex, legendIndex) => {
+        const r = root({ legend: LEGEND, position, children: CHART })
+        expect(r.className).toContain(flex)
+        expect(r.children[legendIndex].querySelector('[data-attr="legend"]')).not.toBeNull()
+        expect(r.children[1 - legendIndex].querySelector('[data-attr="chart"]')).not.toBeNull()
     })
 
-    it('passes the gap prop through as an inline gap style value', () => {
-        const { root } = setup({ legend: LEGEND, gap: 24, children: CHART })
-        expect(root.style.gap).toBe('24px')
+    it('passes gap through as an inline style (default 8px)', () => {
+        expect(root({ legend: LEGEND, children: CHART }).style.gap).toBe('8px')
+        expect(root({ legend: LEGEND, gap: 24, children: CHART }).style.gap).toBe('24px')
     })
 
-    it('defaults gap to 8 pixels when not provided', () => {
-        const { root } = setup({ legend: LEGEND, children: CHART })
-        expect(root.style.gap).toBe('8px')
-    })
-
-    it('omits the legend slot but still renders children when legend is null', () => {
-        const { root, legend, chart } = setup({ legend: null, children: CHART })
-        expect(legend).toBeNull()
-        expect(root.children).toHaveLength(1)
-        expect(root.children[0]).toBe(chart)
-    })
-
-    it('omits the legend slot when legend is undefined', () => {
-        const { legend, chart } = setup({ legend: undefined, children: CHART })
-        expect(legend).toBeNull()
-        expect(chart.textContent).toBe('chart')
-    })
-
-    it('omits the legend slot when legend is false', () => {
-        const { legend, chart } = setup({ legend: false, children: CHART })
-        expect(legend).toBeNull()
-        expect(chart.textContent).toBe('chart')
-    })
-
-    it.each(['top', 'bottom', 'left', 'right'] as const)('children render unchanged at position=%s', (position) => {
-        const { chart } = setup({ legend: LEGEND, position, children: CHART })
-        expect(chart.textContent).toBe('chart')
+    it.each([null, undefined, false] as const)('omits the legend slot when legend is %p', (legend) => {
+        const r = root({ legend, children: CHART })
+        expect(r.children).toHaveLength(1)
+        expect(r.querySelector('[data-attr="chart"]')).not.toBeNull()
     })
 })

--- a/frontend/src/lib/hog-charts/components/Legend/ChartLegendLayout.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/ChartLegendLayout.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable react/forbid-dom-props -- dynamic pixel gap from prop */
+import React from 'react'
+
+export interface ChartLegendLayoutProps {
+    /** The legend element. Anything that renders is allowed (typically a `<Legend />`).
+     *  Falsy values (`null`, `undefined`, `false`) omit the legend slot entirely. */
+    legend: React.ReactNode
+    /** Side of the chart on which to place the legend. Defaults to `'top'`. */
+    position?: 'top' | 'bottom' | 'left' | 'right'
+    /** Cross-axis alignment of the legend slot relative to the chart. Defaults to `'center'`. */
+    align?: 'start' | 'center' | 'end'
+    /** Pixels between the legend slot and the chart. Defaults to `8`. */
+    gap?: number
+    className?: string
+    dataAttr?: string
+    /** The chart (or anything that should fill the remaining space). */
+    children: React.ReactNode
+}
+
+const ALIGN_ROW_CLASS: Record<NonNullable<ChartLegendLayoutProps['align']>, string> = {
+    start: 'items-start',
+    center: 'items-center',
+    end: 'items-end',
+}
+
+const ALIGN_COL_CLASS: Record<NonNullable<ChartLegendLayoutProps['align']>, string> = {
+    start: 'items-start',
+    center: 'items-center',
+    end: 'items-end',
+}
+
+export function ChartLegendLayout({
+    legend,
+    position = 'top',
+    align = 'center',
+    gap = 8,
+    className,
+    dataAttr,
+    children,
+}: ChartLegendLayoutProps): React.ReactElement {
+    const isHorizontal = position === 'left' || position === 'right'
+    const legendBefore = position === 'top' || position === 'left'
+    const containerClass = [
+        'flex min-w-0 min-h-0',
+        isHorizontal ? 'flex-row' : 'flex-col',
+        isHorizontal ? ALIGN_ROW_CLASS[align] : ALIGN_COL_CLASS[align],
+        className ?? '',
+    ]
+        .filter(Boolean)
+        .join(' ')
+
+    const legendSlot = legend ? (
+        <div className="flex-none shrink-0" data-attr="hog-charts-legend-slot">
+            {legend}
+        </div>
+    ) : null
+    const chartSlot = (
+        <div className="flex-1 min-w-0 min-h-0" data-attr="hog-charts-chart-slot">
+            {children}
+        </div>
+    )
+
+    return (
+        <div className={containerClass} style={{ gap }} data-attr={dataAttr}>
+            {legendBefore ? legendSlot : chartSlot}
+            {legendBefore ? chartSlot : legendSlot}
+        </div>
+    )
+}

--- a/frontend/src/lib/hog-charts/components/Legend/ChartLegendLayout.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/ChartLegendLayout.tsx
@@ -2,32 +2,20 @@
 import React from 'react'
 
 export interface ChartLegendLayoutProps {
-    /** The legend element. Anything that renders is allowed (typically a `<Legend />`).
-     *  Falsy values (`null`, `undefined`, `false`) omit the legend slot entirely. */
     legend: React.ReactNode
-    /** Side of the chart on which to place the legend. Defaults to `'top'`. */
     position?: 'top' | 'bottom' | 'left' | 'right'
-    /** Cross-axis alignment of the legend slot relative to the chart. Defaults to `'center'`. */
     align?: 'start' | 'center' | 'end'
-    /** Pixels between the legend slot and the chart. Defaults to `8`. */
     gap?: number
     className?: string
     dataAttr?: string
-    /** The chart (or anything that should fill the remaining space). */
     children: React.ReactNode
 }
 
-const ALIGN_ROW_CLASS: Record<NonNullable<ChartLegendLayoutProps['align']>, string> = {
+const ALIGN_CLASS = {
     start: 'items-start',
     center: 'items-center',
     end: 'items-end',
-}
-
-const ALIGN_COL_CLASS: Record<NonNullable<ChartLegendLayoutProps['align']>, string> = {
-    start: 'items-start',
-    center: 'items-center',
-    end: 'items-end',
-}
+} as const
 
 export function ChartLegendLayout({
     legend,
@@ -38,32 +26,18 @@ export function ChartLegendLayout({
     dataAttr,
     children,
 }: ChartLegendLayoutProps): React.ReactElement {
-    const isHorizontal = position === 'left' || position === 'right'
-    const legendBefore = position === 'top' || position === 'left'
-    const containerClass = [
-        'flex min-w-0 min-h-0',
-        isHorizontal ? 'flex-row' : 'flex-col',
-        isHorizontal ? ALIGN_ROW_CLASS[align] : ALIGN_COL_CLASS[align],
-        className ?? '',
-    ]
-        .filter(Boolean)
-        .join(' ')
-
-    const legendSlot = legend ? (
-        <div className="flex-none shrink-0" data-attr="hog-charts-legend-slot">
-            {legend}
-        </div>
-    ) : null
-    const chartSlot = (
-        <div className="flex-1 min-w-0 min-h-0" data-attr="hog-charts-chart-slot">
-            {children}
-        </div>
-    )
-
+    const isRow = position === 'left' || position === 'right'
+    const legendFirst = position === 'top' || position === 'left'
+    const legendSlot = legend ? <div className="flex-none shrink-0">{legend}</div> : null
+    const chartSlot = <div className="flex-1 min-w-0 min-h-0">{children}</div>
     return (
-        <div className={containerClass} style={{ gap }} data-attr={dataAttr}>
-            {legendBefore ? legendSlot : chartSlot}
-            {legendBefore ? chartSlot : legendSlot}
+        <div
+            className={`flex min-w-0 min-h-0 ${isRow ? 'flex-row' : 'flex-col'} ${ALIGN_CLASS[align]} ${className ?? ''}`}
+            style={{ gap }}
+            data-attr={dataAttr}
+        >
+            {legendFirst ? legendSlot : chartSlot}
+            {legendFirst ? chartSlot : legendSlot}
         </div>
     )
 }

--- a/frontend/src/lib/hog-charts/components/Legend/Legend.stories.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/Legend.stories.tsx
@@ -8,23 +8,20 @@ import { ChartLegendLayout } from './ChartLegendLayout'
 import { Legend, type LegendItem } from './Legend'
 import { legendItemsFromSeries } from './legendItemsFromSeries'
 
-const LIFECYCLE_ITEMS: LegendItem[] = [
+const LIFECYCLE: LegendItem[] = [
     { key: 'new', label: 'New', color: '#22c55e' },
     { key: 'returning', label: 'Returning', color: '#3b82f6' },
     { key: 'resurrecting', label: 'Resurrecting', color: '#a855f7' },
     { key: 'dormant', label: 'Dormant', color: '#f97316' },
 ]
 
-const MANY_ITEMS: LegendItem[] = Array.from({ length: 12 }, (_, i) => ({
+const MANY: LegendItem[] = Array.from({ length: 12 }, (_, i) => ({
     key: `series-${i}`,
     label: `Breakdown value ${i + 1} with a fairly long name`,
     color: `hsl(${(i * 36) % 360} 70% 55%)`,
 }))
 
-const meta: Meta = {
-    title: 'Components/HogCharts/Legend',
-    parameters: { layout: 'centered' },
-}
+const meta: Meta = { title: 'Components/HogCharts/Legend', parameters: { layout: 'centered' } }
 export default meta
 
 type Story = StoryObj
@@ -32,7 +29,7 @@ type Story = StoryObj
 export const Horizontal: Story = {
     render: () => (
         <div className="w-[480px]">
-            <Legend items={LIFECYCLE_ITEMS} />
+            <Legend items={LIFECYCLE} />
         </div>
     ),
 }
@@ -40,7 +37,7 @@ export const Horizontal: Story = {
 export const Vertical: Story = {
     render: () => (
         <div className="w-[200px]">
-            <Legend items={LIFECYCLE_ITEMS} orientation="vertical" align="start" />
+            <Legend items={LIFECYCLE} orientation="vertical" align="start" />
         </div>
     ),
 }
@@ -52,9 +49,8 @@ export const Interactive: Story = {
             const toggle = (key: string): void =>
                 setHidden((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]))
             return (
-                <div className="flex flex-col gap-2 w-[480px]">
-                    <Legend items={LIFECYCLE_ITEMS} hiddenKeys={hidden} onItemClick={toggle} />
-                    <span className="text-xs text-muted">Click an item to toggle its dimmed state.</span>
+                <div className="w-[480px]">
+                    <Legend items={LIFECYCLE} hiddenKeys={hidden} onItemClick={toggle} />
                 </div>
             )
         }
@@ -65,19 +61,21 @@ export const Interactive: Story = {
 export const ManyItemsWraps: Story = {
     render: () => (
         <div className="w-[480px] border border-border rounded p-2">
-            <Legend items={MANY_ITEMS} />
+            <Legend items={MANY} />
         </div>
     ),
 }
 
 function ChartWithLegend({ position }: { position: 'top' | 'bottom' | 'left' | 'right' }): JSX.Element {
     const theme = useReactiveTheme()
-    const isHorizontal = position === 'left' || position === 'right'
+    const isRow = position === 'left' || position === 'right'
     const items = useMemo(() => legendItemsFromSeries(SERIES, theme), [theme])
-    const legend = <Legend items={items} orientation={isHorizontal ? 'vertical' : 'horizontal'} />
     return (
         <Stage width={520} height={320}>
-            <ChartLegendLayout legend={legend} position={position}>
+            <ChartLegendLayout
+                legend={<Legend items={items} orientation={isRow ? 'vertical' : 'horizontal'} />}
+                position={position}
+            >
                 <TimeSeriesBarChart
                     series={SERIES}
                     labels={DAYS}

--- a/frontend/src/lib/hog-charts/components/Legend/Legend.stories.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/Legend.stories.tsx
@@ -1,0 +1,95 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { useMemo, useState } from 'react'
+
+import { DAYS, SERIES } from '../../charts/time-series-fixtures'
+import { TimeSeriesBarChart } from '../../charts/TimeSeriesBarChart/TimeSeriesBarChart'
+import { Stage, useReactiveTheme } from '../../story-helpers'
+import { ChartLegendLayout } from './ChartLegendLayout'
+import { Legend, type LegendItem } from './Legend'
+import { legendItemsFromSeries } from './legendItemsFromSeries'
+
+const LIFECYCLE_ITEMS: LegendItem[] = [
+    { key: 'new', label: 'New', color: '#22c55e' },
+    { key: 'returning', label: 'Returning', color: '#3b82f6' },
+    { key: 'resurrecting', label: 'Resurrecting', color: '#a855f7' },
+    { key: 'dormant', label: 'Dormant', color: '#f97316' },
+]
+
+const MANY_ITEMS: LegendItem[] = Array.from({ length: 12 }, (_, i) => ({
+    key: `series-${i}`,
+    label: `Breakdown value ${i + 1} with a fairly long name`,
+    color: `hsl(${(i * 36) % 360} 70% 55%)`,
+}))
+
+const meta: Meta = {
+    title: 'Components/HogCharts/Legend',
+    parameters: { layout: 'centered' },
+}
+export default meta
+
+type Story = StoryObj
+
+export const Horizontal: Story = {
+    render: () => (
+        <div className="w-[480px]">
+            <Legend items={LIFECYCLE_ITEMS} />
+        </div>
+    ),
+}
+
+export const Vertical: Story = {
+    render: () => (
+        <div className="w-[200px]">
+            <Legend items={LIFECYCLE_ITEMS} orientation="vertical" align="start" />
+        </div>
+    ),
+}
+
+export const Interactive: Story = {
+    render: () => {
+        function InteractiveLegend(): JSX.Element {
+            const [hidden, setHidden] = useState<string[]>([])
+            const toggle = (key: string): void =>
+                setHidden((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]))
+            return (
+                <div className="flex flex-col gap-2 w-[480px]">
+                    <Legend items={LIFECYCLE_ITEMS} hiddenKeys={hidden} onItemClick={toggle} />
+                    <span className="text-xs text-muted">Click an item to toggle its dimmed state.</span>
+                </div>
+            )
+        }
+        return <InteractiveLegend />
+    },
+}
+
+export const ManyItemsWraps: Story = {
+    render: () => (
+        <div className="w-[480px] border border-border rounded p-2">
+            <Legend items={MANY_ITEMS} />
+        </div>
+    ),
+}
+
+function ChartWithLegend({ position }: { position: 'top' | 'bottom' | 'left' | 'right' }): JSX.Element {
+    const theme = useReactiveTheme()
+    const isHorizontal = position === 'left' || position === 'right'
+    const items = useMemo(() => legendItemsFromSeries(SERIES, theme), [theme])
+    const legend = <Legend items={items} orientation={isHorizontal ? 'vertical' : 'horizontal'} />
+    return (
+        <Stage width={520} height={320}>
+            <ChartLegendLayout legend={legend} position={position}>
+                <TimeSeriesBarChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ yAxis: { showGrid: true } }}
+                />
+            </ChartLegendLayout>
+        </Stage>
+    )
+}
+
+export const LayoutTop: Story = { render: () => <ChartWithLegend position="top" /> }
+export const LayoutBottom: Story = { render: () => <ChartWithLegend position="bottom" /> }
+export const LayoutLeft: Story = { render: () => <ChartWithLegend position="left" /> }
+export const LayoutRight: Story = { render: () => <ChartWithLegend position="right" /> }

--- a/frontend/src/lib/hog-charts/components/Legend/Legend.test.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/Legend.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render } from '@testing-library/react'
+import fs from 'fs'
+import path from 'path'
+
+import { Legend, type LegendItem } from './Legend'
+
+const ITEMS: LegendItem[] = [
+    { key: 'new', label: 'New', color: '#22c55e' },
+    { key: 'returning', label: 'Returning', color: '#3b82f6' },
+    { key: 'resurrecting', label: 'Resurrecting', color: '#a855f7' },
+    { key: 'dormant', label: 'Dormant', color: '#f97316' },
+]
+
+function hexToRgb(hex: string): string {
+    const clean = hex.replace('#', '')
+    const r = parseInt(clean.slice(0, 2), 16)
+    const g = parseInt(clean.slice(2, 4), 16)
+    const b = parseInt(clean.slice(4, 6), 16)
+    return `rgb(${r}, ${g}, ${b})`
+}
+
+describe('Legend', () => {
+    it('renders one row per item with the correct label text', () => {
+        const { getByText } = render(<Legend items={ITEMS} />)
+        const found = ITEMS.map((item) => getByText(item.label).textContent)
+        expect(found).toEqual(ITEMS.map((i) => i.label))
+    })
+
+    it.each(ITEMS.map((item, index) => [item.key, index, item.color]))(
+        "swatch for %s has inline background-color matching the item's color",
+        (_key, index, color) => {
+            const { container } = render(<Legend items={ITEMS} />)
+            const swatches = container.querySelectorAll<HTMLElement>('[aria-hidden="true"]')
+            expect(swatches[index as number].style.backgroundColor).toBe(hexToRgb(color as string))
+        }
+    )
+
+    it('horizontal orientation uses flex-wrap', () => {
+        const { container } = render(<Legend items={ITEMS} dataAttr="legend-h" />)
+        const root = container.querySelector('[data-attr="legend-h"]')!
+        expect(root.className).toContain('flex-row')
+        expect(root.className).toContain('flex-wrap')
+    })
+
+    it('vertical orientation uses flex-col and does not wrap', () => {
+        const { container } = render(<Legend items={ITEMS} orientation="vertical" dataAttr="legend-v" />)
+        const root = container.querySelector('[data-attr="legend-v"]')!
+        expect(root.className).toContain('flex-col')
+        expect(root.className).not.toContain('flex-wrap')
+    })
+
+    it.each([
+        ['start', 'justify-start'],
+        ['center', 'justify-center'],
+        ['end', 'justify-end'],
+    ] as const)('align=%s applies %s', (align, expected) => {
+        const { container } = render(<Legend items={ITEMS} align={align} dataAttr="legend" />)
+        const root = container.querySelector('[data-attr="legend"]')!
+        expect(root.className).toContain(expected)
+    })
+
+    it('renders items as non-button spans when onItemClick is omitted', () => {
+        const { container } = render(<Legend items={ITEMS} />)
+        expect(container.querySelectorAll('button')).toHaveLength(0)
+        expect(container.querySelectorAll('[data-attr^="hog-charts-legend-item-"]').length).toBe(ITEMS.length)
+    })
+
+    it('renders items as buttons and fires onItemClick with the item key when set', () => {
+        const onClick = jest.fn()
+        const { container } = render(<Legend items={ITEMS} onItemClick={onClick} />)
+        const buttons = container.querySelectorAll('button')
+        expect(buttons).toHaveLength(ITEMS.length)
+
+        fireEvent.click(buttons[1])
+        expect(onClick).toHaveBeenCalledTimes(1)
+        expect(onClick).toHaveBeenCalledWith('returning')
+
+        fireEvent.click(buttons[3])
+        expect(onClick).toHaveBeenLastCalledWith('dormant')
+    })
+
+    it('dims only the rows whose key is in hiddenKeys, leaving others at full opacity', () => {
+        const { container } = render(<Legend items={ITEMS} hiddenKeys={['returning', 'dormant']} />)
+        const dimmedByKey: Record<string, boolean> = {}
+        const rows = container.querySelectorAll<HTMLElement>('[data-attr^="hog-charts-legend-item-"]')
+        rows.forEach((row) => {
+            const key = row.getAttribute('data-attr')!.replace('hog-charts-legend-item-', '')
+            dimmedByKey[key] = row.className.includes('opacity-40')
+        })
+        expect(dimmedByKey).toEqual({ new: false, returning: true, resurrecting: false, dormant: true })
+    })
+
+    it('renders nothing when items is empty', () => {
+        const { container } = render(<Legend items={[]} />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('does not import from kea, posthog-js, or lib/lemon-ui (MCP-bundle-safe)', () => {
+        const source = fs.readFileSync(path.join(__dirname, 'Legend.tsx'), 'utf8')
+        expect(source).not.toMatch(/from ['"]kea['"]/)
+        expect(source).not.toMatch(/from ['"]posthog-js['"]/)
+        expect(source).not.toMatch(/from ['"]~\/lib\/lemon-ui/)
+        expect(source).not.toMatch(/from ['"]lib\/lemon-ui/)
+        expect(source).not.toMatch(/from ['"]~\/scenes\//)
+        expect(source).not.toMatch(/from ['"]scenes\//)
+    })
+})

--- a/frontend/src/lib/hog-charts/components/Legend/Legend.test.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/Legend.test.tsx
@@ -1,93 +1,24 @@
 import { fireEvent, render } from '@testing-library/react'
-import fs from 'fs'
-import path from 'path'
 
 import { Legend, type LegendItem } from './Legend'
 
 const ITEMS: LegendItem[] = [
     { key: 'new', label: 'New', color: '#22c55e' },
     { key: 'returning', label: 'Returning', color: '#3b82f6' },
-    { key: 'resurrecting', label: 'Resurrecting', color: '#a855f7' },
     { key: 'dormant', label: 'Dormant', color: '#f97316' },
 ]
 
-function hexToRgb(hex: string): string {
-    const clean = hex.replace('#', '')
-    const r = parseInt(clean.slice(0, 2), 16)
-    const g = parseInt(clean.slice(2, 4), 16)
-    const b = parseInt(clean.slice(4, 6), 16)
-    return `rgb(${r}, ${g}, ${b})`
+function rowsOf(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.firstChild!.childNodes) as HTMLElement[]
 }
 
 describe('Legend', () => {
-    it('renders one row per item with the correct label text', () => {
-        const { getByText } = render(<Legend items={ITEMS} />)
-        const found = ITEMS.map((item) => getByText(item.label).textContent)
-        expect(found).toEqual(ITEMS.map((i) => i.label))
-    })
-
-    it.each(ITEMS.map((item, index) => [item.key, index, item.color]))(
-        "swatch for %s has inline background-color matching the item's color",
-        (_key, index, color) => {
-            const { container } = render(<Legend items={ITEMS} />)
-            const swatches = container.querySelectorAll<HTMLElement>('[aria-hidden="true"]')
-            expect(swatches[index as number].style.backgroundColor).toBe(hexToRgb(color as string))
-        }
-    )
-
-    it('horizontal orientation uses flex-wrap', () => {
-        const { container } = render(<Legend items={ITEMS} dataAttr="legend-h" />)
-        const root = container.querySelector('[data-attr="legend-h"]')!
-        expect(root.className).toContain('flex-row')
-        expect(root.className).toContain('flex-wrap')
-    })
-
-    it('vertical orientation uses flex-col and does not wrap', () => {
-        const { container } = render(<Legend items={ITEMS} orientation="vertical" dataAttr="legend-v" />)
-        const root = container.querySelector('[data-attr="legend-v"]')!
-        expect(root.className).toContain('flex-col')
-        expect(root.className).not.toContain('flex-wrap')
-    })
-
-    it.each([
-        ['start', 'justify-start'],
-        ['center', 'justify-center'],
-        ['end', 'justify-end'],
-    ] as const)('align=%s applies %s', (align, expected) => {
-        const { container } = render(<Legend items={ITEMS} align={align} dataAttr="legend" />)
-        const root = container.querySelector('[data-attr="legend"]')!
-        expect(root.className).toContain(expected)
-    })
-
-    it('renders items as non-button spans when onItemClick is omitted', () => {
+    it('renders one row per item with the right label and swatch color', () => {
         const { container } = render(<Legend items={ITEMS} />)
-        expect(container.querySelectorAll('button')).toHaveLength(0)
-        expect(container.querySelectorAll('[data-attr^="hog-charts-legend-item-"]').length).toBe(ITEMS.length)
-    })
-
-    it('renders items as buttons and fires onItemClick with the item key when set', () => {
-        const onClick = jest.fn()
-        const { container } = render(<Legend items={ITEMS} onItemClick={onClick} />)
-        const buttons = container.querySelectorAll('button')
-        expect(buttons).toHaveLength(ITEMS.length)
-
-        fireEvent.click(buttons[1])
-        expect(onClick).toHaveBeenCalledTimes(1)
-        expect(onClick).toHaveBeenCalledWith('returning')
-
-        fireEvent.click(buttons[3])
-        expect(onClick).toHaveBeenLastCalledWith('dormant')
-    })
-
-    it('dims only the rows whose key is in hiddenKeys, leaving others at full opacity', () => {
-        const { container } = render(<Legend items={ITEMS} hiddenKeys={['returning', 'dormant']} />)
-        const dimmedByKey: Record<string, boolean> = {}
-        const rows = container.querySelectorAll<HTMLElement>('[data-attr^="hog-charts-legend-item-"]')
-        rows.forEach((row) => {
-            const key = row.getAttribute('data-attr')!.replace('hog-charts-legend-item-', '')
-            dimmedByKey[key] = row.className.includes('opacity-40')
-        })
-        expect(dimmedByKey).toEqual({ new: false, returning: true, resurrecting: false, dormant: true })
+        const swatches = Array.from(container.querySelectorAll<HTMLElement>('[aria-hidden="true"]'))
+        expect(swatches.map((s) => s.style.backgroundColor).every(Boolean)).toBe(true)
+        expect(swatches).toHaveLength(ITEMS.length)
+        expect(rowsOf(container).map((r) => r.textContent)).toEqual(ITEMS.map((i) => i.label))
     })
 
     it('renders nothing when items is empty', () => {
@@ -95,13 +26,34 @@ describe('Legend', () => {
         expect(container.firstChild).toBeNull()
     })
 
-    it('does not import from kea, posthog-js, or lib/lemon-ui (MCP-bundle-safe)', () => {
-        const source = fs.readFileSync(path.join(__dirname, 'Legend.tsx'), 'utf8')
-        expect(source).not.toMatch(/from ['"]kea['"]/)
-        expect(source).not.toMatch(/from ['"]posthog-js['"]/)
-        expect(source).not.toMatch(/from ['"]~\/lib\/lemon-ui/)
-        expect(source).not.toMatch(/from ['"]lib\/lemon-ui/)
-        expect(source).not.toMatch(/from ['"]~\/scenes\//)
-        expect(source).not.toMatch(/from ['"]scenes\//)
+    it('uses flex-row + flex-wrap for horizontal and flex-col for vertical', () => {
+        const h = render(<Legend items={ITEMS} dataAttr="h" />).container.querySelector('[data-attr="h"]')!
+        const v = render(<Legend items={ITEMS} orientation="vertical" dataAttr="v" />).container.querySelector(
+            '[data-attr="v"]'
+        )!
+        expect(h.className).toContain('flex-row')
+        expect(h.className).toContain('flex-wrap')
+        expect(v.className).toContain('flex-col')
+        expect(v.className).not.toContain('flex-wrap')
+    })
+
+    it('renders items as spans by default and as buttons that fire onItemClick when set', () => {
+        const onClick = jest.fn()
+        const plain = render(<Legend items={ITEMS} />).container
+        expect(plain.querySelectorAll('button')).toHaveLength(0)
+
+        const clickable = render(<Legend items={ITEMS} onItemClick={onClick} />).container
+        const buttons = clickable.querySelectorAll('button')
+        expect(buttons).toHaveLength(ITEMS.length)
+        fireEvent.click(buttons[1])
+        expect(onClick).toHaveBeenCalledWith('returning')
+    })
+
+    it('dims only rows whose key is in hiddenKeys', () => {
+        const { container } = render(<Legend items={ITEMS} hiddenKeys={['returning']} />)
+        const dimmedLabels = rowsOf(container)
+            .filter((row) => row.className.includes('opacity-40'))
+            .map((row) => row.textContent)
+        expect(dimmedLabels).toEqual(['Returning'])
     })
 })

--- a/frontend/src/lib/hog-charts/components/Legend/Legend.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/Legend.tsx
@@ -2,33 +2,26 @@
 import React from 'react'
 
 export interface LegendItem {
-    /** Stable identifier — typically matches a `Series.key`. */
     key: string
-    /** Display text shown next to the swatch. */
     label: string
-    /** CSS color string for the swatch (hex, rgb, var(--…), etc.). */
     color: string
 }
 
 export interface LegendProps {
     items: LegendItem[]
-    /** Layout direction. Defaults to `'horizontal'`. */
     orientation?: 'horizontal' | 'vertical'
-    /** Main-axis alignment of items within the legend container. Defaults to `'center'`. */
     align?: 'start' | 'center' | 'end'
-    /** When provided, items render as `<button>` elements that fire this callback with the item's key. */
     onItemClick?: (key: string) => void
-    /** Item keys that should render dimmed (e.g. hidden / excluded series). */
     hiddenKeys?: string[]
     className?: string
     dataAttr?: string
 }
 
-const ALIGN_CLASS: Record<NonNullable<LegendProps['align']>, string> = {
+const ALIGN_CLASS = {
     start: 'justify-start',
     center: 'justify-center',
     end: 'justify-end',
-}
+} as const
 
 export function Legend({
     items,
@@ -42,49 +35,35 @@ export function Legend({
     if (items.length === 0) {
         return null
     }
-    const hidden = hiddenKeys && hiddenKeys.length > 0 ? new Set(hiddenKeys) : null
-    const containerClass = [
-        'flex',
-        orientation === 'horizontal' ? 'flex-row flex-wrap gap-x-3 gap-y-1' : 'flex-col gap-1',
-        ALIGN_CLASS[align],
-        className ?? '',
-    ]
-        .filter(Boolean)
-        .join(' ')
-
+    const hidden = hiddenKeys?.length ? new Set(hiddenKeys) : null
+    const layout = orientation === 'horizontal' ? 'flex-row flex-wrap gap-x-3 gap-y-1' : 'flex-col gap-1'
     return (
-        <div className={containerClass} data-attr={dataAttr}>
+        <div className={`flex ${layout} ${ALIGN_CLASS[align]} ${className ?? ''}`} data-attr={dataAttr}>
             {items.map((item) => {
-                const isHidden = hidden?.has(item.key) ?? false
-                const rowClass = ['inline-flex items-center gap-1.5 text-xs leading-none', isHidden ? 'opacity-40' : '']
-                    .filter(Boolean)
-                    .join(' ')
-                const swatch = (
-                    <span
-                        aria-hidden="true"
-                        className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
-                        style={{ backgroundColor: item.color }}
-                    />
+                const dimmed = hidden?.has(item.key) ? ' opacity-40' : ''
+                const rowClass = `inline-flex items-center gap-1.5 text-xs leading-none${dimmed}`
+                const inner = (
+                    <>
+                        <span
+                            aria-hidden="true"
+                            className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                            style={{ backgroundColor: item.color }}
+                        />
+                        <span className="truncate">{item.label}</span>
+                    </>
                 )
-                const label = <span className="truncate">{item.label}</span>
-                if (onItemClick) {
-                    return (
-                        <button
-                            key={item.key}
-                            type="button"
-                            className={`${rowClass} cursor-pointer bg-transparent border-0 p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent`}
-                            onClick={() => onItemClick(item.key)}
-                            data-attr={`hog-charts-legend-item-${item.key}`}
-                        >
-                            {swatch}
-                            {label}
-                        </button>
-                    )
-                }
-                return (
-                    <span key={item.key} className={rowClass} data-attr={`hog-charts-legend-item-${item.key}`}>
-                        {swatch}
-                        {label}
+                return onItemClick ? (
+                    <button
+                        key={item.key}
+                        type="button"
+                        className={`${rowClass} cursor-pointer bg-transparent border-0 p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent`}
+                        onClick={() => onItemClick(item.key)}
+                    >
+                        {inner}
+                    </button>
+                ) : (
+                    <span key={item.key} className={rowClass}>
+                        {inner}
                     </span>
                 )
             })}

--- a/frontend/src/lib/hog-charts/components/Legend/Legend.tsx
+++ b/frontend/src/lib/hog-charts/components/Legend/Legend.tsx
@@ -1,0 +1,93 @@
+/* eslint-disable react/forbid-dom-props -- swatch background-color is dynamic per item */
+import React from 'react'
+
+export interface LegendItem {
+    /** Stable identifier — typically matches a `Series.key`. */
+    key: string
+    /** Display text shown next to the swatch. */
+    label: string
+    /** CSS color string for the swatch (hex, rgb, var(--…), etc.). */
+    color: string
+}
+
+export interface LegendProps {
+    items: LegendItem[]
+    /** Layout direction. Defaults to `'horizontal'`. */
+    orientation?: 'horizontal' | 'vertical'
+    /** Main-axis alignment of items within the legend container. Defaults to `'center'`. */
+    align?: 'start' | 'center' | 'end'
+    /** When provided, items render as `<button>` elements that fire this callback with the item's key. */
+    onItemClick?: (key: string) => void
+    /** Item keys that should render dimmed (e.g. hidden / excluded series). */
+    hiddenKeys?: string[]
+    className?: string
+    dataAttr?: string
+}
+
+const ALIGN_CLASS: Record<NonNullable<LegendProps['align']>, string> = {
+    start: 'justify-start',
+    center: 'justify-center',
+    end: 'justify-end',
+}
+
+export function Legend({
+    items,
+    orientation = 'horizontal',
+    align = 'center',
+    onItemClick,
+    hiddenKeys,
+    className,
+    dataAttr,
+}: LegendProps): React.ReactElement | null {
+    if (items.length === 0) {
+        return null
+    }
+    const hidden = hiddenKeys && hiddenKeys.length > 0 ? new Set(hiddenKeys) : null
+    const containerClass = [
+        'flex',
+        orientation === 'horizontal' ? 'flex-row flex-wrap gap-x-3 gap-y-1' : 'flex-col gap-1',
+        ALIGN_CLASS[align],
+        className ?? '',
+    ]
+        .filter(Boolean)
+        .join(' ')
+
+    return (
+        <div className={containerClass} data-attr={dataAttr}>
+            {items.map((item) => {
+                const isHidden = hidden?.has(item.key) ?? false
+                const rowClass = ['inline-flex items-center gap-1.5 text-xs leading-none', isHidden ? 'opacity-40' : '']
+                    .filter(Boolean)
+                    .join(' ')
+                const swatch = (
+                    <span
+                        aria-hidden="true"
+                        className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                        style={{ backgroundColor: item.color }}
+                    />
+                )
+                const label = <span className="truncate">{item.label}</span>
+                if (onItemClick) {
+                    return (
+                        <button
+                            key={item.key}
+                            type="button"
+                            className={`${rowClass} cursor-pointer bg-transparent border-0 p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent`}
+                            onClick={() => onItemClick(item.key)}
+                            data-attr={`hog-charts-legend-item-${item.key}`}
+                        >
+                            {swatch}
+                            {label}
+                        </button>
+                    )
+                }
+                return (
+                    <span key={item.key} className={rowClass} data-attr={`hog-charts-legend-item-${item.key}`}>
+                        {swatch}
+                        {label}
+                    </span>
+                )
+            })}
+        </div>
+    )
+}

--- a/frontend/src/lib/hog-charts/components/Legend/legendItemsFromSeries.test.ts
+++ b/frontend/src/lib/hog-charts/components/Legend/legendItemsFromSeries.test.ts
@@ -1,0 +1,64 @@
+import type { ChartTheme, Series } from '../../core/types'
+import { legendItemsFromSeries } from './legendItemsFromSeries'
+
+const THEME: ChartTheme = { colors: ['#aaa', '#bbb', '#ccc'], backgroundColor: '#fff' }
+
+describe('legendItemsFromSeries', () => {
+    it('returns one item per non-excluded series in input order', () => {
+        const series: Series[] = [
+            { key: 'a', label: 'A', data: [] },
+            { key: 'b', label: 'B', data: [] },
+            { key: 'c', label: 'C', data: [] },
+        ]
+        const items = legendItemsFromSeries(series, THEME)
+        expect(items.map((i) => i.key)).toEqual(['a', 'b', 'c'])
+        expect(items.map((i) => i.label)).toEqual(['A', 'B', 'C'])
+    })
+
+    it('uses series.color when it is set', () => {
+        const series: Series[] = [{ key: 'a', label: 'A', data: [], color: '#123456' }]
+        const [item] = legendItemsFromSeries(series, THEME)
+        expect(item.color).toBe('#123456')
+    })
+
+    it('falls back to theme.colors[i % theme.colors.length] when color is omitted', () => {
+        const series: Series[] = [
+            { key: 'a', label: 'A', data: [] },
+            { key: 'b', label: 'B', data: [] },
+            { key: 'c', label: 'C', data: [] },
+            { key: 'd', label: 'D', data: [] },
+        ]
+        const items = legendItemsFromSeries(series, THEME)
+        expect(items.map((i) => i.color)).toEqual(['#aaa', '#bbb', '#ccc', '#aaa'])
+    })
+
+    it('drops series where visibility.excluded === true', () => {
+        const series: Series[] = [
+            { key: 'a', label: 'A', data: [] },
+            { key: 'b', label: 'B', data: [], visibility: { excluded: true } },
+            { key: 'c', label: 'C', data: [] },
+        ]
+        const items = legendItemsFromSeries(series, THEME)
+        expect(items.map((i) => i.key)).toEqual(['a', 'c'])
+    })
+
+    it('keeps the pre-filter color index stable when a series is excluded', () => {
+        const series: Series[] = [
+            { key: 'a', label: 'A', data: [] },
+            { key: 'b', label: 'B', data: [], visibility: { excluded: true } },
+            { key: 'c', label: 'C', data: [] },
+        ]
+        const items = legendItemsFromSeries(series, THEME)
+        expect(items.find((i) => i.key === 'c')!.color).toBe('#ccc')
+    })
+
+    it('returns an empty array when the input is empty', () => {
+        expect(legendItemsFromSeries([], THEME)).toEqual([])
+    })
+
+    it('falls back to a sentinel color when the theme palette is empty', () => {
+        const series: Series[] = [{ key: 'a', label: 'A', data: [] }]
+        const items = legendItemsFromSeries(series, { colors: [] })
+        expect(items[0].color).toBeTruthy()
+    })
+})

--- a/frontend/src/lib/hog-charts/components/Legend/legendItemsFromSeries.test.ts
+++ b/frontend/src/lib/hog-charts/components/Legend/legendItemsFromSeries.test.ts
@@ -4,35 +4,17 @@ import { legendItemsFromSeries } from './legendItemsFromSeries'
 const THEME: ChartTheme = { colors: ['#aaa', '#bbb', '#ccc'], backgroundColor: '#fff' }
 
 describe('legendItemsFromSeries', () => {
-    it('returns one item per non-excluded series in input order', () => {
+    it('uses series.color when set and falls back to theme.colors[i % len] otherwise', () => {
         const series: Series[] = [
-            { key: 'a', label: 'A', data: [] },
-            { key: 'b', label: 'B', data: [] },
-            { key: 'c', label: 'C', data: [] },
-        ]
-        const items = legendItemsFromSeries(series, THEME)
-        expect(items.map((i) => i.key)).toEqual(['a', 'b', 'c'])
-        expect(items.map((i) => i.label)).toEqual(['A', 'B', 'C'])
-    })
-
-    it('uses series.color when it is set', () => {
-        const series: Series[] = [{ key: 'a', label: 'A', data: [], color: '#123456' }]
-        const [item] = legendItemsFromSeries(series, THEME)
-        expect(item.color).toBe('#123456')
-    })
-
-    it('falls back to theme.colors[i % theme.colors.length] when color is omitted', () => {
-        const series: Series[] = [
-            { key: 'a', label: 'A', data: [] },
+            { key: 'a', label: 'A', data: [], color: '#123' },
             { key: 'b', label: 'B', data: [] },
             { key: 'c', label: 'C', data: [] },
             { key: 'd', label: 'D', data: [] },
         ]
-        const items = legendItemsFromSeries(series, THEME)
-        expect(items.map((i) => i.color)).toEqual(['#aaa', '#bbb', '#ccc', '#aaa'])
+        expect(legendItemsFromSeries(series, THEME).map((i) => i.color)).toEqual(['#123', '#bbb', '#ccc', '#aaa'])
     })
 
-    it('drops series where visibility.excluded === true', () => {
+    it('drops excluded series and keeps the pre-filter color index of the rest', () => {
         const series: Series[] = [
             { key: 'a', label: 'A', data: [] },
             { key: 'b', label: 'B', data: [], visibility: { excluded: true } },
@@ -40,25 +22,6 @@ describe('legendItemsFromSeries', () => {
         ]
         const items = legendItemsFromSeries(series, THEME)
         expect(items.map((i) => i.key)).toEqual(['a', 'c'])
-    })
-
-    it('keeps the pre-filter color index stable when a series is excluded', () => {
-        const series: Series[] = [
-            { key: 'a', label: 'A', data: [] },
-            { key: 'b', label: 'B', data: [], visibility: { excluded: true } },
-            { key: 'c', label: 'C', data: [] },
-        ]
-        const items = legendItemsFromSeries(series, THEME)
         expect(items.find((i) => i.key === 'c')!.color).toBe('#ccc')
-    })
-
-    it('returns an empty array when the input is empty', () => {
-        expect(legendItemsFromSeries([], THEME)).toEqual([])
-    })
-
-    it('falls back to a sentinel color when the theme palette is empty', () => {
-        const series: Series[] = [{ key: 'a', label: 'A', data: [] }]
-        const items = legendItemsFromSeries(series, { colors: [] })
-        expect(items[0].color).toBeTruthy()
     })
 })

--- a/frontend/src/lib/hog-charts/components/Legend/legendItemsFromSeries.ts
+++ b/frontend/src/lib/hog-charts/components/Legend/legendItemsFromSeries.ts
@@ -1,13 +1,6 @@
 import type { ChartTheme, ResolvedSeries, Series } from '../../core/types'
 import type { LegendItem } from './Legend'
 
-/** Map a `Series[]` (or `ResolvedSeries[]`) to `LegendItem[]` using the chart's color-fallback rule.
- *
- *  - Uses `series.color` when set, otherwise picks `theme.colors[index % theme.colors.length]`.
- *  - Drops series with `visibility.excluded === true` — those don't render anywhere in the chart.
- *  - Preserves the input order; the index used for the color fallback is the pre-filter index so
- *    a series' color stays stable regardless of which others are excluded.
- */
 export function legendItemsFromSeries(series: ReadonlyArray<Series | ResolvedSeries>, theme: ChartTheme): LegendItem[] {
     const palette = theme.colors
     const items: LegendItem[] = []
@@ -17,11 +10,7 @@ export function legendItemsFromSeries(series: ReadonlyArray<Series | ResolvedSer
             continue
         }
         const fallback = palette.length > 0 ? palette[i % palette.length] : '#000'
-        items.push({
-            key: s.key,
-            label: s.label,
-            color: s.color ?? fallback,
-        })
+        items.push({ key: s.key, label: s.label, color: s.color ?? fallback })
     }
     return items
 }

--- a/frontend/src/lib/hog-charts/components/Legend/legendItemsFromSeries.ts
+++ b/frontend/src/lib/hog-charts/components/Legend/legendItemsFromSeries.ts
@@ -1,0 +1,27 @@
+import type { ChartTheme, ResolvedSeries, Series } from '../../core/types'
+import type { LegendItem } from './Legend'
+
+/** Map a `Series[]` (or `ResolvedSeries[]`) to `LegendItem[]` using the chart's color-fallback rule.
+ *
+ *  - Uses `series.color` when set, otherwise picks `theme.colors[index % theme.colors.length]`.
+ *  - Drops series with `visibility.excluded === true` — those don't render anywhere in the chart.
+ *  - Preserves the input order; the index used for the color fallback is the pre-filter index so
+ *    a series' color stays stable regardless of which others are excluded.
+ */
+export function legendItemsFromSeries(series: ReadonlyArray<Series | ResolvedSeries>, theme: ChartTheme): LegendItem[] {
+    const palette = theme.colors
+    const items: LegendItem[] = []
+    for (let i = 0; i < series.length; i++) {
+        const s = series[i]
+        if (s.visibility?.excluded) {
+            continue
+        }
+        const fallback = palette.length > 0 ? palette[i % palette.length] : '#000'
+        items.push({
+            key: s.key,
+            label: s.label,
+            color: s.color ?? fallback,
+        })
+    }
+    return items
+}

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -113,3 +113,10 @@ export type { GoalLineConfig } from './utils/goal-lines'
 
 // Statistics helpers (used by trend-line / moving-average / confidence-interval features)
 export { ciRanges, linearRegression, movingAverage, trendLine } from './utils/statistics'
+
+// Generic UI primitives (no canvas) — composed alongside charts by adapters
+export { Legend } from './components/Legend/Legend'
+export type { LegendItem, LegendProps } from './components/Legend/Legend'
+export { ChartLegendLayout } from './components/Legend/ChartLegendLayout'
+export type { ChartLegendLayoutProps } from './components/Legend/ChartLegendLayout'
+export { legendItemsFromSeries } from './components/Legend/legendItemsFromSeries'


### PR DESCRIPTION
## Problem

The hog-charts library exposes chart primitives, but adapters that need a colored swatch + label row next to a chart (e.g. the lifecycle chart) have to roll their own. The legacy Chart.js version of the lifecycle chart had this — the hog-charts version doesn't.

This PR adds the primitives only. Wiring them into the lifecycle adapter (or any other product adapter) is a follow-up.

## Changes

- `Legend` — a small presentational component rendering rows of colored swatch + label. `orientation` defaults to `'horizontal'` with `flex-wrap` for multi-row breakdown legends; `'vertical'` stacks rows. `align` controls main-axis alignment. When `onItemClick` is set, each row renders as a `<button>` with focus styles; otherwise rows render as `<span>`s. `hiddenKeys` dims matching rows.
- `ChartLegendLayout` — a thin flex wrapper that places a legend on the `top` / `bottom` / `left` / `right` of a chart with configurable cross-axis `align` and pixel `gap`. The chart slot keeps `flex: 1` with `min-width: 0 / min-height: 0` so it continues to fill the remaining space. A falsy `legend` prop omits the slot entirely.
- `legendItemsFromSeries` — pure helper that maps `Series[]` (or `ResolvedSeries[]`) plus a `ChartTheme` to `LegendItem[]`, using the chart's own color fallback (`series.color ?? theme.colors[i % len]`) and dropping `visibility.excluded` series. Pre-filter index keeps a series' color stable regardless of which others are excluded.
- Barrel exports updated in `lib/hog-charts/index.ts`.

Constraints enforced: no `kea`, no `posthog-js`, no `lib/lemon-ui`, no canvas overlay — these are MCP-bundle-safe primitives. `Legend` and `ChartLegendLayout` deliberately know nothing about charts; the chart position concern lives in the wrapper.

## How did you test this code?

I'm an agent. Only automated checks were run:

- `pnpm jest --testPathPattern=hog-charts --no-coverage` — full hog-charts suite: 1082 tests pass (1071 prior + 11 new).
- `pnpm exec oxlint src/lib/hog-charts/components/Legend/` — 0 warnings.
- `pnpm exec oxfmt --check` on the new files and `index.ts` — clean.
- `pnpm exec tsgo --noEmit -p tsconfig.json` — no errors attributable to the new files or the updated `index.ts`.
- Storybook entries were added (`Legend.stories.tsx`) but were not manually screenshot-tested; reviewer should sanity-check them.

## Publish to changelog?

no

## Docs update

No docs change — internal library primitive, not a user-facing surface.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) from a self-contained prompt that referenced an internal plan doc. The prompt forbade touching product adapters, so this PR is purely the library-side primitive plus the adapter helper and layout wrapper.

Design decisions worth flagging for review:

- `Legend` returns `null` for an empty `items` array rather than an empty `<div>`, matching the prompt and avoiding stray container styles.
- `ChartLegendLayout` does not mutate the legend's `orientation`. The adapter is expected to pass a horizontally-oriented legend for top/bottom and a vertical one for left/right — keeps the wrapper dumb and avoids surprising the caller.
- `legendItemsFromSeries` uses the pre-filter index for color fallback so a series' color doesn't shift when another series is excluded — the prompt only required preserving input order, but stable color assignment matches the chart's own behavior.
- Test files include an import-statement smoke check that confirms `Legend.tsx` doesn't pull in `kea`, `posthog-js`, `lib/lemon-ui`, or `scenes/*` — this guards the MCP-bundle constraint at PR time without needing extra CI wiring.