### PR TITLE
fix(signals): Reorganize inbox Slack notification

### DIFF
--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -259,19 +259,16 @@ def _build_message_blocks(
     implementation_pr_url: str | None = None,
 ) -> tuple[list[dict], str]:
     title_line = report.title or "New signals inbox item"
-    header_text = f"Inbox for {recipient.plain_name}"
-    if priority:
-        header_text = f"{header_text} · {priority}"
+    header_text = f"📬 {title_line}"
     if len(header_text) > _SLACK_HEADER_MAX_LEN:
         header_text = header_text[: _SLACK_HEADER_MAX_LEN - 3] + "..."
 
-    # Mention goes in the mrkdwn section, not the header — header blocks are
-    # plain_text only, so `<@U…>` would render as literal text and the user
-    # wouldn't get pinged.
-    body_parts: list[str] = []
-    if recipient.slack_mention:
-        body_parts.append(recipient.slack_mention)
-    body_parts.append(f"*{title_line}*")
+    recipient_label = recipient.slack_mention or recipient.plain_name
+    metadata_parts = [f"For {recipient_label}"]
+    if priority:
+        metadata_parts.insert(0, priority)
+
+    body_parts: list[str] = [" • ".join(metadata_parts)]
     summary_text = _summary_excerpt(report.summary or "")
     if summary_text:
         body_parts.append(summary_text)

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -112,7 +112,9 @@ def _latest_priority(report: SignalReport) -> str | None:
 
 @dataclass(frozen=True)
 class _RecipientPresentation:
-    header_label: str  # `<@U…>` mention or display name for the header
+    # `<@U…>` mention if we resolved the user's Slack ID — only renders inside mrkdwn
+    # blocks (header blocks are plain_text and would show the raw `<@U…>` string).
+    slack_mention: str | None
     plain_name: str
 
 
@@ -224,8 +226,8 @@ def _recipient_presentation(
 ) -> _RecipientPresentation:
     plain_name = _posthog_user_display_name(user)
     slack_user_id = lookup_slack_user_id_by_email(slack, user.email) if user.email else None
-    header_label = f"<@{slack_user_id}>" if slack_user_id else plain_name
-    return _RecipientPresentation(header_label=header_label, plain_name=plain_name)
+    slack_mention = f"<@{slack_user_id}>" if slack_user_id else None
+    return _RecipientPresentation(slack_mention=slack_mention, plain_name=plain_name)
 
 
 def _format_source_product_labels(source_products: list[str]) -> str:
@@ -257,13 +259,19 @@ def _build_message_blocks(
     implementation_pr_url: str | None = None,
 ) -> tuple[list[dict], str]:
     title_line = report.title or "New signals inbox item"
-    header_text = f"Inbox for {recipient.header_label}"
+    header_text = f"Inbox for {recipient.plain_name}"
     if priority:
         header_text = f"{header_text} · {priority}"
     if len(header_text) > _SLACK_HEADER_MAX_LEN:
         header_text = header_text[: _SLACK_HEADER_MAX_LEN - 3] + "..."
 
