### PR TITLE
fix: correct typos 'occured' -> 'occurred' and 'innacurate' -> 'inaccurate'

### DIFF
--- a/ee/hogai/session_summaries/session/templates/identify-objectives/prompt.djt
+++ b/ee/hogai/session_summaries/session/templates/identify-objectives/prompt.djt
@@ -12,8 +12,8 @@ You'll receive a list of events with columns:
 - $current_url: Page URL where the interaction happened on (use simplified references from url_mapping)
 - $event_type: Type of interaction (e.g., click, submit) - specifies how the user interacted
 - $elements_chain_ids: IDs of the elements that are part of the interaction
-- $exception_types: Type of the exception occured, if applicable
-- $exception_values: Short description of the exception occured, if applicable
+- $exception_types: Type of the exception occurred, if applicable
+- $exception_values: Short description of the exception occurred, if applicable
 
 Event columns are provided in the order the data for each event. So, the first element of the event is the event name, the second element is the timestamp, etc.
 

--- a/ee/hogai/session_summaries/session/templates/video-validation/validation-prompt.djt
+++ b/ee/hogai/session_summaries/session/templates/video-validation/validation-prompt.djt
@@ -60,7 +60,7 @@ For events requiring updates based on Step 1:
 
 2.2. Revise event descriptions:
    - Focus on the actual user action observed
-   - If no errors occured and the current description is innacurate:
+   - If no errors occurred and the current description is inaccurate:
       - Remove error language
       - Keep descriptions concise (4-8 words)
    - If the current description is accurate:

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -58,7 +58,7 @@ export interface InsightCardProps extends Resizeable {
     loading?: boolean
     /** Whether an error occurred on the server. */
     apiErrored?: boolean
-    /** Might contain more information on the error that occured on the server. */
+    /** Might contain more information on the error that occurred on the server. */
     apiError?: Error
     /** Whether the card should be highlighted with a blue border. */
     highlighted?: boolean

--- a/frontend/src/mocks/utils.ts
+++ b/frontend/src/mocks/utils.ts
@@ -21,7 +21,7 @@ export const mocksToHandlers = (mocks: Mocks): ReturnType<(typeof rest)['get']>[
                         // We currently support a few ways to specify a mock response:
                         // 1. A function that returns a tuple of [status, body]
                         // 2. A function that returns a tuple of [status]
-                        // 3. A function that returns undefined. This represents that a network error has occured
+                        // 3. A function that returns undefined. This represents that a network error has occurred
                         // 4. A function that returns an MSW response
                         // 5. A JSON serializable object that will be returned as the response body
                         if (typeof handler === 'function') {

--- a/frontend/src/scenes/max/__mocks__/summaryMessage.json
+++ b/frontend/src/scenes/max/__mocks__/summaryMessage.json
@@ -1,5 +1,5 @@
 {
     "type": "ai",
-    "content": "Looks like no pageviews have occured. Get some damn users.",
+    "content": "Looks like no pageviews have occurred. Get some damn users.",
     "id": "test-summary-message"
 }

--- a/nodejs/src/ingestion/ai/process-ai-event.test.ts
+++ b/nodejs/src/ingestion/ai/process-ai-event.test.ts
@@ -1232,7 +1232,7 @@ describe('processAiEvent()', () => {
             expect(result.properties!.$ai_total_cost_usd).toBeUndefined()
         })
 
-        it('handles the seperate price for lage prompts', () => {
+        it('handles the separate price for lage prompts', () => {
             const event1 = {
                 ...event,
                 properties: {


### PR DESCRIPTION
Fixes spelling typos across AI prompt templates, JSDoc comments, and mock data. No functional changes.