### PR TITLE
fix(llma): align playground provider with provider key to avoid Azure mismatch

### DIFF
--- a/products/llm_analytics/frontend/playground/llmPlaygroundModelLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundModelLogic.ts
@@ -1,8 +1,6 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
-import { loaders } from 'kea-loaders'
+import { connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
-import api, { ApiError } from 'lib/api'
-import { teamLogic } from 'scenes/teamLogic'
+import { ApiError } from 'lib/api'
 
 import { modelPickerLogic, type ModelOption } from '../modelPickerLogic'
 import { LLMProviderKey, llmProviderKeysLogic, normalizeLLMProvider } from '../settings/llmProviderKeysLogic'
@@ -78,10 +76,6 @@ export const llmPlaygroundModelLogic = kea<llmPlaygroundModelLogicType>([
         ],
     })),
 
-    actions({
-        setActiveProviderKeyId: (id: string | null) => ({ id }),
-    }),
-
     reducers({
         trialModelsErrorStatus: [
             null as number | null,
@@ -93,12 +87,6 @@ export const llmPlaygroundModelLogic = kea<llmPlaygroundModelLogicType>([
                     }
                     return null
                 },
-            },
-        ],
-        activeProviderKeyId: [
-            null as string | null,
-            {
-                setActiveProviderKeyId: (_: string | null, { id }: { id: string | null }) => id,
             },
         ],
         providerKeysSettled: [
@@ -127,27 +115,6 @@ export const llmPlaygroundModelLogic = kea<llmPlaygroundModelLogicType>([
             },
         ],
     }),
