### PR TITLE
feat(cdp): always show reconnect button on integrations

### DIFF
--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { IconTrash } from '@posthog/icons'
+import { IconRefresh, IconTrash } from '@posthog/icons'
 import { LemonBanner, LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
@@ -48,6 +48,18 @@ export function IntegrationView({
 
     suffix = suffix || (
         <div className="flex flex-row gap-2">
+            <LemonButton
+                type="secondary"
+                to={api.integrations.authorizeUrl({
+                    kind: integration.kind,
+                    next: window.location.pathname,
+                })}
+                disableClientSideRouting
+                icon={<IconRefresh />}
+                disabledReason={restrictedReason}
+            >
+                Reconnect
+            </LemonButton>
             <LemonButton
                 type="secondary"
                 status="danger"


### PR DESCRIPTION
## Problem

The "Reconnect" button on the integrations settings page only renders when one of two conditions is true:

1. The integration's `errors` field is non-empty — only ever set to `TOKEN_REFRESH_FAILED`, which requires a refresh-token flow.
2. The `IntegrationScopesWarning` component detects missing scopes, which requires the parent to pass a `schema={{ requiredScopes }}` prop.

For Slack, Slack bot tokens granted via OAuth v2 do not expire (so the first condition is never met) and `SlackIntegration.tsx` calls `IntegrationView` without a `schema` (so the second is also never met). The button never appears, so users with a broken or rotated Slack workspace have no way to re-auth without disconnecting and rebuilding every hog function / subscription / destination referencing the integration `id`.

The backend reconnect path already handles this correctly — `Integration.objects.update_or_create` is keyed on `(team_id, kind, integration_id)` (Slack's `integration_id` is the stable workspace ID from `team.id`), so re-running the OAuth authorize flow updates the existing row in place and preserves the primary key. Downstream references stay intact. This is purely a UI gap.

Closes #41745

## Changes

Add an always-visible "Reconnect" button next to "Disconnect" in the default `suffix` of `IntegrationView`. It points at the same `api.integrations.authorizeUrl({ kind, next })` URL the existing error-banner button uses and is gated by the same `useRestrictedArea` admin check.

Because `IntegrationView` is rendered by every provider's settings panel, every OAuth provider (Slack, Salesforce, Hubspot, Google, LinkedIn, Snapchat, Intercom, Twilio, GitHub) picks up the button automatically.

## How did you test this code?

I'm an agent — no manual UI testing was performed. No automated tests were added or run for this change. A reviewer should verify in the integrations settings page that:

- The Reconnect button renders next to Disconnect for Slack (the original gap).
- Clicking it sends the user through the OAuth authorize flow and returns them to the same settings page.
- After reconnect, the integration row's `id` is unchanged (downstream destinations still work).
- Non-admins see the button disabled with the existing restricted-area reason.
- Providers that already showed Reconnect via the error banner still surface the existing banner; the new button is additive.

## Publish to changelog?

no

## Docs update

No docs change required.

## 🤖 Agent context

Agent-authored via PostHog Code (Slack origin).

Investigation path:

1. Confirmed the backend reconnect flow preserves the integration `id` for every OAuth provider — `OauthIntegration.integration_from_oauth_response` in `posthog/models/integration.py` calls `Integration.objects.update_or_create(team_id, kind, integration_id, defaults={...})`, and Slack uses `id_path="team.id"` so the lookup hits the existing row.
2. Traced why the Reconnect UI wasn't visible for Slack — the two render paths in `IntegrationView.tsx` and `IntegrationScopesWarning.tsx` both have preconditions Slack never satisfies (no refresh-token flow, no `schema` prop from `SlackIntegration.tsx`).
3. Considered alternative fixes (pass `requiredScopes` to `IntegrationView` from `SlackIntegration.tsx`, or special-case Slack in the warning component). Rejected both — the user's stated preference was an unconditional button, and a single change in the shared component benefits every provider uniformly rather than fixing only Slack.

No backend changes were needed because `update_or_create` already does the right thing.