### PR TITLE
feat(subscriptions): order slack channels by recent subscription history

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1320,6 +1320,14 @@ snapshots:
         hash: v1.k794b7964.51cbbaf0fc021a2b1b6a958c86aac9552cf416284578013cebf588db847744a3.-kTEDvju2zH1YGEuPTb6FOtlGQ1PcoXOYuIrIaPAK7o
     components-sharing--recording-sharing-licensed--light:
         hash: v1.k794b7964.346704155419478fe5d7a4f91c20f581582cdc7a0f171da6a248bd88b7cce13c.FBW3MvZx9uaB72cb_zINeWYmxxkiOxhb8OpKfHXBuVE
+    components-slack-channel-picker--alphabetical--dark:
+        hash: v1.k794b7964.c5f45d681dad559cdf8bed1c8e9d31c5dca4d0973e1fbf5d1515ab30c393b554.SYg7auYBsl2kTK9lzMylWzKKRJ9Bf3sT0lwtvlfXx24
+    components-slack-channel-picker--alphabetical--light:
+        hash: v1.k794b7964.726967267332758d5771d2230a569cf7a29bdb38d1244aeb8dcacd86f25f433e.n9EALYKR_pt88G2ZCdyZ4V12Br9qoNbP3w7j2bNQ0Wk
+    components-slack-channel-picker--recently-subscribed-first--dark:
+        hash: v1.k794b7964.de1b275c97b6eac538ac35f64bf4cf3ec79f224cf500d0078f748c063eb83601.qqYmyCsR4ryfUqltT9sX9UikOHaAkMvWoWGDrQZ164s
+    components-slack-channel-picker--recently-subscribed-first--light:
+        hash: v1.k794b7964.54bc88c73e7d32bbab8a32b91162eab1fb1ba78215aa188aa748b65b9fb531b8.YkOXS4kFGcgECAArUGil25uNoJVbhGKe_zYYmpzzu44
     components-sparkline--bar-chart--dark:
         hash: v1.k794b7964.cb1d1d3239f78521823c1278cadb102e136422579a910c3a691c2b6b17ebb962.aj9xFX3wR7NQKuqnk4Tgypbsd2Ase4rHeCGuKjORB3w
     components-sparkline--bar-chart--light:
@@ -4895,7 +4903,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.gaL7vRk-pWoOUkiPi-NGCd1W72x-M5l9jk5Qu-UcjwI
+        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
@@ -2,7 +2,7 @@ import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { ApiError } from 'lib/api'
-import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
+import { getRecentSlackChannelIds } from 'lib/integrations/slackChannel'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
 import { useMocks } from '~/mocks/jest'
@@ -146,9 +146,6 @@ describe('subscriptionLogic', () => {
     })
 
     it('records the channel as recently subscribed when a slack subscription is saved', async () => {
-        const slackLogic = slackIntegrationLogic({ id: 7 })
-        slackLogic.mount()
-
         await expectLogic(newLogic, () => {
             newLogic.actions.submitSubscriptionSuccess({
                 target_type: 'slack',
@@ -157,14 +154,10 @@ describe('subscriptionLogic', () => {
             } as SubscriptionType)
         }).toFinishListeners()
 
-        expect(slackLogic.values.recentlySubscribedChannelIds).toEqual(['C123'])
-        slackLogic.unmount()
+        expect(getRecentSlackChannelIds(7)).toEqual(['C123'])
     })
 
     it('does not record anything for non-slack target types', async () => {
-        const slackLogic = slackIntegrationLogic({ id: 7 })
-        slackLogic.mount()
-
         await expectLogic(newLogic, () => {
             newLogic.actions.submitSubscriptionSuccess({
                 target_type: 'email',
@@ -173,7 +166,6 @@ describe('subscriptionLogic', () => {
             } as SubscriptionType)
         }).toFinishListeners()
 
-        expect(slackLogic.values.recentlySubscribedChannelIds).toEqual([])
-        slackLogic.unmount()
+        expect(getRecentSlackChannelIds(7)).toEqual([])
     })
 })

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
@@ -145,27 +145,18 @@ describe('subscriptionLogic', () => {
         })
     })
 
