### PR TITLE
chore(devex): fix env-vs-project canonical guidance

### DIFF
--- a/.agents/skills/improving-drf-endpoints/SKILL.md
+++ b/.agents/skills/improving-drf-endpoints/SKILL.md
@@ -71,6 +71,28 @@ See [serializer-fields.md](references/serializer-fields.md) for patterns and exa
 
 See [viewset-annotations.md](references/viewset-annotations.md) for patterns and examples.
 
+### URL routing — where to register new team-nested endpoints
+
+PostHog briefly split projects and environments as separate concepts then rolled
+the split back. **`/api/projects/:team_id/...` is the canonical path** for any
+team-nested endpoint. `/api/environments/:team_id/...` is a backward-compat alias
+preserved only for clients that integrated against it during the split.
+
+For a **new** team-nested endpoint, register directly under `projects_router` in
+`posthog/api/__init__.py`:
+
+```python
+projects_router.register(r"my_thing", MyThingViewSet, "project_my_thing", ["team_id"])
+```
+
+Do **not** register new endpoints under `environments_router`. Do **not** use
+`register_grandfathered_environment_nested_viewset` — it exists only for
+endpoints that were already exposed on both routes before the rollback.
+
+If existing clients need `/api/environments/...` too, the OpenAPI postprocess
+hook at `posthog.api.documentation.preprocess_exclude_path_format` auto-marks
+the env-side path as `deprecated: true` whenever both routes exist.
+
 ### Facade products (DataclassSerializer)
 
 For products using the facade pattern (e.g., `visual_review`) with `DataclassSerializer` wrapping frozen dataclasses from `contracts.py`:

--- a/.agents/skills/modifying-taxonomic-filter/references/testing-patterns.md
+++ b/.agents/skills/modifying-taxonomic-filter/references/testing-patterns.md
@@ -28,7 +28,12 @@ bugs. Always read the `search` param:
 }
 ```
 
-**Persons properties live under `/api/environments/:team/`, not `/projects/`.**
+**Persons properties — match what the frontend actually calls.** Today persons
+URLs are constructed against `/api/environments/:team_id/persons/properties` in
+the calling kea logic, so mock at that path. (The backend exposes both
+`/api/projects/` and `/api/environments/` for persons; `/api/projects/` is the
+canonical path but the persons frontend hasn't been migrated.)
+
 Mount shared models in `beforeEach`:
 
 ```tsx

