### PR TITLE
fix(devbox): pin workspace_region on coder update

### DIFF
--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -31,6 +31,7 @@ from .coder import (
     GIT_NAME_PARAMETER,
     GIT_SIGNING_KEY_SECRET,
     REGIONS,
+    WORKSPACE_REGION_PARAMETER,
     _diagnose_unreachable_coder,
     _fail,
     coder_authenticated,
@@ -266,7 +267,21 @@ def _workspace_status_color(status: str) -> str:
     return WORKSPACE_STATUS_COLORS.get(status, "white")
 
 
-def _sync_workspace_parameters(name: str) -> None:
+def _pinned_region_param(workspace: dict[str, Any]) -> dict[str, str]:
+    """Pin `workspace_region` to the workspace's current value for `coder update`.
+
+    Coder re-prompts for any parameter whose template-declared option set has
+    changed since the workspace was created (see coder.com docs on rich
+    parameters). The recent addition of `eu-central-1` did exactly that, so
+    every update path now forwards the current value to suppress the picker.
+    Boxes predating region metadata default to us-east-1 — the only region
+    that existed before the metadata item was added.
+    """
+    region = get_workspace_region(workspace) or DEFAULT_REGION
+    return {WORKSPACE_REGION_PARAMETER: region}
+
+
+def _sync_workspace_parameters(name: str, workspace: dict[str, Any]) -> None:
     """Push local config (git identity, dotfiles) to workspace parameters before start."""
     config = load_config()
     params: dict[str, str] = {}
@@ -281,8 +296,10 @@ def _sync_workspace_parameters(name: str) -> None:
     if dotfiles_uri:
         params[DOTFILES_URI_PARAMETER] = dotfiles_uri
 
-    if params:
-        update_workspace_parameters(name, params)
+    if not params:
+        return
+    params.update(_pinned_region_param(workspace))
+    update_workspace_parameters(name, params)
 
 
 def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: bool) -> None:
@@ -298,7 +315,7 @@ def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: 
         click.echo("Wait for the current operation to complete.")
         return
 
-    _sync_workspace_parameters(name)
+    _sync_workspace_parameters(name, workspace)
 
     if status == "stopped":
         click.echo(f"Starting devbox '{name}'...")
@@ -1315,7 +1332,7 @@ def devbox_update(workspace: str | None, verbose: bool) -> None:
         click.echo(f"Devbox '{name}' is already up to date.")
         return
     config = load_config()
-    params: dict[str, str] = {}
+    params: dict[str, str] = dict(_pinned_region_param(ws))
     if dotfiles_uri := config.get("dotfiles_uri"):
         params[DOTFILES_URI_PARAMETER] = dotfiles_uri
     click.echo(f"Updating '{name}' to the latest template...")

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -1332,7 +1332,7 @@ def devbox_update(workspace: str | None, verbose: bool) -> None:
         click.echo(f"Devbox '{name}' is already up to date.")
         return
     config = load_config()
-    params: dict[str, str] = dict(_pinned_region_param(ws))
+    params: dict[str, str] = _pinned_region_param(ws)
     if dotfiles_uri := config.get("dotfiles_uri"):
         params[DOTFILES_URI_PARAMETER] = dotfiles_uri
     click.echo(f"Updating '{name}' to the latest template...")

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -285,18 +285,6 @@ def _sync_workspace_parameters(name: str) -> None:
         update_workspace_parameters(name, params)
 
 
-def _confirm_apply_template_update() -> bool:
-    """Y/n gate before applying a pending template update.
-
-    Skipped for non-interactive stdin so CI / piped invocations never block.
-    """
-    if not sys.stdin.isatty():
-        return False
-    click.echo()
-    click.echo("Template update available for this devbox.")
-    return click.confirm("Apply now?", default=True)
-
-
 def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: bool) -> None:
     """Handle `devbox:start` when the workspace already exists."""
     status = get_workspace_status(workspace)
@@ -311,14 +299,6 @@ def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: 
         return
 
     _sync_workspace_parameters(name)
