### PR TITLE
feat(llm-gateway): mirror captures to a configurable secondary instance

### DIFF
--- a/services/llm-gateway/src/llm_gateway/callbacks/__init__.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/__init__.py
@@ -16,9 +16,7 @@ def init_callbacks() -> None:
             PostHogCallback(
                 api_key=settings.posthog_project_token,
                 host=settings.posthog_host,
-                # The plan-resolver URL doubles as the customer-origin region
-                # URL stamped on captured events — same value, same per-region
-                # source of truth, no second env to keep in sync.
+                # Reuses the plan-resolver URL — same per-region value.
                 region_url=settings.posthog_api_base_url,
                 secondary_api_key=settings.posthog_secondary_project_token,
                 secondary_host=settings.posthog_secondary_host,

--- a/services/llm-gateway/src/llm_gateway/callbacks/__init__.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/__init__.py
@@ -16,10 +16,13 @@ def init_callbacks() -> None:
             PostHogCallback(
                 api_key=settings.posthog_project_token,
                 host=settings.posthog_host,
+                region_url=settings.posthog_region_url,
+                secondary_api_key=settings.posthog_secondary_project_token,
+                secondary_host=settings.posthog_secondary_host,
             )
         )
 
     callbacks.append(RateLimitCallback())
     callbacks.append(PrometheusCallback())
 
-    litellm.callbacks = callbacks
+    litellm.callbacks = callbacks  # ty: ignore[invalid-assignment]

--- a/services/llm-gateway/src/llm_gateway/callbacks/__init__.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/__init__.py
@@ -16,7 +16,10 @@ def init_callbacks() -> None:
             PostHogCallback(
                 api_key=settings.posthog_project_token,
                 host=settings.posthog_host,
-                region_url=settings.posthog_region_url,
+                # The plan-resolver URL doubles as the customer-origin region
+                # URL stamped on captured events — same value, same per-region
+                # source of truth, no second env to keep in sync.
+                region_url=settings.posthog_api_base_url,
                 secondary_api_key=settings.posthog_secondary_project_token,
                 secondary_host=settings.posthog_secondary_host,
             )

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -113,10 +113,30 @@ class PostHogCallback(InstrumentedCallback):
 
     callback_name = "posthog"
 
-    def __init__(self, api_key: str, host: str):
+    def __init__(
+        self,
+        api_key: str,
+        host: str,
+        region_url: str = "https://us.posthog.com",
+        secondary_api_key: str | None = None,
+        secondary_host: str | None = None,
+    ):
         super().__init__()
         self._api_key = api_key
         self._host = host
+        # Customer-origin region URL stamped on every captured event via the
+        # `instance` group. The PHAI usage report filters on $group_<N> where
+        # N is the destination project's `instance` group_type_index, so the
+        # value must be the customer's region URL — not the capture host's.
+        # That keeps EU events tagged as EU even when the secondary capture
+        # mirrors them to the US instance for engineer visibility.
+        self._region_url = region_url
+        # Optional second capture target. When set, each captured event is
+        # mirrored to this host with the same payload, mirroring the
+        # `ee/hogai/core/runner.py:201-206` pattern that lets EU traffic also
+        # surface on the US dashboard. Set on the EU gateway deployment only.
+        self._secondary_api_key = secondary_api_key
+        self._secondary_host = secondary_host
 
     async def _on_success(
         self, kwargs: dict[str, Any], response_obj: Any, start_time: float, end_time: float, end_user_id: str | None
@@ -192,9 +212,8 @@ class PostHogCallback(InstrumentedCallback):
             "distinct_id": distinct_id,
             "event": "$ai_generation",
             "properties": properties,
+            "groups": self._build_groups(team_id),
         }
-        if team_id:
-            capture_kwargs["groups"] = {"project": team_id}
 
         logger.debug(
             "PostHog capturing event",
@@ -257,9 +276,8 @@ class PostHogCallback(InstrumentedCallback):
             "distinct_id": distinct_id,
             "event": "$ai_generation",
             "properties": properties,
+            "groups": self._build_groups(team_id),
         }
-        if team_id:
-            capture_kwargs["groups"] = {"project": team_id}
 
         logger.debug(
             "PostHog capturing error event",
@@ -270,6 +288,20 @@ class PostHogCallback(InstrumentedCallback):
         )
         self._capture_fire_and_forget(**capture_kwargs)
 