-    it('records the channel as recently subscribed when a slack subscription is saved', async () => {
+    it.each<[string, Partial<SubscriptionType>, string[]]>([
+        ['a slack subscription', { target_type: 'slack', target_value: 'C123|#general', integration_id: 7 }, ['C123']],
+        [
+            'a non-slack target type',
+            { target_type: 'email', target_value: 'ben@posthog.com', integration_id: null },
+            [],
+        ],
+    ])('records the channel recency for %s', async (_label, subscription, expectedIds) => {
         await expectLogic(newLogic, () => {
-            newLogic.actions.submitSubscriptionSuccess({
-                target_type: 'slack',
-                target_value: 'C123|#general',
-                integration_id: 7,
-            } as SubscriptionType)
+            newLogic.actions.submitSubscriptionSuccess(subscription as SubscriptionType)
         }).toFinishListeners()
 
-        expect(getRecentSlackChannelIds(7)).toEqual(['C123'])
-    })
-
-    it('does not record anything for non-slack target types', async () => {
-        await expectLogic(newLogic, () => {
-            newLogic.actions.submitSubscriptionSuccess({
-                target_type: 'email',
-                target_value: 'ben@posthog.com',
-                integration_id: null,
-            } as SubscriptionType)
-        }).toFinishListeners()
-
-        expect(getRecentSlackChannelIds(7)).toEqual([])
+        expect(getRecentSlackChannelIds(7)).toEqual(expectedIds)
     })
 })

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
@@ -2,6 +2,7 @@ import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { ApiError } from 'lib/api'
+import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
 import { useMocks } from '~/mocks/jest'
