### PR TITLE
fix(settings): surface organization update failures with an error toast

### DIFF
--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -184,8 +184,9 @@ export const organizationLogic = kea<organizationLogicType>([
         updateOrganizationSuccess: () => {
             lemonToast.success('Organization updated successfully!')
         },
-        updateOrganizationFailure: ({ error }) => {
-            lemonToast.error(`Failed to update organization: ${error || 'Unknown error'}`)
+        updateOrganizationFailure: ({ error, errorObject }: { error: string; errorObject?: unknown }) => {
+            const apiError = errorObject as ApiError | undefined
+            lemonToast.error(`Failed to update organization: ${apiError?.detail || error || 'Unknown error'}`)
         },
         deleteOrganization: async ({ organizationId, redirectPath }) => {
             try {

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -184,6 +184,9 @@ export const organizationLogic = kea<organizationLogicType>([
         updateOrganizationSuccess: () => {
             lemonToast.success('Organization updated successfully!')
         },
+        updateOrganizationFailure: ({ error }) => {
+            lemonToast.error(`Failed to update organization: ${error || 'Unknown error'}`)
+        },
         deleteOrganization: async ({ organizationId, redirectPath }) => {
             try {
                 await api.delete(`api/organizations/${organizationId}`)


### PR DESCRIPTION
## Problem

A user running self-hosted PostHog reported the AI training opt-out toggle didn't persist — every time they revisited the page the setting appeared to revert. The toggle's loading state and click-blocking were already wired up via LemonSwitch's `loading` prop, so the most plausible cause was a silent PATCH failure: `organizationLogic` had no `updateOrganizationFailure` listener, so when the kea-loaders update failed (network error, validation rejection like `is_hipaa` or `is_ai_training_locked`), `currentOrganizationLoading` flipped back to `false`, `currentOrganization` was left unchanged, and the toggle visually snapped back with zero feedback to the user.

## Changes

- Add an \`updateOrganizationFailure\` listener in \`frontend/src/scenes/organizationLogic.tsx\` that surfaces the failure via \`lemonToast.error\`, mirroring the existing success toast.

This doesn't fix any underlying server-side failure — it just makes failures visible so we (and the reporter) can see *why* the save didn't take.

## How did you test this code?

Agent-authored change. No manual testing performed. The change is a one-line listener addition matching the pattern already used elsewhere (e.g. \`workflowsLogic.loadWorkflowsFailure\`).

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) at the user's direction. The user reported a customer issue with the AI training opt-out toggle not persisting; we queried PostHog for the customer's sessions and discovered they're running self-hosted PostHog (so the actual replays of the bug live on their own instance, not us.posthog.com). After auditing \`organizationLogic.updateOrganization\`, the missing failure listener stood out as the most likely silent-failure path — confirmed by the user and shipped as this PR.

Other suspects discussed but intentionally not actioned here:

- The \`AllowTrainingCallout\` banner's one-click \"Enable\" button can re-opt-in opted-out users from many surfaces; worth a separate discussion about confirm-on-click or hiding it after an explicit opt-out.
- The toggle's loading state is shared with all other org mutations on the page (\`currentOrganizationLoading\`), not a real bug but worth noting.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*