### PR TITLE
feat(settings): clarify restricted org switch tooltips

### DIFF
--- a/frontend/src/scenes/settings/organization/OrgAI.tsx
+++ b/frontend/src/scenes/settings/organization/OrgAI.tsx
@@ -6,6 +6,8 @@ import { useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { organizationLogic } from 'scenes/organizationLogic'
 
+import { ORG_ADMIN_REQUIRED_TOOLTIP } from './organizationSettingsConstants'
+
 export function OrganizationAI(): JSX.Element {
     const { currentOrganization, currentOrganizationLoading } = useValues(organizationLogic)
     const { updateOrganization } = useActions(organizationLogic)
@@ -21,11 +23,7 @@ export function OrganizationAI(): JSX.Element {
                     updateOrganization({ is_ai_data_processing_approved: checked })
                 }}
                 checked={!!currentOrganization?.is_ai_data_processing_approved}
-                disabledReason={
-                    restrictionReason
-                        ? 'You must be an admin or owner of your organization to change this setting'
-                        : undefined
-                }
+                disabledReason={restrictionReason ? ORG_ADMIN_REQUIRED_TOOLTIP : undefined}
                 loading={currentOrganizationLoading}
                 bordered
             />

--- a/frontend/src/scenes/settings/organization/OrgAI.tsx
+++ b/frontend/src/scenes/settings/organization/OrgAI.tsx
@@ -21,7 +21,11 @@ export function OrganizationAI(): JSX.Element {
                     updateOrganization({ is_ai_data_processing_approved: checked })
                 }}
                 checked={!!currentOrganization?.is_ai_data_processing_approved}
-                disabledReason={restrictionReason || undefined}
+                disabledReason={
+                    restrictionReason
+                        ? 'You must be an admin or owner of your organization to change this setting'
+                        : undefined
+                }
                 loading={currentOrganizationLoading}
                 bordered
             />

--- a/frontend/src/scenes/settings/organization/OrgAITraining.tsx
+++ b/frontend/src/scenes/settings/organization/OrgAITraining.tsx
@@ -8,6 +8,7 @@ import { OrganizationMembershipLevel } from 'lib/constants'
 import { organizationLogic } from 'scenes/organizationLogic'
 
 import { AI_TRAINING_URL } from './aiTrainingConstants'
