### PR TITLE
feat(mcp): support 2026-07-28 protocol via strategy-pattern dispatcher

### DIFF
--- a/services/mcp/docs/2026-07-28-protocol-spec.md
+++ b/services/mcp/docs/2026-07-28-protocol-spec.md
@@ -1,0 +1,1019 @@
+<!-- markdownlint-disable MD013 -->
+
+# MCP `2026-07-28` parallel pipeline — implementation spec
+
+**Status:** draft, no code yet.
+**Branch:** `yasen/mcp-2026-07-28-spec` (off `yasen/mcp-confirmation-paradigm`).
+**Owners:** TBD.
+**Target protocol version:** `MCP-Protocol-Version: 2026-07-28` (RC locked 2026-05-21, final 2026-07-28).
+
+This document specifies the changes needed for the Hono MCP server to support
+the `2026-07-28` protocol alongside the current `2025-06-18` protocol. The two
+implementations live side-by-side — every inbound HTTP request is dispatched to
+the right pipeline based on the protocol version the client declares. We do
+not break, deprecate, or remove the existing pipeline; clients on older
+protocols continue to receive the same responses they get today.
+
+The motivating consumer is the `confirmation:` YAML paradigm shipped in PR
+60195: today its elicitation flow rides our cross-pod session bus over SSE,
+which the new protocol explicitly removes. After this work, a confirmation
+gate gracefully degrades to the new continuation-passing form when the client
+is on `2026-07-28`, and continues to use the bus when the client is on
+`2025-06-18`. Tool authors do not see the difference.
+
+## 1. Why a parallel pipeline
+
+The `2026-07-28` RC is a deliberate breaking change to the on-the-wire model
+for server-initiated requests. The headline:
+
+> "Server-initiated requests may now only be issued while the server is
+> actively processing a client request." — SEP-2260
+>
+> "These [server-initiated] interactions are embedded as input requests inside
+> an `IncompleteResult` returned from specific request paths (e.g.,
+> `CallTool`, `GetPrompt`, `ListResources`). The client satisfies the input
+> requests and retries the original request." — SEP-2575, §Response Streaming
+
+The SSE-elicit-then-await pattern that drives our `ElicitBinding` +
+`SessionResponseBus` infrastructure cannot be expressed on `2026-07-28` — there
+is no SSE write-back channel for an `elicitation/create` request, and the
+server cannot block waiting for a reply on the same HTTP request. The
+equivalent flow is:
+
+1. Tool handler decides it needs input → returns synchronously with
+   `resultType: "input_required"` plus an `inputRequests` map and an opaque
+   `requestState` blob.
+2. HTTP request ends. Server keeps no state.
+3. Client renders prompts, collects responses, **issues a new `tools/call`**
+   with the original arguments _and_ `inputResponses` + the echoed
+   `requestState`.
+4. Any server instance picks up the retry. Tool handler resumes from
+   `requestState`, completes the action.
+
+The new model also removes the `initialize`/`initialized` handshake, the
+`Mcp-Session-Id` header, and adds two new mandatory HTTP headers
+(`Mcp-Method`, `Mcp-Name`) — see §2 for the full surface.
+
+Today every Claude Code surface that exists (interactive CLI, Desktop, the VS
+Code extension, Cursor's MCP client) ships `2025-06-18`. The RC has a
+10-week SDK validation window before the final spec date, and even after
+final, third-party clients will lag the spec by months. We have to keep the
+old pipeline running indefinitely. Doing so as a parallel implementation
+keeps the new code isolated, reviewable in one PR, and unambiguous about
+which protocol version each line belongs to.
+
+## 2. Protocol summary — `2026-07-28` on the wire
+
+This section is a self-contained reference of the wire-level changes we need
+to implement. Every quote is from the merged SEP or RC blog post.
+
+### 2.1 Protocol version negotiation (SEP-2575)
+
+- `initialize` / `notifications/initialized` are **removed**. There is no
+  handshake.
+- Every request carries `MCP-Protocol-Version: <version>` as an HTTP header.
+- The same version MUST be present in `_meta["io.modelcontextprotocol/protocolVersion"]`
+  on the request body. Header/body mismatch → `400 Bad Request`.
+- If the server does not implement the requested version, it returns
+  JSON-RPC error code `-32004 UNSUPPORTED_PROTOCOL_VERSION` with body
+  `{ supported: string[], requested: string }`. HTTP status `400`.
+- New RPC `server/discover` lets the client query supported versions +
+  capabilities + serverInfo + instructions up-front. Clients MAY skip it.
+
+### 2.2 Per-request client capabilities (SEP-2575)
+
+- Capabilities live in `_meta["io.modelcontextprotocol/clientCapabilities"]`
+  on **every** request — not once per session.
+- Client info lives in `_meta["io.modelcontextprotocol/clientInfo"]` on every
+  request.
+- The `_meta` shape:
+
+  ```ts
+  interface RequestMetaObject {
+    progressToken?: ProgressToken
+    'io.modelcontextprotocol/protocolVersion': string // required
+    'io.modelcontextprotocol/clientInfo': Implementation // required
+    'io.modelcontextprotocol/clientCapabilities': ClientCapabilities // required
+    'io.modelcontextprotocol/logLevel'?: LoggingLevel // optional
+  }
+  ```
+
+- Missing any required `_meta` field → server returns `INVALID_PARAMS`
+  (`400 Bad Request`).
+- Missing capability the server needs to serve the request →
+  `-32003 MISSING_REQUIRED_CLIENT_CAPABILITY` with
+  `data.requiredCapabilities: ClientCapabilities`.
+
+### 2.3 Sessions are gone (SEP-2567)
+
+- `Mcp-Session-Id` header is **removed** from the protocol. Servers MUST NOT
+  rely on it; clients MUST NOT send it as a routable identifier.
+- All cross-call state moves to "explicit state handles" — a server-minted
+  identifier returned from one tool call and threaded as an ordinary string
+  argument into subsequent calls. This is a tool-design pattern, not a
+  protocol feature; there is no `handles/*` RPC.
+
+### 2.4 Server-initiated requests must be associated with a client request (SEP-2260)
+
+- `elicitation/create`, `sampling/createMessage`, and `roots/list` MUST be
+  issued only in the context of an originating `tools/call`, `resources/read`,
+  or `prompts/get`.
+- They MUST NOT be sent as standalone server-initiated requests on a separate
+  channel. The GET-SSE notification channel still exists for `ping`-style
+  notifications only.
+- The mechanism for delivering them is `InputRequiredResult` (next section).
+
+### 2.5 Multi-Round-Trip Requests (SEP-2322, the load-bearing one)
+
+#### `InputRequiredResult` — replaces the old elicit-over-SSE flow
+
+```ts
+type ResultType = 'complete' | 'input_required'
+
+interface Result {
+  _meta?: MetaObject
+  resultType: ResultType // new — absent ≡ "complete" for back-compat
+  [key: string]: unknown
+}
+
+interface InputRequiredResult extends Result {
+  resultType: 'input_required'
+  inputRequests?: InputRequests
+  requestState?: string // opaque to client; MUST be echoed verbatim
+}
+
+interface InputRequests {
+  [key: string]: InputRequest
+}
+
+type InputRequest = ElicitRequest | CreateMessageRequest | ListRootsRequest
+```
+
+- Keys are author-chosen strings (`"github_login"`, `"confirm"`); they are
+  the correlation between an input request and the matching response.
+- Sent as a normal JSON response on the original HTTP request — _not_ over
+  SSE. The SEP says SSE is allowed but discouraged: "implementations are
+  encouraged to prefer the former [single response]".
+
+#### `InputResponses` — what the client sends back
+
+The client re-issues the same RPC method (e.g. `tools/call`) with the original
+arguments AND two extra params:
+
+```ts
+interface InputResponseRequestParams extends RequestParams {
+  inputResponses?: InputResponses
+  requestState?: string // verbatim from server's earlier InputRequiredResult
+}
+
+type InputResponse = ElicitResult | CreateMessageResult | ListRootsResult
+```
+
+- The retry uses a **different JSON-RPC `id`** — "the JsonRPC Id MUST be
+  different between the requests sent in step 1 and step 3" (SEP-2322).
+- Any server instance can process the retry — that's the whole point.
+
+#### `requestState` semantics
+
+- Opaque to the client.
+- The client MUST echo it verbatim — "Clients MUST NOT inspect, parse, modify,
+  or make any assumptions about the `requestState` contents."
+- Server MUST treat the client as untrusted: validate / authenticate /
+  decrypt / re-bind to the authenticated principal.
+- Recommended encoding: signed JWT or AES-GCM. Plain JSON is allowed only if
+  every field is re-validated as untrusted input.
+- Multi-user replay defense: "if the request state contains any data that is
+  specific to the original user, the server MUST … cryptographically bind the
+  data to the original user and MUST verify that the `requestState` data sent
+  by the client is associated with the currently authenticated user."
+
+#### Which RPCs may return `InputRequiredResult`
+
+| ClientRequest    | InputRequiredResult |
+| ---------------- | :-----------------: |
+| `tools/call`     |         Yes         |
+| `resources/read` |         Yes         |
+| `prompts/get`    |         Yes         |
+| `tasks/payload`  |         Yes         |
+| everything else  |         No          |
+
+#### Error handling for malformed `inputResponses`
+
+> "If the missing information requested is necessary for the server to process
+> the request, then it SHOULD respond with a new `InputRequiredResult`."
+
+The pattern is: if the retry's `inputResponses` don't satisfy the prompts you
+asked for, ask again with a fresh `InputRequiredResult`. Don't return a
+protocol error.
+
+### 2.6 HTTP header standardization (SEP-2243)
+
+- Required on every POST:
+  - `Content-Type: application/json`
+  - `MCP-Protocol-Version: 2026-07-28` (from SEP-2575)
+  - `Mcp-Method: <jsonrpc method>` (e.g. `tools/call`)
+- Required on `tools/call`, `resources/read`, `prompts/get`:
+  - `Mcp-Name: <params.name or params.uri>`
+- The server MUST reject mismatches between the header value and the body
+  value with `400 Bad Request`. Routing infrastructure may use the headers
+  without parsing the body.
+
+### 2.7 SSE narrowed (SEP-2575)
+
+- A response MAY still be delivered as an SSE stream when the response itself
+  contains notifications (`notifications/progress`, `notifications/message`).
+- Server-initiated `elicitation/create` requests are **not** delivered on
+  SSE under any condition — they only appear embedded in an `InputRequiredResult`.
+- Resumable streams (`Last-Event-ID` reconnection) are removed. A dropped
+  connection means the request is cancelled.
+
+### 2.8 Notification subscriptions (SEP-2575)
+
+- The HTTP `GET /mcp` endpoint is **removed**. All communication is POST.
+- A new `subscriptions/listen` RPC opens a long-lived POST whose response is
+  an SSE stream of notifications (`tools/list_changed`,
+  `prompts/list_changed`, etc.). The client opts in to each notification
+  type explicitly.
+- Out of scope for this implementation — we don't need it for the
+  confirmation paradigm.
+
+### 2.9 Error code change (SEP-2164)
+
+- "Resource not found" moves from `-32002` (custom) → `-32602` (JSON-RPC
+  Invalid Params). We don't currently emit `-32002`, so no change for us.
+
+### 2.10 URL-mode elicitation (SEP-1036)
+
+Form-mode elicitation is what we use today. URL-mode elicitation:
+
+```ts
+interface ElicitRequestURLParams {
+  mode: 'url'
+  url: string
+  elicitationId: string
+  message: string
+}
+```
+
+- The client opens `url` in the user's browser; the in-band response is one
+  of `accept | decline | cancel` with no `content` (acceptance just means
+  "I navigated").
+- The server can complete the out-of-band flow and send
+  `notifications/elicitation/complete` with the `elicitationId` when done.
+- A capability declaration looks like `capabilities.elicitation: { form: {}, url: {} }`.
+- Out of scope for v1 of this implementation. We mark it as deferred and
+  emit only `mode: "form"` for now.
+
+## 3. What the existing pipeline already gets right
+
+Before specifying the parallel pipeline, the existing one already does
+several things that the `2026-07-28` flow assumes:
+
+- Per-token rate limiting in `rate-limiter.ts` — survives.
+- Auth + bearer-token plumbing in `request-utils.ts` — survives.
+- Per-token capability cache (`CapabilityStore`, `mcp:client-caps:*`) —
+  partly survives: in the new protocol, capabilities arrive per-request via
+  `_meta`, so the cache becomes a read-through optimization, not a source of
+  truth. Less critical, but harmless to keep.
+- `requestConfirmation()` runtime in `confirmation-runtime.ts` — survives,
+  but the implementation under the hood swaps for the new protocol (see §5.3).
+- `ToolCatalog` + `ToolExecutor` + the tool handler signature — survive
+  unchanged. The handler API doesn't know which protocol delivered the call.
+- The codegen output in `generated/*.ts` — unchanged. The `confirmation:`
+  YAML field's emit stays the same.
+
+What does NOT survive when we serve a `2026-07-28` request:
+
+- The `SessionResponseBus` (`InMemory` and `RedisPolling` impls): the new
+  protocol assumes any server instance can handle the retry from
+  `requestState` alone. No cross-pod await needed.
+- The SSE upgrade race in `dispatchToolsCallWithMaybeSse` and
+  `finalizeSseResponse`: the new protocol responds with plain JSON whether
+  or not the tool elicits.
+- `ElicitBinding` + `firstElicit` race + `createSseResponse`: same reason.
+- The `classifyBody` JSON-RPC-response routing in `streamable-handler.ts`:
+  there are no separate response POSTs in the new protocol; every POST is a
+  fresh `tools/call`.
+
+These all stay in the codebase. They're the implementation of the
+`2025-06-18` pipeline, which we still serve.
+
+## 4. Architecture — version-dispatched pipeline
+
+The split happens at one point: the streamable handler picks a pipeline
+based on the negotiated protocol version, and from then on the two
+pipelines do not share code on the request hot path.
+
+```text
+                  POST /mcp
+                      │
+                      ▼
+              StreamableMcpHandler.fetch
+                      │
+        ┌─────────────┴─────────────┐
+        │                           │
+   parseProtocolVersion        (no version /
+   from headers + _meta         old initialize)
+        │                           │
+        ▼                           ▼
+   ┌────────────┐              ┌────────────┐
+   │ legacy     │              │ legacy     │
+   │ pipeline   │              │ pipeline   │
+   │ (2025-06-18│              │ (initialize│
+   │  default)  │              │  handshake)│
+   └────────────┘              └────────────┘
+        ▲
+        │ same dispatcher we ship today
+        │
+              POST /mcp + MCP-Protocol-Version: 2026-07-28
+                      │
+                      ▼
+              StreamableMcpHandler.fetch
+                      │
+                      ▼
+              v2026 pipeline (new)
+                      │
+                      ▼
+            McpDispatcher2026.handleRequest
+                      │
+        ┌─────────────┼─────────────────────────────┐
+        │             │                             │
+        ▼             ▼                             ▼
+   server/discover  tools/call (initial)     tools/call (retry with
+                       │                       inputResponses + requestState)
+                       ▼                             │
+                  Run tool handler                   ▼
+                       │                       Decode + validate requestState
+                       │                       Reconstruct elicit-completed context
+                       ▼                             │
+                  If elicit not needed →             ▼
+                  return resultType: 'complete'  Run tool handler
+                  + content                          │
+                       │                             ▼
+                  If elicit needed →            If still needs input →
+                  return InputRequiredResult    return InputRequiredResult
+                  with inputRequests + new      with cumulative state
+                  requestState                       │
+                                                If complete →
+                                                return resultType: 'complete'
+```
+
+### 4.1 Pipeline selection
+
+The version is read from the `MCP-Protocol-Version` HTTP header (preferred,
+because routing infrastructure may use it). The body's
+`_meta["io.modelcontextprotocol/protocolVersion"]` must match — if it doesn't,
+reject with `400`. If the header is absent, treat as `2025-06-18` (the legacy
+pipeline is the unambiguous default; this avoids breaking every client that
+ships today). Clients that explicitly opt into the legacy pipeline by sending
+`MCP-Protocol-Version: 2025-06-18` are honored as legacy — there's no future
+in which we'd want to interpret the header differently.
+
+```ts
+function selectPipeline(req: Request): 'legacy' | 'v2026' {
+  const headerVersion = req.headers.get('MCP-Protocol-Version')
+  if (!headerVersion) return 'legacy'
+  if (headerVersion === '2026-07-28') return 'v2026'
+  if (headerVersion === '2025-06-18') return 'legacy' // explicit opt-in
+  // Future versions: extend the table.
+  return 'legacy'
+}
+```
+
+### 4.2 Where the v2026 pipeline lives
+
+New files, all under `services/mcp/src/hono/v2026/`:
+
+```text
+v2026/
+  README.md                     // points at this spec
+  dispatcher.ts                 // McpDispatcher2026
+  request-meta.ts               // parse + validate _meta + headers; reject bad shapes
+  request-state.ts              // encode/decode + sign/verify requestState
+  input-required-result.ts      // build InputRequiredResult payloads
+  input-responses.ts            // decode inputResponses from retry params
+  discover.ts                   // server/discover handler
+  errors.ts                     // -32003, -32004 typed errors + status codes
+  metrics.ts                    // v2026-specific Prometheus metrics
+```
+
+We don't touch the existing `dispatcher.ts`, `request-context.ts`,
+`elicit-binding.ts`, `session-bus/`, `sse-response.ts`, or
+`streamable-handler.ts` other than to add the pipeline branch.
+
+### 4.3 Per-request `_meta` parsing
+
+`request-meta.ts` exposes a single function:
+
+```ts
+interface V2026RequestMeta {
+  protocolVersion: '2026-07-28'
+  clientInfo: { name: string; version: string }
+  clientCapabilities: ClientCapabilities
+  logLevel?: LoggingLevel
+}
+
+function parseV2026Meta(req: Request, body: JSONRPCRequest): V2026RequestMeta
+```
+
+Errors:
+
+- Missing required `_meta` field → `INVALID_PARAMS` (`-32602`), HTTP `400`.
+- Header / body version mismatch → `INVALID_PARAMS`, HTTP `400`.
+- Unsupported version → `UNSUPPORTED_PROTOCOL_VERSION` (`-32004`), HTTP `400`,
+  with `data.supported` listing the versions we know about.
+
+### 4.4 `requestState` encoding
+
+We use an HMAC-SHA256 signed JWT-compact-format token with these claims:
+
+```ts
+interface RequestStateClaims {
+  sub: string // userHash — binds state to the authenticated principal
+  iat: number // issued at — unix seconds
+  exp: number // expiry — iat + 600 (10 min)
+  nonce: string // 128-bit random — prevents trivial replay across users
+  tool: string // tool name — guards against cross-tool state injection
+  round: number // monotonic counter — capped to prevent unbounded loops (see §4.4.1)
+  payload: unknown // tool-author-supplied state (re-validated as untrusted)
+}
+```
+
+Signing key:
+
+- **Dedicated to MCP.** New env var `MCP_REQUEST_STATE_SIGNING_KEY` (32+ bytes
+  of random entropy). Not shared with Django's `SECRET_KEY` — the blast radius
+  for a key compromise stays local to MCP, and rotating one service does not
+  invalidate the other's signed material.
+- **Required in production.** The Hono entrypoint refuses to start when
+  `NODE_ENV === 'production'` and the env var is missing, empty, or shorter
+  than 32 bytes. Mirrors the Django `SECRET_KEY` guard at
+  `posthog/settings/access.py:69-76`.
+- **Rotatable** via an optional secondary key: support
+  `MCP_REQUEST_STATE_SIGNING_KEY_OLD` whose signatures we still accept on
+  verify but never use for signing. Lets us roll a new key forward without
+  invalidating every in-flight retry.
+
+We deliberately do NOT encrypt — the payload's confidentiality is the tool
+author's responsibility, and HMAC is enough for the integrity bind. If a
+specific tool needs confidentiality (e.g. it stores partially-collected
+credentials in `requestState`), it encrypts the `payload` field itself
+before handing it to the framework.
+
+#### 4.4.1 Round counter (multi-round cap)
+
+Tool handlers can issue an `InputRequiredResult` more than once for the same
+logical tool call (e.g. an Azure-DevOps-style flow where the first answer
+unlocks a second prompt). Each round increments `round` in `requestState`.
+The dispatcher enforces a hard cap: when an incoming retry carries
+`round >= MAX_REQUEST_STATE_ROUNDS`, decode succeeds but
+`handleToolsCall` returns a typed error instead of re-invoking the handler.
+The client receives a `complete` result with `isError: true` and a message
+explaining the cap.
+
+- `MAX_REQUEST_STATE_ROUNDS = 10` — a hard-coded constant in
+  `v2026/constants.ts`, not configurable via env. The number is generous
+  enough for legitimate multi-step flows (ADO custom-rules style chains rarely
+  exceed 3–4 prompts), tight enough to bound the cost of a buggy or
+  adversarial loop.
+- Tools approaching the cap should redesign their flow to collect inputs in
+  fewer rounds — combining prompts, using nested schemas, or persisting state
+  to their own backend if the data is large.
+
+On decode:
+
+- Verify signature. Failure → `INVALID_PARAMS` with message
+  `"requestState signature invalid"`. Don't reveal whether the key, nonce,
+  or expiry was the cause.
+- Verify `exp > now`. Expired → tell the client to start over (omit
+  `requestState` from the next `InputRequiredResult`).
+- Verify `sub === currentUserHash`. Mismatch → `INVALID_PARAMS`. This is the
+  cross-user replay defense SEP-2322 mandates.
+- Verify `tool === incoming tool name`. Mismatch → `INVALID_PARAMS`.
+
+We deliberately do NOT encrypt — the payload's confidentiality is the tool
+author's responsibility, and HMAC is enough for the integrity bind. If a
+specific tool needs confidentiality (e.g. it stores partially-collected
+credentials in `requestState`), it encrypts the `payload` field itself
+before handing it to the framework.
+
+### 4.5 Tool handler API surface
+
+The existing `ToolBase['handler']` signature stays:
+
+```ts
+type Handler<Schema, Result> = (context: Context, params: z.infer<Schema>) => Promise<Result>
+```
+
+We extend `Context` (additively, optional fields) with the new-protocol APIs.
+A tool can opt into the new behavior; tools that don't opt in continue to
+work via the existing `context.elicit?` API in the legacy pipeline only.
+
+```ts
+interface Context {
+  // ... existing fields ...
+
+  /**
+   * 2025-06-18 only — sends elicitation/create over SSE and awaits via the
+   * session bus. Undefined when the client did not advertise the capability,
+   * or when the pipeline is v2026.
+   */
+  elicit?: ElicitFn
+
+  /**
+   * Universal: works in BOTH pipelines. The runtime picks the right
+   * underlying mechanism. The handler writes straight-line code; the
+   * v2026 pipeline rebuilds the call frame from `requestState` on retry.
+   */
+  requestInput?: RequestInputFn
+}
+
+interface RequestInputFn {
+  <TSchema extends ElicitRequestFormParams['requestedSchema']>(params: {
+    key: string
+    message: string
+    requestedSchema: TSchema
+  }): Promise<ElicitResult>
+}
+```
+
+`requestInput` is the universal seam. Inside it:
+
+- **Legacy pipeline:** delegates to `context.elicit?.()` (the existing bus
+  flow). If `elicit` is missing, throws `ElicitationNotSupportedError`. No
+  behavior change.
+- **v2026 pipeline:** on the FIRST call, throws a special internal
+  `InputRequiredSignal` carrying the input request + the state to encode.
+  The dispatcher catches it, builds `InputRequiredResult`, encodes
+  `requestState`, returns. On the RETRY (when `inputResponses[key]` is
+  present in the incoming `_meta`-extended params), `requestInput` returns
+  the matching response synchronously without re-invoking the client.
+
+The signal pattern lets tool authors keep writing straight-line code:
+
+```ts
+const result = await context.requestInput({
+  key: 'confirm',
+  message: 'Enable 2FA?',
+  requestedSchema: { type: 'object', properties: {} },
+})
+if (result.action !== 'accept') return refusal()
+// proceed
+```
+
+The runtime decides whether to suspend (throw the signal) or resume (return
+the cached response from inputResponses). The codegen layer in PR #60195's
+`requestConfirmation()` is updated to call `requestInput` instead of
+`elicit` — single change, both pipelines benefit.
+
+### 4.6 `server/discover`
+
+A new method on `McpDispatcher2026`:
+
+```ts
+interface DiscoverResult {
+  supportedVersions: string[] // ["2025-06-18", "2026-07-28"]
+  capabilities: ServerCapabilities
+  serverInfo: { name: 'PostHog'; version: string }
+  instructions?: string
+}
+```
+
+This is also what we recommend clients call **before** any other RPC.
+Existing legacy `initialize` handler stays exactly as is for the legacy
+pipeline.
+
+## 5. File-level deltas
+
+### 5.1 `streamable-handler.ts` — version-dispatch one branch
+
+```ts
+fetch = async (c: HonoCtx): Promise<Response> => {
+  // ... unchanged auth + rate limit ...
+
+  const pipeline = selectPipeline(c.req.raw)
+  if (pipeline === 'v2026') {
+    return await this.dispatcherV2026.handleRequest(c.req.raw, auth.props)
+  }
+  return await this.dispatcher.handleRequest(c.req.raw, auth.props)
+}
+```
+
+`selectPipeline` lives in `v2026/request-meta.ts`. One new branch; nothing
+else changes.
+
+### 5.2 `dispatcher.ts` — unchanged
+
+The legacy dispatcher is the implementation of the `2025-06-18` pipeline.
+We don't modify it. Adding `v2026/dispatcher.ts` is a fresh implementation,
+no shared base class. The cost of duplication is small (the legacy
+dispatcher is ~400 lines) and the value of isolation is high: we can
+delete `dispatcher.ts` cleanly when the legacy protocol is retired.
+
+### 5.3 `confirmation-runtime.ts` — gain a universal seam
+
+Today:
+
+```ts
+export async function requestConfirmation(context, params, options) {
+    if (!context.elicit) return noElicitOutcome(...)
+    const result = await context.elicit({ message, requestedSchema })
+    // ...
+}
+```
+
+After:
+
+```ts
+export async function requestConfirmation(context, params, options) {
+    if (!context.requestInput) return noElicitOutcome(...) // both pipelines reach this if no capability
+    const result = await context.requestInput({
+        key: 'confirm',
+        message,
+        requestedSchema: { type: 'object', properties: {} },
+    })
+    // ... same accept / decline / cancel branches ...
+}
+```
+
+`requestInput` is implemented in both `RequestContext` (legacy) and
+`V2026RequestContext` (new). The legacy one delegates to `context.elicit`
+under the hood — pure refactor, no behavior change.
+
+### 5.4 New: `v2026/dispatcher.ts`
+
+```ts
+class McpDispatcher2026 {
+  async handleRequest(req: Request, props: RequestProperties): Promise<Response> {
+    const body = await parseBody(req)
+    const meta = parseV2026Meta(req, body) // throws → error response
+
+    // server/discover is the only RPC that doesn't carry an MCP-Name header,
+    // and is the only one for which inputResponses are nonsense.
+    if (body.method === 'server/discover') {
+      return handleDiscover(meta, this.serverCapabilities)
+    }
+
+    // Tools/call (initial OR retry — same dispatch path).
+    if (body.method === 'tools/call') {
+      return await this.handleToolsCall(body, meta, props)
+    }
+
+    // Other RPCs (tools/list, prompts/get, resources/read, ping).
+    return await this.handleOther(body, meta, props)
+  }
+
+  private async handleToolsCall(body, meta, props): Promise<Response> {
+    // Decode requestState if present. Reject on signature / sub / exp / tool
+    // mismatch.
+    const priorState = body.params.requestState
+      ? this.requestStateCodec.decode(body.params.requestState, props.userHash, body.params.name)
+      : undefined
+
+    // Build a v2026 Context whose `requestInput` knows about
+    // inputResponses + priorState.
+    const context = await this.buildContext(props, body, meta, priorState)
+
+    try {
+      const result = await this.toolExecutor.handleToolCall(body.params, props, state, context)
+      return jsonRpcCompleteResult(body.id, result)
+    } catch (signal) {
+      if (signal instanceof InputRequiredSignal) {
+        const nextState = this.requestStateCodec.encode({
+          sub: props.userHash,
+          tool: body.params.name,
+          payload: signal.statePayload,
+        })
+        return jsonRpcInputRequiredResult(body.id, signal.inputRequests, nextState)
+      }
+      throw signal
+    }
+  }
+}
+```
+
+### 5.5 New: `v2026/input-required-result.ts`
+
+Builds the response body:
+
+```ts
+function jsonRpcInputRequiredResult(id: string | number, inputRequests: InputRequests, requestState: string): Response {
+  const body = {
+    jsonrpc: '2.0' as const,
+    id,
+    result: {
+      resultType: 'input_required' as const,
+      inputRequests,
+      requestState,
+    },
+  }
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+```
+
+### 5.6 New: `v2026/request-state.ts`
+
+Tiny module wrapping `jose` or `node:crypto` for HMAC signing:
+
+```ts
+class RequestStateCodec {
+  encode(claims: RequestStateClaims): string
+  decode(token: string, expectedUser: string, expectedTool: string): RequestStateClaims
+}
+```
+
+Errors throw structured `RequestStateError` subclasses
+(`SignatureInvalid`, `Expired`, `UserMismatch`, `ToolMismatch`) that the
+dispatcher translates to JSON-RPC errors.
+
+### 5.7 New: `v2026/discover.ts`
+
+Static-ish response. Reads from a constant + the existing instructions
+builder.
+
+### 5.8 New: `tools/types.ts` — `Context.requestInput`
+
+Add the optional field. JSDoc explains the dual-pipeline semantics.
+
+### 5.9 New: `v2026/request-context.ts`
+
+Mirrors the existing `RequestContext` but its `requestInput` implementation
+is the throw-`InputRequiredSignal` / consume-from-`inputResponses` logic.
+The `Context.elicit` field is omitted (always `undefined`) so any tool that
+relied on the legacy API gets `undefined` and falls back via the
+`if (context.requestInput)` check that the universal `requestConfirmation`
+runtime uses.
+
+### 5.10 New metrics
+
+In `v2026/metrics.ts`:
+
+- `mcp_v2026_requests_total{outcome=complete|input_required|error}` — counter,
+  every dispatched `tools/call` request on the v2026 pipeline.
+- `mcp_v2026_request_state_decode_total{result=ok|bad_signature|expired|user_mismatch|tool_mismatch|rounds_exceeded|malformed}` —
+  counter, observability for every decode attempt including failure modes.
+- `mcp_v2026_request_state_expired_total` — counter, dedicated time-series
+  for the expiry case so the 10-minute TTL can be tuned from a single
+  signal. A sustained non-zero rate means the window is too tight for real
+  user latency; alert from this counter and adjust `REQUEST_STATE_TTL_SECONDS`
+  if it fires.
+- `mcp_v2026_input_required_round_trips` — histogram of how many rounds a
+  single logical tool-call took before completing.
+
+The existing `mcp_session_bus_*` and `mcp_client_capability_cache_*`
+counters keep working for legacy traffic. Dashboards stay valid by
+filtering on a new `pipeline` label that we add to existing counters where
+practical.
+
+### 5.11 No change
+
+- `dispatcher.ts`, `request-context.ts`, `elicit-binding.ts`,
+  `session-bus/`, `sse-response.ts`, `streamable-handler.ts` (other than
+  the one new branch), `capability-store.ts`.
+- `generated/*.ts` — codegen output unchanged.
+- `generate-tools.ts` — codegen logic unchanged (the gate calls
+  `requestConfirmation` which calls `requestInput` which the runtime
+  resolves to the right backend).
+- All YAML.
+- All tests for the existing pipeline.
+
+## 6. Confirmation paradigm impact
+
+The whole point of PR #60195 was to make destructive tools declarative.
+We preserve that. The `confirmation:` YAML block continues to work
+unchanged. Under the hood:
+
+| Pipeline     | Client lacks elicit support | Client supports elicit, single round | Multi-round elicit (future)                |
+| ------------ | --------------------------- | ------------------------------------ | ------------------------------------------ |
+| `2025-06-18` | `on_no_elicit` policy fires | SSE + bus round-trip                 | Multiple elicits parked on same bus        |
+| `2026-07-28` | `on_no_elicit` policy fires | One `InputRequiredResult` + retry    | Native — extra rounds reuse `requestState` |
+
+Tool author writes the same YAML; the runtime adapts.
+
+## 7. Testing strategy
+
+### 7.1 Unit tests (TDD-friendly, no live infra)
+
+- `v2026/request-meta.test.ts` — every required/optional `_meta` field
+  permutation; header/body mismatch; unsupported version path.
+- `v2026/request-state.test.ts` — signature roundtrip; tampering detection;
+  expiry; user-mismatch; tool-mismatch; rotating signing key.
+- `v2026/dispatcher.test.ts` — initial call returning `complete`; initial
+  call throwing `InputRequiredSignal` → `InputRequiredResult` with the
+  encoded `requestState`; retry with valid `inputResponses` →
+  `complete`; retry with stale `requestState` → `INVALID_PARAMS`.
+- `v2026/discover.test.ts` — response shape; correct list of supported
+  versions.
+
+### 7.2 Integration tests
+
+Add cases to the existing `mcp-protocol.test.ts` integration suite under
+a `MCP protocol (Hono) — v2026` describe:
+
+- Initialize: no `initialize` RPC; first call is `server/discover`. Returns
+  expected capabilities.
+- A tool with `confirmation:` set to `message: "Proceed?"`,
+  `on_no_elicit: deny`:
+  - Client declares `capabilities.elicitation: {}` → first call returns
+    `InputRequiredResult`; retry with `inputResponses.confirm =
+{action: "accept"}` → `complete` with the API result.
+  - Client does NOT declare elicitation → first call returns `complete`
+    with the `on_no_elicit` denial message.
+- A tool that elicits twice (multi-round): two `InputRequiredResult` cycles,
+  intermediate `requestState` correctly carries the first answer through.
+- Cross-pod simulation: run two `createApp` instances against the same
+  Redis, send the initial call to A, the retry to B → the retry succeeds
+  because `requestState` is self-contained.
+
+### 7.3 Adversarial tests
+
+- Replay: client sends `requestState` issued for user X under user Y's
+  auth → rejected.
+- Tampering: flip a bit in the JWT signature → rejected.
+- Expiry: clock advance past `exp` → rejected.
+- Truncation: client omits `requestState` on retry → server treats as fresh
+  call (no prior state) and the tool's `requestInput` re-issues the prompt.
+- Wrong tool: client sends `requestState` issued for `tool-A` but calls
+  `tool-B` → rejected.
+- Oversize `inputResponses`: ensure rate limiter + body-size guards apply.
+
+### 7.4 Manual / Inspector
+
+Once Claude Code / Inspector ship `2026-07-28` support (not before final
+release), drive an end-to-end with the temp `debug-mcp-ui-apps` scaffold
+the way we did for the legacy pipeline.
+
+## 8. Rollout plan
+
+1. **Land this spec.** No code. Lets reviewers debate the
+   `requestState` design and the `requestInput` signal pattern before any
+   line of code is written.
+2. **PR 1 — scaffolding.** Add `v2026/` directory with `dispatcher.ts`
+   stub (returns `405` for everything), `request-meta.ts`, `request-state.ts`,
+   `errors.ts`, `metrics.ts`. Tests for the codec and meta parser. No
+   wiring to `streamable-handler` yet.
+3. **PR 2 — minimum viable pipeline.** Wire `streamable-handler` to dispatch
+   on the protocol version. Implement `server/discover`, `tools/list`,
+   `tools/call` (no elicit yet, just pass-through). Integration tests
+   confirming a legacy client still works and a v2026 client gets a
+   complete result for a non-elicit tool.
+4. **PR 3 — `requestInput` + `InputRequiredResult`.** Add the signal pattern,
+   refactor `requestConfirmation` to call `requestInput`. Integration tests
+   for the single-round elicit flow. The confirmation paradigm now works on
+   both protocols end-to-end.
+5. **PR 4 — multi-round + adversarial.** Multi-round `requestState` chains
+   and the full adversarial suite. Update the implementing-mcp-tools skill.
+
+Total: ~4 PRs. PR 1 is the only one that could land before final spec; the
+rest should wait for a Claude Code client we can test against.
+
+## 9. Resolved decisions
+
+These were open in the first draft; recording the resolution here so
+reviewers see the rationale alongside the spec.
+
+- **Signing key:** dedicated MCP key, env var `MCP_REQUEST_STATE_SIGNING_KEY`,
+  refuse-to-start in production if missing or < 32 bytes. Not shared with
+  Django's `SECRET_KEY` — independent blast radius and independent rotation.
+  Secondary `MCP_REQUEST_STATE_SIGNING_KEY_OLD` accepted on verify only,
+  enabling zero-downtime key rotation.
+- **`exp` window:** 10 minutes, fixed at `REQUEST_STATE_TTL_SECONDS = 600`.
+  Tracked via `mcp_v2026_request_state_expired_total` for tuning.
+- **Multi-round step counter:** `round` claim in `requestState`, hard cap
+  `MAX_REQUEST_STATE_ROUNDS = 10` as a source constant (no env override).
+  Bounds buggy / adversarial loops without restricting realistic multi-step
+  flows.
+- **Explicit legacy opt-in:** `MCP-Protocol-Version: 2025-06-18` is accepted
+  as an explicit legacy route in the version-dispatch table.
+
+## 10. Deferred follow-ups
+
+- **`server/discover` caching headers** — the response is essentially static
+  per build, but we ship without `Cache-Control` and add it later if traffic
+  patterns make it worthwhile.
+- **URL-mode elicitation (SEP-1036)** — the 2FA tool is the obvious candidate
+  for a future iteration (browser-driven step-up reauth via the PostHog UI).
+  Not on the v1 path.
+
+## Appendix A: Wire-format cheat sheet
+
+### Initial `tools/call` (no elicit needed)
+
+```http
+POST /mcp HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer phx_...
+MCP-Protocol-Version: 2026-07-28
+Mcp-Method: tools/call
+Mcp-Name: get_weather
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {"location": "NYC"},
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientInfo": {"name": "claude-code", "version": "2.1.149"},
+      "io.modelcontextprotocol/clientCapabilities": {}
+    }
+  }
+}
+```
+
+→
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resultType": "complete",
+    "content": [{ "type": "text", "text": "72°F partly cloudy" }],
+    "isError": false
+  }
+}
+```
+
+### `tools/call` that needs confirmation
+
+Initial response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resultType": "input_required",
+    "inputRequests": {
+      "confirm": {
+        "method": "elicitation/create",
+        "params": {
+          "mode": "form",
+          "message": "Enable enforce 2FA on organization acme?",
+          "requestedSchema": { "type": "object", "properties": {} }
+        }
+      }
+    },
+    "requestState": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOi..."
+  }
+}
+```
+
+Client retries with a NEW `id`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "organization-enforce-2fa-update",
+    "arguments": { "orgId": "019e2357-bad3", "enforce_2fa": true },
+    "inputResponses": {
+      "confirm": { "action": "accept" }
+    },
+    "requestState": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOi...",
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "claude-code",
+        "version": "2.1.149"
+      },
+      "io.modelcontextprotocol/clientCapabilities": {
+        "elicitation": { "form": {} }
+      }
+    }
+  }
+}
+```
+
+Server completes:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "resultType": "complete",
+    "content": [{ "type": "text", "text": "Enforce 2FA enabled for organization acme." }],
+    "isError": false
+  }
+}
+```
+
+## References
+
+- [SEP-2322 (MRTR)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322)
+- [SEP-2260 (associate server requests with client requests)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2260)
+- [SEP-2575 (stateless MCP / no `initialize`)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575)
+- [SEP-2567 (sessionless MCP / no `Mcp-Session-Id`)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)
+- [SEP-2243 (HTTP header standardization)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243)
+- [SEP-2164 (resource-not-found error code)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2164)
+- [SEP-1036 (URL-mode elicitation)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1036)
+- [RC blog post](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)

