### PR TITLE
fix(integrations): warn instead of silently substituting stale integration refs

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { IconExternal, IconTrash, IconX } from '@posthog/icons'
-import { LemonButton, LemonMenu, LemonSkeleton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonMenu, LemonSkeleton } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
@@ -40,18 +40,17 @@ export function IntegrationChoice({
     const integrationsOfKind = integrations?.filter((x) => x.kind === kind)
     const integrationKind = integrationsOfKind?.find((integration) => integration.id === value)
 
+    // The stored value points to an integration that's no longer available (deleted, or
+    // re-installed under a new ID). We deliberately do NOT auto-substitute here — that
+    // would silently mask the missing reference and let stale config keep flowing through
+    // saves. The UI surfaces a warning below instead so the user picks explicitly.
+    const valueIsMissing = !integrationsLoading && !!value && !!integrations && !integrationKind
+
     useEffect(() => {
         if (!integrationsLoading && !value && integrationsOfKind?.length) {
             onChange?.(integrationsOfKind[0].id)
         }
     }, [integrationsLoading, onChange, integrationsOfKind?.length, value, integrationsOfKind])
-
-    // Clear stale selection when the integration no longer exists (e.g. after disconnect)
-    useEffect(() => {
-        if (!integrationsLoading && value && integrations && !integrationKind) {
-            onChange?.(null)
-        }
-    }, [integrationsLoading, value, integrations, integrationKind, onChange])
 
     if (!kind) {
         return null
@@ -172,6 +171,15 @@ export function IntegrationChoice({
         <>
             {integrationKind ? (
                 <IntegrationView schema={schema} integration={integrationKind} suffix={button} />
+            ) : valueIsMissing ? (
+                <div className="flex flex-col gap-2">
+                    <LemonBanner type="warning">
+                        The previously selected {kindName} connection (ID: {value}) is no longer available. Pick a
+                        different connection or clear the selection — this step will fail when the workflow runs
+                        otherwise.
+                    </LemonBanner>
+                    {button}
+                </div>
             ) : (
                 button
             )}

--- a/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
@@ -175,8 +175,7 @@ export function IntegrationChoice({
                 <div className="flex flex-col gap-2">
                     <LemonBanner type="warning">
                         The previously selected {kindName} connection (ID: {value}) is no longer available. Pick a
-                        different connection or clear the selection — this connection will fail at runtime
-                        otherwise.
+                        different connection or clear the selection — this connection will fail at runtime otherwise.
                     </LemonBanner>
                     {button}
                 </div>

--- a/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
@@ -175,7 +175,7 @@ export function IntegrationChoice({
                 <div className="flex flex-col gap-2">
                     <LemonBanner type="warning">
                         The previously selected {kindName} connection (ID: {value}) is no longer available. Pick a
-                        different connection or clear the selection — this step will fail when the workflow runs
+                        different connection or clear the selection — this connection will fail at runtime
                         otherwise.
                     </LemonBanner>
                     {button}

--- a/posthog/management/commands/backfill_workflows_slack_integration.py
+++ b/posthog/management/commands/backfill_workflows_slack_integration.py
@@ -1,0 +1,170 @@
+import copy
+import time
+import logging
+from typing import Any
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from posthog.models.hog_flow.hog_flow import HogFlow
+
+logger = logging.getLogger(__name__)
+
+
+# Defaults chosen for the one-off migration on team 2:
+# The Slack integration was re-installed under a new primary key (173069). 40 hogflows
+# still reference the old integration row (54567), which no longer exists, so their
+# Slack steps fail at runtime. The UI auto-substitutes on render but never writes the
+# new id back to the stored config until the user saves.
+DEFAULT_TEAM_ID = 2
+DEFAULT_OLD_INTEGRATION_ID = 54567
+DEFAULT_NEW_INTEGRATION_ID = 173069
+
+
+def _rewrite_slack_workspace_in_actions(
+    actions: Any,
+    old_id: int,
+    new_id: int,
+) -> tuple[Any, list[str]]:
+    """Return (new_actions, changed_action_ids). actions is left untouched if no match.
+
+    Looks for `config.inputs.slack_workspace.value == old_id` on any action and rewrites
+    it to new_id. The integration id is stored as a literal integer (no bytecode), so
+    only the `value` needs swapping.
+    """
+    if not isinstance(actions, list):
+        return actions, []
+
+    changed_ids: list[str] = []
+    new_actions = copy.deepcopy(actions)
+
+    for action in new_actions:
+        if not isinstance(action, dict):
+            continue
+        inputs = (action.get("config") or {}).get("inputs") or {}
+        slack_workspace = inputs.get("slack_workspace")
+        if not isinstance(slack_workspace, dict):
+            continue
+        if slack_workspace.get("value") == old_id:
+            slack_workspace["value"] = new_id
+            changed_ids.append(str(action.get("id") or "<unknown>"))
+
+    return new_actions, changed_ids
+
+
+class Command(BaseCommand):
+    help = (
+        "Rewrite stale Slack integration references in HogFlow actions. "
+        "Defaults target team 2 and the 54567 → 173069 swap; pass overrides for other one-offs."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            default=DEFAULT_TEAM_ID,
+            help=f"Team ID to scope the rewrite to (default: {DEFAULT_TEAM_ID})",
+        )
+        parser.add_argument(
+            "--old-integration-id",
+            type=int,
+            default=DEFAULT_OLD_INTEGRATION_ID,
+            help=f"Integration id to replace (default: {DEFAULT_OLD_INTEGRATION_ID})",
+        )
+        parser.add_argument(
+            "--new-integration-id",
+            type=int,
+            default=DEFAULT_NEW_INTEGRATION_ID,
+            help=f"Integration id to write in its place (default: {DEFAULT_NEW_INTEGRATION_ID})",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Run without making any changes to the database",
+        )
+
+    def handle(self, *args, **options):
+        start_time = time.time()
+        team_id: int = options["team_id"]
+        old_id: int = options["old_integration_id"]
+        new_id: int = options["new_integration_id"]
+        dry_run: bool = options["dry_run"]
+
+        if old_id == new_id:
+            self.stdout.write(self.style.ERROR("--old-integration-id and --new-integration-id must differ"))
+            return
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Running in DRY RUN mode — no changes will be made"))
+
+        self.stdout.write(f"Scanning HogFlows for team {team_id}, swapping slack_workspace {old_id} → {new_id}...")
+
+        # Team 2 has on the order of a few hundred hogflows. Pull them all in one go;
+        # no pagination required at this scale, and a single transaction keeps the
+        # write atomic for the team.
+        flows = list(HogFlow.objects.filter(team_id=team_id).order_by("id"))
+        total_count = len(flows)
+        self.stdout.write(f"Found {total_count} HogFlows on team {team_id}")
+
+        if total_count == 0:
+            return
+
+        updated_flows: list[HogFlow] = []
+        per_flow_changes: list[tuple[str, list[str], list[str]]] = []
+        error_count = 0
+
+        for flow in flows:
+            try:
+                new_actions, actions_changed = _rewrite_slack_workspace_in_actions(flow.actions, old_id, new_id)
+                draft_actions_changed: list[str] = []
+                new_draft = flow.draft
+                if isinstance(flow.draft, dict) and "actions" in flow.draft:
+                    rewritten_draft_actions, draft_actions_changed = _rewrite_slack_workspace_in_actions(
+                        flow.draft.get("actions"), old_id, new_id
+                    )
+                    if draft_actions_changed:
+                        new_draft = {**flow.draft, "actions": rewritten_draft_actions}
+
+                if not actions_changed and not draft_actions_changed:
+                    continue
+
+                flow.actions = new_actions
+                flow.draft = new_draft
+                updated_flows.append(flow)
+                per_flow_changes.append((str(flow.id), actions_changed, draft_actions_changed))
+            except Exception as e:
+                error_count += 1
+                logger.exception(
+                    "Error processing HogFlow id=%s team_id=%s: %s",
+                    flow.id,
+                    flow.team_id,
+                    e,
+                )
+
+        # Report planned changes before writing.
+        for flow_id, actions_changed, draft_actions_changed in per_flow_changes:
+            self.stdout.write(
+                f"  {flow_id}: actions={actions_changed or '[]'} draft.actions={draft_actions_changed or '[]'}"
+            )
+
+        if updated_flows and not dry_run:
+            # bulk_update skips post_save, which means worker reloads won't happen
+            # automatically. That's fine for a one-off backfill — workers refresh their
+            # caches on their own ticking interval, and we'd rather not spam reload
+            # signals for every flow we touch.
+            with transaction.atomic():
+                HogFlow.objects.bulk_update(updated_flows, ["actions", "draft"], batch_size=200)
+
+        duration = time.time() - start_time
+        verb = "Would update" if dry_run else "Updated"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nDone in {duration:.2f}s.\n"
+                f"Scanned: {total_count}\n"
+                f"{verb}: {len(updated_flows)}\n"
+                f"Errors: {error_count}"
+            )
+        )
+
+        if error_count > 0:
+            self.stdout.write(self.style.WARNING(f"Check logs for details on {error_count} errors"))

--- a/posthog/management/commands/backfill_workflows_slack_integration.py
+++ b/posthog/management/commands/backfill_workflows_slack_integration.py
@@ -11,26 +11,22 @@ from posthog.models.hog_flow.hog_flow import HogFlow
 logger = logging.getLogger(__name__)
 
 
-# Defaults chosen for the one-off migration on team 2:
-# The Slack integration was re-installed under a new primary key (173069). 40 hogflows
-# still reference the old integration row (54567), which no longer exists, so their
-# Slack steps fail at runtime. The UI auto-substitutes on render but never writes the
-# new id back to the stored config until the user saves.
-DEFAULT_TEAM_ID = 2
-DEFAULT_OLD_INTEGRATION_ID = 54567
-DEFAULT_NEW_INTEGRATION_ID = 173069
+# One-off backfill for team 2: the Slack integration was re-installed under a new
+# primary key (173069). 40 hogflows still reference the old integration row (54567),
+# which no longer exists, so their Slack steps fail at runtime. The UI auto-substitutes
+# on render but never writes the new id back to the stored config until the user saves.
+# Hard-coded by intent — this is not a generic remapper, just the one swap we need.
+TEAM_ID = 2
+OLD_INTEGRATION_ID = 54567
+NEW_INTEGRATION_ID = 173069
 
 
-def _rewrite_slack_workspace_in_actions(
-    actions: Any,
-    old_id: int,
-    new_id: int,
-) -> tuple[Any, list[str]]:
+def _rewrite_slack_workspace_in_actions(actions: Any) -> tuple[Any, list[str]]:
     """Return (new_actions, changed_action_ids). actions is left untouched if no match.
 
-    Looks for `config.inputs.slack_workspace.value == old_id` on any action and rewrites
-    it to new_id. The integration id is stored as a literal integer (no bytecode), so
-    only the `value` needs swapping.
+    Looks for `config.inputs.slack_workspace.value == OLD_INTEGRATION_ID` on any action
+    and rewrites it to NEW_INTEGRATION_ID. The integration id is stored as a literal
+    integer (no bytecode), so only the `value` needs swapping.
     """
     if not isinstance(actions, list):
         return actions, []
@@ -45,8 +41,8 @@ def _rewrite_slack_workspace_in_actions(
         slack_workspace = inputs.get("slack_workspace")
         if not isinstance(slack_workspace, dict):
             continue
-        if slack_workspace.get("value") == old_id:
-            slack_workspace["value"] = new_id
+        if slack_workspace.get("value") == OLD_INTEGRATION_ID:
+            slack_workspace["value"] = NEW_INTEGRATION_ID
             changed_ids.append(str(action.get("id") or "<unknown>"))
 
     return new_actions, changed_ids
@@ -54,29 +50,11 @@ def _rewrite_slack_workspace_in_actions(
 
 class Command(BaseCommand):
     help = (
-        "Rewrite stale Slack integration references in HogFlow actions. "
-        "Defaults target team 2 and the 54567 → 173069 swap; pass overrides for other one-offs."
+        f"One-off: rewrite stale Slack integration {OLD_INTEGRATION_ID} → {NEW_INTEGRATION_ID} "
+        f"in HogFlow actions on team {TEAM_ID}."
     )
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--team-id",
-            type=int,
-            default=DEFAULT_TEAM_ID,
-            help=f"Team ID to scope the rewrite to (default: {DEFAULT_TEAM_ID})",
-        )
-        parser.add_argument(
-            "--old-integration-id",
-            type=int,
-            default=DEFAULT_OLD_INTEGRATION_ID,
-            help=f"Integration id to replace (default: {DEFAULT_OLD_INTEGRATION_ID})",
-        )
-        parser.add_argument(
-            "--new-integration-id",
-            type=int,
-            default=DEFAULT_NEW_INTEGRATION_ID,
-            help=f"Integration id to write in its place (default: {DEFAULT_NEW_INTEGRATION_ID})",
-        )
         parser.add_argument(
             "--dry-run",
             action="store_true",
@@ -85,26 +63,22 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         start_time = time.time()
-        team_id: int = options["team_id"]
-        old_id: int = options["old_integration_id"]
-        new_id: int = options["new_integration_id"]
         dry_run: bool = options["dry_run"]
-
-        if old_id == new_id:
-            self.stdout.write(self.style.ERROR("--old-integration-id and --new-integration-id must differ"))
-            return
 
         if dry_run:
             self.stdout.write(self.style.WARNING("Running in DRY RUN mode — no changes will be made"))
 
-        self.stdout.write(f"Scanning HogFlows for team {team_id}, swapping slack_workspace {old_id} → {new_id}...")
+        self.stdout.write(
+            f"Scanning HogFlows for team {TEAM_ID}, "
+            f"swapping slack_workspace {OLD_INTEGRATION_ID} → {NEW_INTEGRATION_ID}..."
+        )
 
         # Team 2 has on the order of a few hundred hogflows. Pull them all in one go;
         # no pagination required at this scale, and a single transaction keeps the
         # write atomic for the team.
-        flows = list(HogFlow.objects.filter(team_id=team_id).order_by("id"))
+        flows = list(HogFlow.objects.filter(team_id=TEAM_ID).order_by("id"))
         total_count = len(flows)
-        self.stdout.write(f"Found {total_count} HogFlows on team {team_id}")
+        self.stdout.write(f"Found {total_count} HogFlows on team {TEAM_ID}")
 
         if total_count == 0:
             return
@@ -115,12 +89,12 @@ class Command(BaseCommand):
 
         for flow in flows:
             try:
-                new_actions, actions_changed = _rewrite_slack_workspace_in_actions(flow.actions, old_id, new_id)
+                new_actions, actions_changed = _rewrite_slack_workspace_in_actions(flow.actions)
                 draft_actions_changed: list[str] = []
                 new_draft = flow.draft
                 if isinstance(flow.draft, dict) and "actions" in flow.draft:
                     rewritten_draft_actions, draft_actions_changed = _rewrite_slack_workspace_in_actions(
-                        flow.draft.get("actions"), old_id, new_id
+                        flow.draft.get("actions")
                     )
                     if draft_actions_changed:
                         new_draft = {**flow.draft, "actions": rewritten_draft_actions}

--- a/posthog/management/commands/test/test_backfill_workflows_slack_integration.py
+++ b/posthog/management/commands/test/test_backfill_workflows_slack_integration.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 
+from posthog.management.commands import backfill_workflows_slack_integration as backfill
 from posthog.management.commands.backfill_workflows_slack_integration import _rewrite_slack_workspace_in_actions
 from posthog.models import Team
 from posthog.models.hog_flow.hog_flow import HogFlow
@@ -27,52 +28,55 @@ def _slack_action(action_id: str, slack_workspace_value: int | None) -> dict:
 
 class TestRewriteSlackWorkspaceInActions(BaseTest):
     def test_rewrites_matching_value(self):
-        actions = [_slack_action("a1", 54567)]
-        new_actions, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        actions = [_slack_action("a1", backfill.OLD_INTEGRATION_ID)]
+        new_actions, changed = _rewrite_slack_workspace_in_actions(actions)
         assert changed == ["a1"]
-        assert new_actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 173069
+        assert new_actions[0]["config"]["inputs"]["slack_workspace"]["value"] == backfill.NEW_INTEGRATION_ID
 
     def test_does_not_touch_non_matching_value(self):
         actions = [_slack_action("a1", 99999)]
-        new_actions, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        new_actions, changed = _rewrite_slack_workspace_in_actions(actions)
         assert changed == []
         assert new_actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 99999
 
     def test_handles_missing_slack_workspace_input(self):
         actions = [_slack_action("a1", None)]
-        new_actions, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        new_actions, changed = _rewrite_slack_workspace_in_actions(actions)
         assert changed == []
         assert "slack_workspace" not in new_actions[0]["config"]["inputs"]
 
     def test_mixed_actions_only_changes_matches(self):
         actions = [
-            _slack_action("match", 54567),
+            _slack_action("match", backfill.OLD_INTEGRATION_ID),
             _slack_action("nope", 99999),
             {"id": "trigger", "type": "trigger", "config": {}},
             {"id": "exit", "type": "exit", "config": {"reason": "default"}},
         ]
-        new_actions, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        new_actions, changed = _rewrite_slack_workspace_in_actions(actions)
         assert changed == ["match"]
-        assert new_actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 173069
+        assert new_actions[0]["config"]["inputs"]["slack_workspace"]["value"] == backfill.NEW_INTEGRATION_ID
         assert new_actions[1]["config"]["inputs"]["slack_workspace"]["value"] == 99999
 
     def test_idempotent_when_already_migrated(self):
-        actions = [_slack_action("a1", 173069)]
-        _, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        actions = [_slack_action("a1", backfill.NEW_INTEGRATION_ID)]
+        _, changed = _rewrite_slack_workspace_in_actions(actions)
         assert changed == []
 
     def test_non_list_actions_returned_unchanged(self):
-        new_actions, changed = _rewrite_slack_workspace_in_actions(None, 54567, 173069)
+        new_actions, changed = _rewrite_slack_workspace_in_actions(None)
         assert new_actions is None
         assert changed == []
 
     def test_deepcopy_does_not_mutate_input(self):
-        actions = [_slack_action("a1", 54567)]
-        _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
-        assert actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 54567
+        actions = [_slack_action("a1", backfill.OLD_INTEGRATION_ID)]
+        _rewrite_slack_workspace_in_actions(actions)
+        assert actions[0]["config"]["inputs"]["slack_workspace"]["value"] == backfill.OLD_INTEGRATION_ID
 
 
 class TestBackfillWorkflowsSlackIntegrationCommand(BaseTest):
+    """Tests patch the TEAM_ID constant to point at the test team so we don't need to
+    construct a Team row with a specific primary key."""
+
     def setUp(self):
         super().setUp()
         self.other_team = Team.objects.create(organization=self.organization, name="Other team")
@@ -84,11 +88,11 @@ class TestBackfillWorkflowsSlackIntegrationCommand(BaseTest):
                 status=HogFlow.State.ACTIVE,
                 actions=[
                     {"id": "trigger", "type": "trigger", "config": {}},
-                    _slack_action("slack_step", 54567),
+                    _slack_action("slack_step", backfill.OLD_INTEGRATION_ID),
                 ],
                 draft={
                     "actions": [
-                        _slack_action("slack_step", 54567),
+                        _slack_action("slack_step", backfill.OLD_INTEGRATION_ID),
                     ]
                 },
                 version=1,
@@ -97,56 +101,54 @@ class TestBackfillWorkflowsSlackIntegrationCommand(BaseTest):
                 team=self.team,
                 name="Already migrated",
                 status=HogFlow.State.ACTIVE,
-                actions=[_slack_action("slack_step", 173069)],
+                actions=[_slack_action("slack_step", backfill.NEW_INTEGRATION_ID)],
                 version=1,
             )
             self.other_team_flow = HogFlow.objects.create(
                 team=self.other_team,
                 name="Other team flow",
                 status=HogFlow.State.ACTIVE,
-                actions=[_slack_action("slack_step", 54567)],
+                actions=[_slack_action("slack_step", backfill.OLD_INTEGRATION_ID)],
                 version=1,
             )
 
     def test_dry_run_does_not_modify_db(self):
-        call_command(
-            "backfill_workflows_slack_integration",
-            f"--team-id={self.team.id}",
-            "--old-integration-id=54567",
-            "--new-integration-id=173069",
-            "--dry-run",
-        )
+        with patch.object(backfill, "TEAM_ID", self.team.id):
+            call_command("backfill_workflows_slack_integration", "--dry-run")
 
         self.target_flow.refresh_from_db()
-        assert self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == 54567
-        assert self.target_flow.draft["actions"][0]["config"]["inputs"]["slack_workspace"]["value"] == 54567
+        assert (
+            self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == backfill.OLD_INTEGRATION_ID
+        )
+        assert (
+            self.target_flow.draft["actions"][0]["config"]["inputs"]["slack_workspace"]["value"]
+            == backfill.OLD_INTEGRATION_ID
+        )
 
     def test_rewrites_only_target_team(self):
-        with patch("posthog.models.hog_flow.hog_flow.reload_hog_flows_on_workers"):
-            call_command(
-                "backfill_workflows_slack_integration",
-                f"--team-id={self.team.id}",
-                "--old-integration-id=54567",
-                "--new-integration-id=173069",
-            )
+        with (
+            patch.object(backfill, "TEAM_ID", self.team.id),
+            patch("posthog.models.hog_flow.hog_flow.reload_hog_flows_on_workers"),
+        ):
+            call_command("backfill_workflows_slack_integration")
 
         self.target_flow.refresh_from_db()
         self.untouched_flow.refresh_from_db()
         self.other_team_flow.refresh_from_db()
 
-        assert self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == 173069
-        assert self.target_flow.draft["actions"][0]["config"]["inputs"]["slack_workspace"]["value"] == 173069
-        assert self.untouched_flow.actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 173069
-        # Other team must remain untouched even with the matching old id.
-        assert self.other_team_flow.actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 54567
-
-    def test_aborts_when_old_and_new_are_equal(self):
-        # Running with old == new should refuse rather than no-op silently.
-        call_command(
-            "backfill_workflows_slack_integration",
-            f"--team-id={self.team.id}",
-            "--old-integration-id=54567",
-            "--new-integration-id=54567",
+        assert (
+            self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == backfill.NEW_INTEGRATION_ID
         )
-        self.target_flow.refresh_from_db()
-        assert self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == 54567
+        assert (
+            self.target_flow.draft["actions"][0]["config"]["inputs"]["slack_workspace"]["value"]
+            == backfill.NEW_INTEGRATION_ID
+        )
+        assert (
+            self.untouched_flow.actions[0]["config"]["inputs"]["slack_workspace"]["value"]
+            == backfill.NEW_INTEGRATION_ID
+        )
+        # Other team must remain untouched even with the matching old id.
+        assert (
+            self.other_team_flow.actions[0]["config"]["inputs"]["slack_workspace"]["value"]
+            == backfill.OLD_INTEGRATION_ID
+        )

--- a/posthog/management/commands/test/test_backfill_workflows_slack_integration.py
+++ b/posthog/management/commands/test/test_backfill_workflows_slack_integration.py
@@ -1,0 +1,152 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.core.management import call_command
+
+from posthog.management.commands.backfill_workflows_slack_integration import _rewrite_slack_workspace_in_actions
+from posthog.models import Team
+from posthog.models.hog_flow.hog_flow import HogFlow
+
+
+def _slack_action(action_id: str, slack_workspace_value: int | None) -> dict:
+    inputs: dict = {
+        "channel": {"value": "C123"},
+    }
+    if slack_workspace_value is not None:
+        inputs["slack_workspace"] = {"order": 0, "value": slack_workspace_value, "templating": "hog"}
+    return {
+        "id": action_id,
+        "name": "Slack",
+        "type": "function",
+        "config": {
+            "template_id": "template-slack",
+            "inputs": inputs,
+        },
+    }
+
+
+class TestRewriteSlackWorkspaceInActions(BaseTest):
+    def test_rewrites_matching_value(self):
+        actions = [_slack_action("a1", 54567)]
+        new_actions, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        assert changed == ["a1"]
+        assert new_actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 173069
+
+    def test_does_not_touch_non_matching_value(self):
+        actions = [_slack_action("a1", 99999)]
+        new_actions, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        assert changed == []
+        assert new_actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 99999
+
+    def test_handles_missing_slack_workspace_input(self):
+        actions = [_slack_action("a1", None)]
+        new_actions, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        assert changed == []
+        assert "slack_workspace" not in new_actions[0]["config"]["inputs"]
+
+    def test_mixed_actions_only_changes_matches(self):
+        actions = [
+            _slack_action("match", 54567),
+            _slack_action("nope", 99999),
+            {"id": "trigger", "type": "trigger", "config": {}},
+            {"id": "exit", "type": "exit", "config": {"reason": "default"}},
+        ]
+        new_actions, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        assert changed == ["match"]
+        assert new_actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 173069
+        assert new_actions[1]["config"]["inputs"]["slack_workspace"]["value"] == 99999
+
+    def test_idempotent_when_already_migrated(self):
+        actions = [_slack_action("a1", 173069)]
+        _, changed = _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        assert changed == []
+
+    def test_non_list_actions_returned_unchanged(self):
+        new_actions, changed = _rewrite_slack_workspace_in_actions(None, 54567, 173069)
+        assert new_actions is None
+        assert changed == []
+
+    def test_deepcopy_does_not_mutate_input(self):
+        actions = [_slack_action("a1", 54567)]
+        _rewrite_slack_workspace_in_actions(actions, 54567, 173069)
+        assert actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 54567
+
+
+class TestBackfillWorkflowsSlackIntegrationCommand(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.other_team = Team.objects.create(organization=self.organization, name="Other team")
+
+        with patch("posthog.models.hog_flow.hog_flow.reload_hog_flows_on_workers"):
+            self.target_flow = HogFlow.objects.create(
+                team=self.team,
+                name="Target flow",
+                status=HogFlow.State.ACTIVE,
+                actions=[
+                    {"id": "trigger", "type": "trigger", "config": {}},
+                    _slack_action("slack_step", 54567),
+                ],
+                draft={
+                    "actions": [
+                        _slack_action("slack_step", 54567),
+                    ]
+                },
+                version=1,
+            )
+            self.untouched_flow = HogFlow.objects.create(
+                team=self.team,
+                name="Already migrated",
+                status=HogFlow.State.ACTIVE,
+                actions=[_slack_action("slack_step", 173069)],
+                version=1,
+            )
+            self.other_team_flow = HogFlow.objects.create(
+                team=self.other_team,
+                name="Other team flow",
+                status=HogFlow.State.ACTIVE,
+                actions=[_slack_action("slack_step", 54567)],
+                version=1,
+            )
+
+    def test_dry_run_does_not_modify_db(self):
+        call_command(
+            "backfill_workflows_slack_integration",
+            f"--team-id={self.team.id}",
+            "--old-integration-id=54567",
+            "--new-integration-id=173069",
+            "--dry-run",
+        )
+
+        self.target_flow.refresh_from_db()
+        assert self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == 54567
+        assert self.target_flow.draft["actions"][0]["config"]["inputs"]["slack_workspace"]["value"] == 54567
+
+    def test_rewrites_only_target_team(self):
+        with patch("posthog.models.hog_flow.hog_flow.reload_hog_flows_on_workers"):
+            call_command(
+                "backfill_workflows_slack_integration",
+                f"--team-id={self.team.id}",
+                "--old-integration-id=54567",
+                "--new-integration-id=173069",
+            )
+
+        self.target_flow.refresh_from_db()
+        self.untouched_flow.refresh_from_db()
+        self.other_team_flow.refresh_from_db()
+
+        assert self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == 173069
+        assert self.target_flow.draft["actions"][0]["config"]["inputs"]["slack_workspace"]["value"] == 173069
+        assert self.untouched_flow.actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 173069
+        # Other team must remain untouched even with the matching old id.
+        assert self.other_team_flow.actions[0]["config"]["inputs"]["slack_workspace"]["value"] == 54567
+
+    def test_aborts_when_old_and_new_are_equal(self):
+        # Running with old == new should refuse rather than no-op silently.
+        call_command(
+            "backfill_workflows_slack_integration",
+            f"--team-id={self.team.id}",
+            "--old-integration-id=54567",
+            "--new-integration-id=54567",
+        )
+        self.target_flow.refresh_from_db()
+        assert self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == 54567

--- a/posthog/management/commands/test/test_backfill_workflows_slack_integration.py
+++ b/posthog/management/commands/test/test_backfill_workflows_slack_integration.py
@@ -117,6 +117,7 @@ class TestBackfillWorkflowsSlackIntegrationCommand(BaseTest):
             call_command("backfill_workflows_slack_integration", "--dry-run")
 
         self.target_flow.refresh_from_db()
+        assert self.target_flow.draft is not None
         assert (
             self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == backfill.OLD_INTEGRATION_ID
         )
@@ -136,6 +137,7 @@ class TestBackfillWorkflowsSlackIntegrationCommand(BaseTest):
         self.untouched_flow.refresh_from_db()
         self.other_team_flow.refresh_from_db()
 
+        assert self.target_flow.draft is not None
         assert (
             self.target_flow.actions[1]["config"]["inputs"]["slack_workspace"]["value"] == backfill.NEW_INTEGRATION_ID
         )


### PR DESCRIPTION
## Problem

When a workflow / hog function input refers to an integration that no longer exists, `IntegrationChoice` silently substitutes the missing reference for the first available integration of the same kind. The UI then displays the substitute, but the persisted config still points at the dead ID until the user saves.

We discovered this on the Slack side: 40 hog flows in production still store `slack_workspace: 54567` (an integration that was disconnected and re-installed under ID `173069`). Viewing those workflows in the UI shows `173069` and looks healthy, but at execution time the CDP integration manager looks the value up by primary key and finds nothing, so the Slack step fails.

The two effects that produced this behavior were stacked:

```ts
// (1) auto-pick first available when no value is set
useEffect(() => {
    if (!integrationsLoading && !value && integrationsOfKind?.length) {
        onChange?.(integrationsOfKind[0].id)
    }
}, [...])

// (2) clear value when it refers to a missing integration
useEffect(() => {
    if (!integrationsLoading && value && integrations && !integrationKind) {
        onChange?.(null)
    }
}, [...])
```

`(2)` nulled the stale id, then `(1)` re-populated it with whatever happened to be first, with no signal that anything had changed.

The auto-substitution is also dangerous on its face — for Slack, "the first available workspace" might be a completely different workspace, and a save would silently rewire the destination of every message that step sends.

## Changes

<img width="2270" height="1774" alt="image" src="https://github.com/user-attachments/assets/41f7b62e-6e5f-4068-9df3-2bf7bf42119c" />


- Drop the silent-clear effect.
- When the stored value doesn't resolve to a loaded integration, render a `LemonBanner` (warning) naming the stale ID and prompting an explicit pick or clear. The "Change" / setup / disconnect menu is still attached below the banner so the user can act without leaving the page.
- Leave the "no value at all → auto-select first" effect alone — that one only fires for genuinely empty form state, which is the intended UX when wiring a brand new step.

`IntegrationChoice` is the shared chooser used by hog functions, workflows, batch exports, subscriptions, surveys, and the email templater, so this applies everywhere a stored integration id can drift out of date.

### Before / after

**Before** — opening one of the 40 stale Slack flows shows the new integration as "Connected", masking the broken config.

**After** — same flow shows:

> ⚠ The previously selected Slack connection (ID: 54567) is no longer available. Pick a different connection or clear the selection — this step will fail when the workflow runs otherwise.

…with the "Choose Slack connection" button immediately below.

## How did you test this code?

I'm an agent. I did not exercise the UI manually. What I actually ran:

- `pnpm --filter=@posthog/frontend typescript:check` — no new errors are attributable to this change; the existing failures on master (`workflowLogic.ts`, `WorkflowScene.tsx`, `workflowSceneLogic.ts`) are pre-existing kea generated-type drift unrelated to this file.
- lint-staged formatter ran on commit and made no changes to the file.

Manual verification a human reviewer can do:
1. Open a workflow that has a Slack step pointing at an integration that no longer exists (or temporarily delete the integration row in the DB to fake it).
2. Confirm the warning banner appears with the stale ID and that the menu still lets you pick another or clear.
3. Save the workflow only after picking — confirm the persisted config now contains the chosen id rather than the old one.

## Publish to changelog?

no

## 🤖 Agent context

- Tools/agent: Claude Code (Opus 4.7, 1M context), running in this repo.
- Investigation started from a Slack thread about workflows that "show the new integration in the UI but still reference the old one when listed via SQL". I traced the discrepancy to the two stacked `useEffect`s in `IntegrationChoice.tsx` and confirmed the runtime behavior in `nodejs/src/cdp/services/managers/integration-manager.service.ts` (looks up by primary key, no fallback) and the Slack hog template (`posthog/cdp/templates/slack/template_slack.py`) which dereferences `inputs.slack_workspace.access_token`, so a missing integration fails the step.
- Considered also auto-clearing on explicit "Disconnect integration" inside the menu so an intentional disconnect doesn't leave a warning hanging — decided against bundling that into this PR. The warning is the correct UX after a disconnect too (it's the same broken state from the executor's point of view) and adding the side-effect makes the change non-minimal.
- A complementary one-shot backfill to rewrite the 40 stale `slack_workspace` values from 54567 → 173069 is still needed; this PR only fixes the UI so the broken state is visible going forward.