-
-    if workspace.get("outdated"):
-        if _confirm_apply_template_update():
-            click.echo(f"Updating '{name}' to the latest template...")
-            update_workspace(name, verbose=verbose)
-            click.echo("Updated.")
-        else:
-            click.echo("Skipping template update. Run `hogli devbox:update` when ready.")
 
     if status == "stopped":
         click.echo(f"Starting devbox '{name}'...")

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -294,8 +294,6 @@ def _confirm_apply_template_update() -> bool:
         return False
     click.echo()
     click.echo("Template update available for this devbox.")
-    click.echo("Apply it now to avoid the VS Code Coder extension upgrade prompt,")
-    click.echo("which lands in a read-only Output channel and cannot be answered.")
     return click.confirm("Apply now?", default=True)
 
 
@@ -320,11 +318,7 @@ def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: 
             update_workspace(name, verbose=verbose)
             click.echo("Updated.")
         else:
-            click.echo(
-                "Skipping template update. Run `hogli devbox:update` when ready. "
-                "If VS Code prompts to upgrade, decline it — its Output channel "
-                "is read-only and the prompt cannot be answered."
-            )
+            click.echo("Skipping template update. Run `hogli devbox:update` when ready.")
 
     if status == "stopped":
         click.echo(f"Starting devbox '{name}'...")

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -285,6 +285,20 @@ def _sync_workspace_parameters(name: str) -> None:
         update_workspace_parameters(name, params)
 
 
+def _confirm_apply_template_update() -> bool:
+    """Y/n gate before applying a pending template update.
+
+    Skipped for non-interactive stdin so CI / piped invocations never block.
+    """
+    if not sys.stdin.isatty():
+        return False
+    click.echo()
+    click.echo("Template update available for this devbox.")
+    click.echo("Apply it now to avoid the VS Code Coder extension upgrade prompt,")
+    click.echo("which lands in a read-only Output channel and cannot be answered.")
+    return click.confirm("Apply now?", default=True)
+
+
 def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: bool) -> None:
     """Handle `devbox:start` when the workspace already exists."""
     status = get_workspace_status(workspace)
@@ -299,6 +313,18 @@ def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: 
         return
 
     _sync_workspace_parameters(name)
+
+    if workspace.get("outdated"):
+        if _confirm_apply_template_update():
+            click.echo(f"Updating '{name}' to the latest template...")
+            update_workspace(name, verbose=verbose)
+            click.echo("Updated.")
+        else:
+            click.echo(
+                "Skipping template update. Run `hogli devbox:update` when ready. "
+                "If VS Code prompts to upgrade, decline it — its Output channel "
+                "is read-only and the prompt cannot be answered."
+            )
 
     if status == "stopped":
         click.echo(f"Starting devbox '{name}'...")

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -1218,7 +1218,7 @@ def update_workspace(
     does not declare) are dropped by the retry shim instead of aborting
     the update.
     """
-    base_args = ["coder", "update", name, "--use-parameter-defaults"]
+    base_args = ["coder", "update", name, "--yes", "--use-parameter-defaults"]
     result = _run_with_param_retry(base_args, parameters or {}, verbose=verbose)
     if result.returncode != 0:
         raise SystemExit(result.returncode)
@@ -1238,7 +1238,7 @@ def update_workspace_parameters(name: str, parameters: dict[str, str]) -> None:
     local config key (for example, a saved ``dotfiles_uri`` after the user
     switches templates) does not abort the pre-start sync.
     """
-    base_args = ["coder", "update", name, "--use-parameter-defaults"]
+    base_args = ["coder", "update", name, "--yes", "--use-parameter-defaults"]
     result = _run_with_param_retry(base_args, parameters)
     if result.returncode != 0:
         raise SystemExit(result.returncode)

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -45,10 +45,13 @@ DOTFILES_URI_PARAMETER = "dotfiles_uri"
 DOTFILES_BRANCH_PARAMETER = "dotfiles_branch"
 JETBRAINS_IDES_PARAMETER = "jetbrains_ides"
 
