### PR TITLE
fix(mcp): restore connectionId on execute-sql tool

### DIFF
--- a/ee/hogai/tools/execute_sql/mcp_tool.py
+++ b/ee/hogai/tools/execute_sql/mcp_tool.py
@@ -18,8 +18,9 @@ class ExecuteSQLMCPToolArgs(BaseModel):
     connectionId: str | None = Field(
         default=None,
         description=(
-            "Optional ID of an external data source (e.g. a DuckLake or direct-Postgres connection) "
-            "to run the query against. When omitted, the query runs against the default ClickHouse engine."
+            "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). "
+            "When set, runs the query against that source instead of the ClickHouse catalog. "
+            "Use external-data-sources-list to discover available connection ids."
         ),
     )
 

--- a/ee/hogai/tools/execute_sql/mcp_tool.py
+++ b/ee/hogai/tools/execute_sql/mcp_tool.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Field
 
+from posthog.schema import AssistantHogQLQuery, HogQLQuery
+
 from ee.hogai.chat_agent.schema_generator.parsers import PydanticOutputParserException
 from ee.hogai.chat_agent.sql.mixins import HogQLOutputParserMixin
 from ee.hogai.context.insight.context import InsightContext
@@ -12,6 +14,13 @@ class ExecuteSQLMCPToolArgs(BaseModel):
     truncate: bool = Field(
         default=True,
         description="Whether to truncate large blob/JSON values in results. Set to false for full untruncated results.",
+    )
+    connectionId: str | None = Field(
+        default=None,
+        description=(
+            "Optional ID of an external data source (e.g. a DuckLake or direct-Postgres connection) "
+            "to run the query against. When omitted, the query runs against the default ClickHouse engine."
+        ),
     )
 
 
@@ -27,14 +36,25 @@ class ExecuteSQLMCPTool(HogQLOutputParserMixin, MCPTool[ExecuteSQLMCPToolArgs]):
     args_schema = ExecuteSQLMCPToolArgs
 
     async def execute(self, args: ExecuteSQLMCPToolArgs) -> str:
-        try:
-            validated_query = await self._validate_hogql_query(args.query)
-        except PydanticOutputParserException as e:
-            raise MaxToolRetryableError(f"Query validation failed: {e.validation_message}")
+        query: AssistantHogQLQuery | HogQLQuery
+        if args.connectionId:
+            # Queries targeting an external connection reference tables that aren't in the
+            # default ClickHouse database, so the local parse/print HogQL validation step
+            # would reject them. Defer validation to the runner, which resolves the schema
+            # for the selected connection.
+            cleaned_query = args.query.rstrip(";").strip() if args.query else ""
+            if not cleaned_query:
+                raise MaxToolRetryableError("Query validation failed: Query is empty")
+            query = HogQLQuery(query=cleaned_query, connectionId=args.connectionId)
+        else:
+            try:
+                query = await self._validate_hogql_query(args.query)
+            except PydanticOutputParserException as e:
+                raise MaxToolRetryableError(f"Query validation failed: {e.validation_message}")
 
         insight_context = InsightContext(
             team=self._team,
-            query=validated_query,
+            query=query,
             name="",
             description="",
             user=self._user,

--- a/ee/hogai/tools/execute_sql/test/test_mcp_tool.py
+++ b/ee/hogai/tools/execute_sql/test/test_mcp_tool.py
@@ -1,7 +1,9 @@
 from posthog.test.base import ClickhouseTestMixin, NonAtomicBaseTest, _create_event
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from asgiref.sync import sync_to_async
+
+from posthog.schema import HogQLQuery
 
 from products.product_analytics.backend.models.insight import Insight
 
@@ -60,3 +62,36 @@ class TestExecuteSQLMCPTool(ClickhouseTestMixin, NonAtomicBaseTest):
         )
 
         self.assertIn("Revenue Trends", content)
