### PR TITLE
feat(insights): retention pre-agg read path + routing gate

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -21218,6 +21218,10 @@
                     "description": "Try to automatically convert HogQL queries to use preaggregated tables at the AST level *",
                     "type": "boolean"
                 },
+                "useRetentionPreAggregation": {
+                    "description": "Route retention queries through the `retention_actor_event_day` pre-aggregation when the v1 gate accepts them (recurring or first-occurrence-matching-filters, person retention, no entity property filter, no property aggregation). Default off; falls back to raw events for any query the gate rejects or when materialisation fails.",
+                    "type": "boolean"
+                },
                 "useWebAnalyticsPreAggregatedTables": {
                     "type": "boolean"
                 }

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -428,6 +428,8 @@ export interface HogQLQueryModifiers {
     sessionIdPushdown?: boolean
     /** Pre-filter raw_sessions aggregation by `session_id_v7 IN (cheap pre-aggregation that only materializes the columns referenced by the outer-WHERE session predicate)`. Useful when the breakdown/SELECT pulls in many session columns (e.g. `$channel_type`) but the filter only references one (e.g. `$entry_current_url`). */
     sessionPropertyPreAggregation?: boolean
+    /** Route retention queries through the `retention_actor_event_day` pre-aggregation when the v1 gate accepts them (recurring or first-occurrence-matching-filters, person retention, no entity property filter, no property aggregation). Default off; falls back to raw events for any query the gate rejects or when materialisation fails. */
+    useRetentionPreAggregation?: boolean
     dataWarehouseEventsModifiers?: DataWarehouseEventsModifier[]
     debug?: boolean
     timings?: boolean

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -112,6 +112,7 @@ from posthog.hogql.database.schema.preaggregation_results import PreaggregationR
 from posthog.hogql.database.schema.precalculated_events import PrecalculatedEventsTable
 from posthog.hogql.database.schema.precalculated_person_properties import PrecalculatedPersonPropertiesTable
 from posthog.hogql.database.schema.query_log_archive import QueryLogArchiveTable, RawQueryLogArchiveTable
+from posthog.hogql.database.schema.retention_actor_event_day import RetentionActorEventDayTable
 from posthog.hogql.database.schema.session_replay_events import (
     RawSessionReplayEventsTable,
     SessionReplayEventsTable,
@@ -239,6 +240,7 @@ ROOT_TABLES__DO_NOT_ADD_ANY_MORE: dict[str, TableNode] = {
     "experiment_metric_events_preaggregated": TableNode(
         name="experiment_metric_events_preaggregated", table=ExperimentMetricEventsPreaggregatedTable()
     ),
+    "retention_actor_event_day": TableNode(name="retention_actor_event_day", table=RetentionActorEventDayTable()),
     # Revenue analytics tables
     "persons_revenue_analytics": TableNode(name="persons_revenue_analytics", table=PersonsRevenueAnalyticsTable()),
     "groups_revenue_analytics": TableNode(name="groups_revenue_analytics", table=GroupsRevenueAnalyticsTable()),

--- a/posthog/hogql/database/schema/retention_actor_event_day.py
+++ b/posthog/hogql/database/schema/retention_actor_event_day.py
@@ -1,0 +1,42 @@
+from pydantic import Field
+
+from posthog.hogql.constants import HogQLQuerySettings
+from posthog.hogql.database.models import (
+    DateDatabaseField,
+    DateTimeDatabaseField,
+    FieldOrTable,
+    IntegerDatabaseField,
+    StringDatabaseField,
+    Table,
+)
+
+from posthog.clickhouse.preaggregation.retention_actor_event_day_sql import DISTRIBUTED_RETENTION_ACTOR_EVENT_DAY_TABLE
+
+
+class RetentionActorEventDayTable(Table):
+    # Same hints as `WebStatsPreaggregatedTable`: `load_balancing="in_order"` so reads
+    # land on the same replica that wrote the precompute (read-your-writes), and
+    # `optimize_skip_unused_shards=1` to prune shards using the `job_id IN (...)` filter
+    # (sharded by sipHash64(team_id, actor_id) — the prune is less aggressive than web
+    # analytics' but still wins on multi-team reads).
+    top_level_settings: HogQLQuerySettings | None = Field(
+        default_factory=lambda: HogQLQuerySettings(load_balancing="in_order", optimize_skip_unused_shards=True)
+    )
+
+    fields: dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "job_id": StringDatabaseField(name="job_id"),
+        "day": DateDatabaseField(name="day"),
+        "actor_id": StringDatabaseField(name="actor_id"),
+        "group_type_index": IntegerDatabaseField(name="group_type_index"),
+        "event": StringDatabaseField(name="event"),
+        "first_ts": DateTimeDatabaseField(name="first_ts"),
+        "computed_at": DateTimeDatabaseField(name="computed_at"),
+        "expires_at": DateTimeDatabaseField(name="expires_at"),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return DISTRIBUTED_RETENTION_ACTOR_EVENT_DAY_TABLE()
+
+    def to_printed_hogql(self):
+        return "retention_actor_event_day"

--- a/posthog/hogql_queries/insights/retention/retention_base_query_preagg.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_preagg.py
@@ -1,0 +1,261 @@
+"""
+Pre-aggregated retention base query.
+
+Produces a SelectQuery in the same shape `build_base_query_legacy` emits, but
+reads from `retention_actor_event_day` instead of `events`. The pre-agg table
+already has one row per (team_id, day, actor_id, event) with `min(timestamp)` as
+`first_ts`, so the array aggregates the legacy path runs over raw events
+(`arraySort(groupUniqArrayIf(toStartOfInterval(events.timestamp, ...), ...))`)
+become equivalent aggregates over the pre-agg rows.
+
+v1 routing gate only — same constraints documented in
+`.planning/retention-preagg-implementation-plan.md`:
+
+- recurring OR first-occurrence-matching-filters (NOT first-ever)
+- person retention (not group)
+- no entity-property filter
+- no property aggregation
+- minimum_occurrences == 1
+
+Anything outside that envelope must fall through to the raw events path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr
+
+if TYPE_CHECKING:
+    from posthog.hogql_queries.insights.retention.retention_base_query_fixed import (
+        RetentionFixedIntervalBaseQueryBuilder,
+    )
+
+PREAGG_TABLE = "retention_actor_event_day"
+
+
+def build_preagg_base_query(
+    builder: RetentionFixedIntervalBaseQueryBuilder,
+    job_ids: list[uuid.UUID],
+) -> ast.SelectQuery:
+    """Equivalent retention base query reading from `retention_actor_event_day`.
+
+    `builder` provides access to the same `query_date_range`, entity selection,
+    and outer retention math the legacy path uses. Only the inner-most aggregation
+    (the per-actor array of qualifying interval starts) is replaced with reads
+    against the pre-agg table.
+    """
+    runner = builder.runner
+
+    # Source field for "did this happen during interval X". On the legacy path
+    # this is `events.timestamp`; on pre-agg it's the materialised `first_ts`.
+    start_of_interval_sql = runner.query_date_range.get_start_of_interval_hogql(
+        source=ast.Field(chain=[PREAGG_TABLE, "first_ts"]),
+    )
+
+    # Entity predicates: pre-agg has the `event` column directly, no table prefix needed.
+    # v1 gate excludes entity-property filters, so this is just a string-event comparison.
+    start_entity_expr = _entity_event_filter(runner.start_event)
+    return_entity_expr = _entity_event_filter(runner.return_event)
+
+    # Day-range filter on pre-agg's `day` column. The legacy path filters
+    # `events.timestamp >= date_from AND events.timestamp < date_to`; the
+    # pre-agg equivalent filters by daily bucket.
+    day_range_filter = _day_range_filter(runner)
+
+    # Array aggregates — same shape as build_base_query_legacy, just reading
+    # over pre-agg rows.
+    start_event_timestamps_expr = parse_expr(
+        """
+        arraySort(
+            groupUniqArrayIf(
+                {start_of_interval_sql},
+                {start_entity_expr} and {day_range_filter}
+            )
+        )
+        """,
+        {
+            "start_of_interval_sql": start_of_interval_sql,
+            "start_entity_expr": start_entity_expr,
+            "day_range_filter": day_range_filter,
+        },
+    )
+
+    # First-occurrence wrap. For first-time queries, only keep the actor's
+    # `start_event_timestamps` if their min timestamp falls in the cohort window.
+    # Matches the legacy path's wrapper but uses pre-agg's first_ts column. v1 gate
+    # excludes first-ever (which needs all-time lookback the pre-agg doesn't have)
+    # and entity property filters (so the entity expr is the simple event-name match).
+    if runner.is_first_occurrence_matching_filters:
+        min_timestamp_inner_expr = parse_expr(
+            "minIf({ts}, {expr})",
+            {
+                "ts": ast.Field(chain=[PREAGG_TABLE, "first_ts"]),
+                "expr": start_entity_expr,
+            },
+        )
+        start_event_timestamps_expr = parse_expr(
+            """
+            if(
+                has(
+                    {start_event_timestamps} as _start_event_timestamps,
+                    {min_timestamp}
+                ),
+                _start_event_timestamps,
+                []
+            )
+            """,
+            {
+                "start_event_timestamps": start_event_timestamps_expr,
+                "min_timestamp": runner.query_date_range.date_to_start_of_interval_hogql(min_timestamp_inner_expr),
+            },
+        )
+
+    return_event_timestamps_expr = parse_expr(
+        """
+        arraySort(
+            groupUniqArrayIf(
+                {start_of_interval_sql},
+                {return_entity_expr} and {day_range_filter}
+            )
+        )
+        """,
+        {
+            "start_of_interval_sql": start_of_interval_sql,
+            "return_entity_expr": return_entity_expr,
+            "day_range_filter": day_range_filter,
+        },
+    )
+
+    # The downstream array math (start_interval_index, intervals_from_base) operates
+    # on the internal aliases (_start_event_timestamps, date_range, start_event_timestamps)
+    # rather than on events.* directly, so we reuse the builder's helpers verbatim.
+    is_valid_start_interval = builder._is_valid_start_interval_expr("_start_event_timestamps")
+    intervals_from_base_expr, _retention_value_expr = builder._get_intervals_from_base_exprs()
+
+    select_fields: list[ast.Expr] = [
+        ast.Alias(
+            alias="actor_id",
+            expr=ast.Field(chain=[PREAGG_TABLE, "actor_id"]),
+        ),
+        ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps_expr),
+        builder._date_range_alias(),
+        ast.Alias(alias="return_event_timestamps", expr=return_event_timestamps_expr),
+        ast.Alias(
+            alias="start_interval_index",
+            expr=parse_expr(
+                """
+                arrayJoin(
+                    arrayFilter(
+                        x -> x > -1,
+                        arrayMap(
+                            (interval_index, interval_date, _start_event_timestamps) ->
+                                if({is_valid_start_interval}, interval_index - 1, -1),
+                            arrayEnumerate(date_range),
+                            date_range,
+                            arrayResize(
+                                [start_event_timestamps],
+                                length(date_range),
+                                start_event_timestamps
+                            )
+                        )
+                    )
+                )
+                """,
+                {"is_valid_start_interval": is_valid_start_interval},
+            ),
+        ),
+        ast.Alias(alias="intervals_from_base", expr=intervals_from_base_expr),
+    ]
+
+    # WHERE: scope to this team's materialised rows. team_id is also needed so the
+    # MergeTree ordering key prunes parts; job_id IN (...) ensures we only read the
+    # latest materialisation set for this query.
+    where_filters: list[ast.Expr] = [
+        ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=[PREAGG_TABLE, "team_id"]),
+            right=ast.Constant(value=runner.team.pk),
+        ),
+        _job_id_filter(job_ids),
+        # Pre-event-name filter mirrors the legacy path's `event IN (start, return)` pre-filter.
+        # Lets ClickHouse skip rows for events the read doesn't care about.
+        _event_in_filter(runner),
+    ]
+
+    return ast.SelectQuery(
+        select=select_fields,
+        select_from=ast.JoinExpr(table=ast.Field(chain=[PREAGG_TABLE])),
+        where=ast.And(exprs=where_filters),
+        group_by=[ast.Field(chain=["actor_id"])],
+        having=ast.And(exprs=[ast.Constant(value=1)]),
+    )
+
+
+def _entity_event_filter(entity) -> ast.Expr:
+    """Build `event = '<name>'` for a RetentionEntity. v1 gate excludes actions and
+    entity-property filters, so this only handles raw event names and the "all events"
+    case (entity.id is None)."""
+    if entity.id is None:
+        return ast.Constant(value=True)
+    return parse_expr(
+        "{table_event_field} = {event_name}",
+        {
+            "table_event_field": ast.Field(chain=[PREAGG_TABLE, "event"]),
+            "event_name": ast.Constant(value=entity.id),
+        },
+    )
+
+
+def _day_range_filter(runner) -> ast.Expr:
+    """Filter pre-agg rows by daily bucket for the cohort window. The legacy path
+    filters `events.timestamp` directly; here we filter the materialised `day`."""
+    return ast.And(
+        exprs=[
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.GtEq,
+                left=ast.Field(chain=[PREAGG_TABLE, "day"]),
+                right=ast.Call(
+                    name="toDate",
+                    args=[runner.query_date_range.date_from_to_start_of_interval_hogql()],
+                ),
+            ),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Lt,
+                left=ast.Field(chain=[PREAGG_TABLE, "day"]),
+                right=ast.Call(
+                    name="toDate",
+                    args=[ast.Constant(value=runner.query_date_range.date_to())],
+                ),
+            ),
+        ]
+    )
+
+
+def _event_in_filter(runner) -> ast.Expr:
+    """Pre-filter pre-agg rows by event name. Mirrors the legacy path's
+    `event IN (start, return)` filter so we read only relevant rows."""
+    events_for_entity = runner.get_events_for_entity(runner.start_event) + runner.get_events_for_entity(
+        runner.return_event
+    )
+    unique_events = {e for e in events_for_entity if e is not None}
+    if not unique_events:
+        # One of the entities is "all events" — no pre-filter.
+        return ast.Constant(value=True)
+    return ast.CompareOperation(
+        op=ast.CompareOperationOp.In,
+        left=ast.Field(chain=[PREAGG_TABLE, "event"]),
+        right=ast.Tuple(exprs=[ast.Constant(value=event) for event in sorted(unique_events)]),
+    )
+
+
+def _job_id_filter(job_ids: list[uuid.UUID]) -> ast.Expr:
+    """Filter pre-agg rows to the latest materialisation set for this query.
+    `ensure_precomputed` returns one job_id per (team, day) covered by the cohort window."""
+    return ast.CompareOperation(
+        op=ast.CompareOperationOp.In,
+        left=ast.Field(chain=[PREAGG_TABLE, "job_id"]),
+        right=ast.Tuple(exprs=[ast.Constant(value=str(jid)) for jid in job_ids]),
+    )

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -34,9 +34,11 @@ from posthog.hogql.timings import HogQLTimings
 
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
 from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RetentionFixedIntervalBaseQueryBuilder
+from posthog.hogql_queries.insights.retention.retention_base_query_preagg import build_preagg_base_query
 from posthog.hogql_queries.insights.retention.retention_base_query_rolling import (
     RetentionRollingIntervalBaseQueryBuilder,
 )
+from posthog.hogql_queries.insights.retention.retention_lazy_precompute import ensure_retention_precomputed
 from posthog.hogql_queries.insights.retention.retention_validation_rules import DisallowCumulativeWith24HourWindows
 from posthog.hogql_queries.insights.utils.breakdowns import (
     ALL_USERS_COHORT_ID,
@@ -412,11 +414,59 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
 
         return refresh_frequency
 
+    @cached_property
+    def should_use_retention_preagg(self) -> bool:
+        # v1 routing gate for retention_actor_event_day. Conservative on purpose —
+        # every condition rules out a shape the v1 pre-agg table can't answer correctly.
+        # Expand by extending the pre-agg schema (group_type_index, property columns,
+        # first-ever companion table) — not by relaxing safety checks here.
+        if not self.modifiers.useRetentionPreAggregation:
+            return False
+        # FIRST_EVER needs all-time lookback for the actor's first qualifying event;
+        # the pre-agg only has data inside the materialised window.
+        if self.is_first_ever_occurrence:
+            return False
+        # 24h windows and custom brackets have different per-interval shapes that the
+        # v1 pre-agg builder doesn't reproduce.
+        if self.is_24h_window_calculation or self.is_custom_bracket_retention:
+            return False
+        # v1 materialises person retention only (group_type_index = -1).
+        if self.group_type_index is not None:
+            return False
+        # Property aggregation needs event property values the pre-agg doesn't store.
+        if self.has_property_aggregation:
+            return False
+        # minimum_occurrences > 1 uses groupArrayIf with duplicates — different shape.
+        if (self.query.retentionFilter.minimumOccurrences or 1) > 1:
+            return False
+        # Entity-level property filters need event properties the pre-agg doesn't store.
+        # Pre-agg's event-name pre-filter only catches the raw event name.
+        if self.start_event.properties or self.return_event.properties:
+            return False
+        # v1 only supports raw event entities; actions and DWH entities have richer
+        # filter shapes that the v1 pre-agg builder doesn't translate yet.
+        if self.start_event.type != EntityType.EVENTS or self.return_event.type != EntityType.EVENTS:
+            return False
+        # Same constraints as above for the query-level properties filter — anything
+        # event-property-shaped can't be answered from the pre-agg alone.
+        if self.query.properties:
+            return False
+        return True
+
     def _base_query(
         self,
         start_interval_index_filter: Optional[int] = None,
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
+        if self.should_use_retention_preagg:
+            preagg_query = self._build_preagg_base_query(
+                start_interval_index_filter=start_interval_index_filter,
+                selected_breakdown_value=selected_breakdown_value,
+            )
+            if preagg_query is not None:
+                return preagg_query
+            # Materialisation failed — fall through to raw events. The pre-agg path is
+            # a hint, not a contract; raw events are always correct.
         builder_class = (
             RetentionRollingIntervalBaseQueryBuilder
             if self.is_24h_window_calculation
@@ -426,6 +476,28 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             start_interval_index_filter=start_interval_index_filter,
             selected_breakdown_value=selected_breakdown_value,
         )
+
+    def _build_preagg_base_query(
+        self,
+        start_interval_index_filter: Optional[int] = None,
+        selected_breakdown_value: str | list[str] | int | None = None,
+    ) -> ast.SelectQuery | None:
+        # start_interval_index_filter and selected_breakdown_value are HAVING-clause
+        # post-filters; for v1 we don't reproduce them on the pre-agg path and let
+        # the outer retention query handle filtering. If a caller passes them, fall
+        # through to raw events to avoid silently returning unfiltered results.
+        if start_interval_index_filter is not None or selected_breakdown_value is not None:
+            return None
+
+        materialisation = ensure_retention_precomputed(
+            team=self.team,
+            time_range_start=self.query_date_range.date_from(),
+            time_range_end=self.query_date_range.date_to(),
+        )
+        if not materialisation.ready or not materialisation.job_ids:
+            return None
+        builder = RetentionFixedIntervalBaseQueryBuilder(self)
+        return build_preagg_base_query(builder, materialisation.job_ids)
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
         with self.timings.measure("retention_query"):

--- a/posthog/hogql_queries/insights/retention/test/test_retention_preagg_read_path.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_preagg_read_path.py
@@ -1,0 +1,199 @@
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
+
+from django.test import override_settings
+
+from parameterized import parameterized
+
+from posthog.schema import HogQLQueryModifiers, RetentionQuery
+
+from posthog.clickhouse.client import sync_execute
+from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
+
+from products.analytics_platform.backend.models.preaggregation_job import PreaggregationJob
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestRetentionPreAggRoutingGate(ClickhouseTestMixin, APIBaseTest):
+    """Gate decides whether a query qualifies for the v1 pre-agg path. Each ineligible
+    shape must short-circuit to False so we don't silently route an unsupported query
+    through pre-agg."""
+
+    def _runner(self, *, query_overrides=None, modifier_on=True) -> RetentionQueryRunner:
+        base_query = {
+            "dateRange": {"date_from": "-7d"},
+            "retentionFilter": {
+                "retentionType": "retention_recurring",
+                "targetEntity": {"id": "$pageview", "type": "events"},
+                "returningEntity": {"id": "$pageview", "type": "events"},
+            },
+        }
+        if query_overrides:
+            for key, value in query_overrides.items():
+                if key in {"retentionFilter", "breakdownFilter"} and value is not None:
+                    base_query.setdefault(key, {}).update(value)
+                else:
+                    base_query[key] = value
+        modifiers = HogQLQueryModifiers(useRetentionPreAggregation=modifier_on or None)
+        return RetentionQueryRunner(query=RetentionQuery(**base_query), team=self.team, modifiers=modifiers)
+
+    def test_default_off_when_modifier_unset(self) -> None:
+        # Without the modifier, gate stays False regardless of query shape.
+        assert self._runner(modifier_on=False).should_use_retention_preagg is False
+
+    def test_eligible_recurring_same_entity(self) -> None:
+        # Canonical v1 happy-path shape — recurring, same entity, person retention.
+        assert self._runner().should_use_retention_preagg is True
+
+    def test_eligible_first_time_different_entity(self) -> None:
+        # Different start / return entities are fine — pre-agg captures all events.
+        assert (
+            self._runner(
+                query_overrides={
+                    "retentionFilter": {
+                        "retentionType": "retention_first_time",
+                        "targetEntity": {"id": "$screen", "type": "events"},
+                        "returningEntity": {"id": "$pageview", "type": "events"},
+                    },
+                }
+            ).should_use_retention_preagg
+            is True
+        )
+
+    @parameterized.expand(
+        [
+            # First-ever needs lookback beyond the materialised window.
+            ("first_ever", {"retentionFilter": {"retentionType": "retention_first_ever_occurrence"}}),
+            # Property aggregation needs event property values the pre-agg doesn't store.
+            (
+                "property_aggregation",
+                {
+                    "retentionFilter": {
+                        "aggregationType": "sum",
+                        "aggregationProperty": "revenue",
+                    }
+                },
+            ),
+            # 24h windows have a different per-interval shape the v1 builder doesn't reproduce.
+            ("24h_windows", {"retentionFilter": {"timeWindowMode": "24_hour_windows"}}),
+            # Entity property filter — pre-agg can't filter by event property.
+            (
+                "entity_property_filter",
+                {
+                    "retentionFilter": {
+                        "targetEntity": {
+                            "id": "$pageview",
+                            "type": "events",
+                            "properties": [{"key": "country", "value": "US", "type": "event"}],
+                        }
+                    }
+                },
+            ),
+            # Query-level event property filter — same reason.
+            (
+                "query_property_filter",
+                {"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]},
+            ),
+        ]
+    )
+    def test_gate_rejects(self, _name: str, query_overrides: dict) -> None:
+        assert self._runner(query_overrides=query_overrides).should_use_retention_preagg is False
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestRetentionPreAggCorrectness(ClickhouseTestMixin, APIBaseTest):
+    """Run the same query through both paths and assert identical retention output.
+    Without correctness here, the routing gate would silently serve wrong results."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        PreaggregationJob.objects.filter(team_id=self.team.pk).delete()
+        # See test_retention_lazy_precompute setUp — without stopping TTL merges,
+        # precompute rows can drop before the read.
+        sync_execute("SYSTEM STOP TTL MERGES sharded_retention_actor_event_day")
+
+    def _seed_basic_retention(self) -> None:
+        # Three actors, three days. p1: active 2026-01-01 and 2026-01-02 ($pageview both).
+        # p2: active 2026-01-01 only. p3: active 2026-01-02 only. Standard small retention shape.
+        _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={})
+        _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={})
+        _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={})
+        _create_event(team=self.team, event="$pageview", distinct_id="p1", timestamp="2026-01-01T09:00:00Z")
+        _create_event(team=self.team, event="$pageview", distinct_id="p1", timestamp="2026-01-01T15:00:00Z")
+        _create_event(team=self.team, event="$pageview", distinct_id="p1", timestamp="2026-01-02T11:00:00Z")
+        _create_event(team=self.team, event="$pageview", distinct_id="p2", timestamp="2026-01-01T12:00:00Z")
+        _create_event(team=self.team, event="$pageview", distinct_id="p3", timestamp="2026-01-02T10:00:00Z")
+        flush_persons_and_events()
+
+    def _run_retention(self, *, use_preagg: bool):
+        query = RetentionQuery(
+            dateRange={"date_from": "2026-01-01T00:00:00Z", "date_to": "2026-01-04T00:00:00Z"},
+            retentionFilter={
+                "retentionType": "retention_recurring",
+                "period": "Day",
+                "totalIntervals": 3,
+                "targetEntity": {"id": "$pageview", "type": "events"},
+                "returningEntity": {"id": "$pageview", "type": "events"},
+            },
+        )
+        modifiers = HogQLQueryModifiers(useRetentionPreAggregation=use_preagg or None)
+        runner = RetentionQueryRunner(query=query, team=self.team, modifiers=modifiers)
+        return runner.calculate()
+
+    def test_pre_agg_matches_raw_events_recurring_same_entity(self) -> None:
+        self._seed_basic_retention()
+        raw = self._run_retention(use_preagg=False)
+        preagg = self._run_retention(use_preagg=True)
+
+        # Same retention buckets, same counts. Comparing the result struct directly is
+        # the strongest possible correctness check — if the pre-agg path produced any
+        # divergence we'd see it here.
+        assert len(raw.results) == len(preagg.results)
+        for raw_row, preagg_row in zip(raw.results, preagg.results):
+            assert raw_row.date == preagg_row.date
+            assert len(raw_row.values) == len(preagg_row.values)
+            for raw_bucket, preagg_bucket in zip(raw_row.values, preagg_row.values):
+                assert raw_bucket.count == preagg_bucket.count, (
+                    f"Bucket count mismatch at date {raw_row.date}: raw={raw_bucket.count} preagg={preagg_bucket.count}"
+                )
+
+    def test_pre_agg_matches_raw_events_first_time_same_entity(self) -> None:
+        self._seed_basic_retention()
+        query_kwargs = {
+            "dateRange": {"date_from": "2026-01-01T00:00:00Z", "date_to": "2026-01-04T00:00:00Z"},
+            "retentionFilter": {
+                "retentionType": "retention_first_time",
+                "period": "Day",
+                "totalIntervals": 3,
+                "targetEntity": {"id": "$pageview", "type": "events"},
+                "returningEntity": {"id": "$pageview", "type": "events"},
+            },
+        }
+
+        raw_runner = RetentionQueryRunner(
+            query=RetentionQuery(**query_kwargs),
+            team=self.team,
+            modifiers=HogQLQueryModifiers(useRetentionPreAggregation=None),
+        )
+        preagg_runner = RetentionQueryRunner(
+            query=RetentionQuery(**query_kwargs),
+            team=self.team,
+            modifiers=HogQLQueryModifiers(useRetentionPreAggregation=True),
+        )
+
+        raw = raw_runner.calculate()
+        preagg = preagg_runner.calculate()
+
+        assert len(raw.results) == len(preagg.results)
+        for raw_row, preagg_row in zip(raw.results, preagg.results):
+            assert raw_row.date == preagg_row.date
+            for raw_bucket, preagg_bucket in zip(raw_row.values, preagg_row.values):
+                assert raw_bucket.count == preagg_bucket.count
+
+    def test_falls_through_to_raw_when_materialisation_returns_no_jobs(self) -> None:
+        # When the gate is satisfied but the time range somehow can't be materialised
+        # (no events in the window), ensure the query still returns — falling through
+        # to raw events rather than crashing.
+        # No events seeded here. The query window has nothing to materialise.
+        result = self._run_retention(use_preagg=True)
+        # Empty results are fine — the important thing is the query ran without error.
+        assert result.results is not None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7456,6 +7456,16 @@ class HogQLQueryModifiers(BaseModel):
         default=None,
         description=("Try to automatically convert HogQL queries to use preaggregated tables at the AST level *"),
     )
