### PR TITLE
fix(gateway): address cloudflare provider review feedback

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -9,10 +9,16 @@ import structlog
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from llm_gateway.api.handler import ANTHROPIC_CONFIG, BEDROCK_CONFIG, CLOUDFLARE_CONFIG, _sanitize_request_data, handle_llm_request
+from llm_gateway.api.handler import (
+    ANTHROPIC_CONFIG,
+    BEDROCK_CONFIG,
+    CLOUDFLARE_CONFIG,
+    _sanitize_request_data,
+    handle_llm_request,
+)
 from llm_gateway.bedrock import count_tokens_with_bedrock, ensure_bedrock_configured, map_to_bedrock_model
-from llm_gateway.cloudflare import ensure_cloudflare_configured, make_cloudflare_anthropic_call
 from llm_gateway.circuit_breaker import AnthropicCircuitBreaker
+from llm_gateway.cloudflare import ensure_cloudflare_configured, make_cloudflare_anthropic_call
 from llm_gateway.config import get_settings
 from llm_gateway.dependencies import AnthropicCircuitBreakerDep, RateLimitedUser
 from llm_gateway.metrics.prometheus import (
@@ -283,6 +289,18 @@ async def _handle_count_tokens(
     data = _sanitize_request_data(body.model_dump(exclude_none=True, exclude=GATEWAY_ONLY_FIELDS))
     provider = _get_provider_from_headers(request)
     use_bedrock_fallback = _get_use_bedrock_fallback_from_headers(request)
+
+    if provider == "cloudflare":
+        # Cloudflare has no token-counting endpoint; falling back to Anthropic would silently use the wrong tokenizer.
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": "count_tokens is not supported for the cloudflare provider",
+                    "type": "invalid_request_error",
+                }
+            },
+        )
 
     if provider == "bedrock":
         return await _bedrock_count_tokens_impl(data, body.model, user, product)

--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -9,8 +9,9 @@ import structlog
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from llm_gateway.api.handler import ANTHROPIC_CONFIG, BEDROCK_CONFIG, _sanitize_request_data, handle_llm_request
+from llm_gateway.api.handler import ANTHROPIC_CONFIG, BEDROCK_CONFIG, CLOUDFLARE_CONFIG, _sanitize_request_data, handle_llm_request
 from llm_gateway.bedrock import count_tokens_with_bedrock, ensure_bedrock_configured, map_to_bedrock_model
+from llm_gateway.cloudflare import ensure_cloudflare_configured, make_cloudflare_anthropic_call
 from llm_gateway.circuit_breaker import AnthropicCircuitBreaker
 from llm_gateway.config import get_settings
 from llm_gateway.dependencies import AnthropicCircuitBreakerDep, RateLimitedUser
@@ -83,6 +84,30 @@ def strip_server_side_tools(data: dict[str, Any], *, model: str, product: str) -
         data["tools"] = supported
     else:
         del data["tools"]