+    def _build_groups(self, team_id: int | None) -> dict[str, Any]:
+        """Build the `groups` dict for a captured event.
+
+        Always includes `instance` so the destination project's `instance`
+        group resolves to the customer-origin region URL — this is what the
+        usage report's $group_N filter reads to attribute events to the
+        right regional aggregation run. `project` is included when an
+        authenticated team is known.
+        """
+        groups: dict[str, Any] = {"instance": self._region_url}
+        if team_id:
+            groups["project"] = team_id
+        return groups
+
     def _capture_fire_and_forget(self, **capture_kwargs: Any) -> None:
         """
         Initializes a separate client for the capture operation to avoid payload bloat.
@@ -279,9 +311,24 @@ class PostHogCallback(InstrumentedCallback):
         loop.run_in_executor(None, partial(self._capture_sync, **capture_kwargs))
 
     def _capture_sync(self, **capture_kwargs: Any) -> None:
+        self._capture_to_destination(self._api_key, self._host, **capture_kwargs)
+        if self._secondary_api_key and self._secondary_host:
+            self._capture_to_destination(
+                self._secondary_api_key,
+                self._secondary_host,
+                **capture_kwargs,
+            )
+
+    def _capture_to_destination(self, api_key: str, host: str, **capture_kwargs: Any) -> None:
+        """Fire a single capture against one PostHog instance.
+
+        Each call uses a fresh client so a slow shutdown on one destination
+        doesn't pin a pooled client and to avoid cross-destination state
+        bleed in the SDK.
+        """
         client = Posthog(
-            self._api_key,
-            host=self._host,
+            api_key,
+            host=host,
             sync_mode=True,
             enable_local_evaluation=False,
         )
@@ -289,7 +336,7 @@ class PostHogCallback(InstrumentedCallback):
             client.capture(**capture_kwargs)
         except Exception as e:
             client.capture_exception(e, **capture_kwargs)
-            logger.exception("posthog_capture_failed", error=str(e))
+            logger.exception("posthog_capture_failed", host=host, error=str(e))
         finally:
             client.shutdown()
 

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -316,21 +316,43 @@ class PostHogCallback(InstrumentedCallback):
         loop.run_in_executor(None, partial(self._capture_sync, **capture_kwargs))
 
     def _capture_sync(self, **capture_kwargs: Any) -> None:
-        self._capture_to_destination(self._api_key, self._host, **capture_kwargs)
+        # Wrap each destination in its own try/except so a primary failure
+        # (e.g. Posthog() construction raising, or capture_exception itself
+        # raising inside the inner handler) does not skip the mirror capture
+        # that the regional usage-report depends on.
+        try:
+            self._capture_to_destination(self._api_key, self._host, **capture_kwargs)
+        except Exception as e:
+            logger.exception("posthog_primary_capture_failed", host=self._host, error=str(e))
         if self._secondary_api_key and self._secondary_host:
-            self._capture_to_destination(
-                self._secondary_api_key,
-                self._secondary_host,
-                **capture_kwargs,
-            )
+            try:
+                self._capture_to_destination(
+                    self._secondary_api_key,
+                    self._secondary_host,
+                    **capture_kwargs,
+                )
+            except Exception as e:
+                logger.exception(
+                    "posthog_secondary_capture_failed",
+                    host=self._secondary_host,
+                    error=str(e),
+                )
 
     def _capture_to_destination(self, api_key: str, host: str, **capture_kwargs: Any) -> None:
         """Fire a single capture against one PostHog instance.
 
         Each call uses a fresh client so a slow shutdown on one destination
         doesn't pin a pooled client and to avoid cross-destination state