+import { ORG_ADMIN_REQUIRED_TOOLTIP } from './organizationSettingsConstants'
 
 function AITrainingDescription({ isHipaa, isLocked }: { isHipaa: boolean; isLocked: boolean }): JSX.Element {
     if (isHipaa) {
@@ -51,7 +52,7 @@ export function OrganizationAITrainingOptOut(): JSX.Element {
         : isLocked
           ? 'Please contact us to change this setting.'
           : restrictionReason
-            ? 'You must be an admin or owner of your organization to change this setting'
+            ? ORG_ADMIN_REQUIRED_TOOLTIP
             : undefined
 
     const checked = !isHipaa && !!currentOrganization?.is_ai_training_opted_in

--- a/frontend/src/scenes/settings/organization/OrgAITraining.tsx
+++ b/frontend/src/scenes/settings/organization/OrgAITraining.tsx
@@ -50,7 +50,9 @@ export function OrganizationAITrainingOptOut(): JSX.Element {
         ? 'HIPAA organizations are always opted out of AI training. Please contact us if this needs to change.'
         : isLocked
           ? 'Please contact us to change this setting.'
-          : restrictionReason || undefined
+          : restrictionReason
+            ? 'You must be an admin or owner of your organization to change this setting'
+            : undefined
 
     const checked = !isHipaa && !!currentOrganization?.is_ai_training_opted_in
 

--- a/frontend/src/scenes/settings/organization/OrgIPAnonymizationDefault.tsx
+++ b/frontend/src/scenes/settings/organization/OrgIPAnonymizationDefault.tsx
@@ -21,7 +21,11 @@ export function OrgIPAnonymizationDefault(): JSX.Element {
                 updateOrganization({ default_anonymize_ips: checked })
             }}
             checked={!!currentOrganization?.default_anonymize_ips}
-            disabledReason={restrictionReason || undefined}
+            disabledReason={
+                restrictionReason
+                    ? 'You must be an admin or owner of your organization to change this setting'
+                    : undefined
+            }
             loading={currentOrganizationLoading}
             label="Discard client IP data by default for new projects"
             bordered

--- a/frontend/src/scenes/settings/organization/OrgIPAnonymizationDefault.tsx
+++ b/frontend/src/scenes/settings/organization/OrgIPAnonymizationDefault.tsx
@@ -7,6 +7,8 @@ import { OrganizationMembershipLevel } from 'lib/constants'
 
 import { organizationLogic } from '~/scenes/organizationLogic'
 
+import { ORG_ADMIN_REQUIRED_TOOLTIP } from './organizationSettingsConstants'
+
 export function OrgIPAnonymizationDefault(): JSX.Element {
     const { currentOrganization, currentOrganizationLoading } = useValues(organizationLogic)
     const { updateOrganization } = useActions(organizationLogic)
@@ -21,11 +23,7 @@ export function OrgIPAnonymizationDefault(): JSX.Element {
                 updateOrganization({ default_anonymize_ips: checked })
             }}
             checked={!!currentOrganization?.default_anonymize_ips}
-            disabledReason={
-                restrictionReason
-                    ? 'You must be an admin or owner of your organization to change this setting'
-                    : undefined
-            }
+            disabledReason={restrictionReason ? ORG_ADMIN_REQUIRED_TOOLTIP : undefined}
             loading={currentOrganizationLoading}
             label="Discard client IP data by default for new projects"
             bordered

--- a/frontend/src/scenes/settings/organization/organizationSettingsConstants.ts
+++ b/frontend/src/scenes/settings/organization/organizationSettingsConstants.ts
@@ -1,0 +1,2 @@
+export const ORG_ADMIN_REQUIRED_TOOLTIP =
+    'You must be an admin or owner of your organization to change this setting'

--- a/frontend/src/scenes/settings/organization/organizationSettingsConstants.ts
+++ b/frontend/src/scenes/settings/organization/organizationSettingsConstants.ts
@@ -1,2 +1,1 @@
-export const ORG_ADMIN_REQUIRED_TOOLTIP =
-    'You must be an admin or owner of your organization to change this setting'
+export const ORG_ADMIN_REQUIRED_TOOLTIP = 'You must be an admin or owner of your organization to change this setting'


### PR DESCRIPTION
## Problem

On `/settings/organization-details`, the org-level toggles — **Enable AI training on anonymized data**, **Discard client IP data by default for new projects**, and **Enable PostHog features that use third-party AI services** — are disabled for users below Admin level, but the tooltip explaining *why* used the generic `useRestrictedArea` message ("This area is restricted to organization admins and up. Your level is …"), which doesn't directly tell members what they can do about it.

## Changes

When the switch is disabled because the user lacks the required Admin/Owner access level, show a clearer tooltip: **"You must be an admin or owner of your organization to change this setting"**.

- `OrgAI.tsx` — third-party AI services toggle
- `OrgAITraining.tsx` — AI training opt-in toggle (HIPAA and contract-locked messages are preserved; only the access-level fallback is replaced)
- `OrgIPAnonymizationDefault.tsx` — default IP anonymization toggle

No backend or schema changes.

## How did you test this code?

I'm an agent. I did not run the dev server or the test suite. The change is a literal swap of the `disabledReason` string the `LemonSwitch` already shows as a tooltip when the user's `useRestrictedArea` check returns a restriction reason, so the rendering path is unchanged.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). The user asked to add a tooltip with the exact text "You must be an admin or owner of your organization to change this setting" to the three switches on the org settings page. I located the three components, confirmed they already pipe `useRestrictedArea(...)` into `LemonSwitch.disabledReason` (which renders as a tooltip on hover when the control is disabled), and replaced the generic message with the requested copy. For `OrgAITraining.tsx` I kept the existing HIPAA and contract-locked messages and only replaced the access-level fallback, so those flows still read correctly.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*