### PR TITLE
fix(marketing-analytics): raise precompute today-window ttl to 1h

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
@@ -379,7 +379,13 @@ class ConversionGoalProcessor:
             time_range_start=date_from,
             time_range_end=date_to,
             ttl_seconds={
-                "0d": 15 * 60,
+                # "today" is the only volatile window, but a 15-minute TTL re-materializes it on
+                # nearly every dashboard view (views are typically further apart than 15 min), so the
+                # cache rarely fully hits for recent ranges while still paying the (blocking)
+                # materialization cost. Production logs show ~38% of executions are partial_hits
+                # averaging ~35s, dominated by re-materializing "today". Ad spend / conversions are
+                # not minute-fresh, so 1h trades negligible staleness for far fewer cold re-computes.
+                "0d": 60 * 60,
                 "1d": 60 * 60,
                 "7d": 24 * 60 * 60,
                 "default": 7 * 24 * 60 * 60,


### PR DESCRIPTION
## Problem

The conversion goal precompute uses a 15-minute TTL for the "today" window. Marketing analytics dashboards are typically viewed more than 15 minutes apart, so the "today" window expires between views and gets re-materialized on nearly every load — a partial cache hit that still pays the (synchronous, blocking) materialization cost.

Production `lazy_computation.executed` logs show ~38% of conversion-goal precompute executions are `partial_hit`, averaging ~35s, dominated by re-materializing the recent window. Full cache hits, by contrast, return in tens of milliseconds.

## Changes

Raise the `0d` ("today") TTL from 15 minutes to 1 hour in the conversion goal precompute TTL schedule. Other windows are unchanged.

Ad spend and conversion data are not minute-fresh, so the extra staleness is acceptable. Fewer cold re-computes means more full cache hits and less write churn on the shared `PreaggregationJob` table.

## How did you test this code?

I'm an agent. Lint + type checks ran on commit (ruff + ty, via lint-staged) and passed. Confirmed no existing test pins the 15-minute value; the change is a single config value exercised by the existing precompute tests. The effect will be validated post-deploy via the `lazy_computation.executed` logs (the `cache_state` distribution — expecting `partial_hit` to shift toward `hit`).

## Publish to changelog?

no

## 🤖 Agent context

Investigated the conversion-goal precompute rollout using ClickHouse `system.query_log` (via Metabase) and the `lazy_computation.executed` structured logs (via the logs product).

Findings:
- The ClickHouse read itself improved (p50/p95 roughly 2.2–2.4x vs no precompute).
- End-to-end latency regressed on cache misses because materialization is synchronous/blocking, and the 15-min "today" TTL caused ~38% of executions to be `partial_hit` (~35s avg), constantly re-materializing the recent window. This PR reduces that re-materialization frequency.

Identified as separate follow-ups (not in this PR):
- Opt-in async/background materialization in the `lazy_computation` framework, so a cache miss falls back to the live query instead of blocking on the INSERT.
- No cleanup of expired `PreaggregationJob` rows; under churn this may bloat the shared table (logs show ~29% of cache *hits* still take >2s, consistent with Postgres lookup/contention rather than cold-start).

Considered and rejected: a max-days eligibility gate and table-schema changes (sharding key, replication scheme). The AUX cluster is single-shard, so those do not affect performance here; the latency is wait/churn-bound, not range- or shard-bound. Conversion goals is currently the only consumer exercising the lazy-computation framework at volume, so these are framework gaps surfacing for the first time.