@@ -38,11 +39,21 @@ describe('subscriptionLogic', () => {
     let existingLogic: ReturnType<typeof subscriptionLogic.build>
     beforeEach(async () => {
         jest.clearAllMocks()
+        window.localStorage.clear()
         useMocks({
             get: {
                 '/api/environments/:team/subscriptions': { count: 1, results: [fixtureSubscriptionResponse(1)] },
                 '/api/environments/:team/subscriptions/1': fixtureSubscriptionResponse(1),
                 '/api/projects/:team/integrations': { count: 0, results: [] },
+                '/api/environments/:team/subscriptions/summary_quota': {
+                    active_count: 0,
+                    limit: null,
+                    at_limit: false,
+                },
+            },
+            post: {
+                '/api/environments/:team/subscriptions': (req, res, ctx) =>
+                    res(ctx.json({ id: 42, ...(req.body as Partial<SubscriptionType>) } as SubscriptionType)),
             },
         })
         initKeaTests()
@@ -56,6 +67,10 @@ describe('subscriptionLogic', () => {
         })
         newLogic.mount()
         existingLogic.mount()
+    })
+
+    afterEach(() => {
+        window.localStorage.clear()
     })
 
     it('loads existing subscription', async () => {
@@ -128,5 +143,37 @@ describe('subscriptionLogic', () => {
         expect(newLogic.values.subscriptionManualErrors).toEqual({
             dashboard_export_insights: 'Select at least one insight',
         })
+    })
+
+    it('records the channel as recently subscribed when a slack subscription is saved', async () => {
+        const slackLogic = slackIntegrationLogic({ id: 7 })
+        slackLogic.mount()
+
+        await expectLogic(newLogic, () => {
+            newLogic.actions.submitSubscriptionSuccess({
+                target_type: 'slack',
+                target_value: 'C123|#general',
+                integration_id: 7,
+            } as SubscriptionType)
+        }).toFinishListeners()
+
+        expect(slackLogic.values.recentlySubscribedChannelIds).toEqual(['C123'])
+        slackLogic.unmount()
+    })
+
+    it('does not record anything for non-slack target types', async () => {
+        const slackLogic = slackIntegrationLogic({ id: 7 })
+        slackLogic.mount()
+
+        await expectLogic(newLogic, () => {
+            newLogic.actions.submitSubscriptionSuccess({
+                target_type: 'email',
+                target_value: 'ben@posthog.com',
+                integration_id: null,
+            } as SubscriptionType)
+        }).toFinishListeners()
+
+        expect(slackLogic.values.recentlySubscribedChannelIds).toEqual([])
+        slackLogic.unmount()
     })
 })

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
@@ -5,6 +5,7 @@ import { beforeUnload, router, urlToAction } from 'kea-router'
 
 import api, { ApiError } from 'lib/api'
 import { dayjs } from 'lib/dayjs'
+import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { isEmail, isURL } from 'lib/utils'
 import { getInsightId } from 'scenes/insights/utils'
@@ -177,6 +178,18 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
     })),
 
     listeners(({ actions, values, props }) => ({
+        submitSubscriptionSuccess: ({ subscription }) => {
+            if (subscription?.target_type === 'slack' && subscription.target_value && subscription.integration_id) {
+                const channelId = subscription.target_value.split('|')[0]
+                if (channelId) {
+                    // Mount briefly so the persisted reducer captures the recency even if the picker has already unmounted.
+                    const logic = slackIntegrationLogic({ id: subscription.integration_id })
+                    const unmount = logic.mount()
+                    logic.actions.recordSubscribedChannel(channelId)
+                    unmount()
+                }
+            }
+        },
         submitSubscriptionFailure: ({ error }) => {
             // Kea-forms emits this when client validation fails; fields already show errors.
             if (error instanceof Error && error.message === 'Validation Failed') {

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
@@ -5,7 +5,7 @@ import { beforeUnload, router, urlToAction } from 'kea-router'
 
 import api, { ApiError } from 'lib/api'
 import { dayjs } from 'lib/dayjs'
-import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
+import { recordRecentSlackChannel, slackChannelId } from 'lib/integrations/slackChannel'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { isEmail, isURL } from 'lib/utils'
 import { getInsightId } from 'scenes/insights/utils'
@@ -180,14 +180,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
     listeners(({ actions, values, props }) => ({
         submitSubscriptionSuccess: ({ subscription }) => {
             if (subscription?.target_type === 'slack' && subscription.target_value && subscription.integration_id) {
-                const channelId = subscription.target_value.split('|')[0]
-                if (channelId) {
-                    // Mount briefly so the persisted reducer captures the recency even if the picker has already unmounted.
-                    const logic = slackIntegrationLogic({ id: subscription.integration_id })
-                    const unmount = logic.mount()
-                    logic.actions.recordSubscribedChannel(channelId)
-                    unmount()
-                }
+                recordRecentSlackChannel(subscription.integration_id, slackChannelId(subscription.target_value))
             }
         },
         submitSubscriptionFailure: ({ error }) => {

--- a/frontend/src/lib/integrations/SlackChannelPicker.stories.tsx
+++ b/frontend/src/lib/integrations/SlackChannelPicker.stories.tsx
@@ -1,0 +1,101 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { LemonTag } from '@posthog/lemon-ui'
+
+import { useStorybookMocks } from '~/mocks/browser'
+import { mockIntegration } from '~/test/mocks'
+import { SlackChannelType } from '~/types'
+
+import { recordRecentSlackChannel } from './slackChannel'
+import { SlackChannelPicker } from './SlackIntegrationHelpers'
+import { slackIntegrationLogic } from './slackIntegrationLogic'
+
+const integration = mockIntegration
+
+const channel = (id: string, name: string): SlackChannelType => ({
+    id,
+    name,
+    is_private: false,
+    is_ext_shared: false,
+    is_member: true,
+    is_private_without_access: false,
+})
+
+const channels: SlackChannelType[] = [
+    channel('C1', 'alerts'),
+    channel('C2', 'announcements'),
+    channel('C3', 'deploys'),
+    channel('C4', 'general'),
+    channel('C5', 'incidents'),
+    channel('C6', 'random'),
+]
+
+// `recentlySubscribedChannelIds` read top-to-bottom: index 0 is the most-recently subscribed.
+function OrderingScene({ recentlySubscribedChannelIds }: { recentlySubscribedChannelIds: string[] }): JSX.Element {
+    const logic = slackIntegrationLogic({ id: integration.id })
+    const { slackChannelsForPicker } = useValues(logic)
+    const { loadAllSlackChannels } = useActions(logic)
+
+    useEffect(() => {
+        window.localStorage.clear()
+        // Record oldest first so the most-recent ends up at the front of the store.
+        ;[...recentlySubscribedChannelIds].reverse().forEach((id) => recordRecentSlackChannel(integration.id, id))
+        loadAllSlackChannels()
+        return () => window.localStorage.clear()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    const recent = new Set(recentlySubscribedChannelIds)
+
+    return (
+        <div className="p-4 max-w-md deprecated-space-y-4">
+            <div>
+                <h4>Picker</h4>
+                <SlackChannelPicker integration={integration} onChange={() => {}} />
+            </div>
+            <div>
+                <h4>Order shown in the dropdown</h4>
+                <ol className="deprecated-space-y-1 pl-4">
+                    {slackChannelsForPicker.map((c) => (
+                        <li key={c.id} className="flex items-center justify-between gap-2">
+                            <span>#{c.name}</span>
+                            {recent.has(c.id) ? <LemonTag type="highlight">recents</LemonTag> : null}
+                        </li>
+                    ))}
+                </ol>
+            </div>
+        </div>
+    )
+}
+
+type StoryArgs = { recentlySubscribedChannelIds: string[] }
+
+const meta: Meta<StoryArgs> = {
+    title: 'Components/Slack channel picker',
+    parameters: { layout: 'fullscreen', viewMode: 'story' },
+    render: ({ recentlySubscribedChannelIds }) => {
+        useStorybookMocks({
+            get: {
+                '/api/projects/:id/integrations/:intId/channels': { channels },
+                '/api/environments/:id/integrations/:intId/channels': { channels },
+            },
+        })
+        return <OrderingScene recentlySubscribedChannelIds={recentlySubscribedChannelIds} />
+    },
+}
+export default meta
+
+type Story = StoryObj<StoryArgs>
+
+// No recency recorded yet — channels fall back to plain alphabetical order.
+export const Alphabetical: Story = {
+    args: { recentlySubscribedChannelIds: [] },
+}
+
+// "general" then "alerts" were the last two channels subscribed, so they float to the top
+// (most recent first); everything else stays alphabetical below them.
+export const RecentlySubscribedFirst: Story = {
+    args: { recentlySubscribedChannelIds: ['C4', 'C1'] },
+}

--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -16,6 +16,7 @@ import { IconSlackExternal } from 'lib/lemon-ui/icons'
 
 import { IntegrationType, SlackChannelType } from '~/types'
 
+import { slackChannelId } from './slackChannel'
 import { slackIntegrationLogic } from './slackIntegrationLogic'
 
 export function SlackNotConfiguredBanner(): JSX.Element {
@@ -79,6 +80,7 @@ export type SlackChannelPickerProps = {
 export function SlackChannelPicker({ onChange, value, integration, disabled }: SlackChannelPickerProps): JSX.Element {
     const {
         slackChannels,
+        slackChannelsForPicker,
         allSlackChannels,
         allSlackChannelsLoading,
         slackChannelByIdLoading,
@@ -94,12 +96,15 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
     usePeriodicRerender(channelRefreshButtonDisabledReason ? 1000 : 60_000)
 
     // If slackChannels aren't loaded, make sure we display only the channel name and not the actual underlying value
-    const rawSlackChannelOptions = useMemo(() => getSlackChannelOptions(slackChannels), [slackChannels])
+    const rawSlackChannelOptions = useMemo(
+        () => getSlackChannelOptions(slackChannelsForPicker),
+        [slackChannelsForPicker]
+    )
 
     const slackChannelOptions = (): LemonInputSelectOption[] | null => {
         return rawSlackChannelOptions
             ? rawSlackChannelOptions.filter((x) => {
-                  const [id] = x.key.split('|#')
+                  const id = slackChannelId(x.key)
                   // Only show a private channel if searching for the exact channelId or it's currently selected
                   return !isPrivateChannelWithoutAccess(id) || id === value || id === localValue
               })

--- a/frontend/src/lib/integrations/slackChannel.ts
+++ b/frontend/src/lib/integrations/slackChannel.ts
@@ -1,0 +1,46 @@
+import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
+
+export const RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT = 20
+
+// Slack channel picker values are encoded as `${channelId}|#${channelName}`; callers only ever need the id half.
+export function slackChannelId(channelValue: string): string {
+    return channelValue.split('|')[0]
+}
+
+function storageKey(integrationId: number): string | null {
+    const teamId = getCurrentTeamIdOrNone()
+    if (teamId == null) {
+        return null
+    }
+    return `ph-recent-slack-channels__${teamId}__${integrationId}`
+}
+
+export function getRecentSlackChannelIds(integrationId: number): string[] {
+    const key = storageKey(integrationId)
+    if (!key) {
+        return []
+    }
+    try {
+        const stored = window.localStorage.getItem(key)
+        const parsed = stored ? JSON.parse(stored) : []
+        return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []
+    } catch {
+        return []
+    }
+}
+
+export function recordRecentSlackChannel(integrationId: number, channelId: string): void {
+    const key = storageKey(integrationId)
+    if (!key || !channelId) {
+        return
+    }
+    const next = [channelId, ...getRecentSlackChannelIds(integrationId).filter((id) => id !== channelId)].slice(
+        0,
+        RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT
+    )
+    try {
+        window.localStorage.setItem(key, JSON.stringify(next))
+    } catch {
+        // localStorage may be unavailable (quota, privacy mode); recency is best-effort
+    }
+}

--- a/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
@@ -253,9 +253,7 @@ describe('slackIntegrationLogic — recently subscribed channels', () => {
             for (let i = 0; i < RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT + 5; i++) {
                 logic.actions.recordSubscribedChannel(`C${i}`)
             }
-        }).toMatchValues({
-            recentlySubscribedChannelIds: expect.arrayContaining([]),
-        })
+        }).toFinishListeners()
         expect(logic.values.recentlySubscribedChannelIds).toHaveLength(RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT)
         expect(logic.values.recentlySubscribedChannelIds[0]).toBe(`C${RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT + 4}`)
         expect(logic.values.recentlySubscribedChannelIds).not.toContain('C0')

--- a/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
@@ -7,10 +7,11 @@ import { initKeaTests } from '~/test/init'
 import { SlackChannelType } from '~/types'
 
 import {
+    getRecentSlackChannelIds,
     RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT,
-    SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS,
-    slackIntegrationLogic,
-} from './slackIntegrationLogic'
+    recordRecentSlackChannel,
+} from './slackChannel'
+import { SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS, slackIntegrationLogic } from './slackIntegrationLogic'
 
 const FIXED_NOW = new Date('2026-01-01T12:00:00Z')
 
@@ -179,7 +180,53 @@ const fixtureChannel = (id: string, name: string, extra: Partial<SlackChannelTyp
     ...extra,
 })
 
-describe('slackIntegrationLogic — recently subscribed channels', () => {
+describe('recentSlackChannels store', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    afterEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('prepends, deduplicates, and moves an already-recorded channel back to the top', () => {
+        recordRecentSlackChannel(1, 'C1')
+        recordRecentSlackChannel(1, 'C2')
+        recordRecentSlackChannel(1, 'C1')
+        expect(getRecentSlackChannelIds(1)).toEqual(['C1', 'C2'])
+    })
+
+    it('persists to localStorage so the recency survives a fresh read', () => {
+        recordRecentSlackChannel(1, 'C7')
+        // A brand new read (no in-memory state) must see the persisted value.
+        expect(getRecentSlackChannelIds(1)).toEqual(['C7'])
+    })
+
+    it('scopes recency per integration id', () => {
+        recordRecentSlackChannel(1, 'C1')
+        recordRecentSlackChannel(2, 'C2')
+        expect(getRecentSlackChannelIds(1)).toEqual(['C1'])
+        expect(getRecentSlackChannelIds(2)).toEqual(['C2'])
+    })
+
+    it('caps the recency list at the configured limit and drops the oldest entries', () => {
+        for (let i = 0; i < RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT + 5; i++) {
+            recordRecentSlackChannel(1, `C${i}`)
+        }
+        const ids = getRecentSlackChannelIds(1)
+        expect(ids).toHaveLength(RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT)
+        expect(ids[0]).toBe(`C${RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT + 4}`)
+        expect(ids).not.toContain('C0')
+    })
+
+    it('ignores empty channel ids', () => {
+        recordRecentSlackChannel(1, 'C1')
+        recordRecentSlackChannel(1, '')
+        expect(getRecentSlackChannelIds(1)).toEqual(['C1'])
+    })
+})
+
+describe('slackIntegrationLogic — slackChannelsForPicker', () => {
     let logic: ReturnType<typeof slackIntegrationLogic.build>
     const allChannels = [
         fixtureChannel('C3', 'announcements'),
@@ -188,7 +235,6 @@ describe('slackIntegrationLogic — recently subscribed channels', () => {
     ]
 
     beforeEach(() => {
-        // kea-localstorage hydrates from localStorage on mount; clear so each test starts fresh.
         window.localStorage.clear()
         useMocks({
             get: {
@@ -208,63 +254,36 @@ describe('slackIntegrationLogic — recently subscribed channels', () => {
         window.localStorage.clear()
     })
 
-    it('sorts channels alphabetically by name when no recency is recorded', async () => {
+    it('leaves slackChannels in fetch order, sorting only the picker view', async () => {
         await expectLogic(logic, () => {
             logic.actions.loadAllSlackChannels()
-        })
-            .toFinishAllListeners()
-            .toMatchValues({
-                slackChannels: [
-                    expect.objectContaining({ id: 'C1', name: 'alerts' }),
-                    expect.objectContaining({ id: 'C3', name: 'announcements' }),
-                    expect.objectContaining({ id: 'C2', name: 'general' }),
-                ],
-            })
+        }).toFinishAllListeners()
+
+        expect(logic.values.slackChannels.map((c) => c.id)).toEqual(['C3', 'C1', 'C2'])
+        expect(logic.values.slackChannelsForPicker.map((c) => c.id)).toEqual(['C1', 'C3', 'C2'])
     })
 
     it('puts recently subscribed channels first (most recent first), then alphabetical', async () => {
+        recordRecentSlackChannel(1, 'C2')
+        recordRecentSlackChannel(1, 'C3')
+
         await expectLogic(logic, () => {
             logic.actions.loadAllSlackChannels()
-            logic.actions.recordSubscribedChannel('C2')
-            logic.actions.recordSubscribedChannel('C3')
-        })
-            .toFinishAllListeners()
-            .toMatchValues({
-                slackChannels: [
-                    expect.objectContaining({ id: 'C3', name: 'announcements' }),
-                    expect.objectContaining({ id: 'C2', name: 'general' }),
-                    expect.objectContaining({ id: 'C1', name: 'alerts' }),
-                ],
-            })
+        }).toFinishAllListeners()
+
+        expect(logic.values.slackChannelsForPicker.map((c) => c.id)).toEqual(['C3', 'C2', 'C1'])
     })
 
-    it('deduplicates and moves an already-recorded channel back to the top', async () => {
+    it('refreshes recency from the store each time channels load', async () => {
         await expectLogic(logic, () => {
-            logic.actions.recordSubscribedChannel('C1')
-            logic.actions.recordSubscribedChannel('C2')
-            logic.actions.recordSubscribedChannel('C1')
-        }).toMatchValues({
-            recentlySubscribedChannelIds: ['C1', 'C2'],
-        })
-    })
+            logic.actions.loadAllSlackChannels()
+        }).toFinishAllListeners()
+        expect(logic.values.slackChannelsForPicker.map((c) => c.id)).toEqual(['C1', 'C3', 'C2'])
 
-    it('caps the recency list at the configured limit and drops the oldest entries', async () => {
+        recordRecentSlackChannel(1, 'C2')
         await expectLogic(logic, () => {
-            for (let i = 0; i < RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT + 5; i++) {
-                logic.actions.recordSubscribedChannel(`C${i}`)
-            }
-        }).toFinishListeners()
-        expect(logic.values.recentlySubscribedChannelIds).toHaveLength(RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT)
-        expect(logic.values.recentlySubscribedChannelIds[0]).toBe(`C${RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT + 4}`)
-        expect(logic.values.recentlySubscribedChannelIds).not.toContain('C0')
-    })
-
-    it('ignores empty channel ids', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.recordSubscribedChannel('C1')
-            logic.actions.recordSubscribedChannel('')
-        }).toMatchValues({
-            recentlySubscribedChannelIds: ['C1'],
-        })
+            logic.actions.loadAllSlackChannels()
+        }).toFinishAllListeners()
+        expect(logic.values.slackChannelsForPicker.map((c) => c.id)).toEqual(['C2', 'C1', 'C3'])
     })
 })

--- a/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
@@ -6,7 +6,11 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { SlackChannelType } from '~/types'
 
-import { SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS, slackIntegrationLogic } from './slackIntegrationLogic'
+import {
+    RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT,
+    SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS,
+    slackIntegrationLogic,
+} from './slackIntegrationLogic'
 
 const FIXED_NOW = new Date('2026-01-01T12:00:00Z')
 
@@ -163,5 +167,106 @@ describe('slackIntegrationLogic — getChannelRefreshButtonDisabledReason', () =
         } else {
             expect(reason).not.toBe('')
         }
+    })
+})
+
+const fixtureChannel = (id: string, name: string, extra: Partial<SlackChannelType> = {}): SlackChannelType => ({
+    id,
+    name,
+    is_private: false,
+    is_ext_shared: false,
+    is_member: true,
+    ...extra,
+})
+
+describe('slackIntegrationLogic — recently subscribed channels', () => {
+    let logic: ReturnType<typeof slackIntegrationLogic.build>
+    const allChannels = [
+        fixtureChannel('C3', 'announcements'),
+        fixtureChannel('C1', 'alerts'),
+        fixtureChannel('C2', 'general'),
+    ]
+
+    beforeEach(() => {
+        // kea-localstorage hydrates from localStorage on mount; clear so each test starts fresh.
+        window.localStorage.clear()
+        useMocks({
+            get: {
+                '/api/environments/:team_id/integrations/:id/channels': {
+                    channels: allChannels,
+                    lastRefreshedAt: '2026-01-01T00:00:00Z',
+                },
+            },
+        })
+        initKeaTests()
+        logic = slackIntegrationLogic({ id: 1 })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        window.localStorage.clear()
+    })
+
+    it('sorts channels alphabetically by name when no recency is recorded', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadAllSlackChannels()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                slackChannels: [
+                    expect.objectContaining({ id: 'C1', name: 'alerts' }),
+                    expect.objectContaining({ id: 'C3', name: 'announcements' }),
+                    expect.objectContaining({ id: 'C2', name: 'general' }),
+                ],
+            })
+    })
+
+    it('puts recently subscribed channels first (most recent first), then alphabetical', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadAllSlackChannels()
+            logic.actions.recordSubscribedChannel('C2')
+            logic.actions.recordSubscribedChannel('C3')
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                slackChannels: [
+                    expect.objectContaining({ id: 'C3', name: 'announcements' }),
+                    expect.objectContaining({ id: 'C2', name: 'general' }),
+                    expect.objectContaining({ id: 'C1', name: 'alerts' }),
+                ],
+            })
+    })
+
+    it('deduplicates and moves an already-recorded channel back to the top', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.recordSubscribedChannel('C1')
+            logic.actions.recordSubscribedChannel('C2')
+            logic.actions.recordSubscribedChannel('C1')
+        }).toMatchValues({
+            recentlySubscribedChannelIds: ['C1', 'C2'],
+        })
+    })
+
+    it('caps the recency list at the configured limit and drops the oldest entries', async () => {
+        await expectLogic(logic, () => {
+            for (let i = 0; i < RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT + 5; i++) {
+                logic.actions.recordSubscribedChannel(`C${i}`)
+            }
+        }).toMatchValues({
+            recentlySubscribedChannelIds: expect.arrayContaining([]),
+        })
+        expect(logic.values.recentlySubscribedChannelIds).toHaveLength(RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT)
+        expect(logic.values.recentlySubscribedChannelIds[0]).toBe(`C${RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT + 4}`)
+        expect(logic.values.recentlySubscribedChannelIds).not.toContain('C0')
+    })
+
+    it('ignores empty channel ids', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.recordSubscribedChannel('C1')
+            logic.actions.recordSubscribedChannel('')
+        }).toMatchValues({
+            recentlySubscribedChannelIds: ['C1'],
+        })
     })
 })

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -10,6 +10,10 @@ import { SlackChannelType } from '~/types'
 import type { slackIntegrationLogicType } from './slackIntegrationLogicType'
 
 export const SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS = 30
