### PR TITLE
chore(ci): replace changelog section with checklist in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,13 +26,10 @@
 
 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
 
-## Publish to changelog?
+## Checklist
 
-<!-- For features only -->
-
-<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->
-
-<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
+- [ ] Publish to changelog?
+- [ ] Alert Sales and Marketing teams?
 
 ## Docs update
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@
 
 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
 
-## Checklist
+## Automatic notifications
 
 - [ ] Publish to changelog?
 - [ ] Alert Sales and Marketing teams?


### PR DESCRIPTION
## Problem

The PR template's freeform "Publish to changelog?" section was easy to overlook, and there was no equivalent prompt to notify Sales and Marketing about user-visible changes.

## Changes

- Removed the freeform `## Publish to changelog?` section from `.github/pull_request_template.md`.
- Added a `## Checklist` section with two checkboxes:
  - `Publish to changelog?`
  - `Alert Sales and Marketing teams?`

## How did you test this code?

I'm an agent — no manual testing was performed. The change is a pure markdown edit to the PR template; rendering will be verified by GitHub when this PR opens.

## Checklist

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update required — this is a CI/repo-hygiene change.

## 🤖 Agent context

Authored by an agent on request: convert the freeform changelog section into two explicit checkboxes (changelog publish + Sales/Marketing alert). Considered keeping the explanatory HTML comments from the old section but opted to drop them so the new checklist stays terse; the same intent can be re-added later if reviewers find the prompts ambiguous. No other template sections were touched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*