### PR TITLE
chore(visual-review): document approve and tolerate MCP tools in skill

### DIFF
--- a/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
+++ b/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
@@ -58,13 +58,15 @@ Write tools (require explicit user confirmation — these ship the visual change
 
 Approval call shape:
 
+- `id` (required) — the run UUID. It's the route parameter, so the call fails without it.
 - `approve_all: true` — approves every `changed` and `new` snapshot in the run. Convenient when you've verified every diff is intended.
 - `snapshots: [{identifier, new_hash}]` — explicit list. `new_hash` is the `content_hash` of each snapshot's `current_artifact`. Prefer this when only some diffs are intended.
 - `commit_to_github: true` (default) — pushes the baseline-YAML update straight to the PR branch. Set false to record the approval without a commit.
 
-Toleration call shape:
+Toleration call shape — both fields are required:
 
-- `snapshot_id` — the UUID of the individual snapshot (from `visual-review-runs-snapshots-list`), not the run id.
+- `id` (required) — the run UUID. It's the route parameter, so the call fails without it.
+- `snapshot_id` (required) — the UUID of the individual snapshot to tolerate (from `visual-review-runs-snapshots-list`). This identifies _which_ snapshot inside the run; it does not replace the run `id`.
 
 If approval fails with `409 stale_run`, the run has been superseded — `visual-review-runs-list { pr_number }` and approve the newest one. A successful approval often kicks off a fresh CI run, which is normal.
 

--- a/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
+++ b/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
@@ -17,7 +17,9 @@ A PR with visual changes carries a `visual-review` GitHub status check that stay
 snapshot is approved or tolerated in the [VR UI](https://us.posthog.com/project/2/visual_review).
 
 This skill teaches an agent how to answer the questions a human reviewer would actually ask, by chaining
-the read-only VR MCP tools — instead of reaching for `gh pr view` and tab-hopping to the VR web UI.
+the VR MCP tools — instead of reaching for `gh pr view` and tab-hopping to the VR web UI. The read tools
+cover status / scope / history / triage; two write tools (`approve-create`, `tolerate-create`) let the
+agent act once the user confirms.
 
 ## When this skill applies
 
@@ -34,7 +36,7 @@ is faster — direct them there. This skill is for everything around the diff: s
 
 ## Tools
 
-All read-only. None of these require write scopes; approval/toleration still happens in the web UI.
+Read tools (safe to call freely):
 
 | Tool                                               | Purpose                                                                                                            |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
@@ -46,6 +48,25 @@ All read-only. None of these require write scopes; approval/toleration still hap
 | `posthog:visual-review-runs-tolerated-hashes-list` | Hashes the team has explicitly accepted as "known flake / acceptable variation".                                   |
 | `posthog:visual-review-repos-list`                 | Repos (one per GitHub repo) — usually only one matters; useful for filtering.                                      |
 | `posthog:visual-review-repos-retrieve`             | Repo metadata: baseline file paths, PR-comment configuration.                                                      |
+
+Write tools (require explicit user confirmation — these ship the visual change):
+
+| Tool                                         | Purpose                                                                                                                |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `posthog:visual-review-runs-approve-create`  | Approve `changed` / `new` snapshots in a run. Updates the baseline YAML and (by default) pushes a commit to the PR.    |
+| `posthog:visual-review-runs-tolerate-create` | Mark a single changed snapshot as a known tolerated alternate. Does NOT change the baseline — use for benign variants. |
+
+Approval call shape:
+
+- `approve_all: true` — approves every `changed` and `new` snapshot in the run. Convenient when you've verified every diff is intended.
+- `snapshots: [{identifier, new_hash}]` — explicit list. `new_hash` is the `content_hash` of each snapshot's `current_artifact`. Prefer this when only some diffs are intended.
+- `commit_to_github: true` (default) — pushes the baseline-YAML update straight to the PR branch. Set false to record the approval without a commit.
+
+Toleration call shape:
+
+- `snapshot_id` — the UUID of the individual snapshot (from `visual-review-runs-snapshots-list`), not the run id.
+
+If approval fails with `409 stale_run`, the run has been superseded — `visual-review-runs-list { pr_number }` and approve the newest one. A successful approval often kicks off a fresh CI run, which is normal.
 
 ## Vocabulary cheat sheet
 
@@ -143,8 +164,8 @@ For triage / aggregate questions, a short table beats prose. Group by what the u
 
 ## What NOT to do
 
-- Do not approve or tolerate snapshots from this skill — those endpoints are intentionally not exposed as
-  MCP tools yet. Direct the user to the run's `_posthogUrl`.
+- Do not approve or tolerate without explicit user confirmation. The verdict is yours to recommend; the
+  decision to ship belongs to the user. Once they say "approve those" / "tolerate that", call the tool.
 - Do not assume the failing GitHub check on a PR is unrelated to VR — if a `visual-review` check is red on
   a PR you're working on, that's the trigger to run this skill.
 - Do not declare a verdict from metadata alone when `result: changed`. Pull the baseline and current PNGs


### PR DESCRIPTION
## Problem

While reviewing a VR run today, I followed the `triaging-visual-review-runs` skill, gave a verdict on two diffs, and told the user they had to go approve in the web UI. The skill said: "Do not approve or tolerate snapshots from this skill — those endpoints are intentionally not exposed as MCP tools yet." The write tools have since landed (`visual-review-runs-approve-create`, `visual-review-runs-tolerate-create`), so that instruction is now misdirecting agents away from a perfectly good action.

## Changes

Update `products/visual_review/skills/triaging-visual-review-runs/SKILL.md`:

- Drop the "all read-only" framing in the intro.
- Split the **Tools** table into read tools and write tools, with the call-shape gotchas I hit (`approve_all` vs explicit `snapshots`, `new_hash` = `current_artifact.content_hash`, `commit_to_github`, `snapshot_id`-not-run-id for tolerate).
- Document the `409 stale_run` recovery path — approving a stale run silently fails, and the fix is to list runs by PR number and pick the newest one. A successful approval usually triggers a fresh CI run, which is expected.
- In **What NOT to do**, replace "never approve from the skill" with "never approve without explicit user confirmation."

## How did you test this code?

Agent-authored. I'm an agent — no manual UI testing performed. Verified by:

- Calling `posthog:exec search visual-review` and confirming the two write tools are present.
- Calling `info` on both `visual-review-runs-approve-create` and `visual-review-runs-tolerate-create` to confirm the input schemas match the call shapes I documented.
- Hitting the `409 stale_run` path live during the session that motivated this change — the recovery flow described in the skill is what I actually had to do.

No automated tests touched; this is a markdown-only change to a skill file.

## Publish to changelog?

no

## Docs update

Not user-facing — internal agent skill only.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) in the session referenced via Task-Id in the commit trailer. Trigger: I noticed the stale instruction mid-session while triaging PR #60396's VR run. Paul confirmed in chat that the write tools had landed recently and asked me to update the skill.

No code logic changes — markdown edits to a single SKILL.md file. The plugin copy under \`~/Library/Application Support/.../plugins/posthog/skills/...\` will re-sync from this source on next plugin update.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*