-
-    loaders(() => ({
-        evaluationConfig: {
-            __default: null as { active_provider_key: { id: string } | null } | null,
-            loadEvaluationConfig: async () => {
-                const teamId = teamLogic.values.currentTeamId
-                if (!teamId) {
-                    return null
-                }
-                try {
-                    // nosemgrep: prefer-codegen-api
-                    return (await api.get(`/api/environments/${teamId}/llm_analytics/evaluation_config/`)) as {
-                        active_provider_key: { id: string } | null
-                    }
-                } catch (e) {
-                    console.warn('Failed to load evaluation config', e)
-                    return null
-                }
-            },
-        },
-    })),
 
     selectors({
         effectiveModelOptions: [
@@ -192,13 +159,6 @@ export const llmPlaygroundModelLogic = kea<llmPlaygroundModelLogicType>([
         }
 
         return {
-            loadEvaluationConfigSuccess: ({
-                evaluationConfig,
-            }: {
-                evaluationConfig: { active_provider_key: { id: string } | null } | null
-            }) => {
-                actions.setActiveProviderKeyId(evaluationConfig?.active_provider_key?.id ?? null)
-            },
             loadTrialModelsSuccess: ({ trialModels }: { trialModels: ModelOption[] }) => {
                 if (trialModels.length === 0) {
                     return
@@ -307,9 +267,5 @@ export const llmPlaygroundModelLogic = kea<llmPlaygroundModelLogicType>([
                 actions.clearPendingTargetModel()
             },
         }
-    }),
-
-    afterMount(({ actions }) => {
-        actions.loadEvaluationConfig()
     }),
 ])

--- a/products/llm_analytics/frontend/playground/llmPlaygroundRunLogic.test.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundRunLogic.test.ts
@@ -6,6 +6,7 @@ import api, { ApiError } from 'lib/api'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
+import { llmPlaygroundModelLogic } from './llmPlaygroundModelLogic'
 import { llmPlaygroundPromptsLogic } from './llmPlaygroundPromptsLogic'
 import { appendToolCallChunk, describeError, llmPlaygroundRunLogic, mergeUsage } from './llmPlaygroundRunLogic'
 
@@ -17,9 +18,6 @@ describe('llmPlaygroundRunLogic', () => {
                 '/api/llm_proxy/models/': [
                     { id: 'gpt-5-mini', name: 'GPT-5 Mini', provider: 'OpenAI', description: '' },
                 ],
-                '/api/environments/:team_id/llm_analytics/evaluation_config/': {
-                    active_provider_key: null,
-                },
                 '/api/environments/:team_id/llm_analytics/provider_keys/': {
                     results: [],
                 },
@@ -153,6 +151,85 @@ describe('llmPlaygroundRunLogic', () => {
         logic.unmount()
         streamSpy.mockRestore()
         captureExceptionSpy.mockRestore()
+    })
+
+    describe('completion request provider/key resolution', () => {
+        const azureKeyId = '11111111-1111-1111-1111-111111111111'
+
+        const buildMocks = (
+            keys: { id: string; provider: string; state?: string; name?: string }[],
+            byokByKey: Record<string, { id: string; name: string; provider: string }[]> = {}
+        ): Parameters<typeof useMocks>[0] => ({
+            get: {
+                '/api/llm_proxy/models/': (req: any) => {
+                    const providerKeyId = req.url.searchParams.get('provider_key_id')
+                    if (providerKeyId) {
+                        return [200, byokByKey[providerKeyId] ?? []]
+                    }
+                    return [200, [{ id: 'gpt-5-mini', name: 'GPT-5 Mini', provider: 'OpenAI', description: '' }]]
+                },
+                '/api/environments/:team_id/llm_analytics/provider_keys/': {
+                    results: keys.map((k) => ({
+                        id: k.id,
+                        provider: k.provider,
+                        name: k.name ?? `${k.provider} key`,
+                        state: k.state ?? 'ok',
+                        error_message: null,
+                        api_key_masked: '***',
+                        azure_endpoint_display: null,
+                        api_version_display: null,
+                        created_at: '2026-01-01T00:00:00Z',
+                        created_by: null,
+                        last_used_at: null,
+                    })),
+                },
+            },
+        })
+
+        const runOnce = async (model: string, selectedProviderKeyId: string | null = null): Promise<any> => {
+            const streamSpy = jest.spyOn(api, 'stream').mockImplementation(async (_url, options: any) => {
+                options.onMessage?.({ data: JSON.stringify({ type: 'text', text: 'ok' }) })
+            })
+            const logic = llmPlaygroundRunLogic()
+            logic.mount()
+            const modelLogic = llmPlaygroundModelLogic()
+            modelLogic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            await expectLogic(modelLogic).toFinishAllListeners()
+
+            llmPlaygroundPromptsLogic.actions.setModel(model, selectedProviderKeyId ?? undefined)
+            llmPlaygroundPromptsLogic.actions.setMessages([{ role: 'user', content: 'hello' }])
+            llmPlaygroundRunLogic.actions.submitPrompt()
+            await expectLogic(logic).toFinishAllListeners()
+
+            const payload = streamSpy.mock.calls[0]?.[1]?.data
+            logic.unmount()
+            modelLogic.unmount()
+            streamSpy.mockRestore()
+            return payload
+        }
+
+        it('sends canonical provider value when running a BYOK Azure model', async () => {
+            useMocks(
+                buildMocks([{ id: azureKeyId, provider: 'azure_openai' }], {
+                    [azureKeyId]: [{ id: 'gpt-4.1', name: 'gpt-4.1', provider: 'Azure OpenAI' }],
+                })
+            )
+            const payload = await runOnce('gpt-4.1', azureKeyId)
+            expect(payload).toMatchObject({
+                model: 'gpt-4.1',
+                provider: 'azure_openai',
+                provider_key_id: azureKeyId,
+            })
+        })
+
+        it('does not attach a mismatched-provider key when running a trial model', async () => {
+            // Azure key configured + trial OpenAI model would trigger ProviderMismatchError on the backend.
+            useMocks(buildMocks([{ id: azureKeyId, provider: 'azure_openai' }]))
+            const payload = await runOnce('gpt-5-mini')
+            expect(payload).toMatchObject({ model: 'gpt-5-mini', provider: 'openai' })
+            expect(payload.provider_key_id).toBeUndefined()
+        })
     })
 
     it('captures exceptions thrown before the stream opens', async () => {

--- a/products/llm_analytics/frontend/playground/llmPlaygroundRunLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundRunLogic.ts
@@ -8,7 +8,7 @@ import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { uuid } from 'lib/utils'
 
 import type { ModelOption } from '../modelPickerLogic'
-import { llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
+import { llmProviderKeysLogic, normalizeLLMProvider } from '../settings/llmProviderKeysLogic'
 import { llmPlaygroundModelLogic } from './llmPlaygroundModelLogic'
 import { llmPlaygroundPromptsLogic, type Message, type PromptConfig } from './llmPlaygroundPromptsLogic'
 import type { llmPlaygroundRunLogicType } from './llmPlaygroundRunLogicType'
@@ -166,7 +166,7 @@ export const llmPlaygroundRunLogic = kea<llmPlaygroundRunLogicType>([
             llmPlaygroundPromptsLogic({ tabId }),
             ['promptConfigs'],
             llmPlaygroundModelLogic({ tabId }),
-            ['effectiveModelOptions', 'activeProviderKeyId'],
+            ['effectiveModelOptions'],
             llmProviderKeysLogic,
             ['providerKeys'],
         ],
@@ -319,10 +319,15 @@ export const llmPlaygroundRunLogic = kea<llmPlaygroundRunLogicType>([
                             return
                         }
 
-                        providerKeyId =
-                            resolveProviderKeyForPrompt(prompt, values.effectiveModelOptions, values.providerKeys)
-                                ?.id ?? values.activeProviderKeyId
-                        selectedModelProvider = selectedModel.provider.toLowerCase()
+                        // Derive provider from the resolved key so it always matches provider_key_id.
+                        const effectiveProviderKey = resolveProviderKeyForPrompt(
+                            prompt,
+                            values.effectiveModelOptions,
+                            values.providerKeys
+                        )
+                        providerKeyId = effectiveProviderKey?.id ?? null
+                        selectedModelProvider =
+                            effectiveProviderKey?.provider ?? normalizeLLMProvider(selectedModel.provider) ?? ''
 
                         const requestData: Record<string, unknown> = {
                             system: prompt.systemPrompt,

--- a/products/llm_analytics/frontend/playground/playgroundModelMatching.test.ts
+++ b/products/llm_analytics/frontend/playground/playgroundModelMatching.test.ts
@@ -1,9 +1,12 @@
+import type { ModelOption } from '../modelPickerLogic'
 import type { LLMProviderKey } from '../settings/llmProviderKeysLogic'
+import type { PromptConfig } from './llmPlaygroundPromptsLogic'
 import {
     isTraceLikeSelection,
     matchClosestModel,
     matchClosestModelOption,
     type MatchModelOption,
+    resolveProviderKeyForPrompt,
     resolveTraceModelSelection,
 } from './playgroundModelMatching'
 
@@ -126,6 +129,61 @@ describe('playgroundModelMatching', () => {
             const keys = [providerKey('key-a', 'anthropic'), providerKey('key-z', 'anthropic')]
             const result = resolveTraceModelSelection('claude-sonnet-4', 'anthropic', models, keys)
             expect(result.providerKeyId).toBe('key-a')
+        })
+    })
+
+    describe('resolveProviderKeyForPrompt', () => {
+        const promptOf = (overrides: Partial<PromptConfig>): Pick<PromptConfig, 'model' | 'selectedProviderKeyId'> => ({
+            model: '',
+            selectedProviderKeyId: null,
+            ...overrides,
+        })
+        const modelOption = (overrides: Partial<ModelOption> & Pick<ModelOption, 'id' | 'provider'>): ModelOption => ({
+            name: overrides.id,
+            description: '',
+            ...overrides,
+        })
+
+        it('returns the explicitly selected key when present', () => {
+            const prompt = promptOf({ model: 'gpt-4.1', selectedProviderKeyId: 'azure-key' })
+            const modelOptions = [modelOption({ id: 'gpt-4.1', provider: 'Azure OpenAI', providerKeyId: 'azure-key' })]
+            const keys = [providerKey('azure-key', 'azure_openai')]
+            expect(resolveProviderKeyForPrompt(prompt, modelOptions, keys)?.id).toBe('azure-key')
+        })
+
+        it('uses the model option providerKeyId for BYOK models', () => {
+            const prompt = promptOf({ model: 'gpt-4.1' })
+            const modelOptions = [modelOption({ id: 'gpt-4.1', provider: 'Azure OpenAI', providerKeyId: 'azure-key' })]
+            const keys = [providerKey('azure-key', 'azure_openai')]
+            expect(resolveProviderKeyForPrompt(prompt, modelOptions, keys)?.id).toBe('azure-key')
+        })
+
+        it('matches the trial model provider against the user-configured keys', () => {
+            const prompt = promptOf({ model: 'gpt-5-mini' })
+            const modelOptions = [modelOption({ id: 'gpt-5-mini', provider: 'OpenAI' })]
+            const keys = [providerKey('openai-key', 'openai')]
+            expect(resolveProviderKeyForPrompt(prompt, modelOptions, keys)?.id).toBe('openai-key')
+        })
+
+        it('does not match an Azure key when the trial model is OpenAI', () => {
+            const prompt = promptOf({ model: 'gpt-5-mini' })
+            const modelOptions = [modelOption({ id: 'gpt-5-mini', provider: 'OpenAI' })]
+            const keys = [providerKey('azure-key', 'azure_openai')]
+            expect(resolveProviderKeyForPrompt(prompt, modelOptions, keys)).toBeNull()
+        })
+
+        it('normalizes the display provider name when matching against keys', () => {
+            const prompt = promptOf({ model: 'gpt-4.1' })
+            const modelOptions = [modelOption({ id: 'gpt-4.1', provider: 'Azure OpenAI' })]
+            const keys = [providerKey('azure-key', 'azure_openai')]
+            expect(resolveProviderKeyForPrompt(prompt, modelOptions, keys)?.id).toBe('azure-key')
+        })
+
+        it('ignores invalid keys when matching by provider', () => {
+            const prompt = promptOf({ model: 'gpt-5-mini' })
+            const modelOptions = [modelOption({ id: 'gpt-5-mini', provider: 'OpenAI' })]
+            const keys = [providerKey('openai-key', 'openai', 'invalid')]
+            expect(resolveProviderKeyForPrompt(prompt, modelOptions, keys)).toBeNull()
         })
     })
 })

--- a/products/llm_analytics/frontend/playground/playgroundModelMatching.ts
+++ b/products/llm_analytics/frontend/playground/playgroundModelMatching.ts
@@ -316,6 +316,9 @@ export function resolveProviderKeyForPrompt(
         }
     }
 
-    const provider = selectedModel.provider.toLowerCase()
+    const provider = normalizeLLMProvider(selectedModel.provider)
+    if (!provider) {
+        return null
+    }
     return providerKeys.find((k) => k.provider === provider && k.state !== 'invalid') ?? null
 }


### PR DESCRIPTION
## Problem

The AI observability playground was constructing the completion request's `provider` field from the selected model's display string (`selectedModel.provider.toLowerCase()`) while resolving `provider_key_id` independently. The two could disagree:

- With an Azure OpenAI key set as the team's evaluation default and a trial OpenAI model selected, the request went out as `provider: "openai"` with the Azure `provider_key_id`. The backend's `Client._validate_provider` rejected the mismatch with `ProviderMismatchError`.
- BYOK Azure deployments produced `provider: "azure openai"` (display name lowercased, space preserved). The `LLMProvider.choices` `ChoiceField` rejected this as an invalid choice (the canonical value is `azure_openai` with an underscore).

## Changes

- Derive the request's `provider` from the resolved `LLMProviderKey`, so it always agrees with `provider_key_id`.
- Normalize the model's display provider via `normalizeLLMProvider` (which handles `Azure OpenAI` → `azure_openai`, `Google` → `gemini`, etc.) instead of `.toLowerCase()`.
- Drop the `activeProviderKeyId` fallback in `llmPlaygroundRunLogic` — it could only fire when all matching keys were `state: 'invalid'`, in which case attaching the invalid key just produced a different backend error.
- Remove the now-orphaned `activeProviderKeyId` reducer/action/listener and the `evaluationConfig` loader that fed it (no remaining consumers).

## How did you test this code?

I'm an agent (PostHog Code). Automated tests I ran:

- ` jest products/llm_analytics/frontend/playground/` — 148 tests pass (was 149 before; removed one misleading test that didn't exercise the path it claimed to).
- New test cases:
  - `playgroundModelMatching.test.ts` — 6 cases covering `resolveProviderKeyForPrompt` (explicit selection, BYOK lookup, trial provider matching, Azure-vs-OpenAI mismatch, display-name normalization, invalid-key skipping).
  - `llmPlaygroundRunLogic.test.ts` — 2 integration cases verifying the outgoing request payload's `provider`/`provider_key_id` pair for BYOK Azure and the trial-model-with-mismatched-active-key scenario.

I did not manually exercise the playground in a running app.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). I ran the `rs-self-review` discipline three times against my own diff before pushing — first pass surfaced a too-broad `activeProviderKeyId` fallback I'd left in defensively; second pass caught a misleading test that passed via the wrong code path; third pass caught orphaned state plumbing that became dead after the fallback was removed. Each round narrowed the diff. The current shape is the minimal correct fix plus the cleanup directly caused by it; broader dead-code sweeps (other unused selectors, stale test mocks in unrelated files) were left as follow-ups to keep PR scope tight.