### PR TITLE
feat(dashboards): add DashboardWidget model and table migration (1/11)

### DIFF
--- a/.semgrep/rules/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/idor-team-scoped-models.yaml
@@ -81,6 +81,7 @@ rules:
                               |DAG
                               |Dashboard
                               |DashboardTemplate
+                              |DashboardWidget
                               |DataColorTheme
                               |DataModelingJob
                               |Dataset
@@ -308,6 +309,7 @@ rules:
                         |DAG
                         |Dashboard
                         |DashboardTemplate
+                        |DashboardWidget
                         |DataColorTheme
                         |DataModelingJob
                         |Dataset

--- a/products/dashboards/backend/migrations/0007_dashboardwidget_table.py
+++ b/products/dashboards/backend/migrations/0007_dashboardwidget_table.py
@@ -1,0 +1,90 @@
+# Generated manually for dashboard widget entity
+
+import django.utils.timezone
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dashboards", "0006_migrate_product_analytics_models"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="DashboardWidget",
+                    fields=[
+                        (
+                            "id",
+                            models.UUIDField(
+                                default=posthog.models.utils.uuid7,
+                                editable=False,
+                                primary_key=True,
+                                serialize=False,
+                            ),
+                        ),
+                        ("widget_type", models.CharField(max_length=64)),
+                        ("name", models.CharField(blank=True, max_length=400, null=True)),
+                        ("description", models.TextField(blank=True)),
+                        ("config", models.JSONField(default=dict)),
+                        (
+                            "last_modified_at",
+                            models.DateTimeField(default=django.utils.timezone.now),
+                        ),
+                        (
+                            "created_by",
+                            models.ForeignKey(
+                                blank=True,
+                                null=True,
+                                on_delete=django.db.models.deletion.SET_NULL,
+                                to=settings.AUTH_USER_MODEL,
+                            ),
+                        ),
+                        (
+                            "last_modified_by",
+                            models.ForeignKey(
+                                blank=True,
+                                null=True,
+                                on_delete=django.db.models.deletion.SET_NULL,
+                                related_name="modified_dashboard_widgets",
+                                to=settings.AUTH_USER_MODEL,
+                            ),
+                        ),
+                        (
+                            "team",
+                            models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="posthog.team"),
+                        ),
+                    ],
+                    options={
+                        "db_table": "posthog_dashboardwidget",
+                    },
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                        CREATE TABLE "posthog_dashboardwidget" (
+                            "id" uuid NOT NULL PRIMARY KEY,
+                            "widget_type" varchar(64) NOT NULL,
+                            "name" varchar(400) NULL,
+                            "description" text NOT NULL,
+                            "config" jsonb NOT NULL,
+                            "last_modified_at" timestamp with time zone NOT NULL,
+                            "created_by_id" integer NULL REFERENCES "posthog_user" ("id") DEFERRABLE INITIALLY DEFERRED,
+                            "last_modified_by_id" integer NULL REFERENCES "posthog_user" ("id") DEFERRABLE INITIALLY DEFERRED,
+                            "team_id" integer NOT NULL REFERENCES "posthog_team" ("id") DEFERRABLE INITIALLY DEFERRED
+                        );
+                        CREATE INDEX IF NOT EXISTS "posthog_dashboardwidget_created_by_id" ON "posthog_dashboardwidget" ("created_by_id");
+                        CREATE INDEX IF NOT EXISTS "posthog_dashboardwidget_last_modified_by_id" ON "posthog_dashboardwidget" ("last_modified_by_id");
+                        CREATE INDEX IF NOT EXISTS "posthog_dashboardwidget_team_id" ON "posthog_dashboardwidget" ("team_id");
+                    """,
+                    reverse_sql='DROP TABLE IF EXISTS "posthog_dashboardwidget"',
+                ),
+            ],
+        ),
+    ]

--- a/products/dashboards/backend/migrations/0007_dashboardwidget_table.py
+++ b/products/dashboards/backend/migrations/0007_dashboardwidget_table.py
@@ -1,6 +1,7 @@
 # Generated manually for dashboard widget entity
 
 import django.utils.timezone
+import django.db.models.manager
 import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
@@ -60,8 +61,12 @@ class Migration(migrations.Migration):
                             models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="posthog.team"),
                         ),
                     ],
+                    managers=[
+                        ("all_teams", django.db.models.manager.Manager()),
+                    ],
                     options={
                         "db_table": "posthog_dashboardwidget",
+                        "default_manager_name": "all_teams",
                     },
                 ),
             ],

--- a/products/dashboards/backend/migrations/max_migration.txt
+++ b/products/dashboards/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0006_migrate_product_analytics_models
+0007_dashboardwidget_table

--- a/products/dashboards/backend/models/__init__.py
+++ b/products/dashboards/backend/models/__init__.py
@@ -1,11 +1,13 @@
 from .dashboard import Dashboard
 from .dashboard_templates import DashboardTemplate
 from .dashboard_tile import ButtonTile, DashboardTile, Text
+from .dashboard_widget import DashboardWidget
 
 __all__ = [
     "ButtonTile",
     "Dashboard",
     "DashboardTemplate",
     "DashboardTile",
+    "DashboardWidget",
     "Text",
 ]

--- a/products/dashboards/backend/models/dashboard_widget.py
+++ b/products/dashboards/backend/models/dashboard_widget.py
@@ -1,0 +1,31 @@
+from django.db import models
+from django.utils import timezone
+
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
+from posthog.models.scoping.root_mixin import TeamScopedRootMixin
+from posthog.models.utils import UUIDModel
+
+
+class DashboardWidget(ModelActivityMixin, TeamScopedRootMixin, UUIDModel):
+    widget_type = models.CharField(max_length=64)
+    name = models.CharField(max_length=400, null=True, blank=True)
+    description = models.TextField(blank=True)
+    config = models.JSONField(default=dict)
+
+    created_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True)
+    last_modified_at = models.DateTimeField(default=timezone.now)
+    last_modified_by = models.ForeignKey(
+        "posthog.User",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="modified_dashboard_widgets",
+    )
+
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
+
+    all_teams = models.Manager()  # noqa: DJ012
+
+    class Meta(TeamScopedRootMixin.Meta):
+        db_table = "posthog_dashboardwidget"
+        default_manager_name = "all_teams"


### PR DESCRIPTION
## Problem

Dashboard widgets need a first-class persisted entity (`DashboardWidget`) separate from insights and text tiles. This stack starts with schema-only changes so each migration can ship and deploy independently.

This PR is **1/10** in the dashboard widgets Graphite stack (migration foundation).

## Changes

- Add `DashboardWidget` model (`products/dashboards/backend/models/dashboard_widget.py`)
- Migration `0007_dashboardwidget_table` — creates `posthog_dashboardwidget` (new table only, no locks on existing dashboard tables)
- Wire model into `products/dashboards/backend/models/__init__.py`

## How did you test this code?

- Agent: did not run manual migrations locally
- `hogli test products/dashboards/backend/` — not run on this slice alone; migration is additive-only

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

skip-inkeep-docs (internal schema prep)

## 🤖 Agent context

- Agent-assisted split of the `dashboard-widget-foundation` WIP branch into a 10-PR Graphite stack for safer review and deploy
- Lock-risk migrations are isolated into separate PRs (this one is low risk: new table only)
- No product behavior change until later stack PRs
