### PR TITLE
feat(llm-gateway): emit cache & reasoning token breakdown on $ai_generation events

### DIFF
--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -161,16 +161,22 @@ class PostHogCallback(InstrumentedCallback):
             "$ai_billable": _is_product_billable(product),
         }
 
-        # Cache token breakdown is reported by LiteLLM in the response usage object
-        # for providers that support prompt caching (Anthropic). Emit the fields
-        # only when present so non-caching providers don't pollute events with
-        # zeros, matching the schema in posthog/models/ai_events/sql.py.
+        # Cache and reasoning token breakdowns are reported by LiteLLM in the
+        # response usage object for providers that support them (Anthropic for
+        # cache, OpenAI o-series for reasoning). Emit the fields only when
+        # present so providers that don't report them don't pollute events with
+        # zeros, matching the schema in posthog/models/ai_events/sql.py and the
+        # parity established by posthoganalytics' langchain CallbackHandler.
         cache_read_input_tokens = usage_object.get("cache_read_input_tokens")
         if cache_read_input_tokens is not None:
             properties["$ai_cache_read_input_tokens"] = cache_read_input_tokens
         cache_creation_input_tokens = usage_object.get("cache_creation_input_tokens")
         if cache_creation_input_tokens is not None:
             properties["$ai_cache_creation_input_tokens"] = cache_creation_input_tokens
+        completion_tokens_details = usage_object.get("completion_tokens_details") or {}
+        reasoning_tokens = completion_tokens_details.get("reasoning_tokens")
+        if reasoning_tokens is not None:
+            properties["$ai_reasoning_tokens"] = reasoning_tokens
 
         posthog_properties = get_posthog_properties() or {}
         if isinstance(posthog_properties, dict):

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -145,6 +145,7 @@ class PostHogCallback(InstrumentedCallback):
         )
 
         is_streaming = standard_logging_object.get("stream", False)
+        usage_object = (standard_logging_object.get("metadata") or {}).get("usage_object") or {}
 
         properties: dict[str, Any] = {
             "$ai_model": standard_logging_object.get("model", ""),
@@ -159,6 +160,17 @@ class PostHogCallback(InstrumentedCallback):
             "ai_product": product,
             "$ai_billable": _is_product_billable(product),
         }
+
+        # Cache token breakdown is reported by LiteLLM in the response usage object
+        # for providers that support prompt caching (Anthropic). Emit the fields
+        # only when present so non-caching providers don't pollute events with
+        # zeros, matching the schema in posthog/models/ai_events/sql.py.
+        cache_read_input_tokens = usage_object.get("cache_read_input_tokens")
+        if cache_read_input_tokens is not None:
+            properties["$ai_cache_read_input_tokens"] = cache_read_input_tokens
+        cache_creation_input_tokens = usage_object.get("cache_creation_input_tokens")
+        if cache_creation_input_tokens is not None:
+            properties["$ai_cache_creation_input_tokens"] = cache_creation_input_tokens
 
         posthog_properties = get_posthog_properties() or {}
         if isinstance(posthog_properties, dict):

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -307,6 +307,55 @@ class TestPostHogCallback:
         assert "$ai_cache_creation_input_tokens" not in props
 
     @pytest.mark.asyncio
