### PR TITLE
feat(llma): copy link to skill file

### DIFF
--- a/products/ai_observability/frontend/skills/LLMSkillScene.tsx
+++ b/products/ai_observability/frontend/skills/LLMSkillScene.tsx
@@ -10,10 +10,12 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
 import { NotFound } from 'lib/components/NotFound'
 import { dayjs } from 'lib/dayjs'
+import { IconLink } from 'lib/lemon-ui/icons'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonMarkdownWithMermaid } from 'lib/lemon-ui/LemonMarkdown'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -554,21 +556,39 @@ function SkillFileViewer({
     const isMarkdown = file.content_type === 'text/markdown' || file.path.endsWith('.md')
     const codeLanguage = isMarkdown ? null : getFileLanguage(file.path, file.content_type)
 
+    const copyFileLink = (): void => {
+        const path = combineUrl(urls.aiObservabilitySkill(skillName), {
+            file: file.path,
+            version,
+        }).url
+        void copyToClipboard(`${window.location.origin}${path}`, 'file link')
+    }
+
     return (
         <div ref={containerRef} className="rounded border">
-            <button
-                type="button"
-                className="flex w-full cursor-pointer items-center gap-2 border-none bg-transparent px-3 py-2 text-left text-sm hover:bg-fill-secondary"
-                onClick={() => toggleExpand()}
-                data-attr={`llma-skill-file-toggle-${file.path}`}
-            >
-                <IconChevronRight
-                    className={`h-3.5 w-3.5 shrink-0 text-muted transition-transform ${expanded ? 'rotate-90' : ''}`}
+            <div className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-fill-secondary">
+                <button
+                    type="button"
+                    className="flex flex-1 cursor-pointer items-center gap-2 border-none bg-transparent p-0 text-left"
+                    onClick={() => toggleExpand()}
+                    data-attr={`llma-skill-file-toggle-${file.path}`}
+                >
+                    <IconChevronRight
+                        className={`h-3.5 w-3.5 shrink-0 text-muted transition-transform ${expanded ? 'rotate-90' : ''}`}
+                    />
+                    <IconDocument className="h-3.5 w-3.5 shrink-0 text-muted" />
+                    <span className="font-mono flex-1">{file.path}</span>
+                    <span className="text-muted-alt text-xs">{file.content_type}</span>
+                </button>
+                <LemonButton
+                    size="xsmall"
+                    noPadding
+                    icon={<IconLink />}
+                    tooltip="Copy link to this file"
+                    onClick={copyFileLink}
+                    data-attr={`llma-skill-file-copy-link-${file.path}`}
                 />
-                <IconDocument className="h-3.5 w-3.5 shrink-0 text-muted" />
-                <span className="font-mono flex-1">{file.path}</span>
-                <span className="text-muted-alt text-xs">{file.content_type}</span>
-            </button>
+            </div>
             {expanded && (
                 <div className="border-t bg-bg-light px-3 py-2">
                     {contentLoading ? (

--- a/products/ai_observability/frontend/skills/LLMSkillScene.tsx
+++ b/products/ai_observability/frontend/skills/LLMSkillScene.tsx
@@ -557,11 +557,8 @@ function SkillFileViewer({
     const codeLanguage = isMarkdown ? null : getFileLanguage(file.path, file.content_type)
 
     const copyFileLink = (): void => {
-        const path = combineUrl(urls.aiObservabilitySkill(skillName), {
-            file: file.path,
-            version,
-        }).url
-        void copyToClipboard(`${window.location.origin}${path}`, 'file link')
+        const path = urls.aiObservabilitySkill(skillName, { file: file.path, version })
+        void copyToClipboard(urls.absolute(urls.currentProject(path)), 'file link')
     }
 
     return (


### PR DESCRIPTION
## Problem

When sharing a specific file inside an LLM analytics skill, you'd have to tell the recipient the file path and ask them to expand it manually. The skill viewer already supports a `?file=<path>` query param that auto-opens (and scrolls to) a file on load — there just wasn't a way to grab that URL from the UI.

## Changes

Adds a small "copy link" icon next to each bundled file row in the skill viewer. Clicking it copies the full URL with the `file` query param set to that file's path. If you're viewing a historical version (not latest), the URL also includes `version=<n>` so the recipient lands on the same version.

Implementation:
- `SkillFileViewer` row now wraps the expand toggle plus a new `IconLink` `LemonButton` in a flex container, so the icon button doesn't fire the toggle.
- URL is built with the existing `combineUrl` helper and `urls.aiObservabilitySkill(skillName)`, then prefixed with `window.location.origin`.
- Reuses the shared `copyToClipboard` util so the user gets the standard toast confirmation.

No backend / API changes — the deep-link behavior was already implemented; this just surfaces a way to copy the link.

## How did you test this code?

I'm an agent. No manual browser testing was done. Verified:
- Type imports resolve (`IconLink` from `lib/lemon-ui/icons`, `copyToClipboard` from `lib/utils/copyToClipboard`).
- The existing autoOpen path in `SkillFileViewer` keys off `searchParams.file === file.path`, which is exactly what the copied URL sets.
- Import order matches oxfmt convention (case-insensitive within group).

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Trigger was a Slack request to be able to copy a direct link to a file inside a skill so it can be shared. Touched only the skill scene component — both the deep-link param (`?file=`) and the historical-version param (`?version=`) were already wired up, so this is a pure UI add.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*