-        bleed in the SDK.
+        bleed in the SDK. Mutable `properties` / `groups` dicts are
+        shallow-copied per destination so an in-place mutation by the SDK
+        (adding `$lib`, `$lib_version`, distinct-id resolution, etc.) on
+        one capture cannot bleed into the other.
         """
+        capture_kwargs = dict(capture_kwargs)
+        if "properties" in capture_kwargs:
+            capture_kwargs["properties"] = dict(capture_kwargs["properties"])
+        if "groups" in capture_kwargs:
+            capture_kwargs["groups"] = dict(capture_kwargs["groups"])
         client = Posthog(
             api_key,
             host=host,

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -178,6 +178,11 @@ class PostHogCallback(InstrumentedCallback):
             "$ai_span_id": str(uuid4()),
             "ai_product": product,
             "$ai_billable": _is_product_billable(product),
+            # Stamped explicitly to bypass the SDK's group_type_index lookup.
+            # The AI usage report hardcodes `$group_1` (posthog/tasks/usage_report.py)
+            # so the gateway must guarantee that slot regardless of how the
+            # destination team's group types are registered.
+            "$group_1": self._region_url,
         }
 
         posthog_properties = get_posthog_properties() or {}
@@ -257,6 +262,7 @@ class PostHogCallback(InstrumentedCallback):
             "$ai_error": standard_logging_object.get("error_str", ""),
             "ai_product": product,
             "$ai_billable": _is_product_billable(product),
+            "$group_1": self._region_url,
         }
 
         posthog_properties = get_posthog_properties() or {}

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -316,27 +316,17 @@ class PostHogCallback(InstrumentedCallback):
         loop.run_in_executor(None, partial(self._capture_sync, **capture_kwargs))
 
     def _capture_sync(self, **capture_kwargs: Any) -> None:
-        # Wrap each destination in its own try/except so a primary failure
-        # (e.g. Posthog() construction raising, or capture_exception itself
-        # raising inside the inner handler) does not skip the mirror capture
-        # that the regional usage-report depends on.
-        try:
-            self._capture_to_destination(self._api_key, self._host, **capture_kwargs)
-        except Exception as e:
-            logger.exception("posthog_primary_capture_failed", host=self._host, error=str(e))
+        # No outer try/except: the destinations feed regional billing
+        # aggregations, so we want them to succeed or fail together. If the
+        # primary raises, the secondary intentionally does not run so the two
+        # PostHog instances stay in sync rather than diverging on billing state.
+        self._capture_to_destination(self._api_key, self._host, **capture_kwargs)
         if self._secondary_api_key and self._secondary_host:
-            try:
-                self._capture_to_destination(
-                    self._secondary_api_key,
-                    self._secondary_host,
-                    **capture_kwargs,
-                )
-            except Exception as e:
-                logger.exception(
-                    "posthog_secondary_capture_failed",
-                    host=self._secondary_host,
-                    error=str(e),
-                )
+            self._capture_to_destination(
+                self._secondary_api_key,
+                self._secondary_host,
+                **capture_kwargs,
+            )
 
     def _capture_to_destination(self, api_key: str, host: str, **capture_kwargs: Any) -> None:
         """Fire a single capture against one PostHog instance.

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -297,10 +297,9 @@ class PostHogCallback(InstrumentedCallback):
     def _build_groups(self, team_id: int | None) -> dict[str, Any]:
         """Build the `groups` dict for a captured event.
 
-        Always includes `instance` so the destination project's `instance`
-        group resolves to the customer-origin region URL — this is what the
-        usage report's $group_N filter reads to attribute events to the
-        right regional aggregation run. `project` is included when an
+        Billing region attribution comes from the hardcoded `$group_1`
+        property; the `instance` group here keeps LLM Analytics group
+        breakdowns working naturally. `project` is included when an
         authenticated team is known.
         """
         groups: dict[str, Any] = {"instance": self._region_url}

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -150,14 +150,6 @@ class Settings(BaseSettings):
     posthog_secondary_project_token: str | None = None
     posthog_secondary_host: str | None = None
 
-    # Customer-origin region URL stamped on every captured $ai_generation
-    # event as $group_1. The AI usage report filters by this property to
-    # decide which regional aggregation run owns the event, so it must
-    # reflect where the customer lives — *not* where the event is being
-    # sent — and stay consistent across primary and secondary capture.
-    # See posthog/tasks/usage_report.py for the consuming query.
-    posthog_region_url: str = "https://us.posthog.com"
-
     metrics_enabled: bool = True
 
     # ~600 bytes per entry (key + AuthenticatedUser + LRU overhead), 10000 entries ≈ 6 MB

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -143,10 +143,9 @@ class Settings(BaseSettings):
     posthog_host: str = "https://us.i.posthog.com"
 
     # Optional secondary capture target. When set, every $ai_generation event
