### PR TITLE
fix(navigation): align icons consistently in collapsed sidebar

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/Nav.stories.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.stories.tsx
@@ -1,0 +1,62 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { useActions } from 'kea'
+
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { App } from 'scenes/App'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import { panelLayoutLogic } from '../panelLayoutLogic'
+
+const meta: Meta<typeof App> = {
+    component: App,
+    title: 'Scenes-App/Navigation',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2025-10-10',
+        pageUrl: urls.dashboards(),
+        testOptions: {
+            includeNavigationInSnapshot: true,
+            viewportWidths: ['narrow', 'medium', 'wide'],
+        },
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/dashboard_templates/': {},
+                '/api/projects/:id/integrations': { results: [] },
+                '/api/organizations/:organization_id/pipeline_destinations/': { results: [] },
+                '/api/projects/:id/pipeline_destination_configs/': { results: [] },
+                '/api/projects/:id/batch_exports/': { results: [] },
+                '/api/projects/:id/surveys/': { results: [] },
+                '/api/projects/:id/surveys/responses_count/': { results: [] },
+                '/api/environments/:team_id/exports/': { results: [] },
+                '/api/environments/:team_id/events': { results: [] },
+            },
+            post: {
+                '/api/environments/:team_id/query/:kind': {},
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj<typeof App>
+
+export const Expanded: Story = {
+    render: () => {
+        const { toggleLayoutNavCollapsed } = useActions(panelLayoutLogic)
+        useOnMountEffect(() => toggleLayoutNavCollapsed(false))
+        return <App />
+    },
+}
+
+export const Collapsed: Story = {
+    render: () => {
+        const { toggleLayoutNavCollapsed } = useActions(panelLayoutLogic)
+        useOnMountEffect(() => toggleLayoutNavCollapsed(true))
+        return <App />
+    },
+}

--- a/frontend/src/layout/panel-layout/ai-first/Nav.stories.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.stories.tsx
@@ -1,13 +1,26 @@
-import { Meta, StoryObj } from '@storybook/react'
-import { useActions } from 'kea'
+import { Decorator, Meta, StoryObj } from '@storybook/react'
 
-import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
 import { mswDecorator } from '~/mocks/browser'
 
-import { panelLayoutLogic } from '../panelLayoutLogic'
+import {
+    errorTrackingEventsQueryResponse,
+    errorTrackingQueryResponse,
+    errorTrackingTypeIssue,
+} from 'products/error_tracking/frontend/__mocks__/error_tracking_query'
+
+// Seeding the persisted value before <App /> mounts lets panelLayoutLogic initialise in the
+// desired state without mounting the logic early in a decorator, which would hijack routing.
+const NAV_COLLAPSED_STORAGE_KEY = 'layout.panel-layout.panelLayoutLogic.isLayoutNavCollapsedDesktop'
+
+const withNavCollapsed = (collapsed: boolean): Decorator => {
+    return function WithNavCollapsed(Story) {
+        window.localStorage.setItem(NAV_COLLAPSED_STORAGE_KEY, JSON.stringify(collapsed))
+        return <Story />
+    }
+}
 
 const meta: Meta<typeof App> = {
     component: App,
@@ -15,28 +28,25 @@ const meta: Meta<typeof App> = {
     parameters: {
         layout: 'fullscreen',
         viewMode: 'story',
-        mockDate: '2025-10-10',
-        pageUrl: urls.dashboards(),
+        mockDate: '2024-07-09',
+        pageUrl: urls.errorTracking(),
         testOptions: {
             includeNavigationInSnapshot: true,
-            viewportWidths: ['narrow', 'medium', 'wide'],
+            viewportWidths: ['wide'],
         },
     },
     decorators: [
         mswDecorator({
             get: {
-                '/api/projects/:team_id/dashboard_templates/': {},
-                '/api/projects/:id/integrations': { results: [] },
-                '/api/organizations/:organization_id/pipeline_destinations/': { results: [] },
-                '/api/projects/:id/pipeline_destination_configs/': { results: [] },
-                '/api/projects/:id/batch_exports/': { results: [] },
-                '/api/projects/:id/surveys/': { results: [] },
-                '/api/projects/:id/surveys/responses_count/': { results: [] },
-                '/api/environments/:team_id/exports/': { results: [] },
-                '/api/environments/:team_id/events': { results: [] },
+                'api/projects/:team_id/error_tracking/issue/:id': async (_, res, ctx) => {
+                    return res(ctx.json(errorTrackingTypeIssue))
+                },
             },
             post: {
-                '/api/environments/:team_id/query/:kind': {},
+                '/api/environments/:team_id/query/ErrorTrackingQuery': async (_, res, ctx) =>
+                    res(ctx.json(errorTrackingQueryResponse)),
+                '/api/environments/:team_id/query/EventsQuery': async (_, res, ctx) =>
+                    res(ctx.json(errorTrackingEventsQueryResponse)),
             },
         }),
     ],
@@ -46,17 +56,9 @@ export default meta
 type Story = StoryObj<typeof App>
 
 export const Expanded: Story = {
-    render: () => {
-        const { toggleLayoutNavCollapsed } = useActions(panelLayoutLogic)
-        useOnMountEffect(() => toggleLayoutNavCollapsed(false))
-        return <App />
-    },
+    decorators: [withNavCollapsed(false)],
 }
 
 export const Collapsed: Story = {
-    render: () => {
-        const { toggleLayoutNavCollapsed } = useActions(panelLayoutLogic)
-        useOnMountEffect(() => toggleLayoutNavCollapsed(true))
-        return <App />
-    },
+    decorators: [withNavCollapsed(true)],
 }

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -141,8 +141,9 @@ export function Nav(): JSX.Element {
                     )}
                 >
                     <div
-                        className={cn('flex gap-1 rounded-md w-full px-2 pt-2 pb-1', {
-                            'flex-col items-center pt-2 pb-0': isLayoutNavCollapsed,
+                        className={cn('flex rounded-md w-full px-2 pt-2 pb-1', {
+                            'gap-1': !isLayoutNavCollapsed,
+                            'flex-col items-center gap-px pt-2 pb-0': isLayoutNavCollapsed,
                         })}
                     >
                         <NewAccountMenu isLayoutNavCollapsed={isLayoutNavCollapsed} />
@@ -166,7 +167,7 @@ export function Nav(): JSX.Element {
 
                         {isLayoutNavCollapsed && (
                             <ButtonPrimitive
-                                className="group w-full justify-center"
+                                className="group"
                                 data-attr="nav-tab-chat-collapsed"
                                 iconOnly
                                 tooltip="Chat"

--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -81,8 +81,8 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                         <ButtonPrimitive
                             {...props}
                             iconOnly={isLayoutNavCollapsed}
-                            className={cn('relative flex-1 py-1 min-w-0 group', {
-                                'pl-[3px] gap-[6px]': !isLayoutNavCollapsed,
+                            className={cn('relative py-1 min-w-0 group', {
+                                'flex-1 pl-[3px] gap-[6px]': !isLayoutNavCollapsed,
                             })}
                             data-attr="new-account-menu-button"
                             tooltip={


### PR DESCRIPTION
## Problem

When the left navigation collapses (icon-only mode, triggered by dragging the resizer below 100px or via the keyboard shortcut), the icons in the header stack don't line up cleanly with the navigation items below them. From a Slack report: *"i like that the sidebar collapses when window narrow - but it's a little [picasso] that it's not aligned"*.

Three concrete causes in `Nav.tsx` / `NewAccountMenu.tsx` when `isLayoutNavCollapsed` is true:

1. The header inner div uses `gap-1` (4px) between the account / search / chat icons, while every other vertical section of the nav uses `gap-px` (1px). This creates a visible jump in vertical rhythm right where the header meets the rest of the nav.
2. The chat button (only rendered in collapsed mode) had `w-full justify-center` on top of `iconOnly`. That made it 29px wide while the surrounding `iconOnly` Account / Search buttons stayed at 30px square — so its hover/active background didn't line up with the others.
3. The account-menu trigger kept `flex-1` even when the parent was `flex-col`. In a column flex, `flex-1` means *grow on the cross axis* (vertically), which can stretch the button out of its expected square shape next to fixed-size siblings.

## Changes

- `Nav.tsx`: gate `gap-1` to the expanded layout and apply `gap-px` when collapsed, so the header icons share the same 1px rhythm as the rest of the column.
- `Nav.tsx`: drop `w-full justify-center` from the collapsed-only chat button — `iconOnly` already centers the icon and gives the button the same 30px square as its siblings.
- `NewAccountMenu.tsx`: only apply `flex-1` in the expanded layout, where it correctly fills horizontal space next to the search icon. In the collapsed (column-flex) layout the class is dropped, so the trigger keeps its square shape.

No behavior outside the collapsed sidebar changes — the expanded layout still uses `gap-1`, the account trigger still uses `flex-1` to fill the header row, and the chat button still toggles the chat panel.

## How did you test this code?

I'm an agent. I made the change based on reading the components and tracing the Tailwind class interactions; I did not start the dev server or load the UI manually. Worth a human pass in the browser to confirm the icons line up at every theme / org-logo state.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Tool used: PostHog Code (Claude).

What I traced before changing anything:

- Walked the JSX of `Nav.tsx`, `NavBarFooter.tsx`, `NavTabBrowse.tsx`, `NewAccountMenu.tsx`, and `ButtonPrimitives.{tsx,scss}` to understand how each icon ends up positioned in the 45px collapsed nav (`--project-navbar-width-collapsed`).
- Computed the resulting horizontal positions: the 30px `iconOnly` buttons sit centered at nav-x 22.5px across every section, so the underlying horizontal alignment is fine — the visual issue lives in *spacing* (gap) and *button width* mismatches in the header stack itself, not in cross-section column alignment.
- Considered also nudging the `NewAccountMenu` `UploadedLogo` from `size="small"` (20px) down to `size="xsmall"` (16px) in collapsed mode so it matches the search / chat icon sizes. Rejected for now: the slightly larger org logo seems intentional as a brand marker, and changing it would also affect the expanded layout, which is out of scope for this fix.

Did NOT touch:
- the resize / auto-collapse logic (\`panelLayoutLogic\`, the \`Resizer\` \`closeThreshold\`).
- the mobile (<992px) overlay behavior.
- \`NavBarFooter\` — its \`items-start\` outer wrapper looked suspicious but every inner column already uses \`items-center w-full\`, so the start alignment has no observable effect in the collapsed state.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*