### PR TITLE
fix(hogli): suppress first-run telemetry notice in CI

### DIFF
--- a/tools/hogli/src/hogli/telemetry.py
+++ b/tools/hogli/src/hogli/telemetry.py
@@ -141,6 +141,11 @@ class TelemetryClient:
         _save_config(config)
 
     def show_first_run_notice_if_needed(self) -> None:
+        # CI is auto-opted-out via is_ci(); the notice would be noise in build
+        # logs and instructs users to set POSTHOG_TELEMETRY_OPT_OUT=1, which is
+        # redundant when the CI gate already disables tracking.
+        if is_ci():
+            return
         config = _load_config()
         if config.get("first_run_notice_shown"):
             return

--- a/tools/hogli/tests/test_telemetry.py
+++ b/tools/hogli/tests/test_telemetry.py
@@ -149,6 +149,14 @@ class TestFirstRunNotice:
         captured_second = capsys.readouterr()
         assert captured_second.err == ""
 
+    @pytest.mark.parametrize("ci_var", telemetry._CI_ENV_VARS)
+    def test_suppressed_in_ci(self, monkeypatch: pytest.MonkeyPatch, telemetry_config: Path, capsys, ci_var: str):
+        monkeypatch.setenv(ci_var, "true")
+        telemetry.show_first_run_notice_if_needed()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert not telemetry_config.exists()
+
 
 class TestTelemetryCommands:
     @pytest.fixture


### PR DESCRIPTION
## Problem

`hogli` already disables event tracking when any common CI env var is set (`is_ci()`), but `show_first_run_notice_if_needed()` runs unconditionally. The notice — including an instruction to set `POSTHOG_TELEMETRY_OPT_OUT=1` — was printing in every CI log (e.g. the linked Depot run), suggesting tracking was active when it wasn't.

## Changes

- Short-circuit `show_first_run_notice_if_needed()` when `is_ci()` is true. No notice, no config write.
- Parametrized test covering every entry in `_CI_ENV_VARS`.

## How did you test this code?

Agent-authored. Ran `hogli test tools/hogli/tests/test_telemetry.py` locally — 49 passed. No manual testing.

## Publish to changelog?

no

## 🤖 Agent context

- Investigated via `gh run view` on the linked Actions run, which surfaced the first-run notice in `Prime posthog from cached schema`.
- Confirmed `is_enabled()` already gates on `is_ci()`, so no events were ever sent from CI — only the notice was leaking.
- Considered gating the call at the `cli.py` caller, but kept the check inside `telemetry.py` so every caller (and future ones) is covered.