### PR TITLE
feat(insights): add transforms for horizontal funnel bar chart

### DIFF
--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
@@ -1,0 +1,297 @@
+import { EntityTypes, FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
+
+import {
+    buildFunnelBarHorizontalData,
+    FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
+    FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX,
+} from './funnelBarHorizontalTransforms'
+
+type StepOverrides = Partial<FunnelStepWithConversionMetrics> & {
+    fromBasisStep: number
+    fromPrevious?: number
+    total?: number
+}
+
+function makeStep({
+    fromBasisStep,
+    fromPrevious,
+    total,
+    ...overrides
+}: StepOverrides): FunnelStepWithConversionMetrics {
+    return {
+        action_id: 'action',
+        average_conversion_time: null,
+        median_conversion_time: null,
+        count: 0,
+        name: 'Step',
+        order: 0,
+        type: EntityTypes.EVENTS,
+        converted_people_url: '',
+        dropped_people_url: null,
+        droppedOffFromPrevious: 0,
+        conversionRates: {
+            fromPrevious: fromPrevious ?? fromBasisStep,
+            total: total ?? fromBasisStep,
+            fromBasisStep,
+        },
+        ...overrides,
+    }
+}
+
+const options = {
+    stepReference: FunnelStepReference.total,
+    getColor: () => '#1d4aff',
+    getLabel: (variant: FunnelStepWithConversionMetrics) => String(variant.breakdown_value ?? variant.name),
+    fillerColor: '#eef0f3',
+}
+
+describe('buildFunnelBarHorizontalData', () => {
+    it('returns empty series + labels when given no steps', () => {
+        expect(buildFunnelBarHorizontalData([], options)).toEqual({ series: [], labels: [] })
+    })
+
+    it('emits one label per step', () => {
+        const steps = [
+            makeStep({ count: 100, fromBasisStep: 1, name: 'Viewed' }),
+            makeStep({ count: 50, fromBasisStep: 0.5, name: 'Signed up' }),
+            makeStep({ count: 20, fromBasisStep: 0.2, name: 'Purchased' }),
+        ]
+        const { labels } = buildFunnelBarHorizontalData(steps, options)
+        expect(labels).toHaveLength(3)
+    })
+
+    describe('non-breakdown funnel', () => {
+        const noBreakdownSteps = [
+            makeStep({ count: 100, fromBasisStep: 1, name: 'Viewed' }),
+            makeStep({ count: 50, fromBasisStep: 0.5, name: 'Signed up' }),
+            makeStep({ count: 20, fromBasisStep: 0.2, name: 'Purchased' }),
+        ]
+
+        it('emits one segment series + one filler series, each with one value per step', () => {
+            const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, options)
+
+            expect(series).toHaveLength(2)
+            expect(series[0].data).toEqual([100, 50, 20])
+            expect(series[1].data).toEqual([0, 50, 80])
+        })
+
+        it('tags each series with its drop-off / breakdown role for click + tooltip routing', () => {
+            const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, options)
+
+            expect(series[0].meta).toEqual({ isDropOff: false, breakdownIndex: null })
+            expect(series[1].meta).toEqual({ isDropOff: true, breakdownIndex: null })
+        })
+
+        it('hides the filler from the tooltip so it doesn’t double up with FunnelTooltip’s drop-off section', () => {
+            const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, options)
+            expect(series[1].visibility?.tooltip).toBe(false)
+        })
+
+        it('colors the segment from the representative step and the filler from options.fillerColor', () => {
+            const getColor = jest.fn(() => '#abcabc')
+            const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, { ...options, getColor })
+
+            expect(series[0].color).toBe('#abcabc')
+            expect(series[1].color).toBe(options.fillerColor)
+            expect(getColor).toHaveBeenCalledWith(noBreakdownSteps[0])
+        })
+    })
+
+    describe('breakdown funnel', () => {
+        const breakdownSteps = [
+            makeStep({
+                count: 100,
+                fromBasisStep: 1,
+                nested_breakdown: [
+                    makeStep({ count: 60, fromBasisStep: 1, breakdown_value: 'mobile' }),
+                    makeStep({ count: 40, fromBasisStep: 1, breakdown_value: 'desktop' }),
+                ],
+            }),
+            makeStep({
+                count: 40,
+                fromBasisStep: 0.4,
+                nested_breakdown: [
+                    makeStep({ count: 30, fromBasisStep: 0.5, breakdown_value: 'mobile' }),
+                    makeStep({ count: 10, fromBasisStep: 0.25, breakdown_value: 'desktop' }),
+                ],
+            }),
+        ]
+
+        it('emits one series per variant plus the trailing filler', () => {
+            const { series } = buildFunnelBarHorizontalData(breakdownSteps, options)
+
+            expect(series).toHaveLength(3)
+            expect(series.map((s) => s.label)).toEqual(['mobile', 'desktop', 'Drop-off'])
+        })
+
+        it('builds per-step fractions per variant against the configured basis step', () => {
+            const { series } = buildFunnelBarHorizontalData(breakdownSteps, options)
+            expect(series[0].data).toEqual([60, 30])
+            expect(series[1].data).toEqual([40, 10])
+            expect(series[2].data).toEqual([0, 60])
+        })
+
+        it('tags each segment with its source breakdownIndex', () => {
+            const { series } = buildFunnelBarHorizontalData(breakdownSteps, options)
+            expect(series[0].meta).toEqual({ isDropOff: false, breakdownIndex: 0 })
+            expect(series[1].meta).toEqual({ isDropOff: false, breakdownIndex: 1 })
+        })
+
+        it('zeros a missing variant at a later step rather than rolling its count into another bar', () => {
+            const skewed = [
+                makeStep({
+                    count: 100,
+                    fromBasisStep: 1,
+                    nested_breakdown: [
+                        makeStep({ count: 60, fromBasisStep: 1, breakdown_value: 'mobile' }),
+                        makeStep({ count: 40, fromBasisStep: 1, breakdown_value: 'desktop' }),
+                    ],
+                }),
+                makeStep({
+                    count: 50,
+                    fromBasisStep: 0.5,
+                    nested_breakdown: [makeStep({ count: 50, fromBasisStep: 0.5, breakdown_value: 'mobile' })],
+                }),
+            ]
+
+            const { series } = buildFunnelBarHorizontalData(skewed, options)
+            expect(series).toHaveLength(3)
+            expect(series[0].data).toEqual([60, 50]) // mobile
+            expect(series[1].data).toEqual([40, 0]) // desktop — missing in step 1
+            expect(series[2].data).toEqual([0, 50]) // filler
+        })
+    })
+
+    describe('single-visible-breakdown collapse', () => {
+        const collapsedSteps = [
+            makeStep({
+                count: 100,
+                fromBasisStep: 1,
+                nested_breakdown: [makeStep({ count: 100, fromBasisStep: 1, breakdown_value: 'mobile' })],
+            }),
+            makeStep({
+                count: 50,
+                fromBasisStep: 0.5,
+                nested_breakdown: [makeStep({ count: 50, fromBasisStep: 0.5, breakdown_value: 'mobile' })],
+            }),
+        ]
+        const breakdownFilter = { breakdown: '$browser' }
+
+        it('collapses to one segment + filler, sourced from the single visible variant', () => {
+            const { series } = buildFunnelBarHorizontalData(collapsedSteps, { ...options, breakdownFilter })
+
+            expect(series).toHaveLength(2)
+            expect(series[0].label).toBe('mobile')
+            expect(series[0].data).toEqual([100, 50])
+            expect(series[0].meta?.breakdownIndex).toBe(0)
+            expect(series[1].data).toEqual([0, 50])
+        })
+
+        it('falls back to the parent step’s rate when no breakdownFilter is set', () => {
+            const { series } = buildFunnelBarHorizontalData(collapsedSteps, options)
+
+            expect(series[0].data).toEqual([100, 50])
+            expect(series[0].meta?.breakdownIndex).toBeNull()
+        })
+    })
+
+    describe('reference step', () => {
+        it.each([
+            { stepReference: FunnelStepReference.total, expected: [100, 50, 20] },
+            { stepReference: FunnelStepReference.previous, expected: [100, 50, 20] },
+        ])(
+            'uses precomputed fromBasisStep for non-breakdown layouts (stepReference=$stepReference)',
+            ({ stepReference, expected }) => {
+                const steps = [
+                    makeStep({ count: 100, fromBasisStep: 1, name: 'Viewed' }),
+                    makeStep({ count: 50, fromBasisStep: 0.5, name: 'Signed up' }),
+                    makeStep({ count: 20, fromBasisStep: 0.2, name: 'Purchased' }),
+                ]
+                const { series } = buildFunnelBarHorizontalData(steps, { ...options, stepReference })
+                expect(series[0].data).toEqual(expected)
+            }
+        )
+
+        it('honors stepReference.previous as the basis for breakdown fractions', () => {
+            const steps: FunnelStepWithConversionMetrics[] = [
+                makeStep({ count: 100, fromBasisStep: 1, name: 'Viewed' }),
+                makeStep({ count: 50, fromBasisStep: 0.5, name: 'Signed up' }),
+                makeStep({
+                    count: 30,
+                    fromBasisStep: 0.3,
+                    name: 'Purchased',
+                    nested_breakdown: [
+                        makeStep({ count: 20, fromBasisStep: 0.4, breakdown_value: 'mobile' }),
+                        makeStep({ count: 10, fromBasisStep: 0.2, breakdown_value: 'desktop' }),
+                    ],
+                }),
+            ]
+            const { series } = buildFunnelBarHorizontalData(steps, {
+                ...options,
+                stepReference: FunnelStepReference.previous,
+            })
+            // Step 0 has no nested_breakdown, so non-breakdown path is taken regardless of stepReference.
+            expect(series[0].data).toEqual([100, 50, 30])
+        })
+    })
+
+    describe('zero-basis-count step', () => {
+        it('emits a zero segment + full filler when basisStep.count is 0', () => {
+            const steps = [
+                makeStep({
+                    count: 0,
+                    fromBasisStep: 0,
+                    name: 'Viewed',
+                    nested_breakdown: [
+                        makeStep({ count: 0, fromBasisStep: 0, breakdown_value: 'mobile' }),
+                        makeStep({ count: 0, fromBasisStep: 0, breakdown_value: 'desktop' }),
+                    ],
+                }),
+                makeStep({
+                    count: 0,
+                    fromBasisStep: 0,
+                    name: 'Purchased',
+                    nested_breakdown: [
+                        makeStep({ count: 0, fromBasisStep: 0, breakdown_value: 'mobile' }),
+                        makeStep({ count: 0, fromBasisStep: 0, breakdown_value: 'desktop' }),
+                    ],
+                }),
+            ]
+            const { series } = buildFunnelBarHorizontalData(steps, options)
+            expect(series.map((s) => s.data)).toEqual([
+                [0, 0],
+                [0, 0],
+                [100, 100],
+            ])
+        })
+    })
+
+    describe('series keys', () => {
+        it('namespaces segment keys by breakdown index', () => {
+            const steps = [
+                makeStep({
+                    count: 100,
+                    fromBasisStep: 1,
+                    nested_breakdown: [
+                        makeStep({ count: 60, fromBasisStep: 1, breakdown_value: 'mobile' }),
+                        makeStep({ count: 40, fromBasisStep: 1, breakdown_value: 'desktop' }),
+                    ],
+                }),
+                makeStep({
+                    count: 50,
+                    fromBasisStep: 0.5,
+                    nested_breakdown: [
+                        makeStep({ count: 30, fromBasisStep: 0.5, breakdown_value: 'mobile' }),
+                        makeStep({ count: 20, fromBasisStep: 0.4, breakdown_value: 'desktop' }),
+                    ],
+                }),
+            ]
+            const { series } = buildFunnelBarHorizontalData(steps, options)
+            expect(series.map((s) => s.key)).toEqual([
+                `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}0`,
+                `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}1`,
+                FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
+            ])
+        })
+    })
+})

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
@@ -1,0 +1,125 @@
+import type { Series } from 'lib/hog-charts'
+import { getReferenceStep, getStepBreakdownSeries } from 'scenes/funnels/funnelUtils'
+
+import type { BreakdownFilter } from '~/queries/schema/schema-general'
+import { FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
+
+export const FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX = 'funnel-bar-horizontal-segment-'
+export const FUNNEL_BAR_HORIZONTAL_FILLER_KEY = 'funnel-bar-horizontal-filler'
+
+const RATE_TO_PERCENT = 100
+
+export interface FunnelBarHorizontalSegmentMeta {
+    isDropOff: boolean
+    breakdownIndex: number | null
+}
+
+export interface FunnelBarHorizontalData {
+    series: Series<FunnelBarHorizontalSegmentMeta>[]
+    labels: string[]
+}
+
+interface BuildOptions {
+    stepReference: FunnelStepReference
+    breakdownFilter?: BreakdownFilter | null
+    getColor: (series: FunnelStepWithConversionMetrics) => string
+    getLabel: (series: FunnelStepWithConversionMetrics) => string
+    fillerColor: string
+}
+
+function isBreakdownLayout(steps: FunnelStepWithConversionMetrics[]): boolean {
+    const first = steps[0]
+    return Array.isArray(first?.nested_breakdown) && first.nested_breakdown.length > 1
+}
+
+function variantAtStep(
+    step: FunnelStepWithConversionMetrics,
+    breakdownIndex: number
+): FunnelStepWithConversionMetrics | null {
+    return step.nested_breakdown?.[breakdownIndex] ?? null
+}
+
+export function buildFunnelBarHorizontalData(
+    steps: FunnelStepWithConversionMetrics[],
+    options: BuildOptions
+): FunnelBarHorizontalData {
+    if (steps.length === 0) {
+        return { series: [], labels: [] }
+    }
+
+    const labels = steps.map((step) => step.name)
+
+    if (isBreakdownLayout(steps)) {
+        return { series: buildBreakdownSeries(steps, options), labels }
+    }
+    return { series: buildSingleSeries(steps, options), labels }
+}
+
+function buildBreakdownSeries(
+    steps: FunnelStepWithConversionMetrics[],
+    options: BuildOptions
+): Series<FunnelBarHorizontalSegmentMeta>[] {
+    const breakdownCount = steps[0].nested_breakdown!.length
+    const series: Series<FunnelBarHorizontalSegmentMeta>[] = []
+
+    for (let breakdownIndex = 0; breakdownIndex < breakdownCount; breakdownIndex++) {
+        const fractions = steps.map((step, stepIndex) => {
+            const variant = variantAtStep(step, breakdownIndex)
+            if (!variant) {
+                return 0
+            }
+            const basisCount = getReferenceStep(steps, options.stepReference, stepIndex).count
+            return basisCount > 0 ? variant.count / basisCount : 0
+        })
+        const representative = variantAtStep(steps[0], breakdownIndex)!
+        series.push({
+            key: `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}${breakdownIndex}`,
+            label: options.getLabel(representative),
+            data: fractions.map((f) => f * RATE_TO_PERCENT),
+            color: options.getColor(representative),
+            meta: { isDropOff: false, breakdownIndex },
+        })
+    }
+
+    series.push(buildFiller(steps, series, options.fillerColor))
+    return series
+}
+
+function buildSingleSeries(
+    steps: FunnelStepWithConversionMetrics[],
+    options: BuildOptions
+): Series<FunnelBarHorizontalSegmentMeta>[] {
+    const displaySteps = steps.map((step) => getStepBreakdownSeries(step, options.breakdownFilter) ?? step)
+    const fractions = displaySteps.map((s) => s.conversionRates.fromBasisStep)
+    const representative = displaySteps[0]
+    const isSingleBreakdownCollapse = displaySteps[0] !== steps[0]
+
+    const segment: Series<FunnelBarHorizontalSegmentMeta> = {
+        key: `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}0`,
+        label: options.getLabel(representative),
+        data: fractions.map((f) => f * RATE_TO_PERCENT),
+        color: options.getColor(representative),
+        meta: { isDropOff: false, breakdownIndex: isSingleBreakdownCollapse ? 0 : null },
+    }
+
+    return [segment, buildFiller(steps, [segment], options.fillerColor)]
+}
+
+function buildFiller(
+    steps: FunnelStepWithConversionMetrics[],
+    segments: Series<FunnelBarHorizontalSegmentMeta>[],
+    color: string
+): Series<FunnelBarHorizontalSegmentMeta> {
+    const fillerData = steps.map((_, stepIndex) => {
+        const covered = segments.reduce((sum, s) => sum + (s.data[stepIndex] ?? 0), 0)
+        return Math.max(0, RATE_TO_PERCENT - covered)
+    })
+    return {
+        key: FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
+        label: 'Drop-off',
+        data: fillerData,
+        color,
+        visibility: { tooltip: false },
+        meta: { isDropOff: true, breakdownIndex: null },
+    }
+}


### PR DESCRIPTION
## Problem

Splitting the horizontal funnel bar chart adapter (#60385) into reviewable chunks. This PR is the pure data layer; the render layer follows in a stacked PR.

## Changes

`buildFunnelBarHorizontalData(steps, options)` turns the funnel's `visibleStepsWithConversionMetrics` into the hog-charts `series` + `labels` shape — one chart with N stacked bands (one per step), where each band's bars are anchored to 100% via a transparent filler series. Reuses `getReferenceStep`, `getStepBreakdownSeries`, and `getFunnelsColor` from the existing funnel utilities so behavior matches the legacy chart.

No rendering, no wiring, no flag yet. 17 parameterized tests cover no/single/multi-step funnels, breakdown variants (including collapsing-to-a-single-visible-breakdown), \`total\` vs \`previous\` reference, drop-off filler placement, and zero-count edge cases.

## 🤖 Agent context

Pure data extraction from the inlined adapter in PR #60385, so reviewers can land the math independently of the React layer.

## How did you test this code?

- [x] Jest tests for the transforms (\`funnelBarHorizontalTransforms.test.ts\`)
- [x] Manually traced filler logic against legacy \`FunnelBarHorizontal\` output for the breakdown / drop-off cases