### PR TITLE
fix(tasks): stop stamping hedgehog when pr opens mid-run

### DIFF
--- a/products/slack_app/backend/tests/test_post_slack_update.py
+++ b/products/slack_app/backend/tests/test_post_slack_update.py
@@ -107,7 +107,7 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_in_progress_with_pr_swaps_reaction_and_deletes_progress(
+    def test_in_progress_with_pr_deletes_progress_without_swapping_reaction(
         self,
         mock_task_run_class,
         mock_handler_init,
@@ -126,7 +126,7 @@ class TestPostSlackUpdate(TestCase):
         post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
 
         mock_post_progress.assert_not_called()
-        mock_update_reaction.assert_called_once_with("hedgehog")
+        mock_update_reaction.assert_not_called()
         mock_delete_progress.assert_called_once()
 
     @patch.object(SlackThreadHandler, "delete_progress")
@@ -166,7 +166,7 @@ class TestPostSlackUpdate(TestCase):
             "https://github.com/org/repo/pull/1",
             "http://localhost:8000/project/1/tasks/10?runId=run-1",
         )
-        mock_update_reaction.assert_called_once_with("hedgehog")
+        mock_update_reaction.assert_not_called()
         mock_delete_progress.assert_called_once()
         mock_post_progress.assert_not_called()
         mock_task_run_class.update_state_atomic.assert_called_once_with(

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -70,7 +70,6 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
         else:
             if pr_url:
                 _post_pr_opened_notification_once(task_run, handler, pr_url, task_url)
-                handler.update_reaction("hedgehog")
                 handler.delete_progress()
                 return
             stage = _get_stage_from_status(task_run.status, task_run.stage)


### PR DESCRIPTION
## Problem

Follow-up to #59858. That PR removed the `:hedgehog:` swap from the interim Slack relay path, but `post_slack_update` still flipped the reaction to `:hedgehog:` the first time it saw a `pr_url` while the run was non-terminal. The reaction is meant to signal "task done" — flipping it on PR-open while the agent is still alive and handling follow-ups is the same wrong signal Richard reported.

## Changes

- `products/tasks/backend/temporal/process_task/activities/post_slack_update.py`: drop `handler.update_reaction("hedgehog")` from the in-progress + `pr_url` branch. The PR-opened notification and `delete_progress()` calls stay; we still surface the PR, just without claiming the task is finished. Terminal statuses (`COMPLETED`, `CANCELLED`) and the post-cleanup branches keep their existing hedgehog swaps, so the reaction still lands once the run is actually done.
- `products/slack_app/backend/tests/test_post_slack_update.py`: update the two tests that pinned the old behavior (`test_in_progress_with_pr_*`) to assert `update_reaction` is **not** called in that branch, and rename `test_in_progress_with_pr_swaps_reaction_and_deletes_progress` → `test_in_progress_with_pr_deletes_progress_without_swapping_reaction`.

## How did you test this code?

I'm an agent. I did not run the test suite locally — `hogli`, `flox`, and `uv` aren't available in this sandbox. The change is mechanical (one line removed, two assertions inverted) and the existing tests in `test_post_slack_update.py` cover the affected branch.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by PostHog Code in response to Richard's "stop giving me the hog" follow-up on #59858.

- Traced reaction stamping by greps for `update_reaction` / `reactions_add` across the slack relay + task workflow code paths.
- Considered also removing the `delete_progress()` call in the same branch — rejected: deleting the in-progress message when the PR is opened is independent UX and unrelated to the reaction complaint.
- Considered swapping the reaction to something neutral (e.g. clearing back to `:eyes:`) — rejected: `update_reaction` only adds, and the existing in-progress reaction stays in place if we don't touch it, which matches the desired "still working" signal.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*