-# Create-time region selector. The template defines `workspace_region` with a
-# us-east-1 default; eu-central-1 only becomes a valid option once the EU
-# infrastructure is live. The chosen value is immutable after creation, so it
-# is forwarded on `coder create` only -- never on update or the parameter sync.
+# Region selector. The template defines `workspace_region` with a us-east-1
+# default; eu-central-1 became a valid option when the EU infrastructure went
+# live. The value is immutable after creation, but it must still be forwarded
+# on `coder update` and the parameter sync -- when a template author changes a
+# parameter's allowed values, Coder re-prompts existing workspaces for that
+# parameter regardless of `--use-parameter-defaults`, and the prompt is not
+# bypassable by any flag. Pinning the current value short-circuits the picker.
 # Valid values match the template contract exactly.
 WORKSPACE_REGION_PARAMETER = "workspace_region"
 REGIONS = ("us-east-1", "eu-central-1")
@@ -1218,7 +1221,7 @@ def update_workspace(
     does not declare) are dropped by the retry shim instead of aborting
     the update.
     """
-    base_args = ["coder", "update", name, "--yes", "--use-parameter-defaults"]
+    base_args = ["coder", "update", name, "--use-parameter-defaults"]
     result = _run_with_param_retry(base_args, parameters or {}, verbose=verbose)
     if result.returncode != 0:
         raise SystemExit(result.returncode)
@@ -1238,7 +1241,7 @@ def update_workspace_parameters(name: str, parameters: dict[str, str]) -> None:
     local config key (for example, a saved ``dotfiles_uri`` after the user
     switches templates) does not abort the pre-start sync.
     """
-    base_args = ["coder", "update", name, "--yes", "--use-parameter-defaults"]
+    base_args = ["coder", "update", name, "--use-parameter-defaults"]
     result = _run_with_param_retry(base_args, parameters)
     if result.returncode != 0:
         raise SystemExit(result.returncode)

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -1678,7 +1678,10 @@ class TestDevboxCommands:
         assert result.exit_code == 0
         assert "Updating" in result.output
         assert captured["name"] == "devbox-test-user"
-        assert captured["parameters"] == {"dotfiles_uri": "https://github.com/user/dotfiles"}
+        assert captured["parameters"] == {
+            "dotfiles_uri": "https://github.com/user/dotfiles",
+            "workspace_region": coder.DEFAULT_REGION,
+        }
 
     def test_devbox_update_skips_when_up_to_date(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(devbox_cli, "ensure_runtime_ready", lambda: None)
@@ -2168,6 +2171,7 @@ class TestStartExistingWorkspace:
                 "git_name": "PostHog Engineer",
                 "git_email": "test-user@example.com",
                 "dotfiles_uri": "https://github.com/user/dotfiles",
+                "workspace_region": coder.DEFAULT_REGION,
             },
         }
 
@@ -2191,6 +2195,43 @@ class TestStartExistingWorkspace:
         devbox_cli._start_existing_workspace("devbox-test-user", {"latest_build": {"status": "stopped"}}, verbose=False)
 
         assert calls == ["start"]