--- a/services/mcp/src/hono/app.ts
+++ b/services/mcp/src/hono/app.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 
+import type { McpDispatcher } from './dispatcher'
 import { httpMetrics, securityHeaders } from './middleware'
 import { registerPublicRoutes } from './public-routes'
 import { type BusAwaitMetrics, createPromBusMetrics, type SessionResponseBus } from './session-bus'
@@ -28,6 +29,12 @@ export interface CreateAppOptions {
      * this undefined or pass a spy.
      */
     busMetrics?: BusAwaitMetrics
+    /**
+     * Override the v2026 dispatcher for integration tests. Production loads
+     * the signing key from `MCP_REQUEST_STATE_SIGNING_KEY` at startup;
+     * tests inject a codec backed by a fixed key + clock.
+     */
+    dispatcher2026?: McpDispatcher
 }
 
 const sseRedirect = (c: HonoCtx): Response => {
@@ -49,11 +56,18 @@ export function createApp(redis: RedisWithPing, options: CreateAppOptions = {}):
     app.all('/sse', sseRedirect)
     app.all('/sse/*', sseRedirect)
 
-    const dispatcherOptions: { sessionBus?: SessionResponseBus; busMetrics?: BusAwaitMetrics } = {
+    const dispatcherOptions: {
+        sessionBus?: SessionResponseBus
+        busMetrics?: BusAwaitMetrics
+        dispatcher2026?: McpDispatcher
+    } = {
         busMetrics: options.busMetrics ?? createPromBusMetrics(),
     }
     if (options.sessionBus !== undefined) {
         dispatcherOptions.sessionBus = options.sessionBus
+    }
+    if (options.dispatcher2026 !== undefined) {
+        dispatcherOptions.dispatcher2026 = options.dispatcher2026
     }
     const streamable = new StreamableMcpHandler(redis, lifecycle, dispatcherOptions)
 

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -1,14 +1,33 @@
-import {
-    ErrorCode,
-    JSONRPC_VERSION,
-    LATEST_PROTOCOL_VERSION,
-    SUPPORTED_PROTOCOL_VERSIONS,
-} from '@modelcontextprotocol/sdk/types.js'
+/**
+ * Shared MCP dispatcher for the Hono server.
+ *
+ * One class handles both `2025-06-18` and `2026-07-28` traffic. The
+ * protocol-specific bits live in `ProtocolStrategy`:
+ *
+ *   - `preDispatch.validate` — per-request validation
+ *     (legacy: noop; v2026: headers + `_meta`).
+ *   - `handshake` — the protocol's handshake RPC
+ *     (legacy: `initialize`; v2026: `server/discover`).
+ *   - `toolCall.dispatchToolsCall` — single-message `tools/call`
+ *     (legacy: SSE-upgrade race; v2026: `InputRequiredResult`).
+ *   - `toolCall.deliverInboundResponse?` — legacy-only seam for routing
+ *     inbound JSON-RPC responses to the session bus. v2026 has no
+ *     separate response POSTs.
+ *
+ * Everything else (`tools/list`, `ping`, `resources/*`, `prompts/*`,
+ * JSON-RPC parse and error responses, top-level batch dispatch) is
+ * shared here.
+ *
+ * Two instances are constructed at startup — one per protocol — sharing
+ * the underlying catalog, state resolver, and tool executor. The
+ * streamable handler selects between them per request.
+ */
+
+import { ErrorCode, JSONRPC_VERSION } from '@modelcontextprotocol/sdk/types.js'
 import type {
     CallToolRequest,
     GetPromptRequest,
     InitializeRequest,
-    InitializeResult,
     JSONRPCMessage,
     JSONRPCRequest,
     ListPromptsRequest,
@@ -18,43 +37,21 @@ import type {
     ReadResourceRequest,
 } from '@modelcontextprotocol/sdk/types.js'
 
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import type { RequestProperties } from '@/lib/request-properties'
 
-import { trackInitEvent } from './analytics'
 import type { RedisLike } from './cache/RedisCache'
-import { CapabilityStore, projectClientCapabilities, supportsAnyElicitation } from './capability-store'
 import { getEnv } from './constants'
-import { ElicitBinding } from './elicit-binding'
+import { loadGuidelines } from './guidelines-loader'
 import { InstructionsBuilder } from './instructions'
-import { initDurationSeconds, initTotal } from './metrics'
+import type { ProtocolStrategy } from './protocol-strategy'
 import { RequestStateResolver, type ResolvedState } from './request-state-resolver'
 import { ResourceCatalog } from './resource-catalog'
-import { type BusAwaitMetrics, RedisPollingSessionResponseBus, type SessionResponseBus } from './session-bus'
-import { createSseResponse, type SseResponseHandle } from './sse-response'
 import { ToolCatalog } from './tool-catalog'
 import { ToolExecutor } from './tool-executor'
+import { V2026ProtocolError } from './v2026/errors'
 
 export { McpDispatcher }
 export type { ResolvedState } from './request-state-resolver'
-
-function loadGuidelines(): string {
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const mod = require('@shared/guidelines.md')
-        return typeof mod === 'string' ? mod : (mod?.default ?? '')
-    } catch {
-        // @shared alias only resolves in the esbuild production bundle.
-        // Fall back to reading from disk (works in Vitest/test contexts).
-    }
-    try {
-        const fs = require('node:fs')
-        const path = require('node:path')
-        return fs.readFileSync(path.resolve(process.cwd(), 'shared/guidelines.md'), 'utf-8')
-    } catch {
-        return ''
-    }
-}
 
 const MAX_BATCH_SIZE = 100
 const MAX_BODY_BYTES = 1_048_576
@@ -85,7 +82,7 @@ type JsonRpcResultResponse = { jsonrpc: typeof JSONRPC_VERSION; id: number | str
 type JsonRpcErrorResponse = {
     jsonrpc: typeof JSONRPC_VERSION
     id: number | string
-    error: { code: number; message: string }
+    error: { code: number; message: string; data?: Record<string, unknown> }
 }
 type JsonRpcResponse = JsonRpcResultResponse | JsonRpcErrorResponse
 
@@ -97,66 +94,44 @@ function jsonRpcMethodError(id: number | string, code: number, message: string):
     return { jsonrpc: JSONRPC_VERSION, id, error: { code, message } }
 }
 
-function jsonRpcErrorResponse(id: unknown, code: number, message: string): Response {
+function jsonRpcErrorResponse(id: unknown, code: number, message: string, httpStatus = 200): Response {
     return new Response(JSON.stringify({ jsonrpc: JSONRPC_VERSION, id: id ?? null, error: { code, message } }), {
-        status: 200,
+        status: httpStatus,
         headers: { 'Content-Type': 'application/json' },
     })
 }
 
-export interface McpDispatcherOptions {
-    /**
-     * Cross-pod session bus. Defaults to a Redis-polling bus over the same
-     * `RedisLike` client. Tests can inject `InMemorySessionResponseBus`.
-     */
-    sessionBus?: SessionResponseBus
-    /**
-     * Per-await metrics adapter (e.g. Prometheus). Defaults to no-op.
-     */
-    busMetrics?: BusAwaitMetrics
-    /**
-     * Per-token cache of `initialize` capabilities. Defaults to a
-     * Redis-backed store using the same `RedisLike` client. Tests can inject
-     * a stub backed by an in-memory Map.
-     */
-    capabilityStore?: CapabilityStore
+export interface SharedDispatcherDeps {
+    catalog: ToolCatalog
+    resourceCatalog: ResourceCatalog
+    stateResolver: RequestStateResolver
+    toolExecutor: ToolExecutor
+    instructionsBuilder: InstructionsBuilder
+}
+
+/**
+ * Build the shared dependencies once. Two dispatcher instances (one per
+ * protocol) share these — catalog warmup is idempotent and per-request
+ * state resolution is stateless across calls.
+ */
+export function buildSharedDeps(catalog: ToolCatalog, redis: RedisLike): SharedDispatcherDeps {
+    const env = getEnv()
+    const resourceCatalog = new ResourceCatalog(env)
+    const stateResolver = new RequestStateResolver(catalog, redis, env)
+    const instructionsBuilder = new InstructionsBuilder(loadGuidelines())
+    const toolExecutor = new ToolExecutor(catalog, instructionsBuilder)
+    return { catalog, resourceCatalog, stateResolver, toolExecutor, instructionsBuilder }
 }
 
 class McpDispatcher {
-    private readonly catalog: ToolCatalog
-    private readonly resourceCatalog: ResourceCatalog
-    private readonly stateResolver: RequestStateResolver
-    private readonly toolExecutor: ToolExecutor
-    private readonly instructionsBuilder: InstructionsBuilder
-    private readonly sessionBus: SessionResponseBus
-    private readonly busMetrics: BusAwaitMetrics | undefined
-    private readonly capabilityStore: CapabilityStore
+    private readonly shared: SharedDispatcherDeps
+    readonly strategy: ProtocolStrategy
 
     private warmupPromise: Promise<void> | undefined
 
-    constructor(catalog: ToolCatalog, redis: RedisLike, options: McpDispatcherOptions = {}) {
-        const env = getEnv()
-        this.catalog = catalog
-        this.resourceCatalog = new ResourceCatalog(env)
-        this.stateResolver = new RequestStateResolver(catalog, redis, env)
-        this.instructionsBuilder = new InstructionsBuilder(loadGuidelines())
-        this.toolExecutor = new ToolExecutor(catalog, this.instructionsBuilder)
-        this.sessionBus = options.sessionBus ?? new RedisPollingSessionResponseBus(redis)
-        this.busMetrics = options.busMetrics
-        this.capabilityStore = options.capabilityStore ?? new CapabilityStore(redis)
-    }
-
-    /**
-     * Production delivery seam for inbound JSONRPC responses.
-     *
-     * The streamable handler classifies an inbound POST body and, when it's a
-     * response to a server-initiated request (today: `elicitation/create`),
-     * calls `dispatcher.bus.deliver(id, payload)` to route it to whichever
-     * pod is parked on the matching await. Tests also use this accessor to
-     * inject replies into the bus directly.
-     */
-    get bus(): SessionResponseBus {
-        return this.sessionBus
+    constructor(shared: SharedDispatcherDeps, strategy: ProtocolStrategy) {
+        this.shared = shared
+        this.strategy = strategy
     }
 
     async warmup(): Promise<void> {
@@ -165,8 +140,8 @@ class McpDispatcher {
     }
 
     private async doWarmup(): Promise<void> {
-        await this.catalog.warmup()
-        await this.resourceCatalog.warmup()
+        await this.shared.catalog.warmup()
+        await this.shared.resourceCatalog.warmup()
     }
 
     async handleRequest(req: Request, props: RequestProperties): Promise<Response> {
@@ -182,7 +157,22 @@ class McpDispatcher {
             return jsonRpcErrorResponse(null, ErrorCode.ParseError, 'Parse error: Invalid JSON')
         }
 
+        // Per-protocol validation (v2026 checks headers + _meta; legacy noop).
+        try {
+            await this.strategy.preDispatch.validate(req, body, props)
+        } catch (err) {
+            return mapProtocolError(err, body)
+        }
+
         const wasArray = Array.isArray(body)
+        if (wasArray && !this.strategy.allowBatches) {
+            return jsonRpcErrorResponse(
+                null,
+                ErrorCode.InvalidRequest,
+                `JSON-RPC batches are not supported in ${this.strategy.version} protocol`,
+                400
+            )
+        }
         const messages: JSONRPCMessage[] = wasArray ? (body as JSONRPCMessage[]) : [body as JSONRPCMessage]
 
         if (messages.length > MAX_BATCH_SIZE) {
@@ -194,158 +184,32 @@ class McpDispatcher {
             return new Response(null, { status: 202 })
         }
 
-        const needsState = requests.some((r) => TRACKED_METHODS.has(r.method))
-        const state = needsState ? await this.stateResolver.resolve(props) : undefined
+        const needsState = requests.some(
+            (r) => TRACKED_METHODS.has(r.method) || r.method === this.strategy.handshake.method
+        )
+        const state = needsState ? await this.shared.stateResolver.resolve(props) : undefined
 
-        // Single-message tools/call can upgrade to SSE if the tool handler
-        // calls `context.elicit()`. Batches and other methods stay on the
-        // plain JSON path — server-initiated elicits don't fit the batch
-        // request/response shape and aren't valid for non-tool methods.
+        // Single-message `tools/call` runs through the strategy — that's
+        // where elicitation diverges. Batches and other methods take the
+        // shared path (server-initiated elicits don't fit batches anyway).
         if (!wasArray && requests.length === 1 && requests[0]!.method === Method.ToolsCall) {
-            return await this.dispatchToolsCallWithMaybeSse(requests[0]!, props, state!, req.signal)
-        }
-
-        if (!wasArray && requests.length === 1) {
-            const result = await this.dispatch(requests[0]!, props, state)
-            return new Response(JSON.stringify(result), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-            })
-        }
-
-        const results = await Promise.all(requests.map((r) => this.dispatch(r, props, state)))
-        return new Response(JSON.stringify(results), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-        })
-    }
-
-    /**
-     * Dispatch a single `tools/call` request that may surface an elicit.
-     *
-     * Runs the tool handler concurrently with a watcher for the first elicit.
-     * Whichever finishes first decides the response shape:
-     * - **Handler completes first** → return plain JSON, exactly as the
-     *   pre-elicit code path did. Zero extra cost when no elicit fires.
-     * - **First elicit fires first** → return the SSE response immediately
-     *   (already carrying the `elicitation/create` message). Continue
-     *   awaiting the handler in the background; when it resolves, write
-     *   the final JSONRPC result to the SSE stream and close it.
-     */
-    private async dispatchToolsCallWithMaybeSse(
-        request: JSONRPCRequest,
-        props: RequestProperties,
-        state: ResolvedState,
-        requestSignal: AbortSignal
-    ): Promise<Response> {
-        const { id, params } = request
-
-        // Only install the elicit binding when the client declared elicitation
-        // support at initialize. Otherwise leave `Context.elicit` undefined —
-        // tool handlers checking `if (context.elicit)` see the truthful answer
-        // and fall back, no SSE round-trip required. This is the spec-compliant
-        // gate; without it we'd push a server-initiated request the client
-        // never agreed to support.
-        const caps = await this.capabilityStore.get(props.userHash)
-        const elicitAllowed = supportsAnyElicitation(caps)
-
-        type HandlerOutcome = { kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }
-
-        if (!elicitAllowed) {
-            // Fast path: no binding, no SSE possible. Behaves exactly like a
-            // pre-elicit tool call.
-            const outcome: HandlerOutcome = await this.toolExecutor
-                .handleToolCall(params, props, state)
-                .then((value): HandlerOutcome => ({ kind: 'success', value }))
-                .catch((error): HandlerOutcome => ({ kind: 'error', error }))
-            const result = this.buildToolsCallJsonRpcResponse(id, outcome)
-            return new Response(JSON.stringify(result), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-            })
-        }
-
-        const binding = new ElicitBinding({
-            bus: this.sessionBus,
-            createSseHandle: async () => createSseResponse(),
-            requestSignal,
-            ...(this.busMetrics !== undefined ? { gatewayOptions: { metrics: this.busMetrics } } : {}),
-        })
-        state.reqCtx.setElicitBinding(binding)
-
-        const handlerPromise: Promise<HandlerOutcome> = this.toolExecutor
-            .handleToolCall(params, props, state)
-            .then((value): HandlerOutcome => ({ kind: 'success', value }))
-            .catch((error): HandlerOutcome => ({ kind: 'error', error }))
-
-        // Wait for whichever happens first.
-        const winner = await Promise.race([
-            handlerPromise.then(() => 'handler' as const),
-            binding.firstElicit.then(() => 'elicit' as const),
-        ])
-
-        if (winner === 'handler') {
-            const outcome = await handlerPromise
-            const result = this.buildToolsCallJsonRpcResponse(id, outcome)
-            return new Response(JSON.stringify(result), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-            })
-        }
-
-        // SSE path — the binding already wrote `elicitation/create` to the
-        // writer. Hand the response back to the client now; flush the
-        // handler's eventual result asynchronously.
-        const sseHandle = binding.getSseHandle()
-        if (!sseHandle) {
-            // Should never happen: firstElicit resolved but no handle was
-            // recorded. Treat as internal error.
-            const fallback = jsonRpcMethodError(id, ErrorCode.InternalError, 'Internal error')
-            return new Response(JSON.stringify(fallback), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-            })
-        }
-
-        void this.finalizeSseResponse(sseHandle, id, handlerPromise)
-        return sseHandle.response
-    }
-
-    /**
-     * Wait for the tool handler to complete, then write the final JSONRPC
-     * result (or error) to the SSE writer and close the stream. Errors
-     * during the writes themselves are swallowed — the client has already
-     * disconnected at that point.
-     */
-    private async finalizeSseResponse(
-        sseHandle: SseResponseHandle,
-        id: number | string,
-        handlerPromise: Promise<{ kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }>
-    ): Promise<void> {
-        try {
-            const outcome = await handlerPromise
-            const result = this.buildToolsCallJsonRpcResponse(id, outcome)
-            await sseHandle.writer.write(result)
-        } catch (error) {
-            console.error('[McpDispatcher] SSE finalize failed:', error)
-        } finally {
             try {
-                await sseHandle.writer.close()
-            } catch {
-                /* already closed */
+                return await this.strategy.toolCall.dispatchToolsCall(requests[0]!, props, state!, req.signal)
+            } catch (err) {
+                return mapProtocolError(err, body)
             }
         }
-    }
 
-    private buildToolsCallJsonRpcResponse(
-        id: number | string,
-        outcome: { kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }
-    ): JsonRpcResponse {
-        if (outcome.kind === 'success') {
-            return jsonRpcResult(id, outcome.value)
+        try {
+            if (!wasArray && requests.length === 1) {
+                const result = await this.dispatch(requests[0]!, props, state)
+                return jsonResponse(result)
+            }
+            const results = await Promise.all(requests.map((r) => this.dispatch(r, props, state)))
+            return jsonResponse(results)
+        } catch (err) {
+            return mapProtocolError(err, body)
         }
-        console.error('[McpDispatcher] Internal error:', outcome.error)
-        return jsonRpcMethodError(id, ErrorCode.InternalError, 'Internal error')
     }
 
     private async dispatch(
@@ -356,72 +220,71 @@ class McpDispatcher {
         const { id, method, params } = request
 
         try {
+            // The strategy's handshake method (initialize OR server/discover)
+            // takes precedence — it owns the shape of the result.
+            if (method === this.strategy.handshake.method) {
+                const result = await this.strategy.handshake.handle(request, props, state!)
+                return jsonRpcResult(id, result)
+            }
+
             switch (method) {
-                case Method.Initialize:
-                    return jsonRpcResult(id, await this.handleInitialize(params, props, state!))
                 case Method.ToolsList:
-                    return jsonRpcResult(id, await this.toolExecutor.handleToolsList(state!, props))
+                    return jsonRpcResult(id, await this.shared.toolExecutor.handleToolsList(state!, props))
                 case Method.ToolsCall:
-                    return jsonRpcResult(id, await this.toolExecutor.handleToolCall(params, props, state!))
+                    // Batched tools/call only — single-message hits the
+                    // strategy path above. No elicit support in batches.
+                    return jsonRpcResult(
+                        id,
+                        await this.shared.toolExecutor.handleToolCall(
+                            params as Record<string, unknown> | undefined,
+                            props,
+                            state!
+                        )
+                    )
                 case Method.ResourcesList:
-                    return jsonRpcResult(id, this.resourceCatalog.getResourcesList())
+                    return jsonRpcResult(id, this.shared.resourceCatalog.getResourcesList())
                 case Method.ResourcesRead:
-                    return jsonRpcResult(id, this.resourceCatalog.readResource(params))
+                    return jsonRpcResult(id, this.shared.resourceCatalog.readResource(params))
                 case Method.PromptsList:
-                    return jsonRpcResult(id, this.resourceCatalog.getPromptsList())
+                    return jsonRpcResult(id, this.shared.resourceCatalog.getPromptsList())
                 case Method.PromptsGet:
-                    return jsonRpcResult(id, this.resourceCatalog.getPrompt(params))
+                    return jsonRpcResult(id, this.shared.resourceCatalog.getPrompt(params))
                 case Method.Ping:
                     return jsonRpcResult(id, {})
                 default:
                     return jsonRpcMethodError(id, ErrorCode.MethodNotFound, 'Method not found')
             }
         } catch (error) {
+            if (error instanceof V2026ProtocolError) {
+                return { jsonrpc: JSONRPC_VERSION, id, error: { code: error.code, message: error.message } }
+            }
             console.error('[McpDispatcher] Internal error:', error)
             return jsonRpcMethodError(id, ErrorCode.InternalError, 'Internal error')
         }
     }
+}
 
-    private async handleInitialize(
-        params: Record<string, unknown> | undefined,
-        props: RequestProperties,
-        state: ResolvedState
-    ): Promise<InitializeResult> {
-        try {
-            const requestedVersion = (params?.protocolVersion as string) ?? LATEST_PROTOCOL_VERSION
-            const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion)
-                ? requestedVersion
-                : LATEST_PROTOCOL_VERSION
-
-            // Cache the client's declared capabilities so subsequent stateless
-            // requests can gate server-initiated calls (elicitation/create
-            // today). Always overwrite so a re-initialize with FEWER
-            // capabilities than a prior session correctly downgrades the
-            // cached state. Best-effort write: a Redis blip just costs an
-            // extra fail-closed bounce on the next tool/call.
-            const projectedCaps = projectClientCapabilities(params?.['capabilities'])
-            await this.capabilityStore.set(props.userHash, projectedCaps)
-
-            const instructions = await this.instructionsBuilder.build(props, state)
-
-            initDurationSeconds.observe(props.requestStartTime ? (Date.now() - props.requestStartTime) / 1000 : 0)
-            initTotal.inc({ status: 'success' })
-
-            void trackInitEvent(props, state)
-
-            return {
-                protocolVersion,
-                capabilities: {
-                    tools: { listChanged: false },
-                    resources: { listChanged: false },
-                    prompts: { listChanged: false },
-                },
-                serverInfo: { name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION },
-                ...(instructions ? { instructions } : {}),
-            }
-        } catch (error) {
-            initTotal.inc({ status: 'error' })
-            throw error
-        }
+function mapProtocolError(err: unknown, body: unknown): Response {
+    if (err instanceof V2026ProtocolError) {
+        const id = isRecord(body) && 'id' in body ? (body['id'] as string | number | null) : null
+        return new Response(
+            JSON.stringify({
+                jsonrpc: JSONRPC_VERSION,
+                id,
+                error: err.data
+                    ? { code: err.code, message: err.message, data: err.data }
+                    : { code: err.code, message: err.message },
+            }),
+            { status: err.httpStatus, headers: { 'Content-Type': 'application/json' } }
+        )
     }
+    throw err
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function jsonResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
 }

--- a/services/mcp/src/hono/guidelines-loader.ts
+++ b/services/mcp/src/hono/guidelines-loader.ts
@@ -1,0 +1,30 @@
+/**
+ * Loads `shared/guidelines.md` for the InstructionsBuilder.
+ *
+ * Two-stage lookup keeps dev/test and production bundle behavior aligned:
+ *   1. Try the `@shared/guidelines.md` esbuild alias — works in the
+ *      production bundle.
+ *   2. Fall back to reading from disk relative to cwd — works in Vitest /
+ *      stdio dev / any plain Node runtime.
+ *
+ * Extracted from the legacy dispatcher so both protocol pipelines share it.
+ */
+
+export function loadGuidelines(): string {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const mod = require('@shared/guidelines.md')
+        return typeof mod === 'string' ? mod : (mod?.default ?? '')
+    } catch {
+        // @shared alias only resolves in the esbuild production bundle.
+    }
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const fs = require('node:fs')
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const path = require('node:path')
+        return fs.readFileSync(path.resolve(process.cwd(), 'shared/guidelines.md'), 'utf-8')
+    } catch {
+        return ''
+    }
+}

--- a/services/mcp/src/hono/protocol-strategy.ts
+++ b/services/mcp/src/hono/protocol-strategy.ts
@@ -1,0 +1,96 @@
+/**
+ * Strategy seams between the two MCP protocol versions the Hono dispatcher
+ * supports (`2025-06-18` and `2026-07-28`).
+ *
+ * Only the parts that genuinely differ are abstracted here — everything else
+ * (`tools/list`, `ping`, `resources/*`, `prompts/*`, JSON-RPC parse,
+ * top-level error responses) is shared in `McpDispatcher`.
+ *
+ * Three seams:
+ *
+ *   1. `PreDispatchStrategy` — per-request validation of protocol-specific
+ *      headers and request shape. Legacy does almost nothing; v2026 validates
+ *      `MCP-Protocol-Version`, `Mcp-Method`, and the `_meta` block.
+ *   2. `HandshakeStrategy` — owns the protocol's handshake RPC
+ *      (`initialize` for legacy, `server/discover` for v2026). Used for both
+ *      method matching and result construction.
+ *   3. `ToolCallStrategy` — owns `tools/call` end-to-end, because the two
+ *      protocols use fundamentally different mechanisms for surfacing
+ *      elicitation: legacy upgrades to SSE and parks on the cross-pod bus;
+ *      v2026 returns `InputRequiredResult` synchronously with a signed
+ *      `requestState` blob.
+ *
+ * A `ProtocolStrategy` bundles all three plus a flag for whether JSON-RPC
+ * batches are allowed (legacy yes; v2026 no per SEP-2575).
+ */
+
+import type { JSONRPCRequest } from '@modelcontextprotocol/sdk/types.js'
+
+import type { RequestProperties } from '@/lib/request-properties'
+
+import type { ResolvedState } from './request-state-resolver'
+
+/**
+ * Per-request validation hook. Throws to short-circuit with a JSON-RPC error
+ * (typically via `V2026ProtocolError` for v2026, or a JSON-RPC error code
+ * for any custom legacy validation).
+ *
+ * Runs once per HTTP request, BEFORE body classification and state
+ * resolution. Cheap by design — anything expensive (state resolution,
+ * capability lookups) belongs inside the per-method strategies.
+ */
+export interface PreDispatchStrategy {
+    validate(req: Request, body: unknown, props: RequestProperties): Promise<void>
+}
+
+/**
+ * Handler for the protocol's handshake RPC. The dispatcher calls
+ * `handle(...)` only when `method === request.method` matches. Returns the
+ * result object (which the dispatcher wraps in JSON-RPC envelope).
+ */
+export interface HandshakeStrategy {
+    /** Method name this handshake handles, e.g. `'initialize'` or `'server/discover'`. */
+    readonly method: string
+    handle(request: JSONRPCRequest, props: RequestProperties, state: ResolvedState): Promise<unknown>
+}
+
+/**
+ * The `tools/call` dispatch path. Owns the entire flow including any
+ * protocol-specific elicitation mechanism, returning the final HTTP
+ * response. This is the largest divergence between protocols, so it gets
+ * its own seam rather than parameter hooks on a shared method.
+ */
+export interface ToolCallStrategy {
+    dispatchToolsCall(
+        request: JSONRPCRequest,
+        props: RequestProperties,
+        state: ResolvedState,
+        signal: AbortSignal
+    ): Promise<Response>
+
+    /**
+     * Legacy-only: route an inbound JSON-RPC *response* (the client's reply
+     * to a server-initiated `elicitation/create`) to the session bus.
+     *
+     * Undefined on v2026 — the new protocol doesn't have separate
+     * response POSTs; every retry is a full `tools/call`.
+     */
+    deliverInboundResponse?(id: string | number, payload: unknown): Promise<void>
+}
+
+/**
+ * Composite for a protocol. The dispatcher receives one of these at
+ * construction time; the streamable handler chooses between two
+ * pre-built instances based on the `MCP-Protocol-Version` header.
+ */
+export interface ProtocolStrategy {
+    readonly version: 'legacy' | 'v2026'
+    readonly preDispatch: PreDispatchStrategy
+    readonly handshake: HandshakeStrategy
+    readonly toolCall: ToolCallStrategy
+    /**
+     * Whether JSON-RPC batches are accepted. Legacy: yes. v2026: no
+     * (per SEP-2575 — every request is its own continuation-passing call).
+     */
+    readonly allowBatches: boolean
+}

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -152,6 +152,25 @@ export class RequestContext {
                 return (params, options) => binding.invoke(params, options)
             },
         })