+    useRetentionPreAggregation: bool | None = Field(
+        default=None,
+        description=(
+            "Route retention queries through the `retention_actor_event_day`"
+            " pre-aggregation when the v1 gate accepts them (recurring or"
+            " first-occurrence-matching-filters, person retention, no entity property"
+            " filter, no property aggregation). Default off; falls back to raw events"
+            " for any query the gate rejects or when materialisation fails."
+        ),
+    )
     useWebAnalyticsPreAggregatedTables: bool | None = None
 
 

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -450,6 +450,8 @@ export interface HogQLQueryModifiersApi {
     usePreaggregatedIntermediateResults?: boolean | null
     /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
     usePreaggregatedTableTransforms?: boolean | null
+    /** Route retention queries through the `retention_actor_event_day` pre-aggregation when the v1 gate accepts them (recurring or first-occurrence-matching-filters, person retention, no entity property filter, no property aggregation). Default off; falls back to raw events for any query the gate rejects or when materialisation fails. */
+    useRetentionPreAggregation?: boolean | null
     useWebAnalyticsPreAggregatedTables?: boolean | null
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1599,6 +1599,8 @@ export namespace Schemas {
       usePreaggregatedIntermediateResults?: boolean | null;
       /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
       usePreaggregatedTableTransforms?: boolean | null;
+      /** Route retention queries through the `retention_actor_event_day` pre-aggregation when the v1 gate accepts them (recurring or first-occurrence-matching-filters, person retention, no entity property filter, no property aggregation). Default off; falls back to raw events for any query the gate rejects or when materialisation fails. */
+      useRetentionPreAggregation?: boolean | null;
       useWebAnalyticsPreAggregatedTables?: boolean | null;
     }
 


### PR DESCRIPTION
## Problem

M1 + M2 (foundation in #60410) shipped the `retention_actor_event_day` table and materialisation pipeline but no read path — the runner still uses raw events for every query. This PR wires the runner to actually use the pre-agg when a query is shaped to benefit from it.

## Changes

### v1 routing gate on the runner

New cached property `RetentionQueryRunner.should_use_retention_preagg` checks:

- `useRetentionPreAggregation` modifier is `True` (default off, so this PR ships dark)
- `retentionType` is `RECURRING` or `RETENTION_FIRST_TIME` (NOT `FIRST_EVER` — needs all-time lookback)
- `group_type_index is None` (v1 materialises person retention only)
- No property aggregation (pre-agg doesn't store event properties)
- `minimum_occurrences == 1` (different aggregate shape for >1)
- No entity-property filters on targetEntity / returningEntity
- No query-level event-property filters
- Both entities are raw `EntityType.EVENTS` (not actions, not DWH)
- Not a 24h-window or custom-bracket query

When the gate is satisfied, `_base_query()` calls `ensure_retention_precomputed` and dispatches to the new pre-agg builder. When it fails or materialisation returns no jobs, the runner falls through to today's raw events path — pre-agg is a hint, not a contract.

### Pre-agg base query builder

New file `retention_base_query_preagg.py` with `build_preagg_base_query(builder, job_ids)`. Emits a `SelectQuery` in the same shape `build_base_query_legacy` produces (same `actor_id`, `start_event_timestamps`, `return_event_timestamps`, `start_interval_index`, `intervals_from_base` columns), just reading from `retention_actor_event_day` instead of `events`.

The downstream array math (`_is_valid_start_interval_expr`, `_get_intervals_from_base_exprs`, `_date_range_alias`) operates on internal aliases (`_start_event_timestamps`, `date_range`) rather than `events.*` directly, so it's reused verbatim from the legacy builder. Only the inner-most aggregation changes — reading over pre-agg rows instead of raw events.

The first-occurrence anchor expression is reimplemented inline because the legacy `get_first_time_anchor_expr` references `events.timestamp`. The pre-agg version uses `minIf(first_ts, event = start_entity)`.

### HogQL database registration

`RetentionActorEventDayTable` in `posthog/hogql/database/schema/`, registered as a root-level table in `database.py` so HogQL can resolve unqualified `retention_actor_event_day` references.

### Modifier

`useRetentionPreAggregation?: boolean` in `HogQLQueryModifiers`. Default off.

## How did you test this code?

I'm an agent. Listing what I actually ran locally:

- 11 tests in `test_retention_preagg_read_path.py`, all passing:
  - **8 routing gate tests**: default-off behaviour, recurring same-entity (eligible), first-time different-entity (eligible), and 5 parameterized rejection cases (first-ever, property aggregation, 24h windows, entity-property filter, query-property filter)
  - **3 correctness tests**: pre-agg vs raw events on shared synthetic data, asserting byte-identical retention bucket counts. Covers recurring same-entity, first-time same-entity, and the empty-window fall-through case
- Full retention test suite (`test_retention_query_runner.py` + my new file + `test_retention_lazy_precompute.py`): **132 passing, 12 failing** — the 12 failures match the pre-existing master-baseline set, verified by `git stash` + rerun. **Zero new failures introduced by this PR.**
- `ruff check` and `ruff format` pass
- Pre-commit hooks (`lint:python:fix`, `format:python`, `uv run ty check`) all clean

## Publish to changelog?

no

## 🤖 Agent context

Stacked on top of #60410 (M1 + M2). Co-authored with Claude Opus 4.7 (1M context). Implementation plan: `.planning/retention-preagg-implementation-plan.md`. This PR is M3 of that plan.

Things worth flagging for review:

- **Why no shadow mode in this PR.** I want shadow mode (run both paths, log divergences) before any team's traffic actually consumes the pre-agg result — and the modifier defaults to off so nothing routes through yet, giving us time to ship shadow mode as a follow-up. Splitting it out keeps both PRs reviewable. Shadow mode arrives in the next PR before M4 (flag wiring).
- **Why fall-through on materialisation failure.** `ensure_retention_precomputed` can return `ready=False` with errors (CH unavailable, query parse failure, etc.). The runner falls through to raw events in that case rather than surfacing an error — pre-agg is an optimisation, not a contract, and the raw path is always correct.
- **Why `start_interval_index_filter` and `selected_breakdown_value` fall through.** These are HAVING-clause post-filters used by the actor-drill-down path. For v1 I don't reproduce them on the pre-agg side; if a caller passes them, we fall through. The drill-down path can be added in a follow-up; for now the gate naturally excludes it.
- **Why register at root level, not under `posthog.*`.** Some pre-agg tables in `database.py` are at root, others under `posthog.*`. I put `retention_actor_event_day` at root so the builder can reference it as `retention_actor_event_day` directly (matching how `preaggregation_results` and the experiment pre-aggs are registered).
- **First-occurrence anchor inlined, not delegated.** The legacy `get_first_time_anchor_expr` builds `minIf(events.timestamp, …)` and there's no clean way to pass a different timestamp source. Inlining the equivalent expression for `first_ts` was simpler than refactoring the helper to take a source field. Worth revisiting if we need it in more places.

Follow-up PRs (still in plan):

- **M3b** — shadow mode + divergence logging
- **M4** — per-team feature flag wiring (turn this team's modifier on automatically based on rollout list)
- **M5** — backfill command
- **M6** — monitoring
- **M7** — first-team rollout
