### PR TITLE
feat(dashboards): validate dashboard tile widget constraints (4/11)

### DIFF
--- a/products/dashboards/backend/migrations/0010_validate_dashboardtile_check.py
+++ b/products/dashboards/backend/migrations/0010_validate_dashboardtile_check.py
@@ -1,0 +1,19 @@
+# Generated manually for dashboard widget entity
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dashboards", "0009_dashboardtile_check_4way"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                ALTER TABLE "posthog_dashboardtile" VALIDATE CONSTRAINT "dash_tile_exactly_one_related_object";
+                ALTER TABLE "posthog_dashboardtile" VALIDATE CONSTRAINT "posthog_dashboardtile_widget_id_fk";
+            """,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/products/dashboards/backend/migrations/max_migration.txt
+++ b/products/dashboards/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0009_dashboardtile_check_4way
+0010_validate_dashboardtile_check


### PR DESCRIPTION
## Problem

After adding widget FK and 4-way exclusivity as `NOT VALID`, we must validate constraints in a standalone PR — this can scan the tile table and is the highest-risk migration step.

This PR is **4/10** in the dashboard widgets Graphite stack.

**Depends on:** PR 3 (4-way CHECK `NOT VALID`)

## Changes

- Migration `0010_validate_dashboardtile_check` — `VALIDATE CONSTRAINT` for widget FK and tile exclusivity check

## How did you test this code?

- Agent: did not run manual migrations locally
- Validation should be fast while all `widget_id` values are null

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Isolated validation PR per django-migrations locking guidance
- No application code changes — deploy-only migration
