### PR TITLE
fix(data-warehouse): duckdb table functions denylist

### DIFF
--- a/posthog/hogql/database/schema/duckdb_table_functions.py
+++ b/posthog/hogql/database/schema/duckdb_table_functions.py
@@ -9,6 +9,55 @@ from posthog.hogql.database.models import (
 )
 from posthog.hogql.errors import QueryError
 
+_DANGEROUS_TABLE_FUNCTION_NAMES: frozenset[str] = frozenset(
+    {
+        "read_text",
+        "read_blob",
+        "glob",
+        "read_csv",
+        "read_csv_auto",
+        "read_json",
+        "read_json_auto",
+        "read_json_objects",
+        "read_json_objects_auto",
+        "read_ndjson",
+        "read_ndjson_auto",
+        "read_ndjson_objects",
+        "read_parquet",
+        "parquet_scan",
+        "parquet_metadata",
+        "parquet_schema",
+        "parquet_file_metadata",
+        "parquet_kv_metadata",
+        "parquet_bloom_probe",
+        "read_xlsx",
+        "read_avro",
+        "iceberg_scan",
+        "iceberg_metadata",
+        "iceberg_snapshots",
+        "delta_scan",
+        "sqlite_scan",
+        "sqlite_attach",
+        "postgres_scan",
+        "postgres_scan_pushdown",
+        "postgres_attach",
+        "postgres_query",
+        "mysql_scan",
+        "mysql_query",
+    }
+)
+_DANGEROUS_TABLE_FUNCTION_PREFIXES = ("read_", "scan_")
+_DANGEROUS_TABLE_FUNCTION_SUFFIXES = ("_scan", "_attach", "_query")
+
+
+def is_dangerous_table_function(name: str) -> bool:
+    lowered = name.lower()
+    return (
+        lowered in _DANGEROUS_TABLE_FUNCTION_NAMES
+        or lowered.startswith(_DANGEROUS_TABLE_FUNCTION_PREFIXES)
+        or lowered.endswith(_DANGEROUS_TABLE_FUNCTION_SUFFIXES)
+    )
+
 
 class RangeTable(FunctionCallTable, DANGEROUS_NoTeamIdCheckTable):
     """DuckDB/Postgres range(start, stop, step) table function. Returns a single column of integers."""