+        // Universal seam. In the legacy pipeline it delegates to `elicit`,
+        // which is the binding-backed SSE round-trip. Tools that use the
+        // universal API work unchanged when v2026 takes over.
+        Object.defineProperty(ctx, 'requestInput', {
+            enumerable: true,
+            configurable: false,
+            get(): Context['requestInput'] {
+                const binding = self.elicitBinding
+                if (!binding) {
+                    return undefined
+                }
+                return async (params) => {
+                    return await binding.invoke({
+                        message: params.message,
+                        requestedSchema: params.requestedSchema,
+                    })
+                }
+            },
+        })
         return ctx
     }
 

--- a/services/mcp/src/hono/strategies/legacy/handshake.ts
+++ b/services/mcp/src/hono/strategies/legacy/handshake.ts
@@ -1,0 +1,72 @@
+/**
+ * Legacy `initialize` handshake handler.
+ *
+ * Negotiates protocol version, caches the client's declared elicitation
+ * capability for the v1 dispatcher to consult on subsequent `tools/call`
+ * requests, builds the per-request instructions string, and emits init
+ * analytics.
+ */
+
+import {
+    LATEST_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    type InitializeResult,
+    type JSONRPCRequest,
+} from '@modelcontextprotocol/sdk/types.js'
+
+import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
+import type { RequestProperties } from '@/lib/request-properties'
+
+import { trackInitEvent } from '../../analytics'
+import { type CachedClientCapabilities, CapabilityStore, projectClientCapabilities } from '../../capability-store'
+import { InstructionsBuilder } from '../../instructions'
+import { initDurationSeconds, initTotal } from '../../metrics'
+import type { HandshakeStrategy } from '../../protocol-strategy'
+import type { ResolvedState } from '../../request-state-resolver'
+
+export class LegacyHandshakeStrategy implements HandshakeStrategy {
+    readonly method = 'initialize'
+
+    constructor(
+        private readonly capabilityStore: CapabilityStore,
+        private readonly instructionsBuilder: InstructionsBuilder
+    ) {}
+
+    async handle(request: JSONRPCRequest, props: RequestProperties, state: ResolvedState): Promise<InitializeResult> {
+        const params = request.params as Record<string, unknown> | undefined
+        try {
+            const requestedVersion = (params?.['protocolVersion'] as string) ?? LATEST_PROTOCOL_VERSION
+            const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion)
+                ? requestedVersion
+                : LATEST_PROTOCOL_VERSION
+
+            // Cache the client's declared capabilities for subsequent
+            // stateless requests to gate elicitation/create. Always
+            // overwrite — a re-initialize with FEWER capabilities than a
+            // prior session must downgrade.
+            const projectedCaps: CachedClientCapabilities = projectClientCapabilities(params?.['capabilities'])
+            await this.capabilityStore.set(props.userHash, projectedCaps)
+
+            const instructions = await this.instructionsBuilder.build(props, state)
+
+            initDurationSeconds.observe(props.requestStartTime ? (Date.now() - props.requestStartTime) / 1000 : 0)
+            initTotal.inc({ status: 'success' })
+
+            void trackInitEvent(props, state)
+
+            return {
+                protocolVersion,
+                capabilities: {
+                    tools: { listChanged: false },
+                    resources: { listChanged: false },
+                    prompts: { listChanged: false },
+                },
+                serverInfo: { name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION },
+                ...(instructions ? { instructions } : {}),
+            }
+        } catch (error) {
+            initTotal.inc({ status: 'error' })
+            throw error
+        }
+    }
+}