--- a/.agents/skills/writing-kea-logics/references/testing.md
+++ b/.agents/skills/writing-kea-logics/references/testing.md
@@ -19,9 +19,9 @@ describe('fooLogic', () => {
   beforeEach(() => {
     useMocks({
       get: {
-        '/api/environments/:team_id/foos/:id/': (req) => [200, { id: req.params.id, name: 'hello' }],
+        '/api/projects/:team_id/foos/:id/': (req) => [200, { id: req.params.id, name: 'hello' }],
       },
-      post: { '/api/environments/:team_id/foos/': { id: 'new', name: 'new' } },
+      post: { '/api/projects/:team_id/foos/': { id: 'new', name: 'new' } },
     })
     initKeaTests()
     logic = fooLogic({ fooId: '123' })

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -244,19 +244,33 @@ def register_grandfathered_environment_nested_viewset(
     prefix: str, viewset: type[viewsets.GenericViewSet], basename: str, parents_query_lookups: list[str]
 ) -> tuple[NestedRegistryItem, NestedRegistryItem]:
     """
-    Register the environment-specific viewset under both /environments/:team_id/ (correct endpoint)
-    and /projects/:team_id/ (legacy, but supported for backward compatibility endpoint).
-    DO NOT USE ON ANY NEW ENDPOINT YOU'RE ADDING!
+    Register a team-nested viewset under both /api/projects/:team_id/ (canonical)
+    and /api/environments/:team_id/ (backward-compat alias).
+
+    Background: PostHog briefly split projects and environments as separate
+    concepts then rolled the split back. /api/projects/ is the canonical path;
+    /api/environments/ is preserved only for clients that integrated against it
+    during the split (SDKs, customer integrations) and is auto-marked
+    `deprecated: true` in the generated OpenAPI schema by the postprocess hook
+    in posthog.api.documentation whenever a matching /api/projects/ route exists.
+
+    DO NOT USE FOR NEW ENDPOINTS. New team-nested endpoints should register
+    directly under projects_router. This helper exists to preserve the dual-route
+    surface for endpoints that were already exposed both ways before the rollback.
+
+    Returns (environment_nested, project_nested) — note that despite the names,
+    the project_nested route is the canonical one; the environment_nested route
+    is the deprecated alias.
     """
     if parents_query_lookups[0] != "team_id":
-        raise ValueError("Only endpoints with team_id as the first parent query lookup can be environment-nested")
+        raise ValueError("Only endpoints with team_id as the first parent query lookup can be team-nested")
     if not basename.startswith("environment_"):
-        raise ValueError("Only endpoints with a basename starting with `environment_` can be environment-nested")
+        raise ValueError("Only endpoints with a basename starting with `environment_` can use this helper")
     environment_nested = environments_router.register(prefix, viewset, basename, parents_query_lookups)
-    legacy_project_nested = projects_router.register(
+    project_nested = projects_router.register(
         prefix, viewset, basename.replace("environment_", "project_"), parents_query_lookups
     )
-    return environment_nested, legacy_project_nested
+    return environment_nested, project_nested
 
 
 environment_plugins_configs_router, legacy_project_plugins_configs_router = (

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -54,7 +54,7 @@ class DefaultRouterPlusPlus(ExtendedDefaultRouter):
 # NOTE: Previously known as the StructuredViewSetMixin
 # IMPORTANT: Almost all viewsets should inherit from this mixin. It should be the first thing it inherits from to ensure
 # that typing works as expected
-class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" in name
+class TeamAndOrgViewSetMixin(_GenericViewSet):
     # This flag disables nested routing handling, reverting to the old request.user.team behavior
     # Allows for a smoother transition from the old flat API structure to the newer nested one
     param_derived_from_user_current_team: Optional[Literal["team_id", "project_id"]] = None


### PR DESCRIPTION
## Problem

PostHog briefly split projects and environments, then rolled the split back. `/api/projects/:team_id/...` is the canonical path; `/api/environments/:team_id/...` exists as a backward-compat alias and is auto-marked `deprecated: true` in the generated OpenAPI schema.

The in-tree docs, helper docstring, and a couple of skill files still pointed in the **opposite** direction — telling authors `/api/environments/` was the "correct endpoint" and projects was legacy. Following that bad signal, a long list of endpoints landed env-only after the rollback. PR 2 (stacked on this one) actually adds the missing canonical routes; this PR makes sure future authors don't recreate the same backlog by fixing the guidance they read first.

## Changes

Pure docs / comments / skill prose. No runtime behaviour changes.

- `posthog/api/__init__.py` — rewrite the docstring on `register_grandfathered_environment_nested_viewset` to reflect reality (projects canonical, env deprecated alias, env side auto-marked deprecated by the postprocess hook). Mention that for *new* endpoints, authors should register directly under `projects_router`.
- `posthog/api/routing.py` — drop the stale `TODO: Rename to include "Env" in name` on `TeamAndOrgViewSetMixin`. That rename direction is gone.
- `.agents/skills/improving-drf-endpoints/SKILL.md` — new short "URL routing" section so the skill that fires on viewset/serializer edits surfaces the convention.
- `.agents/skills/writing-kea-logics/references/testing.md` — flip the example mock URL to `/api/projects/...`.
- `.agents/skills/modifying-taxonomic-filter/references/testing-patterns.md` — soften the "persons properties live under env, not projects" line to "match what the calling logic actually does; backend exposes both."

## How did you test this code?

This is an agent-authored PR. No manual testing. Changes are documentation only — no functions or routes touched, so existing CI suffices.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) in the course of investigating which products had landed endpoints env-only after the rollback. The starting question was a misreading of the situation — assumption was that `/api/environments/` was the new format we wanted to converge on; the codebase docstring on `register_grandfathered_environment_nested_viewset` reinforced that. Slack context from @yasen and @reece (paraphrased: env split is rolled back, both will eventually merge, but for now `/api/projects/` is the canonical one) reversed the conclusion. From there the agent forensically audited which endpoints had landed env-only since the rollback (PR 2 is the cleanup of that backlog) and traced the bad steering back to this single misleading docstring plus a few skill files that propagated the same line.

The helper itself isn't renamed — there are ~50 existing call sites still using the `environment_*` basename convention, and a rename diff would be noisy without buying anything. The function's *body* already does the right thing (registers projects path, which the postprocess hook then treats as canonical); only the docstring was lying.

PR 2 will stack on top of this and adds the canonical `/api/projects/` route registration for the env-only endpoints discovered in the audit, plus two semgrep rules to lock in the convention going forward.