--- a/posthog/hogql/database/schema/duckdb_table_functions.py
+++ b/posthog/hogql/database/schema/duckdb_table_functions.py
@@ -11,6 +11,7 @@ from posthog.hogql.errors import QueryError
 
 _DANGEROUS_TABLE_FUNCTION_NAMES: frozenset[str] = frozenset(
     {
+        "query",
         "read_text",
         "read_blob",
         "glob",
@@ -47,7 +48,7 @@ _DANGEROUS_TABLE_FUNCTION_NAMES: frozenset[str] = frozenset(
     }
 )
 _DANGEROUS_TABLE_FUNCTION_PREFIXES = ("read_", "scan_")
-_DANGEROUS_TABLE_FUNCTION_SUFFIXES = ("_scan", "_attach", "_query")
+_DANGEROUS_TABLE_FUNCTION_SUFFIXES = ("_scan", "_attach")
 
 
 def is_dangerous_table_function(name: str) -> bool:

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -17,7 +17,10 @@ from posthog.hogql.database.s3_table import (
     DataWarehouseTable as HogQLDataWarehouseTable,
     S3Table,
 )
-from posthog.hogql.database.schema.duckdb_table_functions import build_opaque_function_call_table
+from posthog.hogql.database.schema.duckdb_table_functions import (
+    build_opaque_function_call_table,
+    is_dangerous_table_function,
+)
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.persons import PersonsTable
 from posthog.hogql.errors import ImpossibleASTError, NotImplementedError, QueryError, ResolutionError
@@ -2110,6 +2113,9 @@ class Resolver(CloningVisitor):
             return None
 
         if not _SAFE_TABLE_FUNCTION_NAME_RE.match(function_name):
+            return None
+
+        if is_dangerous_table_function(function_name):
             return None
 
         return build_opaque_function_call_table(function_name)

--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -11,6 +11,7 @@ import psycopg
 from parameterized import parameterized
 
 from posthog.hogql.constants import HogQLGlobalSettings
+from posthog.hogql.database.schema.duckdb_table_functions import is_dangerous_table_function
 from posthog.hogql.errors import ExposedHogQLError, QueryError
 from posthog.hogql.escape_sql import escape_postgres_identifier
 from posthog.hogql.query import (
@@ -417,6 +418,7 @@ class TestDirectPostgresQuery(APIBaseTest):
             ("read_csv", "SELECT * FROM read_csv('http://169.254.169.254/latest/meta-data')"),
             ("glob", "SELECT * FROM glob('/etc/*')"),
             ("postgres_query", "SELECT * FROM postgres_query('db', 'SELECT 1')"),
+            ("query", "SELECT * FROM query('SELECT * FROM read_text(''/etc/passwd'')')"),
         ]
     )
     def test_generate_sql_rejects_dangerous_table_function_even_if_cached_in_metadata(
@@ -443,8 +445,33 @@ class TestDirectPostgresQuery(APIBaseTest):
 
         executor = HogQLQueryExecutor(query=query, team=self.team, connection_id=str(source.id))
 
-        with self.assertRaises((QueryError, ExposedHogQLError)):
+        with self.assertRaises((QueryError, ExposedHogQLError)) as ctx:
             executor.generate_clickhouse_sql()
+
+        # Must fail at resolve time, not as an accepted opaque table (which fails generically at print).
+        self.assertNotIn("is not supported in ClickHouse dialect", str(ctx.exception))
+
+    @parameterized.expand(
+        [
+            ("query", True),
+            ("read_csv", True),
+            ("postgres_query", True),
+            ("glob", True),
+            ("READ_TEXT", True),
+            ("read_anything", True),
+            ("scan_anything", True),
+            ("foo_scan", True),
+            ("foo_attach", True),
+            ("build_query", False),
+            ("get_query", False),
+            ("run_query", False),
+            ("range", False),
+            ("generate_series", False),
+            ("unnest", False),
+        ]
+    )
+    def test_is_dangerous_table_function(self, function_name: str, expected: bool):
+        self.assertEqual(is_dangerous_table_function(function_name), expected)
 
     def test_generate_sql_for_duckdb_direct_postgres_table_uses_connection_catalog(self):
         source = ExternalDataSource.objects.create(

--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -411,6 +411,41 @@ class TestDirectPostgresQuery(APIBaseTest):
         self.assertIn(expected_sql_fragment, sql)
         self.assertEqual(executor.direct_postgres_source_id, str(source.id))
 
+    @parameterized.expand(
+        [
+            ("read_text", "SELECT * FROM read_text('/etc/passwd')"),
+            ("read_csv", "SELECT * FROM read_csv('http://169.254.169.254/latest/meta-data')"),
+            ("glob", "SELECT * FROM glob('/etc/*')"),
+            ("postgres_query", "SELECT * FROM postgres_query('db', 'SELECT 1')"),
+        ]
+    )
+    def test_generate_sql_rejects_dangerous_table_function_even_if_cached_in_metadata(
+        self, function_name: str, query: str
+    ):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source_id",
+            connection_id="connection_id",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type="Postgres",
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            prefix="ph3",
+            job_inputs={
+                "host": "localhost",
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "ph3",
+            },
+            connection_metadata={"available_table_functions": [function_name]},
+        )
+
+        executor = HogQLQueryExecutor(query=query, team=self.team, connection_id=str(source.id))
+
+        with self.assertRaises((QueryError, ExposedHogQLError)):
+            executor.generate_clickhouse_sql()
+
     def test_generate_sql_for_duckdb_direct_postgres_table_uses_connection_catalog(self):
         source = ExternalDataSource.objects.create(
             team=self.team,

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -22,6 +22,8 @@ from psycopg import sql
 from psycopg.adapt import Loader
 from structlog.types import FilteringBoundLogger
 
+from posthog.hogql.database.schema.duckdb_table_functions import is_dangerous_table_function
+
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import (
@@ -729,6 +731,9 @@ def get_connection_metadata(
                 available_table_functions = _normalize_function_names([row[0] for row in cursor.fetchall()])
             except Exception as error:
                 capture_exception(error)
+
+            available_functions = [fn for fn in available_functions if not is_dangerous_table_function(fn)]
+            available_table_functions = [fn for fn in available_table_functions if not is_dangerous_table_function(fn)]
 
             return {
                 "database": current_database,


### PR DESCRIPTION
## Problem

DuckDB/DuckGres table functions like `read_csv`, `read_parquet`, `glob`, and `postgres_query` read local files or remote URLs. Exposing them to introspected `FROM func(args)` calls allows arbitrary file read and SSRF.

## Changes

- Add `is_dangerous_table_function()` — denylist of file/network readers (including `query`, which evaluates arbitrary SQL) plus `read_`/`scan_` prefix and `_scan`/`_attach` suffix heuristics.
- Filter them out of connection metadata at ingest, and reject them in the resolver even when stale cached metadata lists them.

## How did you test this code?

Agent-authored (Claude Code). Parameterized tests cover both the resolver rejection (`read_text`, `read_csv` SSRF, `glob`, `postgres_query`, and the `query('… read_text …')` bypass — asserting failure at resolve time, not the generic opaque-print error) and the `is_dangerous_table_function` helper directly (including that `build_query`/`get_query`/`run_query` are not over-blocked). Run locally: 20 passed.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code. Denylist chosen as the immediate fix; allowlist of single-column helpers is the durable follow-up. Enforced at both ingest and resolve time so cached metadata can't bypass it. The `_query` suffix heuristic was dropped after review — it over-blocked legitimate user functions, and the dangerous names (`postgres_query`, `mysql_query`, `query`) are listed explicitly. Requires human review.