--- a/services/mcp/src/hono/strategies/legacy/tool-call.ts
+++ b/services/mcp/src/hono/strategies/legacy/tool-call.ts
@@ -1,0 +1,165 @@
+/**
+ * Legacy (`2025-06-18`) `tools/call` dispatch.
+ *
+ * Race between the tool handler and the first elicit:
+ *
+ * - Handler completes first → return plain JSON.
+ * - First elicit fires first → upgrade response to SSE, flush the
+ *   `elicitation/create` message, continue awaiting the handler in the
+ *   background, then write the final tool result to the SSE stream and close.
+ *
+ * Capability-gated: the binding is only installed when the client declared
+ * `elicitation` at initialize. Otherwise the handler runs without one and
+ * `context.requestInput` resolves to `undefined`.
+ */
+
+import { ErrorCode, JSONRPC_VERSION, type JSONRPCRequest } from '@modelcontextprotocol/sdk/types.js'
+
+import type { RequestProperties } from '@/lib/request-properties'
+
+import { CapabilityStore, supportsAnyElicitation } from '../../capability-store'
+import { ElicitBinding } from '../../elicit-binding'
+import type { ProtocolStrategy, ToolCallStrategy } from '../../protocol-strategy'
+import type { ResolvedState } from '../../request-state-resolver'
+import { type BusAwaitMetrics, type SessionResponseBus } from '../../session-bus'
+import { createSseResponse, type SseResponseHandle } from '../../sse-response'
+import { ToolExecutor } from '../../tool-executor'
+
+type JsonRpcResponse =
+    | { jsonrpc: typeof JSONRPC_VERSION; id: number | string; result: unknown }
+    | { jsonrpc: typeof JSONRPC_VERSION; id: number | string; error: { code: number; message: string } }
+
+type HandlerOutcome = { kind: 'success'; value: unknown } | { kind: 'error'; error: unknown }
+
+export interface LegacyToolCallDeps {
+    capabilityStore: CapabilityStore
+    sessionBus: SessionResponseBus
+    busMetrics: BusAwaitMetrics | undefined
+    toolExecutor: ToolExecutor
+}
+
+export class LegacyToolCallStrategy implements ToolCallStrategy {
+    constructor(private readonly deps: LegacyToolCallDeps) {}
+
+    /** Legacy seam: inbound JSON-RPC responses go to the session bus. */
+    async deliverInboundResponse(id: string | number, payload: unknown): Promise<void> {
+        await this.deps.sessionBus.deliver(id, payload)
+    }
+
+    async dispatchToolsCall(
+        request: JSONRPCRequest,
+        props: RequestProperties,
+        state: ResolvedState,
+        requestSignal: AbortSignal
+    ): Promise<Response> {
+        const { id, params } = request
+
+        const caps = await this.deps.capabilityStore.get(props.userHash)
+        const elicitAllowed = supportsAnyElicitation(caps)
+
+        if (!elicitAllowed) {
+            // Fast path — no binding, no SSE possible. Same shape as a
+            // pre-elicit tool call.
+            const outcome = await this.runHandler(params, props, state)
+            return jsonResponse(this.buildJsonRpcResponse(id, outcome))
+        }
+
+        const binding = new ElicitBinding({
+            bus: this.deps.sessionBus,
+            createSseHandle: async () => createSseResponse(),
+            requestSignal,
+            ...(this.deps.busMetrics !== undefined ? { gatewayOptions: { metrics: this.deps.busMetrics } } : {}),
+        })
+        state.reqCtx.setElicitBinding(binding)
+
+        const handlerPromise = this.runHandler(params, props, state)
+
+        const winner = await Promise.race([
+            handlerPromise.then(() => 'handler' as const),
+            binding.firstElicit.then(() => 'elicit' as const),
+        ])
+
+        if (winner === 'handler') {
+            const outcome = await handlerPromise
+            return jsonResponse(this.buildJsonRpcResponse(id, outcome))
+        }
+
+        // SSE path — the binding already wrote `elicitation/create`.
+        // Return the streaming Response now; flush the final tool result
+        // asynchronously.
+        const sseHandle = binding.getSseHandle()
+        if (!sseHandle) {
+            return jsonResponse(internalError(id))
+        }
+        void this.finalizeSseResponse(sseHandle, id, handlerPromise)
+        return sseHandle.response
+    }
+
+    private async runHandler(params: unknown, props: RequestProperties, state: ResolvedState): Promise<HandlerOutcome> {
+        return await this.deps.toolExecutor
+            .handleToolCall(params as Record<string, unknown> | undefined, props, state)
+            .then((value): HandlerOutcome => ({ kind: 'success', value }))
+            .catch((error): HandlerOutcome => ({ kind: 'error', error }))
+    }
+
+    private async finalizeSseResponse(
+        sseHandle: SseResponseHandle,
+        id: number | string,
+        handlerPromise: Promise<HandlerOutcome>
+    ): Promise<void> {
+        try {
+            const outcome = await handlerPromise
+            const result = this.buildJsonRpcResponse(id, outcome)
+            await sseHandle.writer.write(result)
+        } catch (error) {
+            console.error('[LegacyToolCallStrategy] SSE finalize failed:', error)
+        } finally {
+            try {
+                await sseHandle.writer.close()
+            } catch {
+                /* already closed */
+            }
+        }
+    }
+
+    private buildJsonRpcResponse(id: number | string, outcome: HandlerOutcome): JsonRpcResponse {
+        if (outcome.kind === 'success') {
+            return { jsonrpc: JSONRPC_VERSION, id, result: outcome.value }
+        }
+        console.error('[LegacyToolCallStrategy] Internal error:', outcome.error)
+        return internalError(id)
+    }
+}
+
+function internalError(id: number | string): JsonRpcResponse {
+    return { jsonrpc: JSONRPC_VERSION, id, error: { code: ErrorCode.InternalError, message: 'Internal error' } }
+}
+
+function jsonResponse(body: JsonRpcResponse): Response {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    })
+}
+
+// Re-export the strategy aggregate factory so call sites get a single import.
+export function buildLegacyStrategy(deps: {
+    capabilityStore: CapabilityStore
+    sessionBus: SessionResponseBus
+    busMetrics: BusAwaitMetrics | undefined
+    toolExecutor: ToolExecutor
+    handshake: import('./handshake').LegacyHandshakeStrategy
+}): ProtocolStrategy {
+    return {
+        version: 'legacy',
+        allowBatches: true,
+        preDispatch: { async validate() {} },
+        handshake: deps.handshake,
+        toolCall: new LegacyToolCallStrategy({
+            capabilityStore: deps.capabilityStore,
+            sessionBus: deps.sessionBus,
+            busMetrics: deps.busMetrics,
+            toolExecutor: deps.toolExecutor,
+        }),
+    }
+}

--- a/services/mcp/src/hono/streamable-handler.ts
+++ b/services/mcp/src/hono/streamable-handler.ts
@@ -1,26 +1,86 @@
+/**
+ * HTTP entry-point for the MCP server.
+ *
+ * Owns auth, rate-limiting, body classification (legacy-only), and protocol
+ * routing. Holds one `McpDispatcher` per protocol; both share the underlying
+ * tool catalog + state resolver via `buildSharedDeps`.
+ */
+
 import type { Lifecycle } from './app'
 import type { RedisLike } from './cache/RedisCache'
-import { McpDispatcher, type McpDispatcherOptions } from './dispatcher'
+import { CapabilityStore } from './capability-store'
+import { buildSharedDeps, McpDispatcher, type SharedDispatcherDeps } from './dispatcher'
 import { buildRateLimitResponse, DEFAULT_BURST_LIMIT, DEFAULT_SUSTAINED_LIMIT, RateLimiter } from './rate-limiter'
 import { authenticateAndParse, handleCatchError } from './request-utils'
+import { type BusAwaitMetrics, RedisPollingSessionResponseBus, type SessionResponseBus } from './session-bus'
+import { LegacyHandshakeStrategy } from './strategies/legacy/handshake'
+import { buildLegacyStrategy } from './strategies/legacy/tool-call'
 import { ToolCatalog } from './tool-catalog'
 import type { HonoCtx } from './types'