+
+
+async def _send_cloudflare_messages(
+    request_data: dict[str, Any],
+    user: RateLimitedUser,
+    is_streaming: bool,
+    product: str,
+) -> dict[str, Any] | StreamingResponse:
+    settings = get_settings()
+    api_base, api_key = ensure_cloudflare_configured(settings)
+
+    data = dict(request_data)
+    original_model = data["model"]
+    llm_call = make_cloudflare_anthropic_call(api_base, api_key)
+
+    return await handle_llm_request(
+        request_data=data,
+        user=user,
+        model=original_model,
+        is_streaming=is_streaming,
+        provider_config=CLOUDFLARE_CONFIG,
+        llm_call=llm_call,
+        product=product,
+    )
 
 
 async def _send_bedrock_messages(
@@ -196,6 +221,9 @@ async def _handle_anthropic_messages(
     data = body.model_dump(exclude_none=True, exclude=GATEWAY_ONLY_FIELDS)
     provider = _get_provider_from_headers(request)
     use_bedrock_fallback = _get_use_bedrock_fallback_from_headers(request)
+
+    if provider == "cloudflare":
+        return await _send_cloudflare_messages(data, user, body.stream or False, product)
 
     if provider == "bedrock":
         return await _send_bedrock_messages(data, user, request, body.stream or False, product)

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -45,6 +45,7 @@ BEDROCK_CONFIG = ProviderConfig(name="bedrock", endpoint_name="bedrock_messages"
 OPENAI_CONFIG = ProviderConfig(name="openai", endpoint_name="chat_completions")
 OPENAI_RESPONSES_CONFIG = ProviderConfig(name="openai", endpoint_name="responses")
 OPENAI_TRANSCRIPTION_CONFIG = ProviderConfig(name="openai", endpoint_name="audio_transcriptions")
+CLOUDFLARE_CONFIG = ProviderConfig(name="cloudflare", endpoint_name="cloudflare_messages")
 
 # Google providers require litellm[google], which we don't install. Reject these
 # at the edge so litellm doesn't crash deep in vertex_llm_base with an ImportError.

--- a/services/llm-gateway/src/llm_gateway/api/openai.py
+++ b/services/llm-gateway/src/llm_gateway/api/openai.py
@@ -5,11 +5,14 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
 
 from llm_gateway.api.handler import (
+    CLOUDFLARE_CONFIG,
     OPENAI_CONFIG,
     OPENAI_RESPONSES_CONFIG,
     OPENAI_TRANSCRIPTION_CONFIG,
     handle_llm_request,
 )
+from llm_gateway.cloudflare import ensure_cloudflare_configured
+from llm_gateway.config import get_settings
 from llm_gateway.dependencies import RateLimitedUser
 from llm_gateway.models.openai import ChatCompletionRequest, ResponsesRequest, TranscriptionRequest
 from llm_gateway.products.config import validate_product
@@ -24,12 +27,39 @@ def _normalize_model_name(model: str) -> str:
     return f"openai/{model}"
 
 
+def _is_cloudflare_model(model: str) -> bool:
+    return model.startswith("@cf/")
+
+
+def _make_cloudflare_completion_call(api_base: str, api_key: str):
+    async def llm_call(**kwargs):
+        kwargs["api_base"] = api_base
+        kwargs["api_key"] = api_key
+        kwargs["model"] = f"openai/{kwargs['model']}"
+        return await litellm.acompletion(**kwargs)
+
+    return llm_call
+
+
 async def _handle_chat_completions(
     body: ChatCompletionRequest,
     user: RateLimitedUser,
     product: str = "llm_gateway",
 ) -> dict[str, Any] | StreamingResponse:
     data = body.model_dump(exclude_none=True)
+
+    if _is_cloudflare_model(body.model):
+        settings = get_settings()
+        api_base, api_key = ensure_cloudflare_configured(settings)
+        return await handle_llm_request(
+            request_data=data,
+            user=user,
+            model=body.model,
+            is_streaming=body.stream or False,
+            provider_config=CLOUDFLARE_CONFIG,
+            llm_call=_make_cloudflare_completion_call(api_base, api_key),
+            product=product,
+        )
 
     return await handle_llm_request(
         request_data=data,

--- a/services/llm-gateway/src/llm_gateway/api/openai.py
+++ b/services/llm-gateway/src/llm_gateway/api/openai.py
@@ -11,7 +11,7 @@ from llm_gateway.api.handler import (
     OPENAI_TRANSCRIPTION_CONFIG,
     handle_llm_request,
 )
-from llm_gateway.cloudflare import ensure_cloudflare_configured
+from llm_gateway.cloudflare import ensure_cloudflare_configured, make_cloudflare_completion_call
 from llm_gateway.config import get_settings
 from llm_gateway.dependencies import RateLimitedUser
 from llm_gateway.models.openai import ChatCompletionRequest, ResponsesRequest, TranscriptionRequest
@@ -31,16 +31,6 @@ def _is_cloudflare_model(model: str) -> bool:
     return model.startswith("@cf/")
 
 
-def _make_cloudflare_completion_call(api_base: str, api_key: str):
-    async def llm_call(**kwargs):
-        kwargs["api_base"] = api_base
-        kwargs["api_key"] = api_key
-        kwargs["model"] = f"openai/{kwargs['model']}"
-        return await litellm.acompletion(**kwargs)
-
-    return llm_call
-
-
 async def _handle_chat_completions(
     body: ChatCompletionRequest,
     user: RateLimitedUser,
@@ -57,7 +47,7 @@ async def _handle_chat_completions(
             model=body.model,
             is_streaming=body.stream or False,
             provider_config=CLOUDFLARE_CONFIG,
-            llm_call=_make_cloudflare_completion_call(api_base, api_key),
+            llm_call=make_cloudflare_completion_call(api_base, api_key),
             product=product,
         )
 

--- a/services/llm-gateway/src/llm_gateway/cloudflare.py
+++ b/services/llm-gateway/src/llm_gateway/cloudflare.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import HTTPException
+
+from llm_gateway.config import Settings
+
+
+def cloudflare_api_base(account_id: str) -> str:
+    return f"https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1"
+
+
+def ensure_cloudflare_configured(settings: Settings) -> tuple[str, str]:
+    """Validate Cloudflare credentials and return (api_base, api_key)."""
+    if not settings.cloudflare_api_key or not settings.cloudflare_account_id:
+        raise HTTPException(
+            status_code=503,
+            detail={"error": {"message": "Cloudflare Workers AI not configured", "type": "configuration_error"}},
+        )
+    return cloudflare_api_base(settings.cloudflare_account_id), settings.cloudflare_api_key
+
+
+def make_cloudflare_anthropic_call(api_base: str, api_key: str) -> Callable[..., Awaitable[Any]]:
+    """Build an llm_call that adapts Anthropic Messages format to Cloudflare Workers AI.
+
+    Uses litellm's built-in adapter to translate Anthropic <-> OpenAI chat/completions
+    format, routing through CF's OpenAI-compatible endpoint.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+        LiteLLMMessagesToCompletionTransformationHandler,
+    )
+
+    async def llm_call(**kwargs: Any) -> Any:
+        kwargs["api_base"] = api_base
+        kwargs["api_key"] = api_key
+        kwargs["model"] = f"openai/{kwargs['model']}"
+        return await LiteLLMMessagesToCompletionTransformationHandler.async_anthropic_messages_handler(**kwargs)
+
+    return llm_call

--- a/services/llm-gateway/src/llm_gateway/cloudflare.py
+++ b/services/llm-gateway/src/llm_gateway/cloudflare.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+import litellm
 from fastapi import HTTPException
+from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+    LiteLLMMessagesToCompletionTransformationHandler,
+)
 
 from llm_gateway.config import Settings
 
@@ -22,20 +26,31 @@ def ensure_cloudflare_configured(settings: Settings) -> tuple[str, str]:
     return cloudflare_api_base(settings.cloudflare_account_id), settings.cloudflare_api_key
 
 
+def _inject_cloudflare_params(kwargs: dict[str, Any], api_base: str, api_key: str) -> None:
+    kwargs["api_base"] = api_base
+    kwargs["api_key"] = api_key
+    kwargs["model"] = f"openai/{kwargs['model']}"
+
+
 def make_cloudflare_anthropic_call(api_base: str, api_key: str) -> Callable[..., Awaitable[Any]]:
     """Build an llm_call that adapts Anthropic Messages format to Cloudflare Workers AI.
 
     Uses litellm's built-in adapter to translate Anthropic <-> OpenAI chat/completions
     format, routing through CF's OpenAI-compatible endpoint.
     """
-    from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
-        LiteLLMMessagesToCompletionTransformationHandler,
-    )
 
     async def llm_call(**kwargs: Any) -> Any:
-        kwargs["api_base"] = api_base
-        kwargs["api_key"] = api_key
-        kwargs["model"] = f"openai/{kwargs['model']}"
+        _inject_cloudflare_params(kwargs, api_base, api_key)
         return await LiteLLMMessagesToCompletionTransformationHandler.async_anthropic_messages_handler(**kwargs)
+
+    return llm_call
+
+
+def make_cloudflare_completion_call(api_base: str, api_key: str) -> Callable[..., Awaitable[Any]]:
+    """Build an llm_call that routes OpenAI chat/completions requests to Cloudflare."""
+
+    async def llm_call(**kwargs: Any) -> Any:
+        _inject_cloudflare_params(kwargs, api_base, api_key)
+        return await litellm.acompletion(**kwargs)
 
     return llm_call

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -137,6 +137,8 @@ class Settings(BaseSettings):
     openai_organization: str | None = None
     openrouter_api_key: str | None = None
     fireworks_api_key: str | None = None
+    cloudflare_api_key: str | None = None
+    cloudflare_account_id: str | None = None
 
     # Project token for AI observability events
     posthog_project_token: str | None = None

--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -130,6 +130,10 @@ def export_provider_credentials(settings: Settings) -> None:
         os.environ["OPENROUTER_API_KEY"] = settings.openrouter_api_key
     if settings.fireworks_api_key:
         os.environ["FIREWORKS_API_KEY"] = settings.fireworks_api_key
+    if settings.cloudflare_api_key:
+        os.environ["CLOUDFLARE_API_KEY"] = settings.cloudflare_api_key
+    if settings.cloudflare_account_id:
+        os.environ["CLOUDFLARE_ACCOUNT_ID"] = settings.cloudflare_account_id
 
 
 @asynccontextmanager

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from typing import Any
 
 import litellm
 import structlog
@@ -17,6 +18,23 @@ CACHE_TTL_SECONDS = 300
 COST_ALIASES: dict[str, str] = {
     "openai/@cf/moonshotai/kimi-k2.6": "moonshot/kimi-k2.6",
 }
+
+
+def apply_cost_aliases(model_cost: dict[str, Any]) -> None:
+    """Mutate model_cost to add alias keys for non-canonical provider routings.
+
+    Every writer to `litellm.model_cost` must call this — otherwise alias-routed
+    models fall back to default cost in the rate-limiting callback. A missing
+    canonical is logged so cost map regressions surface in alerting instead of
+    silently routing requests through the default fallback cost.
+    """
+    for alias, canonical in COST_ALIASES.items():
+        if alias in model_cost:
+            continue
+        if canonical in model_cost:
+            model_cost[alias] = model_cost[canonical]
+        else:
+            logger.warning("cost_alias_canonical_missing", alias=alias, canonical=canonical)
 
 
 class CostRefreshService:
@@ -45,9 +63,7 @@ class CostRefreshService:
     def refresh(self) -> None:
         try:
             model_cost = get_model_cost_map(url=model_cost_map_url)
-            for alias, canonical in COST_ALIASES.items():
-                if canonical in model_cost and alias not in model_cost:
-                    model_cost[alias] = model_cost[canonical]
+            apply_cost_aliases(model_cost)
             litellm.model_cost = model_cost
             self._last_refresh = time.monotonic()
             logger.info("model_cost_refreshed", model_count=len(model_cost))

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
@@ -11,6 +11,13 @@ logger = structlog.get_logger(__name__)
 
 CACHE_TTL_SECONDS = 300
 
+# Models routed through non-canonical litellm providers (e.g. Cloudflare via
+# openai/ prefix) won't match their cost map entry. Map the key we actually
+# pass to litellm → the canonical key in the cost map.
+COST_ALIASES: dict[str, str] = {
+    "openai/@cf/moonshotai/kimi-k2.6": "moonshot/kimi-k2.6",
+}
+
 
 class CostRefreshService:
     """Singleton service that periodically refreshes litellm.model_cost."""
@@ -38,6 +45,9 @@ class CostRefreshService:
     def refresh(self) -> None:
         try:
             model_cost = get_model_cost_map(url=model_cost_map_url)
+            for alias, canonical in COST_ALIASES.items():
+                if canonical in model_cost and alias not in model_cost:
+                    model_cost[alias] = model_cost[canonical]
             litellm.model_cost = model_cost
             self._last_refresh = time.monotonic()
             logger.info("model_cost_refreshed", model_count=len(model_cost))

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_service.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_service.py
@@ -8,6 +8,8 @@ import structlog
 from litellm import model_cost_map_url
 from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 
+from llm_gateway.rate_limiting.cost_refresh import apply_cost_aliases
+
 logger = structlog.get_logger(__name__)
 
 TARGET_LIMIT_COST_PER_HOUR: Final[float] = 60.0
@@ -73,6 +75,7 @@ class ModelCostService:
     def _refresh_cache(self) -> None:
         try:
             model_cost = get_model_cost_map(url=model_cost_map_url)
+            apply_cost_aliases(model_cost)
             litellm.model_cost = model_cost
             self._costs = cast(dict[str, ModelCost], model_cost)
             new_limits: dict[str, ModelLimits] = {}

--- a/services/llm-gateway/src/llm_gateway/request_context.py
+++ b/services/llm-gateway/src/llm_gateway/request_context.py
@@ -113,10 +113,12 @@ def extract_posthog_provider_from_headers(request: Request) -> str | None:
 
     normalized_provider = provider.strip().lower()
     if not normalized_provider:
-        raise ValueError(f"Invalid {POSTHOG_PROVIDER_HEADER} header value. Expected one of: anthropic, bedrock.")
-    if normalized_provider not in {"anthropic", "bedrock"}:
         raise ValueError(
-            f"Invalid {POSTHOG_PROVIDER_HEADER} header value '{provider}'. Expected one of: anthropic, bedrock."
+            f"Invalid {POSTHOG_PROVIDER_HEADER} header value. Expected one of: anthropic, bedrock, cloudflare."
+        )
+    if normalized_provider not in {"anthropic", "bedrock", "cloudflare"}:
+        raise ValueError(
+            f"Invalid {POSTHOG_PROVIDER_HEADER} header value '{provider}'. Expected one of: anthropic, bedrock, cloudflare."
         )
     return normalized_provider
 

--- a/services/llm-gateway/tests/integration/conftest.py
+++ b/services/llm-gateway/tests/integration/conftest.py
@@ -17,6 +17,8 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
 FIREWORKS_API_KEY = os.environ.get("FIREWORKS_API_KEY")
+CLOUDFLARE_API_KEY = os.environ.get("CLOUDFLARE_API_KEY")
+CLOUDFLARE_ACCOUNT_ID = os.environ.get("CLOUDFLARE_ACCOUNT_ID")
 BEDROCK_REGION = (
     os.environ.get("LLM_GATEWAY_BEDROCK_REGION_NAME")
     or os.environ.get("AWS_REGION")
@@ -81,6 +83,15 @@ MOCK_MODEL_COSTS = {
         "input_cost_per_token": 0.0000002,
         "output_cost_per_token": 0.0000002,
     },
+    "openai/@cf/moonshotai/kimi-k2.6": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 262144,
+        "supports_vision": True,
+        "supports_function_calling": True,
+        "mode": "chat",
+        "input_cost_per_token": 0.00000095,
+        "output_cost_per_token": 0.000004,
+    },
 }
 
 
@@ -131,6 +142,12 @@ def run_gateway_server(configure_all_providers: bool = False, bedrock_region_nam
         env_patches["ANTHROPIC_API_KEY"] = "sk-ant-test-fake-key"
         env_patches["OPENROUTER_API_KEY"] = "or-test-fake-key"
         env_patches["FIREWORKS_API_KEY"] = "fw-test-fake-key"
+    if CLOUDFLARE_API_KEY:
+        env_patches["LLM_GATEWAY_CLOUDFLARE_API_KEY"] = CLOUDFLARE_API_KEY
+        env_patches["CLOUDFLARE_API_KEY"] = CLOUDFLARE_API_KEY
+    if CLOUDFLARE_ACCOUNT_ID:
+        env_patches["LLM_GATEWAY_CLOUDFLARE_ACCOUNT_ID"] = CLOUDFLARE_ACCOUNT_ID
+        env_patches["CLOUDFLARE_ACCOUNT_ID"] = CLOUDFLARE_ACCOUNT_ID
 
     with patch.dict(os.environ, env_patches):
         get_settings.cache_clear()
@@ -217,4 +234,27 @@ def bedrock_anthropic_client(bedrock_gateway_url):
         api_key=TEST_POSTHOG_API_KEY,
         base_url=bedrock_gateway_url,
         default_headers={"X-PostHog-Provider": "bedrock"},
+    )
+
+
+@pytest.fixture
+def cloudflare_gateway_url():
+    with run_gateway_server() as url:
+        yield url
+
+
+@pytest.fixture
+def cloudflare_anthropic_client(cloudflare_gateway_url):
+    return Anthropic(
+        api_key=TEST_POSTHOG_API_KEY,
+        base_url=cloudflare_gateway_url,
+        default_headers={"X-PostHog-Provider": "cloudflare"},
+    )
+
+
+@pytest.fixture
+def cloudflare_openai_client(cloudflare_gateway_url):
+    return OpenAI(
+        api_key=TEST_POSTHOG_API_KEY,
+        base_url=f"{cloudflare_gateway_url}/v1",
     )

--- a/services/llm-gateway/tests/integration/test_anthropic_sdk.py
+++ b/services/llm-gateway/tests/integration/test_anthropic_sdk.py
@@ -15,13 +15,22 @@ from urllib.request import urlopen
 
 import pytest
 from anthropic import Anthropic, BadRequestError
-from anthropic.types import TextBlock, ToolParam, ToolUseBlock
+from anthropic.types import TextBlock, ThinkingBlock, ToolParam, ToolUseBlock
 
-from .conftest import BEDROCK_REGION, TEST_POSTHOG_API_KEY
+from .conftest import BEDROCK_REGION, CLOUDFLARE_API_KEY, CLOUDFLARE_ACCOUNT_ID, TEST_POSTHOG_API_KEY
 
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+CLOUDFLARE_CONFIGURED = bool(CLOUDFLARE_API_KEY and CLOUDFLARE_ACCOUNT_ID)
 
 TEST_IMAGE_URL = "https://posthog.com/brand/posthog-logo.png"
+
+
+def _get_text_block(response) -> TextBlock:
+    """Extract the first TextBlock from a response, skipping ThinkingBlocks."""
+    for block in response.content:
+        if isinstance(block, TextBlock):
+            return block
+    raise AssertionError(f"No TextBlock found in response content: {response.content}")
 
 
 @dataclass
@@ -43,6 +52,11 @@ class SDKTestConfig:
             id="bedrock",
             marks=pytest.mark.skipif(not BEDROCK_REGION, reason="Bedrock region not configured"),
         ),
+        pytest.param(
+            "cloudflare",
+            id="cloudflare",
+            marks=pytest.mark.skipif(not CLOUDFLARE_CONFIGURED, reason="CLOUDFLARE_API_KEY/ACCOUNT_ID not set"),
+        ),
     ]
 )
 def sdk_config(request) -> SDKTestConfig:
@@ -50,6 +64,14 @@ def sdk_config(request) -> SDKTestConfig:
         url = request.getfixturevalue("gateway_url")
         client = Anthropic(api_key=TEST_POSTHOG_API_KEY, base_url=url)
         return SDKTestConfig(client=client, model="claude-haiku-4-5-20251001", provider="anthropic")
+    elif request.param == "cloudflare":
+        url = request.getfixturevalue("cloudflare_gateway_url")
+        client = Anthropic(
+            api_key=TEST_POSTHOG_API_KEY,
+            base_url=url,
+            default_headers={"X-PostHog-Provider": "cloudflare"},
+        )
+        return SDKTestConfig(client=client, model="@cf/moonshotai/kimi-k2.6", provider="cloudflare")
     else:
         url = request.getfixturevalue("bedrock_gateway_url")
         client = Anthropic(
@@ -65,14 +87,13 @@ class TestAnthropicMessages:
         response = sdk_config.client.messages.create(
             model=sdk_config.model,
             messages=[{"role": "user", "content": "Say 'hello' and nothing else."}],
-            max_tokens=10,
+            max_tokens=300,
         )
 
         assert response is not None
         assert len(response.content) > 0
-        first_block = response.content[0]
-        assert isinstance(first_block, TextBlock)
-        assert first_block.text is not None
+        text_block = _get_text_block(response)
+        assert text_block.text is not None
         assert response.usage is not None
         assert response.usage.input_tokens > 0
         assert response.usage.output_tokens > 0
@@ -81,7 +102,7 @@ class TestAnthropicMessages:
         with sdk_config.client.messages.stream(
             model=sdk_config.model,
             messages=[{"role": "user", "content": "Say 'hi' and nothing else."}],
-            max_tokens=10,
+            max_tokens=300,
         ) as stream:
             text = stream.get_final_text()
 
@@ -93,66 +114,59 @@ class TestAnthropicMessages:
             model=sdk_config.model,
             system="You are a helpful assistant that only says 'OK'.",
             messages=[{"role": "user", "content": "Hello"}],
-            max_tokens=10,
+            max_tokens=300,
         )
 
         assert response is not None
-        first_block = response.content[0]
-        assert isinstance(first_block, TextBlock)
-        assert first_block.text is not None
+        text_block = _get_text_block(response)
+        assert text_block.text is not None
 
     def test_with_temperature(self, sdk_config: SDKTestConfig):
         response = sdk_config.client.messages.create(
             model=sdk_config.model,
             messages=[{"role": "user", "content": "Say 'test'"}],
-            max_tokens=10,
+            max_tokens=300,
             temperature=0.0,
         )
 
         assert response is not None
-        first_block = response.content[0]
-        assert isinstance(first_block, TextBlock)
-        assert first_block.text is not None
+        text_block = _get_text_block(response)
+        assert text_block.text is not None
 
 
 class TestAnthropicMultipleModels:
-    def test_haiku_request(self, sdk_config: SDKTestConfig):
+    def test_basic_request(self, sdk_config: SDKTestConfig):
         response = sdk_config.client.messages.create(
             model=sdk_config.model,
             messages=[{"role": "user", "content": "Say 'A'"}],
-            max_tokens=5,
+            max_tokens=200,
         )
 
         assert response is not None
-        first_block = response.content[0]
-        assert isinstance(first_block, TextBlock)
-        assert first_block.text is not None
+        text_block = _get_text_block(response)
+        assert text_block.text is not None
 
     def test_sequential_requests_same_model(self, sdk_config: SDKTestConfig):
         response1 = sdk_config.client.messages.create(
             model=sdk_config.model,
             messages=[{"role": "user", "content": "Say '1'"}],
-            max_tokens=5,
+            max_tokens=200,
         )
 
         response2 = sdk_config.client.messages.create(
             model=sdk_config.model,
             messages=[{"role": "user", "content": "Say '2'"}],
-            max_tokens=5,
+            max_tokens=200,
         )
 
-        first_block1 = response1.content[0]
-        first_block2 = response2.content[0]
-        assert isinstance(first_block1, TextBlock)
-        assert isinstance(first_block2, TextBlock)
-        assert first_block1.text is not None
-        assert first_block2.text is not None
+        assert _get_text_block(response1).text is not None
+        assert _get_text_block(response2).text is not None
 
     def test_streaming_then_non_streaming(self, sdk_config: SDKTestConfig):
         with sdk_config.client.messages.stream(
             model=sdk_config.model,
             messages=[{"role": "user", "content": "Say 'stream'"}],
-            max_tokens=10,
+            max_tokens=300,
         ) as stream:
             text = stream.get_final_text()
         assert len(text) > 0
@@ -160,11 +174,9 @@ class TestAnthropicMultipleModels:
         response = sdk_config.client.messages.create(
             model=sdk_config.model,
             messages=[{"role": "user", "content": "Say 'sync'"}],
-            max_tokens=10,
+            max_tokens=300,
         )
-        first_block = response.content[0]
-        assert isinstance(first_block, TextBlock)
-        assert first_block.text is not None
+        assert _get_text_block(response).text is not None
 
 
 class TestAnthropicToolUse:
@@ -230,8 +242,8 @@ class TestAnthropicToolUse:
 
 class TestAnthropicVision:
     def test_image_url_input(self, sdk_config: SDKTestConfig):
-        if sdk_config.provider == "bedrock":
-            pytest.skip("Bedrock does not support URL image source")
+        if sdk_config.provider in ("bedrock", "cloudflare"):
+            pytest.skip(f"{sdk_config.provider} does not support URL image source via Anthropic format")
 
         response = sdk_config.client.messages.create(
             model=sdk_config.model,
@@ -247,16 +259,17 @@ class TestAnthropicVision:
                     ],
                 }
             ],
-            max_tokens=50,
+            max_tokens=200,
         )
 
         assert response is not None
         assert len(response.content) > 0
-        first_block = response.content[0]
-        assert isinstance(first_block, TextBlock)
-        assert first_block.text is not None
+        text_block = _get_text_block(response)
+        assert text_block.text is not None
 
     def test_image_base64_input(self, sdk_config: SDKTestConfig):
+        if sdk_config.provider == "cloudflare":
+            pytest.skip("Cloudflare adapter does not support Anthropic vision content blocks")
         image_data = urlopen(TEST_IMAGE_URL).read()
         base64_image = base64.standard_b64encode(image_data).decode("utf-8")
 
@@ -278,14 +291,13 @@ class TestAnthropicVision:
                     ],
                 }
             ],
-            max_tokens=100,
+            max_tokens=300,
         )
 
         assert response is not None
         assert len(response.content) > 0
-        first_block = response.content[0]
-        assert isinstance(first_block, TextBlock)
-        assert first_block.text is not None
+        text_block = _get_text_block(response)
+        assert text_block.text is not None
 
 
 class TestAnthropicMultiTurn:
@@ -298,13 +310,12 @@ class TestAnthropicMultiTurn:
                 {"role": "assistant", "content": "Hello Alice!"},
                 {"role": "user", "content": "What is my name?"},
             ],
-            max_tokens=20,
+            max_tokens=300,
         )
 
         assert response is not None
-        first_block = response.content[0]
-        assert isinstance(first_block, TextBlock)
-        assert "alice" in first_block.text.lower()
+        text_block = _get_text_block(response)
+        assert "alice" in text_block.text.lower()
 
 
 class TestAnthropicValidationErrors:
@@ -318,6 +329,8 @@ class TestAnthropicValidationErrors:
     def test_invalid_parameters_rejected(
         self, sdk_config: SDKTestConfig, invalid_param: str, value: float, expected_error: str
     ):
+        if sdk_config.provider == "cloudflare":
+            pytest.skip("Cloudflare Workers AI handles parameter validation differently")
         kwargs: dict[str, Any] = {
             "model": sdk_config.model,
             "messages": [{"role": "user", "content": "Hi"}],
@@ -329,6 +342,8 @@ class TestAnthropicValidationErrors:
         assert expected_error in str(exc_info.value).lower()
 
     def test_empty_messages_rejected(self, sdk_config: SDKTestConfig):
+        if sdk_config.provider == "cloudflare":
+            pytest.skip("Cloudflare Workers AI handles parameter validation differently")
         with pytest.raises(BadRequestError) as exc_info:
             sdk_config.client.messages.create(
                 model=sdk_config.model,

--- a/services/llm-gateway/tests/integration/test_anthropic_sdk.py
+++ b/services/llm-gateway/tests/integration/test_anthropic_sdk.py
@@ -15,9 +15,9 @@ from urllib.request import urlopen
 
 import pytest
 from anthropic import Anthropic, BadRequestError
-from anthropic.types import TextBlock, ThinkingBlock, ToolParam, ToolUseBlock
+from anthropic.types import TextBlock, ToolParam, ToolUseBlock
 
-from .conftest import BEDROCK_REGION, CLOUDFLARE_API_KEY, CLOUDFLARE_ACCOUNT_ID, TEST_POSTHOG_API_KEY
+from .conftest import BEDROCK_REGION, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_KEY, TEST_POSTHOG_API_KEY
 
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 CLOUDFLARE_CONFIGURED = bool(CLOUDFLARE_API_KEY and CLOUDFLARE_ACCOUNT_ID)

--- a/services/llm-gateway/tests/integration/test_openai_sdk.py
+++ b/services/llm-gateway/tests/integration/test_openai_sdk.py
@@ -7,6 +7,7 @@ Run with: pytest tests/integration/test_openai_sdk.py -v
 
 import json
 import os
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -14,11 +15,44 @@ from openai import BadRequestError, OpenAI
 from openai.types import Model
 from openai.types.chat import ChatCompletionToolChoiceOptionParam, ChatCompletionToolParam
 
+from .conftest import CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_KEY
+
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+CLOUDFLARE_CONFIGURED = bool(CLOUDFLARE_API_KEY and CLOUDFLARE_ACCOUNT_ID)
 
 skip_without_openai_key = pytest.mark.skipif(not OPENAI_API_KEY, reason="OPENAI_API_KEY not set")
 
 TEST_IMAGE_URL = "https://posthog.com/brand/posthog-logo.png"
+
+
+@dataclass
+class OpenAISDKTestConfig:
+    client: OpenAI
+    model: str
+    provider: str
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "openai",
+            id="openai",
+            marks=pytest.mark.skipif(not OPENAI_API_KEY, reason="OPENAI_API_KEY not set"),
+        ),
+        pytest.param(
+            "cloudflare",
+            id="cloudflare",
+            marks=pytest.mark.skipif(not CLOUDFLARE_CONFIGURED, reason="CLOUDFLARE_API_KEY/ACCOUNT_ID not set"),
+        ),
+    ]
+)
+def oai_sdk_config(request) -> OpenAISDKTestConfig:
+    if request.param == "openai":
+        client = request.getfixturevalue("openai_client")
+        return OpenAISDKTestConfig(client=client, model="gpt-4o-mini", provider="openai")
+    else:
+        client = request.getfixturevalue("cloudflare_openai_client")
+        return OpenAISDKTestConfig(client=client, model="@cf/moonshotai/kimi-k2.6", provider="cloudflare")
 
 
 class TestOpenAIModelsEndpoint:
@@ -53,13 +87,12 @@ class TestOpenAIModelsEndpoint:
         assert model.object == "model"
 
 
-@skip_without_openai_key
-class TestOpenAIChatCompletions:
-    def test_non_streaming_request(self, openai_client: OpenAI):
-        response = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+class TestChatCompletions:
+    def test_non_streaming_request(self, oai_sdk_config: OpenAISDKTestConfig):
+        response = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "Say 'hello' and nothing else."}],
-            max_tokens=10,
+            max_tokens=300,
         )
 
         assert response is not None
@@ -69,11 +102,11 @@ class TestOpenAIChatCompletions:
         assert response.usage.prompt_tokens > 0
         assert response.usage.completion_tokens > 0
 
-    def test_streaming_request(self, openai_client: OpenAI):
-        stream = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+    def test_streaming_request(self, oai_sdk_config: OpenAISDKTestConfig):
+        stream = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "Say 'hi' and nothing else."}],
-            max_tokens=10,
+            max_tokens=300,
             stream=True,
         )
 
@@ -83,24 +116,24 @@ class TestOpenAIChatCompletions:
         content_chunks = [c for c in chunks if c.choices and c.choices[0].delta.content]
         assert len(content_chunks) > 0
 
-    def test_with_system_message(self, openai_client: OpenAI):
-        response = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+    def test_with_system_message(self, oai_sdk_config: OpenAISDKTestConfig):
+        response = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[
                 {"role": "system", "content": "You are a helpful assistant that only says 'OK'."},
                 {"role": "user", "content": "Hello"},
             ],
-            max_tokens=10,
+            max_tokens=300,
         )
 
         assert response is not None
         assert response.choices[0].message.content is not None
 
-    def test_with_temperature(self, openai_client: OpenAI):
-        response = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+    def test_with_temperature(self, oai_sdk_config: OpenAISDKTestConfig):
+        response = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "Say 'test'"}],
-            max_tokens=10,
+            max_tokens=300,
             temperature=0.0,
         )
 
@@ -108,55 +141,53 @@ class TestOpenAIChatCompletions:
         assert response.choices[0].message.content is not None
 
 
-@skip_without_openai_key
-class TestOpenAIMultipleModels:
-    def test_gpt4o_mini_request(self, openai_client: OpenAI):
-        response = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+class TestMultipleModels:
+    def test_basic_request(self, oai_sdk_config: OpenAISDKTestConfig):
+        response = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "Say 'A'"}],
-            max_tokens=5,
+            max_tokens=300,
         )
 
         assert response is not None
         assert response.choices[0].message.content is not None
 
-    def test_sequential_requests_same_model(self, openai_client: OpenAI):
-        response1 = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+    def test_sequential_requests_same_model(self, oai_sdk_config: OpenAISDKTestConfig):
+        response1 = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "Say '1'"}],
-            max_tokens=5,
+            max_tokens=300,
         )
 
-        response2 = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+        response2 = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "Say '2'"}],
-            max_tokens=5,
+            max_tokens=300,
         )
 
         assert response1.choices[0].message.content is not None
         assert response2.choices[0].message.content is not None
 
-    def test_streaming_then_non_streaming(self, openai_client: OpenAI):
-        stream = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+    def test_streaming_then_non_streaming(self, oai_sdk_config: OpenAISDKTestConfig):
+        stream = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "Say 'stream'"}],
-            max_tokens=10,
+            max_tokens=300,
             stream=True,
         )
         chunks = list(stream)
         assert len(chunks) > 0
 
-        response = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+        response = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "Say 'sync'"}],
-            max_tokens=10,
+            max_tokens=300,
         )
         assert response.choices[0].message.content is not None
 
 
-@skip_without_openai_key
-class TestOpenAIToolCalling:
-    def test_tool_definition_and_response(self, openai_client: OpenAI):
+class TestToolCalling:
+    def test_tool_definition_and_response(self, oai_sdk_config: OpenAISDKTestConfig):
         tools: list[ChatCompletionToolParam] = [
             {
                 "type": "function",
@@ -175,12 +206,12 @@ class TestOpenAIToolCalling:
             }
         ]
 
-        response = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+        response = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "What's the weather in Paris?"}],
             tools=tools,
             tool_choice="auto",
-            max_tokens=100,
+            max_tokens=200,
         )
 
         assert response is not None
@@ -194,7 +225,10 @@ class TestOpenAIToolCalling:
             args = json.loads(tool_call.function.arguments)
             assert "location" in args
 
-    def test_tool_choice_required(self, openai_client: OpenAI):
+    def test_tool_choice_required(self, oai_sdk_config: OpenAISDKTestConfig):
+        if oai_sdk_config.provider == "cloudflare":
+            pytest.skip("Cloudflare Workers AI does not support tool_choice with specific function")
+
         tools: list[ChatCompletionToolParam] = [
             {
                 "type": "function",
@@ -214,12 +248,12 @@ class TestOpenAIToolCalling:
 
         tool_choice: ChatCompletionToolChoiceOptionParam = {"type": "function", "function": {"name": "calculate"}}
 
-        response = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+        response = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
             messages=[{"role": "user", "content": "What is 2+2?"}],
             tools=tools,
             tool_choice=tool_choice,
-            max_tokens=100,
+            max_tokens=200,
         )
 
         tool_calls = response.choices[0].message.tool_calls
@@ -227,6 +261,25 @@ class TestOpenAIToolCalling:
         tool_call = tool_calls[0]
         assert hasattr(tool_call, "function")
         assert tool_call.function.name == "calculate"
+
+
+class TestMultiTurnParametrized:
+    def test_conversation_history(self, oai_sdk_config: OpenAISDKTestConfig):
+        response = oai_sdk_config.client.chat.completions.create(
+            model=oai_sdk_config.model,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant. Be very brief."},
+                {"role": "user", "content": "My name is Alice."},
+                {"role": "assistant", "content": "Hello Alice!"},
+                {"role": "user", "content": "What is my name?"},
+            ],
+            max_tokens=300,
+        )
+
+        assert response is not None
+        content = response.choices[0].message.content
+        assert content is not None
+        assert "alice" in content.lower()
 
 
 @skip_without_openai_key
@@ -243,7 +296,7 @@ class TestOpenAIVision:
                     ],
                 }
             ],
-            max_tokens=50,
+            max_tokens=300,
         )
 
         assert response is not None
@@ -261,7 +314,7 @@ class TestOpenAIVision:
                     ],
                 }
             ],
-            max_tokens=100,
+            max_tokens=300,
         )
 
         assert response is not None
@@ -301,7 +354,7 @@ class TestOpenAIJSONMode:
                 {"role": "user", "content": "Say hello"},
             ],
             response_format={"type": "json_object"},
-            max_tokens=50,
+            max_tokens=300,
         )
 
         assert response is not None

--- a/services/llm-gateway/tests/test_anthropic.py
+++ b/services/llm-gateway/tests/test_anthropic.py
@@ -485,8 +485,6 @@ class TestAnthropicMessagesEndpoint:
         authenticated_client: TestClient,
         provider_mock_response: dict,
     ) -> None:
-        from llm_gateway.cloudflare import make_cloudflare_anthropic_call
-
         mock_response = MagicMock()
         mock_response.model_dump = MagicMock(return_value=provider_mock_response)
 
@@ -951,6 +949,21 @@ class TestAnthropicCountTokensEndpoint:
         assert response.status_code == 400
         assert response.json()["error"]["type"] == "invalid_request_error"
         assert "Expected one of: anthropic, bedrock, cloudflare" in response.json()["error"]["message"]
+
+    def test_cloudflare_provider_rejected(
+        self,
+        authenticated_client: TestClient,
+        valid_request_body: dict,
+    ) -> None:
+        response = authenticated_client.post(
+            "/v1/messages/count_tokens",
+            json=valid_request_body,
+            headers={"Authorization": "Bearer phx_test_key", "X-PostHog-Provider": "cloudflare"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"]["type"] == "invalid_request_error"
+        assert "cloudflare" in response.json()["error"]["message"]
 
     def test_invalid_fallback_header_returns_400(
         self,

--- a/services/llm-gateway/tests/test_anthropic.py
+++ b/services/llm-gateway/tests/test_anthropic.py
@@ -478,6 +478,44 @@ class TestAnthropicMessagesEndpoint:
         assert "provider" not in call_kwargs
         assert "use_bedrock_fallback" not in call_kwargs
 
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_cloudflare_provider_routes_to_cloudflare(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        provider_mock_response: dict,
+    ) -> None:
+        from llm_gateway.cloudflare import make_cloudflare_anthropic_call
+
+        mock_response = MagicMock()
+        mock_response.model_dump = MagicMock(return_value=provider_mock_response)
+
+        with patch(
+            "llm_gateway.api.anthropic.make_cloudflare_anthropic_call",
+        ) as mock_make_call:
+            mock_llm_call = AsyncMock(return_value=mock_response)
+            mock_make_call.return_value = mock_llm_call
+
+            with patch(
+                "llm_gateway.api.anthropic.ensure_cloudflare_configured",
+                return_value=("https://api.cloudflare.com/ai/v1", "test-key"),
+            ):
+                response = authenticated_client.post(
+                    "/v1/messages",
+                    json={
+                        "model": "@cf/moonshotai/kimi-k2.6",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                    headers={
+                        "Authorization": "Bearer phx_test_key",
+                        "X-PostHog-Provider": "cloudflare",
+                    },
+                )
+
+            assert response.status_code == 200
+            mock_make_call.assert_called_once()
+            mock_anthropic.assert_not_called()
+
     def test_invalid_provider_header_returns_400(
         self,
         authenticated_client: TestClient,
@@ -491,7 +529,7 @@ class TestAnthropicMessagesEndpoint:
 
         assert response.status_code == 400
         assert response.json()["error"]["type"] == "invalid_request_error"
-        assert "Expected one of: anthropic, bedrock" in response.json()["error"]["message"]
+        assert "Expected one of: anthropic, bedrock, cloudflare" in response.json()["error"]["message"]
 
     def test_invalid_fallback_header_returns_400(
         self,
@@ -912,7 +950,7 @@ class TestAnthropicCountTokensEndpoint:
 
         assert response.status_code == 400
         assert response.json()["error"]["type"] == "invalid_request_error"
-        assert "Expected one of: anthropic, bedrock" in response.json()["error"]["message"]
+        assert "Expected one of: anthropic, bedrock, cloudflare" in response.json()["error"]["message"]
 
     def test_invalid_fallback_header_returns_400(
         self,

--- a/services/llm-gateway/tests/test_cost_refresh.py
+++ b/services/llm-gateway/tests/test_cost_refresh.py
@@ -1,11 +1,67 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
+import litellm
 import pytest
 
-from llm_gateway.rate_limiting.cost_refresh import CostRefreshService
+from llm_gateway.rate_limiting.cost_refresh import CostRefreshService, apply_cost_aliases
+from llm_gateway.rate_limiting.model_cost_service import ModelCostService
+
+
+class TestApplyCostAliases:
+    def test_adds_alias_when_canonical_present(self) -> None:
+        cost: dict[str, Any] = {
+            "moonshot/kimi-k2.6": {"input_cost_per_token": 0.001, "output_cost_per_token": 0.002},
+        }
+        apply_cost_aliases(cost)
+        assert cost["openai/@cf/moonshotai/kimi-k2.6"] == cost["moonshot/kimi-k2.6"]
+
+    def test_does_not_overwrite_existing_alias(self) -> None:
+        cost: dict[str, Any] = {
+            "moonshot/kimi-k2.6": {"input_cost_per_token": 0.001},
+            "openai/@cf/moonshotai/kimi-k2.6": {"input_cost_per_token": 0.999},
+        }
+        apply_cost_aliases(cost)
+        assert cost["openai/@cf/moonshotai/kimi-k2.6"]["input_cost_per_token"] == 0.999
+
+    @patch("llm_gateway.rate_limiting.cost_refresh.logger")
+    def test_warns_when_canonical_missing(self, mock_logger: MagicMock) -> None:
+        cost: dict[str, Any] = {"gpt-4o": {}}
+        apply_cost_aliases(cost)
+        assert "openai/@cf/moonshotai/kimi-k2.6" not in cost
+        mock_logger.warning.assert_called_once_with(
+            "cost_alias_canonical_missing",
+            alias="openai/@cf/moonshotai/kimi-k2.6",
+            canonical="moonshot/kimi-k2.6",
+        )
+
+    @patch("llm_gateway.rate_limiting.cost_refresh.logger")
+    def test_does_not_warn_when_alias_already_present(self, mock_logger: MagicMock) -> None:
+        cost: dict[str, Any] = {"openai/@cf/moonshotai/kimi-k2.6": {"input_cost_per_token": 0.999}}
+        apply_cost_aliases(cost)
+        mock_logger.warning.assert_not_called()
+
+
+class TestModelCostServiceAliases:
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self) -> Iterator[None]:
+        ModelCostService.reset_instance()
+        yield
+        ModelCostService.reset_instance()
+
+    @patch("llm_gateway.rate_limiting.model_cost_service.get_model_cost_map")
+    def test_refresh_cache_applies_cost_aliases(self, mock_get_cost_map: MagicMock) -> None:
+        mock_get_cost_map.return_value = {
+            "moonshot/kimi-k2.6": {"input_cost_per_token": 0.001, "output_cost_per_token": 0.002},
+        }
+        service = ModelCostService.get_instance()
+        cost_for_alias = service.get_costs("openai/@cf/moonshotai/kimi-k2.6")
+
+        assert cost_for_alias == {"input_cost_per_token": 0.001, "output_cost_per_token": 0.002}
+        assert "openai/@cf/moonshotai/kimi-k2.6" in litellm.model_cost
 
 
 class TestCostRefreshService:
@@ -28,8 +84,6 @@ class TestCostRefreshService:
 
     @patch("llm_gateway.rate_limiting.cost_refresh.get_model_cost_map")
     def test_refresh_updates_litellm_model_cost(self, mock_get_cost_map: MagicMock) -> None:
-        import litellm
-
         mock_costs = {
             "gpt-4": {"input_cost_per_token": 0.00003, "output_cost_per_token": 0.00006},
             "claude-3-opus": {"input_cost_per_token": 0.000015, "output_cost_per_token": 0.000075},

--- a/services/llm-gateway/tests/test_openai.py
+++ b/services/llm-gateway/tests/test_openai.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -225,6 +225,35 @@ class TestChatCompletionsEndpoint:
         assert "base_url" not in forwarded_metadata["nested"]
         assert forwarded_metadata["safe"] == "value"
         assert forwarded_metadata["nested"]["keep"] == "ok"
+
+    @patch("llm_gateway.api.openai.litellm.acompletion")
+    @patch("llm_gateway.api.openai.make_cloudflare_completion_call")
+    @patch("llm_gateway.api.openai.ensure_cloudflare_configured")
+    def test_cf_model_routes_through_cloudflare(
+        self,
+        mock_ensure_configured: MagicMock,
+        mock_make_call: MagicMock,
+        mock_acompletion: MagicMock,
+        authenticated_client: TestClient,
+        mock_openai_response: dict,
+    ) -> None:
+        mock_ensure_configured.return_value = ("https://api.cloudflare.com/ai/v1", "test-key")
+        mock_response = MagicMock()
+        mock_response.model_dump = MagicMock(return_value=mock_openai_response)
+        mock_make_call.return_value = AsyncMock(return_value=mock_response)
+
+        response = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "@cf/moonshotai/kimi-k2.6",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+            headers={"Authorization": "Bearer phx_test_key"},
+        )
+
+        assert response.status_code == 200
+        mock_make_call.assert_called_once_with("https://api.cloudflare.com/ai/v1", "test-key")
+        mock_acompletion.assert_not_called()
 
 
 class TestUnsupportedModelRejection:


### PR DESCRIPTION
## Problem

PR #59961 landed with unaddressed bot findings on cost-throttle bypass, a fragile lazy litellm import, and duplicated cloudflare credential-injection. The count_tokens endpoint also silently routes `X-PostHog-Provider: cloudflare` to Anthropic.

## Changes

- Apply cost aliases from both writers (`CostRefreshService` and `ModelCostService`) and warn on missing canonicals.
- Reject cloudflare on `/v1/messages/count_tokens` with 400; hoist the experimental litellm import; dedupe the credential-injection closure into `cloudflare.py`.
- Add unit coverage for OpenAI `@cf/` routing, count_tokens rejection, and the cost-alias contract.

## How did you test this code?

I'm an agent. Ran `pytest --ignore=tests/integration` against the gateway: 878 passed. Integration tests for cloudflare paths require `CLOUDFLARE_API_KEY` and `CLOUDFLARE_ACCOUNT_ID` and were not exercised.

## Publish to changelog?

no

## Docs update

N/A

## 🤖 Agent context

Tool: PostHog Code. Took over PR #59961 by @joshsny to address review feedback (greptile, Copilot, veria-ai) plus one bot-missed finding: count_tokens silently routed `X-PostHog-Provider: cloudflare` to Anthropic. Ran three `/rs-self-review` passes which surfaced and applied five additional issues (silent no-op in `apply_cost_aliases`, missing alias-contract tests, missing OpenAI `@cf/` routing test, duplicated inline imports, over-long comment).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*