### PR TITLE
chore(dags): route revenue analytics slack alerts to web analytics

### DIFF
--- a/posthog/dags/common/owners.py
+++ b/posthog/dags/common/owners.py
@@ -17,6 +17,5 @@ class JobOwners(str, Enum):
     TEAM_MANAGED_WAREHOUSE = "team-managed-warehouse"
     TEAM_POSTHOG_AI = "team-posthog-ai"
     TEAM_QUERY_PERFORMANCE = "team-query-performance"
-    TEAM_REVENUE_ANALYTICS = "team-revenue-analytics"
     TEAM_WAREHOUSE_SOURCES = "team-warehouse-sources"
     TEAM_WEB_ANALYTICS = "team-web-analytics"

--- a/posthog/dags/slack_alerts.py
+++ b/posthog/dags/slack_alerts.py
@@ -23,7 +23,7 @@ notification_channel_per_team = {
     JobOwners.TEAM_LOGS.value: "#alerts-logs-prod",
     JobOwners.TEAM_POSTHOG_AI.value: "#alerts-max-ai",
     JobOwners.TEAM_QUERY_PERFORMANCE.value: "#alerts-query-performance",
-    JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-growth",
+    JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-web-analytics",
     JobOwners.TEAM_WAREHOUSE_SOURCES.value: "#alerts-warehouse-sources",
     JobOwners.TEAM_WEB_ANALYTICS.value: "#alerts-web-analytics",
 }

--- a/posthog/dags/slack_alerts.py
+++ b/posthog/dags/slack_alerts.py
@@ -23,7 +23,6 @@ notification_channel_per_team = {
     JobOwners.TEAM_LOGS.value: "#alerts-logs-prod",
     JobOwners.TEAM_POSTHOG_AI.value: "#alerts-max-ai",
     JobOwners.TEAM_QUERY_PERFORMANCE.value: "#alerts-query-performance",
-    JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-web-analytics",
     JobOwners.TEAM_WAREHOUSE_SOURCES.value: "#alerts-warehouse-sources",
     JobOwners.TEAM_WEB_ANALYTICS.value: "#alerts-web-analytics",
 }

--- a/posthog/dags/tests/test_slack_alerts.py
+++ b/posthog/dags/tests/test_slack_alerts.py
@@ -33,7 +33,7 @@ class TestSlackAlertsRouting:
     def test_asset_job_with_mixed_steps_routes_to_web_analytics(self):
         mock_run = mock.MagicMock(spec=dagster.DagsterRun)
         mock_run.job_name = "__ASSET_JOB"
-        mock_run.tags = {"owner": JobOwners.TEAM_REVENUE_ANALYTICS.value}
+        mock_run.tags = {"owner": JobOwners.TEAM_DATA_MODELING.value}
 
         error_message = "Execution of run for \"__ASSET_JOB\" failed. Steps failed: ['some_other_asset', 'web_pre_aggregated_bounces', 'clickhouse_asset']."
 
@@ -44,13 +44,13 @@ class TestSlackAlertsRouting:
     def test_asset_job_without_web_steps_uses_original_owner(self):
         mock_run = mock.MagicMock(spec=dagster.DagsterRun)
         mock_run.job_name = "__ASSET_JOB"
-        mock_run.tags = {"owner": JobOwners.TEAM_REVENUE_ANALYTICS.value}
+        mock_run.tags = {"owner": JobOwners.TEAM_DATA_MODELING.value}
 
-        error_message = "Execution of run for \"__ASSET_JOB\" failed. Steps failed: ['revenue_analytics_daily', 'exchange_rates_hourly']."
+        error_message = "Execution of run for \"__ASSET_JOB\" failed. Steps failed: ['exchange_rates_daily', 'exchange_rates_hourly']."
 
         result = get_job_owner_for_alert(mock_run, error_message)
 
-        assert result == JobOwners.TEAM_REVENUE_ANALYTICS.value
+        assert result == JobOwners.TEAM_DATA_MODELING.value
 
     def test_asset_job_no_failed_steps_uses_original_owner(self):
         mock_run = mock.MagicMock(spec=dagster.DagsterRun)

--- a/products/revenue_analytics/dags/exchange_rate.py
+++ b/products/revenue_analytics/dags/exchange_rate.py
@@ -301,13 +301,13 @@ def hourly_exchange_rates_in_clickhouse(
 daily_exchange_rates_job = dagster.define_asset_job(
     name="daily_exchange_rates_job",
     selection=[daily_exchange_rates.key, daily_exchange_rates_in_clickhouse.key],
-    tags={"owner": JobOwners.TEAM_REVENUE_ANALYTICS.value},
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
 )
 
 hourly_exchange_rates_job = dagster.define_asset_job(
     name="hourly_exchange_rates_job",
     selection=[hourly_exchange_rates.key, hourly_exchange_rates_in_clickhouse.key],
-    tags={"owner": JobOwners.TEAM_REVENUE_ANALYTICS.value},
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
 )
 
 


### PR DESCRIPTION
## Problem

The `team-revenue-analytics` team no longer exists — its scope has been absorbed into the Web analytics team. The Dagster `JobOwners` enum, the slack alert routing, and the asset job tags still referenced the defunct owner, so failure alerts and ownership tags were pointing at a team that isn't there.

## Changes

- `posthog/dags/common/owners.py`: remove the `TEAM_REVENUE_ANALYTICS` enum member entirely.
- `posthog/dags/slack_alerts.py`: drop the `TEAM_REVENUE_ANALYTICS → #alerts-growth` mapping. Revenue analytics jobs are now owned by `TEAM_WEB_ANALYTICS`, which already routes to `#alerts-web-analytics`.
- `products/revenue_analytics/dags/exchange_rate.py`: retag the `daily_exchange_rates_job` and `hourly_exchange_rates_job` jobs with `JobOwners.TEAM_WEB_ANALYTICS` so failures attribute and route correctly.
- `posthog/dags/tests/test_slack_alerts.py`: replace `TEAM_REVENUE_ANALYTICS` fixtures with `TEAM_DATA_MODELING` so the "original owner is preserved when no web step failed" assertion still tests a distinct, non-web owner.

Only the Dagster ownership surface is touched — the revenue analytics _product_ (models, configs, frontend) is unchanged; only the team-level Dagster owner is being retired.

## How did you test this code?

I'm an agent. No manual testing was performed. The change is a small enum/string refactor; the existing unit tests in `posthog/dags/tests/test_slack_alerts.py` cover the routing behavior and were updated to keep covering the same cases under a different placeholder owner.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) via PostHog Code. Original ask was just to repoint the revenue analytics slack alerts at `#alerts-web-analytics`. The user then clarified that `team-revenue-analytics` doesn't exist anymore as a team at all, so the right fix is to delete the enum and reassign the jobs directly to `TEAM_WEB_ANALYTICS` rather than keep an alias in the channel-mapping dict. I grepped for every reference to `TEAM_REVENUE_ANALYTICS` / `team-revenue-analytics` in the repo and updated the four files that referenced the Dagster owner; unrelated mentions of revenue analytics (Django models, migrations, product code, a frontend comment about a feature-flag owner) were left alone because they describe the still-existing product, not the retired team owner.