+import { PROTOCOL_VERSION_2025_06_18, PROTOCOL_VERSION_2026_07_28, PROTOCOL_VERSION_HEADER } from './v2026/constants'
+import { V2026HandshakeStrategy } from './v2026/handshake'
+import { loadSigningKeysFromEnv, RequestStateCodec } from './v2026/request-state'
+import { buildV2026Strategy } from './v2026/tool-call'
+
+export interface StreamableMcpHandlerOptions {
+    /** Override the session bus for the legacy pipeline (tests inject InMemory). */
+    sessionBus?: SessionResponseBus
+    /** Override the bus metrics adapter (default: prom-client). */
+    busMetrics?: BusAwaitMetrics
+    /** Override the capability cache (legacy initialize-driven). */
+    capabilityStore?: CapabilityStore
+    /** Override the v2026 dispatcher (tests inject a deterministic codec). */
+    dispatcher2026?: McpDispatcher
+    /** Override the legacy dispatcher (rare — for diagnostic tests). */
+    dispatcherLegacy?: McpDispatcher
+}
 
 export class StreamableMcpHandler {
-    private readonly dispatcher: McpDispatcher
+    private readonly dispatcherLegacy: McpDispatcher
+    private readonly dispatcher2026: McpDispatcher
     private readonly rateLimiter: RateLimiter
 
     constructor(
         redis: RedisLike,
         private readonly lifecycle: Lifecycle,
-        options: McpDispatcherOptions = {}
+        options: StreamableMcpHandlerOptions = {}
     ) {
-        this.dispatcher = new McpDispatcher(new ToolCatalog(), redis, options)
+        const catalog = new ToolCatalog()
+        const shared: SharedDispatcherDeps = buildSharedDeps(catalog, redis)
+
+        const capabilityStore = options.capabilityStore ?? new CapabilityStore(redis)
+        const sessionBus = options.sessionBus ?? new RedisPollingSessionResponseBus(redis)
+        const busMetrics = options.busMetrics
+
+        const legacyHandshake = new LegacyHandshakeStrategy(capabilityStore, shared.instructionsBuilder)
+        const legacyStrategy = buildLegacyStrategy({
+            capabilityStore,
+            sessionBus,
+            busMetrics,
+            toolExecutor: shared.toolExecutor,
+            handshake: legacyHandshake,
+        })
+        this.dispatcherLegacy = options.dispatcherLegacy ?? new McpDispatcher(shared, legacyStrategy)
+
+        if (options.dispatcher2026) {
+            this.dispatcher2026 = options.dispatcher2026
+        } else {
+            const { primary, secondary } = loadSigningKeysFromEnv()
+            const codec = new RequestStateCodec(primary, secondary)
+            const v2026Handshake = new V2026HandshakeStrategy(shared.instructionsBuilder)
+            const v2026Strategy = buildV2026Strategy({
+                codec,
+                toolExecutor: shared.toolExecutor,
+                handshake: v2026Handshake,
+            })
+            this.dispatcher2026 = new McpDispatcher(shared, v2026Strategy)
+        }
+
         this.rateLimiter = new RateLimiter(redis, [DEFAULT_BURST_LIMIT, DEFAULT_SUSTAINED_LIMIT])
     }
 
     async warmup(): Promise<void> {
-        await this.dispatcher.warmup()
+        await Promise.all([this.dispatcherLegacy.warmup(), this.dispatcher2026.warmup()])
     }
 
     fetch = async (c: HonoCtx): Promise<Response> => {
@@ -43,47 +103,68 @@ export class StreamableMcpHandler {
             return buildRateLimitResponse(rateLimit)
         }
 
-        // Classify the body before handing it to the dispatcher. A JSONRPC
-        // *response* (no `method`, has `result`/`error`, has `id`) is the
-        // client's reply to a server-initiated request (today: elicitation/
-        // create) and is routed across pods via the session bus — it never
-        // reaches the dispatcher. Everything else (requests / batches / no
-        // body / parse errors) falls through unchanged.
-        const classification = await classifyBody(c.req.raw)
-        if (classification.kind === 'response') {
+        const dispatcher = selectPipeline(c.req.raw) === 'v2026' ? this.dispatcher2026 : this.dispatcherLegacy
+
+        // The legacy strategy treats inbound JSON-RPC responses (replies to a
+        // server-initiated `elicitation/create`) as bus deliveries, not as
+        // dispatcher requests. v2026 has no separate response POSTs — every
+        // retry is a fresh `tools/call` — so this branch is legacy-only.
+        if (dispatcher.strategy.toolCall.deliverInboundResponse) {
+            const classification = await classifyBody(c.req.raw)
+            if (classification.kind === 'response') {
+                try {
+                    await dispatcher.strategy.toolCall.deliverInboundResponse(classification.id, classification.payload)
+                } catch (error) {
+                    return handleCatchError(error, auth.props)
+                }
+                return new Response(null, { status: 202 })
+            }
             try {
-                await this.dispatcher.bus.deliver(classification.id, classification.payload)
+                return await dispatcher.handleRequest(classification.req, auth.props)
             } catch (error) {
                 return handleCatchError(error, auth.props)
             }
-            return new Response(null, { status: 202 })
         }
 
         try {
-            return await this.dispatcher.handleRequest(classification.req, auth.props)
+            return await dispatcher.handleRequest(c.req.raw, auth.props)
         } catch (error) {
             return handleCatchError(error, auth.props)
         }
     }
 }
 
+/**
+ * Choose the protocol pipeline for an incoming request. The
+ * `MCP-Protocol-Version` header is authoritative — routing infrastructure
+ * may inspect it without parsing the body.
+ *
+ * - `2026-07-28` → v2026.
+ * - `2025-06-18` (explicit) → legacy.
+ * - No header → legacy (every client in the field today omits this header).
+ * - Anything else → legacy. The v2026 dispatcher's meta parser would
+ *   reject mismatches itself.
+ */
+export function selectPipeline(req: Request): 'legacy' | 'v2026' {
+    const headerVersion = req.headers.get(PROTOCOL_VERSION_HEADER)
+    if (headerVersion === PROTOCOL_VERSION_2026_07_28) {
+        return 'v2026'
+    }
+    if (headerVersion === PROTOCOL_VERSION_2025_06_18 || !headerVersion) {
+        return 'legacy'
+    }
+    return 'legacy'
+}
+
+// ---------------------------------------------------------------------------
+// Body classification — legacy only. Determines whether an inbound POST is a
+// JSON-RPC request (→ dispatcher) or a response (→ session bus).
+// ---------------------------------------------------------------------------
+
 export type BodyClassification =
     | { kind: 'request'; req: Request }
     | { kind: 'response'; id: string | number; payload: unknown }
 
-/**
- * Read the request body once and classify it. Returns a fresh `Request`
- * for the dispatcher to re-parse when the body is a request — we cloned
- * the original before reading, so the dispatcher's body parse stays
- * intact.
- *
- * The classifier is intentionally conservative: ambiguous shapes
- * (arrays, missing id, parse failures) fall through as `request` so
- * existing dispatcher behavior is unchanged.
- *
- * Exported so the unit suite can exercise the routing decisions
- * (request vs response vs malformed) without spinning up the full app.
- */
 export async function classifyBody(req: Request): Promise<BodyClassification> {
     let bodyText: string
     try {
@@ -114,7 +195,7 @@ export async function classifyBody(req: Request): Promise<BodyClassification> {
     }
 
     const message = parsed as Record<string, unknown>
-    const id = message.id
+    const id = message['id']
     const hasResult = 'result' in message
     const hasError = 'error' in message
     const hasMethod = 'method' in message
@@ -122,6 +203,6 @@ export async function classifyBody(req: Request): Promise<BodyClassification> {
     if (!isResponse) {
         return { kind: 'request', req: rebuilt }
     }
-    const payload = hasError ? { error: message.error } : message.result
+    const payload = hasError ? { error: message['error'] } : message['result']
     return { kind: 'response', id: id as string | number, payload }
 }

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -20,6 +20,7 @@ import type { InstructionsBuilder } from './instructions'
 import { toolCallDurationSeconds, toolCallsTotal, toolErrorsTotal } from './metrics'
 import type { ResolvedState } from './request-state-resolver'
 import type { ToolCatalog } from './tool-catalog'
+import { isInputRequiredSignal } from './v2026/input-required-signal'
 
 interface ResolvedTool {
     name: string
@@ -149,6 +150,14 @@ export class ToolExecutor {
                 distinctId,
             })
         } catch (error: unknown) {
+            // The v2026 pipeline's `requestInput` throws `InputRequiredSignal`
+            // as a control-flow signal that the dispatcher catches to build
+            // an `InputRequiredResult`. It is NOT a tool failure; let it
+            // propagate unchanged.
+            if (isInputRequiredSignal(error)) {
+                stop({ status: 'success' })
+                throw error
+            }
             toolCallsTotal.inc({ tool: tool.name, status: 'error' })
             stop({ status: 'error' })
             classifyToolError(error, tool.name)

--- a/services/mcp/src/hono/v2026/constants.ts
+++ b/services/mcp/src/hono/v2026/constants.ts
@@ -1,0 +1,62 @@
+/**
+ * Hard-coded constants for the 2026-07-28 protocol pipeline.
+ *
+ * None of these are env-configurable on purpose. They define the protocol
+ * contract or the safety bounds the dispatcher enforces; changing them is a
+ * code change reviewed by humans, not a deployment knob.
+ */
+
+/** The MCP protocol version this pipeline implements. */
+export const PROTOCOL_VERSION_2026_07_28 = '2026-07-28' as const
+
+/** Legacy protocol version accepted as an explicit opt-in to the legacy pipeline. */
+export const PROTOCOL_VERSION_2025_06_18 = '2025-06-18' as const
+
+/**
+ * How long a `requestState` token stays valid after issue, in seconds.
+ *
+ * 10 minutes is a balance between human attention spans on a confirmation
+ * modal (a few minutes is realistic; longer is rare) and bounding the
+ * window a leaked or guessed token is usable. Tuned via the
+ * `mcp_v2026_request_state_expired_total` counter — a sustained non-zero
+ * rate is the signal to raise this.
+ */
+export const REQUEST_STATE_TTL_SECONDS = 600
+
+/**
+ * Maximum number of `InputRequiredResult` rounds for one logical tool call.
+ *
+ * Each round increments the `round` claim in `requestState`. The dispatcher
+ * refuses to issue another input request when the incoming round counter
+ * reaches this cap, preventing buggy tool loops or adversarial retries from
+ * burning CPU/Redis indefinitely. 10 is generous for legitimate multi-step
+ * flows (the SEP's ADO custom-rules example tops out at 3 rounds) and tight
+ * enough to bound damage.
+ */
+export const MAX_REQUEST_STATE_ROUNDS = 10
+
+/**
+ * Minimum acceptable length of `MCP_REQUEST_STATE_SIGNING_KEY`, in bytes.
+ * 32 bytes (256 bits) matches the HMAC-SHA256 output size; shorter keys
+ * lose security without adding convenience.
+ */
+export const SIGNING_KEY_MIN_BYTES = 32
+
+/** HTTP header carrying the protocol version (SEP-2575, SEP-2243). */
+export const PROTOCOL_VERSION_HEADER = 'mcp-protocol-version'
+
+/** HTTP header carrying the JSON-RPC method name (SEP-2243). */
+export const METHOD_HEADER = 'mcp-method'
+
+/** HTTP header carrying the tool/resource/prompt name (SEP-2243). */
+export const NAME_HEADER = 'mcp-name'
+
+/** Required _meta keys on every request payload (SEP-2575). */
+export const META_KEY_PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion'
+export const META_KEY_CLIENT_INFO = 'io.modelcontextprotocol/clientInfo'
+export const META_KEY_CLIENT_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities'
+export const META_KEY_LOG_LEVEL = 'io.modelcontextprotocol/logLevel'
+
+/** Env vars for the signing key. */
+export const SIGNING_KEY_ENV_VAR = 'MCP_REQUEST_STATE_SIGNING_KEY'
+export const SIGNING_KEY_OLD_ENV_VAR = 'MCP_REQUEST_STATE_SIGNING_KEY_OLD'

--- a/services/mcp/src/hono/v2026/elicit-result-shape.ts
+++ b/services/mcp/src/hono/v2026/elicit-result-shape.ts
@@ -1,0 +1,15 @@
+/**
+ * Lightweight type-guard for incoming `inputResponses` entries.
+ *
+ * The dispatcher receives `inputResponses: { [key]: unknown }` from the
+ * client and must verify each entry conforms to `ElicitResult` before
+ * caching it in `requestState` or returning it from `requestInput`.
+ *
+ * Re-uses the SDK's Zod schema so the shape tracks the spec.
+ */
+
+import { ElicitResultSchema, type ElicitResult } from '@modelcontextprotocol/sdk/types.js'
+
+export function isElicitResult(value: unknown): value is ElicitResult {
+    return ElicitResultSchema.safeParse(value).success
+}

--- a/services/mcp/src/hono/v2026/errors.ts
+++ b/services/mcp/src/hono/v2026/errors.ts
@@ -1,0 +1,84 @@
+/**
+ * Typed errors for the v2026 pipeline.
+ *
+ * Two layers:
+ *   1. `RequestStateError` family — internal codec failures. The dispatcher
+ *      catches these and maps them to JSON-RPC error responses.
+ *   2. `V2026ProtocolError` — JSON-RPC error envelope with the spec-defined
+ *      codes (`-32003` MISSING_REQUIRED_CLIENT_CAPABILITY,
+ *      `-32004` UNSUPPORTED_PROTOCOL_VERSION) and HTTP status hints.
+ */
+
+/** JSON-RPC error codes defined by SEP-2575. */
+export const JSON_RPC_ERROR = {
+    INVALID_PARAMS: -32602,
+    MISSING_REQUIRED_CLIENT_CAPABILITY: -32003,
+    UNSUPPORTED_PROTOCOL_VERSION: -32004,
+} as const
+
+/** Base class for every `requestState` decode failure. */
+export abstract class RequestStateError extends Error {
+    /** Short identifier used as a Prometheus metric label. */
+    abstract readonly metricLabel: string
+    constructor(message: string) {
+        super(message)
+        this.name = this.constructor.name
+    }
+}
+
+export class RequestStateMalformed extends RequestStateError {
+    readonly metricLabel = 'malformed'
+}
+export class RequestStateSignatureInvalid extends RequestStateError {
+    readonly metricLabel = 'bad_signature'
+}
+export class RequestStateExpired extends RequestStateError {
+    readonly metricLabel = 'expired'
+}
+export class RequestStateUserMismatch extends RequestStateError {
+    readonly metricLabel = 'user_mismatch'
+}
+export class RequestStateToolMismatch extends RequestStateError {
+    readonly metricLabel = 'tool_mismatch'
+}
+export class RequestStateRoundsExceeded extends RequestStateError {
+    readonly metricLabel = 'rounds_exceeded'
+}
+
+/**
+ * Errors that bubble up as JSON-RPC error envelopes with a specific HTTP
+ * status. The dispatcher serializes these directly.
+ */
+export class V2026ProtocolError extends Error {
+    constructor(
+        readonly code: number,
+        message: string,
+        readonly httpStatus: number,
+        readonly data?: Record<string, unknown>
+    ) {
+        super(message)
+        this.name = 'V2026ProtocolError'
+    }
+}
+
+export function unsupportedProtocolVersion(requested: string, supported: string[]): V2026ProtocolError {
+    return new V2026ProtocolError(
+        JSON_RPC_ERROR.UNSUPPORTED_PROTOCOL_VERSION,
+        `Unsupported protocol version: ${requested}`,
+        400,
+        { requested, supported }
+    )
+}
+
+export function invalidParams(message: string, data?: Record<string, unknown>): V2026ProtocolError {
+    return new V2026ProtocolError(JSON_RPC_ERROR.INVALID_PARAMS, message, 400, data)
+}
+
+export function missingRequiredClientCapability(requiredCapabilities: unknown): V2026ProtocolError {
+    return new V2026ProtocolError(
+        JSON_RPC_ERROR.MISSING_REQUIRED_CLIENT_CAPABILITY,
+        'Missing required client capability',
+        400,
+        { requiredCapabilities }
+    )
+}

--- a/services/mcp/src/hono/v2026/handshake.ts
+++ b/services/mcp/src/hono/v2026/handshake.ts
@@ -1,0 +1,51 @@
+/**
+ * v2026 `server/discover` handshake handler.
+ *
+ * Returns the static-per-build server info, the list of supported protocol
+ * versions, the server-side capabilities (tools/resources/prompts), and
+ * the per-request instructions.
+ */
+
+import type { JSONRPCRequest } from '@modelcontextprotocol/sdk/types.js'
+
+import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
+import type { RequestProperties } from '@/lib/request-properties'
+
+import type { InstructionsBuilder } from '../instructions'
+import type { HandshakeStrategy } from '../protocol-strategy'
+import type { ResolvedState } from '../request-state-resolver'
+import { PROTOCOL_VERSION_2025_06_18, PROTOCOL_VERSION_2026_07_28 } from './constants'
+
+export interface DiscoverResult {
+    supportedVersions: string[]
+    capabilities: {
+        tools: { listChanged: boolean }
+        resources: { listChanged: boolean }
+        prompts: { listChanged: boolean }
+    }
+    serverInfo: { name: string; version: string }
+    instructions?: string
+}
+
+export class V2026HandshakeStrategy implements HandshakeStrategy {
+    readonly method = 'server/discover'
+
+    constructor(private readonly instructionsBuilder: InstructionsBuilder) {}
+
+    async handle(_request: JSONRPCRequest, props: RequestProperties, state: ResolvedState): Promise<DiscoverResult> {
+        const instructions = await this.instructionsBuilder.build(props, state)
+        const result: DiscoverResult = {
+            supportedVersions: [PROTOCOL_VERSION_2026_07_28, PROTOCOL_VERSION_2025_06_18],
+            capabilities: {
+                tools: { listChanged: false },
+                resources: { listChanged: false },
+                prompts: { listChanged: false },
+            },
+            serverInfo: { name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION },
+        }
+        if (instructions) {
+            result.instructions = instructions
+        }
+        return result
+    }
+}

--- a/services/mcp/src/hono/v2026/input-required-signal.ts
+++ b/services/mcp/src/hono/v2026/input-required-signal.ts
@@ -1,0 +1,27 @@
+/**
+ * Internal control-flow signal thrown by `Context.requestInput` when the
+ * handler needs to surface a new input request.
+ *
+ * The dispatcher catches it, encodes the cumulative answers into a fresh
+ * `requestState`, and returns an `InputRequiredResult` to the client.
+ *
+ * Not exposed to tool authors — the universal seam is `context.requestInput`,
+ * which throws this internally and the dispatcher handles it. Tool code
+ * never sees a `throw` happen at the `await` site.
+ */
+
+import type { ElicitRequestFormParams } from '@modelcontextprotocol/sdk/types.js'
+
+export class InputRequiredSignal extends Error {
+    constructor(
+        readonly key: string,
+        readonly elicitParams: ElicitRequestFormParams
+    ) {
+        super(`requestInput("${key}") needs a response — surfaced as InputRequiredResult`)
+        this.name = 'InputRequiredSignal'
+    }
+}
+
+export function isInputRequiredSignal(value: unknown): value is InputRequiredSignal {
+    return value instanceof InputRequiredSignal
+}

--- a/services/mcp/src/hono/v2026/metrics.ts
+++ b/services/mcp/src/hono/v2026/metrics.ts
@@ -1,0 +1,52 @@
+/**
+ * Prometheus metrics emitted by the v2026 pipeline.
+ *
+ * Co-located with the pipeline to keep the legacy `metrics.ts` from drifting.
+ * Anything observed about the new protocol lives here.
+ */
+
+import { Counter, Histogram } from 'prom-client'
+
+/**
+ * One increment per dispatched v2026 `tools/call`. `outcome` distinguishes
+ * a `complete` result from an `input_required` round-trip from an error
+ * response.
+ */
+export const v2026RequestsTotal = new Counter({
+    name: 'mcp_v2026_requests_total',
+    help: 'Total requests dispatched by the v2026 MCP pipeline.',
+    labelNames: ['outcome'] as const,
+})
+
+/**
+ * Every decode of an incoming `requestState`. `result=ok` is the happy path;
+ * the other labels match `RequestStateError.metricLabel` for direct
+ * traceability between code and metric.
+ */
+export const v2026RequestStateDecodeTotal = new Counter({
+    name: 'mcp_v2026_request_state_decode_total',
+    help: 'Outcomes of decoding inbound v2026 requestState tokens.',
+    labelNames: ['result'] as const,
+})
+
+/**
+ * Dedicated counter for the expiry case — sustained non-zero rate is the
+ * signal that `REQUEST_STATE_TTL_SECONDS` is too tight for real user
+ * latency. Refining via this one signal keeps the TTL tunable from the
+ * dashboard.
+ */
+export const v2026RequestStateExpiredTotal = new Counter({
+    name: 'mcp_v2026_request_state_expired_total',
+    help: 'Inbound v2026 requestState tokens rejected because they were past their exp claim.',
+})
+
+/**
+ * How many `InputRequiredResult` rounds a single logical tool call took
+ * before producing a `complete` result. 1 is the typical case (one elicit,
+ * one retry).
+ */
+export const v2026InputRequiredRoundTrips = new Histogram({
+    name: 'mcp_v2026_input_required_round_trips',
+    help: 'Distribution of InputRequiredResult rounds per logical v2026 tool call.',
+    buckets: [1, 2, 3, 5, 8, 10],
+})

--- a/services/mcp/src/hono/v2026/pre-dispatch.ts
+++ b/services/mcp/src/hono/v2026/pre-dispatch.ts
@@ -1,0 +1,28 @@
+/**
+ * v2026 pre-dispatch validation.
+ *
+ * Runs once per HTTP request before the dispatcher classifies the body.
+ * Validates the SEP-2243 routing headers and the SEP-2575 per-request
+ * `_meta` shape against the body. Throws `V2026ProtocolError` (caught by
+ * the dispatcher and serialized as a JSON-RPC error) on any mismatch.
+ *
+ * Delegates to `parseV2026Meta` which already implements the rules — this
+ * class is the thin adapter that the shared dispatcher calls via the
+ * `PreDispatchStrategy` seam.
+ */
+
+import type { RequestProperties } from '@/lib/request-properties'
+
+import type { PreDispatchStrategy } from '../protocol-strategy'
+import { parseV2026Meta } from './request-meta'
+
+export class V2026PreDispatch implements PreDispatchStrategy {
+    async validate(req: Request, body: unknown, _props: RequestProperties): Promise<void> {
+        // Reject non-object bodies up-front: `parseV2026Meta` expects a
+        // JSON-RPC message shape.
+        if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+            return
+        }
+        parseV2026Meta(req, body as Record<string, unknown>)
+    }
+}

--- a/services/mcp/src/hono/v2026/request-context.ts
+++ b/services/mcp/src/hono/v2026/request-context.ts
@@ -1,0 +1,83 @@
+/**
+ * `RequestContext` adapter for the v2026 pipeline.
+ *
+ * Mirrors the legacy `RequestContext` API but its `Context.requestInput`
+ * implementation does not push over SSE / park on a bus — it consults the
+ * incoming `inputResponses` plus the prior-rounds answers decoded from
+ * `requestState`. If the key has an answer, return it; otherwise throw
+ * `InputRequiredSignal` for the dispatcher to convert into an
+ * `InputRequiredResult`.
+ *
+ * The legacy `Context.elicit` field is left `undefined` on this pipeline so
+ * that tools still using the legacy API see "no capability" and fall back
+ * the same way they would for a client that didn't declare elicitation
+ * support. Tools should migrate to `requestInput` to keep working under
+ * both protocol versions.
+ */
+
+import type { ElicitResult } from '@modelcontextprotocol/sdk/types.js'
+
+import type { Context, RequestInputParams } from '@/tools/types'
+
+import type { RequestContext as LegacyRequestContext } from '../request-context'
+import { isElicitResult } from './elicit-result-shape'
+import { InputRequiredSignal } from './input-required-signal'
+
+/**
+ * Map of `requestInput` key → response. Built from:
+ *   - The decoded prior `requestState`'s answers (rounds 0..N-1).
+ *   - The current request's `inputResponses` field (this round's answers).
+ * Merged together; later writes win on key collision.
+ */
+export type AnswerMap = Record<string, ElicitResult>
+
+export interface V2026RequestContextDeps {
+    /** The legacy RequestContext provides everything except elicit/requestInput. */
+    legacy: LegacyRequestContext
+    /** Answers seen so far across all rounds. */
+    answers: AnswerMap
+}
+
+export class V2026RequestContext {
+    constructor(private readonly deps: V2026RequestContextDeps) {}
+
+    /**
+     * Build the `Context` object handed to tool handlers. Reuses everything
+     * the legacy context provides (api, cache, stateManager, sessionManager,
+     * getDistinctId, trackEvent) and overrides `elicit` (always undefined)
+     * + `requestInput` (v2026 semantics).
+     */
+    async getContext(): Promise<Context> {
+        const base = await this.deps.legacy.getContext()
+        const answers = this.deps.answers
+        const ctx: Context = {
+            api: base.api,
+            cache: base.cache,
+            env: base.env,
+            stateManager: base.stateManager,
+            sessionManager: base.sessionManager,
+            getDistinctId: base.getDistinctId,
+            trackEvent: base.trackEvent,
+        }
+        // The v2026 pipeline does not push elicitation/create — leave the
+        // legacy field undefined so any code still branching on it falls
+        // back gracefully.
+        Object.defineProperty(ctx, 'requestInput', {
+            enumerable: true,
+            configurable: false,
+            value: async (params: RequestInputParams): Promise<ElicitResult> => {
+                const existing = answers[params.key]
+                if (existing !== undefined) {
+                    return existing
+                }
+                throw new InputRequiredSignal(params.key, {
+                    message: params.message,
+                    requestedSchema: params.requestedSchema,
+                })
+            },
+        })
+        return ctx
+    }
+}
+
+export { isElicitResult }

--- a/services/mcp/src/hono/v2026/request-meta.ts
+++ b/services/mcp/src/hono/v2026/request-meta.ts
@@ -1,0 +1,152 @@
+/**
+ * Parse + validate per-request `_meta` and the SEP-2243 routing headers for
+ * the v2026 pipeline. The result is a fully-typed `V2026RequestMeta`; any
+ * deviation throws `V2026ProtocolError` with the right JSON-RPC code +
+ * HTTP status.
+ */
+
+import {
+    META_KEY_CLIENT_CAPABILITIES,
+    META_KEY_CLIENT_INFO,
+    META_KEY_LOG_LEVEL,
+    META_KEY_PROTOCOL_VERSION,
+    METHOD_HEADER,
+    NAME_HEADER,
+    PROTOCOL_VERSION_2026_07_28,
+    PROTOCOL_VERSION_HEADER,
+} from './constants'
+import { invalidParams, unsupportedProtocolVersion } from './errors'
+
+type LoggingLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency'
+const LOG_LEVELS: ReadonlySet<string> = new Set([
+    'debug',
+    'info',
+    'notice',
+    'warning',
+    'error',
+    'critical',
+    'alert',
+    'emergency',
+])
+
+export interface Implementation {
+    name: string
+    version: string
+    [key: string]: unknown
+}
+
+/** Narrow shape — we only care about the fields the dispatcher branches on today. */
+export interface ClientCapabilities {
+    elicitation?: { form?: object; url?: object }
+    sampling?: object
+    roots?: object
+    [key: string]: unknown
+}
+
+export interface V2026RequestMeta {
+    protocolVersion: typeof PROTOCOL_VERSION_2026_07_28
+    clientInfo: Implementation
+    clientCapabilities: ClientCapabilities
+    logLevel?: LoggingLevel
+    /** Method from the routing header — must match the body's method. */
+    method: string
+    /** Name from the routing header (when applicable: tools/call, resources/read, prompts/get). */
+    name: string | undefined
+}
+
+const SUPPORTED_VERSIONS = [PROTOCOL_VERSION_2026_07_28]
+
+interface JsonRpcRequestLike {
+    jsonrpc?: unknown
+    method?: unknown
+    params?: unknown
+    [key: string]: unknown
+}
+
+/**
+ * Parse the routing headers + `_meta`. Caller is expected to have already
+ * deserialized the JSON-RPC body. The function:
+ *
+ *   1. Pulls the routing headers (`MCP-Protocol-Version`, `Mcp-Method`,
+ *      `Mcp-Name`).
+ *   2. Validates the body's method matches `Mcp-Method`.
+ *   3. Extracts and validates `params._meta` per SEP-2575.
+ *   4. Verifies the meta `protocolVersion` matches the header (SEP-2575
+ *      §Per-request Version).
+ */
+export function parseV2026Meta(req: Request, body: JsonRpcRequestLike): V2026RequestMeta {
+    const headerVersion = req.headers.get(PROTOCOL_VERSION_HEADER)
+    const method = req.headers.get(METHOD_HEADER)
+    const headerName = req.headers.get(NAME_HEADER) ?? undefined
+
+    if (!headerVersion) {
+        throw invalidParams(`Missing ${PROTOCOL_VERSION_HEADER} header`)
+    }
+    if (!SUPPORTED_VERSIONS.includes(headerVersion as typeof PROTOCOL_VERSION_2026_07_28)) {
+        throw unsupportedProtocolVersion(headerVersion, SUPPORTED_VERSIONS)
+    }
+    if (!method) {
+        throw invalidParams(`Missing ${METHOD_HEADER} header`)
+    }
+    if (typeof body.method !== 'string') {
+        throw invalidParams('Request body missing `method`')
+    }
+    if (method !== body.method) {
+        throw invalidParams(`${METHOD_HEADER} header (${method}) does not match body method (${body.method})`)
+    }
+
+    const params = isRecord(body.params) ? body.params : undefined
+    const meta = params && isRecord(params['_meta']) ? params['_meta'] : undefined
+    if (!meta) {
+        throw invalidParams('Request params missing `_meta`')
+    }
+
+    const bodyVersion = meta[META_KEY_PROTOCOL_VERSION]
+    if (typeof bodyVersion !== 'string') {
+        throw invalidParams(`Missing ${META_KEY_PROTOCOL_VERSION} in _meta`)
+    }
+    if (bodyVersion !== headerVersion) {
+        throw invalidParams(
+            `Header ${PROTOCOL_VERSION_HEADER} (${headerVersion}) does not match _meta (${bodyVersion})`
+        )
+    }
+
+    const clientInfo = meta[META_KEY_CLIENT_INFO]
+    if (!isImplementation(clientInfo)) {
+        throw invalidParams(`Missing or malformed ${META_KEY_CLIENT_INFO} in _meta`)
+    }
+
+    const clientCapabilities = meta[META_KEY_CLIENT_CAPABILITIES]
+    if (!isRecord(clientCapabilities)) {
+        throw invalidParams(`Missing or malformed ${META_KEY_CLIENT_CAPABILITIES} in _meta`)
+    }
+
+    const logLevelRaw = meta[META_KEY_LOG_LEVEL]
+    let logLevel: LoggingLevel | undefined
+    if (logLevelRaw !== undefined) {
+        if (typeof logLevelRaw !== 'string' || !LOG_LEVELS.has(logLevelRaw)) {
+            throw invalidParams(`Invalid ${META_KEY_LOG_LEVEL} value`)
+        }
+        logLevel = logLevelRaw as LoggingLevel
+    }
+
+    return {
+        protocolVersion: PROTOCOL_VERSION_2026_07_28,
+        clientInfo,
+        clientCapabilities,
+        ...(logLevel ? { logLevel } : {}),
+        method,
+        name: headerName,
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isImplementation(value: unknown): value is Implementation {
+    if (!isRecord(value)) {
+        return false
+    }
+    return typeof value['name'] === 'string' && typeof value['version'] === 'string'
+}

--- a/services/mcp/src/hono/v2026/request-state.ts
+++ b/services/mcp/src/hono/v2026/request-state.ts
@@ -1,0 +1,253 @@
+/**
+ * `requestState` codec for the v2026 MCP pipeline.
+ *
+ * Encodes a small set of HMAC-signed claims into a JWT-compact-format token
+ * (`header.payload.signature`) that the server stamps into every
+ * `InputRequiredResult` and validates on every retry. The token carries:
+ *
+ *   - `sub`   — userHash, binding the state to the authenticated principal
+ *   - `tool`  — tool name, blocking cross-tool replay
+ *   - `round` — monotonic counter capped at MAX_REQUEST_STATE_ROUNDS
+ *   - `iat`   — issued-at, unix seconds
+ *   - `exp`   — iat + REQUEST_STATE_TTL_SECONDS
+ *   - `nonce` — 128 random bits
+ *   - `payload` — opaque tool-author state, re-validated as untrusted on read
+ *
+ * Signed with HMAC-SHA256. Two keys may be configured: the primary
+ * (`MCP_REQUEST_STATE_SIGNING_KEY`) is used for both sign + verify; an
+ * optional secondary (`MCP_REQUEST_STATE_SIGNING_KEY_OLD`) is verify-only,
+ * enabling zero-downtime rotation. The codec does NOT encrypt — confidentiality
+ * of `payload` is the tool author's responsibility.
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+
+import {
+    MAX_REQUEST_STATE_ROUNDS,
+    REQUEST_STATE_TTL_SECONDS,
+    SIGNING_KEY_ENV_VAR,
+    SIGNING_KEY_MIN_BYTES,
+    SIGNING_KEY_OLD_ENV_VAR,
+} from './constants'
+import {
+    RequestStateExpired,
+    RequestStateMalformed,
+    RequestStateRoundsExceeded,
+    RequestStateSignatureInvalid,
+    RequestStateToolMismatch,
+    RequestStateUserMismatch,
+} from './errors'
+
+export interface RequestStateClaims {
+    sub: string
+    tool: string
+    round: number
+    iat: number
+    exp: number
+    nonce: string
+    payload: unknown
+}
+
+interface RequestStateHeader {
+    alg: 'HS256'
+    typ: 'MCP-REQ-STATE'
+}
+
+const HEADER: RequestStateHeader = { alg: 'HS256', typ: 'MCP-REQ-STATE' }
+
+export interface CodecOptions {
+    /** Override `Date.now()` for tests. */
+    now?: () => number
+    /** Override the entropy source for tests. */
+    randomNonce?: () => string
+}
+
+/**
+ * Stateless codec — pure functions of the configured keys + options. Created
+ * once at startup and reused.
+ */
+export class RequestStateCodec {
+    private readonly primaryKey: Buffer
+    private readonly secondaryKey: Buffer | undefined
+    private readonly now: () => number
+    private readonly randomNonce: () => string
+
+    constructor(primary: Buffer, secondary: Buffer | undefined, options: CodecOptions = {}) {
+        this.primaryKey = primary
+        this.secondaryKey = secondary
+        this.now = options.now ?? (() => Date.now())
+        this.randomNonce = options.randomNonce ?? (() => randomBytes(16).toString('hex'))
+    }
+
+    /**
+     * Encode a fresh `requestState` token bound to the (user, tool, round).
+     * `payload` is whatever the tool author wants to carry forward; it
+     * round-trips through the client opaquely.
+     */
+    encode(input: { sub: string; tool: string; round: number; payload: unknown }): string {
+        const nowSeconds = Math.floor(this.now() / 1000)
+        const claims: RequestStateClaims = {
+            sub: input.sub,
+            tool: input.tool,
+            round: input.round,
+            iat: nowSeconds,
+            exp: nowSeconds + REQUEST_STATE_TTL_SECONDS,
+            nonce: this.randomNonce(),
+            payload: input.payload,
+        }
+        const headerB64 = base64UrlEncode(JSON.stringify(HEADER))
+        const payloadB64 = base64UrlEncode(JSON.stringify(claims))
+        const signingInput = `${headerB64}.${payloadB64}`
+        const signature = sign(signingInput, this.primaryKey)
+        return `${signingInput}.${signature}`
+    }
+
+    /**
+     * Decode + verify an inbound token against the currently authenticated
+     * (user, tool). Throws `RequestStateError` subclasses for any failure
+     * mode — the dispatcher maps these to JSON-RPC error responses.
+     */
+    decode(token: string, expectedSub: string, expectedTool: string): RequestStateClaims {
+        const parts = token.split('.')
+        if (parts.length !== 3) {
+            throw new RequestStateMalformed('requestState token must have three dot-separated segments')
+        }
+        const [headerB64, payloadB64, signatureB64] = parts as [string, string, string]
+
+        const signingInput = `${headerB64}.${payloadB64}`
+        if (!verify(signingInput, signatureB64, this.primaryKey, this.secondaryKey)) {
+            throw new RequestStateSignatureInvalid('requestState signature does not match any configured key')
+        }
+
+        let parsedHeader: unknown
+        let parsedClaims: unknown
+        try {
+            parsedHeader = JSON.parse(base64UrlDecode(headerB64).toString('utf8'))
+            parsedClaims = JSON.parse(base64UrlDecode(payloadB64).toString('utf8'))
+        } catch {
+            throw new RequestStateMalformed('requestState header or payload is not valid JSON')
+        }
+        if (!isMcpHeader(parsedHeader)) {
+            throw new RequestStateMalformed('requestState header alg/typ mismatch')
+        }
+        const claims = asClaims(parsedClaims)
+
+        const nowSeconds = Math.floor(this.now() / 1000)
+        if (claims.exp <= nowSeconds) {
+            throw new RequestStateExpired(`requestState expired at ${claims.exp}, now=${nowSeconds}`)
+        }
+        if (!timingSafeStringEqual(claims.sub, expectedSub)) {
+            throw new RequestStateUserMismatch('requestState sub does not match the authenticated user')
+        }
+        if (!timingSafeStringEqual(claims.tool, expectedTool)) {
+            throw new RequestStateToolMismatch('requestState tool does not match the invoked tool')
+        }
+        if (claims.round >= MAX_REQUEST_STATE_ROUNDS) {
+            throw new RequestStateRoundsExceeded(
+                `requestState round ${claims.round} >= cap ${MAX_REQUEST_STATE_ROUNDS}`
+            )
+        }
+        return claims
+    }
+}
+
+/**
+ * Load the signing keys from the environment. Fails loud in production when
+ * the primary is missing or too short — mirrors Django's `SECRET_KEY` guard.
+ * Returns `undefined` for the secondary if it isn't configured.
+ */
+export function loadSigningKeysFromEnv(env: NodeJS.ProcessEnv = process.env): {
+    primary: Buffer
+    secondary: Buffer | undefined
+} {
+    const primaryRaw = env[SIGNING_KEY_ENV_VAR] ?? ''
+    const primary = Buffer.from(primaryRaw, 'utf8')
+    if (primary.length < SIGNING_KEY_MIN_BYTES) {
+        if (env.NODE_ENV === 'production') {
+            throw new Error(
+                `${SIGNING_KEY_ENV_VAR} must be set to at least ${SIGNING_KEY_MIN_BYTES} bytes in production`
+            )
+        }
+        // Non-production: warn + use a placeholder so dev/test still work.
+        // The placeholder is deterministic so encoded tokens roundtrip across
+        // restarts; production must never see this branch.
+        console.warn(
+            `[v2026] ${SIGNING_KEY_ENV_VAR} not set or too short; using insecure dev placeholder. Never deploy this.`
+        )
+        return { primary: Buffer.from('dev-placeholder-key-do-not-use-in-prod', 'utf8'), secondary: undefined }
+    }
+    const secondaryRaw = env[SIGNING_KEY_OLD_ENV_VAR]
+    const secondary =
+        secondaryRaw && secondaryRaw.length >= SIGNING_KEY_MIN_BYTES ? Buffer.from(secondaryRaw, 'utf8') : undefined
+    return { primary, secondary }
+}
+
+// --- helpers ---
+
+function sign(input: string, key: Buffer): string {
+    return base64UrlEncode(createHmac('sha256', key).update(input).digest())
+}
+
+function verify(input: string, signatureB64: string, primary: Buffer, secondary: Buffer | undefined): boolean {
+    const provided = base64UrlDecode(signatureB64)
+    const primarySig = createHmac('sha256', primary).update(input).digest()
+    if (constantTimeEqual(provided, primarySig)) {
+        return true
+    }
+    if (secondary) {
+        const secondarySig = createHmac('sha256', secondary).update(input).digest()
+        if (constantTimeEqual(provided, secondarySig)) {
+            return true
+        }
+    }
+    return false
+}
+
+function constantTimeEqual(a: Buffer, b: Buffer): boolean {
+    if (a.length !== b.length) {
+        return false
+    }
+    return timingSafeEqual(a, b)
+}
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+    const aBuf = Buffer.from(a, 'utf8')
+    const bBuf = Buffer.from(b, 'utf8')
+    return constantTimeEqual(aBuf, bBuf)
+}
+
+function base64UrlEncode(input: string | Buffer): string {
+    const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : input
+    return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+}
+
+function base64UrlDecode(input: string): Buffer {
+    const padded = input + '='.repeat((4 - (input.length % 4)) % 4)
+    return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+}
+
+function isMcpHeader(value: unknown): value is RequestStateHeader {
+    if (value === null || typeof value !== 'object') {
+        return false
+    }
+    const obj = value as Record<string, unknown>
+    return obj['alg'] === 'HS256' && obj['typ'] === 'MCP-REQ-STATE'
+}
+
+function asClaims(value: unknown): RequestStateClaims {
+    if (value === null || typeof value !== 'object') {
+        throw new RequestStateMalformed('requestState payload is not an object')
+    }
+    const obj = value as Record<string, unknown>
+    if (
+        typeof obj['sub'] !== 'string' ||
+        typeof obj['tool'] !== 'string' ||
+        typeof obj['round'] !== 'number' ||
+        typeof obj['iat'] !== 'number' ||
+        typeof obj['exp'] !== 'number' ||
+        typeof obj['nonce'] !== 'string'
+    ) {
+        throw new RequestStateMalformed('requestState payload is missing required claims')
+    }
+    return obj as unknown as RequestStateClaims
+}

--- a/services/mcp/src/hono/v2026/tool-call.ts
+++ b/services/mcp/src/hono/v2026/tool-call.ts
@@ -1,0 +1,198 @@
+/**
+ * v2026 `tools/call` dispatch.
+ *
+ * Stateless continuation-passing: the tool handler runs with a
+ * v2026-flavored `Context` whose `requestInput` resolves answers from the
+ * incoming `inputResponses` + decoded `requestState`, or throws
+ * `InputRequiredSignal` to surface a new prompt. The signal is caught
+ * here, encoded into a fresh `requestState`, and returned as
+ * `InputRequiredResult`. Any server instance can pick up the retry.
+ */
+
+import { JSONRPC_VERSION, type JSONRPCRequest } from '@modelcontextprotocol/sdk/types.js'
+
+import type { RequestProperties } from '@/lib/request-properties'
+
+import type { ProtocolStrategy, ToolCallStrategy } from '../protocol-strategy'
+import type { ResolvedState } from '../request-state-resolver'
+import type { ToolExecutor } from '../tool-executor'
+import { isElicitResult } from './elicit-result-shape'
+import { RequestStateError, RequestStateExpired, invalidParams, V2026ProtocolError } from './errors'
+import { isInputRequiredSignal } from './input-required-signal'
+import {
+    v2026InputRequiredRoundTrips,
+    v2026RequestStateDecodeTotal,
+    v2026RequestStateExpiredTotal,
+    v2026RequestsTotal,
+} from './metrics'
+import { V2026PreDispatch } from './pre-dispatch'
+import { V2026RequestContext, type AnswerMap } from './request-context'
+import { RequestStateCodec } from './request-state'
+
+export interface V2026ToolCallDeps {
+    codec: RequestStateCodec
+    toolExecutor: ToolExecutor
+}
+
+export class V2026ToolCallStrategy implements ToolCallStrategy {
+    constructor(private readonly deps: V2026ToolCallDeps) {}
+
+    async dispatchToolsCall(
+        request: JSONRPCRequest,
+        props: RequestProperties,
+        state: ResolvedState,
+        _signal: AbortSignal
+    ): Promise<Response> {
+        const params = (request.params ?? {}) as Record<string, unknown>
+        const toolName = params['name']
+        if (typeof toolName !== 'string') {
+            throw invalidParams('tools/call params.name must be a string')
+        }
+
+        // Decode any prior requestState. Failures are reported as
+        // INVALID_PARAMS — the client can drop the requestState and start a
+        // fresh tool call.
+        let priorAnswers: AnswerMap = {}
+        let priorRound = 0
+        const incomingState = params['requestState']
+        if (incomingState !== undefined) {
+            if (typeof incomingState !== 'string') {
+                throw invalidParams('requestState must be a string')
+            }
+            try {
+                const claims = this.deps.codec.decode(incomingState, props.userHash, toolName)
+                v2026RequestStateDecodeTotal.inc({ result: 'ok' })
+                priorRound = claims.round
+                priorAnswers = decodeAnswersFromClaims(claims.payload)
+            } catch (err) {
+                if (err instanceof RequestStateError) {
+                    v2026RequestStateDecodeTotal.inc({ result: err.metricLabel })
+                    if (err instanceof RequestStateExpired) {
+                        v2026RequestStateExpiredTotal.inc()
+                    }
+                    throw invalidParams(`requestState rejected: ${err.message}`)
+                }
+                throw err
+            }
+        }
+
+        const newAnswers = parseInputResponses(params['inputResponses'])
+        const combinedAnswers: AnswerMap = { ...priorAnswers, ...newAnswers }
+
+        // Wrap the resolved context with the v2026 adapter so the handler
+        // sees a `requestInput` that resolves from `combinedAnswers` (or
+        // throws InputRequiredSignal for unanswered keys).
+        const v2026Ctx = new V2026RequestContext({ legacy: state.reqCtx, answers: combinedAnswers })
+        const augmentedState: ResolvedState = { ...state, context: await v2026Ctx.getContext() }
+
+        const callParams = { name: toolName, arguments: params['arguments'] }
+
+        let handlerResult: unknown
+        try {
+            handlerResult = await this.deps.toolExecutor.handleToolCall(callParams, props, augmentedState)
+        } catch (err) {
+            if (isInputRequiredSignal(err)) {
+                const round = priorRound + 1
+                const nextState = this.deps.codec.encode({
+                    sub: props.userHash,
+                    tool: toolName,
+                    round,
+                    payload: { priorAnswers: combinedAnswers },
+                })
+                v2026RequestsTotal.inc({ outcome: 'input_required' })
+                return jsonResponse({
+                    jsonrpc: JSONRPC_VERSION,
+                    id: request.id,
+                    result: {
+                        resultType: 'input_required',
+                        inputRequests: {
+                            [err.key]: {
+                                method: 'elicitation/create',
+                                params: {
+                                    mode: 'form',
+                                    message: err.elicitParams.message,
+                                    requestedSchema: err.elicitParams.requestedSchema,
+                                },
+                            },
+                        },
+                        requestState: nextState,
+                    },
+                })
+            }
+            throw err
+        }
+
+        v2026RequestsTotal.inc({ outcome: 'complete' })
+        v2026InputRequiredRoundTrips.observe(priorRound + 1)
+        return jsonResponse({
+            jsonrpc: JSONRPC_VERSION,
+            id: request.id,
+            result: {
+                resultType: 'complete',
+                ...(typeof handlerResult === 'object' && handlerResult !== null
+                    ? handlerResult
+                    : { value: handlerResult }),
+            },
+        })
+    }
+}
+
+function decodeAnswersFromClaims(payload: unknown): AnswerMap {
+    if (payload === null || typeof payload !== 'object') {
+        return {}
+    }
+    const obj = payload as Record<string, unknown>
+    const priorAnswers = obj['priorAnswers']
+    if (priorAnswers === null || typeof priorAnswers !== 'object') {
+        return {}
+    }
+    const result: AnswerMap = {}
+    for (const [key, value] of Object.entries(priorAnswers as Record<string, unknown>)) {
+        if (isElicitResult(value)) {
+            result[key] = value
+        }
+    }
+    return result
+}
+
+function parseInputResponses(value: unknown): AnswerMap {
+    if (value === undefined || value === null) {
+        return {}
+    }
+    if (typeof value !== 'object' || Array.isArray(value)) {
+        throw invalidParams('inputResponses must be an object')
+    }
+    const result: AnswerMap = {}
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+        if (!isElicitResult(entry)) {
+            throw invalidParams(`inputResponses.${key} is not a valid ElicitResult`)
+        }
+        result[key] = entry
+    }
+    return result
+}
+
+function jsonResponse(body: Record<string, unknown>): Response {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    })
+}
+
+/** Compose a complete `ProtocolStrategy` for `2026-07-28`. */
+export function buildV2026Strategy(deps: {
+    codec: RequestStateCodec
+    toolExecutor: ToolExecutor
+    handshake: import('./handshake').V2026HandshakeStrategy
+}): ProtocolStrategy {
+    return {
+        version: 'v2026',
+        allowBatches: false,
+        preDispatch: new V2026PreDispatch(),
+        handshake: deps.handshake,
+        toolCall: new V2026ToolCallStrategy({ codec: deps.codec, toolExecutor: deps.toolExecutor }),
+    }
+}
+
+// Re-export for the protocol-strategy interface assignability check in tests.
+export type { V2026ProtocolError }

