### PR TITLE
fix(integrations): don't trigger slack channel search on input focus

### DIFF
--- a/frontend/src/lib/integrations/SlackChannelPicker.test.tsx
+++ b/frontend/src/lib/integrations/SlackChannelPicker.test.tsx
@@ -105,9 +105,11 @@ describe('SlackChannelPicker', () => {
         const input = container.querySelector<HTMLInputElement>('input[data-attr="select-slack-channel"]')!
         await userEvent.click(input)
 
-        // Give kea-loaders' debounce (300ms breakpoint on non-empty search) a chance to fire if
-        // the guard were missing — still expect only the initial empty-search call.
-        await new Promise((resolve) => setTimeout(resolve, 400))
+        // Give kea-loaders' debounce (300ms breakpoint on non-empty search) plus the fetch round-trip
+        // a generous buffer to fire if the guard were missing. We deliberately wait well past the
+        // breakpoint window so a slow CI runner can't produce a false negative by observing
+        // `['']` before the unwanted request lands.
+        await new Promise((resolve) => setTimeout(resolve, 1000))
         expect(channelsRequestSearchQueries).toEqual([''])
     })
 
@@ -128,11 +130,13 @@ describe('SlackChannelPicker', () => {
         await userEvent.type(input, 'general')
 
         // The typed text differs from any currently displayed key, so the server-side search fires.
+        // Timeout is generous: userEvent.type sims each keystroke, intermediate calls are cancelled
+        // by the breakpoint, and the final search waits 300ms before fetching — well within 5s.
         await waitFor(
             () => {
                 expect(channelsRequestSearchQueries).toContain('general')
             },
-            { timeout: 1500 }
+            { timeout: 5000 }
         )
     })
 })