+
+    async def test_connection_id_skips_local_validation_and_wraps_in_hogql_query(self):
+        # When a connectionId is set the query may reference tables that only exist on the
+        # external connection, so we must bypass the local HogQL parse/print step and pass
+        # a real HogQLQuery (which carries connectionId) down to the runner.
+        captured: dict = {}
+
+        async def fake_execute_and_format(self, *args, **kwargs):
+            captured["query"] = self.query
+            return "ok"
+
+        with (
+            patch(
+                "ee.hogai.tools.execute_sql.mcp_tool.InsightContext.execute_and_format",
+                new=fake_execute_and_format,
+            ),
+            patch.object(self.tool, "_validate_hogql_query", new=AsyncMock()) as validate_mock,
+        ):
+            result = await self.tool.execute(
+                ExecuteSQLMCPToolArgs(query="SELECT * FROM ducklake_orders", connectionId="conn_abc"),
+            )
+
+        self.assertEqual(result, "ok")
+        validate_mock.assert_not_awaited()
+        self.assertIsInstance(captured["query"], HogQLQuery)
+        self.assertEqual(captured["query"].connectionId, "conn_abc")
+        self.assertEqual(captured["query"].query, "SELECT * FROM ducklake_orders")
+
+    async def test_connection_id_with_empty_query_raises(self):
+        with self.assertRaises(MaxToolRetryableError):
+            await self.tool.execute(
+                ExecuteSQLMCPToolArgs(query="   ", connectionId="conn_abc"),
+            )

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -133,6 +133,10 @@
                     "default": true,
                     "description": "Whether to truncate large blob/JSON values in results. Defaults to true. Set to false when you need full untruncated results (e.g., for dumping to a file).",
                     "type": "boolean"
+                },
+                "connectionId": {
+                    "description": "Optional ID of an external data source (e.g. a DuckLake or direct-Postgres connection) to run the query against. When omitted, the query runs against the default ClickHouse engine.",
+                    "type": "string"
                 }
             },
             "required": ["query"]

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -135,7 +135,7 @@
                     "type": "boolean"
                 },
                 "connectionId": {
-                    "description": "Optional ID of an external data source (e.g. a DuckLake or direct-Postgres connection) to run the query against. When omitted, the query runs against the default ClickHouse engine.",
+                    "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, runs the query against that source instead of the ClickHouse catalog. Use external-data-sources-list to discover available connection ids.",
                     "type": "string"
                 }
             },

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -611,7 +611,7 @@ export const ExecuteSQLSchema = z.object({
         .string()
         .optional()
         .describe(
-            'Optional ID of an external data source (e.g. a DuckLake or direct-Postgres connection) to run the query against. When omitted, the query runs against the default ClickHouse engine.'
+            'Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, runs the query against that source instead of the ClickHouse catalog. Use external-data-sources-list to discover available connection ids.'
         ),
 })
 

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -607,6 +607,12 @@ export const ExecuteSQLSchema = z.object({
         .describe(
             'Whether to truncate large blob/JSON values in results. Defaults to true. Set to false when you need full untruncated results (e.g., for dumping to a file).'
         ),
+    connectionId: z
+        .string()
+        .optional()
+        .describe(
+            'Optional ID of an external data source (e.g. a DuckLake or direct-Postgres connection) to run the query against. When omitted, the query runs against the default ClickHouse engine.'
+        ),
 })
 
 export const ReadDataWarehouseSchemaSchema = z