-    # is mirrored to this PostHog instance after the primary capture. Used so
-    # the EU gateway can fan out a copy to the US instance for engineer
-    # visibility on a single dashboard, the way ee/hogai/core/runner.py
-    # already does for the PostHog AI web path.
+    # is mirrored to this PostHog instance after the primary capture, so the
+    # EU deployment can land EU customer events on EU PostHog (team_id=1)
+    # for the regional billing usage_report to attribute them.
     posthog_secondary_project_token: str | None = None
     posthog_secondary_host: str | None = None
 

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -142,6 +142,22 @@ class Settings(BaseSettings):
     posthog_project_token: str | None = None
     posthog_host: str = "https://us.i.posthog.com"
 
+    # Optional secondary capture target. When set, every $ai_generation event
+    # is mirrored to this PostHog instance after the primary capture. Used so
+    # the EU gateway can fan out a copy to the US instance for engineer
+    # visibility on a single dashboard, the way ee/hogai/core/runner.py
+    # already does for the PostHog AI web path.
+    posthog_secondary_project_token: str | None = None
+    posthog_secondary_host: str | None = None
+
+    # Customer-origin region URL stamped on every captured $ai_generation
+    # event as $group_1. The AI usage report filters by this property to
+    # decide which regional aggregation run owns the event, so it must
+    # reflect where the customer lives — *not* where the event is being
+    # sent — and stay consistent across primary and secondary capture.
+    # See posthog/tasks/usage_report.py for the consuming query.
+    posthog_region_url: str = "https://us.posthog.com"
+
     metrics_enabled: bool = True
 
     # ~600 bytes per entry (key + AuthenticatedUser + LRU overhead), 10000 entries ≈ 6 MB

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -454,6 +454,10 @@ class TestPostHogCallback:
 
         call_kwargs = mock_client.capture.call_args.kwargs
         assert call_kwargs["groups"] == {"instance": "https://eu.posthog.com", "project": 456}