-    body_parts = [f"*{title_line}*"]
+    # Mention goes in the mrkdwn section, not the header — header blocks are
+    # plain_text only, so `<@U…>` would render as literal text and the user
+    # wouldn't get pinged.
+    body_parts: list[str] = []
+    if recipient.slack_mention:
+        body_parts.append(recipient.slack_mention)
+    body_parts.append(f"*{title_line}*")
     summary_text = _summary_excerpt(report.summary or "")
     if summary_text:
         body_parts.append(summary_text)

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -275,7 +275,9 @@ def _build_message_blocks(
     if len(header_text) > _SLACK_HEADER_MAX_LEN:
         header_text = header_text[: _SLACK_HEADER_MAX_LEN - 3] + "..."
 
-    recipient_label = recipient.slack_mention or recipient.plain_name.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    recipient_label = recipient.slack_mention or recipient.plain_name.replace("&", "&amp;").replace(
+        "<", "&lt;"
+    ).replace(">", "&gt;")
     metadata_parts = [f"Matched to {recipient_label} per code"]
     if priority:
         metadata_parts.insert(0, _slack_priority_label(priority))

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -59,6 +59,14 @@ _PRIORITY_ORDER: tuple[str, ...] = (
     AutonomyPriority.P4,
 )
 
+_SLACK_PRIORITY_LABELS: dict[str, str] = {
+    AutonomyPriority.P0: "🆘 P0",
+    AutonomyPriority.P1: "‼️ P1",
+    AutonomyPriority.P2: "❗ P2",
+    AutonomyPriority.P3: "⚠️ P3",
+    AutonomyPriority.P4: "👀 P4",
+}
+
 _SOURCE_PRODUCT_LABELS: dict[str, str] = {
     choice.value: str(choice.label) for choice in SignalSourceConfig.SourceProduct
 }
@@ -71,6 +79,10 @@ def _priority_rank(value: str | None) -> int | None:
         return _PRIORITY_ORDER.index(value)
     except ValueError:
         return None
+
+
+def _slack_priority_label(value: str) -> str:
+    return _SLACK_PRIORITY_LABELS.get(value, value)
 
 
 def _meets_min_priority(report_priority: str | None, min_priority: str | None) -> bool:
@@ -266,7 +278,7 @@ def _build_message_blocks(
     recipient_label = recipient.slack_mention or recipient.plain_name
     metadata_parts = [f"Matched to {recipient_label} per code"]
     if priority:
-        metadata_parts.insert(0, priority)
+        metadata_parts.insert(0, _slack_priority_label(priority))
 
     body_parts: list[str] = [f"*{' • '.join(metadata_parts)}*"]
     summary_text = _summary_excerpt(report.summary or "")

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -264,11 +264,11 @@ def _build_message_blocks(
         header_text = header_text[: _SLACK_HEADER_MAX_LEN - 3] + "..."
 
     recipient_label = recipient.slack_mention or recipient.plain_name
-    metadata_parts = [f"For {recipient_label}"]
+    metadata_parts = [f"Matched to {recipient_label} per code"]
     if priority:
         metadata_parts.insert(0, priority)
 
-    body_parts: list[str] = [" • ".join(metadata_parts)]
+    body_parts: list[str] = [f"*{' • '.join(metadata_parts)}*"]
     summary_text = _summary_excerpt(report.summary or "")
     if summary_text:
         body_parts.append(summary_text)

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -275,7 +275,7 @@ def _build_message_blocks(
     if len(header_text) > _SLACK_HEADER_MAX_LEN:
         header_text = header_text[: _SLACK_HEADER_MAX_LEN - 3] + "..."
 
-    recipient_label = recipient.slack_mention or recipient.plain_name
+    recipient_label = recipient.slack_mention or recipient.plain_name.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
     metadata_parts = [f"Matched to {recipient_label} per code"]
     if priority:
         metadata_parts.insert(0, _slack_priority_label(priority))

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -77,12 +77,12 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
         recipient=recipient,
     )
 
-    assert blocks[0]["text"]["text"] == "Inbox for Marcus Twix · P1"
+    assert blocks[0]["text"]["text"] == "📬 Checkout errors spiked"
     section_text = blocks[1]["text"]["text"]
     assert "Suggested for" not in section_text
     # Mention belongs in the mrkdwn section so Slack actually pings the user.
-    assert "<@U123>" in section_text
-    assert "*Checkout errors spiked*" in section_text
+    assert section_text.startswith("P1 • For <@U123>")
+    assert "*Checkout errors spiked*" not in section_text
     assert "Error rate rose after deploy." in section_text
     assert "Ignored second line." not in section_text
     context_text = blocks[2]["elements"][0]["text"]
@@ -130,6 +130,7 @@ def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
         implementation_pr_url=None,
     )
 
+    assert blocks[1]["text"]["text"] == "For Marcus Twix"
     assert len(blocks[3]["elements"]) == 1
 
 
@@ -287,8 +288,8 @@ def test_dispatch_sends_to_configured_reviewer(org_and_team):
     assert call_kwargs["channel"] == "C123"
     assert "Inbox for Reviewer Bot (P1)" in call_kwargs["text"]
     blocks = call_kwargs["blocks"]
-    assert blocks[0]["text"]["text"] == "Inbox for Reviewer Bot · P1"
-    assert "<@U_REVIEWER>" in blocks[1]["text"]["text"]
+    assert blocks[0]["text"]["text"] == "📬 Test report"
+    assert blocks[1]["text"]["text"].startswith("P1 • For <@U_REVIEWER>")
     assert blocks[3]["elements"][0]["url"] == f"posthog-code://inbox/{report.id}"
 
 

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -81,7 +81,7 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
     section_text = blocks[1]["text"]["text"]
     assert "Suggested for" not in section_text
     # Mention belongs in the mrkdwn section so Slack actually pings the user.
-    assert section_text.startswith("P1 • For <@U123>")
+    assert section_text.startswith("*P1 • Matched to <@U123> per code*")
     assert "*Checkout errors spiked*" not in section_text
     assert "Error rate rose after deploy." in section_text
     assert "Ignored second line." not in section_text
@@ -130,7 +130,7 @@ def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
         implementation_pr_url=None,
     )
 
-    assert blocks[1]["text"]["text"] == "For Marcus Twix"
+    assert blocks[1]["text"]["text"] == "*Matched to Marcus Twix per code*"
     assert len(blocks[3]["elements"]) == 1
 
 
@@ -289,7 +289,7 @@ def test_dispatch_sends_to_configured_reviewer(org_and_team):
     assert "Inbox for Reviewer Bot (P1)" in call_kwargs["text"]
     blocks = call_kwargs["blocks"]
     assert blocks[0]["text"]["text"] == "📬 Test report"
-    assert blocks[1]["text"]["text"].startswith("P1 • For <@U_REVIEWER>")
+    assert blocks[1]["text"]["text"].startswith("*P1 • Matched to <@U_REVIEWER> per code*")
     assert blocks[3]["elements"][0]["url"] == f"posthog-code://inbox/{report.id}"
 
 

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -81,7 +81,7 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
     section_text = blocks[1]["text"]["text"]
     assert "Suggested for" not in section_text
     # Mention belongs in the mrkdwn section so Slack actually pings the user.
-    assert section_text.startswith("*P1 • Matched to <@U123> per code*")
+    assert section_text.startswith("*‼️ P1 • Matched to <@U123> per code*")
     assert "*Checkout errors spiked*" not in section_text
     assert "Error rate rose after deploy." in section_text
     assert "Ignored second line." not in section_text
@@ -132,6 +132,29 @@ def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
 
     assert blocks[1]["text"]["text"] == "*Matched to Marcus Twix per code*"
     assert len(blocks[3]["elements"]) == 1
+
+
+@pytest.mark.parametrize(
+    ("priority", "expected_priority_label"),
+    [
+        (AutonomyPriority.P0, "🆘 P0"),
+        (AutonomyPriority.P1, "‼️ P1"),
+        (AutonomyPriority.P2, "❗ P2"),
+        (AutonomyPriority.P3, "⚠️ P3"),
+        (AutonomyPriority.P4, "👀 P4"),
+    ],
+)
+def test_build_message_blocks_prefixes_priority_with_emoji(priority: str, expected_priority_label: str) -> None:
+    report = SignalReport(id="report-uuid", title="Priority test")
+    recipient = _RecipientPresentation(slack_mention="<@U123>", plain_name="Marcus Twix")
+    blocks, _ = _build_message_blocks(
+        report,
+        priority=priority,
+        source_products=[],
+        recipient=recipient,
+    )
+
+    assert blocks[1]["text"]["text"] == f"*{expected_priority_label} • Matched to <@U123> per code*"
 
 
 def test_recipient_presentation_uses_slack_mention_when_lookup_succeeds() -> None:
@@ -289,7 +312,7 @@ def test_dispatch_sends_to_configured_reviewer(org_and_team):
     assert "Inbox for Reviewer Bot (P1)" in call_kwargs["text"]
     blocks = call_kwargs["blocks"]
     assert blocks[0]["text"]["text"] == "📬 Test report"
-    assert blocks[1]["text"]["text"].startswith("*P1 • Matched to <@U_REVIEWER> per code*")
+    assert blocks[1]["text"]["text"].startswith("*‼️ P1 • Matched to <@U_REVIEWER> per code*")
     assert blocks[3]["elements"][0]["url"] == f"posthog-code://inbox/{report.id}"
 
 

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -69,7 +69,7 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
         summary="Error rate rose after deploy.\nIgnored second line.",
         signal_count=12,
     )
