### PR TITLE
feat(customer-analytics): Add HogQL accounts table tab

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4127,25 +4127,25 @@ snapshots:
     scenes-app-batchexports--runs-with-data--light:
         hash: v1.k794b7964.f4a8d5cc4f5447f093d5ddbbcd8572e13f7297a7db8a89504f9290226e60a2bc._CkUe6i49hMMGaDUNDHeNZDgaVp5DJQCay44V8WqfR4
     scenes-app-customer-analytics-accounts--default--dark:
-        hash: v1.k794b7964.8ddf102b0108b91a52951024c33339f08a6cbdd230f958b5f00160a5098def04.puKFKu2ZXvg0GZzKsGqUkx4KHnR_j_rFDLyl0L9DwzY
+        hash: v1.k794b7964.2f5fdfd19ec46068c974dde60066c24cfe81c010a04b30e7dc2a281e898e4552.n_f6CbLocH6mJ2AeT_GzEby8ZCNjNPBTZ7k4ZvV9p1c
     scenes-app-customer-analytics-accounts--default--light:
-        hash: v1.k794b7964.fc8512f86a3d07c776d032b3749290ac0f02f87906d5877c9c03ff9be1b4d388.eB1OqmAMpy1uwUJQQuB8Sx8P646zyR4LwOKVqaMQSo4
+        hash: v1.k794b7964.79b97000448cd16b57f3618f0aa88d96e7fa56f873ea991510874c4d38aa8f30.QdV_2IzfgOiwwJ1YpnyBDUdNBOw3-Y6ISjR4jWPRYyw
     scenes-app-customer-analytics-accounts--empty--dark:
-        hash: v1.k794b7964.fa9e2a43db5870612712960e39941f70959c176409ff3a279c61d1b6d33ce453.aJmFmbFQdClkztlbYnbGonlJBKP3czl0XW2bS2YjSZ4
+        hash: v1.k794b7964.ebf6cdc3ffcd87e1614101beedd2f9165fe87a332977747cae25b332329bb852.uF6reWk9bNsSw7WWEV3KjDFMfEg_s_qpq4S4oo54Bvg
     scenes-app-customer-analytics-accounts--empty--light:
-        hash: v1.k794b7964.d8ed0a191a6a50347d8cc250bdbebeea6dcf0fb0e542971ddf7a2177e8b3883f.FY-nlG9hzFq0_GZnGS2uZu2AMmxS_ycV1t-xMZsSWMY
+        hash: v1.k794b7964.fb3f3b11f2c297a7b4ed7e26e865f1b0232fb89ee7f64f66156fde1eebc670c2.NqjaSrcZVHoLIkt_S-UuF-JwYI-Itha7Ckuw5GkD4Dg
     scenes-app-customer-analytics-accounts--feature-gate-off--dark:
         hash: v1.k794b7964.7750bce37ad591ab773135ad1a9b8738ac790727774c03d3aa7b5abbfc42fab0.KbXf74dR5pSVh6Wc8mSjrNGqL8LbTcsMl78W7WVvTXU
     scenes-app-customer-analytics-accounts--feature-gate-off--light:
         hash: v1.k794b7964.102431e5d999bc15bb9589ef2eccc8d0e44a779b9c820279aa1637d293edf403.AxkbpynMmXkyb0voFylEK03iBfJO43IXPpsGqxgzTkE
     scenes-app-customer-analytics-accounts--row-expanded-empty--dark:
-        hash: v1.k794b7964.b4dc25994c12835e1d2c78db56ad115a5cdadd5ed15f6960bff256f20ee2032b.FG3qUrIgM9cvKzOhnnC5I-Og7t3VsSxmqPi9hAZDyrc
+        hash: v1.k794b7964.f4a1756ff3324f5ec87a42c1f6f40d3a19f794da8506c71344c821e8e14cabc6.SzisY-HCjHbQJRDvck4ADTZd60v0IHwfbXI4wlQ9c_E
     scenes-app-customer-analytics-accounts--row-expanded-empty--light:
-        hash: v1.k794b7964.2034a479b936c4532d32da344d97eb9165205165a3fa77db68a83553e3efeea7.KOchCQsonn3B1M9_mfH4CJyges_n9nXiffeu7zk5yl0
+        hash: v1.k794b7964.d6e84c6da22409b03fd4dd1969f1aef3a2cc7dea0fc44988d2894ef7e0c3bdd2.5Q6N6QSvL1hc02YQRBAOkzrS418sXo87ij7S02ierIQ
     scenes-app-customer-analytics-accounts--row-expanded-with-note--dark:
-        hash: v1.k794b7964.2edbd8ec456cf2604474ac5653320b756331f86bfe73801df3bbeebc9c424da0.ykw_x-QQYJkmwUFDLH1GJg8HylDV2RA4YpyRSWSAuRw
+        hash: v1.k794b7964.0a0d1b32483192fda88dfc775725fe2df00ca6ba0ed969b3a93ab42e02454ba1.K2vJPKWjZ0CtP20CY80Aa0t2vVkBZAmmeM78vqtZx5w
     scenes-app-customer-analytics-accounts--row-expanded-with-note--light:
-        hash: v1.k794b7964.fd505fec90590a232e951f4e76fe9c2fe9defcb8c13c1d5d49d791c7d1ac5747.WTfRLxuOo1ulkq2MW7SlqmKFbGMNI9tHh1EWJ6YSL0U
+        hash: v1.k794b7964.9f478491d60d6c23237f6d9cb118b02a1d4642381d9ddab3d59cc87a94766a26.dSnxPzlQcBDlH-bqMCOGD8AEmcS9dwe-cu3U8oAgUL8
     scenes-app-customer-analytics-dashboard--b-2-b-mode-with-groups-enabled--dark:
         hash: v1.k794b7964.b1e7b3b4db44122983952ce49cdcb2721216d6e09cdda2e03d88250a66f9531d.XEmKGVDBb7ph1xN1zMKNGWDQAkJPR509WPM2orhsrZo
     scenes-app-customer-analytics-dashboard--b-2-b-mode-with-groups-enabled--light:
@@ -4889,7 +4889,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
         hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
-        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
+        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.EIwByuofuT77yP259A9ffqfjSFwW9MrUDOvsZNA_aZM
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
         hash: v1.k794b7964.d64808d2bfc36017f89b57feeaa373e20188738a622801207fa1beb59d02fdd9.cFuKF_Ow887Z3X3BoNhtTvkUWY2vips9HDBe-B02eQE
     scenes-app-insights-funnels--funnel-time-to-convert--light:

--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -1,5 +1,6 @@
 import { Node } from '~/queries/schema/schema-general'
 import {
+    isAccountsQuery,
     isActorsQuery,
     isEndpointsUsageTableQuery,
     isEventsQuery,
@@ -158,6 +159,13 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
         features.add(QueryFeature.resultIsArrayOfArrays)
         features.add(QueryFeature.displayResponseError)
         features.add(QueryFeature.hideLoadNextButton)
+    }
+
+    if (isAccountsQuery(query)) {
+        features.add(QueryFeature.columnsInResponse)
+        features.add(QueryFeature.resultIsArrayOfArrays)
+        features.add(QueryFeature.displayResponseError)
+        features.add(QueryFeature.selectAndOrderByColumns)
     }
 
     return features

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -5,6 +5,7 @@ import { getAppContext } from 'lib/utils/getAppContext'
 
 import { ProductAnalyticsInsightNodeKind } from '~/queries/nodes/InsightQuery/defaults'
 import {
+    AccountsQuery,
     ActionsNode,
     ActorsQuery,
     AnyDataWarehouseNode,
@@ -902,6 +903,10 @@ export function isValidQueryForExperiment(query: Node): boolean {
 
 export function isGroupsQuery(node?: Record<string, any> | null): node is GroupsQuery {
     return node?.kind === NodeKind.GroupsQuery
+}
+
+export function isAccountsQuery(node?: Record<string, any> | null): node is AccountsQuery {
+    return node?.kind === NodeKind.AccountsQuery
 }
 
 export const TRAILING_MATH_TYPES = new Set<MathType>([BaseMathType.WeeklyActiveUsers, BaseMathType.MonthlyActiveUsers])

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -10,7 +10,12 @@ import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { QueryContext, QueryContextColumn } from '~/queries/types'
 
 import { AccountNotebooksExpansion } from './AccountNotebooksExpansion'
-import { ACCOUNTS_HOGQL_COLUMN_NAMES, AccountRoleKey, accountsLogic } from './accountsLogic'
+import {
+    ACCOUNTS_HOGQL_COLUMN_NAMES,
+    ACCOUNTS_HOGQL_DATA_NODE_KEY,
+    AccountRoleKey,
+    accountsLogic,
+} from './accountsLogic'
 
 type AccountAssignment = { id: number; email: string } | null
 
@@ -95,10 +100,13 @@ function RoleAssignmentCell({
     value: unknown
     role: AccountRoleKey
 }): JSX.Element {
-    const { isRoleSaving } = useValues(accountsLogic)
+    const { isRoleSaving, accountOverrides } = useValues(accountsLogic)
     const { updateAccountRole } = useActions(accountsLogic)
     const accountId = String(getCell(record, 'id') ?? '')
-    const assignment = tupleToAssignment(value)
+    const overrideProperties = accountId ? accountOverrides[accountId]?.properties : undefined
+    const overrideRole = overrideProperties != null ? overrideProperties[role] : undefined
+    const assignment: AccountAssignment =
+        overrideRole === undefined ? tupleToAssignment(value) : (overrideRole as AccountAssignment)
     const saving = accountId ? isRoleSaving(accountId, role) : false
 
     return (
@@ -187,7 +195,7 @@ export function AccountsHogQLTable(): JSX.Element {
             setQuery={() => {
                 // Filters are owned by accountsLogic; column/sort changes from the DataTable are ignored on purpose.
             }}
-            context={CONTEXT}
+            context={{ ...CONTEXT, dataNodeLogicKey: ACCOUNTS_HOGQL_DATA_NODE_KEY }}
             readOnly
         />
     )

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -1,8 +1,181 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, ProfilePicture } from '@posthog/lemon-ui'
+
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { MemberSelect } from 'lib/components/MemberSelect'
+import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
+import { QueryContext, QueryContextColumn } from '~/queries/types'
 
-import { accountsLogic } from './accountsLogic'
+import { AccountNotebooksExpansion } from './AccountNotebooksExpansion'
+import { ACCOUNTS_HOGQL_COLUMN_NAMES, AccountRoleKey, accountsLogic } from './accountsLogic'
+
+type AccountAssignment = { id: number; email: string } | null
+
+const ROLE_LABELS: Record<AccountRoleKey, string> = {
+    csm: 'CSM',
+    account_executive: 'Account executive',
+    account_owner: 'Account owner',
+}
+
+// Maps logical column names used by the cell renderers to the actual column
+// names in the HogQL response. `id` and `external_id` come back under the
+// `context.columns.X` prefix so DataTable's existing hidden-flag path filters
+// them out of the visible columns — we still need them in the row tuple for
+// the row-expand id and the Account cell's external_id rendering.
+const COLUMN_KEY_OVERRIDES: Record<string, string> = {
+    id: 'context.columns.id',
+    external_id: 'context.columns.external_id',
+}
+
+function columnIndex(name: string): number {
+    return ACCOUNTS_HOGQL_COLUMN_NAMES.indexOf(COLUMN_KEY_OVERRIDES[name] ?? name)
+}
+
+function getCell(record: unknown, column: string): unknown {
+    if (!Array.isArray(record)) {
+        return undefined
+    }
+    const index = columnIndex(column)
+    return index >= 0 ? record[index] : undefined
+}
+
+function tupleToAssignment(value: unknown): AccountAssignment {
+    if (!Array.isArray(value)) {
+        return null
+    }
+    const [id, email] = value as [unknown, unknown]
+    if (id === null || id === undefined || typeof email !== 'string' || !email) {
+        return null
+    }
+    const numericId = typeof id === 'number' ? id : Number(id)
+    if (!Number.isFinite(numericId)) {
+        return null
+    }
+    return { id: numericId, email }
+}
+
+function NameCell({ record }: { record: unknown }): JSX.Element {
+    const name = String(getCell(record, 'name') ?? '')
+    const externalId = getCell(record, 'external_id')
+    return (
+        <div className="flex flex-col min-w-40">
+            <span className="font-medium">{name}</span>
+            {typeof externalId === 'string' && externalId ? (
+                <CopyToClipboardInline
+                    explicitValue={externalId}
+                    iconStyle={{ color: 'var(--color-accent)' }}
+                    description="account ID"
+                >
+                    {externalId}
+                </CopyToClipboardInline>
+            ) : null}
+        </div>
+    )
+}
+
+function TagsCell({ value }: { value: unknown }): JSX.Element {
+    const tags = Array.isArray(value) ? (value.filter((t) => typeof t === 'string') as string[]) : []
+    return tags.length > 0 ? <ObjectTags tags={tags} staticOnly /> : <span className="text-muted">—</span>
+}
+
+function NotebookCountCell({ value }: { value: unknown }): JSX.Element {
+    const count = Number(value) || 0
+    return count > 0 ? <span>{count}</span> : <span className="text-muted">—</span>
+}
+
+function RoleAssignmentCell({
+    record,
+    value,
+    role,
+}: {
+    record: unknown
+    value: unknown
+    role: AccountRoleKey
+}): JSX.Element {
+    const { isRoleSaving } = useValues(accountsLogic)
+    const { updateAccountRole } = useActions(accountsLogic)
+    const accountId = String(getCell(record, 'id') ?? '')
+    const assignment = tupleToAssignment(value)
+    const saving = accountId ? isRoleSaving(accountId, role) : false
+
+    return (
+        <div data-attr={`accounts-${role}-cell`}>
+            <MemberSelect
+                value={assignment?.id ?? null}
+                defaultLabel="Unassigned"
+                onChange={(user) => accountId && updateAccountRole(accountId, role, user)}
+            >
+                {(selectedUser) => (
+                    <LemonButton
+                        type="tertiary"
+                        size="small"
+                        loading={saving}
+                        disabledReason={saving ? 'Saving…' : undefined}
+                        icon={
+                            selectedUser ? (
+                                <ProfilePicture user={selectedUser} size="sm" />
+                            ) : assignment ? (
+                                <ProfilePicture user={{ email: assignment.email }} size="sm" />
+                            ) : undefined
+                        }
+                    >
+                        {assignment ? (
+                            <span className="text-sm">{assignment.email}</span>
+                        ) : (
+                            <span className="text-muted">Unassigned</span>
+                        )}
+                    </LemonButton>
+                )}
+            </MemberSelect>
+        </div>
+    )
+}
+
+const HIDDEN_COLUMN: QueryContextColumn = { hidden: true }
+
+const CONTEXT: QueryContext = {
+    columns: {
+        id: HIDDEN_COLUMN,
+        external_id: HIDDEN_COLUMN,
+        name: {
+            title: 'Account',
+            render: ({ record }) => <NameCell record={record} />,
+        },
+        tag_names: {
+            title: 'Tags',
+            render: ({ value }) => <TagsCell value={value} />,
+        },
+        notebook_count: {
+            title: 'Notes',
+            render: ({ value }) => <NotebookCountCell value={value} />,
+        },
+        csm: {
+            title: ROLE_LABELS.csm,
+            render: ({ record, value }) => <RoleAssignmentCell record={record} value={value} role="csm" />,
+        },
+        account_executive: {
+            title: ROLE_LABELS.account_executive,
+            render: ({ record, value }) => (
+                <RoleAssignmentCell record={record} value={value} role="account_executive" />
+            ),
+        },
+        account_owner: {
+            title: ROLE_LABELS.account_owner,
+            render: ({ record, value }) => <RoleAssignmentCell record={record} value={value} role="account_owner" />,
+        },
+    },
+    expandable: {
+        noIndent: true,
+        expandedRowRender: ({ result }) => {
+            const accountId = Array.isArray(result) ? String(result[columnIndex('id')] ?? '') : ''
+            return accountId ? <AccountNotebooksExpansion accountId={accountId} /> : null
+        },
+        rowExpandable: ({ result }) => Array.isArray(result) && !!result[columnIndex('id')],
+    },
+}
 
 export function AccountsHogQLTable(): JSX.Element {
     const { hogqlQuery } = useValues(accountsLogic)
@@ -14,6 +187,7 @@ export function AccountsHogQLTable(): JSX.Element {
             setQuery={() => {
                 // Filters are owned by accountsLogic; column/sort changes from the DataTable are ignored on purpose.
             }}
+            context={CONTEXT}
             readOnly
         />
     )

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -1,12 +1,15 @@
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 
-import { LemonButton, ProfilePicture } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton, LemonTable, ProfilePicture } from '@posthog/lemon-ui'
 
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { MemberSelect } from 'lib/components/MemberSelect'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
+import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
+import { DataTableNode } from '~/queries/schema/schema-general'
 import { QueryContext, QueryContextColumn } from '~/queries/types'
 
 import { AccountNotebooksExpansion } from './AccountNotebooksExpansion'
@@ -24,6 +27,15 @@ const ROLE_LABELS: Record<AccountRoleKey, string> = {
     account_executive: 'Account executive',
     account_owner: 'Account owner',
 }
+
+const COLUMN_WIDTHS = {
+    name: '240px',
+    tag_names: '280px',
+    notebook_count: '80px',
+    csm: '220px',
+    account_executive: '220px',
+    account_owner: '220px',
+} as const
 
 // Maps logical column names used by the cell renderers to the actual column
 // names in the HogQL response. `id` and `external_id` come back under the
@@ -144,34 +156,40 @@ function RoleAssignmentCell({
 
 const HIDDEN_COLUMN: QueryContextColumn = { hidden: true }
 
-const CONTEXT: QueryContext = {
+const CONTEXT: QueryContext<DataTableNode> = {
     columns: {
         id: HIDDEN_COLUMN,
         external_id: HIDDEN_COLUMN,
         name: {
             title: 'Account',
+            width: COLUMN_WIDTHS.name,
             render: ({ record }) => <NameCell record={record} />,
         },
         tag_names: {
             title: 'Tags',
+            width: COLUMN_WIDTHS.tag_names,
             render: ({ value }) => <TagsCell value={value} />,
         },
         notebook_count: {
             title: 'Notes',
+            width: COLUMN_WIDTHS.notebook_count,
             render: ({ value }) => <NotebookCountCell value={value} />,
         },
         csm: {
             title: ROLE_LABELS.csm,
+            width: COLUMN_WIDTHS.csm,
             render: ({ record, value }) => <RoleAssignmentCell record={record} value={value} role="csm" />,
         },
         account_executive: {
             title: ROLE_LABELS.account_executive,
+            width: COLUMN_WIDTHS.account_executive,
             render: ({ record, value }) => (
                 <RoleAssignmentCell record={record} value={value} role="account_executive" />
             ),
         },
         account_owner: {
             title: ROLE_LABELS.account_owner,
+            width: COLUMN_WIDTHS.account_owner,
             render: ({ record, value }) => <RoleAssignmentCell record={record} value={value} role="account_owner" />,
         },
     },
@@ -181,22 +199,95 @@ const CONTEXT: QueryContext = {
             const accountId = Array.isArray(result) ? String(result[columnIndex('id')] ?? '') : ''
             return accountId ? <AccountNotebooksExpansion accountId={accountId} /> : null
         },
-        rowExpandable: ({ result }) => Array.isArray(result) && !!result[columnIndex('id')],
     },
 }
 
-export function AccountsHogQLTable(): JSX.Element {
-    const { hogqlQuery } = useValues(accountsLogic)
+const SKELETON_ROW_COUNT = 5
 
+const SKELETON_COLUMNS: LemonTableColumns<{ key: number }> = [
+    {
+        title: 'Account',
+        width: COLUMN_WIDTHS.name,
+        render: () => (
+            <div className="flex flex-col gap-2 mb-1 min-w-40">
+                <LemonSkeleton className="h-4 w-32" />
+                <LemonSkeleton className="h-3 w-24" />
+            </div>
+        ),
+    },
+    {
+        title: 'Tags',
+        width: COLUMN_WIDTHS.tag_names,
+        render: () => (
+            <div className="flex gap-1">
+                <LemonSkeleton className="h-5 w-16 rounded-full" />
+                <LemonSkeleton className="h-5 w-20 rounded-full" />
+            </div>
+        ),
+    },
+    {
+        title: 'Notes',
+        width: COLUMN_WIDTHS.notebook_count,
+        render: () => <LemonSkeleton className="h-4 w-4" />,
+    },
+    ...(['csm', 'account_executive', 'account_owner'] as const).map((role) => ({
+        title: ROLE_LABELS[role],
+        width: COLUMN_WIDTHS[role],
+        render: () => (
+            <div className="flex items-center gap-2">
+                <LemonSkeleton.Circle className="h-5 w-5" />
+                <LemonSkeleton className="h-4 w-24" />
+            </div>
+        ),
+    })),
+]
+
+function AccountsHogQLSkeleton(): JSX.Element {
+    return (
+        <LemonTable
+            className="DataTable"
+            columns={SKELETON_COLUMNS}
+            dataSource={Array.from({ length: SKELETON_ROW_COUNT }, (_, key) => ({ key }))}
+            rowKey="key"
+            expandable={{
+                noIndent: true,
+                expandedRowRender: () => null,
+                rowExpandable: () => true,
+            }}
+        />
+    )
+}
+
+function AccountsHogQLDataTable({ query }: { query: DataTableNode }): JSX.Element {
+    const { responseLoading, response } = useValues(dataNodeLogic)
+    if (responseLoading && !response) {
+        return <AccountsHogQLSkeleton />
+    }
     return (
         <DataTable
             uniqueKey="customer-analytics-accounts-hogql"
-            query={hogqlQuery}
+            query={query}
             setQuery={() => {
                 // Filters are owned by accountsLogic; column/sort changes from the DataTable are ignored on purpose.
             }}
             context={{ ...CONTEXT, dataNodeLogicKey: ACCOUNTS_HOGQL_DATA_NODE_KEY }}
             readOnly
         />
+    )
+}
+
+export function AccountsHogQLTable(): JSX.Element {
+    const { hogqlQuery } = useValues(accountsLogic)
+
+    return (
+        <BindLogic
+            logic={dataNodeLogic}
+            props={{
+                key: ACCOUNTS_HOGQL_DATA_NODE_KEY,
+                query: hogqlQuery.source,
+            }}
+        >
+            <AccountsHogQLDataTable query={hogqlQuery} />
+        </BindLogic>
     )
 }

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -93,32 +93,25 @@ function NameCell({ record }: { record: unknown }): JSX.Element {
     )
 }
 
-function TagsCell({ value }: { value: unknown }): JSX.Element {
-    const tags = Array.isArray(value) ? (value.filter((t) => typeof t === 'string') as string[]) : []
+function TagsCell({ record }: { record: unknown }): JSX.Element {
+    const raw = getCell(record, 'tag_names')
+    const tags = Array.isArray(raw) ? (raw.filter((t) => typeof t === 'string') as string[]) : []
     return tags.length > 0 ? <ObjectTags tags={tags} staticOnly /> : <span className="text-muted">—</span>
 }
 
-function NotebookCountCell({ value }: { value: unknown }): JSX.Element {
-    const count = Number(value) || 0
+function NotebookCountCell({ record }: { record: unknown }): JSX.Element {
+    const count = Number(getCell(record, 'notebook_count')) || 0
     return count > 0 ? <span>{count}</span> : <span className="text-muted">—</span>
 }
 
-function RoleAssignmentCell({
-    record,
-    value,
-    role,
-}: {
-    record: unknown
-    value: unknown
-    role: AccountRoleKey
-}): JSX.Element {
+function RoleAssignmentCell({ record, role }: { record: unknown; role: AccountRoleKey }): JSX.Element {
     const { isRoleSaving, accountOverrides } = useValues(accountsLogic)
     const { updateAccountRole } = useActions(accountsLogic)
     const accountId = String(getCell(record, 'id') ?? '')
     const overrideProperties = accountId ? accountOverrides[accountId]?.properties : undefined
     const overrideRole = overrideProperties != null ? overrideProperties[role] : undefined
     const assignment: AccountAssignment =
-        overrideRole === undefined ? tupleToAssignment(value) : (overrideRole as AccountAssignment)
+        overrideRole === undefined ? tupleToAssignment(getCell(record, role)) : (overrideRole as AccountAssignment)
     const saving = accountId ? isRoleSaving(accountId, role) : false
 
     return (
@@ -168,29 +161,27 @@ const CONTEXT: QueryContext<DataTableNode> = {
         tag_names: {
             title: 'Tags',
             width: COLUMN_WIDTHS.tag_names,
-            render: ({ value }) => <TagsCell value={value} />,
+            render: ({ record }) => <TagsCell record={record} />,
         },
         notebook_count: {
             title: 'Notes',
             width: COLUMN_WIDTHS.notebook_count,
-            render: ({ value }) => <NotebookCountCell value={value} />,
+            render: ({ record }) => <NotebookCountCell record={record} />,
         },
         csm: {
             title: ROLE_LABELS.csm,
             width: COLUMN_WIDTHS.csm,
-            render: ({ record, value }) => <RoleAssignmentCell record={record} value={value} role="csm" />,
+            render: ({ record }) => <RoleAssignmentCell record={record} role="csm" />,
         },
         account_executive: {
             title: ROLE_LABELS.account_executive,
             width: COLUMN_WIDTHS.account_executive,
-            render: ({ record, value }) => (
-                <RoleAssignmentCell record={record} value={value} role="account_executive" />
-            ),
+            render: ({ record }) => <RoleAssignmentCell record={record} role="account_executive" />,
         },
         account_owner: {
             title: ROLE_LABELS.account_owner,
             width: COLUMN_WIDTHS.account_owner,
-            render: ({ record, value }) => <RoleAssignmentCell record={record} value={value} role="account_owner" />,
+            render: ({ record }) => <RoleAssignmentCell record={record} role="account_owner" />,
         },
     },
     expandable: {

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -1,0 +1,20 @@
+import { useValues } from 'kea'
+
+import { DataTable } from '~/queries/nodes/DataTable/DataTable'
+
+import { accountsLogic } from './accountsLogic'
+
+export function AccountsHogQLTable(): JSX.Element {
+    const { hogqlQuery } = useValues(accountsLogic)
+
+    return (
+        <DataTable
+            uniqueKey="customer-analytics-accounts-hogql"
+            query={hogqlQuery}
+            setQuery={() => {
+                // Filters are owned by accountsLogic; column/sort changes from the DataTable are ignored on purpose.
+            }}
+            readOnly
+        />
+    )
+}

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTabContent.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTabContent.tsx
@@ -1,11 +1,35 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+
+import { AccountsHogQLTable } from './AccountsHogQLTable'
+import { accountsLogic, AccountsView } from './accountsLogic'
 import { AccountsTabFilters } from './AccountsTabFilters'
 import { AccountsTable } from './AccountsTable'
 
 export function AccountsTabContent(): JSX.Element {
+    const { activeView } = useValues(accountsLogic)
+    const { setActiveView } = useActions(accountsLogic)
+
     return (
         <div className="flex flex-col gap-3">
             <AccountsTabFilters />
-            <AccountsTable />
+            <LemonTabs
+                activeKey={activeView}
+                onChange={(key) => setActiveView(key as AccountsView)}
+                tabs={[
+                    {
+                        key: 'endpoint',
+                        label: 'REST endpoint',
+                        content: <AccountsTable />,
+                    },
+                    {
+                        key: 'hogql',
+                        label: 'HogQL query',
+                        content: <AccountsHogQLTable />,
+                    },
+                ]}
+            />
         </div>
     )
 }

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -5,6 +5,7 @@ import posthog from 'posthog-js'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { AccountsQuery, DataTableNode, NodeKind } from '~/queries/schema/schema-general'
 import type { UserBasicType } from '~/types'
 
@@ -18,6 +19,8 @@ import { CUSTOMER_ANALYTICS_DEFAULT_QUERY_TAGS } from '../../constants'
 import type { accountsLogicType } from './accountsLogicType'
 
 export const ACCOUNTS_PAGE_SIZE = 20
+
+export const ACCOUNTS_HOGQL_DATA_NODE_KEY = 'customer-analytics-accounts-hogql'
 
 // Columns aliased into the `context.columns.X` namespace are present in the response
 // (so the table cell renderers can reach `id` / `external_id` via the row tuple) but
@@ -88,6 +91,7 @@ export const accountsLogic = kea<accountsLogicType>([
         roleUpdateStarted: (accountId: string, role: AccountRoleKey) => ({ accountId, role }),
         roleUpdateFinished: (accountId: string, role: AccountRoleKey) => ({ accountId, role }),
         replaceAccount: (account: AccountApi) => ({ account }),
+        revertAccountOverride: (accountId: string) => ({ accountId }),
     }),
     reducers({
         searchQuery: [
@@ -156,6 +160,11 @@ export const accountsLogic = kea<accountsLogicType>([
             {} as Record<string, AccountApi>,
             {
                 replaceAccount: (state, { account }) => ({ ...state, [account.id]: account }),
+                revertAccountOverride: (state, { accountId }) => {
+                    const next = { ...state }
+                    delete next[accountId]
+                    return next
+                },
                 loadAccountsSuccess: () => ({}),
             },
         ],
@@ -310,6 +319,7 @@ export const accountsLogic = kea<accountsLogicType>([
         },
         refresh: () => {
             actions.loadAccounts()
+            dataNodeLogic.findMounted({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY })?.actions.loadData('force_async')
         },
         updateAccountRole: async ({ accountId, role, user }) => {
             if (values.isRoleSaving(accountId, role)) {
@@ -319,16 +329,25 @@ export const accountsLogic = kea<accountsLogicType>([
             if (!account) {
                 return
             }
+            const previousOverride = values.accountOverrides[accountId]
             const nextProperties: PatchedAccountApiProperties = {
                 ...account.properties,
                 [role]: user ? { id: user.id, email: user.email } : null,
             }
+            const optimisticAccount: AccountApi = { ...account, properties: nextProperties }
             const projectId = String(values.currentTeamId)
             actions.roleUpdateStarted(accountId, role)
+            actions.replaceAccount(optimisticAccount)
             try {
                 const updated = await accountsPartialUpdate(projectId, accountId, { properties: nextProperties })
                 actions.replaceAccount(updated)
+                dataNodeLogic.findMounted({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY })?.actions.loadData('force_async')
             } catch (error) {
+                if (previousOverride) {
+                    actions.replaceAccount(previousOverride)
+                } else {
+                    actions.revertAccountOverride(accountId)
+                }
                 posthog.captureException(error as Error, { scope: 'accountsLogic.updateAccountRole' })
                 lemonToast.error(`Failed to update ${ROLE_LABELS[role]}`)
             } finally {

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -19,6 +19,31 @@ import type { accountsLogicType } from './accountsLogicType'
 
 export const ACCOUNTS_PAGE_SIZE = 20
 
+// Columns aliased into the `context.columns.X` namespace are present in the response
+// (so the table cell renderers can reach `id` / `external_id` via the row tuple) but
+// hidden from the visible columns via QueryContextColumn.hidden = true.
+export const ACCOUNTS_HOGQL_SELECT: string[] = [
+    'id AS `context.columns.id`',
+    'name',
+    'external_id AS `context.columns.external_id`',
+    'accounts.tags.names AS tag_names',
+    'accounts.notebooks.count AS notebook_count',
+    'csm',
+    'account_executive',
+    'account_owner',
+]
+
+export const ACCOUNTS_HOGQL_COLUMN_NAMES: string[] = [
+    'context.columns.id',
+    'name',
+    'context.columns.external_id',
+    'tag_names',
+    'notebook_count',
+    'csm',
+    'account_executive',
+    'account_owner',
+]
+
 export type RoleFilterValue = number | null
 
 export type AccountsView = 'endpoint' | 'hogql'
@@ -211,7 +236,7 @@ export const accountsLogic = kea<accountsLogicType>([
             ): DataTableNode => {
                 const source: AccountsQuery = {
                     kind: NodeKind.AccountsQuery,
-                    select: ['id', 'name', 'external_id', 'created_at', 'properties'],
+                    select: ACCOUNTS_HOGQL_SELECT,
                     tags: { ...CUSTOMER_ANALYTICS_DEFAULT_QUERY_TAGS, name: 'customer_analytics_accounts_list' },
                 }
                 const trimmed = searchQuery.trim()

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -5,6 +5,7 @@ import posthog from 'posthog-js'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { AccountsQuery, DataTableNode, NodeKind } from '~/queries/schema/schema-general'
 import type { UserBasicType } from '~/types'
 
 import { accountsList, accountsPartialUpdate } from 'products/customer_analytics/frontend/generated/api'
@@ -13,11 +14,14 @@ import type {
     PatchedAccountApiProperties,
 } from 'products/customer_analytics/frontend/generated/api.schemas'
 
+import { CUSTOMER_ANALYTICS_DEFAULT_QUERY_TAGS } from '../../constants'
 import type { accountsLogicType } from './accountsLogicType'
 
 export const ACCOUNTS_PAGE_SIZE = 20
 
 export type RoleFilterValue = number | null
+
+export type AccountsView = 'endpoint' | 'hogql'
 
 export type AccountRoleKey = 'csm' | 'account_executive' | 'account_owner'
 
@@ -49,6 +53,7 @@ export const accountsLogic = kea<accountsLogicType>([
         setAccountExecutiveFilter: (value: RoleFilterValue) => ({ value }),
         setAccountOwnerFilter: (value: RoleFilterValue) => ({ value }),
         setCurrentPage: (page: number) => ({ page }),
+        setActiveView: (view: AccountsView) => ({ view }),
         refresh: true,
         updateAccountRole: (accountId: string, role: AccountRoleKey, user: UserBasicType | null) => ({
             accountId,
@@ -100,6 +105,12 @@ export const accountsLogic = kea<accountsLogicType>([
             1,
             {
                 setCurrentPage: (_, { page }) => page,
+            },
+        ],
+        activeView: [
+            'endpoint' as AccountsView,
+            {
+                setActiveView: (_, { view }) => view,
             },
         ],
         savingRoles: [
@@ -180,6 +191,54 @@ export const accountsLogic = kea<accountsLogicType>([
             (savingRoles: Record<string, true>) =>
                 (accountId: string, role: AccountRoleKey): boolean =>
                     !!savingRoles[savingRoleKey(accountId, role)],
+        ],
+        hogqlQuery: [
+            (s) => [
+                s.searchQuery,
+                s.tagsFilter,
+                s.allRolesUnassigned,
+                s.csmFilter,
+                s.accountExecutiveFilter,
+                s.accountOwnerFilter,
+            ],
+            (
+                searchQuery: string,
+                tagsFilter: string[],
+                allRolesUnassigned: boolean,
+                csmFilter: RoleFilterValue,
+                accountExecutiveFilter: RoleFilterValue,
+                accountOwnerFilter: RoleFilterValue
+            ): DataTableNode => {
+                const source: AccountsQuery = {
+                    kind: NodeKind.AccountsQuery,
+                    select: ['id', 'name', 'external_id', 'created_at', 'properties'],
+                    tags: { ...CUSTOMER_ANALYTICS_DEFAULT_QUERY_TAGS, name: 'customer_analytics_accounts_list' },
+                }
+                const trimmed = searchQuery.trim()
+                if (trimmed) {
+                    source.search = trimmed
+                }
+                if (tagsFilter.length > 0) {
+                    source.tagNames = tagsFilter
+                }
+                if (allRolesUnassigned) {
+                    source.allRolesUnassigned = true
+                }
+                if (csmFilter !== null) {
+                    source.csm = csmFilter
+                }
+                if (accountExecutiveFilter !== null) {
+                    source.accountExecutive = accountExecutiveFilter
+                }
+                if (accountOwnerFilter !== null) {
+                    source.accountOwner = accountOwnerFilter
+                }
+                return {
+                    kind: NodeKind.DataTableNode,
+                    source,
+                    full: true,
+                }
+            },
         ],
     }),
     listeners(({ actions, values }) => ({


### PR DESCRIPTION
## Problem

The Customer Analytics Accounts list is REST-only, so there is no way to validate the HogQL path or to enrich rows with derived columns from `system.accounts` (tags, notebooks, role assignments).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- Add HogQL accounts table tab alongside the existing REST endpoint tab [temporary, for testing/validation purposes]
- Render Account / Tags / Notes / CSM / AE / Owner cells via `context.columns` plus an expandable notebooks row
- Make `DataTable` respect `context.columns[name].hidden` on direct column-name keys (was only the `context.columns.<name>` prefix path)
- Apply role updates optimistically with revert-on-failure; Refresh button bypasses cache via `force_async`
- Add an accounts-specific skeleton with column widths matching the loaded layout so the table doesn't shift on first paint

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually in the UI, asserting the new table has the same functionalities than the old one

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- Add the `skip-migration-service-check` label if every migration here is DB-noop (e.g. `SeparateDatabaseAndState` with empty `database_operations`, or pure `RunPython`) and it's safe to ship alongside service code. -->

## 🤖 Agent context

Authored by PostHog Code. Stacked on top of #60460. The only `DataTable` change is the hidden-flag fix — the rest of the loading behaviour (skeleton, column widths, optimistic state) is intentionally product-local so we don't change how every other DataTable consumer renders during load.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)