--- a/services/mcp/src/tools/confirmation-runtime.ts
+++ b/services/mcp/src/tools/confirmation-runtime.ts
@@ -39,7 +39,11 @@ export async function requestConfirmation<P extends Record<string, unknown>>(
 ): Promise<ConfirmationOutcome> {
     const actionLabel = options.actionLabel ?? 'this action'
 
-    if (!context.elicit) {
+    // `requestInput` is the universal seam — works on both 2025-06-18 (where
+    // it delegates to elicit) and 2026-07-28 (where it throws an
+    // InputRequiredSignal the dispatcher catches). Undefined means no
+    // capability available; fall back per policy.
+    if (!context.requestInput) {
         return noElicitOutcome(options.onNoElicit, actionLabel)
     }
 
@@ -47,7 +51,8 @@ export async function requestConfirmation<P extends Record<string, unknown>>(
 
     let elicitResult
     try {
-        elicitResult = await context.elicit({
+        elicitResult = await context.requestInput({
+            key: 'confirm',
             message: prompt,
             // Empty schema → clients render just the action buttons.
             // The protocol-level `action` field is the explicit-intent signal;

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -122,14 +122,63 @@ export type Context = {
      *   authors should catch and fall back to a non-interactive path.
      * - `SessionBusUnhealthyError` if the bus transport or payload validation
      *   fails (structurally malformed responses, not protocol-level errors).
+     *
+     * NOTE: `elicit` is legacy (2025-06-18 protocol only). New code should
+     * use `requestInput` below — same intent, works on both protocol versions.
      */
     elicit?: ElicitFn
+
+    /**
+     * Universal input-request seam. Works on both protocol pipelines:
+     *
+     * - 2025-06-18: delegates to `elicit` under the hood (pushes
+     *   `elicitation/create` over SSE and awaits a reply via the session bus).
+     * - 2026-07-28: throws an internal `InputRequiredSignal` that the
+     *   dispatcher catches, turning into an `InputRequiredResult`. On retry,
+     *   returns the corresponding entry from `inputResponses`.
+     *
+     * Tool authors write straight-line code:
+     *
+     * ```ts
+     * const result = await context.requestInput({
+     *     key: 'confirm',
+     *     message: 'Proceed?',
+     *     requestedSchema: { type: 'object', properties: {} },
+     * })
+     * if (result.action !== 'accept') return cancellation()
+     * ```
+     *
+     * Undefined when no elicitation capability was negotiated. Tool authors
+     * MUST treat `if (context.requestInput)` as a capability check.
+     *
+     * IMPORTANT (2026-07-28 only): handlers may be re-invoked multiple times
+     * as the protocol round-trips. Code BEFORE a `requestInput` call runs on
+     * every round; side-effects there must be idempotent. Place destructive
+     * side-effects AFTER the `accept` branch.
+     */
+    requestInput?: RequestInputFn
 }
 
 export type ElicitFn = (
     params: ElicitRequestFormParams,
     options?: { timeoutMs?: number; signal?: AbortSignal }
 ) => Promise<ElicitResult>
+
+export type RequestInputFn = (params: RequestInputParams) => Promise<ElicitResult>
+
+export interface RequestInputParams {
+    /**
+     * Author-chosen identifier for this input request. Used to correlate
+     * the response on retry. Stable within a single tool's logic — if a
+     * handler issues two requestInput calls in sequence, they must use
+     * different keys.
+     */
+    key: string
+    /** Prompt text shown to the user. */
+    message: string
+    /** JSON Schema for the expected response content. Empty `properties` for action-only confirmations. */
+    requestedSchema: ElicitRequestFormParams['requestedSchema']
+}
 
 export type Tool<TSchema extends z.ZodType = z.ZodType, TResult = unknown> = {
     name: string

--- a/services/mcp/tests/hono/dispatcher-profile.perf.ts
+++ b/services/mcp/tests/hono/dispatcher-profile.perf.ts
@@ -23,9 +23,13 @@ vi.mock('@/resources', () => ({
     getPromptsFromManifest: vi.fn().mockResolvedValue([]),
 }))
 
-import type { RequestProperties } from '@/lib/request-properties'
-import { McpDispatcher } from '@/hono/dispatcher'
+import { CapabilityStore } from '@/hono/capability-store'
+import { buildSharedDeps, McpDispatcher } from '@/hono/dispatcher'
+import { InMemorySessionResponseBus } from '@/hono/session-bus'
+import { LegacyHandshakeStrategy } from '@/hono/strategies/legacy/handshake'
+import { buildLegacyStrategy } from '@/hono/strategies/legacy/tool-call'
 import { ToolCatalog } from '@/hono/tool-catalog'
+import type { RequestProperties } from '@/lib/request-properties'
 
 class MockRedis {
     private store = new Map<string, string>()
@@ -185,7 +189,16 @@ describe('McpDispatcher profiling', () => {
 
         const redis = new MockRedis()
         catalog = new ToolCatalog()
-        dispatcher = new McpDispatcher(catalog, redis as any)
+        const shared = buildSharedDeps(catalog, redis as any)
+        const capabilityStore = new CapabilityStore(redis as any)
+        const legacyStrategy = buildLegacyStrategy({
+            capabilityStore,
+            sessionBus: new InMemorySessionResponseBus(),
+            busMetrics: undefined,
+            toolExecutor: shared.toolExecutor,
+            handshake: new LegacyHandshakeStrategy(capabilityStore, shared.instructionsBuilder),
+        })
+        dispatcher = new McpDispatcher(shared, legacyStrategy)
         await dispatcher.warmup()
 
         // Prime the warm cache

--- a/services/mcp/tests/hono/v2026/dispatcher.test.ts
+++ b/services/mcp/tests/hono/v2026/dispatcher.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+import { buildSharedDeps, McpDispatcher, type SharedDispatcherDeps } from '@/hono/dispatcher'
+import { ToolCatalog } from '@/hono/tool-catalog'
+import { V2026HandshakeStrategy } from '@/hono/v2026/handshake'
+import { RequestStateCodec } from '@/hono/v2026/request-state'
+import { buildV2026Strategy } from '@/hono/v2026/tool-call'
+import type { Context } from '@/tools/types'
+
+import { makeRedisRateLimitStubs } from '../helpers/redis-rate-limit-stubs'
+
+const V = '2026-07-28'
+
+function inMemoryRedis(): RedisLike {
+    const store = new Map<string, string>()
+    return {
+        get: async (key) => store.get(key) ?? null,
+        set: async (key, value) => {
+            store.set(key, String(value))
+            return 'OK'
+        },
+        del: async (...keys) => {
+            let n = 0
+            for (const k of keys) {
+                if (store.delete(k)) {
+                    n++
+                }
+            }
+            return n
+        },
+        scan: async (cursor) => {
+            const cur = String(cursor)
+            return [cur === '0' ? 'next' : '0', cur === '0' ? Array.from(store.keys()) : []] as [string, string[]]
+        },
+        ...makeRedisRateLimitStubs(),
+    }
+}
+
+function makeCodec(): RequestStateCodec {
+    return new RequestStateCodec(Buffer.alloc(32, 0x42), undefined, {
+        now: () => 1_700_000_000_000,
+        randomNonce: () => 'fixed',
+    })
+}
+
+interface TestRig {
+    dispatcher: McpDispatcher
+    codec: RequestStateCodec
+    shared: SharedDispatcherDeps
+}
+
+function makeDispatcher(): TestRig {
+    const codec = makeCodec()
+    const shared = buildSharedDeps(new ToolCatalog(), inMemoryRedis())
+    const strategy = buildV2026Strategy({
+        codec,
+        toolExecutor: shared.toolExecutor,
+        handshake: new V2026HandshakeStrategy(shared.instructionsBuilder),
+    })
+    return { dispatcher: new McpDispatcher(shared, strategy), codec, shared }
+}
+
+type ExecutorFn = (params: unknown, props: unknown, state: { context: Context }) => Promise<unknown>
+
+/**
+ * Stub out the shared tool executor and state resolver so the test can
+ * control what the handler does and inspect the dispatcher's response
+ * shape without spinning up a real catalog + upstream API.
+ */
+function stubExecutorAndState(shared: SharedDispatcherDeps, onCall: ExecutorFn): void {
+    ;(shared.toolExecutor as unknown as { handleToolCall: typeof onCall }).handleToolCall = vi.fn(onCall)
+    shared.stateResolver.resolve = vi.fn(async () => ({
+        reqCtx: {
+            getContext: async () => ({}),
+            getSessionUuid: async () => undefined,
+        },
+        context: {} as never,
+        distinctId: 'did',
+        version: 1,
+        useSingleExec: false,
+        apiKeyScopes: [],
+        clientProfile: {} as never,
+        allTools: [],
+    })) as never
+}
+
+function makeReq(opts: {
+    method: string
+    body: Record<string, unknown>
+    extraHeaders?: Record<string, string>
+}): Request {
+    return new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+            'mcp-protocol-version': V,
+            'mcp-method': opts.method,
+            'content-type': 'application/json',
+            ...opts.extraHeaders,
+        },
+        body: JSON.stringify(opts.body),
+    })
+}
+
+function withMeta(method: string, params: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        jsonrpc: '2.0',
+        id: 1,
+        method,
+        params: {
+            ...params,
+            _meta: {
+                'io.modelcontextprotocol/protocolVersion': V,
+                'io.modelcontextprotocol/clientInfo': { name: 'test', version: '0' },
+                'io.modelcontextprotocol/clientCapabilities': {},
+            },
+        },
+    }
+}
+
+function mockProps(userHash: string = 'user-hash-1'): import('@/lib/request-properties').RequestProperties {
+    return {
+        apiToken: 'phx_test',
+        userHash,
+        version: 1,
+    }
+}
+
+describe('McpDispatcher (v2026 strategy) — request validation', () => {
+    it('rejects requests missing the protocol version header', async () => {
+        const { dispatcher } = makeDispatcher()
+        const req = new Request('http://localhost/mcp', {
+            method: 'POST',
+            headers: { 'mcp-method': 'ping', 'content-type': 'application/json' },
+            body: JSON.stringify(withMeta('ping')),
+        })
+        const res = await dispatcher.handleRequest(req, mockProps())
+        expect(res.status).toBe(400)
+        const body = (await res.json()) as { error: { code: number } }
+        expect(body.error.code).toBe(-32602)
+    })
+
+    it('rejects an unsupported protocol version with code -32004 + data.supported', async () => {
+        const { dispatcher } = makeDispatcher()
+        const req = new Request('http://localhost/mcp', {
+            method: 'POST',
+            headers: {
+                'mcp-protocol-version': '1999-01-01',
+                'mcp-method': 'ping',
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify(withMeta('ping')),
+        })
+        const res = await dispatcher.handleRequest(req, mockProps())
+        expect(res.status).toBe(400)
+        const body = (await res.json()) as { error: { code: number; data: { supported: string[] } } }
+        expect(body.error.code).toBe(-32004)
+        expect(body.error.data.supported).toEqual([V])
+    })
+
+    it('rejects header/body method mismatch', async () => {
+        const { dispatcher } = makeDispatcher()
+        const req = new Request('http://localhost/mcp', {
+            method: 'POST',
+            headers: {
+                'mcp-protocol-version': V,
+                'mcp-method': 'tools/call',
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify(withMeta('tools/list')),
+        })
+        const res = await dispatcher.handleRequest(req, mockProps())
+        expect(res.status).toBe(400)
+    })
+
+    it('rejects malformed JSON with a parse error', async () => {
+        const { dispatcher } = makeDispatcher()
+        const req = new Request('http://localhost/mcp', {
+            method: 'POST',
+            headers: {
+                'mcp-protocol-version': V,
+                'mcp-method': 'ping',
+                'content-type': 'application/json',
+            },
+            body: '{not json',
+        })
+        const res = await dispatcher.handleRequest(req, mockProps())
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as { error: { code: number } }
+        expect(body.error.code).toBe(-32700)
+    })
+
+    it('rejects batches (not supported in 2026-07-28)', async () => {
+        const { dispatcher } = makeDispatcher()
+        const req = new Request('http://localhost/mcp', {
+            method: 'POST',
+            headers: {
+                'mcp-protocol-version': V,
+                'mcp-method': 'ping',
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify([withMeta('ping')]),
+        })
+        const res = await dispatcher.handleRequest(req, mockProps())
+        expect(res.status).toBe(400)
+        const body = (await res.json()) as { error: { message: string } }
+        expect(body.error.message).toMatch(/batches/i)
+    })
+
+    it('rejects unknown methods with -32601', async () => {
+        const { dispatcher, shared } = makeDispatcher()
+        stubExecutorAndState(shared, async () => null)
+        const res = await dispatcher.handleRequest(
+            makeReq({ method: 'fictional/method', body: withMeta('fictional/method') }),
+            mockProps()
+        )
+        const body = (await res.json()) as { error: { code: number } }
+        expect(body.error.code).toBe(-32601)
+    })
+})
+
+describe('McpDispatcher (v2026 strategy) — ping', () => {
+    it('returns a result with empty object', async () => {
+        const { dispatcher } = makeDispatcher()
+        const res = await dispatcher.handleRequest(makeReq({ method: 'ping', body: withMeta('ping') }), mockProps())
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as { result: unknown }
+        expect(body.result).toEqual({})
+    })
+})
+
+describe('McpDispatcher (v2026 strategy) — requestState round-trip via tools/call', () => {
+    it('returns input_required + signed requestState when the handler throws InputRequiredSignal', async () => {
+        const { dispatcher, shared } = makeDispatcher()
+        stubExecutorAndState(shared, async (_params, _props, state) => {
+            await state.context.requestInput!({
+                key: 'confirm',
+                message: 'Proceed?',
+                requestedSchema: { type: 'object', properties: {} },
+            })
+            return null
+        })
+
+        const res = await dispatcher.handleRequest(
+            makeReq({
+                method: 'tools/call',
+                body: withMeta('tools/call', { name: 'sample-tool', arguments: {} }),
+                extraHeaders: { 'mcp-name': 'sample-tool' },
+            }),
+            mockProps()
+        )
+
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as {
+            result: { resultType: string; inputRequests: Record<string, unknown>; requestState: string }
+        }
+        expect(body.result.resultType).toBe('input_required')
+        expect(body.result.inputRequests.confirm).toMatchObject({
+            method: 'elicitation/create',
+            params: { mode: 'form', message: 'Proceed?' },
+        })
+        expect(typeof body.result.requestState).toBe('string')
+        expect(body.result.requestState.split('.')).toHaveLength(3)
+    })
+
+    it('decodes prior requestState on retry and returns the answer from requestInput', async () => {
+        const { dispatcher, codec, shared } = makeDispatcher()
+        const userHash = 'user-1'
+        const requestState = codec.encode({
+            sub: userHash,
+            tool: 'sample-tool',
+            round: 1,
+            payload: { priorAnswers: {} },
+        })
+
+        let resolvedAnswer: unknown
+        stubExecutorAndState(shared, async (_params, _props, state) => {
+            resolvedAnswer = await state.context.requestInput!({
+                key: 'confirm',
+                message: 'Proceed?',
+                requestedSchema: { type: 'object', properties: {} },
+            })
+            return { ok: true }
+        })
+
+        const res = await dispatcher.handleRequest(
+            makeReq({
+                method: 'tools/call',
+                body: withMeta('tools/call', {
+                    name: 'sample-tool',
+                    arguments: {},
+                    inputResponses: { confirm: { action: 'accept' } },
+                    requestState,
+                }),
+                extraHeaders: { 'mcp-name': 'sample-tool' },
+            }),
+            mockProps(userHash)
+        )
+
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as { result: { resultType: string; ok?: boolean } }
+        expect(body.result.resultType).toBe('complete')
+        expect(body.result.ok).toBe(true)
+        expect(resolvedAnswer).toEqual({ action: 'accept' })
+    })
+
+    it('rejects a requestState signed under a different userHash', async () => {
+        const { dispatcher, codec, shared } = makeDispatcher()
+        stubExecutorAndState(shared, async () => null)
+        const stolen = codec.encode({
+            sub: 'victim-hash',
+            tool: 'sample-tool',
+            round: 1,
+            payload: { priorAnswers: {} },
+        })
+
+        const res = await dispatcher.handleRequest(
+            makeReq({
+                method: 'tools/call',
+                body: withMeta('tools/call', {
+                    name: 'sample-tool',
+                    arguments: {},
+                    inputResponses: { confirm: { action: 'accept' } },
+                    requestState: stolen,
+                }),
+                extraHeaders: { 'mcp-name': 'sample-tool' },
+            }),
+            mockProps('attacker-hash')
+        )
+        expect(res.status).toBe(400)
+        const body = (await res.json()) as { error: { code: number; message: string } }
+        expect(body.error.code).toBe(-32602)
+        expect(body.error.message).toMatch(/requestState rejected/)
+    })
+
+    it('rejects an inputResponses entry that is not a valid ElicitResult', async () => {
+        const { dispatcher, shared } = makeDispatcher()
+        stubExecutorAndState(shared, async () => null)
+
+        const res = await dispatcher.handleRequest(
+            makeReq({
+                method: 'tools/call',
+                body: withMeta('tools/call', {
+                    name: 'sample-tool',
+                    arguments: {},
+                    inputResponses: { confirm: { not: 'a valid result' } },
+                }),
+                extraHeaders: { 'mcp-name': 'sample-tool' },
+            }),
+            mockProps()
+        )
+        expect(res.status).toBe(400)
+        const body = (await res.json()) as { error: { code: number; message: string } }
+        expect(body.error.code).toBe(-32602)
+        expect(body.error.message).toMatch(/inputResponses\.confirm/)
+    })
+})

--- a/services/mcp/tests/hono/v2026/request-meta.test.ts
+++ b/services/mcp/tests/hono/v2026/request-meta.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+
+import { JSON_RPC_ERROR, V2026ProtocolError } from '@/hono/v2026/errors'
+import { parseV2026Meta } from '@/hono/v2026/request-meta'
+
+const V = '2026-07-28'
+
+function makeRequest(headers: Record<string, string>): Request {
+    return new Request('http://localhost/mcp', { method: 'POST', headers })
+}
+
+function validBody(method: string, paramsOverride?: Record<string, unknown>): Record<string, unknown> {
+    const params: Record<string, unknown> = {
+        ...paramsOverride,
+        _meta: {
+            'io.modelcontextprotocol/protocolVersion': V,
+            'io.modelcontextprotocol/clientInfo': { name: 'claude-code', version: '2.1.149' },
+            'io.modelcontextprotocol/clientCapabilities': { elicitation: {} },
+        },
+    }
+    return { jsonrpc: '2.0', id: 1, method, params }
+}
+
+describe('parseV2026Meta', () => {
+    it('parses a fully-formed tools/call request', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': V,
+            'mcp-method': 'tools/call',
+            'mcp-name': 'org-update',
+        })
+        const meta = parseV2026Meta(req, validBody('tools/call', { name: 'org-update' }))
+        expect(meta.protocolVersion).toBe(V)
+        expect(meta.method).toBe('tools/call')
+        expect(meta.name).toBe('org-update')
+        expect(meta.clientInfo.name).toBe('claude-code')
+        expect(meta.clientCapabilities.elicitation).toEqual({})
+    })
+
+    it('parses an optional logLevel from _meta', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': V,
+            'mcp-method': 'tools/call',
+        })
+        const body = validBody('tools/call')
+        ;(body.params as Record<string, unknown>)['_meta'] = {
+            ...((body.params as Record<string, unknown>)['_meta'] as Record<string, unknown>),
+            'io.modelcontextprotocol/logLevel': 'info',
+        }
+        const meta = parseV2026Meta(req, body)
+        expect(meta.logLevel).toBe('info')
+    })
+
+    it('rejects an invalid logLevel value', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': V,
+            'mcp-method': 'tools/call',
+        })
+        const body = validBody('tools/call')
+        ;(body.params as Record<string, unknown>)['_meta'] = {
+            ...((body.params as Record<string, unknown>)['_meta'] as Record<string, unknown>),
+            'io.modelcontextprotocol/logLevel': 'ludicrous',
+        }
+        try {
+            parseV2026Meta(req, body)
+            throw new Error('expected to throw')
+        } catch (err) {
+            expect(err).toBeInstanceOf(V2026ProtocolError)
+            expect((err as V2026ProtocolError).code).toBe(JSON_RPC_ERROR.INVALID_PARAMS)
+        }
+    })
+
+    it('rejects missing protocol version header', () => {
+        const req = makeRequest({ 'mcp-method': 'tools/call' })
+        try {
+            parseV2026Meta(req, validBody('tools/call'))
+            throw new Error('expected to throw')
+        } catch (err) {
+            expect((err as V2026ProtocolError).code).toBe(JSON_RPC_ERROR.INVALID_PARAMS)
+            expect((err as V2026ProtocolError).httpStatus).toBe(400)
+        }
+    })
+
+    it('rejects an unsupported protocol version', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': '1999-01-01',
+            'mcp-method': 'tools/call',
+        })
+        try {
+            parseV2026Meta(req, validBody('tools/call'))
+            throw new Error('expected to throw')
+        } catch (err) {
+            const e = err as V2026ProtocolError
+            expect(e.code).toBe(JSON_RPC_ERROR.UNSUPPORTED_PROTOCOL_VERSION)
+            expect(e.data?.requested).toBe('1999-01-01')
+            expect(e.data?.supported).toEqual([V])
+        }
+    })
+
+    it('rejects missing method header', () => {
+        const req = makeRequest({ 'mcp-protocol-version': V })
+        try {
+            parseV2026Meta(req, validBody('tools/call'))
+            throw new Error('expected to throw')
+        } catch (err) {
+            expect((err as V2026ProtocolError).code).toBe(JSON_RPC_ERROR.INVALID_PARAMS)
+        }
+    })
+
+    it('rejects header/body method mismatch', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': V,
+            'mcp-method': 'tools/call',
+        })
+        try {
+            parseV2026Meta(req, validBody('tools/list'))
+            throw new Error('expected to throw')
+        } catch (err) {
+            const e = err as V2026ProtocolError
+            expect(e.code).toBe(JSON_RPC_ERROR.INVALID_PARAMS)
+            expect(e.message).toMatch(/does not match/)
+        }
+    })
+
+    it('rejects header/body protocol-version mismatch', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': V,
+            'mcp-method': 'tools/call',
+        })
+        const body = validBody('tools/call')
+        ;(body.params as Record<string, unknown>)['_meta'] = {
+            ...((body.params as Record<string, unknown>)['_meta'] as Record<string, unknown>),
+            'io.modelcontextprotocol/protocolVersion': '2099-01-01',
+        }
+        try {
+            parseV2026Meta(req, body)
+            throw new Error('expected to throw')
+        } catch (err) {
+            expect((err as V2026ProtocolError).code).toBe(JSON_RPC_ERROR.INVALID_PARAMS)
+        }
+    })
+
+    it('rejects missing _meta', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': V,
+            'mcp-method': 'tools/call',
+        })
+        try {
+            parseV2026Meta(req, { jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} })
+            throw new Error('expected to throw')
+        } catch (err) {
+            const e = err as V2026ProtocolError
+            expect(e.code).toBe(JSON_RPC_ERROR.INVALID_PARAMS)
+            expect(e.message).toMatch(/_meta/)
+        }
+    })
+
+    it('rejects missing clientInfo', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': V,
+            'mcp-method': 'tools/call',
+        })
+        const body = validBody('tools/call')
+        const meta = (body.params as Record<string, unknown>)['_meta'] as Record<string, unknown>
+        delete meta['io.modelcontextprotocol/clientInfo']
+        try {
+            parseV2026Meta(req, body)
+            throw new Error('expected to throw')
+        } catch (err) {
+            const e = err as V2026ProtocolError
+            expect(e.code).toBe(JSON_RPC_ERROR.INVALID_PARAMS)
+            expect(e.message).toMatch(/clientInfo/)
+        }
+    })
+
+    it('rejects missing clientCapabilities', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': V,
+            'mcp-method': 'tools/call',
+        })
+        const body = validBody('tools/call')
+        const meta = (body.params as Record<string, unknown>)['_meta'] as Record<string, unknown>
+        delete meta['io.modelcontextprotocol/clientCapabilities']
+        try {
+            parseV2026Meta(req, body)
+            throw new Error('expected to throw')
+        } catch (err) {
+            const e = err as V2026ProtocolError
+            expect(e.code).toBe(JSON_RPC_ERROR.INVALID_PARAMS)
+            expect(e.message).toMatch(/clientCapabilities/)
+        }
+    })
+
+    it('accepts an empty capabilities object', () => {
+        const req = makeRequest({
+            'mcp-protocol-version': V,
+            'mcp-method': 'tools/list',
+        })
+        const body = validBody('tools/list')
+        const meta = (body.params as Record<string, unknown>)['_meta'] as Record<string, unknown>
+        meta['io.modelcontextprotocol/clientCapabilities'] = {}
+        const parsed = parseV2026Meta(req, body)
+        expect(parsed.clientCapabilities).toEqual({})
+    })
+
+    it('case-insensitively reads header values', () => {
+        // The HTTP spec is case-insensitive on header names; Request normalizes
+        // them. Sanity check the helpers don't accidentally require lowercase.
+        const req = new Request('http://localhost/mcp', {
+            method: 'POST',
+            headers: {
+                'MCP-Protocol-Version': V,
+                'Mcp-Method': 'tools/call',
+            },
+        })
+        const meta = parseV2026Meta(req, validBody('tools/call'))
+        expect(meta.protocolVersion).toBe(V)
+    })
+})