-    recipient = _RecipientPresentation(header_label="<@U123>", plain_name="Marcus Twix")
+    recipient = _RecipientPresentation(slack_mention="<@U123>", plain_name="Marcus Twix")
     blocks, text = _build_message_blocks(
         report,
         priority="P1",
@@ -77,9 +77,11 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
         recipient=recipient,
     )
 
-    assert blocks[0]["text"]["text"] == "Inbox for <@U123> · P1"
+    assert blocks[0]["text"]["text"] == "Inbox for Marcus Twix · P1"
     section_text = blocks[1]["text"]["text"]
     assert "Suggested for" not in section_text
+    # Mention belongs in the mrkdwn section so Slack actually pings the user.
+    assert "<@U123>" in section_text
     assert "*Checkout errors spiked*" in section_text
     assert "Error rate rose after deploy." in section_text
     assert "Ignored second line." not in section_text
@@ -100,7 +102,7 @@ def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -
         summary="Error rate rose after deploy.",
         signal_count=12,
     )
-    recipient = _RecipientPresentation(header_label="<@U123>", plain_name="Marcus Twix")
+    recipient = _RecipientPresentation(slack_mention="<@U123>", plain_name="Marcus Twix")
     pr_url = "https://github.com/org/repo/pull/42"
     blocks, _ = _build_message_blocks(
         report,
@@ -119,7 +121,7 @@ def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -
 
 def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
     report = SignalReport(id="report-uuid", title="No PR yet")
-    recipient = _RecipientPresentation(header_label="Marcus Twix", plain_name="Marcus Twix")
+    recipient = _RecipientPresentation(slack_mention=None, plain_name="Marcus Twix")
     blocks, _ = _build_message_blocks(
         report,
         priority=None,
@@ -142,7 +144,7 @@ def test_recipient_presentation_uses_slack_mention_when_lookup_succeeds() -> Non
     ):
         presentation = _recipient_presentation(user, slack, integration)
 
-    assert presentation.header_label == "<@U_SLACK>"
+    assert presentation.slack_mention == "<@U_SLACK>"
     assert presentation.plain_name == "Marcus Twix"
 
 
@@ -157,7 +159,8 @@ def test_recipient_presentation_falls_back_to_name_when_slack_user_not_found() -
     ):
         presentation = _recipient_presentation(user, slack, integration)
 