+    async def test_on_success_emits_reasoning_tokens_when_present(
+        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
+    ) -> None:
+        _, mock_client = mock_posthog_client
+        kwargs = {
+            "standard_logging_object": {
+                "model": "gpt-5.2",
+                "custom_llm_provider": "openai",
+                "prompt_tokens": 50,
+                "completion_tokens": 200,
+                "metadata": {
+                    "usage_object": {
+                        "completion_tokens_details": {"reasoning_tokens": 120},
+                    },
+                },
+            },
+            "litellm_params": {},
+        }
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="slack_app_routing"),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        props = mock_client.capture.call_args.kwargs["properties"]
+        assert props["$ai_reasoning_tokens"] == 120
+
+    @pytest.mark.asyncio
+    async def test_on_success_omits_reasoning_tokens_when_absent(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        _, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="slack_app"),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        props = mock_client.capture.call_args.kwargs["properties"]
+        assert "$ai_reasoning_tokens" not in props
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("product", ["wizard", "posthog_code", "llm_gateway"])
     async def test_on_success_includes_ai_product(
         self,

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -255,6 +255,58 @@ class TestPostHogCallback:
         assert callback.callback_name == "posthog"
 
     @pytest.mark.asyncio
+    async def test_on_success_emits_cache_tokens_when_present(
+        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
+    ) -> None:
+        _, mock_client = mock_posthog_client
+        kwargs = {
+            "standard_logging_object": {
+                "model": "claude-sonnet-4-6",
+                "custom_llm_provider": "anthropic",
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "metadata": {
+                    "usage_object": {
+                        "cache_read_input_tokens": 60,
+                        "cache_creation_input_tokens": 30,
+                    },
+                },
+            },
+            "litellm_params": {},
+        }
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="slack_app"),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        props = mock_client.capture.call_args.kwargs["properties"]
+        assert props["$ai_cache_read_input_tokens"] == 60
+        assert props["$ai_cache_creation_input_tokens"] == 30
+
+    @pytest.mark.asyncio
+    async def test_on_success_omits_cache_tokens_when_absent(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        _, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="slack_app"),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        props = mock_client.capture.call_args.kwargs["properties"]
+        assert "$ai_cache_read_input_tokens" not in props
+        assert "$ai_cache_creation_input_tokens" not in props
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("product", ["wizard", "posthog_code", "llm_gateway"])
     async def test_on_success_includes_ai_product(
         self,


### PR DESCRIPTION
## Problem

LiteLLM hands the gateway per-call usage details in `standard_logging_object.metadata.usage_object`, including `cache_read_input_tokens`, `cache_creation_input_tokens` (Anthropic prompt caching) and `completion_tokens_details.reasoning_tokens` (OpenAI o-series and similar). The Prometheus callback already consumes all three (`callbacks/prometheus.py:42-46`), and `posthoganalytics`' langchain `CallbackHandler` emits them on every `$ai_generation` it captures (`ai/langchain/callbacks.py:610-614`) — but the PostHog callback in the gateway was dropping them.

Result: gateway-routed traces in LLM Analytics showed `$ai_input_tokens` / `$ai_output_tokens` but no cache or reasoning breakdown, and `posthog/tasks/llm_analytics_usage_report.py:375-377` (which sums these fields) was silently aggregating zero for any gateway traffic. The dollar amount (`$ai_total_cost_usd`) is unaffected — LiteLLM bakes pricing in — but the token accounting underneath it was not reconstructable from the events.

## Changes

In `services/llm-gateway/src/llm_gateway/callbacks/posthog.py`, pull `usage_object` from the same path Prometheus uses and conditionally emit on `$ai_generation`:

- `$ai_cache_read_input_tokens`
- `$ai_cache_creation_input_tokens`
- `$ai_reasoning_tokens`

Conditional emission matches the `Nullable(Int64)` schema in `posthog/models/ai_events/sql.py:262-263` and skips providers that don't surface these keys at all. `_on_failure` is unchanged (no usage data on failed calls).

Parity after this PR:

| Field | PostHog AI | Gateway (before) | Gateway (after) |
|---|---|---|---|
| `$ai_input_tokens` / `$ai_output_tokens` | yes | yes | yes |
| `$ai_total_cost_usd` | yes | yes | yes |
| `$ai_cache_read_input_tokens` / `$ai_cache_creation_input_tokens` | yes (cross-provider normalized) | no | yes (Anthropic; OpenAI's `prompt_tokens_details.cached_tokens` still not handled) |
| `$ai_reasoning_tokens` | yes | no | yes |

## How did you test this code?

I'm an agent. Verification:

- **Unit**: `uv run pytest tests/callbacks/test_posthog.py` — 56 passed, four new tests covering present/absent behavior for each field. Full gateway suite: 930 passed.
- **End-to-end on local**: ran the gateway from this worktree, fired two `claude-sonnet-4-5` calls 12k chars apart with `cache_control: ephemeral` on the system block. Captured events showed `$ai_cache_creation_input_tokens: 8741` on call 1 and `$ai_cache_read_input_tokens: 8741` on call 2, with cost dropping ~12× between the two (matching Anthropic's cache discount). `$ai_reasoning_tokens` shipped on every event (0 for Claude, as expected). No reasoning-model end-to-end run yet — the code path is identical to cache, just a different `usage_object` key.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7, 1M context) at Vojta's direction. Notes for the reviewer:

- **Cost-breakdown components** (`$ai_input_cost_usd`, `$ai_output_cost_usd`, `$ai_saved_cache_cost_usd`) deliberately left out — `posthoganalytics` doesn't emit them either, so adding them to the gateway would be a one-sided source, not a parity fix.
- **OpenAI `prompt_tokens_details.cached_tokens` path** also left out — that's a separate normalization the gateway's Prometheus callback doesn't handle either. Worth a follow-up if OpenAI traffic from Slack becomes large enough to care about its cache visibility.
- **`$ai_span_name` / `$ai_parent_id`** are langchain-specific span concepts that don't map onto the gateway's flat call model. Callers can pass either via `x-posthog-property-*` headers if they need them, since the existing `posthog_properties` merge handles arbitrary fields.