### PR TITLE
chore(django): reduce person fetch batch limit to 250

### DIFF
--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -50,7 +50,7 @@ from posthog.settings import TEST
 
 logger = structlog.get_logger(__name__)
 
-PERSONHOG_BATCH_SIZE = 500
+PERSONHOG_BATCH_SIZE = 250
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Problem

Person records can be large, so the tails of fetching persons by ids response sizes can end up ballooning. The tradeoff of more requests/lookups to have less data over the wire for a single response response appears to be the correct one.

## Changes

Reduce the batch limit on fetching person ids from 500 at a time to 250.

## How did you test this code?

Current tests already cover this. Just reducing the batch size number which will have to be tested on deploy.