+        # $group_1 is stamped explicitly so the usage-report query's hardcoded
+        # filter matches regardless of how the destination team registers
+        # `instance` in GroupTypeMapping.
+        assert call_kwargs["properties"]["$group_1"] == "https://eu.posthog.com"
 
     @pytest.mark.asyncio
     async def test_on_success_mirrors_to_secondary_destination_when_configured(
@@ -486,13 +490,16 @@ class TestPostHogCallback:
             assert secondary_call.kwargs["host"] == "https://us.i.posthog.com"
             assert mock_client.capture.call_count == 2
 
-            # Both copies carry the EU origin region so the US-region usage report
-            # filter ($group_1 = 'https://us.posthog.com') excludes the mirrored copy.
+            # Both copies carry the EU origin region — via the SDK `groups` arg
+            # and via an explicit $group_1 property — so the US-region usage
+            # report filter ($group_1 = 'https://us.posthog.com') excludes the
+            # mirrored copy and does not double-count.
             for capture_call in mock_client.capture.call_args_list:
                 assert capture_call.kwargs["groups"] == {
                     "instance": "https://eu.posthog.com",
                     "project": 456,
                 }
+                assert capture_call.kwargs["properties"]["$group_1"] == "https://eu.posthog.com"
 
     @pytest.mark.asyncio
     async def test_on_success_skips_secondary_destination_when_unconfigured(

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -96,7 +96,7 @@ class TestPostHogCallback:
 
             assert call_kwargs["distinct_id"] == "user-distinct-id-123"
             assert call_kwargs["event"] == "$ai_generation"
-            assert call_kwargs["groups"] == {"project": 456}
+            assert call_kwargs["groups"] == {"instance": "https://us.posthog.com", "project": 456}
 
             props = call_kwargs["properties"]
             assert props["$ai_model"] == "claude-3-opus"
@@ -127,8 +127,11 @@ class TestPostHogCallback:
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
 
             call_kwargs = mock_client.capture.call_args.kwargs
-            # distinct_id should be a UUID string since no auth user
-            assert "groups" not in call_kwargs  # No team_id means no groups
+            # distinct_id should be a UUID string since no auth user.
+            # The instance group is always set so the destination project can
+            # resolve $group_<N> for the region URL filter in the usage report,
+            # even when no authenticated team is known.
+            assert call_kwargs["groups"] == {"instance": "https://us.posthog.com"}
 
     @pytest.mark.asyncio
     async def test_on_success_uses_end_user_id_for_distinct_id(
@@ -397,7 +400,7 @@ class TestPostHogCallback:
 
             call_kwargs = mock_client.capture.call_args.kwargs
             assert call_kwargs["distinct_id"] == "openai-end-user-456"
-            assert call_kwargs["groups"] == {"project": 456}
+            assert call_kwargs["groups"] == {"instance": "https://us.posthog.com", "project": 456}
 
             props = call_kwargs["properties"]
             assert props["$ai_trace_id"] == _normalize_trace_id("metadata-user-id")
@@ -427,6 +430,89 @@ class TestPostHogCallback:
             assert call_kwargs["distinct_id"] == "openai-end-user-789"
             assert call_kwargs["properties"]["$ai_trace_id"] == _normalize_trace_id("trace-id-from-metadata")
             assert _is_uuid(call_kwargs["properties"]["$ai_trace_id"])
+
+    @pytest.mark.asyncio
+    async def test_on_success_uses_configured_region_url_in_groups(
+        self,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        _, mock_client = mock_posthog_client
+        callback = PostHogCallback(
+            api_key="eu-key",
+            host="https://eu.i.posthog.com",
+            region_url="https://eu.posthog.com",
+        )
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="slack_app"),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        call_kwargs = mock_client.capture.call_args.kwargs
+        assert call_kwargs["groups"] == {"instance": "https://eu.posthog.com", "project": 456}
+
+    @pytest.mark.asyncio
+    async def test_on_success_mirrors_to_secondary_destination_when_configured(
+        self,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+    ) -> None:
+        mock_client = MagicMock()
+        with patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client) as mock_cls:
+            callback = PostHogCallback(
+                api_key="eu-key",
+                host="https://eu.i.posthog.com",
+                region_url="https://eu.posthog.com",
+                secondary_api_key="us-key",
+                secondary_host="https://us.i.posthog.com",
+            )
+            kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+            with (
+                patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+                patch("llm_gateway.callbacks.posthog.get_product", return_value="slack_app"),
+            ):
+                await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            # One Posthog client constructed per destination, each captured once.
+            primary_call, secondary_call = mock_cls.call_args_list
+            assert primary_call.args == ("eu-key",)
+            assert primary_call.kwargs["host"] == "https://eu.i.posthog.com"
+            assert secondary_call.args == ("us-key",)
+            assert secondary_call.kwargs["host"] == "https://us.i.posthog.com"
+            assert mock_client.capture.call_count == 2
+
+            # Both copies carry the EU origin region so the US-region usage report
+            # filter ($group_1 = 'https://us.posthog.com') excludes the mirrored copy.
+            for capture_call in mock_client.capture.call_args_list:
+                assert capture_call.kwargs["groups"] == {
+                    "instance": "https://eu.posthog.com",
+                    "project": 456,
+                }
+
+    @pytest.mark.asyncio
+    async def test_on_success_skips_secondary_destination_when_unconfigured(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        mock_cls, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="slack_app"),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        assert mock_cls.call_count == 1
+        assert mock_client.capture.call_count == 1
 
 
 class TestNormalizeTraceId:

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -521,6 +521,50 @@ class TestPostHogCallback:
         assert mock_cls.call_count == 1
         assert mock_client.capture.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_on_failure_mirrors_to_secondary_destination_when_configured(
+        self,
+        auth_user: AuthenticatedUser,
+    ) -> None:
+        mock_client = MagicMock()
+        with patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client) as mock_cls:
+            callback = PostHogCallback(
+                api_key="eu-key",
+                host="https://eu.i.posthog.com",
+                region_url="https://eu.posthog.com",
+                secondary_api_key="us-key",
+                secondary_host="https://us.i.posthog.com",
+            )
+            kwargs = {
+                "standard_logging_object": {
+                    "model": "claude-sonnet-4-6",
+                    "custom_llm_provider": "anthropic",
+                    "error_str": "boom",
+                },
+                "litellm_params": {},
+            }
+
+            with (
+                patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+                patch("llm_gateway.callbacks.posthog.get_product", return_value="slack_app"),
+            ):
+                await callback._on_failure(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            primary_call, secondary_call = mock_cls.call_args_list
+            assert primary_call.args == ("eu-key",)
+            assert primary_call.kwargs["host"] == "https://eu.i.posthog.com"
+            assert secondary_call.args == ("us-key",)
+            assert secondary_call.kwargs["host"] == "https://us.i.posthog.com"
+            assert mock_client.capture.call_count == 2
+
+            for capture_call in mock_client.capture.call_args_list:
+                assert capture_call.kwargs["groups"] == {
+                    "instance": "https://eu.posthog.com",
+                    "project": 456,
+                }
+                assert capture_call.kwargs["properties"]["$group_1"] == "https://eu.posthog.com"
+                assert capture_call.kwargs["properties"]["$ai_is_error"] is True
+
 
 class TestNormalizeTraceId:
     def test_returns_fresh_uuid_when_value_is_falsy(self) -> None:


### PR DESCRIPTION
## Problem

The LLM gateway captures every `$ai_generation` event to a single PostHog instance (currently `https://us.i.posthog.com` in both regional deployments). The regional usage-report runs in `posthog/tasks/usage_report.py:1082-1241` aggregate per region — EU run from team_id=1 on EU, US run from team_id=2 on US — and filter by `$group_<N>` matching the customer region URL. Today EU gateway events never land in EU PostHog at all, so EU customer spend is invisible to billing.

`ee/hogai/core/runner.py:201-206` already solves this for the PostHog AI web path by appending a US client when the deployment is EU; this PR ports the same idea to the gateway's flat-call model.

Context from the internal Slack thread that prompted this work: https://posthog.slack.com/archives/C0ADR896HJ9/p1779955029038159?thread_ts=1779805800.149569&cid=C0ADR896HJ9

## Changes

- New optional settings: `posthog_secondary_project_token`, `posthog_secondary_host`. Region URL is reused from `posthog_api_base_url` (same per-deployment value).
- `PostHogCallback` now stamps `$group_1` directly on every event (the value the billing query at `posthog/tasks/usage_report.py:1200` hardcodes) and also passes `groups={"instance": region_url, "project": team_id}` so SDK group resolution stays consistent.
- When secondary host+token are configured, the same payload is mirrored to a second instance. Exceptions propagate across both destinations so the two PostHog instances stay in sync on billing state.
- Unset secondary settings → behaviour identical to today.

## Companion PR

Charts override that wires up the EU fanout: PostHog/charts#11401

## Deployment order

Either order works. The gateway's pydantic settings use the default `extra="ignore"` policy (env_prefix only, no override), so unknown `LLM_GATEWAY_POSTHOG_SECONDARY_*` env vars are silently dropped by a binary that doesn't know about them. The gateway code is also backward-compatible when those settings are unset.

End state is the same regardless of order — EU billing starts working only once **both** PRs are deployed. Pick whichever fits your deploy windows; the only thing that goes live on this PR alone is the `$group_1` stamp on every captured event (using the existing `posthog_api_base_url` value per deployment), which makes this PR the cleaner rollback target if anything looks off.

## Testing

I'm an agent.

- `uv run pytest tests/callbacks/test_posthog.py` — 56 passed, four new tests covering region URL stamping, secondary mirroring on `_on_success`, secondary mirroring on `_on_failure`, and the no-secondary fallback. Full gateway suite: 932 passed.
- **End-to-end on local** (the worktree's `bin/mprocs.yaml` was wired up with the new env vars so the local gateway picked them up on restart):
  - Scenario A: gateway running without `LLM_GATEWAY_POSTHOG_SECONDARY_*` → exactly one `PostHog capturing event` log per request, properties carry `$group_1: "https://us.posthog.com"`, groups carries `{"instance": "https://us.posthog.com", "project": <team_id>}`. Confirms backward compatibility.
  - Scenario B: gateway running with `LLM_GATEWAY_POSTHOG_API_BASE_URL=https://eu.posthog.com` and both `LLM_GATEWAY_POSTHOG_SECONDARY_*` set → both destinations receive the event (verified via temporary debug logs `posthog_capture_sync_entered` + `posthog_capture_firing_secondary`, then removed), and both copies carry `$group_1: "https://eu.posthog.com"` so the US-region usage-report filter excludes the mirror.
- `ruff check` and `ruff format --check` on touched files — clean.

## Publish to changelog?

no

## 🤖 Agent context

Co-authored with Claude Code at Vojta's direction. The staged rollout (charts keeps primary on US in Phase 1, flips later) was specifically chosen so today's billing/observability path is untouched while EU billing starts being attributed correctly via the secondary fanout.