### PR TITLE
fix(ci): close stale-bot gaps for re-marking and active-PR auto-close

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,8 +5,6 @@ on:
 
 permissions:
     contents: read
-    issues: write
-    pull-requests: write
 
 jobs:
     stale:
@@ -26,9 +24,22 @@ jobs:
                     echo "skip=false" >> $GITHUB_OUTPUT
                   fi
 
+            # App token gives higher API rate limits (15k/hr vs 1k/hr for GITHUB_TOKEN)
+            # and lets a full cycle through every open issue + PR complete in one run,
+            # which is required for the action's state model to re-evaluate PRs that
+            # were unstaled mid-cycle.
+            - name: Get app token
+              id: app-token
+              if: steps.holiday.outputs.skip != 'true'
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_PRIVATE_KEY }}
+
             - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
               if: steps.holiday.outputs.skip != 'true'
               with:
+                  repo-token: ${{ steps.app-token.outputs.token }}
                   days-before-issue-stale: 730
                   days-before-issue-close: 14
                   stale-issue-message: "This issue hasn't seen activity in two years! If you want to keep it open, please remove the `stale` label – otherwise this will be closed in two weeks."
@@ -40,7 +51,7 @@ jobs:
                   stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, please remove the `stale` label – otherwise this will be closed in another week. If you want to permanently keep it open, use the `waiting` label."
                   close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
                   stale-pr-label: stale
-                  remove-pr-stale-when-updated: false
+                  remove-pr-stale-when-updated: true
                   exempt-pr-labels: 'waiting'
                   enable-statistics: true
-                  operations-per-run: 250
+                  operations-per-run: 5000


### PR DESCRIPTION
## Problem

Two gaps in the stale-PR workflow that have been silently misbehaving:

**1. PRs unstaled by their author were never re-marked.** `actions/stale` keeps a per-cycle "already processed this run" set: every issue/PR the action visits — even one it decides isn't stale and takes no action on — is added to the set and skipped for the rest of the cycle. The set only resets when the action gets all the way through the open issue + PR list. With `operations-per-run: 250` and PostHog's volume (~7k open issues + ~200 open PRs), a single cycle was taking weeks to complete. So if an author removed the `stale` label and went idle, the bot would visit the PR once while it was still fresh, stamp it as processed, and not look again until the cycle finally rolled over — by which time the author had usually force-pushed and bumped `updated_at` again. The bot looked broken; it was actually just rate-limited by its own budget. Example: #54280 was unstaled on Apr 22 and sat completely idle for 36 days without ever being re-marked.

**2. Pushing commits to a stale PR did not clear the label.** `remove-pr-stale-when-updated: false` meant an author actively addressing review feedback would still get auto-closed seven days later. Not the behavior most contributors expect.

## Changes

```yaml
operations-per-run: 250 → 5000        # fits a full cycle in one run
remove-pr-stale-when-updated: false → true   # pushes / comments un-stale a PR
repo-token: ${{ steps.app-token.outputs.token }}   # 15k req/hr vs 1k via GITHUB_TOKEN
```

Piggybacks on the existing `POSTHOG_SCHEDULED_ACTIONS` GitHub App that already powers `update-ai-costs`, `browserslist`, and `update-bot-ips` — same `actions/create-github-app-token` SHA-pinned step. With the app token providing auth via `repo-token`, the workflow-level `issues: write` / `pull-requests: write` permissions on `GITHUB_TOKEN` are no longer needed and have been dropped (matching the `auto-assign-reviewers` pattern).

The holiday-skip behavior, message text, thresholds (7-day stale / 7-day close on PRs, 730 / 14 on issues), and `waiting` exempt label are all unchanged.

## How did you test this code?

I'm Claude (Opus 4.7) — agent-authored, no manual run of the workflow.

- Verified the `actions/stale` state model and per-cycle skip behavior by reading `src/classes/issues-processor.ts` in `actions/stale@v10.2.0`:
  - `state.addIssueToProcessed(issue)` is called on every visited issue regardless of whether the action mutated it
  - `state.reset()` only fires when `issues.length <= 0` returns from the listing call (i.e. all issues exhausted)
  - Staleness decision is purely `!_updatedSince(issue.updated_at, daysBeforeStale)` — there's no exemption based on prior manual label removal, so the only reason re-marking wouldn't happen is the per-cycle skip set
- Verified empirically against #54280: stale label added Apr 22 08:06 UTC by `github-actions[bot]`, manually removed same day, zero activity (no commits, no comments) for 36 days, no re-mark — fits the cycle-too-long hypothesis exactly
- Cross-checked app choice: `POSTHOG_SCHEDULED_ACTIONS` is already used by 3 other scheduled workflows (`update-ai-costs.yml`, `browserslist.yml`, `update-bot-ips.yml`) — semantic fit for a daily cron, and avoids the naming mismatch of having stale comments appear under "Assign Reviewers"
- Did not exercise the workflow live; it'll fire on the next 07:30 UTC Mon–Fri tick. The `enable-statistics: true` output should show whether a full cycle now completes in one run (look for "Statistics" block in the action log)

If 5000 turns out to still be too low, the budget can be bumped further without other changes.

## Publish to changelog?

no

## 🤖 Agent context

Authored via Claude Code (Opus 4.7) in a session with @webjunkie investigating why the stale bot never re-marked #54280 after a manual `stale` label removal.

Decisions worth flagging:

- **Cycle-too-long was the actual gap, not `operations-per-run` exhaustion per se.** Initial hypothesis was that the action gives up mid-list when budget runs out and loses its place — debunked by reading the source: state persists in the actions cache across runs. The real issue is that an issue visited *as not stale* still consumes its slot in the per-cycle "processed" set, so it isn't reconsidered until the whole list has been walked. With 250 ops/run that walk was taking many weeks. 5000 should comfortably fit one full pass in a single run for current repo size.
- **App-token over `GITHUB_TOKEN`**: primary motivation is the 15× higher API rate limit, which the action will actually use when it's no longer artificially capped at 250 ops. The identity change (comments now come from the scheduled-actions app rather than `github-actions[bot]`) is incidental but matches what other scheduled workflows already do.
- **`remove-pr-stale-when-updated` flip is a separate bug** from the cycle issue and could ship on its own, but the two changes are scoped narrowly enough together that bundling keeps the PR focused on "make the stale workflow actually behave the way contributors expect".
- Considered but rejected: switching to a non-stock implementation with a `since`-filtered listing pattern. Out of scope and not warranted while the stock action's knobs cover the gap.

Reviewer ask: app-token piggybacking is fine to validate by inspection — the secret refs and SHA-pinned action match the existing pattern verbatim. The `enable-statistics` output on the first run will tell us whether 5000 is the right number.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHBJdB5s5xAykSUpJ9sMLk)_