+
+    def test_sync_pins_workspace_region_from_metadata_to_suppress_picker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When a `coder update` actually fires, pin the current region.
+
+        Coder re-prompts for any parameter whose template-declared option set
+        changed since workspace creation. Forwarding the workspace's current
+        region as `--parameter workspace_region=<value>` short-circuits that
+        picker -- the prompt is otherwise unanswerable from environments that
+        can't deliver stdin (e.g. an IDE's read-only output channel).
+        """
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(devbox_cli, "get_workspace_status", lambda ws: "stopped")
+        monkeypatch.setattr(
+            devbox_cli,
+            "load_config",
+            lambda: {"dotfiles_uri": "https://github.com/user/dotfiles"},
+        )
+        monkeypatch.setattr(
+            devbox_cli,
+            "update_workspace_parameters",
+            lambda name, params: captured.update({"name": name, "params": params}),
+        )
+        monkeypatch.setattr(devbox_cli, "start_workspace", lambda name, verbose=False: None)
+        monkeypatch.setattr(devbox_cli, "extract_workspace_label", lambda name: None)
+
+        workspace = {
+            "latest_build": {
+                "status": "stopped",
+                "resources": [{"metadata": [{"key": coder.REGION_METADATA_KEY, "value": "eu-central-1"}]}],
+            },
+        }
+        devbox_cli._start_existing_workspace("devbox-test-user", workspace, verbose=False)
+
+        assert captured["params"] == {
+            "dotfiles_uri": "https://github.com/user/dotfiles",
+            "workspace_region": "eu-central-1",
+        }
 
     def test_skips_sync_for_running_workspace(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls: list[str] = []


### PR DESCRIPTION
## Problem

When `coder update` runs against a workspace whose template has had its `workspace_region` option set modified since the workspace was created (e.g. the recent addition of `eu-central-1`), Coder surfaces an interactive picker to select the new value. Per Coder's docs: "when template authors modify parameter options (add, remove, or substitute values), workspace users will be prompted to select the new value." Neither `--use-parameter-defaults` nor `--yes` bypasses this picker — it's a parameter-collection prompt, not a confirmation. (For the same reason, `coder create` had to start forwarding `--preset` explicitly; see comment at `coder.py:33`.)

When the picker fires in an environment that can't deliver stdin — for example an IDE's read-only output channel — the command wedges with no way out. Reported in the wild this morning after a manual `hogli devbox:update`.

Note: `coder update` doesn't even accept `--yes` (confirmed in `coder/cli/update.go` — it only registers `parameterFlags.allOptions()` and `bflags.cliOptions()`, neither of which contains `cliui.SkipPromptOption()`). Earlier commits on this branch tried to add `--yes` to `coder update`; that would have broken the command outright with an unknown-flag error. Reverted.

## Changes

- New helper `_pinned_region_param(workspace)` in `cli.py`: reads the workspace's current region from coder metadata, defaulting to `us-east-1` for boxes that predate the region metadata item.
- `_sync_workspace_parameters(name, workspace)` now takes the workspace dict and merges the pinned region into the params dict — only when other params are being pushed, preserving the "skip when nothing to sync" fast path.
- `devbox:update` always merges the pinned region into its params dict (it always invokes `coder update`).
- Comment block at `coder.py:48` rewritten to explain why region is forwarded on update — the previous comment's "immutable, so never forward on update" logic is what allowed the bug to land.
- The retry shim in `_run_with_param_retry` already handles the template-no-longer-declares-this-parameter case, so this is forward-compatible with template changes.

(Earlier commits on this branch went through a Y/n gate on `devbox:start` and an incorrect `--yes` addition before landing on the actual fix. Cumulative branch diff against master is only the changes described above — happy to squash on merge.)

## How did you test this code?

I'm an agent. No manual run on a real devbox.
- Updated existing tests `test_syncs_then_starts_when_stopped` and `test_devbox_update_applies_when_outdated` to assert the pinned region appears in the params dict.
- Added `test_sync_pins_workspace_region_from_metadata_to_suppress_picker` exercising the metadata-driven region pin.
- Existing `test_update_paths_drop_unknown_params_and_retry` already covers the case where Coder rejects a forwarded parameter — confirms `workspace_region` is dropped cleanly if the template removes it.
- Full `test_devbox.py` suite: 241 passed.
- `ruff check`, `ruff format --check`, pre-commit (`bin/hogli lint:python:fix`, `bin/hogli format:python`, `uv run ty check`) all green.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Tooling: Claude Code (Opus 4.7), `/wt` worktree skill, `/code-review` for the calibration pass that surfaced the wrong-flag issue.
- Two false starts before the right fix: (1) a Y/n gate on `devbox:start` based on a misread of the symptom, (2) adding `--yes` to `coder update` based on a misread of which Coder prompt was wedging. Both reverted on this branch. The actual mechanism is the rich-parameter picker that fires when a template's option set changes, which only goes away when callers forward the current value explicitly — same pattern as `--preset` on create.
- Verified `coder update`'s flag set by reading `coder/cli/update.go` and `coder/cli/parameter.go` upstream; `--yes` is not a valid flag for update (it's a per-command option attached via `cliui.SkipPromptOption()` on commands like `start`/`stop`/`restart`/`delete`).
- Considered widening the region pin to also fire when no other params need pushing (i.e. always invoke `coder update` on `devbox:start` to clear any pending parameter prompt proactively). Out of scope: that adds a Coder round-trip on every start without addressing a known wedge surface — left as a follow-up if reviewers want it.