### PR TITLE
fix: correct typo 'seperate' → 'separate' in test description

### DIFF
--- a/nodejs/src/ingestion/ai/process-ai-event.test.ts
+++ b/nodejs/src/ingestion/ai/process-ai-event.test.ts
@@ -1232,7 +1232,7 @@ describe('processAiEvent()', () => {
             expect(result.properties!.$ai_total_cost_usd).toBeUndefined()
         })
 
-        it('handles the separate price for lage prompts', () => {
+        it('handles the separate price for large prompts', () => {
             const event1 = {
                 ...event,
                 properties: {

--- a/nodejs/src/ingestion/ai/process-ai-event.test.ts
+++ b/nodejs/src/ingestion/ai/process-ai-event.test.ts
@@ -1232,7 +1232,7 @@ describe('processAiEvent()', () => {
             expect(result.properties!.$ai_total_cost_usd).toBeUndefined()
         })
 
-        it('handles the seperate price for lage prompts', () => {
+        it('handles the separate price for lage prompts', () => {
             const event1 = {
                 ...event,
                 properties: {


### PR DESCRIPTION
## Changes

Corrects a typo in the test description for AI event processing:
- \seperate\ → \separate\

This is a minor documentation fix with no functional changes.