--- a/frontend/src/lib/integrations/SlackChannelPicker.test.tsx
+++ b/frontend/src/lib/integrations/SlackChannelPicker.test.tsx
@@ -1,0 +1,138 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { IntegrationType } from '~/types'
+
+import { SlackChannelPicker } from './SlackIntegrationHelpers'
+
+const INTEGRATION: IntegrationType = {
+    id: 1,
+    kind: 'slack',
+    display_name: 'Fake Workspace',
+    icon_url: '',
+    config: {},
+    created_by: null,
+    created_at: '2026-01-01T00:00:00Z',
+}
+
+const CHANNELS = [
+    {
+        id: 'C0B6HUH9FUH',
+        name: 'test-slack-notifications',
+        is_private: false,
+        is_member: true,
+        is_ext_shared: false,
+        is_private_without_access: false,
+    },
+    {
+        id: 'C111111111',
+        name: 'general',
+        is_private: false,
+        is_member: true,
+        is_ext_shared: false,
+        is_private_without_access: false,
+    },
+]
+
+describe('SlackChannelPicker', () => {
+    let channelsRequestSearchQueries: (string | null)[] = []
+
+    beforeEach(() => {
+        channelsRequestSearchQueries = []
+        useMocks({
+            get: {
+                '/api/environments/:team_id/integrations/:id/channels': (req: any) => {
+                    const search = req.url.searchParams.get('search')
+                    const channelId = req.url.searchParams.get('channel_id')
+                    if (channelId) {
+                        const match = CHANNELS.find((c) => c.id === channelId)
+                        return [200, { channels: match ? [match] : [] }]
+                    }
+                    channelsRequestSearchQueries.push(search)
+                    // Server-side search: substring match in name or id (mirrors the backend).
+                    const filtered = search
+                        ? CHANNELS.filter(
+                              (c) =>
+                                  c.name.toLowerCase().includes(search.toLowerCase()) ||
+                                  c.id.toLowerCase().includes(search.toLowerCase())
+                          )
+                        : CHANNELS
+                    return [
+                        200,
+                        {
+                            channels: filtered,
+                            lastRefreshedAt: '2026-01-01T00:00:00Z',
+                            has_more: false,
+                        },
+                    ]
+                },
+            },
+        })
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('does not search for the composite key when the input is focused with an existing value', async () => {
+        // The saved value is the composite "id|#name" — what the picker stores after a user selection.
+        const { container } = render(
+            <Provider>
+                <SlackChannelPicker
+                    integration={INTEGRATION}
+                    value="C0B6HUH9FUH|#test-slack-notifications"
+                    onChange={jest.fn()}
+                />
+            </Provider>
+        )
+
+        // Initial useEffect-driven load — single GET /channels with empty search.
+        await waitFor(() => {
+            expect(channelsRequestSearchQueries).toEqual([''])
+        })
+
+        // Focus the picker. LemonInputSelect._onFocus auto-fills the input with the selected
+        // option's composite key, which lands in onInputChange. Before the fix this would have
+        // triggered a second GET /channels?search=C0B6HUH9FUH|#test-slack-notifications, returning
+        // zero matches and wiping the cached channel list. After the fix, no extra request fires
+        // because the val equals the currently displayed key.
+        const input = container.querySelector<HTMLInputElement>('input[data-attr="select-slack-channel"]')!
+        await userEvent.click(input)
+
+        // Give kea-loaders' debounce (300ms breakpoint on non-empty search) a chance to fire if
+        // the guard were missing — still expect only the initial empty-search call.
+        await new Promise((resolve) => setTimeout(resolve, 400))
+        expect(channelsRequestSearchQueries).toEqual([''])
+    })
+
+    it('still searches when the user actually types a different value', async () => {
+        // Render without an initial value so the input starts empty and typing isn't appended
+        // to LemonInputSelect's auto-fill of an existing selection.
+        const { container } = render(
+            <Provider>
+                <SlackChannelPicker integration={INTEGRATION} onChange={jest.fn()} />
+            </Provider>
+        )
+        await waitFor(() => {
+            expect(channelsRequestSearchQueries).toEqual([''])
+        })
+
+        const input = container.querySelector<HTMLInputElement>('input[data-attr="select-slack-channel"]')!
+        await userEvent.click(input)
+        await userEvent.type(input, 'general')
+
+        // The typed text differs from any currently displayed key, so the server-side search fires.
+        await waitFor(
+            () => {
+                expect(channelsRequestSearchQueries).toContain('general')
+            },
+            { timeout: 1500 }
+        )
+    })
+})

--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -139,7 +139,12 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
                         const idCandidate = val.trim().toUpperCase()
                         if (SLACK_CHANNEL_ID_PATTERN.test(idCandidate)) {
                             loadSlackChannelById(idCandidate)
-                        } else {
+                        } else if (val !== modifiedValue) {
+                            // LemonInputSelect auto-fills the input with the selected option's key on
+                            // focus (see LemonInputSelect._onFocus). Don't treat that auto-fill as a
+                            // search — the composite "id|#name" matches no channel server-side and
+                            // would overwrite the cached list with [], so the bare ID could no longer
+                            // resolve to a name after blur.
                             loadAllSlackChannels(false, val)
                         }
                         setLocalValue(val)


### PR DESCRIPTION
## Problem

Follow-up regression from #60267. When a destination's Slack channel picker is opened with a value already set and the user clicks into the input, the picker can lose name resolution after blur — only the bare channel ID ends up displayed.

The cause is in `SlackChannelPicker.onInputChange`. `LemonInputSelect._onFocus` (see `frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx:529-533`) auto-fills the input with the selected option's key (`"C0B6HUH9FUH|#test-slack-notifications"`) when single-mode is focused with a value set, which fires `onInputChange(compositeKey)`. After #60267 that path falls through to `loadAllSlackChannels(false, compositeKey)`, sending the composite string as a search query. The backend returns no matches for it, the loader overwrites the cached channel list with `[]`, and after blur the bare ID can no longer resolve to a `#name (ID)` label.

A related fix already on master routes ID-shaped input (`/^[CGD][A-Z0-9]{8,}$/`) to a direct lookup, but the composite key with `|#` falls through to the search branch and still wipes the cache.

## Changes

`frontend/src/lib/integrations/SlackIntegrationHelpers.tsx`: in `onInputChange`, skip the server-side search when `val` matches the currently displayed `modifiedValue`. Real user typing produces a different `val` and still triggers a fetch, so search behavior is preserved.

## How did you test this code?

Agent-authored — no manual browser testing. The existing `slackIntegrationLogic.test.ts` suite (6 tests including the search-then-clear regression test) still passes. The fix lives in the component's `onInputChange`, which isn't covered by a component-level test today; happy to add one if you want, but I'd want to set up the picker test harness as its own follow-up.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (claude-opus-4-7) after the user reported the regression on the merged PR with screenshots showing the bare-ID display state after click-in/click-away. The fix combines the master-side ID-pattern routing with the new `val !== modifiedValue` guard, so:
- ID-shape input → direct lookup only (unchanged)
- Free-text typing where `val !== modifiedValue` → search (preserved)
- Focus-time auto-fill where `val === modifiedValue` → no-op (the new guard)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM6UMp2xeAUrLXxAi84xL7)_