### PR TITLE
fix(integrations): Use GitHub OAuth fast path on web

### DIFF
--- a/posthog/api/test/test_user_integration.py
+++ b/posthog/api/test/test_user_integration.py
@@ -163,12 +163,8 @@ class TestUserIntegrationEndpoints(APIBaseTest):
         self.assertIn("client_id=gh_client_123", url)
         self.assertIn("redirect_uri=https%3A%2F%2Fus.posthog.com%2Fcomplete%2Fgithub-link%2F", url)
 
-    @override_settings(GITHUB_APP_CLIENT_ID="gh_client_123")
-    @patch(
-        "posthog.api.github_callback.personal_state.get_instance_settings",
-        return_value={"GITHUB_APP_SLUG": "posthog-dev"},
-    )
-    def test_github_start_returns_install_url_even_when_team_has_github_integration(self, _mock_settings):
+    @override_settings(GITHUB_APP_CLIENT_ID="gh_client_123", SITE_URL="https://us.posthog.com")
+    def test_github_start_web_fast_path_returns_oauth_url_when_team_has_github_integration(self):
         Integration.objects.create(
             team=self.team,
             kind="github",
@@ -181,8 +177,11 @@ class TestUserIntegrationEndpoints(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertIn("install_url", data)
-        self.assertEqual(data.get("connect_flow"), "app_install")
-        self.assertIn("github.com/apps/posthog-dev/installations/new", data["install_url"])
+        self.assertEqual(data.get("connect_flow"), "oauth_authorize")
+        url = data["install_url"]
+        self.assertIn("github.com/login/oauth/authorize", url)
+        self.assertIn("client_id=gh_client_123", url)
+        self.assertIn("redirect_uri=https%3A%2F%2Fus.posthog.com%2Fcomplete%2Fgithub-link%2F", url)
 
     @override_settings(
         GITHUB_APP_CLIENT_ID="gh_client_123", SITE_URL="https://us.posthog.com", GITHUB_APP_CLIENT_SECRET="s"

--- a/posthog/api/user_integration.py
+++ b/posthog/api/user_integration.py
@@ -296,12 +296,12 @@ class UserIntegrationViewSet(viewsets.GenericViewSet):
         page handles both cases: orgs where the app is installed show "Configure"
         (no admin needed), orgs where it isn't show "Install" (needs admin).
 
-        **First-party app fast path:** when ``connect_from`` is one of
-        ``APP_CONNECT_FROM_VALUES`` (e.g. ``"posthog_code"`` or ``"posthog_mobile"``),
-        the current project already has a team-level GitHub installation, and the
-        user has no ``UserIntegration`` for that installation yet, we skip the org
-        picker and redirect straight to ``/login/oauth/authorize`` so the user
-        only authorizes themselves and returns to the originating client immediately.
+        **OAuth fast path:** when the current project already has a team-level
+        GitHub installation, and the user has no ``UserIntegration`` for that
+        installation yet, we skip the org picker and redirect straight to
+        ``/login/oauth/authorize`` so the user only authorizes themselves.
+        ``connect_from`` is preserved for first-party clients so they return to
+        the originating client immediately.
 
         In both cases the response key is ``install_url`` for compatibility with callers.
         """
@@ -313,9 +313,10 @@ class UserIntegrationViewSet(viewsets.GenericViewSet):
         team = _resolve_team_for_github_start(user, self.request)
         connect_from = request.data.get("connect_from")
 
+        if fast_path_response := _attempt_app_oauth_fast_path(user, team, token, state, connect_from):
+            return fast_path_response
+
         if connect_from in APP_CONNECT_FROM_VALUES:
-            if fast_path_response := _attempt_app_oauth_fast_path(user, team, token, state, connect_from):
-                return fast_path_response
             if _team_github_installation_id(team) is None:
                 cache.set(
                     f"{GITHUB_INSTALL_STATE_CACHE_PREFIX}{token}",
@@ -436,10 +437,9 @@ def _attempt_app_oauth_fast_path(
     user: User, team: Any, token: str, state: str, connect_from: str | None
 ) -> Response | None:
     """If the team has a GitHub installation the user hasn't linked yet, return
-    an OAuth-only ``/login/oauth/authorize`` redirect so first-party app users
-    (PostHog Code, mobile) authorize and return immediately — no org picker
-    needed. ``connect_from`` is preserved so the callback returns to the right
-    client.
+    an OAuth-only ``/login/oauth/authorize`` redirect so users authorize against
+    the already-installed App — no org picker needed. ``connect_from`` is
+    preserved so first-party app callbacks return to the right client.
 
     Returns ``None`` when the fast path doesn't apply (no team integration,
     user already linked, or missing config).

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -873,12 +873,12 @@ user can pick any GitHub org (new or already connected).  GitHub's install
 page handles both cases: orgs where the app is installed show "Configure"
 (no admin needed), orgs where it isn't show "Install" (needs admin).
 
-**First-party app fast path:** when ``connect_from`` is one of
-``APP_CONNECT_FROM_VALUES`` (e.g. ``"posthog_code"`` or ``"posthog_mobile"``),
-the current project already has a team-level GitHub installation, and the
-user has no ``UserIntegration`` for that installation yet, we skip the org
-picker and redirect straight to ``/login/oauth/authorize`` so the user
-only authorizes themselves and returns to the originating client immediately.
+**OAuth fast path:** when the current project already has a team-level
+GitHub installation, and the user has no ``UserIntegration`` for that
+installation yet, we skip the org picker and redirect straight to
+``/login/oauth/authorize`` so the user only authorizes themselves.
+``connect_from`` is preserved for first-party clients so they return to
+the originating client immediately.
 
 In both cases the response key is ``install_url`` for compatibility with callers.
  * @summary Start GitHub personal integration linking

--- a/products/integrations/frontend/generated/api.zod.ts
+++ b/products/integrations/frontend/generated/api.zod.ts
@@ -366,12 +366,12 @@ user can pick any GitHub org (new or already connected).  GitHub's install
 page handles both cases: orgs where the app is installed show "Configure"
 (no admin needed), orgs where it isn't show "Install" (needs admin).
 
-**First-party app fast path:** when ``connect_from`` is one of
-``APP_CONNECT_FROM_VALUES`` (e.g. ``"posthog_code"`` or ``"posthog_mobile"``),
-the current project already has a team-level GitHub installation, and the
-user has no ``UserIntegration`` for that installation yet, we skip the org
-picker and redirect straight to ``/login/oauth/authorize`` so the user
-only authorizes themselves and returns to the originating client immediately.
+**OAuth fast path:** when the current project already has a team-level
+GitHub installation, and the user has no ``UserIntegration`` for that
+installation yet, we skip the org picker and redirect straight to
+``/login/oauth/authorize`` so the user only authorizes themselves.
+``connect_from`` is preserved for first-party clients so they return to
+the originating client immediately.
 
 In both cases the response key is ``install_url`` for compatibility with callers.
  * @summary Start GitHub personal integration linking


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a project already has a team-level GitHub App installation, a web user connecting their personal GitHub account still gets sent through the GitHub App installation picker. If they are not an owner of the GitHub organization that owns the installation, GitHub can block them with an organization-owner requirement even though all PostHog needs is user OAuth authorization for the already-installed App.

## Changes

Let's run the existing personal GitHub OAuth fast path for web flows as well as first-party app flows.

## How did you test this code?

Updated a test.

## Publish to changelog?

no

## Docs update

No docs update needed.