### PR TITLE
fix(replay): stop playlist loading bar overflowing into player

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
@@ -274,9 +274,9 @@ export function Playlist({
                     className="Playlist__list flex flex-col relative overflow-hidden h-full w-full"
                 >
                     <div className="flex flex-col relative w-full bg-bg-light overflow-hidden h-full Playlist__list">
-                        <DraggableToNotebook href={urls.replay(ReplayTabs.Home, filters)}>
-                            <div className="flex flex-col gap-1">
-                                <div className="shrink-0 bg-bg-3000 relative flex justify-between items-center gap-0.5 whitespace-nowrap border-b">
+                        <div className="relative">
+                            <DraggableToNotebook href={urls.replay(ReplayTabs.Home, filters)}>
+                                <div className="shrink-0 bg-bg-3000 flex justify-between items-center gap-0.5 whitespace-nowrap border-b">
                                     {title && <TitleWithCount title={title} count={itemsCount} />}
                                     <div className="flex items-center gap-0.5">
                                         <LemonButton
@@ -298,9 +298,9 @@ export function Playlist({
                                         />
                                     </div>
                                 </div>
-                                <LemonTableLoader loading={sessionRecordingsResponseLoading} />
-                            </div>
-                        </DraggableToNotebook>
+                            </DraggableToNotebook>
+                            <LemonTableLoader loading={sessionRecordingsResponseLoading} />
+                        </div>
                         <div className="overflow-y-auto flex-1 min-h-0" onScroll={handleScroll} ref={contentRef}>
                             {sectionCount > 1 ? (
                                 <LemonCollapse


### PR DESCRIPTION
## Problem

On the session replay page during loading, the animated loading bar at the top of the playlist column overflowed horizontally into the player area instead of being constrained to the playlist width.

## Changes

The `LemonTableLoader` (the swooping bar shown while recordings load) sat inside the `DraggableToNotebook` `<span>`, which has `position: relative` in its SCSS. Because the loader is `position: absolute; width: 100%`, it sized itself to that span — and the span sized to its content, which included a `whitespace-nowrap` header. When the title row was wider than the playlist column, the loader overflowed with it into the player.

This PR:

- Moves `LemonTableLoader` out of `DraggableToNotebook` into a new `relative` block-level wrapper that fills the playlist column, so the loader can no longer escape the column width.
- Drops the unused `relative` on the header row itself — it had no absolutely-positioned children that depended on it.

## How did you test this code?

I'm an agent. No manual browser test was run. No automated tests were added or run for this CSS-only change.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7).
- A teammate flagged that on the loading screen the playlist header had a stray \`relative\` that didn't belong, and that the "horizontally scrolling header" — the loading bar — was overflowing into the player. Traced the absolute-positioned \`LemonTableLoader\` back to the \`.DraggableToNotebook\` span (\`position: relative\` via SCSS), whose width was being driven by its \`whitespace-nowrap\` child. Considered (and rejected) removing \`position: relative\` from \`DraggableToNotebook.scss\` because that's shared with other call sites. The chosen fix is the most local: re-parent the loader to a new wrapper inside the playlist column, and clean up the redundant \`relative\` on the header row.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*