-    assert presentation.header_label == "Marcus Twix"
+    assert presentation.slack_mention is None
+    assert presentation.plain_name == "Marcus Twix"
 
 
 @pytest.fixture
@@ -284,7 +287,8 @@ def test_dispatch_sends_to_configured_reviewer(org_and_team):
     assert call_kwargs["channel"] == "C123"
     assert "Inbox for Reviewer Bot (P1)" in call_kwargs["text"]
     blocks = call_kwargs["blocks"]
-    assert blocks[0]["text"]["text"] == "Inbox for <@U_REVIEWER> · P1"
+    assert blocks[0]["text"]["text"] == "Inbox for Reviewer Bot · P1"
+    assert "<@U_REVIEWER>" in blocks[1]["text"]["text"]
     assert blocks[3]["elements"][0]["url"] == f"posthog-code://inbox/{report.id}"
 
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-delete-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-delete-tile.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A unique integer value identifying this dashboard.",
+            "type": "number"
+        },
+        "tile_id": {
+            "description": "ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs.",
+            "type": "number"
+        }
+    },
+    "required": ["id", "tile_id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Slack mentions don't render in header blocks, so the reviewer mention showed up as raw `<@U...>` text instead of pinging them:

```
[ header  · plain_text  ]  Inbox for <@U...> · P3
[ section · mrkdwn       ]  *fix(errors): classify SAMPLING_NOT_SUPPORTED as user-safe error*
                            A user-authored HogQL query is generating a noisy error tracking issue…
...footer+buttons
```

## Changes

Putting the report title in the header. Moving the reviewer mention into the mrkdwn body. Showing the metadata line as `*P3 • Matched to <@U...> per code*`.  
  
After:

```
[ header  · plain_text  ]  📬 fix(errors): classify SAMPLING_NOT_SUPPORTED as user-safe error
[ section · mrkdwn       ]  *⚠️ P3 • Matched to @Michael per code*
                            A user-authored HogQL query is generating a noisy error tracking issue…
...footer+buttons
```

## How did you test this code?

Updated the existing Slack inbox notification tests.

## Publish to changelog?

no

## Docs update

No docs needed.