--- a/services/mcp/tests/hono/v2026/request-state.test.ts
+++ b/services/mcp/tests/hono/v2026/request-state.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest'
+
+import { MAX_REQUEST_STATE_ROUNDS, REQUEST_STATE_TTL_SECONDS } from '@/hono/v2026/constants'
+import {
+    RequestStateExpired,
+    RequestStateMalformed,
+    RequestStateRoundsExceeded,
+    RequestStateSignatureInvalid,
+    RequestStateToolMismatch,
+    RequestStateUserMismatch,
+} from '@/hono/v2026/errors'
+import { RequestStateCodec, loadSigningKeysFromEnv } from '@/hono/v2026/request-state'
+
+function makeCodec(now: number = 1_700_000_000_000): {
+    codec: RequestStateCodec
+    advance: (deltaMs: number) => void
+} {
+    const key = Buffer.alloc(32, 0x42)
+    let clock = now
+    const codec = new RequestStateCodec(key, undefined, {
+        now: () => clock,
+        randomNonce: () => 'fixed-nonce-for-tests',
+    })
+    return { codec, advance: (deltaMs) => (clock += deltaMs) }
+}
+
+describe('RequestStateCodec', () => {
+    it('round-trips claims through encode + decode', () => {
+        const { codec } = makeCodec()
+        const token = codec.encode({ sub: 'user-1', tool: 'org-update', round: 0, payload: { step: 1 } })
+        const decoded = codec.decode(token, 'user-1', 'org-update')
+        expect(decoded.sub).toBe('user-1')
+        expect(decoded.tool).toBe('org-update')
+        expect(decoded.round).toBe(0)
+        expect(decoded.payload).toEqual({ step: 1 })
+        expect(decoded.exp).toBe(decoded.iat + REQUEST_STATE_TTL_SECONDS)
+    })
+
+    it('rejects a token whose signature was tampered with', () => {
+        const { codec } = makeCodec()
+        const token = codec.encode({ sub: 'user-1', tool: 'org-update', round: 0, payload: null })
+        // Flip a character in the signature segment.
+        const segments = token.split('.')
+        const sig = segments[2]!
+        const tampered = `${segments[0]}.${segments[1]}.${sig.slice(0, -1)}${sig.slice(-1) === 'A' ? 'B' : 'A'}`
+        expect(() => codec.decode(tampered, 'user-1', 'org-update')).toThrow(RequestStateSignatureInvalid)
+    })
+
+    it('rejects a token whose payload was tampered with', () => {
+        const { codec } = makeCodec()
+        const token = codec.encode({ sub: 'user-1', tool: 'org-update', round: 0, payload: null })
+        const [header, _payload, sig] = token.split('.')
+        // Replace the payload with a different base64-encoded claims blob.
+        const forged = Buffer.from(
+            JSON.stringify({
+                sub: 'user-2',
+                tool: 'org-update',
+                round: 0,
+                iat: 0,
+                exp: 9_999_999_999,
+                nonce: 'x',
+                payload: null,
+            }),
+            'utf8'
+        )
+            .toString('base64')
+            .replace(/=/g, '')
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+        expect(() => codec.decode(`${header}.${forged}.${sig}`, 'user-2', 'org-update')).toThrow(
+            RequestStateSignatureInvalid
+        )
+    })
+
+    it('rejects a token after exp has passed', () => {
+        const { codec, advance } = makeCodec()
+        const token = codec.encode({ sub: 'user-1', tool: 'org-update', round: 0, payload: null })
+        advance((REQUEST_STATE_TTL_SECONDS + 1) * 1000)
+        expect(() => codec.decode(token, 'user-1', 'org-update')).toThrow(RequestStateExpired)
+    })
+
+    it('rejects a token replayed under a different authenticated user', () => {
+        const { codec } = makeCodec()
+        const token = codec.encode({ sub: 'user-1', tool: 'org-update', round: 0, payload: null })
+        expect(() => codec.decode(token, 'user-attacker', 'org-update')).toThrow(RequestStateUserMismatch)
+    })
+
+    it('rejects a token replayed against a different tool', () => {
+        const { codec } = makeCodec()
+        const token = codec.encode({ sub: 'user-1', tool: 'org-update', round: 0, payload: null })
+        expect(() => codec.decode(token, 'user-1', 'other-tool')).toThrow(RequestStateToolMismatch)
+    })
+
+    it('rejects a token whose round counter already reached the cap', () => {
+        const { codec } = makeCodec()
+        const token = codec.encode({
+            sub: 'user-1',
+            tool: 'org-update',
+            round: MAX_REQUEST_STATE_ROUNDS,
+            payload: null,
+        })
+        expect(() => codec.decode(token, 'user-1', 'org-update')).toThrow(RequestStateRoundsExceeded)
+    })
+
+    it('allows the last legal round (cap - 1)', () => {
+        const { codec } = makeCodec()
+        const token = codec.encode({
+            sub: 'user-1',
+            tool: 'org-update',
+            round: MAX_REQUEST_STATE_ROUNDS - 1,
+            payload: null,
+        })
+        const decoded = codec.decode(token, 'user-1', 'org-update')
+        expect(decoded.round).toBe(MAX_REQUEST_STATE_ROUNDS - 1)
+    })
+
+    it('rejects malformed tokens (wrong segment count)', () => {
+        const { codec } = makeCodec()
+        expect(() => codec.decode('only.two', 'user-1', 'tool')).toThrow(RequestStateMalformed)
+        expect(() => codec.decode('a.b.c.d', 'user-1', 'tool')).toThrow(RequestStateMalformed)
+        expect(() => codec.decode('', 'user-1', 'tool')).toThrow(RequestStateMalformed)
+    })
+
+    it('rejects a token whose header has the wrong alg', () => {
+        const { codec } = makeCodec()
+        const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'MCP-REQ-STATE' }), 'utf8')
+            .toString('base64')
+            .replace(/=/g, '')
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+        const token = codec.encode({ sub: 'user-1', tool: 'tool', round: 0, payload: null })
+        const [, payload, sig] = token.split('.')
+        // Re-sign would require the same key, so we expect the tampered header
+        // to fail the signature check OR the alg check. Either rejection is OK
+        // for the spec — both are "malformed/invalid".
+        expect(() => codec.decode(`${header}.${payload}.${sig}`, 'user-1', 'tool')).toThrow()
+    })
+})
+
+describe('RequestStateCodec — key rotation', () => {
+    it('verifies tokens signed with the secondary key', () => {
+        const primary = Buffer.alloc(32, 0x11)
+        const secondary = Buffer.alloc(32, 0x22)
+        const oldCodec = new RequestStateCodec(secondary, undefined, { now: () => 1_700_000_000_000 })
+        const newCodec = new RequestStateCodec(primary, secondary, { now: () => 1_700_000_000_000 })
+
+        const token = oldCodec.encode({ sub: 'user-1', tool: 'tool', round: 0, payload: null })
+        // The rotated server (primary + secondary) accepts the old token.
+        const decoded = newCodec.decode(token, 'user-1', 'tool')
+        expect(decoded.sub).toBe('user-1')
+    })
+
+    it('signs new tokens with the primary key only, not the secondary', () => {
+        const primary = Buffer.alloc(32, 0x11)
+        const secondary = Buffer.alloc(32, 0x22)
+        const onlyOld = new RequestStateCodec(secondary, undefined, { now: () => 1_700_000_000_000 })
+        const rotated = new RequestStateCodec(primary, secondary, { now: () => 1_700_000_000_000 })
+
+        // A token freshly signed by the rotated server must NOT verify against
+        // the old key alone — only the primary, or another rotated server.
+        const token = rotated.encode({ sub: 'user-1', tool: 'tool', round: 0, payload: null })
+        expect(() => onlyOld.decode(token, 'user-1', 'tool')).toThrow(RequestStateSignatureInvalid)
+    })
+})
+
+describe('loadSigningKeysFromEnv', () => {
+    it('throws in production when the key is missing', () => {
+        expect(() => loadSigningKeysFromEnv({ NODE_ENV: 'production' })).toThrow(/must be set to at least/)
+    })
+
+    it('throws in production when the key is too short', () => {
+        expect(() =>
+            loadSigningKeysFromEnv({ NODE_ENV: 'production', MCP_REQUEST_STATE_SIGNING_KEY: 'short' })
+        ).toThrow(/must be set to at least/)
+    })
+
+    it('returns the placeholder in non-production when the key is missing', () => {
+        const { primary, secondary } = loadSigningKeysFromEnv({ NODE_ENV: 'development' })
+        expect(primary.length).toBeGreaterThan(0)
+        expect(secondary).toBeUndefined()
+    })
+
+    it('returns the primary key when sufficiently long', () => {
+        const longKey = 'a'.repeat(32)
+        const { primary } = loadSigningKeysFromEnv({
+            NODE_ENV: 'production',
+            MCP_REQUEST_STATE_SIGNING_KEY: longKey,
+        })
+        expect(primary.toString('utf8')).toBe(longKey)
+    })
+
+    it('returns the secondary key when configured and long enough', () => {
+        const longKey = 'a'.repeat(32)
+        const longOld = 'b'.repeat(32)
+        const { secondary } = loadSigningKeysFromEnv({
+            NODE_ENV: 'production',
+            MCP_REQUEST_STATE_SIGNING_KEY: longKey,
+            MCP_REQUEST_STATE_SIGNING_KEY_OLD: longOld,
+        })
+        expect(secondary?.toString('utf8')).toBe(longOld)
+    })
+
+    it('ignores a too-short secondary key', () => {
+        const longKey = 'a'.repeat(32)
+        const { secondary } = loadSigningKeysFromEnv({
+            NODE_ENV: 'production',
+            MCP_REQUEST_STATE_SIGNING_KEY: longKey,
+            MCP_REQUEST_STATE_SIGNING_KEY_OLD: 'short',
+        })
+        expect(secondary).toBeUndefined()
+    })
+})