+export const RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT = 20
+
+const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
+const persistConfig = { persist: true, prefix: `${teamId}__` }
 
 export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
     props({} as { id: number }),
@@ -21,6 +25,7 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
     actions({
         loadAllSlackChannels: (forceRefresh: boolean = false, search: string = '') => ({ forceRefresh, search }),
         loadSlackChannelById: (channelId: string) => ({ channelId }),
+        recordSubscribedChannel: (channelId: string) => ({ channelId }),
     }),
 
     loaders(({ props }) => ({
@@ -60,17 +65,38 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
                 loadSlackChannelByIdSuccess: (_, { slackChannelById }) => slackChannelById,
             },
         ],
+        recentlySubscribedChannelIds: [
+            [] as string[],
+            persistConfig,
+            {
+                recordSubscribedChannel: (state, { channelId }) => {
+                    if (!channelId) {
+                        return state
+                    }
+                    const next = [channelId, ...state.filter((id) => id !== channelId)]
+                    return next.slice(0, RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT)
+                },
+            },
+        ],
     }),
 
     selectors({
         slackChannels: [
-            (s) => [s._fetchedSlackChannels, s._fetchedSlackChannelById],
-            (_fetchedSlackChannels, _fetchedSlackChannelById): SlackChannelType[] => {
+            (s) => [s._fetchedSlackChannels, s._fetchedSlackChannelById, s.recentlySubscribedChannelIds],
+            (_fetchedSlackChannels, _fetchedSlackChannelById, recentlySubscribedChannelIds): SlackChannelType[] => {
                 const channels = [..._fetchedSlackChannels]
                 if (_fetchedSlackChannelById && !channels.find((x) => x.id === _fetchedSlackChannelById.id)) {
                     channels.push(_fetchedSlackChannelById)
                 }
-                return channels
+                const recencyIndex = new Map(recentlySubscribedChannelIds.map((id, idx) => [id, idx]))
+                return channels.sort((a, b) => {
+                    const aRecency = recencyIndex.get(a.id) ?? Number.POSITIVE_INFINITY
+                    const bRecency = recencyIndex.get(b.id) ?? Number.POSITIVE_INFINITY
+                    if (aRecency !== bRecency) {
+                        return aRecency - bRecency
+                    }
+                    return a.name.localeCompare(b.name)
+                })
             },
         ],
         isMemberOfSlackChannel: [

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -1,8 +1,9 @@
-import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
+import { getRecentSlackChannelIds, slackChannelId } from 'lib/integrations/slackChannel'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 import { SlackChannelType } from '~/types'
@@ -10,10 +11,6 @@ import { SlackChannelType } from '~/types'
 import type { slackIntegrationLogicType } from './slackIntegrationLogicType'
 
 export const SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS = 30
-export const RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT = 20
-
-const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
-const persistConfig = { persist: true, prefix: `${teamId}__` }
 
 export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
     props({} as { id: number }),
@@ -25,7 +22,7 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
     actions({
         loadAllSlackChannels: (forceRefresh: boolean = false, search: string = '') => ({ forceRefresh, search }),
         loadSlackChannelById: (channelId: string) => ({ channelId }),
-        recordSubscribedChannel: (channelId: string) => ({ channelId }),
+        setRecentlySubscribedChannelIds: (channelIds: string[]) => ({ channelIds }),
     }),
 
     loaders(({ props }) => ({
@@ -52,7 +49,7 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
         ],
     })),
 
-    reducers({
+    reducers(({ props }) => ({
         _fetchedSlackChannels: [
             [] as SlackChannelType[],
             {
@@ -66,30 +63,35 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
             },
         ],
         recentlySubscribedChannelIds: [
-            [] as string[],
-            persistConfig,
+            getRecentSlackChannelIds(props.id),
             {
-                recordSubscribedChannel: (state, { channelId }) => {
-                    if (!channelId) {
-                        return state
-                    }
-                    const next = [channelId, ...state.filter((id) => id !== channelId)]
-                    return next.slice(0, RECENTLY_SUBSCRIBED_SLACK_CHANNELS_LIMIT)
-                },
+                setRecentlySubscribedChannelIds: (_, { channelIds }) => channelIds,
             },
         ],
-    }),
+    })),
+
+    listeners(({ props, actions }) => ({
+        loadAllSlackChannelsSuccess: () => {
+            actions.setRecentlySubscribedChannelIds(getRecentSlackChannelIds(props.id))
+        },
+    })),
 
     selectors({
         slackChannels: [
-            (s) => [s._fetchedSlackChannels, s._fetchedSlackChannelById, s.recentlySubscribedChannelIds],
-            (_fetchedSlackChannels, _fetchedSlackChannelById, recentlySubscribedChannelIds): SlackChannelType[] => {
+            (s) => [s._fetchedSlackChannels, s._fetchedSlackChannelById],
+            (_fetchedSlackChannels, _fetchedSlackChannelById): SlackChannelType[] => {
                 const channels = [..._fetchedSlackChannels]
                 if (_fetchedSlackChannelById && !channels.find((x) => x.id === _fetchedSlackChannelById.id)) {
                     channels.push(_fetchedSlackChannelById)
                 }
+                return channels
+            },
+        ],
+        slackChannelsForPicker: [
+            (s) => [s.slackChannels, s.recentlySubscribedChannelIds],
+            (slackChannels, recentlySubscribedChannelIds): SlackChannelType[] => {
                 const recencyIndex = new Map(recentlySubscribedChannelIds.map((id, idx) => [id, idx]))
-                return channels.sort((a, b) => {
+                return [...slackChannels].sort((a, b) => {
                     const aRecency = recencyIndex.get(a.id) ?? Number.POSITIVE_INFINITY
                     const bRecency = recencyIndex.get(b.id) ?? Number.POSITIVE_INFINITY
                     if (aRecency !== bRecency) {
@@ -102,19 +104,15 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
         isMemberOfSlackChannel: [
             (s) => [s.slackChannels],
             (slackChannels: SlackChannelType[]) => {
-                return (channel: string) => {
-                    const [channelId] = channel.split('|')
-                    return slackChannels.find((x) => x.id === channelId)?.is_member ?? false
-                }
+                return (channel: string) =>
+                    slackChannels.find((x) => x.id === slackChannelId(channel))?.is_member ?? false
             },
         ],
         isPrivateChannelWithoutAccess: [
             (s) => [s.slackChannels],
             (slackChannels: SlackChannelType[]) => {
-                return (channel: string) => {
-                    const [channelId] = channel.split('|')
-                    return slackChannels.find((x) => x.id === channelId)?.is_private_without_access ?? false
-                }
+                return (channel: string) =>
+                    slackChannels.find((x) => x.id === slackChannelId(channel))?.is_private_without_access ?? false
             },
         ],
         getChannelRefreshButtonDisabledReason: [


### PR DESCRIPTION
## Problem

When setting up several Slack subscriptions in a row — e.g. subscribing a batch of insights or dashboards to the same channel — the channel picker lists channels in whatever order the Slack API returns them, so the user has to re-find the same channel every time. This came out of a real pain point: subscribing many insights to one channel.

## Changes

Order the Slack channel picker by "most recently subscribed to" first, then alphabetically, so repeat subscriptions surface the channel you just used.

- **New shared `recentSlackChannels` store** (`frontend/src/lib/integrations/slackChannel.ts`) — a small localStorage-backed module, keyed per team + integration, capped at 20 entries. Exposes `recordRecentSlackChannel`, `getRecentSlackChannelIds`, and a `slackChannelId(value)` parser for the `id|#name` picker-value format. Team id is read lazily and the store bails out when it's unknown, so recency can never land under an `undefined` key.
- **`slackIntegrationLogic`** — adds a dedicated `slackChannelsForPicker` selector that applies the recency-then-alphabetical sort. The general `slackChannels` selector stays the plain merged list, so membership / private-access lookups and other consumers keep stable ordering. Recency is refreshed from the store whenever channels (re)load — which is every time the picker opens or searches.
- **`subscriptionLogic`** — on a successful Slack subscription save, records the channel via `recordRecentSlackChannel(...)`. No cross-logic lifecycle coupling; it just writes the store.
- **`SlackChannelPicker`** — consumes `slackChannelsForPicker` for display order; membership lookups stay on `slackChannels`.
- **Storybook** — `Components/Slack channel picker` with `Alphabetical` and `RecentlySubscribedFirst` stories, each rendering the real picker plus an explicit "order shown in the dropdown" list (recents badged) so the ordering is visible in visual review.

## How did you test this code?

I'm an agent (PostHog Code) — no manual browser testing. Automated only:

- `slackIntegrationLogic.test.ts` and `subscriptionLogic.test.ts` pass, including store unit tests (dedup, cap, per-integration scoping, localStorage persistence) and `slackChannelsForPicker` ordering/refresh tests.
- `typescript:check` clean; oxlint + oxfmt clean.
- Visual review baselines for the two new stories reviewed and approved.

## Automatic notifications

- [ ] Publish to changelog? — no
- [ ] Alert Sales and Marketing teams? — no

## 🤖 Agent context

Authored by Claude (PostHog Code).

The first cut persisted recency via kea-localstorage on `slackIntegrationLogic` and had `subscriptionLogic` briefly mount/unmount that logic to write the value. qa-swarm review (convergent across reviewers) flagged the lifecycle coupling (FeatureEnvy), a module-load team-id capture that could write under an `undefined` key, and folding the recency sort into the general `slackChannels` selector — which silently reorders for every consumer and, after rebasing onto current master, broke a server-side-search pagination test that expects fetch order.

The rework introduces the shared `recentSlackChannels` store both consumers talk to: it removes the mount/unmount dance, reads the team id lazily, splits the picker sort into its own selector, and expresses the `id|#name` parse once. Deferred with replies on the threads: aging out stale recency ids (server-side channel search makes reconciliation against the loaded set unsafe), capture-based observability, and a grouped "Recently used" header (the picker uses the flat `LemonInputSelect`, not the sectioned `LemonSelect`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