--- a/services/mcp/src/tools/posthogAiTools/executeSql.ts
+++ b/services/mcp/src/tools/posthogAiTools/executeSql.ts
@@ -16,6 +16,7 @@ export const executeSqlHandler: ToolBase<typeof schema, string>['handler'] = asy
     const result = await invokeMcpTool(context, 'execute_sql', {
         query: params.query,
         truncate: params.truncate ?? true,
+        ...(params.connectionId !== undefined && { connectionId: params.connectionId }),
     })
 
     if (!result.success) {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/execute-sql.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/execute-sql.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "connectionId": {
-            "description": "Optional ID of an external data source (e.g. a DuckLake or direct-Postgres connection) to run the query against. When omitted, the query runs against the default ClickHouse engine.",
+            "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, runs the query against that source instead of the ClickHouse catalog. Use external-data-sources-list to discover available connection ids.",
             "type": "string"
         },
         "query": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/execute-sql.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/execute-sql.json
@@ -1,6 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "connectionId": {
+            "description": "Optional ID of an external data source (e.g. a DuckLake or direct-Postgres connection) to run the query against. When omitted, the query runs against the default ClickHouse engine.",
+            "type": "string"
+        },
         "query": {
             "description": "The final SQL query to be executed.",
             "minLength": 1,


### PR DESCRIPTION
## Problem

The `query-run` MCP tool accepted a `HogQLQuery` body, which carried an optional `connectionId` for routing queries against an external data warehouse connection (e.g. DuckLake, direct Postgres). The replacement `execute-sql` tool's input schema is just `{ query, truncate }` — there is no way to target a non-default connection, so users that relied on `connectionId` can no longer query their external warehouse via the MCP.

## Changes

- `ExecuteSQLMCPToolArgs` gains an optional `connectionId: str | None` field.
- When `connectionId` is set, the tool wraps the query in a real `HogQLQuery(query=..., connectionId=...)` and skips the local HogQL parse/print validation step. That validation builds the default ClickHouse database for table resolution, so queries against external-connection-only tables would always be rejected before reaching the runner. `HogQLQueryRunner` already resolves the schema for the selected connection at execute time, so this is the right layer to validate.
- When `connectionId` is omitted, behaviour is unchanged — the existing `AssistantHogQLQuery` validation path runs.
- Matching `connectionId` field added to the Zod `ExecuteSQLSchema` and forwarded through the TS handler.

End-to-end flow with `connectionId`: TS handler → `invokeMcpTool` POSTs args → Pydantic validates → `HogQLQuery(query, connectionId)` is handed to `InsightContext` → `execute_and_format_query` dumps + re-validates, falling through `AssistantSupportedQueryRoot` (which rejects the extra `connectionId` via `extra="forbid"`) to `QuerySchemaRoot`, which accepts the real `HogQLQuery` → `HogQLQueryRunner` reads `self.query.connectionId` and routes via `get_direct_external_data_source_for_connection`.

## How did you test this code?

I'm an agent (Claude / Claude Code) — no manual testing performed. I added two unit tests covering the new path:

- `test_connection_id_skips_local_validation_and_wraps_in_hogql_query` — asserts that `_validate_hogql_query` is *not* called when `connectionId` is set, and that the query reaching `InsightContext` is a `HogQLQuery` carrying the supplied `connectionId`.
- `test_connection_id_with_empty_query_raises` — asserts the empty-query guard still fires when `connectionId` is set.

I did **not** run the test suite, ruff, or `pnpm typescript:check` locally — flox/uv weren't available in the agent environment. CI is the source of truth for this PR.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude Code (PostHog Code task `e582d64f-f10d-4f6f-a4cb-2656def3b12c`) in response to a Slack report from a user that they could no longer query their external warehouse via the MCP after `query-run` was replaced by `execute-sql`.

Decisions along the way:

- **Scope kept tight to `connectionId`.** `HogQLQuery` also exposes `sendRawQuery`, which is typically wanted for native Postgres passthrough on a direct connection. I considered adding it too but the original report was specifically about `connectionId`; if users need raw-SQL passthrough as well, it's a small follow-up.
- **Skip local HogQL validation when `connectionId` is set.** `_validate_hogql_query_sync` calls `prepare_and_print_ast` against the default ClickHouse database, so any reference to a table that only exists on the external connection would always fail. The runner already handles schema resolution per-connection, so validation belongs there, not here. The empty-query guard is preserved on both branches.
- **Use the real `HogQLQuery` (not `AssistantHogQLQuery`).** `AssistantHogQLQuery` is `extra="forbid"` and has no `connectionId` field, so it would strip the value. Passing `HogQLQuery` works because `execute_and_format_query` re-validates with `AssistantSupportedQueryRoot` first (which fails on the extra field) and then falls back to `QuerySchemaRoot`, which has the real `HogQLQuery` in its union and preserves `connectionId`.
- **Naming.** Both Python and TS sides use `connectionId` (camelCase) to mirror the existing `HogQLQuery.connectionId` field rather than introducing a snake_case alias.