--- a/services/mcp/tests/unit/confirmation-runtime.test.ts
+++ b/services/mcp/tests/unit/confirmation-runtime.test.ts
@@ -4,9 +4,9 @@ import { ElicitationNotSupportedError } from '@/hono/session-bus'
 import { requestConfirmation } from '@/tools/confirmation-runtime'
 import type { Context } from '@/tools/types'
 
-type ElicitFn = NonNullable<Context['elicit']>
+type RequestInputFn = NonNullable<Context['requestInput']>
 
-function makeContext(elicit: ElicitFn | undefined): Context {
+function makeContext(requestInput: RequestInputFn | undefined): Context {
     // The runtime helper only touches `context.elicit`. Everything else is
     // stubbed to `null as never` — accessing them in the helper would be a
     // bug, and the test will surface it as a TypeError if it ever happens.
@@ -20,8 +20,8 @@ function makeContext(elicit: ElicitFn | undefined): Context {
         getDistinctId: () => Promise.resolve('did'),
         trackEvent: () => Promise.resolve(),
     } as Context
-    if (elicit) {
-        ctx.elicit = elicit
+    if (requestInput) {
+        ctx.requestInput = requestInput
     }
     return ctx
 }
@@ -77,16 +77,16 @@ describe('requestConfirmation — no elicit available', () => {
 
 describe('requestConfirmation — elicit available', () => {
     it('emits an empty requestedSchema (no form fields, just action buttons)', async () => {
-        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
+        const requestInput = vi.fn<RequestInputFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
-            makeContext(elicit),
+            makeContext(requestInput),
             {},
             {
                 message: 'Proceed?',
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit).toHaveBeenCalledWith(
+        expect(requestInput).toHaveBeenCalledWith(
             expect.objectContaining({
                 requestedSchema: { type: 'object', properties: {} },
             })
@@ -94,9 +94,9 @@ describe('requestConfirmation — elicit available', () => {
     })
 
     it('returns accepted when the user accepts', async () => {
-        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
+        const requestInput = vi.fn<RequestInputFn>(async () => ({ action: 'accept' as const }))
         const outcome = await requestConfirmation(
-            makeContext(elicit),
+            makeContext(requestInput),
             { id: 42 },
             {
                 message: 'Delete {id}?',
@@ -104,8 +104,8 @@ describe('requestConfirmation — elicit available', () => {
             }
         )
         expect(outcome.kind).toBe('accepted')
-        expect(elicit).toHaveBeenCalledTimes(1)
-        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Delete 42?' }))
+        expect(requestInput).toHaveBeenCalledTimes(1)
+        expect(requestInput).toHaveBeenCalledWith(expect.objectContaining({ message: 'Delete 42?' }))
     })
 
     it.each([
@@ -114,9 +114,9 @@ describe('requestConfirmation — elicit available', () => {
     ])(
         'returns cancelled with a $expectedWord reason when the user $action',
         async ({ action, label, expectedWord }) => {
-            const elicit = vi.fn<ElicitFn>(async () => ({ action }))
+            const requestInput = vi.fn<RequestInputFn>(async () => ({ action }))
             const outcome = await requestConfirmation(
-                makeContext(elicit),
+                makeContext(requestInput),
                 {},
                 {
                     message: 'Proceed?',
@@ -139,11 +139,11 @@ describe('requestConfirmation — elicit available', () => {
     ])(
         'treats runtime ElicitationNotSupportedError as the no-elicit branch ($policy)',
         async ({ policy, expectedKind }) => {
-            const elicit = vi.fn<ElicitFn>(async () => {
+            const requestInput = vi.fn<RequestInputFn>(async () => {
                 throw new ElicitationNotSupportedError(-32601, 'Method not found')
             })
             const outcome = await requestConfirmation(
-                makeContext(elicit),
+                makeContext(requestInput),
                 {},
                 {
                     message: 'Proceed?',
@@ -155,12 +155,12 @@ describe('requestConfirmation — elicit available', () => {
     )
 
     it('propagates non-NotSupported errors (e.g. bus unhealthy) — does not swallow', async () => {
-        const elicit = vi.fn<ElicitFn>(async () => {
+        const requestInput = vi.fn<RequestInputFn>(async () => {
             throw new Error('bus unhealthy')
         })
         await expect(
             requestConfirmation(
-                makeContext(elicit),
+                makeContext(requestInput),
                 {},
                 {
                     message: 'Proceed?',
@@ -173,49 +173,49 @@ describe('requestConfirmation — elicit available', () => {
 
 describe('requestConfirmation — message templating', () => {
     it('interpolates {paramName} placeholders from params', async () => {
-        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
+        const requestInput = vi.fn<RequestInputFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
-            makeContext(elicit),
+            makeContext(requestInput),
             { orgId: 'acme', count: 3 },
             {
                 message: 'Delete {count} items from {orgId}?',
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Delete 3 items from acme?' }))
+        expect(requestInput).toHaveBeenCalledWith(expect.objectContaining({ message: 'Delete 3 items from acme?' }))
     })
 
     it('leaves unknown placeholders literal so authors notice missing keys', async () => {
-        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
+        const requestInput = vi.fn<RequestInputFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
-            makeContext(elicit),
+            makeContext(requestInput),
             {},
             {
                 message: 'Delete {missing}?',
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Delete {missing}?' }))
+        expect(requestInput).toHaveBeenCalledWith(expect.objectContaining({ message: 'Delete {missing}?' }))
     })
 
     it('leaves null/undefined param values as literal placeholders, not the string "null"', async () => {
-        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
+        const requestInput = vi.fn<RequestInputFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
-            makeContext(elicit),
+            makeContext(requestInput),
             { id: null },
             {
                 message: 'Action on {id}',
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Action on {id}' }))
+        expect(requestInput).toHaveBeenCalledWith(expect.objectContaining({ message: 'Action on {id}' }))
     })
 
     it('calls the builder when provided and uses its return value', async () => {
-        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
+        const requestInput = vi.fn<RequestInputFn>(async () => ({ action: 'accept' as const }))
         const builder = vi.fn(async () => 'Built prompt')
         await requestConfirmation(
-            makeContext(elicit),
+            makeContext(requestInput),
             { id: 1 },
             {
                 builder,
@@ -223,19 +223,19 @@ describe('requestConfirmation — message templating', () => {
             }
         )
         expect(builder).toHaveBeenCalledTimes(1)
-        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Built prompt' }))
+        expect(requestInput).toHaveBeenCalledWith(expect.objectContaining({ message: 'Built prompt' }))
     })
 
     it('awaits sync builders too', async () => {
-        const elicit = vi.fn<ElicitFn>(async () => ({ action: 'accept' as const }))
+        const requestInput = vi.fn<RequestInputFn>(async () => ({ action: 'accept' as const }))
         await requestConfirmation(
-            makeContext(elicit),
+            makeContext(requestInput),
             {},
             {
                 builder: () => 'Sync prompt',
                 onNoElicit: 'deny',
             }
         )
-        expect(elicit).toHaveBeenCalledWith(expect.objectContaining({ message: 'Sync prompt' }))
+        expect(requestInput).toHaveBeenCalledWith(expect.objectContaining({ message: 'Sync prompt' }))
     })
 })


### PR DESCRIPTION
> **Note:** This is an illustrative / proof-of-concept implementation, not intended for production deployment. The 2026-07-28 spec is still RC and no Claude client supports it; the parallel-pipeline pattern shown here also becomes unnecessary once the older protocol is retired.

## Problem

MCP 2026-07-28 RC removes SSE for server-initiated requests, moving to continuation-passing with \`InputRequiredResult\` + \`requestState\`. The Hono server must serve both protocols side by side.

## Changes

- Document the protocol surface and design under \`services/mcp/docs/\`
- Refactor \`McpDispatcher\` to one class + a \`ProtocolStrategy\` for the diverging seams
- Add legacy and v2026 strategies sharing the catalog, state resolver, and tool executor
- Add \`Context.requestInput\` as the universal elicitation seam
- Sign \`requestState\` with HMAC-SHA256 + rotation; refuse to start in production without \`MCP_REQUEST_STATE_SIGNING_KEY\`
- Cap multi-round elicit at \`MAX_REQUEST_STATE_ROUNDS = 10\`
- Route by \`MCP-Protocol-Version: 2026-07-28\`; everything else stays legacy

## How did you test this code?

- 31 unit tests added
- All existing 313 hono and 1323 unit tests still pass
- No end-to-end client testing — no client currently ships 2026-07-28

## Publish to changelog?

no