### PR TITLE
feat(auth): add need help link to 2FA page

### DIFF
--- a/frontend/src/scenes/authentication/Login2FA.tsx
+++ b/frontend/src/scenes/authentication/Login2FA.tsx
@@ -5,8 +5,10 @@ import { LemonButton, LemonDivider, LemonInput } from '@posthog/lemon-ui'
 
 import { BridgePage } from 'lib/components/BridgePage/BridgePage'
 import passkeyLogo from 'lib/components/SocialLoginButton/passkey.svg'
+import { supportLogic } from 'lib/components/Support/supportLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonField } from 'lib/lemon-ui/LemonField'
+import { Link } from 'lib/lemon-ui/Link'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 
@@ -17,6 +19,7 @@ export function Login2FA(): JSX.Element {
         useValues(login2FALogic)
     const { beginPasskey2FA } = useActions(login2FALogic)
     const { preflight } = useValues(preflightLogic)
+    const { openSupportForm } = useActions(supportLogic)
 
     return (
         <BridgePage
@@ -31,7 +34,26 @@ export function Login2FA(): JSX.Element {
         >
             <div className="deprecated-space-y-2">
                 <h2>Two-Factor Authentication</h2>
-                <p>Enter a token from your authenticator app, use your passkey, or enter a backup code.</p>
+                <p>
+                    Enter a token from your authenticator app, use your passkey, or enter a backup code.
+                    {preflight?.cloud && (
+                        <>
+                            {' '}
+                            <Link
+                                data-attr="2fa-contact-support"
+                                onClick={(e) => {
+                                    e.preventDefault()
+                                    openSupportForm({
+                                        kind: 'support',
+                                        target_area: 'login',
+                                    })
+                                }}
+                            >
+                                Need help?
+                            </Link>
+                        </>
+                    )}
+                </p>
 
                 {passkeysAvailable && (
                     <>


### PR DESCRIPTION
## Problem

Throughout the login flow, PostHog already exposes a "Need help?" / contact-support affordance to unauthenticated users — on `Login`, `PasswordReset`, and `InviteSignup`. The 2FA page (`/login/2fa`) had no such link.

This is the one place a user can be permanently locked out: they've passed primary auth but lost their authenticator device, passkey, **and** backup codes. Without a visible support path **before** submission, those users have no way forward.

## Changes

Added a "Need help?" link next to the description text on the 2FA page:

> Enter a token from your authenticator app, use your passkey, or enter a backup code. **Need help?**

Clicking it opens the support modal in support mode (`kind: 'support'`, `target_area: 'login'`) — matching the inline "Need help?" link already used inside `Login.tsx`'s error banner. Gated on `preflight?.cloud`, same as the other support affordances across the auth flow (PostHog only offers support to cloud customers).

Single file changed: `frontend/src/scenes/authentication/Login2FA.tsx`. No logic changes, no new component, no new generated types.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual testing in a browser. What I did run:

- `pnpm --filter=@posthog/frontend format` on the edited file — passed (oxlint + oxfmt clean).
- `pnpm --filter=@posthog/frontend typescript:check` — crashed locally with a Node OOM (V8 abort, unrelated to this change); leaving CI to verify typecheck.

Manual verification steps for the reviewer (requires cloud preflight — locally `CLOUD_DEPLOYMENT=DEV ./bin/start`):

1. Visit `/login/2fa` while in the 2FA step of login.
2. Confirm "Need help?" renders inline after the description, before any submission.
3. Click it — support modal should open in support mode with `target_area: 'login'`.
4. Submit an invalid token — link should still be visible alongside the error banner.
5. On a non-cloud preflight, the link should not render.

## Publish to changelog?

no

## 🤖 Agent context

- **Tool**: PostHog Code (Claude Opus 4.7) — plan-then-execute flow.
- **Approach considered**: passing `<SupportModalButton />` to `BridgePage`'s `footer` slot, matching `Login.tsx`/`PasswordReset.tsx`/`InviteSignup.tsx`. Rejected after user feedback — they wanted the link inline near the description, not in the footer, so locked-out users notice it the moment they realize none of the listed 2FA methods work for them.
- **Chosen pattern**: inline `<Link>` + `openSupportForm({ kind: 'support', target_area: 'login' })`, copied directly from the existing pattern in `Login.tsx`'s error banner — same data-attr convention, same support kind, same target area.
- **Drive-by noticed but not fixed**: opening the support modal logs a React 18 warning ("Attempted to synchronously unmount a root while React was already rendering") from `frontend/src/lib/components/Support/SupportModal.tsx:67-80`, where `destroy()` calls `root.unmount()` synchronously inside `LemonModal`'s `onAfterClose`. Pre-existing on every entry point to `openSupportForm`, not introduced here — left out of scope.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*