### PR TITLE
feat(slack): randomize ack emoji on @PostHog mentions

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -18,10 +18,10 @@ from posthog.temporal.common.heartbeat import Heartbeater
 
 from products.slack_app.backend.models import SlackThreadTaskMapping
 from products.slack_app.backend.slack_thread import (
-    RANDOM_ACK_EMOJIS,
     SlackThreadContext,
     SlackThreadHandler,
-    random_ack_emoji,
+    ack_emoji_for,
+    stale_ack_emojis_for,
 )
 from products.tasks.backend.models import Task
 from products.tasks.backend.repo_selection import (
@@ -1145,7 +1145,10 @@ def create_posthog_code_task_for_repo_activity(
 
     user_message_ts = event.get("ts")
     if user_message_ts:
-        _safe_react(slack.client, channel, user_message_ts, random_ack_emoji())
+        # Deterministic per ts so activity retries (maximum_attempts=3) land on
+        # the same emoji and `_safe_react`'s `already_reacted` short-circuit
+        # keeps the ack idempotent.
+        _safe_react(slack.client, channel, user_message_ts, ack_emoji_for(user_message_ts))
 
     user_text = re.sub(r"<@[A-Z0-9]+>", "", event.get("text", "")).strip()
     title = user_text[:255] if user_text else "Task from Slack"
@@ -1599,7 +1602,7 @@ def _set_followup_done_reaction(slack: Any, channel: str, user_message_ts: str |
     if not user_message_ts:
         return
 
-    for stale_emoji in ("eyes", *RANDOM_ACK_EMOJIS):
+    for stale_emoji in stale_ack_emojis_for(user_message_ts):
         try:
             slack.client.reactions_remove(channel=channel, timestamp=user_message_ts, name=stale_emoji)
         except Exception:

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -17,7 +17,12 @@ from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 
 from products.slack_app.backend.models import SlackThreadTaskMapping
-from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler
+from products.slack_app.backend.slack_thread import (
+    RANDOM_ACK_EMOJIS,
+    SlackThreadContext,
+    SlackThreadHandler,
+    random_ack_emoji,
+)
 from products.tasks.backend.models import Task
 from products.tasks.backend.repo_selection import (
     RepoSelectionRejectedError,
@@ -1126,8 +1131,8 @@ def create_posthog_code_task_for_repo_activity(
     )
     slack = SlackIntegration(integration)
 
-    # Refuse before the :seedling: reaction or the permalink fetch: a denied
-    # mention should not first ack-react and then refuse a second later.
+    # Refuse before the ack reaction or the permalink fetch: a denied mention
+    # should not first ack-react and then refuse a second later.
     if _block_if_team_over_quota(
         integration=integration,
         slack=slack,
@@ -1140,7 +1145,7 @@ def create_posthog_code_task_for_repo_activity(
 
     user_message_ts = event.get("ts")
     if user_message_ts:
-        _safe_react(slack.client, channel, user_message_ts, "seedling")
+        _safe_react(slack.client, channel, user_message_ts, random_ack_emoji())
 
     user_text = re.sub(r"<@[A-Z0-9]+>", "", event.get("text", "")).strip()
     title = user_text[:255] if user_text else "Task from Slack"
@@ -1594,7 +1599,7 @@ def _set_followup_done_reaction(slack: Any, channel: str, user_message_ts: str |
     if not user_message_ts:
         return
 
-    for stale_emoji in ("eyes", "seedling"):
+    for stale_emoji in ("eyes", *RANDOM_ACK_EMOJIS):
         try:
             slack.client.reactions_remove(channel=channel, timestamp=user_message_ts, name=stale_emoji)
         except Exception:

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -1,5 +1,5 @@
 import re
-import random
+import hashlib
 from dataclasses import dataclass
 from typing import Any
 
@@ -15,6 +15,12 @@ UPSTREAM_PROVIDER_FAILURE_MESSAGE = (
     "The upstream AI provider failed to process the request. Please retry the task in a few minutes."
 )
 UPSTREAM_PROVIDER_ERROR_STATUS_PATTERN = re.compile(r"\bapi error:\s*(?:429|5\d\d)\b", re.IGNORECASE)
+
+# Legacy fixed ack emoji. Tasks ack'd before the deterministic pool landed used
+# `:seedling:` exclusively; cleanup still tries to remove it so in-flight tasks
+# at deploy time don't end up with a stale reaction. Can be dropped a release
+# cycle after this lands.
+_LEGACY_ACK_EMOJI = "seedling"
 
 # Pool of fun, universally-available Slack emoji names used to acknowledge a mention
 # before the bot starts the longer-running work. Anything in this pool is treated as
@@ -76,8 +82,30 @@ RANDOM_ACK_EMOJIS: tuple[str, ...] = (
 )
 
 
-def random_ack_emoji() -> str:
-    return random.choice(RANDOM_ACK_EMOJIS)
+def ack_emoji_for(message_ts: str) -> str:
+    """Pick an emoji from the ack pool deterministically per Slack message ts.
+
+    `create_posthog_code_task_for_repo_activity` retries up to 3 times. With a
+    truly random pick, each retry could choose a different emoji and bypass
+    `_safe_react`'s `already_reacted` short-circuit, piling extra reactions on
+    the user's mention. Keying the choice on the message ts keeps every replay
+    landing on the same emoji. `hashlib` (not `hash()`) is used so the choice
+    is stable across worker processes — PYTHONHASHSEED randomization would
+    otherwise diverge per replay.
+    """
+    digest = hashlib.sha256(message_ts.encode("utf-8")).digest()
+    return RANDOM_ACK_EMOJIS[int.from_bytes(digest[:4], "big") % len(RANDOM_ACK_EMOJIS)]
+
+
+def stale_ack_emojis_for(message_ts: str) -> tuple[str, ...]:
+    """Reactions a cleanup pass should try to remove from `message_ts`.
+
+    `eyes` is the follow-up ack, the deterministic pool pick is the initial
+    ack, and `_LEGACY_ACK_EMOJI` covers tasks ack'd before this pool landed.
+    Keeping the set small (vs. iterating the full pool) avoids burning the
+    `reactions.remove` rate limit on guaranteed-`no_reaction` calls.
+    """
+    return ("eyes", ack_emoji_for(message_ts), _LEGACY_ACK_EMOJI)
 
 
 def _format_task_error(error: str) -> str:
@@ -181,7 +209,7 @@ class SlackThreadHandler:
         target_ts = self.context.user_message_ts or self.context.thread_ts
         try:
             client = self._get_client()
-            for stale in (*RANDOM_ACK_EMOJIS, "eyes"):
+            for stale in stale_ack_emojis_for(target_ts):
                 try:
                     client.reactions_remove(channel=self.context.channel, timestamp=target_ts, name=stale)
                 except Exception:

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -1,4 +1,5 @@
 import re
+import random
 from dataclasses import dataclass
 from typing import Any
 
@@ -14,6 +15,32 @@ UPSTREAM_PROVIDER_FAILURE_MESSAGE = (
     "The upstream AI provider failed to process the request. Please retry the task in a few minutes."
 )
 UPSTREAM_PROVIDER_ERROR_STATUS_PATTERN = re.compile(r"\bapi error:\s*(?:429|5\d\d)\b", re.IGNORECASE)
+
+# Pool of fun, universally-available Slack emoji names used to acknowledge a mention
+# before the bot starts the longer-running work. Anything in this pool is treated as
+# an in-progress signal by `update_reaction` / `_set_followup_done_reaction` and is
+# cleaned up when the bot reaches a terminal state. Keep these distinct from the
+# stage-specific reactions (:mag: for searching, :hedgehog: for done, :x: for failed)
+# and from "eyes" (the follow-up ack), so the cleanup pool stays unambiguous.
+RANDOM_ACK_EMOJIS: tuple[str, ...] = (
+    "seedling",
+    "wave",
+    "sparkles",
+    "rocket",
+    "robot_face",
+    "thinking_face",
+    "hammer_and_wrench",
+    "gear",
+    "coffee",
+    "nerd_face",
+    "zap",
+    "crystal_ball",
+    "mage",
+)
+
+
+def random_ack_emoji() -> str:
+    return random.choice(RANDOM_ACK_EMOJIS)
 
 
 def _format_task_error(error: str) -> str:
@@ -117,7 +144,7 @@ class SlackThreadHandler:
         target_ts = self.context.user_message_ts or self.context.thread_ts
         try:
             client = self._get_client()
-            for stale in ("seedling", "eyes"):
+            for stale in (*RANDOM_ACK_EMOJIS, "eyes"):
                 try:
                     client.reactions_remove(channel=self.context.channel, timestamp=target_ts, name=stale)
                 except Exception:

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -23,19 +23,56 @@ UPSTREAM_PROVIDER_ERROR_STATUS_PATTERN = re.compile(r"\bapi error:\s*(?:429|5\d\
 # stage-specific reactions (:mag: for searching, :hedgehog: for done, :x: for failed)
 # and from "eyes" (the follow-up ack), so the cleanup pool stays unambiguous.
 RANDOM_ACK_EMOJIS: tuple[str, ...] = (
+    # Friendly greetings & thinking
     "seedling",
     "wave",
-    "sparkles",
-    "rocket",
     "robot_face",
     "thinking_face",
-    "hammer_and_wrench",
-    "gear",
-    "coffee",
     "nerd_face",
+    "sunglasses",
+    # Energy & magic
+    "sparkles",
+    "rocket",
     "zap",
     "crystal_ball",
     "mage",
+    "star2",
+    "dizzy",
+    "rainbow",
+    # Working / tinkering
+    "hammer_and_wrench",
+    "gear",
+    "coffee",
+    "keyboard",
+    "telescope",
+    "brain",
+    "bulb",
+    "compass",
+    # Nature & luck
+    "four_leaf_clover",
+    "cherry_blossom",
+    "sunflower",
+    "herb",
+    # Animal companions
+    "owl",
+    "otter",
+    "penguin",
+    "fox_face",
+    "bee",
+    "butterfly",
+    "unicorn_face",
+    "turtle",
+    "panda_face",
+    "koala",
+    "hamster",
+    # Play & whimsy
+    "art",
+    "balloon",
+    "game_die",
+    # Characters
+    "ninja",
+    "alien",
+    "space_invader",
 )
 
 

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -103,9 +103,14 @@ def stale_ack_emojis_for(message_ts: str) -> tuple[str, ...]:
     `eyes` is the follow-up ack, the deterministic pool pick is the initial
     ack, and `_LEGACY_ACK_EMOJI` covers tasks ack'd before this pool landed.
     Keeping the set small (vs. iterating the full pool) avoids burning the
-    `reactions.remove` rate limit on guaranteed-`no_reaction` calls.
+    `reactions.remove` rate limit on guaranteed-`no_reaction` calls. The
+    legacy emoji is also a pool member, so we dedupe when the deterministic
+    pick coincidentally lands on it.
     """
-    return ("eyes", ack_emoji_for(message_ts), _LEGACY_ACK_EMOJI)
+    emojis = ["eyes", ack_emoji_for(message_ts)]
+    if _LEGACY_ACK_EMOJI not in emojis:
+        emojis.append(_LEGACY_ACK_EMOJI)
+    return tuple(emojis)
 
 
 def _format_task_error(error: str) -> str:

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -5,10 +5,12 @@ from django.test import TestCase
 from parameterized import parameterized
 
 from products.slack_app.backend.slack_thread import (
+    RANDOM_ACK_EMOJIS,
     UPSTREAM_PROVIDER_FAILURE_MESSAGE,
     SlackThreadContext,
     SlackThreadHandler,
     _format_task_error,
+    random_ack_emoji,
 )
 
 
@@ -84,7 +86,7 @@ class TestSlackThreadHandler(TestCase):
         mock_client.chat_delete.assert_not_called()
 
     @patch.object(SlackThreadHandler, "_get_client")
-    def test_update_reaction_removes_seedling_and_eyes(self, mock_get_client):
+    def test_update_reaction_clears_ack_pool_and_eyes(self, mock_get_client):
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
 
@@ -97,11 +99,17 @@ class TestSlackThreadHandler(TestCase):
         handler = SlackThreadHandler(context)
         handler.update_reaction("hedgehog")
 
-        remove_calls = mock_client.reactions_remove.call_args_list
-        assert len(remove_calls) == 2
-        assert remove_calls[0].kwargs["name"] == "seedling"
-        assert remove_calls[1].kwargs["name"] == "eyes"
+        removed_names = [call.kwargs["name"] for call in mock_client.reactions_remove.call_args_list]
+        # Every ack-pool emoji is attempted (Slack returns no_reaction for missing ones) plus the
+        # follow-up "eyes" reaction, so any prior in-progress signal is cleared before the final state.
+        for ack in RANDOM_ACK_EMOJIS:
+            assert ack in removed_names
+        assert "eyes" in removed_names
         mock_client.reactions_add.assert_called_once_with(channel="C001", timestamp="1234.5678", name="hedgehog")
+
+    def test_random_ack_emoji_is_in_pool(self):
+        for _ in range(50):
+            assert random_ack_emoji() in RANDOM_ACK_EMOJIS
 
     @patch.object(SlackThreadHandler, "_get_client")
     def test_post_pr_opened_posts_buttons(self, mock_get_client):

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -123,6 +123,15 @@ class TestSlackThreadHandler(TestCase):
         assert "seedling" in stale
         assert ack_emoji_for("1234.5678") in stale
 
+    def test_stale_ack_emojis_for_dedupes_when_pick_is_seedling(self):
+        # `seedling` is both in the pool and the legacy ack — when the deterministic
+        # pick coincidentally lands on it, the tuple should not contain a duplicate.
+        seedling_ts = "1700000000.000005"
+        assert ack_emoji_for(seedling_ts) == "seedling", "fixture ts no longer maps to seedling"
+        stale = stale_ack_emojis_for(seedling_ts)
+        assert stale == ("eyes", "seedling")
+        assert stale.count("seedling") == 1
+
     @patch.object(SlackThreadHandler, "_get_client")
     def test_post_pr_opened_posts_buttons(self, mock_get_client):
         mock_client = MagicMock()

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -10,7 +10,8 @@ from products.slack_app.backend.slack_thread import (
     SlackThreadContext,
     SlackThreadHandler,
     _format_task_error,
-    random_ack_emoji,
+    ack_emoji_for,
+    stale_ack_emojis_for,
 )
 
 
@@ -86,7 +87,7 @@ class TestSlackThreadHandler(TestCase):
         mock_client.chat_delete.assert_not_called()
 
     @patch.object(SlackThreadHandler, "_get_client")
-    def test_update_reaction_clears_ack_pool_and_eyes(self, mock_get_client):
+    def test_update_reaction_clears_stale_ack_emojis(self, mock_get_client):
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
 
@@ -100,16 +101,27 @@ class TestSlackThreadHandler(TestCase):
         handler.update_reaction("hedgehog")
 
         removed_names = [call.kwargs["name"] for call in mock_client.reactions_remove.call_args_list]
-        # Every ack-pool emoji is attempted (Slack returns no_reaction for missing ones) plus the
-        # follow-up "eyes" reaction, so any prior in-progress signal is cleared before the final state.
-        for ack in RANDOM_ACK_EMOJIS:
-            assert ack in removed_names
-        assert "eyes" in removed_names
+        # Only the candidate ack reactions for this specific ts are removed (not the whole pool),
+        # so cleanup stays cheap regardless of pool size.
+        assert removed_names == list(stale_ack_emojis_for("1234.5678"))
         mock_client.reactions_add.assert_called_once_with(channel="C001", timestamp="1234.5678", name="hedgehog")
 
-    def test_random_ack_emoji_is_in_pool(self):
-        for _ in range(50):
-            assert random_ack_emoji() in RANDOM_ACK_EMOJIS
+    def test_ack_emoji_for_is_deterministic_per_ts(self):
+        # Same ts must always pick the same emoji — activity retries depend on this for
+        # `_safe_react`'s `already_reacted` short-circuit to keep the ack idempotent.
+        assert ack_emoji_for("1700000001.000100") == ack_emoji_for("1700000001.000100")
+        assert ack_emoji_for("1700000001.000100") in RANDOM_ACK_EMOJIS
+        # Different ts values should reach across the pool (sanity check, not a uniformity claim).
+        reached = {ack_emoji_for(f"1700000000.{i:06d}") for i in range(500)}
+        assert len(reached) >= len(RANDOM_ACK_EMOJIS) // 2
+
+    def test_stale_ack_emojis_for_includes_legacy_seedling_and_eyes(self):
+        # `seedling` was the fixed pre-pool ack; tasks ack'd before this code shipped
+        # must still be cleanable. `eyes` is the follow-up ack.
+        stale = stale_ack_emojis_for("1234.5678")
+        assert "eyes" in stale
+        assert "seedling" in stale
+        assert ack_emoji_for("1234.5678") in stale
 
     @patch.object(SlackThreadHandler, "_get_client")
     def test_post_pr_opened_posts_buttons(self, mock_get_client):


### PR DESCRIPTION
## Problem

The @PostHog Slack bot always acknowledges a mention with the same `:seedling:` reaction. It would feel more alive to pick a fun emoji at random — so every thread gets a different little "I see you, working on it" signal.

## Changes

- Curated a small pool of universally-available standard Slack emojis (`:seedling:` plus `:wave:` `:sparkles:` `:rocket:` `:robot_face:` `:thinking_face:` `:hammer_and_wrench:` `:gear:` `:coffee:` `:nerd_face:` `:zap:` `:crystal_ball:` `:mage:`) and added a `random_ack_emoji()` helper in `products/slack_app/backend/slack_thread.py`.
- `create_posthog_code_task_for_repo_activity` now picks from that pool instead of hardcoding `seedling`.
- Both cleanup paths — `SlackThreadHandler.update_reaction` and `_set_followup_done_reaction` — iterate the full pool (plus `eyes` for the follow-up ack) when clearing the in-progress reaction before adding the final-state emoji, so any chosen ack is swapped out cleanly.
- Stage-specific reactions stay as-is: `:mag:` for "searching for a repo", `:eyes:` for follow-up ack, `:hedgehog:`/`:x:` for terminal states.
- `seedling` deliberately stays in the pool so tasks acked under the old code path still get cleaned up correctly.

Scope: only the `slack-posthog-code` mention bot (the coding-agent flow). The Max AI bot in `slack_conversation.py` is untouched.

No new OAuth scopes are needed — only the existing `reactions:write` is used. (Fetching workspace custom emojis via `emoji.list` would have required adding `emoji:read` and forcing every existing install to reconnect, so that's deliberately out of scope here.)

## How did you test this code?

I'm an agent. I ran:
- `ruff check` and `ruff format --check` on the three changed files — clean.
- Ad-hoc Python checks against the helper: 200 random picks all land in the pool, the full pool is reachable, and both cleanup functions emit a `reactions_remove` call for every pool emoji plus `eyes`.

I did not run the existing `products/slack_app/backend/tests/` suite end-to-end (the harness needs Postgres which isn't available in this sandbox). The existing `test_update_reaction_removes_seedling_and_eyes` test was rewritten to assert the new cleanup-pool semantics, and `test_followup_forwarding.py`'s `assert_any_call(..., name="seedling")` / `assert_any_call(..., name="eyes")` assertions still hold because `seedling` and `eyes` remain in the iterated set.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude (PostHog Code session).

Decisions worth flagging for the reviewer:
- **Curated standards-only pool vs. fetching workspace emojis.** I weighed calling `emoji.list` so each tenant's custom emojis could be included. Rejected because the current `POSTHOG_CODE_REQUIRED_SLACK_SCOPES` set doesn't include `emoji:read` and adding it would force a reconnect for every existing install (same pain as the 2026-05-04 scope expansion). The curated pool ships immediately with zero migration cost. Adding `emoji:read` + caching can be a follow-up if folks miss the custom emojis.
- **Kept `seedling` in the pool.** This is what every in-flight task ack'd with before this PR. Keeping it in the pool means the existing cleanup paths still find and remove it on already-running tasks, with no special migration step.
- **Cleanup cost.** Both `update_reaction` and `_set_followup_done_reaction` now make ~14 `reactions.remove` calls per terminal-state transition instead of 2. Each call to a non-existent reaction returns `no_reaction` quickly; total latency is roughly ~1s per transition. That's hidden inside background Temporal activities, not a user-facing roundtrip. I considered tracking the chosen emoji on `SlackThreadTaskMapping` to avoid the iteration but it required a migration for what is essentially a fun feature, so I kept it simple.
- **Pool composition.** Avoided emojis already used for specific stages (`mag`, `hedgehog`, `x`, `eyes`, `checkered_flag`) and stuck to universally-available standard Slack/Unicode names so `reactions.add` never gets `invalid_name` for a custom-emoji tenant that hasn't added a particular workspace emoji.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*