### PR TITLE
chore(hogql): tune parse_*_seconds histogram buckets for sub-ms parses

### DIFF
--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -207,11 +207,17 @@ _BACKEND_VERSION: dict[HogQLParserBackend, str] = {
     "python": "n/a",
 }
 
+# Parse durations span ~10μs (rust-py) to a few ms (cpp typical) to seconds (pathological queries). Default Prometheus
+# buckets bottom out at 5ms, so every sub-ms parse lands in the lowest bucket and histogram_quantile is useless at this
+# scale; the 1-2-5 progression below gives usable resolution from 5μs through 10s.
+_PARSE_DURATION_BUCKETS = (5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 5e-3, 1e-2, 5e-2, 1e-1, 5e-1, 1, 5, 10)
+
 RULE_TO_HISTOGRAM: dict[ParseRule, Histogram] = {
     rule: Histogram(
         f"parse_{rule}_seconds",
         f"Time to parse {rule} expression",
         labelnames=["backend", "version"],
+        buckets=_PARSE_DURATION_BUCKETS,
     )
     for rule in (ParseRule.EXPR, ParseRule.ORDER_EXPR, ParseRule.SELECT, ParseRule.FULL_TEMPLATE_STRING)
 }


### PR DESCRIPTION
## Problem

[#60201](https://github.com/PostHog/posthog/pull/60201) shipped per-backend parse timings on the existing Prometheus histograms `parse_expr_seconds`, `parse_order_expr_seconds`, `parse_select_seconds`, and `parse_full_template_string_seconds` in `posthog/hogql/parser.py`. Looking at the live metrics, the default Prometheus buckets (lowest bound 5ms) are far too coarse for these parses. rust-py runs around 10μs, cpp is typically under 1ms, and pathological queries can take seconds. With the default buckets, every typical parse lands in the lowest bucket and `histogram_quantile` is effectively useless at this scale.

Means (`_sum / _count`) are fine, and the current dashboards use those, but quantiles are not usable.

## Changes

Add an explicit `buckets=` tuple on the four `parse_*_seconds` histograms: a 1-2-5 progression from 5μs through 10s (14 buckets). This is the entire change; no other files are touched.

```python
_PARSE_DURATION_BUCKETS = (5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 5e-3, 1e-2, 5e-2, 1e-1, 5e-1, 1, 5, 10)
```

## How did you test this code?

Agent-authored (Claude Code); requires human review. This is a histogram bucket config change with no logic touches. Python syntax check on `posthog/hogql/parser.py` passes. No tests assert on bucket values; CI will run the full backend suite. No manual or UI testing was done.

## Publish to changelog?

no, internal observability tuning.

## Docs update

No user-facing changes.

## 🤖 Agent context

Source: observation from [#60201](https://github.com/PostHog/posthog/pull/60201) once the shadow-parser rollout reached Grafana. The existing histograms were created with `prometheus_client`'s default buckets, which start at 5ms; with rust-py parses around 10μs and cpp typically sub-ms, p50/p90/p99 all collapsed into the lowest bucket. The fix sets `buckets=` on the same `Histogram` instances and leaves everything else untouched.

Behavior note for the rollout window: quantile queries that span the bucket-change boundary will look odd for a short period (old samples have only the 5ms-and-up buckets, new samples have the full 5μs-through-10s range). Mean-based dashboards (`_sum / _count`) are unaffected.

Cardinality: modest. 14 buckets × 4 rules × small number of backends × small number of versions, which is well within typical Prometheus sizing.

Tools: Claude Code (Edit, Bash, gh).
