### PR TITLE
feat(dashboards): add session replay dashboard widget (9/11)

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1481,9 +1481,9 @@ snapshots:
     components-verticalnesteddnd--base--light:
         hash: v1.k794b7964.253572e7c878adb761595b38b07c93ba529e1bf165d0e67fe79550ef784dcf5d.um0bjxs1ERf6_rMKphvKrO7fE5D7cV_HaikHm5fGsM8
     dashboards-dashboard-widgets-overview--all-widget-types--dark:
-        hash: v1.k794b7964.16e7827f2f44eacd81f37bcae46809c232783c05ffa6cd3ff3965e1ceabec48e.1dqZxbw0PVEgD_mT4bej_AxQXCHQZ05XqQrDCKKqnHM
+        hash: v1.k794b7964.46c83f5df1d41693e18baf11ace6a8196433f97bca5a0f01c62160c517285066.M0vFUw5jIHgQtbwrmQgTeA0u1_RWRUqLzcI-4yShpPw
     dashboards-dashboard-widgets-overview--all-widget-types--light:
-        hash: v1.k794b7964.a5b2813dc22662e817214a4a6632021c7f28ef817813f0a4e1322ebdec864eb6.kDG_VO59wYZ-hYOP6tbGcpB3j81SjRsqkATi3ylN_Vk
+        hash: v1.k794b7964.5cddc2fcd7be9f78e520e5b892963e14e75225510b10d8f2a7916c32f55198a9.Em6s5yImFvW3u223eY-y_eAfuY2WUdMzCRBX4fnBma4
     dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--empty--dark:
         hash: v1.k794b7964.37b0f3093591c5d717106e98dc91ca4288d2562cdb240750c1223ae2bce4f8af.K92XY4q1UjFlYZ0DhQ8G02rowmJ7Ed0FxirKIANkTog
     dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--empty--light:
@@ -1508,6 +1508,26 @@ snapshots:
         hash: v1.k794b7964.321b3a05b437647379f82a1396417ca3836e3b8324edb45bdc22681f7dc75e64.GGZFGrydw_LpK5CDXm34dVegUKo1vvp6Rjk5vqcfOvs
     dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:
         hash: v1.k794b7964.589ad6d84fdd1cb75c0a4fc17062f7c8223d922f410a787935dce4ebdf5ddd0e.bxVCTsAm5NufSyxv1SecNVFONuo6SGSz2L_Q53-M29g
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings--empty--dark:
+        hash: v1.k794b7964.0889c484f8f0d9ee048083e9fa2fc738841b146b21b8aa3a94a4c1bc872131b2.IMQafZvuzRCegEV39NlJB0NswElKBpcQBYAomG2lg70
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings--empty--light:
+        hash: v1.k794b7964.63e0696f90177908357ba0981fef6d29deeb5151fba8f093557bf5f7cdf701ac.wBAQlaLkNJ7fm5hMJxB54hIM3m0iDefdOvPEzsmVroU
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings--loading--dark:
+        hash: v1.k794b7964.fbbec720a0aea882f3b3ebf771b37ddb27d82b3ac726b45deb1a69e3f066d01f.ckn1xNOukgjUkCXmWqIO5tRMsJjay4599TUJaFO_kNw
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings--loading--light:
+        hash: v1.k794b7964.f2c8a5cd75ce9c7ddf2de592775a10549a0b99afcc316f0d3f69ff3ca9696672.GTV3Hl1KhQ6WYStJnBvZ1xqdhF5_GWbfhQ95EKAGzoo
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings--populated--dark:
+        hash: v1.k794b7964.119f5a129c51f51bc0d050245e38e19c7b43d3bfb0f195c23f4b27ec5bfa59ab.O5GZxPy4-zuvRpeiTcZ03BWaHInTeaksKfpwAS6aMtY
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings--populated--light:
+        hash: v1.k794b7964.c47ee9f1d086074cfae6888c6d936c87f4db6587f5f137d5b900f01816a91ae3.Gq8myNhj042VlCaWubVnkiNSsTRQteL1HBQPkHfhnUI
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings--setup-unavailable--dark:
+        hash: v1.k794b7964.4d843ded3453a2be0dd16f6bb4efe34dd8de634388ed8073cf7c748b6614e186.RKgAGczYSH33uEfBaYGMSlXx7pa4c2QToaJprdtWnKs
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings--setup-unavailable--light:
+        hash: v1.k794b7964.6fc2668cd7bab46bf06a6bf27c9932197f83602d8a5bc1235ecf113dd39e498d.qB69GwThpUyt3z_aOk6gUZbTj3vJBfXm3gDR7FzuA50
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings-widget-settings--default--dark:
+        hash: v1.k794b7964.c5434bc55d32b51eac6a19e9c4aa9704662ab4d738ab6c0e27f09f1f80d61ef3.Y4anfV8zrl54px4sfbVRujK5F1DQ5_448DvdY0cps5I
+    dashboards-dashboard-widgets-widget-types-session-replay-recent-recordings-widget-settings--default--light:
+        hash: v1.k794b7964.fa606138cd2e3f82ddfad9a9da33f0982699f92c2ce19346b032c26055880a5f._ocZVep957TFyWHeqMQlWkROMOZl4ICfQwqzVyvQ7X8
     dashboards-dashboard-widgets-widgetcard--dashboard-tile-populated--dark:
         hash: v1.k794b7964.44c19632537a43879cd2fb8196905bf21e18e784b907a6851aa9d49ec7f45ce7.WRJJJH-g5HOJnILNLSsqi-nP04K6dA4KQiUwxLxbiVk
     dashboards-dashboard-widgets-widgetcard--dashboard-tile-populated--light:

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -709,6 +709,7 @@ def get_replay_listing_throttle_error(request, view) -> str | None:
         if wait:
             return f"Rate limit exceeded. Expected available in {wait} seconds."
         return "Rate limit exceeded. Try again later."
+    # None: both listing burst and sustained throttles allowed the request.
     return None
 
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -696,6 +696,22 @@ class ListingSustainedRateThrottle(_TierAwareReplayThrottle):
         return listing_rates()
 
 
+def get_replay_listing_throttle_error(request, view) -> str | None:
+    """Return a client-facing error when replay listing throttles would block this request."""
+    auth_type = _request_auth_type(request)
+    for throttle_cls in (ListingBurstRateThrottle, ListingSustainedRateThrottle):
+        throttle = throttle_cls()
+        if throttle.allow_request(request, view):
+            continue
+        wait = throttle.wait()
+        scope = throttle.scope or "listing"
+        SESSION_RECORDING_THROTTLED.labels(location=scope, auth_type=auth_type).inc()
+        if wait:
+            return f"Rate limit exceeded. Expected available in {wait} seconds."
+        return "Rate limit exceeded. Try again later."
+    return None
+
+
 class SharingTokenReplayThrottle(SimpleRateThrottle):
     """Per-token cap for replay endpoints reached via a sharing-token authenticator."""
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -541,6 +541,34 @@ def list_recordings_response(
     return response
 
 
+class _SessionRecordingListViewShim:
+    """Minimal view shim so SessionRecordingSerializer skips list-view N+1 loads."""
+
+    action = "list"
+
+
+def session_recording_list_serializer_context(team: Team) -> dict[str, Any]:
+    return {"view": _SessionRecordingListViewShim(), "get_team": lambda: team}
+
+
+def run_recordings_list_query(
+    query: RecordingsQuery,
+    *,
+    user: User | None,
+    team: Team,
+    allow_event_property_expansion: bool = False,
+) -> dict[str, Any]:
+    """Fetch and serialize recordings the same way as SessionRecordingViewSet.list."""
+    listing_result = list_recordings_from_query(
+        query=query,
+        user=user,
+        team=team,
+        allow_event_property_expansion=allow_event_property_expansion,
+    )
+    response = list_recordings_response(listing_result, context=session_recording_list_serializer_context(team))
+    return cast(dict[str, Any], response.data)
+
+
 def ensure_not_weak(etag: str) -> str:
     """
     minio at least doesn't like weak etags, so we need to strip the W/ prefix if it exists.

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -82,7 +82,7 @@ from products.dashboards.backend.api.dashboard_ai import generate_refresh_analys
 from products.dashboards.backend.api.dashboard_template_json_schema_parser import (
     DashboardTemplateCreationJSONSchemaParser,
 )
-from products.dashboards.backend.api.widget_openapi_serializers import ErrorTrackingListWidgetConfigSerializer
+from products.dashboards.backend.api.widget_openapi_serializers import DashboardWidgetConfigField
 from products.dashboards.backend.constants import DASHBOARD_GRID_COLUMN_COUNT, MAX_WIDGETS_BATCH_SIZE
 from products.dashboards.backend.feature_flags import dashboard_widgets_enabled
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -478,7 +478,7 @@ class DashboardWidgetCoreRequestSerializer(serializers.Serializer):
         max_length=64,
         help_text=WIDGET_TYPE_API_HELP,
     )
-    config = serializers.JSONField(
+    config = DashboardWidgetConfigField(
         required=False,
         help_text=(
             "Widget-specific configuration. Shape depends on widget_type; "
@@ -501,7 +501,7 @@ class DashboardWidgetCoreRequestSerializer(serializers.Serializer):
 
 
 class AddDashboardWidgetRequestSerializer(DashboardWidgetCoreRequestSerializer):
-    config = serializers.JSONField(
+    config = DashboardWidgetConfigField(
         help_text=(
             "Widget-specific configuration. Shape depends on widget_type; "
             "see dashboard-widget-catalog-list for config_schema_hints. "
@@ -665,7 +665,7 @@ class DashboardWidgetSerializer(serializers.ModelSerializer):
         allow_blank=True,
         help_text="Optional markdown description shown on the dashboard tile when enabled.",
     )
-    config = ErrorTrackingListWidgetConfigSerializer(
+    config = DashboardWidgetConfigField(
         required=False,
         help_text="Widget-specific configuration JSON for this widget type.",
     )

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -72,6 +72,7 @@ from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControl, UserAccessControlSerializerMixin
 from posthog.renderers import SafeJSONRenderer, ServerSentEventRenderer
 from posthog.resource_limits import LimitKey, check_count_limit
+from posthog.session_recordings.session_recording_api import get_replay_listing_throttle_error
 from posthog.user_permissions import UserPermissionsSerializerMixin
 from posthog.utils import filters_override_requested_by_client, str_to_bool, variables_override_requested_by_client
 
@@ -476,13 +477,12 @@ class DashboardWidgetCoreRequestSerializer(serializers.Serializer):
         max_length=64,
         help_text=WIDGET_TYPE_API_HELP,
     )
-    config = ErrorTrackingListWidgetConfigSerializer(
+    config = serializers.JSONField(
         required=False,
         help_text=(
             "Widget-specific configuration. Shape depends on widget_type; "
-            "see dashboard-widget-catalog-list for other types. "
-            f"For error_tracking_list, use the schema below (currently the only supported type: "
-            f"{', '.join(sorted(EXPECTED_WIDGET_TYPES))})."
+            "see dashboard-widget-catalog-list for config_schema_hints. "
+            f"Supported types: {', '.join(sorted(EXPECTED_WIDGET_TYPES))}."
         ),
     )
     name = serializers.CharField(
@@ -500,12 +500,11 @@ class DashboardWidgetCoreRequestSerializer(serializers.Serializer):
 
 
 class AddDashboardWidgetRequestSerializer(DashboardWidgetCoreRequestSerializer):
-    config = ErrorTrackingListWidgetConfigSerializer(
+    config = serializers.JSONField(
         help_text=(
             "Widget-specific configuration. Shape depends on widget_type; "
-            "see dashboard-widget-catalog-list for other types. "
-            f"For error_tracking_list, use the schema below (currently the only supported type: "
-            f"{', '.join(sorted(EXPECTED_WIDGET_TYPES))})."
+            "see dashboard-widget-catalog-list for config_schema_hints. "
+            f"Supported types: {', '.join(sorted(EXPECTED_WIDGET_TYPES))}."
         ),
     )
     layouts = TileLayoutsSerializer(
@@ -2637,6 +2636,17 @@ class DashboardsViewSet(
                     "error": scope_error,
                 }
                 continue
+
+            if widget.widget_type == "session_replay_list":
+                throttle_error = get_replay_listing_throttle_error(request, self)
+                if throttle_error:
+                    results_by_id[tile_id] = {
+                        "tile_id": tile_id,
+                        "widget_type": widget.widget_type,
+                        "result": None,
+                        "error": throttle_error,
+                    }
+                    continue
 
             query_work_items.append(
                 {

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -101,6 +101,7 @@ from products.dashboards.backend.widget_layouts import (
 )
 from products.dashboards.backend.widget_registry import (
     EXPECTED_WIDGET_TYPES,
+    SESSION_REPLAY_LIST_WIDGET_TYPE,
     get_widget_registry_entry,
     validate_widget_config,
 )
@@ -2637,7 +2638,7 @@ class DashboardsViewSet(
                 }
                 continue
 
-            if widget.widget_type == "session_replay_list":
+            if widget.widget_type == SESSION_REPLAY_LIST_WIDGET_TYPE:
                 throttle_error = get_replay_listing_throttle_error(request, self)
                 if throttle_error:
                     results_by_id[tile_id] = {

--- a/products/dashboards/backend/api/test/test_dashboard_widgets.py
+++ b/products/dashboards/backend/api/test/test_dashboard_widgets.py
@@ -700,6 +700,28 @@ class TestDashboardWidgets(APIBaseTest):
         assert "widget_id" in widget_added_calls[0][0][2]
 
     @override_settings(IN_UNIT_TESTING=True)
+    @patch("products.dashboards.backend.api.dashboard.report_user_action")
+    def test_add_session_replay_widget_fires_dashboard_widget_added_event(self, mock_report_user_action) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        mock_report_user_action.reset_mock()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/widgets/batch/",
+            {
+                "widgets": [
+                    {"widget_type": "session_replay_list", "config": {"limit": 5}, "name": "Recent replays"},
+                ]
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        widget_added_calls = [
+            call for call in mock_report_user_action.call_args_list if call[0][1] == "dashboard widget added"
+        ]
+        assert len(widget_added_calls) == 1
+        assert widget_added_calls[0][0][2]["widget_type"] == "session_replay_list"
+
+    @override_settings(IN_UNIT_TESTING=True)
     def test_can_batch_create_widget_tiles(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
 

--- a/products/dashboards/backend/api/test/test_run_widgets.py
+++ b/products/dashboards/backend/api/test/test_run_widgets.py
@@ -169,7 +169,7 @@ class TestDashboardRunWidgets(APIBaseTest):
         self.assertEqual(body["results"][0]["result"]["limit"], 10)
         mock_calculate.assert_called_once()
 
-    @patch("products.dashboards.backend.widgets.session_replay_list.list_recordings_from_query")
+    @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_runs_session_replay_widget_for_requested_tile(self, mock_list_recordings: MagicMock) -> None:
         mock_list_recordings.return_value = ([], False, None, None)
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
@@ -195,7 +195,7 @@ class TestDashboardRunWidgets(APIBaseTest):
         "posthog.session_recordings.session_recording_api.ListingBurstRateThrottle.allow_request", return_value=False
     )
     @patch("posthog.session_recordings.session_recording_api.ListingBurstRateThrottle.wait", return_value=30)
-    @patch("products.dashboards.backend.widgets.session_replay_list.list_recordings_from_query")
+    @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_run_widgets_applies_replay_listing_throttles(
         self,
         mock_list_recordings: MagicMock,
@@ -215,7 +215,7 @@ class TestDashboardRunWidgets(APIBaseTest):
         self.assertEqual(body["results"][0]["error"], "Rate limit exceeded. Expected available in 30 seconds.")
         mock_list_recordings.assert_not_called()
 
-    @patch("products.dashboards.backend.widgets.session_replay_list.list_recordings_from_query")
+    @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_tags_queries_in_debug_mode(self, mock_list_recordings: MagicMock) -> None:
         from django.test.utils import override_settings
 
@@ -244,7 +244,7 @@ class TestDashboardRunWidgets(APIBaseTest):
         self.assertEqual(result["limit"], 10)
         mock_list_recordings.assert_called_once()
 
-    @patch("products.dashboards.backend.widgets.session_replay_list.list_recordings_from_query")
+    @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_serializes_recordings_with_person(self, mock_list_recordings: MagicMock) -> None:
         from posthog.models import Person
         from posthog.session_recordings.models.session_recording import SessionRecording

--- a/products/dashboards/backend/api/test/test_run_widgets.py
+++ b/products/dashboards/backend/api/test/test_run_widgets.py
@@ -10,11 +10,7 @@ from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.rbac.user_access_control import AccessControlLevel, UserAccessControl
 from posthog.scopes import APIScopeObject
 
-from products.dashboards.backend.constants import (
-    DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT,
-    DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT,
-    MAX_WIDGETS_BATCH_SIZE,
-)
+from products.dashboards.backend.constants import DEFAULT_WIDGET_LIST_LIMIT, MAX_WIDGETS_BATCH_SIZE
 from products.dashboards.backend.widget_registry import EXPECTED_WIDGET_TYPES, WIDGET_REGISTRY, validate_widget_config
 from products.dashboards.backend.widgets.error_tracking_list import validate_error_tracking_list_config
 from products.dashboards.backend.widgets.session_replay_list import (
@@ -40,7 +36,7 @@ class TestWidgetRegistry(APIBaseTest):
 
     def test_validate_error_tracking_list_config_defaults(self) -> None:
         validated = validate_error_tracking_list_config({})
-        assert validated["limit"] == DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT
+        assert validated["limit"] == DEFAULT_WIDGET_LIST_LIMIT
         assert validated["orderBy"] == "occurrences"
         assert "filterTestAccounts" not in validated
 
@@ -69,7 +65,7 @@ class TestWidgetRegistry(APIBaseTest):
 
     def test_validate_session_replay_list_config_defaults(self) -> None:
         validated = validate_session_replay_list_config({})
-        assert validated["limit"] == DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT
+        assert validated["limit"] == DEFAULT_WIDGET_LIST_LIMIT
         assert validated["orderBy"] == "start_time"
         assert "filterTestAccounts" not in validated
 
@@ -168,6 +164,33 @@ class TestDashboardRunWidgets(APIBaseTest):
         self.assertEqual(body["results"][0]["result"]["limit"], 10)
         mock_list_recordings.assert_called_once()
         self.assertEqual(mock_list_recordings.call_args.kwargs["user"], self.user)
+
+    @patch(
+        "posthog.session_recordings.session_recording_api.ListingSustainedRateThrottle.allow_request", return_value=True
+    )
+    @patch(
+        "posthog.session_recordings.session_recording_api.ListingBurstRateThrottle.allow_request", return_value=False
+    )
+    @patch("posthog.session_recordings.session_recording_api.ListingBurstRateThrottle.wait", return_value=30)
+    @patch("products.dashboards.backend.widgets.session_replay_list.list_recordings_from_query")
+    def test_run_widgets_applies_replay_listing_throttles(
+        self,
+        mock_list_recordings: MagicMock,
+        _mock_wait: MagicMock,
+        _mock_burst_allow: MagicMock,
+        _mock_sustained_allow: MagicMock,
+    ) -> None:
+        mock_list_recordings.return_value = ([], False, None, None)
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(
+            dashboard_id, widget_type="session_replay_list", config={"limit": 10}
+        )
+        tile_id = dashboard_json["tiles"][0]["id"]
+
+        body = self._run(dashboard_id, [tile_id])
+
+        self.assertEqual(body["results"][0]["error"], "Rate limit exceeded. Expected available in 30 seconds.")
+        mock_list_recordings.assert_not_called()
 
     @patch("products.dashboards.backend.widgets.session_replay_list.list_recordings_from_query")
     def test_session_replay_widget_tags_queries_in_debug_mode(self, mock_list_recordings: MagicMock) -> None:

--- a/products/dashboards/backend/api/test/test_run_widgets.py
+++ b/products/dashboards/backend/api/test/test_run_widgets.py
@@ -1,20 +1,28 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
+from django.test.utils import override_settings
+
 from parameterized import parameterized
 from rest_framework import status
 
 from posthog.api.test.dashboards import DashboardAPI
+from posthog.clickhouse.client.execute import UntaggedQueryError
+from posthog.clickhouse.query_tagging import Feature, Product, get_query_tags
+from posthog.models import Person
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.rbac.user_access_control import AccessControlLevel, UserAccessControl
 from posthog.scopes import APIScopeObject
+from posthog.session_recordings.models.session_recording import SessionRecording
 
 from products.dashboards.backend.constants import DEFAULT_WIDGET_LIST_LIMIT, MAX_WIDGETS_BATCH_SIZE
+from products.dashboards.backend.widget_catalog import WIDGET_CATALOG
 from products.dashboards.backend.widget_registry import EXPECTED_WIDGET_TYPES, WIDGET_REGISTRY, validate_widget_config
 from products.dashboards.backend.widgets.error_tracking_list import validate_error_tracking_list_config
 from products.dashboards.backend.widgets.session_replay_list import (
     SESSION_REPLAY_ORDER_BY,
+    run_session_replay_list_widget,
     validate_session_replay_list_config,
 )
 from products.error_tracking.backend.api.query_utils import ERROR_TRACKING_LISTING_VOLUME_RESOLUTION
@@ -22,8 +30,6 @@ from products.error_tracking.backend.api.query_utils import ERROR_TRACKING_LISTI
 
 class TestWidgetRegistry(APIBaseTest):
     def test_widget_registry_catalog_and_expected_types_stay_in_sync(self) -> None:
-        from products.dashboards.backend.widget_catalog import WIDGET_CATALOG
-
         registry_types = frozenset(WIDGET_REGISTRY.keys())
         assert EXPECTED_WIDGET_TYPES == registry_types
         assert frozenset(WIDGET_CATALOG.keys()) == registry_types
@@ -217,13 +223,6 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_tags_queries_in_debug_mode(self, mock_list_recordings: MagicMock) -> None:
-        from django.test.utils import override_settings
-
-        from posthog.clickhouse.client.execute import UntaggedQueryError
-        from posthog.clickhouse.query_tagging import Feature, Product, get_query_tags
-
-        from products.dashboards.backend.widgets.session_replay_list import run_session_replay_list_widget
-
         mock_list_recordings.return_value = ([], False, None, None)
 
         def assert_tagged(*_args: object, **_kwargs: object) -> tuple[list[object], bool, None, None]:
@@ -246,9 +245,6 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_serializes_recordings_with_person(self, mock_list_recordings: MagicMock) -> None:
-        from posthog.models import Person
-        from posthog.session_recordings.models.session_recording import SessionRecording
-
         person = Person.objects.create(team=self.team, properties={"email": "widget-test@example.com"})
         recording = SessionRecording(
             session_id="019e6a07-04fe-792c-b828-49375b8d42e8",

--- a/products/dashboards/backend/api/test/test_run_widgets.py
+++ b/products/dashboards/backend/api/test/test_run_widgets.py
@@ -10,9 +10,17 @@ from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.rbac.user_access_control import AccessControlLevel, UserAccessControl
 from posthog.scopes import APIScopeObject
 
-from products.dashboards.backend.constants import DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT, MAX_WIDGETS_BATCH_SIZE
+from products.dashboards.backend.constants import (
+    DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT,
+    DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT,
+    MAX_WIDGETS_BATCH_SIZE,
+)
 from products.dashboards.backend.widget_registry import EXPECTED_WIDGET_TYPES, WIDGET_REGISTRY, validate_widget_config
 from products.dashboards.backend.widgets.error_tracking_list import validate_error_tracking_list_config
+from products.dashboards.backend.widgets.session_replay_list import (
+    SESSION_REPLAY_ORDER_BY,
+    validate_session_replay_list_config,
+)
 from products.error_tracking.backend.api.query_utils import ERROR_TRACKING_LISTING_VOLUME_RESOLUTION
 
 
@@ -58,6 +66,21 @@ class TestWidgetRegistry(APIBaseTest):
             {"dateRange": {"date_from": "-7d", "date_to": "ignored", "evil": 1}}
         )
         assert validated["dateRange"] == {"date_from": "-7d"}
+
+    def test_validate_session_replay_list_config_defaults(self) -> None:
+        validated = validate_session_replay_list_config({})
+        assert validated["limit"] == DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT
+        assert validated["orderBy"] == "start_time"
+        assert "filterTestAccounts" not in validated
+
+    def test_validate_session_replay_list_config_rejects_invalid_order_by(self) -> None:
+        with self.assertRaises(Exception):
+            validate_session_replay_list_config({"orderBy": "not_a_field"})
+
+    @parameterized.expand(sorted(SESSION_REPLAY_ORDER_BY))
+    def test_validate_session_replay_list_config_accepts_order_by(self, order_by: str) -> None:
+        validated = validate_session_replay_list_config({"orderBy": order_by})
+        assert validated["orderBy"] == order_by
 
 
 class TestDashboardRunWidgets(APIBaseTest):
@@ -126,6 +149,80 @@ class TestDashboardRunWidgets(APIBaseTest):
         self.assertIsNone(body["results"][0]["error"])
         self.assertEqual(body["results"][0]["result"]["limit"], 10)
         mock_calculate.assert_called_once()
+
+    @patch("products.dashboards.backend.widgets.session_replay_list.list_recordings_from_query")
+    def test_runs_session_replay_widget_for_requested_tile(self, mock_list_recordings: MagicMock) -> None:
+        mock_list_recordings.return_value = ([], False, None, None)
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(
+            dashboard_id, widget_type="session_replay_list", config={"limit": 10}
+        )
+        tile_id = dashboard_json["tiles"][0]["id"]
+
+        body = self._run(dashboard_id, [tile_id])
+
+        self.assertEqual(len(body["results"]), 1)
+        self.assertEqual(body["results"][0]["tile_id"], tile_id)
+        self.assertEqual(body["results"][0]["widget_type"], "session_replay_list")
+        self.assertIsNone(body["results"][0]["error"])
+        self.assertEqual(body["results"][0]["result"]["limit"], 10)
+        mock_list_recordings.assert_called_once()
+        self.assertEqual(mock_list_recordings.call_args.kwargs["user"], self.user)
+
+    @patch("products.dashboards.backend.widgets.session_replay_list.list_recordings_from_query")
+    def test_session_replay_widget_tags_queries_in_debug_mode(self, mock_list_recordings: MagicMock) -> None:
+        from django.test.utils import override_settings
+
+        from posthog.clickhouse.client.execute import UntaggedQueryError
+        from posthog.clickhouse.query_tagging import Feature, Product, get_query_tags
+
+        from products.dashboards.backend.widgets.session_replay_list import run_session_replay_list_widget
+
+        mock_list_recordings.return_value = ([], False, None, None)
+
+        def assert_tagged(*_args: object, **_kwargs: object) -> tuple[list[object], bool, None, None]:
+            tags = get_query_tags()
+            if tags.product != Product.REPLAY or tags.feature != Feature.QUERY:
+                raise UntaggedQueryError("session replay widget must tag ClickHouse queries")
+            return ([], False, None, None)
+
+        mock_list_recordings.side_effect = assert_tagged
+
+        with override_settings(DEBUG=True, TEST=False):
+            result = run_session_replay_list_widget(
+                self.team,
+                {"limit": 10, "dateRange": {"date_from": "-7d"}},
+                user=self.user,
+            )
+
+        self.assertEqual(result["limit"], 10)
+        mock_list_recordings.assert_called_once()
+
+    @patch("products.dashboards.backend.widgets.session_replay_list.list_recordings_from_query")
+    def test_session_replay_widget_serializes_recordings_with_person(self, mock_list_recordings: MagicMock) -> None:
+        from posthog.models import Person
+        from posthog.session_recordings.models.session_recording import SessionRecording
+
+        person = Person.objects.create(team=self.team, properties={"email": "widget-test@example.com"})
+        recording = SessionRecording(
+            session_id="019e6a07-04fe-792c-b828-49375b8d42e8",
+            team=self.team,
+            distinct_id="widget-test-distinct",
+            duration=120,
+        )
+        recording.person = person
+        mock_list_recordings.return_value = ([recording], False, None, None)
+
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(
+            dashboard_id, widget_type="session_replay_list", config={"limit": 10}
+        )
+        tile_id = dashboard_json["tiles"][0]["id"]
+
+        body = self._run(dashboard_id, [tile_id])
+
+        self.assertIsNone(body["results"][0]["error"])
+        self.assertEqual(body["results"][0]["result"]["results"][0]["person"]["name"], "widget-test@example.com")
 
     @patch("products.dashboards.backend.widgets.error_tracking_list.ErrorTrackingQueryRunner")
     def test_run_widgets_requests_listing_volume_resolution(self, mock_runner_cls: MagicMock) -> None:

--- a/products/dashboards/backend/api/test/test_run_widgets.py
+++ b/products/dashboards/backend/api/test/test_run_widgets.py
@@ -73,6 +73,29 @@ class TestWidgetRegistry(APIBaseTest):
         with self.assertRaises(Exception):
             validate_session_replay_list_config({"orderBy": "not_a_field"})
 
+    def test_validate_session_replay_list_config_rejects_invalid_filter_test_accounts(self) -> None:
+        with self.assertRaises(Exception):
+            validate_session_replay_list_config({"filterTestAccounts": "yes"})
+
+    def test_validate_session_replay_list_config_rejects_high_limit(self) -> None:
+        with self.assertRaises(Exception):
+            validate_session_replay_list_config({"limit": 100})
+
+    @parameterized.expand(["-1h", "-3h", "-24h"])
+    def test_validate_session_replay_list_config_accepts_short_date_ranges(self, date_from: str) -> None:
+        validated = validate_session_replay_list_config({"dateRange": {"date_from": date_from}})
+        assert validated["dateRange"] == {"date_from": date_from}
+
+    def test_validate_session_replay_list_config_rejects_unsupported_date_range(self) -> None:
+        with self.assertRaises(Exception):
+            validate_session_replay_list_config({"dateRange": {"date_from": "-48h"}})
+
+    def test_validate_session_replay_list_config_strips_unknown_date_range_keys(self) -> None:
+        validated = validate_session_replay_list_config(
+            {"dateRange": {"date_from": "-7d", "date_to": "ignored", "evil": 1}}
+        )
+        assert validated["dateRange"] == {"date_from": "-7d"}
+
     @parameterized.expand(sorted(SESSION_REPLAY_ORDER_BY))
     def test_validate_session_replay_list_config_accepts_order_by(self, order_by: str) -> None:
         validated = validate_session_replay_list_config({"orderBy": order_by})

--- a/products/dashboards/backend/api/test/test_widget_access.py
+++ b/products/dashboards/backend/api/test/test_widget_access.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from rest_framework.exceptions import PermissionDenied
 
-from posthog.auth import PersonalAPIKeyAuthentication
+from posthog.auth import IDJagAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.rbac.user_access_control import AccessControlLevel, UserAccessControl
 from posthog.scopes import APIScopeObject
@@ -93,6 +93,29 @@ class TestWidgetAccess(BaseTest):
         assert entry is not None
         authenticator = PersonalAPIKeyAuthentication()
         authenticator.personal_api_key = PersonalAPIKey(scopes=["error_tracking:write"])
+        request = MagicMock()
+        request.successful_authenticator = authenticator
+
+        self.assertIsNone(get_widget_api_scope_error(entry, request))
+
+    def test_get_widget_api_scope_error_denies_missing_scope_on_id_jag(self) -> None:
+        entry = get_widget_registry_entry("session_replay_list")
+        assert entry is not None
+        authenticator = IDJagAccessTokenAuthentication()
+        authenticator.scopes = ["dashboard:read", "dashboard:write"]
+        request = MagicMock()
+        request.successful_authenticator = authenticator
+
+        self.assertEqual(
+            get_widget_api_scope_error(entry, request),
+            "API key missing required scope 'session_recording:read'",
+        )
+
+    def test_get_widget_api_scope_error_allows_id_jag_with_required_scope(self) -> None:
+        entry = get_widget_registry_entry("session_replay_list")
+        assert entry is not None
+        authenticator = IDJagAccessTokenAuthentication()
+        authenticator.scopes = ["dashboard:write", "session_recording:read"]
         request = MagicMock()
         request.successful_authenticator = authenticator
 

--- a/products/dashboards/backend/api/widget_openapi_serializers.py
+++ b/products/dashboards/backend/api/widget_openapi_serializers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema_field
 from rest_framework import serializers
 
 from products.dashboards.backend.constants import (
@@ -8,6 +9,7 @@ from products.dashboards.backend.constants import (
     WIDGET_DATE_FROM_VALUES,
 )
 from products.dashboards.backend.widgets.error_tracking_list import ERROR_TRACKING_ORDER_BY
+from products.dashboards.backend.widgets.session_replay_list import SESSION_REPLAY_ORDER_BY
 
 _ERROR_TRACKING_WIDGET_STATUS_CHOICES = [
     "archived",
@@ -63,3 +65,55 @@ class ErrorTrackingListWidgetConfigSerializer(serializers.Serializer):
         required=False,
         help_text="When omitted, follows the project default for filtering test accounts.",
     )
+
+
+class SessionReplayListWidgetConfigSerializer(serializers.Serializer):
+    limit = serializers.IntegerField(
+        min_value=1,
+        max_value=MAX_WIDGET_RESULT_LIMIT,
+        default=DEFAULT_WIDGET_LIST_LIMIT,
+        required=False,
+        help_text="Maximum number of recordings to return.",
+    )
+    orderBy = serializers.ChoiceField(
+        choices=sorted(SESSION_REPLAY_ORDER_BY),
+        default="start_time",
+        required=False,
+        help_text="Recording ranking column.",
+    )
+    orderDirection = serializers.ChoiceField(
+        choices=["ASC", "DESC"],
+        default="DESC",
+        required=False,
+        help_text="Sort direction for orderBy.",
+    )
+    dateRange = WidgetDateRangeSerializer(
+        required=False,
+        allow_null=True,
+        help_text="Optional relative date range override.",
+    )
+    filterTestAccounts = serializers.BooleanField(
+        required=False,
+        help_text="When omitted, follows the project default for filtering test accounts.",
+    )
+
+
+_DashboardWidgetConfigOpenApi = PolymorphicProxySerializer(
+    component_name="DashboardWidgetConfig",
+    serializers=[
+        ErrorTrackingListWidgetConfigSerializer,
+        SessionReplayListWidgetConfigSerializer,
+    ],
+    resource_type_field_name=None,
+)
+
+
+@extend_schema_field(_DashboardWidgetConfigOpenApi)
+class DashboardWidgetConfigField(serializers.JSONField):
+    """JSONField annotated with per-widget-type config schemas for OpenAPI generation.
+
+    Runtime validation uses validate_widget_config; this field only improves generated
+    client/MCP schemas so agents can see the supported config shapes.
+    """
+
+    pass

--- a/products/dashboards/backend/api/widget_openapi_serializers.py
+++ b/products/dashboards/backend/api/widget_openapi_serializers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from rest_framework import serializers
 
 from products.dashboards.backend.constants import (
-    DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT,
+    DEFAULT_WIDGET_LIST_LIMIT,
     MAX_WIDGET_RESULT_LIMIT,
     WIDGET_DATE_FROM_VALUES,
 )
@@ -32,7 +32,7 @@ class ErrorTrackingListWidgetConfigSerializer(serializers.Serializer):
     limit = serializers.IntegerField(
         min_value=1,
         max_value=MAX_WIDGET_RESULT_LIMIT,
-        default=DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT,
+        default=DEFAULT_WIDGET_LIST_LIMIT,
         required=False,
         help_text="Maximum number of issues to return.",
     )

--- a/products/dashboards/backend/constants.py
+++ b/products/dashboards/backend/constants.py
@@ -7,6 +7,9 @@ MAX_WIDGET_RESULT_LIMIT = 25
 # Default row count for error_tracking_list when config omits limit (matches catalog + OpenAPI).
 DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT = 10
 
+# Default row count for session_replay_list when config omits limit (matches catalog + OpenAPI).
+DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT = 10
+
 # Cap widgets per batch create / run-widgets request.
 MAX_WIDGETS_BATCH_SIZE = 10
 

--- a/products/dashboards/backend/constants.py
+++ b/products/dashboards/backend/constants.py
@@ -4,11 +4,8 @@ DASHBOARD_GRID_COLUMN_COUNT = 12
 # Cap per-query row count so run-widgets responses stay bounded.
 MAX_WIDGET_RESULT_LIMIT = 25
 
-# Default row count for error_tracking_list when config omits limit (matches catalog + OpenAPI).
-DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT = 10
-
-# Default row count for session_replay_list when config omits limit (matches catalog + OpenAPI).
-DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT = 10
+# Default row count for list widgets when config omits limit (matches catalog + OpenAPI).
+DEFAULT_WIDGET_LIST_LIMIT = 10
 
 # Cap widgets per batch create / run-widgets request.
 MAX_WIDGETS_BATCH_SIZE = 10

--- a/products/dashboards/backend/widget_access.py
+++ b/products/dashboards/backend/widget_access.py
@@ -5,7 +5,7 @@ from typing import cast
 from rest_framework import exceptions
 from rest_framework.request import Request
 
-from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.auth import IDJagAccessTokenAuthentication, OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.rbac.user_access_control import AccessControlLevel, UserAccessControl
 from posthog.scopes import APIScopeObject
 
@@ -21,6 +21,8 @@ def _get_request_api_key_scopes(request: Request) -> list[str] | None:
     if isinstance(authenticator, OAuthAccessTokenAuthentication):
         token_scope_string = authenticator.access_token.scope
         return token_scope_string.split() if token_scope_string else []
+    if isinstance(authenticator, IDJagAccessTokenAuthentication):
+        return list(authenticator.scopes)
     return None
 
 

--- a/products/dashboards/backend/widget_catalog.py
+++ b/products/dashboards/backend/widget_catalog.py
@@ -4,10 +4,12 @@ from typing import Any, NotRequired, TypedDict
 
 from products.dashboards.backend.constants import (
     DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT,
+    DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT,
     MAX_WIDGET_RESULT_LIMIT,
     WIDGET_DATE_FROM_VALUES,
 )
 from products.dashboards.backend.widgets.error_tracking_list import ERROR_TRACKING_ORDER_BY
+from products.dashboards.backend.widgets.session_replay_list import SESSION_REPLAY_ORDER_BY
 
 
 class WidgetCatalogEntry(TypedDict):
@@ -68,6 +70,46 @@ WIDGET_CATALOG: dict[str, WidgetCatalogEntry] = {
         "required_product_access": "error_tracking",
         "product_access_denied_message": "You do not have access to error tracking.",
         "availability_requirements": ["exception_autocapture"],
+    },
+    "session_replay_list": {
+        "widget_type": "session_replay_list",
+        "group_id": "session_replay",
+        "group_label": "Session replay",
+        "label": "Recent recordings",
+        "description": "Recent session recordings you can open in the replay player.",
+        "config_schema_hints": {
+            "limit": {
+                "type": "integer",
+                "min": 1,
+                "max": MAX_WIDGET_RESULT_LIMIT,
+                "default": DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT,
+            },
+            "orderBy": {
+                "type": "string",
+                "choices": sorted(SESSION_REPLAY_ORDER_BY),
+                "default": "start_time",
+            },
+            "orderDirection": {
+                "type": "string",
+                "choices": ["ASC", "DESC"],
+                "default": "DESC",
+            },
+            "dateRange": {
+                "date_from": {
+                    "type": "string",
+                    "choices": sorted(WIDGET_DATE_FROM_VALUES),
+                    "optional": True,
+                },
+            },
+            "filterTestAccounts": {
+                "type": "boolean",
+                "optional": True,
+                "uses_project_default": True,
+            },
+        },
+        "required_product_access": "session_recording",
+        "product_access_denied_message": "You do not have access to session replay.",
+        "availability_requirements": ["session_replay_enabled"],
     },
 }
 

--- a/products/dashboards/backend/widget_catalog.py
+++ b/products/dashboards/backend/widget_catalog.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import Any, NotRequired, TypedDict
 
 from products.dashboards.backend.constants import (
-    DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT,
-    DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT,
+    DEFAULT_WIDGET_LIST_LIMIT,
     MAX_WIDGET_RESULT_LIMIT,
     WIDGET_DATE_FROM_VALUES,
 )
@@ -37,7 +36,7 @@ WIDGET_CATALOG: dict[str, WidgetCatalogEntry] = {
                 "type": "integer",
                 "min": 1,
                 "max": MAX_WIDGET_RESULT_LIMIT,
-                "default": DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT,
+                "default": DEFAULT_WIDGET_LIST_LIMIT,
             },
             "orderBy": {
                 "type": "string",
@@ -82,7 +81,7 @@ WIDGET_CATALOG: dict[str, WidgetCatalogEntry] = {
                 "type": "integer",
                 "min": 1,
                 "max": MAX_WIDGET_RESULT_LIMIT,
-                "default": DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT,
+                "default": DEFAULT_WIDGET_LIST_LIMIT,
             },
             "orderBy": {
                 "type": "string",

--- a/products/dashboards/backend/widget_registry.py
+++ b/products/dashboards/backend/widget_registry.py
@@ -34,11 +34,6 @@ from products.dashboards.backend.widgets.session_replay_list import (
 EXPECTED_WIDGET_TYPES = frozenset({"error_tracking_list", "session_replay_list"})
 
 DashboardWidgetType = Literal["error_tracking_list", "session_replay_list"]
-DashboardWidgetTypeInput = Literal["error_tracking_list", "error_tracking", "session_replay_list"]
-
-WIDGET_TYPE_ALIASES: dict[str, str] = {
-    "error_tracking": "error_tracking_list",
-}
 
 
 class WidgetRegistryEntry(TypedDict):

--- a/products/dashboards/backend/widget_registry.py
+++ b/products/dashboards/backend/widget_registry.py
@@ -25,11 +25,20 @@ from products.dashboards.backend.widgets.error_tracking_list import (
     run_error_tracking_list_widget,
     validate_error_tracking_list_config,
 )
+from products.dashboards.backend.widgets.session_replay_list import (
+    run_session_replay_list_widget,
+    validate_session_replay_list_config,
+)
 
 # Canonical widget types. Must match WIDGET_REGISTRY keys.
-EXPECTED_WIDGET_TYPES = frozenset({"error_tracking_list"})
+EXPECTED_WIDGET_TYPES = frozenset({"error_tracking_list", "session_replay_list"})
 
-DashboardWidgetType = Literal["error_tracking_list"]
+DashboardWidgetType = Literal["error_tracking_list", "session_replay_list"]
+DashboardWidgetTypeInput = Literal["error_tracking_list", "error_tracking", "session_replay_list"]
+
+WIDGET_TYPE_ALIASES: dict[str, str] = {
+    "error_tracking": "error_tracking_list",
+}
 
 
 class WidgetRegistryEntry(TypedDict):
@@ -46,6 +55,12 @@ WIDGET_REGISTRY: dict[str, WidgetRegistryEntry] = {
         "query_fn": run_error_tracking_list_widget,
         "required_scopes": ["error_tracking:read"],
         "required_product_access": "error_tracking",
+    },
+    "session_replay_list": {
+        "validate_config": validate_session_replay_list_config,
+        "query_fn": run_session_replay_list_widget,
+        "required_scopes": ["session_recording:read"],
+        "required_product_access": "session_recording",
     },
 }
 

--- a/products/dashboards/backend/widget_registry.py
+++ b/products/dashboards/backend/widget_registry.py
@@ -30,8 +30,11 @@ from products.dashboards.backend.widgets.session_replay_list import (
     validate_session_replay_list_config,
 )
 
-# Canonical widget types. Must match WIDGET_REGISTRY keys.
-EXPECTED_WIDGET_TYPES = frozenset({"error_tracking_list", "session_replay_list"})
+# Canonical widget type identifiers. Must match WIDGET_REGISTRY keys.
+ERROR_TRACKING_LIST_WIDGET_TYPE = "error_tracking_list"
+SESSION_REPLAY_LIST_WIDGET_TYPE = "session_replay_list"
+
+EXPECTED_WIDGET_TYPES = frozenset({ERROR_TRACKING_LIST_WIDGET_TYPE, SESSION_REPLAY_LIST_WIDGET_TYPE})
 
 DashboardWidgetType = Literal["error_tracking_list", "session_replay_list"]
 
@@ -45,13 +48,13 @@ class WidgetRegistryEntry(TypedDict):
 
 # Per-type validate_config / query_fn / access control. Keys must match EXPECTED_WIDGET_TYPES.
 WIDGET_REGISTRY: dict[str, WidgetRegistryEntry] = {
-    "error_tracking_list": {
+    ERROR_TRACKING_LIST_WIDGET_TYPE: {
         "validate_config": validate_error_tracking_list_config,
         "query_fn": run_error_tracking_list_widget,
         "required_scopes": ["error_tracking:read"],
         "required_product_access": "error_tracking",
     },
-    "session_replay_list": {
+    SESSION_REPLAY_LIST_WIDGET_TYPE: {
         "validate_config": validate_session_replay_list_config,
         "query_fn": run_session_replay_list_widget,
         "required_scopes": ["session_recording:read"],

--- a/products/dashboards/backend/widgets/config.py
+++ b/products/dashboards/backend/widgets/config.py
@@ -8,7 +8,11 @@ from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from posthog.models.team import Team
 
-from products.dashboards.backend.constants import WIDGET_DATE_FROM_VALUES
+from products.dashboards.backend.constants import (
+    DEFAULT_WIDGET_LIST_LIMIT,
+    MAX_WIDGET_RESULT_LIMIT,
+    WIDGET_DATE_FROM_VALUES,
+)
 
 
 def resolve_filter_test_accounts(config: dict[str, Any], team: Team) -> bool:
@@ -29,6 +33,33 @@ def merge_base_widget_config_fields(config: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(value, bool):
         raise DRFValidationError({"config": "filterTestAccounts must be a boolean."})
     return {"filterTestAccounts": value}
+
+
+def validate_widget_list_limit(config: dict[str, Any]) -> int:
+    limit = config.get("limit", DEFAULT_WIDGET_LIST_LIMIT)
+    if not isinstance(limit, int) or limit < 1 or limit > MAX_WIDGET_RESULT_LIMIT:
+        raise DRFValidationError({"config": f"limit must be an integer between 1 and {MAX_WIDGET_RESULT_LIMIT}."})
+    return limit
+
+
+def validate_widget_list_order_by(config: dict[str, Any], *, allowed: frozenset[str], default: str) -> str:
+    order_by = config.get("orderBy", default)
+    if order_by not in allowed:
+        raise DRFValidationError({"config": f"orderBy must be one of: {', '.join(sorted(allowed))}."})
+    return order_by
+
+
+def validate_widget_list_order_direction(config: dict[str, Any]) -> str:
+    order_direction = config.get("orderDirection", "DESC")
+    if order_direction not in {"ASC", "DESC"}:
+        raise DRFValidationError({"config": "orderDirection must be ASC or DESC."})
+    return order_direction
+
+
+def validate_widget_list_date_range_if_present(config: dict[str, Any]) -> dict[str, object] | None:
+    if "dateRange" not in config:
+        return None
+    return validate_widget_date_range(config.get("dateRange"))
 
 
 def validate_widget_date_range(date_range: object) -> dict[str, object] | None:

--- a/products/dashboards/backend/widgets/error_tracking_list.py
+++ b/products/dashboards/backend/widgets/error_tracking_list.py
@@ -10,11 +10,13 @@ from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.team import Team
 from posthog.models.user import User
 
-from products.dashboards.backend.constants import DEFAULT_WIDGET_LIST_LIMIT, MAX_WIDGET_RESULT_LIMIT
 from products.dashboards.backend.widgets.config import (
     merge_base_widget_config_fields,
     resolve_filter_test_accounts,
-    validate_widget_date_range,
+    validate_widget_list_date_range_if_present,
+    validate_widget_list_limit,
+    validate_widget_list_order_by,
+    validate_widget_list_order_direction,
 )
 from products.error_tracking.backend.api.query import is_error_tracking_query_v3_enabled, query_v3_volume_resolution
 from products.error_tracking.backend.api.query_utils import (
@@ -34,23 +36,15 @@ def validate_error_tracking_list_config(config: dict[str, Any]) -> dict[str, Any
     if not isinstance(config, dict):
         raise DRFValidationError({"config": "Config must be an object."})
 
-    limit = config.get("limit", DEFAULT_WIDGET_LIST_LIMIT)
-    if not isinstance(limit, int) or limit < 1 or limit > MAX_WIDGET_RESULT_LIMIT:
-        raise DRFValidationError({"config": f"limit must be an integer between 1 and {MAX_WIDGET_RESULT_LIMIT}."})
-
-    order_by = config.get("orderBy", "occurrences")
-    if order_by not in ERROR_TRACKING_ORDER_BY:
-        raise DRFValidationError({"config": f"orderBy must be one of: {', '.join(sorted(ERROR_TRACKING_ORDER_BY))}."})
-
-    order_direction = config.get("orderDirection", "DESC")
-    if order_direction not in {"ASC", "DESC"}:
-        raise DRFValidationError({"config": "orderDirection must be ASC or DESC."})
+    limit = validate_widget_list_limit(config)
+    order_by = validate_widget_list_order_by(config, allowed=ERROR_TRACKING_ORDER_BY, default="occurrences")
+    order_direction = validate_widget_list_order_direction(config)
 
     status_value = config.get("status", "active")
     if status_value not in {"archived", "active", "resolved", "pending_release", "suppressed", "all"}:
         raise DRFValidationError({"config": "status is invalid for error tracking widget config."})
 
-    validated_date_range = validate_widget_date_range(config.get("dateRange")) if "dateRange" in config else None
+    validated_date_range = validate_widget_list_date_range_if_present(config)
 
     return {
         "limit": limit,

--- a/products/dashboards/backend/widgets/error_tracking_list.py
+++ b/products/dashboards/backend/widgets/error_tracking_list.py
@@ -10,7 +10,7 @@ from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.team import Team
 from posthog.models.user import User
 
-from products.dashboards.backend.constants import DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT, MAX_WIDGET_RESULT_LIMIT
+from products.dashboards.backend.constants import DEFAULT_WIDGET_LIST_LIMIT, MAX_WIDGET_RESULT_LIMIT
 from products.dashboards.backend.widgets.config import (
     merge_base_widget_config_fields,
     resolve_filter_test_accounts,
@@ -34,7 +34,7 @@ def validate_error_tracking_list_config(config: dict[str, Any]) -> dict[str, Any
     if not isinstance(config, dict):
         raise DRFValidationError({"config": "Config must be an object."})
 
-    limit = config.get("limit", DEFAULT_ERROR_TRACKING_LIST_WIDGET_LIMIT)
+    limit = config.get("limit", DEFAULT_WIDGET_LIST_LIMIT)
     if not isinstance(limit, int) or limit < 1 or limit > MAX_WIDGET_RESULT_LIMIT:
         raise DRFValidationError({"config": f"limit must be an integer between 1 and {MAX_WIDGET_RESULT_LIMIT}."})
 

--- a/products/dashboards/backend/widgets/session_replay_list.py
+++ b/products/dashboards/backend/widgets/session_replay_list.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from rest_framework.exceptions import ValidationError as DRFValidationError
+
+from posthog.schema import RecordingOrder, RecordingOrderDirection, RecordingsQuery
+
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.models.team import Team
+from posthog.models.user import User
+from posthog.session_recordings.session_recording_api import SessionRecordingSerializer, list_recordings_from_query
+
+from products.dashboards.backend.constants import DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT, MAX_WIDGET_RESULT_LIMIT
+from products.dashboards.backend.widgets.config import (
+    merge_base_widget_config_fields,
+    resolve_filter_test_accounts,
+    validate_widget_date_range,
+)
+
+SESSION_REPLAY_ORDER_BY = frozenset(
+    {
+        "start_time",
+        "activity_score",
+        "recording_duration",
+        "duration",
+        "click_count",
+        "console_error_count",
+    }
+)
+
+
+class _SessionRecordingListViewShim:
+    """Skip list-view N+1 paths in SessionRecordingSerializer (external refs, summaries)."""
+
+    action = "list"
+
+
+ORDER_BY_TO_RECORDING_ORDER: dict[str, RecordingOrder] = {
+    "start_time": RecordingOrder.START_TIME,
+    "activity_score": RecordingOrder.ACTIVITY_SCORE,
+    "recording_duration": RecordingOrder.RECORDING_DURATION,
+    "duration": RecordingOrder.DURATION,
+    "click_count": RecordingOrder.CLICK_COUNT,
+    "console_error_count": RecordingOrder.CONSOLE_ERROR_COUNT,
+}
+
+
+def validate_session_replay_list_config(config: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(config, dict):
+        raise DRFValidationError({"config": "Config must be an object."})
+
+    limit = config.get("limit", DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT)
+    if not isinstance(limit, int) or limit < 1 or limit > MAX_WIDGET_RESULT_LIMIT:
+        raise DRFValidationError({"config": f"limit must be an integer between 1 and {MAX_WIDGET_RESULT_LIMIT}."})
+
+    order_by = config.get("orderBy", "start_time")
+    if order_by not in SESSION_REPLAY_ORDER_BY:
+        raise DRFValidationError({"config": f"orderBy must be one of: {', '.join(sorted(SESSION_REPLAY_ORDER_BY))}."})
+
+    order_direction = config.get("orderDirection", "DESC")
+    if order_direction not in {"ASC", "DESC"}:
+        raise DRFValidationError({"config": "orderDirection must be ASC or DESC."})
+
+    validated_date_range = validate_widget_date_range(config.get("dateRange")) if "dateRange" in config else None
+
+    return {
+        "limit": limit,
+        "orderBy": order_by,
+        "orderDirection": order_direction,
+        **({"dateRange": validated_date_range} if validated_date_range is not None else {}),
+        **merge_base_widget_config_fields(config),
+    }
+
+
+def _build_recordings_query(team: Team, config: dict[str, Any]) -> RecordingsQuery:
+    limit = cast(int, config["limit"])
+    order_by = cast(str, config.get("orderBy", "start_time"))
+    order_direction = cast(str, config.get("orderDirection", "DESC"))
+    date_range_raw = config.get("dateRange")
+    date_from = "-7d"
+    if isinstance(date_range_raw, dict) and isinstance(date_range_raw.get("date_from"), str):
+        date_from = date_range_raw["date_from"]
+
+    return RecordingsQuery(
+        kind="RecordingsQuery",
+        limit=limit,
+        offset=0,
+        date_from=date_from,
+        date_to=None,
+        filter_test_accounts=resolve_filter_test_accounts(config, team),
+        order=ORDER_BY_TO_RECORDING_ORDER[order_by],
+        order_direction=RecordingOrderDirection(order_direction),
+    )
+
+
+def run_session_replay_list_widget(team: Team, config: dict[str, Any], user: User | None = None) -> dict[str, Any]:
+    query = _build_recordings_query(team, config)
+    with tags_context(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk):
+        recordings, has_more, _, _next_cursor = list_recordings_from_query(
+            query=query,
+            user=user,
+            team=team,
+            allow_event_property_expansion=False,
+        )
+    serializer = SessionRecordingSerializer(
+        recordings,
+        many=True,
+        context={"view": _SessionRecordingListViewShim(), "get_team": lambda: team},
+    )
+    results = cast(list[dict[str, Any]], serializer.data)
+    limit = cast(int, config["limit"])
+    return {
+        "results": results[:limit],
+        "hasMore": has_more,
+        "limit": limit,
+        "offset": 0,
+    }

--- a/products/dashboards/backend/widgets/session_replay_list.py
+++ b/products/dashboards/backend/widgets/session_replay_list.py
@@ -11,11 +11,13 @@ from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.session_recordings.session_recording_api import SessionRecordingSerializer, list_recordings_from_query
 
-from products.dashboards.backend.constants import DEFAULT_WIDGET_LIST_LIMIT, MAX_WIDGET_RESULT_LIMIT
 from products.dashboards.backend.widgets.config import (
     merge_base_widget_config_fields,
     resolve_filter_test_accounts,
-    validate_widget_date_range,
+    validate_widget_list_date_range_if_present,
+    validate_widget_list_limit,
+    validate_widget_list_order_by,
+    validate_widget_list_order_direction,
 )
 
 SESSION_REPLAY_ORDER_BY = frozenset(
@@ -50,19 +52,10 @@ def validate_session_replay_list_config(config: dict[str, Any]) -> dict[str, Any
     if not isinstance(config, dict):
         raise DRFValidationError({"config": "Config must be an object."})
 
-    limit = config.get("limit", DEFAULT_WIDGET_LIST_LIMIT)
-    if not isinstance(limit, int) or limit < 1 or limit > MAX_WIDGET_RESULT_LIMIT:
-        raise DRFValidationError({"config": f"limit must be an integer between 1 and {MAX_WIDGET_RESULT_LIMIT}."})
-
-    order_by = config.get("orderBy", "start_time")
-    if order_by not in SESSION_REPLAY_ORDER_BY:
-        raise DRFValidationError({"config": f"orderBy must be one of: {', '.join(sorted(SESSION_REPLAY_ORDER_BY))}."})
-
-    order_direction = config.get("orderDirection", "DESC")
-    if order_direction not in {"ASC", "DESC"}:
-        raise DRFValidationError({"config": "orderDirection must be ASC or DESC."})
-
-    validated_date_range = validate_widget_date_range(config.get("dateRange")) if "dateRange" in config else None
+    limit = validate_widget_list_limit(config)
+    order_by = validate_widget_list_order_by(config, allowed=SESSION_REPLAY_ORDER_BY, default="start_time")
+    order_direction = validate_widget_list_order_direction(config)
+    validated_date_range = validate_widget_list_date_range_if_present(config)
 
     return {
         "limit": limit,

--- a/products/dashboards/backend/widgets/session_replay_list.py
+++ b/products/dashboards/backend/widgets/session_replay_list.py
@@ -4,12 +4,13 @@ from typing import Any, cast
 
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
-from posthog.schema import RecordingOrder, RecordingOrderDirection, RecordingsQuery
+from posthog.schema import RecordingOrder
 
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.team import Team
 from posthog.models.user import User
-from posthog.session_recordings.session_recording_api import SessionRecordingSerializer, list_recordings_from_query
+from posthog.session_recordings.session_recording_api import run_recordings_list_query
+from posthog.session_recordings.utils import filter_from_params_to_query
 
 from products.dashboards.backend.widgets.config import (
     merge_base_widget_config_fields,
@@ -30,13 +31,6 @@ SESSION_REPLAY_ORDER_BY = frozenset(
         "console_error_count",
     }
 )
-
-
-class _SessionRecordingListViewShim:
-    """Skip list-view N+1 paths in SessionRecordingSerializer (external refs, summaries)."""
-
-    action = "list"
-
 
 ORDER_BY_TO_RECORDING_ORDER: dict[str, RecordingOrder] = {
     "start_time": RecordingOrder.START_TIME,
@@ -66,46 +60,38 @@ def validate_session_replay_list_config(config: dict[str, Any]) -> dict[str, Any
     }
 
 
-def _build_recordings_query(team: Team, config: dict[str, Any]) -> RecordingsQuery:
-    limit = cast(int, config["limit"])
+def _build_recordings_query(team: Team, config: dict[str, Any]):
     order_by = cast(str, config.get("orderBy", "start_time"))
-    order_direction = cast(str, config.get("orderDirection", "DESC"))
     date_range_raw = config.get("dateRange")
     date_from = "-7d"
     if isinstance(date_range_raw, dict) and isinstance(date_range_raw.get("date_from"), str):
         date_from = date_range_raw["date_from"]
 
-    return RecordingsQuery(
-        kind="RecordingsQuery",
-        limit=limit,
-        offset=0,
-        date_from=date_from,
-        date_to=None,
-        filter_test_accounts=resolve_filter_test_accounts(config, team),
-        order=ORDER_BY_TO_RECORDING_ORDER[order_by],
-        order_direction=RecordingOrderDirection(order_direction),
+    return filter_from_params_to_query(
+        {
+            "limit": config["limit"],
+            "offset": 0,
+            "date_from": date_from,
+            "filter_test_accounts": resolve_filter_test_accounts(config, team),
+            "order": ORDER_BY_TO_RECORDING_ORDER[order_by],
+            "order_direction": config.get("orderDirection", "DESC"),
+        }
     )
 
 
 def run_session_replay_list_widget(team: Team, config: dict[str, Any], user: User | None = None) -> dict[str, Any]:
     query = _build_recordings_query(team, config)
+    limit = cast(int, config["limit"])
     with tags_context(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk):
-        recordings, has_more, _, _next_cursor = list_recordings_from_query(
+        data = run_recordings_list_query(
             query=query,
             user=user,
             team=team,
             allow_event_property_expansion=False,
         )
-    serializer = SessionRecordingSerializer(
-        recordings,
-        many=True,
-        context={"view": _SessionRecordingListViewShim(), "get_team": lambda: team},
-    )
-    results = cast(list[dict[str, Any]], serializer.data)
-    limit = cast(int, config["limit"])
     return {
-        "results": results[:limit],
-        "hasMore": has_more,
+        "results": data["results"],
+        "hasMore": data["has_next"],
         "limit": limit,
-        "offset": 0,
+        "offset": query.offset or 0,
     }

--- a/products/dashboards/backend/widgets/session_replay_list.py
+++ b/products/dashboards/backend/widgets/session_replay_list.py
@@ -11,7 +11,7 @@ from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.session_recordings.session_recording_api import SessionRecordingSerializer, list_recordings_from_query
 
-from products.dashboards.backend.constants import DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT, MAX_WIDGET_RESULT_LIMIT
+from products.dashboards.backend.constants import DEFAULT_WIDGET_LIST_LIMIT, MAX_WIDGET_RESULT_LIMIT
 from products.dashboards.backend.widgets.config import (
     merge_base_widget_config_fields,
     resolve_filter_test_accounts,
@@ -50,7 +50,7 @@ def validate_session_replay_list_config(config: dict[str, Any]) -> dict[str, Any
     if not isinstance(config, dict):
         raise DRFValidationError({"config": "Config must be an object."})
 
-    limit = config.get("limit", DEFAULT_SESSION_REPLAY_LIST_WIDGET_LIMIT)
+    limit = config.get("limit", DEFAULT_WIDGET_LIST_LIMIT)
     if not isinstance(limit, int) or limit < 1 or limit > MAX_WIDGET_RESULT_LIMIT:
         raise DRFValidationError({"config": f"limit must be an integer between 1 and {MAX_WIDGET_RESULT_LIMIT}."})
 

--- a/products/dashboards/frontend/components/WidgetCard/widgetCardStoryFixtures.tsx
+++ b/products/dashboards/frontend/components/WidgetCard/widgetCardStoryFixtures.tsx
@@ -103,6 +103,7 @@ export function withErrorTrackingProjectState(configured: boolean): Decorator {
 export function withSessionReplayProjectState(enabled: boolean): Decorator {
     return (Story: React.ComponentType): JSX.Element => {
         teamLogic.mount()
+        filterTestAccountsDefaultsLogic.mount()
         teamLogic.actions.loadCurrentTeamSuccess({
             ...MOCK_DEFAULT_TEAM,
             session_recording_opt_in: enabled,

--- a/products/dashboards/frontend/components/WidgetCard/widgetCardStoryFixtures.tsx
+++ b/products/dashboards/frontend/components/WidgetCard/widgetCardStoryFixtures.tsx
@@ -98,3 +98,15 @@ export function withErrorTrackingProjectState(configured: boolean): Decorator {
         return <Story />
     }
 }
+
+/** Configured = session replay enabled for the project. Unconfigured = availability setup prompt. */
+export function withSessionReplayProjectState(enabled: boolean): Decorator {
+    return (Story: React.ComponentType): JSX.Element => {
+        teamLogic.mount()
+        teamLogic.actions.loadCurrentTeamSuccess({
+            ...MOCK_DEFAULT_TEAM,
+            session_recording_opt_in: enabled,
+        })
+        return <Story />
+    }
+}

--- a/products/dashboards/frontend/components/WidgetCard/widgetOverviewStoryFixtures.ts
+++ b/products/dashboards/frontend/components/WidgetCard/widgetOverviewStoryFixtures.ts
@@ -66,6 +66,90 @@ export const errorTrackingSampleIssues = [
     },
 ]
 
+export const sessionReplaySampleRecordings = [
+    {
+        id: 'overview-recording-1',
+        viewed: false,
+        viewers: [],
+        recording_duration: 248,
+        start_time: '2026-05-26T08:00:00.000Z',
+        end_time: '2026-05-26T08:04:08.000Z',
+        distinct_id: 'user-1',
+        click_count: 12,
+        keypress_count: 34,
+        person: {
+            id: 1,
+            name: 'Alex Chen',
+            distinct_ids: ['user-1'],
+            properties: {
+                $geoip_country_code: 'US',
+                $browser: 'Chrome',
+                $device_type: 'Desktop',
+                $os: 'Mac OS X',
+            },
+            created_at: '2026-05-01T10:00:00.000Z',
+            is_identified: true,
+        },
+        activity_score: 76,
+        snapshot_source: 'web' as const,
+        start_url: 'https://app.example.test/dashboard',
+    },
+    {
+        id: 'overview-recording-2',
+        viewed: false,
+        viewers: [],
+        recording_duration: 132,
+        start_time: '2026-05-25T12:00:00.000Z',
+        end_time: '2026-05-25T12:02:12.000Z',
+        distinct_id: 'user-2',
+        click_count: 4,
+        keypress_count: 9,
+        person: {
+            id: 2,
+            name: 'Sam Rivera',
+            distinct_ids: ['user-2'],
+            properties: {
+                $geoip_country_code: 'AU',
+                $browser: 'Chrome',
+                $device_type: 'Desktop',
+                $os: 'Mac OS X',
+            },
+            created_at: '2026-05-01T10:00:00.000Z',
+            is_identified: true,
+        },
+        activity_score: 48,
+        snapshot_source: 'web' as const,
+        start_url: 'https://app.example.test/settings',
+    },
+    {
+        id: 'overview-recording-3',
+        viewed: false,
+        viewers: [],
+        recording_duration: 89,
+        start_time: '2026-05-24T15:00:00.000Z',
+        end_time: '2026-05-24T15:01:29.000Z',
+        distinct_id: 'user-3',
+        click_count: 2,
+        keypress_count: 5,
+        person: {
+            id: 3,
+            name: 'Jordan Lee',
+            distinct_ids: ['user-3'],
+            properties: {
+                $geoip_country_code: 'GB',
+                $browser: 'Firefox',
+                $device_type: 'Desktop',
+                $os: 'Windows',
+            },
+            created_at: '2026-05-01T10:00:00.000Z',
+            is_identified: true,
+        },
+        activity_score: 31,
+        snapshot_source: 'web' as const,
+        start_url: 'https://app.example.test/onboarding',
+    },
+]
+
 /** New widget types: add a case here. See products/dashboards/CONTRIBUTING.md. */
 export function getWidgetOverviewDemoState(catalogKey: DashboardWidgetCatalogKey): WidgetOverviewDemoState {
     const catalogEntry = DASHBOARD_WIDGET_CATALOG[catalogKey]
@@ -82,6 +166,19 @@ export function getWidgetOverviewDemoState(catalogKey: DashboardWidgetCatalogKey
                 loading: false,
                 result: {
                     results: errorTrackingSampleIssues,
+                    hasMore: true,
+                    limit: 10,
+                },
+            }
+        case 'session_replay_list':
+            return {
+                title: defaultTitle,
+                description: catalogEntry.description,
+                showDescription: true,
+                config: { ...defaultConfig, orderBy: 'start_time' },
+                loading: false,
+                result: {
+                    results: sessionReplaySampleRecordings,
                     hasMore: true,
                     limit: 10,
                 },

--- a/products/dashboards/frontend/components/WidgetCard/widgetOverviewStoryFixtures.ts
+++ b/products/dashboards/frontend/components/WidgetCard/widgetOverviewStoryFixtures.ts
@@ -1,5 +1,5 @@
 import type { DashboardWidgetCatalogKey } from '../../widget_types/catalog'
-import { DASHBOARD_WIDGET_CATALOG } from '../../widget_types/catalog'
+import { getDashboardWidgetCatalogEntry } from '../../widget_types/catalog'
 
 export type WidgetOverviewDemoState = {
     title?: string
@@ -152,7 +152,7 @@ export const sessionReplaySampleRecordings = [
 
 /** New widget types: add a case here. See products/dashboards/CONTRIBUTING.md. */
 export function getWidgetOverviewDemoState(catalogKey: DashboardWidgetCatalogKey): WidgetOverviewDemoState {
-    const catalogEntry = DASHBOARD_WIDGET_CATALOG[catalogKey]
+    const catalogEntry = getDashboardWidgetCatalogEntry(catalogKey)
     const defaultConfig = catalogEntry.defaultConfig as Record<string, unknown>
     const defaultTitle = catalogEntry.headerTitle ?? catalogEntry.label
 

--- a/products/dashboards/frontend/components/WidgetCard/widgetOverviewStoryFixtures.ts
+++ b/products/dashboards/frontend/components/WidgetCard/widgetOverviewStoryFixtures.ts
@@ -78,7 +78,7 @@ export const sessionReplaySampleRecordings = [
         click_count: 12,
         keypress_count: 34,
         person: {
-            id: 1,
+            id: '1',
             name: 'Alex Chen',
             distinct_ids: ['user-1'],
             properties: {
@@ -105,7 +105,7 @@ export const sessionReplaySampleRecordings = [
         click_count: 4,
         keypress_count: 9,
         person: {
-            id: 2,
+            id: '2',
             name: 'Sam Rivera',
             distinct_ids: ['user-2'],
             properties: {
@@ -132,7 +132,7 @@ export const sessionReplaySampleRecordings = [
         click_count: 2,
         keypress_count: 5,
         person: {
-            id: 3,
+            id: '3',
             name: 'Jordan Lee',
             distinct_ids: ['user-3'],
             properties: {

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7704,11 +7704,11 @@ export interface UpdateTextTileRequestApi {
 
 export interface AddDashboardWidgetRequestApi {
     /**
-     * Widget type identifier. Supported values: error_tracking_list. Use dashboard-widget-catalog-list for config_schema_hints per type.
+     * Widget type identifier. Supported values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for config_schema_hints per type.
      * @maxLength 64
      */
     widget_type: string
-    /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for other types. For error_tracking_list, use the schema below (currently the only supported type: error_tracking_list). */
+    /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for other types. For error_tracking_list, use the schema below (currently the only supported type: error_tracking_list, session_replay_list). */
     config: ErrorTrackingListWidgetConfigApi
     /**
      * Optional custom display name for the widget tile.

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7708,8 +7708,8 @@ export interface AddDashboardWidgetRequestApi {
      * @maxLength 64
      */
     widget_type: string
-    /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for other types. For error_tracking_list, use the schema below (currently the only supported type: error_tracking_list, session_replay_list). */
-    config: ErrorTrackingListWidgetConfigApi
+    /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for config_schema_hints. Supported types: error_tracking_list, session_replay_list. */
+    config: unknown
     /**
      * Optional custom display name for the widget tile.
      * @maxLength 400

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7548,6 +7548,55 @@ export interface ErrorTrackingListWidgetConfigApi {
     filterTestAccounts?: boolean
 }
 
+/**
+ * * `activity_score` - activity_score
+ * `click_count` - click_count
+ * `console_error_count` - console_error_count
+ * `duration` - duration
+ * `recording_duration` - recording_duration
+ * `start_time` - start_time
+ */
+export type SessionReplayListWidgetConfigOrderByEnumApi =
+    (typeof SessionReplayListWidgetConfigOrderByEnumApi)[keyof typeof SessionReplayListWidgetConfigOrderByEnumApi]
+
+export const SessionReplayListWidgetConfigOrderByEnumApi = {
+    ActivityScore: 'activity_score',
+    ClickCount: 'click_count',
+    ConsoleErrorCount: 'console_error_count',
+    Duration: 'duration',
+    RecordingDuration: 'recording_duration',
+    StartTime: 'start_time',
+} as const
+
+export interface SessionReplayListWidgetConfigApi {
+    /**
+     * Maximum number of recordings to return.
+     * @minimum 1
+     * @maximum 25
+     */
+    limit?: number
+    /** Recording ranking column.
+
+  * `activity_score` - activity_score
+  * `click_count` - click_count
+  * `console_error_count` - console_error_count
+  * `duration` - duration
+  * `recording_duration` - recording_duration
+  * `start_time` - start_time */
+    orderBy?: SessionReplayListWidgetConfigOrderByEnumApi
+    /** Sort direction for orderBy.
+
+  * `ASC` - ASC
+  * `DESC` - DESC */
+    orderDirection?: OrderDirectionEnumApi
+    /** Optional relative date range override. */
+    dateRange?: WidgetDateRangeApi | null
+    /** When omitted, follows the project default for filtering test accounts. */
+    filterTestAccounts?: boolean
+}
+
+export type DashboardWidgetConfigApi = ErrorTrackingListWidgetConfigApi | SessionReplayListWidgetConfigApi
+
 export interface DashboardWidgetApi {
     readonly id: string
     readonly created_by: UserBasicApi
@@ -7566,7 +7615,7 @@ export interface DashboardWidgetApi {
     /** Optional markdown description shown on the dashboard tile when enabled. */
     description?: string
     /** Widget-specific configuration JSON for this widget type. */
-    config?: ErrorTrackingListWidgetConfigApi
+    config?: DashboardWidgetConfigApi
     readonly dashboard_tiles: readonly DashboardTileBasicApi[]
     readonly last_modified_at: string
     team: number
@@ -7709,7 +7758,7 @@ export interface AddDashboardWidgetRequestApi {
      */
     widget_type: string
     /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for config_schema_hints. Supported types: error_tracking_list, session_replay_list. */
-    config: unknown
+    config: DashboardWidgetConfigApi
     /**
      * Optional custom display name for the widget tile.
      * @maxLength 400

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -475,12 +475,6 @@ export const DashboardsUpdateTextTileCreateBody = /* @__PURE__ */ zod.object({
  */
 export const dashboardsWidgetsBatchCreateBodyWidgetsItemWidgetTypeMax = 64
 
-export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneLimitDefault = 10
-export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneLimitMax = 25
-
-export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOrderByDefault = `occurrences`
-export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOrderDirectionDefault = `DESC`
-export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneStatusDefault = `active`
 export const dashboardsWidgetsBatchCreateBodyWidgetsItemNameMax = 400
 
 export const dashboardsWidgetsBatchCreateBodyWidgetsMax = 10
@@ -496,64 +490,9 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod.object({
                         'Widget type identifier. Supported values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for config_schema_hints per type.'
                     ),
                 config: zod
-                    .object({
-                        limit: zod
-                            .number()
-                            .min(1)
-                            .max(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneLimitMax)
-                            .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneLimitDefault)
-                            .describe('Maximum number of issues to return.'),
-                        orderBy: zod
-                            .enum(['last_seen', 'first_seen', 'occurrences', 'users', 'sessions'])
-                            .describe(
-                                '\* `last_seen` - last_seen\n\* `first_seen` - first_seen\n\* `occurrences` - occurrences\n\* `users` - users\n\* `sessions` - sessions'
-                            )
-                            .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOrderByDefault)
-                            .describe(
-                                'Issue ranking column.\n\n\* `first_seen` - first_seen\n\* `last_seen` - last_seen\n\* `occurrences` - occurrences\n\* `sessions` - sessions\n\* `users` - users'
-                            ),
-                        orderDirection: zod
-                            .enum(['ASC', 'DESC'])
-                            .describe('\* `ASC` - ASC\n\* `DESC` - DESC')
-                            .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOrderDirectionDefault)
-                            .describe('Sort direction for orderBy.\n\n\* `ASC` - ASC\n\* `DESC` - DESC'),
-                        status: zod
-                            .enum(['archived', 'active', 'resolved', 'pending_release', 'suppressed', 'all'])
-                            .describe(
-                                '\* `archived` - archived\n\* `active` - active\n\* `resolved` - resolved\n\* `pending_release` - pending_release\n\* `suppressed` - suppressed\n\* `all` - all'
-                            )
-                            .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneStatusDefault)
-                            .describe(
-                                'Issue status filter.\n\n\* `archived` - archived\n\* `active` - active\n\* `resolved` - resolved\n\* `pending_release` - pending_release\n\* `suppressed` - suppressed\n\* `all` - all'
-                            ),
-                        dateRange: zod
-                            .union([
-                                zod.object({
-                                    date_from: zod
-                                        .union([
-                                            zod
-                                                .enum(['-14d', '-1h', '-24h', '-30d', '-3h', '-7d', '-90d'])
-                                                .describe(
-                                                    '\* `-14d` - -14d\n\* `-1h` - -1h\n\* `-24h` - -24h\n\* `-30d` - -30d\n\* `-3h` - -3h\n\* `-7d` - -7d\n\* `-90d` - -90d'
-                                                ),
-                                            zod.null(),
-                                        ])
-                                        .optional()
-                                        .describe(
-                                            "Relative lookback window (for example '-7d'). Omit to use the project default range.\n\n\* `-14d` - -14d\n\* `-1h` - -1h\n\* `-24h` - -24h\n\* `-30d` - -30d\n\* `-3h` - -3h\n\* `-7d` - -7d\n\* `-90d` - -90d"
-                                        ),
-                                }),
-                                zod.null(),
-                            ])
-                            .optional()
-                            .describe('Optional relative date range override.'),
-                        filterTestAccounts: zod
-                            .boolean()
-                            .optional()
-                            .describe('When omitted, follows the project default for filtering test accounts.'),
-                    })
+                    .unknown()
                     .describe(
-                        'Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for other types. For error_tracking_list, use the schema below (currently the only supported type: error_tracking_list, session_replay_list).'
+                        'Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for config_schema_hints. Supported types: error_tracking_list, session_replay_list.'
                     ),
                 name: zod
                     .string()

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -493,7 +493,7 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod.object({
                     .string()
                     .max(dashboardsWidgetsBatchCreateBodyWidgetsItemWidgetTypeMax)
                     .describe(
-                        'Widget type identifier. Supported values: error_tracking_list. Use dashboard-widget-catalog-list for config_schema_hints per type.'
+                        'Widget type identifier. Supported values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for config_schema_hints per type.'
                     ),
                 config: zod
                     .object({
@@ -553,7 +553,7 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod.object({
                             .describe('When omitted, follows the project default for filtering test accounts.'),
                     })
                     .describe(
-                        'Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for other types. For error_tracking_list, use the schema below (currently the only supported type: error_tracking_list).'
+                        'Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for other types. For error_tracking_list, use the schema below (currently the only supported type: error_tracking_list, session_replay_list).'
                     ),
                 name: zod
                     .string()

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -475,6 +475,17 @@ export const DashboardsUpdateTextTileCreateBody = /* @__PURE__ */ zod.object({
  */
 export const dashboardsWidgetsBatchCreateBodyWidgetsItemWidgetTypeMax = 64
 
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneLimitDefault = 10
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneLimitMax = 25
+
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneOrderByDefault = `occurrences`
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneOrderDirectionDefault = `DESC`
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneStatusDefault = `active`
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneTwoLimitDefault = 10
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneTwoLimitMax = 25
+
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneTwoOrderByDefault = `start_time`
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneTwoOrderDirectionDefault = `DESC`
 export const dashboardsWidgetsBatchCreateBodyWidgetsItemNameMax = 400
 
 export const dashboardsWidgetsBatchCreateBodyWidgetsMax = 10
@@ -490,7 +501,118 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod.object({
                         'Widget type identifier. Supported values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for config_schema_hints per type.'
                     ),
                 config: zod
-                    .unknown()
+                    .union([
+                        zod.object({
+                            limit: zod
+                                .number()
+                                .min(1)
+                                .max(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneLimitMax)
+                                .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneLimitDefault)
+                                .describe('Maximum number of issues to return.'),
+                            orderBy: zod
+                                .enum(['last_seen', 'first_seen', 'occurrences', 'users', 'sessions'])
+                                .describe(
+                                    '\* `last_seen` - last_seen\n\* `first_seen` - first_seen\n\* `occurrences` - occurrences\n\* `users` - users\n\* `sessions` - sessions'
+                                )
+                                .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneOrderByDefault)
+                                .describe(
+                                    'Issue ranking column.\n\n\* `first_seen` - first_seen\n\* `last_seen` - last_seen\n\* `occurrences` - occurrences\n\* `sessions` - sessions\n\* `users` - users'
+                                ),
+                            orderDirection: zod
+                                .enum(['ASC', 'DESC'])
+                                .describe('\* `ASC` - ASC\n\* `DESC` - DESC')
+                                .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneOrderDirectionDefault)
+                                .describe('Sort direction for orderBy.\n\n\* `ASC` - ASC\n\* `DESC` - DESC'),
+                            status: zod
+                                .enum(['archived', 'active', 'resolved', 'pending_release', 'suppressed', 'all'])
+                                .describe(
+                                    '\* `archived` - archived\n\* `active` - active\n\* `resolved` - resolved\n\* `pending_release` - pending_release\n\* `suppressed` - suppressed\n\* `all` - all'
+                                )
+                                .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneOneStatusDefault)
+                                .describe(
+                                    'Issue status filter.\n\n\* `archived` - archived\n\* `active` - active\n\* `resolved` - resolved\n\* `pending_release` - pending_release\n\* `suppressed` - suppressed\n\* `all` - all'
+                                ),
+                            dateRange: zod
+                                .union([
+                                    zod.object({
+                                        date_from: zod
+                                            .union([
+                                                zod
+                                                    .enum(['-14d', '-1h', '-24h', '-30d', '-3h', '-7d', '-90d'])
+                                                    .describe(
+                                                        '\* `-14d` - -14d\n\* `-1h` - -1h\n\* `-24h` - -24h\n\* `-30d` - -30d\n\* `-3h` - -3h\n\* `-7d` - -7d\n\* `-90d` - -90d'
+                                                    ),
+                                                zod.null(),
+                                            ])
+                                            .optional()
+                                            .describe(
+                                                "Relative lookback window (for example '-7d'). Omit to use the project default range.\n\n\* `-14d` - -14d\n\* `-1h` - -1h\n\* `-24h` - -24h\n\* `-30d` - -30d\n\* `-3h` - -3h\n\* `-7d` - -7d\n\* `-90d` - -90d"
+                                            ),
+                                    }),
+                                    zod.null(),
+                                ])
+                                .optional()
+                                .describe('Optional relative date range override.'),
+                            filterTestAccounts: zod
+                                .boolean()
+                                .optional()
+                                .describe('When omitted, follows the project default for filtering test accounts.'),
+                        }),
+                        zod.object({
+                            limit: zod
+                                .number()
+                                .min(1)
+                                .max(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneTwoLimitMax)
+                                .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneTwoLimitDefault)
+                                .describe('Maximum number of recordings to return.'),
+                            orderBy: zod
+                                .enum([
+                                    'activity_score',
+                                    'click_count',
+                                    'console_error_count',
+                                    'duration',
+                                    'recording_duration',
+                                    'start_time',
+                                ])
+                                .describe(
+                                    '\* `activity_score` - activity_score\n\* `click_count` - click_count\n\* `console_error_count` - console_error_count\n\* `duration` - duration\n\* `recording_duration` - recording_duration\n\* `start_time` - start_time'
+                                )
+                                .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneTwoOrderByDefault)
+                                .describe(
+                                    'Recording ranking column.\n\n\* `activity_score` - activity_score\n\* `click_count` - click_count\n\* `console_error_count` - console_error_count\n\* `duration` - duration\n\* `recording_duration` - recording_duration\n\* `start_time` - start_time'
+                                ),
+                            orderDirection: zod
+                                .enum(['ASC', 'DESC'])
+                                .describe('\* `ASC` - ASC\n\* `DESC` - DESC')
+                                .default(dashboardsWidgetsBatchCreateBodyWidgetsItemConfigOneTwoOrderDirectionDefault)
+                                .describe('Sort direction for orderBy.\n\n\* `ASC` - ASC\n\* `DESC` - DESC'),
+                            dateRange: zod
+                                .union([
+                                    zod.object({
+                                        date_from: zod
+                                            .union([
+                                                zod
+                                                    .enum(['-14d', '-1h', '-24h', '-30d', '-3h', '-7d', '-90d'])
+                                                    .describe(
+                                                        '\* `-14d` - -14d\n\* `-1h` - -1h\n\* `-24h` - -24h\n\* `-30d` - -30d\n\* `-3h` - -3h\n\* `-7d` - -7d\n\* `-90d` - -90d'
+                                                    ),
+                                                zod.null(),
+                                            ])
+                                            .optional()
+                                            .describe(
+                                                "Relative lookback window (for example '-7d'). Omit to use the project default range.\n\n\* `-14d` - -14d\n\* `-1h` - -1h\n\* `-24h` - -24h\n\* `-30d` - -30d\n\* `-3h` - -3h\n\* `-7d` - -7d\n\* `-90d` - -90d"
+                                            ),
+                                    }),
+                                    zod.null(),
+                                ])
+                                .optional()
+                                .describe('Optional relative date range override.'),
+                            filterTestAccounts: zod
+                                .boolean()
+                                .optional()
+                                .describe('When omitted, follows the project default for filtering test accounts.'),
+                        }),
+                    ])
                     .describe(
                         'Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for config_schema_hints. Supported types: error_tracking_list, session_replay_list.'
                     ),

--- a/products/dashboards/frontend/types.ts
+++ b/products/dashboards/frontend/types.ts
@@ -1,4 +1,4 @@
 /**
  * Product RBAC for gated widget types. New types: extend union here — see products/dashboards/CONTRIBUTING.md.
  */
-export type DashboardWidgetProductAccess = 'error_tracking'
+export type DashboardWidgetProductAccess = 'error_tracking' | 'session_recording'

--- a/products/dashboards/frontend/widgetProductAccess.ts
+++ b/products/dashboards/frontend/widgetProductAccess.ts
@@ -7,6 +7,7 @@ import type { DashboardWidgetProductAccess } from './types'
 const WIDGET_PRODUCT_ACCESS_CHECKS = {
     // New gated widget types: add a case here — CONTRIBUTING.md
     error_tracking: () => userHasAccess(AccessControlResourceType.ErrorTracking, AccessControlLevel.Viewer),
+    session_recording: () => userHasAccess(AccessControlResourceType.SessionRecording, AccessControlLevel.Viewer),
 } satisfies Record<DashboardWidgetProductAccess, () => boolean>
 
 export function userHasDashboardWidgetProductAccess(productAccess: DashboardWidgetProductAccess | undefined): boolean {

--- a/products/dashboards/frontend/widget_types/catalog.ts
+++ b/products/dashboards/frontend/widget_types/catalog.ts
@@ -2,7 +2,8 @@ import { urls } from 'scenes/urls'
 
 import type { DashboardWidgetProductAccess } from '../types'
 import { ErrorTrackingWidgetPreview } from '../widgets/previews/ErrorTrackingWidgetPreview'
-import { errorTrackingWidgetConfigSchema } from './configSchemas'
+import { SessionReplayWidgetPreview } from '../widgets/previews/SessionReplayWidgetPreview'
+import { errorTrackingWidgetConfigSchema, sessionReplayWidgetConfigSchema } from './configSchemas'
 import type { WidgetAvailabilityConfig } from './widgetAvailability'
 
 export const DASHBOARD_WIDGET_HEADER_LAYOUTS = ['simple', 'dashboard_tile'] as const
@@ -26,6 +27,7 @@ export const DEFAULT_DASHBOARD_WIDGET_HEADER_META = {
 /** Product area labels keyed by catalog `groupId`. New groups: add here. */
 export const DASHBOARD_WIDGET_GROUP_LABELS = {
     error_tracking: 'Error tracking',
+    session_replay: 'Session replay',
 } as const satisfies Record<string, string>
 
 export function getDashboardWidgetGroupLabel(groupId: string): string {
@@ -65,6 +67,31 @@ export const DASHBOARD_WIDGET_CATALOG = {
         productAccess: 'error_tracking',
         titleHref: urls.errorTracking(),
     },
+    session_replay_list: {
+        groupId: 'session_replay',
+        label: 'Recent recordings',
+        description: 'Recent session recordings you can open in the replay player.',
+        headerTitle: 'Recent recordings',
+        defaultConfig: sessionReplayWidgetConfigSchema.parse({
+            dateRange: { date_from: '-7d' },
+        }),
+        defaultLayout: { w: 6, h: 5, minW: 6, minH: 3 },
+        productAccess: 'session_recording',
+        headerLayout: 'dashboard_tile' satisfies DashboardWidgetHeaderLayout,
+        headerMeta: {
+            showWidgetType: true,
+            showDateRange: true,
+        } satisfies DashboardWidgetHeaderMeta,
+        titleHref: urls.replay(),
+        availability: {
+            requirement: 'session_replay_enabled',
+            unavailableTitle: 'Session replay is not enabled',
+            unavailableReason:
+                'Turn on session recordings for this project to watch recent replays from your dashboard.',
+            setupActionLabel: 'Enable session replay',
+            docsHref: 'https://posthog.com/docs/session-replay',
+        },
+    },
 } as const satisfies Record<string, DashboardWidgetCatalogEntry>
 
 export type DashboardWidgetCatalogKey = keyof typeof DASHBOARD_WIDGET_CATALOG
@@ -72,6 +99,7 @@ export type DashboardWidgetCatalogKey = keyof typeof DASHBOARD_WIDGET_CATALOG
 /** New widget types: add preview components here. See products/dashboards/CONTRIBUTING.md. */
 export const DASHBOARD_WIDGET_PREVIEWS: Record<DashboardWidgetCatalogKey, () => JSX.Element> = {
     error_tracking_list: ErrorTrackingWidgetPreview,
+    session_replay_list: SessionReplayWidgetPreview,
 }
 
 export type ResolvedDashboardWidgetCatalogEntry = DashboardWidgetCatalogEntry & {

--- a/products/dashboards/frontend/widget_types/catalog.ts
+++ b/products/dashboards/frontend/widget_types/catalog.ts
@@ -77,11 +77,6 @@ export const DASHBOARD_WIDGET_CATALOG = {
         }),
         defaultLayout: { w: 6, h: 5, minW: 6, minH: 3 },
         productAccess: 'session_recording',
-        headerLayout: 'dashboard_tile' satisfies DashboardWidgetHeaderLayout,
-        headerMeta: {
-            showWidgetType: true,
-            showDateRange: true,
-        } satisfies DashboardWidgetHeaderMeta,
         titleHref: urls.replay(),
         availability: {
             requirement: 'session_replay_enabled',

--- a/products/dashboards/frontend/widget_types/configSchemas.ts
+++ b/products/dashboards/frontend/widget_types/configSchemas.ts
@@ -74,13 +74,25 @@ export const errorTrackingWidgetConfigSchema = baseWidgetConfigSchema.extend({
 
 export type ErrorTrackingWidgetConfig = z.infer<typeof errorTrackingWidgetConfigSchema>
 
+/** Shared form fields for list-style dashboard widget settings modals. */
+export function widgetListFormSchema<TOrderBy extends z.ZodType>(
+    orderBySchema: TOrderBy
+): z.ZodObject<{
+    limit: typeof widgetLimitFieldSchema
+    orderBy: TOrderBy
+    dateFrom: typeof widgetDateFromSchema
+    filterTestAccounts: z.ZodBoolean
+}> {
+    return z.object({
+        limit: widgetLimitFieldSchema,
+        orderBy: orderBySchema,
+        dateFrom: widgetDateFromSchema,
+        filterTestAccounts: z.boolean(),
+    })
+}
+
 /** Form fields edited in the error tracking widget settings modal. */
-export const errorTrackingWidgetFormSchema = z.object({
-    limit: widgetLimitFieldSchema,
-    orderBy: errorTrackingWidgetConfigSchema.shape.orderBy,
-    dateFrom: widgetDateFromSchema,
-    filterTestAccounts: z.boolean(),
-})
+export const errorTrackingWidgetFormSchema = widgetListFormSchema(errorTrackingWidgetConfigSchema.shape.orderBy)
 
 export const sessionReplayWidgetConfigSchema = baseWidgetConfigSchema.extend({
     limit: widgetLimitFieldSchema.default(10),
@@ -94,9 +106,4 @@ export const sessionReplayWidgetConfigSchema = baseWidgetConfigSchema.extend({
 export type SessionReplayWidgetConfig = z.infer<typeof sessionReplayWidgetConfigSchema>
 
 /** Form fields edited in the session replay widget settings modal. */
-export const sessionReplayWidgetFormSchema = z.object({
-    limit: widgetLimitFieldSchema,
-    orderBy: sessionReplayWidgetConfigSchema.shape.orderBy,
-    dateFrom: widgetDateFromSchema,
-    filterTestAccounts: z.boolean(),
-})
+export const sessionReplayWidgetFormSchema = widgetListFormSchema(sessionReplayWidgetConfigSchema.shape.orderBy)

--- a/products/dashboards/frontend/widget_types/configSchemas.ts
+++ b/products/dashboards/frontend/widget_types/configSchemas.ts
@@ -81,3 +81,15 @@ export const errorTrackingWidgetFormSchema = z.object({
     dateFrom: widgetDateFromSchema,
     filterTestAccounts: z.boolean(),
 })
+
+export const sessionReplayWidgetConfigSchema = baseWidgetConfigSchema.extend({
+    limit: widgetLimitFieldSchema.default(10),
+    orderBy: z
+        .enum(['start_time', 'activity_score', 'recording_duration', 'duration', 'click_count', 'console_error_count'])
+        .default('start_time'),
+    orderDirection: widgetOrderDirectionSchema,
+    dateRange: widgetDateRangeSchema,
+})
+
+export type SessionReplayWidgetConfig = z.infer<typeof sessionReplayWidgetConfigSchema>
+

--- a/products/dashboards/frontend/widget_types/configSchemas.ts
+++ b/products/dashboards/frontend/widget_types/configSchemas.ts
@@ -93,3 +93,10 @@ export const sessionReplayWidgetConfigSchema = baseWidgetConfigSchema.extend({
 
 export type SessionReplayWidgetConfig = z.infer<typeof sessionReplayWidgetConfigSchema>
 
+/** Form fields edited in the session replay widget settings modal. */
+export const sessionReplayWidgetFormSchema = z.object({
+    limit: widgetLimitFieldSchema,
+    orderBy: sessionReplayWidgetConfigSchema.shape.orderBy,
+    dateFrom: widgetDateFromSchema,
+    filterTestAccounts: z.boolean(),
+})

--- a/products/dashboards/frontend/widget_types/widgetAvailability.ts
+++ b/products/dashboards/frontend/widget_types/widgetAvailability.ts
@@ -7,7 +7,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import type { TeamPublicType, TeamType } from '~/types'
 
 /** New catalog-driven setup requirements: add here — CONTRIBUTING.md */
-export type WidgetAvailabilityRequirementId = 'exception_autocapture'
+export type WidgetAvailabilityRequirementId = 'exception_autocapture' | 'session_replay_enabled'
 
 export type WidgetAvailabilityPresentation = {
     productName: string
@@ -25,6 +25,12 @@ export const WIDGET_AVAILABILITY_PRESENTATION: Record<WidgetAvailabilityRequirem
             productKey: ProductKey.ERROR_TRACKING,
             thingName: 'exception',
             settingsUrl: urls.settings('environment-error-tracking', 'error-tracking-exception-autocapture'),
+        },
+        session_replay_enabled: {
+            productName: 'Session replay',
+            productKey: ProductKey.SESSION_REPLAY,
+            thingName: 'session recording',
+            settingsUrl: urls.settings('environment-replay'),
         },
     }
 
@@ -54,6 +60,8 @@ export function isWidgetAvailabilityRequirementMet(
         // New requirements: add a case here — CONTRIBUTING.md
         case 'exception_autocapture':
             return !!team?.autocapture_exceptions_opt_in
+        case 'session_replay_enabled':
+            return !!team?.session_recording_opt_in
         default: {
             const _exhaustive: never = requirement
             return _exhaustive

--- a/products/dashboards/frontend/widgets/error_tracking/editErrorTrackingWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/error_tracking/editErrorTrackingWidgetModalLogic.ts
@@ -187,10 +187,10 @@ export const editErrorTrackingWidgetModalLogic = kea<editErrorTrackingWidgetModa
         const baseConfig = parseErrorTrackingWidgetConfig(props.config)
 
         return {
+            ...getWidgetEditModalTileDefaults(props),
             limit: baseConfig.limit,
             orderBy: baseConfig.orderBy,
             dateFrom: baseConfig.dateRange?.date_from ?? '-7d',
-            ...getWidgetEditModalTileDefaults(props),
             filterTestAccounts: resolveWidgetFilterTestAccounts(
                 baseConfig.filterTestAccounts,
                 values.filterTestAccountsDefault

--- a/products/dashboards/frontend/widgets/error_tracking/editErrorTrackingWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/error_tracking/editErrorTrackingWidgetModalLogic.ts
@@ -187,10 +187,10 @@ export const editErrorTrackingWidgetModalLogic = kea<editErrorTrackingWidgetModa
         const baseConfig = parseErrorTrackingWidgetConfig(props.config)
 
         return {
-            ...getWidgetEditModalTileDefaults(props),
             limit: baseConfig.limit,
             orderBy: baseConfig.orderBy,
             dateFrom: baseConfig.dateRange?.date_from ?? '-7d',
+            ...getWidgetEditModalTileDefaults(props),
             filterTestAccounts: resolveWidgetFilterTestAccounts(
                 baseConfig.filterTestAccounts,
                 values.filterTestAccountsDefault

--- a/products/dashboards/frontend/widgets/error_tracking/errorTrackingWidgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/error_tracking/errorTrackingWidgetConfigValidation.ts
@@ -1,43 +1,30 @@
-import { z, type ZodError } from 'zod'
-
-import { ApiError } from 'lib/api-error'
+import { z } from 'zod'
 
 import {
     errorTrackingWidgetConfigSchema,
     errorTrackingWidgetFormSchema,
     type ErrorTrackingWidgetConfig,
 } from '../../widget_types/configSchemas'
+import {
+    buildWidgetConfigFromForm,
+    parseWidgetConfig,
+    parseWidgetConfigApiError,
+    validateWidgetConfigInput as validateWidgetConfigInputShared,
+} from '../widgetConfigValidation'
 
 type ErrorTrackingWidgetFormField = keyof z.infer<typeof errorTrackingWidgetFormSchema>
 
 export type ErrorTrackingWidgetFieldErrors = Partial<Record<ErrorTrackingWidgetFormField, string>>
 
-function fieldErrorsFromZodError(error: ZodError): ErrorTrackingWidgetFieldErrors {
-    const { fieldErrors } = z.flattenError(error)
-
-    return Object.fromEntries(
-        (Object.entries(fieldErrors) as [string, string[]][]).flatMap(([field, messages]) =>
-            messages.length > 0 ? [[field, messages[0]]] : []
-        )
-    )
-}
-
 export function parseErrorTrackingWidgetConfig(config: Record<string, unknown>): ErrorTrackingWidgetConfig {
-    const parsed = errorTrackingWidgetConfigSchema.safeParse(config)
-    return parsed.success ? parsed.data : errorTrackingWidgetConfigSchema.parse({})
+    return parseWidgetConfig(errorTrackingWidgetConfigSchema, config)
 }
 
 export function buildErrorTrackingWidgetConfig(
     formInput: z.infer<typeof errorTrackingWidgetFormSchema>,
     baseConfig: ErrorTrackingWidgetConfig
 ): ErrorTrackingWidgetConfig {
-    return errorTrackingWidgetConfigSchema.parse({
-        ...baseConfig,
-        limit: formInput.limit,
-        orderBy: formInput.orderBy,
-        filterTestAccounts: formInput.filterTestAccounts,
-        dateRange: { date_from: formInput.dateFrom },
-    })
+    return buildWidgetConfigFromForm(errorTrackingWidgetConfigSchema, formInput, baseConfig)
 }
 
 export function validateErrorTrackingWidgetConfigInput(input: {
@@ -49,46 +36,22 @@ export function validateErrorTrackingWidgetConfigInput(input: {
 }):
     | { success: true; config: ErrorTrackingWidgetConfig }
     | { success: false; fieldErrors: ErrorTrackingWidgetFieldErrors } {
-    const parsed = errorTrackingWidgetFormSchema.safeParse({
-        limit: input.limit,
-        orderBy: input.orderBy,
-        dateFrom: input.dateFrom,
-        filterTestAccounts: input.filterTestAccounts,
+    return validateWidgetConfigInputShared({
+        formSchema: errorTrackingWidgetFormSchema,
+        buildConfig: buildErrorTrackingWidgetConfig,
+        input,
     })
-
-    if (!parsed.success) {
-        return { success: false, fieldErrors: fieldErrorsFromZodError(parsed.error) }
-    }
-
-    return {
-        success: true,
-        config: buildErrorTrackingWidgetConfig(parsed.data, input.baseConfig),
-    }
 }
 
 export function parseErrorTrackingWidgetConfigApiError(
     error: unknown,
     config: Record<string, unknown>
 ): ErrorTrackingWidgetFieldErrors | null {
-    if (!(error instanceof ApiError)) {
-        return null
-    }
-
-    const parsedConfig = errorTrackingWidgetConfigSchema.safeParse(config)
-    if (parsedConfig.success) {
-        return null
-    }
-
-    const formInput = {
-        limit: (config.limit as number) ?? 0,
-        orderBy: (config.orderBy as ErrorTrackingWidgetConfig['orderBy']) ?? 'occurrences',
-        dateFrom: (config.dateRange as { date_from?: string } | undefined)?.date_from ?? '-7d',
-        filterTestAccounts: (config.filterTestAccounts as boolean) ?? false,
-    }
-    const parsedForm = errorTrackingWidgetFormSchema.safeParse(formInput)
-    if (!parsedForm.success) {
-        return fieldErrorsFromZodError(parsedForm.error)
-    }
-
-    return fieldErrorsFromZodError(parsedConfig.error)
+    return parseWidgetConfigApiError({
+        error,
+        config,
+        configSchema: errorTrackingWidgetConfigSchema,
+        formSchema: errorTrackingWidgetFormSchema,
+        defaultOrderBy: 'occurrences',
+    })
 }

--- a/products/dashboards/frontend/widgets/error_tracking/errorTrackingWidgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/error_tracking/errorTrackingWidgetConfigValidation.ts
@@ -9,6 +9,7 @@ import {
     buildWidgetConfigFromForm,
     parseWidgetConfig,
     parseWidgetConfigApiError,
+    type WidgetListFormInput,
     validateWidgetConfigInput as validateWidgetConfigInputShared,
 } from '../widgetConfigValidation'
 
@@ -21,7 +22,7 @@ export function parseErrorTrackingWidgetConfig(config: Record<string, unknown>):
 }
 
 export function buildErrorTrackingWidgetConfig(
-    formInput: z.infer<typeof errorTrackingWidgetFormSchema>,
+    formInput: WidgetListFormInput,
     baseConfig: ErrorTrackingWidgetConfig
 ): ErrorTrackingWidgetConfig {
     return buildWidgetConfigFromForm(errorTrackingWidgetConfigSchema, formInput, baseConfig)

--- a/products/dashboards/frontend/widgets/previews/SessionReplayWidgetPreview.test.tsx
+++ b/products/dashboards/frontend/widgets/previews/SessionReplayWidgetPreview.test.tsx
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom'
+
+import { render, screen, cleanup } from '@testing-library/react'
+
+import { initKeaTests } from '~/test/init'
+
+import { SessionReplayWidgetPreview } from './SessionReplayWidgetPreview'
+
+jest.mock('scenes/session-recordings/playlist/SessionRecordingPreview', () => ({
+    SessionRecordingPreview: ({ recording }: { recording: { id: string } }): JSX.Element => (
+        <div data-attr="session-recording-preview">{recording.id}</div>
+    ),
+}))
+
+describe('SessionReplayWidgetPreview', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    it('renders recording rows using SessionRecordingPreview', () => {
+        render(<SessionReplayWidgetPreview />)
+
+        expect(screen.getAllByTestId('session-recording-preview')).toHaveLength(3)
+        expect(screen.getByText('overview-recording-1')).toBeInTheDocument()
+        expect(screen.getByText('overview-recording-2')).toBeInTheDocument()
+        expect(screen.getByText('overview-recording-3')).toBeInTheDocument()
+    })
+})

--- a/products/dashboards/frontend/widgets/previews/SessionReplayWidgetPreview.tsx
+++ b/products/dashboards/frontend/widgets/previews/SessionReplayWidgetPreview.tsx
@@ -1,0 +1,18 @@
+import 'scenes/session-recordings/playlist/SessionRecordingPreview.scss'
+import { SessionRecordingPreview } from 'scenes/session-recordings/playlist/SessionRecordingPreview'
+
+import { sessionReplaySampleRecordings } from '../../components/WidgetCard/widgetOverviewStoryFixtures'
+
+const PREVIEW_ORDER = 'start_time' as const
+
+export function SessionReplayWidgetPreview(): JSX.Element {
+    return (
+        <div className="flex flex-col shadow-sm">
+            {sessionReplaySampleRecordings.map((recording) => (
+                <div key={recording.id} className="border-b">
+                    <SessionRecordingPreview recording={recording} order={PREVIEW_ORDER} />
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/products/dashboards/frontend/widgets/registry.test.tsx
+++ b/products/dashboards/frontend/widgets/registry.test.tsx
@@ -26,9 +26,18 @@ describe('dashboard widget registry', () => {
         expect(posthog.captureException).not.toHaveBeenCalled()
     })
 
+    it('registers session_replay_list widget', () => {
+        const definition = getDashboardWidgetDefinition('session_replay_list')
+        expect(definition?.Component).toBeTruthy()
+        expect(definition?.EditModal).toBeTruthy()
+        expect(definition?.productAccess).toBe('session_recording')
+        expect(definition?.parseConfigApiError).toBeTruthy()
+    })
+
     it('delegates config api error parsing to the widget registry entry', () => {
         expect(parseDashboardWidgetConfigApiError('unknown_widget_type', new Error('nope'), {})).toBeNull()
         expect(parseDashboardWidgetConfigApiError('error_tracking_list', new Error('nope'), {})).toBeNull()
+        expect(parseDashboardWidgetConfigApiError('session_replay_list', new Error('nope'), {})).toBeNull()
     })
 
     it('registers every catalog key', () => {

--- a/products/dashboards/frontend/widgets/registry.tsx
+++ b/products/dashboards/frontend/widgets/registry.tsx
@@ -7,6 +7,9 @@ import type { WidgetAvailabilityConfig } from '../widget_types/widgetAvailabilit
 import { EditErrorTrackingWidgetModal } from './error_tracking/EditErrorTrackingWidgetModal'
 import { ErrorTrackingWidget } from './error_tracking/ErrorTrackingWidget'
 import { parseErrorTrackingWidgetConfigApiError } from './error_tracking/errorTrackingWidgetConfigValidation'
+import { EditSessionReplayWidgetModal } from './session_replay/EditSessionReplayWidgetModal'
+import { SessionReplayWidget } from './session_replay/SessionReplayWidget'
+import { parseSessionReplayWidgetConfigApiError } from './session_replay/sessionReplayWidgetConfigValidation'
 
 export type DashboardWidgetConfigApiErrorParser = (
     error: unknown,
@@ -101,6 +104,12 @@ export const DASHBOARD_WIDGET_REGISTRY = {
         EditModal: EditErrorTrackingWidgetModal,
         productAccess: 'error_tracking',
         parseConfigApiError: parseErrorTrackingWidgetConfigApiError,
+    },
+    session_replay_list: {
+        Component: SessionReplayWidget,
+        EditModal: EditSessionReplayWidgetModal,
+        productAccess: 'session_recording',
+        parseConfigApiError: parseSessionReplayWidgetConfigApiError,
     },
 } satisfies Record<DashboardWidgetCatalogKey, DashboardWidgetDefinition>
 

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.stories.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.stories.tsx
@@ -14,7 +14,6 @@ function EditSessionReplayWidgetModalStory({
     isOpen = true,
     onClose = () => undefined,
     onSave = () => Promise.resolve(),
-    onSaveMetadata = () => Promise.resolve(),
     config = DEFAULT_CONFIG,
     name = 'Recent recordings',
     defaultTitle = SESSION_REPLAY_CATALOG.headerTitle ?? SESSION_REPLAY_CATALOG.label,
@@ -27,7 +26,6 @@ function EditSessionReplayWidgetModalStory({
             onClose={onClose}
             config={config}
             onSave={onSave}
-            onSaveMetadata={onSaveMetadata}
             name={name}
             defaultTitle={defaultTitle}
             description={description}

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.stories.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { withSessionReplayProjectState } from '../../components/WidgetCard/widgetCardStoryFixtures'
+import { getDashboardWidgetCatalogEntry } from '../../widget_types/catalog'
+import type { DashboardWidgetEditModalProps } from '../registry'
+import { EditSessionReplayWidgetModal } from './EditSessionReplayWidgetModal'
+
+const SESSION_REPLAY_CATALOG = getDashboardWidgetCatalogEntry('session_replay_list')!
+const DEFAULT_CONFIG = SESSION_REPLAY_CATALOG.defaultConfig as Record<string, unknown>
+
+type EditSessionReplayWidgetModalStoryProps = Partial<DashboardWidgetEditModalProps>
+
+function EditSessionReplayWidgetModalStory({
+    isOpen = true,
+    onClose = () => undefined,
+    onSave = () => Promise.resolve(),
+    onSaveMetadata = () => Promise.resolve(),
+    config = DEFAULT_CONFIG,
+    name = 'Recent recordings',
+    defaultTitle = SESSION_REPLAY_CATALOG.headerTitle ?? SESSION_REPLAY_CATALOG.label,
+    description = 'Recent session recordings you can open in the replay player.',
+    ...props
+}: EditSessionReplayWidgetModalStoryProps): JSX.Element {
+    return (
+        <EditSessionReplayWidgetModal
+            isOpen={isOpen}
+            onClose={onClose}
+            config={config}
+            onSave={onSave}
+            onSaveMetadata={onSaveMetadata}
+            name={name}
+            defaultTitle={defaultTitle}
+            description={description}
+            {...props}
+        />
+    )
+}
+
+const meta: Meta<typeof EditSessionReplayWidgetModalStory> = {
+    title: 'Dashboards/Dashboard Widgets/Widget types/Session replay/Recent recordings/Widget settings',
+    component: EditSessionReplayWidgetModalStory,
+    parameters: {
+        layout: 'fullscreen',
+    },
+    decorators: [],
+    args: {
+        config: { ...DEFAULT_CONFIG, orderBy: 'start_time', filterTestAccounts: true },
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof EditSessionReplayWidgetModalStory>
+
+export const Default: Story = {
+    decorators: [withSessionReplayProjectState(true)],
+}

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.test.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.test.tsx
@@ -59,7 +59,8 @@ describe('EditSessionReplayWidgetModal', () => {
                 orderBy: 'start_time',
                 filterTestAccounts: true,
                 dateRange: { date_from: '-7d' },
-            })
+            }),
+            {}
         )
     })
 

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.test.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.test.tsx
@@ -1,0 +1,75 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import { EditSessionReplayWidgetModal } from './EditSessionReplayWidgetModal'
+
+describe('EditSessionReplayWidgetModal', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    beforeEach(() => {
+        initKeaTests(true, {
+            test_account_filters: [{ key: 'email', value: '@posthog.com', operator: 'not_icontains', type: 'person' }],
+        })
+        filterTestAccountsDefaultsLogic.mount()
+    })
+
+    it('saves widget config from default session replay settings', async () => {
+        const onSave = jest.fn().mockResolvedValue(undefined)
+
+        render(
+            <EditSessionReplayWidgetModal
+                isOpen
+                onClose={jest.fn()}
+                config={{
+                    limit: 10,
+                    orderBy: 'start_time',
+                    orderDirection: 'DESC',
+                    filterTestAccounts: true,
+                    dateRange: { date_from: '-7d' },
+                }}
+                onSave={onSave}
+            />
+        )
+
+        const dialog = screen.getByRole('dialog')
+        await userEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+
+        expect(onSave).toHaveBeenCalledWith(
+            expect.objectContaining({
+                limit: 10,
+                orderBy: 'start_time',
+                filterTestAccounts: true,
+                dateRange: { date_from: '-7d' },
+            })
+        )
+    })
+
+    it('shows inline error for limit above 25 instead of saving', async () => {
+        const onSave = jest.fn()
+
+        render(
+            <EditSessionReplayWidgetModal
+                isOpen
+                onClose={jest.fn()}
+                config={{ limit: 10, orderBy: 'start_time', dateRange: { date_from: '-7d' } }}
+                onSave={onSave}
+            />
+        )
+
+        const limitInput = screen.getByRole('spinbutton')
+        await userEvent.clear(limitInput)
+        await userEvent.type(limitInput, '30')
+
+        expect(screen.getByText('Must be an integer between 1 and 25.')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Save' })).toHaveAttribute('aria-disabled', 'true')
+        expect(onSave).not.toHaveBeenCalled()
+    })
+})

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.test.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.test.tsx
@@ -1,3 +1,5 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
 import '@testing-library/jest-dom'
 
 import { cleanup, render, screen, within } from '@testing-library/react'
@@ -6,6 +8,7 @@ import userEvent from '@testing-library/user-event'
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
 
 import { initKeaTests } from '~/test/init'
+import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { EditSessionReplayWidgetModal } from './EditSessionReplayWidgetModal'
 
@@ -16,7 +19,15 @@ describe('EditSessionReplayWidgetModal', () => {
 
     beforeEach(() => {
         initKeaTests(true, {
-            test_account_filters: [{ key: 'email', value: '@posthog.com', operator: 'not_icontains', type: 'person' }],
+            ...MOCK_DEFAULT_TEAM,
+            test_account_filters: [
+                {
+                    key: 'email',
+                    value: '@posthog.com',
+                    operator: PropertyOperator.NotIContains,
+                    type: PropertyFilterType.Person,
+                },
+            ],
         })
         filterTestAccountsDefaultsLogic.mount()
     })

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
@@ -6,10 +6,10 @@ import { LemonField } from 'lib/lemon-ui/LemonField/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
-import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 
-import { DASHBOARD_WIDGET_CATALOG } from '../../widget_types/catalog'
+import { getDashboardWidgetGroupLabel } from '../../widget_types/catalog'
 import { WIDGET_DATE_RANGE_SELECT_OPTIONS } from '../../widget_types/configSchemas'
+import { EditWidgetModalFiltersSection } from '../EditWidgetModalFiltersSection'
 import { EditWidgetModalTileDetailsSection } from '../EditWidgetModalTileDetailsSection'
 import type { DashboardWidgetEditModalProps } from '../registry'
 import { editSessionReplayWidgetModalLogic } from './editSessionReplayWidgetModalLogic'
@@ -42,7 +42,6 @@ function EditSessionReplayWidgetModalContents(): JSX.Element {
     } = useActions(editSessionReplayWidgetModalLogic)
 
     const showTileDetails = !!onSaveMetadata
-    const catalogEntry = DASHBOARD_WIDGET_CATALOG.session_replay_list
 
     return (
         <LemonModal
@@ -80,24 +79,14 @@ function EditSessionReplayWidgetModalContents(): JSX.Element {
                     />
                 ) : null}
                 {showTileDetails ? <LemonDivider className="my-0" /> : null}
-                <section className="flex flex-col gap-3">
-                    <h5 className="text-sm font-semibold m-0">Filters</h5>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                        <div className="sm:col-span-2">
-                            <TestAccountFilter
-                                size="small"
-                                filters={{ filter_test_accounts: filterTestAccounts }}
-                                onChange={({ filter_test_accounts }) =>
-                                    setFilterTestAccounts(filter_test_accounts ?? false)
-                                }
-                                disabledReason={saving ? 'Saving…' : undefined}
-                            />
-                        </div>
-                    </div>
-                </section>
+                <EditWidgetModalFiltersSection
+                    filterTestAccounts={filterTestAccounts}
+                    saving={saving}
+                    setFilterTestAccounts={setFilterTestAccounts}
+                />
                 <LemonDivider className="my-0" />
                 <section className="flex flex-col gap-3">
-                    <h5 className="text-sm font-semibold m-0">{catalogEntry.groupLabel}</h5>
+                    <h5 className="text-sm font-semibold m-0">{getDashboardWidgetGroupLabel('session_replay')}</h5>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                         <LemonField.Pure
                             label="Date range"

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
@@ -28,7 +28,6 @@ function EditSessionReplayWidgetModalContents(): JSX.Element {
         saveDisabledReason,
         onClose,
         defaultTitle,
-        onSaveMetadata,
     } = useValues(editSessionReplayWidgetModalLogic)
     const {
         setLimit,
@@ -41,7 +40,7 @@ function EditSessionReplayWidgetModalContents(): JSX.Element {
         submit,
     } = useActions(editSessionReplayWidgetModalLogic)
 
-    const showTileDetails = !!onSaveMetadata
+    const showTileDetails = true
 
     return (
         <LemonModal
@@ -151,7 +150,6 @@ export function EditSessionReplayWidgetModal({
     name,
     defaultTitle,
     description,
-    onSaveMetadata,
 }: DashboardWidgetEditModalProps): JSX.Element | null {
     if (!isOpen) {
         return null
@@ -160,7 +158,7 @@ export function EditSessionReplayWidgetModal({
     return (
         <BindLogic
             logic={editSessionReplayWidgetModalLogic}
-            props={{ onClose, config, onSave, name, defaultTitle, description, onSaveMetadata }}
+            props={{ onClose, config, onSave, name, defaultTitle, description }}
         >
             <EditSessionReplayWidgetModalContents />
         </BindLogic>

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
@@ -1,7 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
 
-import { LemonTextArea } from '@posthog/lemon-ui'
-
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonField } from 'lib/lemon-ui/LemonField/LemonField'
@@ -12,16 +10,12 @@ import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 
 import { DASHBOARD_WIDGET_CATALOG } from '../../widget_types/catalog'
 import { WIDGET_DATE_RANGE_SELECT_OPTIONS } from '../../widget_types/configSchemas'
+import { EditWidgetModalTileDetailsSection } from '../EditWidgetModalTileDetailsSection'
 import type { DashboardWidgetEditModalProps } from '../registry'
-import {
-    editSessionReplayWidgetModalLogic,
-    type EditSessionReplayWidgetModalLogicProps,
-} from './editSessionReplayWidgetModalLogic'
+import { editSessionReplayWidgetModalLogic } from './editSessionReplayWidgetModalLogic'
 import { SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS } from './utils'
 
-const widgetSettingsFieldFullWidthClass = 'sm:col-span-2'
-
-function EditSessionReplayWidgetModalForm(props: EditSessionReplayWidgetModalLogicProps): JSX.Element {
+function EditSessionReplayWidgetModalContents(): JSX.Element {
     const {
         limit,
         orderBy,
@@ -32,6 +26,9 @@ function EditSessionReplayWidgetModalForm(props: EditSessionReplayWidgetModalLog
         activeFieldErrors,
         saving,
         saveDisabledReason,
+        onClose,
+        defaultTitle,
+        onSaveMetadata,
     } = useValues(editSessionReplayWidgetModalLogic)
     const {
         setLimit,
@@ -44,19 +41,20 @@ function EditSessionReplayWidgetModalForm(props: EditSessionReplayWidgetModalLog
         submit,
     } = useActions(editSessionReplayWidgetModalLogic)
 
+    const showTileDetails = !!onSaveMetadata
     const catalogEntry = DASHBOARD_WIDGET_CATALOG.session_replay_list
 
     return (
         <LemonModal
             isOpen
-            onClose={props.onClose}
+            onClose={onClose}
             title="Widget settings"
             description="Configure tile details and which session recordings appear on this dashboard."
             width={680}
             footer={
                 <>
                     <div className="flex-1" />
-                    <LemonButton type="secondary" onClick={props.onClose} disabled={saving}>
+                    <LemonButton type="secondary" onClick={onClose} disabled={saving}>
                         Cancel
                     </LemonButton>
                     <LemonButton
@@ -71,111 +69,86 @@ function EditSessionReplayWidgetModalForm(props: EditSessionReplayWidgetModalLog
             }
         >
             <div className="flex flex-col gap-4">
-                {props.onSaveMetadata && (
-                    <section className="flex flex-col gap-3">
-                        <h5 className="text-sm font-semibold m-0">Tile details</h5>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                            <LemonField.Pure
-                                className={widgetSettingsFieldFullWidthClass}
-                                label="Title"
-                                help="Shown on the tile. Leave empty to use the default title."
-                            >
-                                <LemonInput
-                                    value={tileName}
-                                    onChange={setTileName}
-                                    placeholder={props.defaultTitle ?? 'Untitled'}
-                                    maxLength={400}
-                                    disabled={saving}
-                                />
-                            </LemonField.Pure>
-                            <LemonField.Pure
-                                className={widgetSettingsFieldFullWidthClass}
-                                label="Description"
-                                help="Shown under the tile title. Supports markdown. Leave empty to hide."
-                            >
-                                <LemonTextArea
-                                    value={tileDescription}
-                                    onChange={setTileDescription}
-                                    placeholder="Enter description (optional)"
-                                    minRows={2}
-                                    disabled={saving}
-                                />
-                            </LemonField.Pure>
+                {showTileDetails ? (
+                    <EditWidgetModalTileDetailsSection
+                        tileName={tileName}
+                        tileDescription={tileDescription}
+                        defaultTitle={defaultTitle}
+                        saving={saving}
+                        setTileName={setTileName}
+                        setTileDescription={setTileDescription}
+                    />
+                ) : null}
+                {showTileDetails ? <LemonDivider className="my-0" /> : null}
+                <section className="flex flex-col gap-3">
+                    <h5 className="text-sm font-semibold m-0">Filters</h5>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div className="sm:col-span-2">
+                            <TestAccountFilter
+                                size="small"
+                                filters={{ filter_test_accounts: filterTestAccounts }}
+                                onChange={({ filter_test_accounts }) =>
+                                    setFilterTestAccounts(filter_test_accounts ?? false)
+                                }
+                                disabledReason={saving ? 'Saving…' : undefined}
+                            />
                         </div>
-                    </section>
-                )}
-                <>
-                    {props.onSaveMetadata && <LemonDivider className="my-0" />}
-                    <section className="flex flex-col gap-3">
-                        <h5 className="text-sm font-semibold m-0">Filters</h5>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                            <div className={widgetSettingsFieldFullWidthClass}>
-                                <TestAccountFilter
-                                    size="small"
-                                    filters={{ filter_test_accounts: filterTestAccounts }}
-                                    onChange={({ filter_test_accounts }) =>
-                                        setFilterTestAccounts(filter_test_accounts ?? false)
-                                    }
-                                    disabledReason={saving ? 'Saving…' : undefined}
-                                />
-                            </div>
-                        </div>
-                    </section>
-                    <LemonDivider className="my-0" />
-                    <section className="flex flex-col gap-3">
-                        <h5 className="text-sm font-semibold m-0">{catalogEntry.groupLabel}</h5>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                            <LemonField.Pure
-                                label="Date range"
-                                help="Only include recordings started in this period."
-                                error={activeFieldErrors.dateFrom}
-                            >
-                                <LemonSelect
-                                    fullWidth
-                                    value={dateFrom}
-                                    onChange={(value) => {
-                                        setDateFrom(value)
-                                        clearFieldError('dateFrom')
-                                    }}
-                                    options={WIDGET_DATE_RANGE_SELECT_OPTIONS}
-                                />
-                            </LemonField.Pure>
-                            <LemonField.Pure
-                                label="Number of recordings"
-                                help="Show up to 25 recordings on the tile."
-                                error={activeFieldErrors.limit}
-                            >
-                                <LemonInput
-                                    type="number"
-                                    min={1}
-                                    max={25}
-                                    fullWidth
-                                    value={limit}
-                                    onChange={(value) => {
-                                        setLimit(Number(value))
-                                        clearFieldError('limit')
-                                    }}
-                                />
-                            </LemonField.Pure>
-                            <LemonField.Pure
-                                className={widgetSettingsFieldFullWidthClass}
-                                label="Sort by"
-                                help="Order recordings by this metric within the date range."
-                                error={activeFieldErrors.orderBy}
-                            >
-                                <LemonSelect
-                                    fullWidth
-                                    value={orderBy}
-                                    onChange={(value) => {
-                                        setOrderBy(value)
-                                        clearFieldError('orderBy')
-                                    }}
-                                    options={[...SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS]}
-                                />
-                            </LemonField.Pure>
-                        </div>
-                    </section>
-                </>
+                    </div>
+                </section>
+                <LemonDivider className="my-0" />
+                <section className="flex flex-col gap-3">
+                    <h5 className="text-sm font-semibold m-0">{catalogEntry.groupLabel}</h5>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <LemonField.Pure
+                            label="Date range"
+                            help="Only include recordings started in this period."
+                            error={activeFieldErrors.dateFrom}
+                        >
+                            <LemonSelect
+                                fullWidth
+                                value={dateFrom}
+                                onChange={(value) => {
+                                    setDateFrom(value)
+                                    clearFieldError('dateFrom')
+                                }}
+                                options={WIDGET_DATE_RANGE_SELECT_OPTIONS}
+                            />
+                        </LemonField.Pure>
+                        <LemonField.Pure
+                            label="Number of recordings"
+                            help="Show up to 25 recordings on the tile."
+                            error={activeFieldErrors.limit}
+                        >
+                            <LemonInput
+                                type="number"
+                                min={1}
+                                max={25}
+                                fullWidth
+                                value={limit}
+                                onChange={(value) => {
+                                    setLimit(Number(value))
+                                    clearFieldError('limit')
+                                }}
+                            />
+                        </LemonField.Pure>
+                        <LemonField.Pure
+                            className="sm:col-span-2"
+                            label="Sort by"
+                            help="Order recordings by this metric within the date range."
+                            error={activeFieldErrors.orderBy}
+                        >
+                            <LemonSelect
+                                fullWidth
+                                value={orderBy}
+                                onChange={(value) => {
+                                    setOrderBy(value)
+                                    clearFieldError('orderBy')
+                                }}
+                                options={[...SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS]}
+                            />
+                        </LemonField.Pure>
+                    </div>
+                </section>
             </div>
         </LemonModal>
     )
@@ -183,15 +156,24 @@ function EditSessionReplayWidgetModalForm(props: EditSessionReplayWidgetModalLog
 
 export function EditSessionReplayWidgetModal({
     isOpen,
-    ...formProps
+    onClose,
+    config,
+    onSave,
+    name,
+    defaultTitle,
+    description,
+    onSaveMetadata,
 }: DashboardWidgetEditModalProps): JSX.Element | null {
     if (!isOpen) {
         return null
     }
 
     return (
-        <BindLogic logic={editSessionReplayWidgetModalLogic} props={formProps}>
-            <EditSessionReplayWidgetModalForm {...formProps} />
+        <BindLogic
+            logic={editSessionReplayWidgetModalLogic}
+            props={{ onClose, config, onSave, name, defaultTitle, description, onSaveMetadata }}
+        >
+            <EditSessionReplayWidgetModalContents />
         </BindLogic>
     )
 }

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
@@ -32,7 +32,6 @@ function EditSessionReplayWidgetModalForm(props: EditSessionReplayWidgetModalLog
         activeFieldErrors,
         saving,
         saveDisabledReason,
-        defaultTitle,
     } = useValues(editSessionReplayWidgetModalLogic)
     const {
         setLimit,
@@ -84,7 +83,7 @@ function EditSessionReplayWidgetModalForm(props: EditSessionReplayWidgetModalLog
                                 <LemonInput
                                     value={tileName}
                                     onChange={setTileName}
-                                    placeholder={defaultTitle}
+                                    placeholder={props.defaultTitle ?? 'Untitled'}
                                     maxLength={400}
                                     disabled={saving}
                                 />

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
@@ -1,0 +1,198 @@
+import { BindLogic, useActions, useValues } from 'kea'
+
+import { LemonTextArea } from '@posthog/lemon-ui'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { LemonField } from 'lib/lemon-ui/LemonField/LemonField'
+import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
+
+import { DASHBOARD_WIDGET_CATALOG } from '../../widget_types/catalog'
+import { WIDGET_DATE_RANGE_SELECT_OPTIONS } from '../../widget_types/configSchemas'
+import type { DashboardWidgetEditModalProps } from '../registry'
+import {
+    editSessionReplayWidgetModalLogic,
+    type EditSessionReplayWidgetModalLogicProps,
+} from './editSessionReplayWidgetModalLogic'
+import { SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS } from './utils'
+
+const widgetSettingsFieldFullWidthClass = 'sm:col-span-2'
+
+function EditSessionReplayWidgetModalForm(props: EditSessionReplayWidgetModalLogicProps): JSX.Element {
+    const {
+        limit,
+        orderBy,
+        dateFrom,
+        tileName,
+        tileDescription,
+        filterTestAccounts,
+        activeFieldErrors,
+        saving,
+        saveDisabledReason,
+        defaultTitle,
+    } = useValues(editSessionReplayWidgetModalLogic)
+    const {
+        setLimit,
+        setOrderBy,
+        setDateFrom,
+        setTileName,
+        setTileDescription,
+        setFilterTestAccounts,
+        clearFieldError,
+        submit,
+    } = useActions(editSessionReplayWidgetModalLogic)
+
+    const catalogEntry = DASHBOARD_WIDGET_CATALOG.session_replay_list
+
+    return (
+        <LemonModal
+            isOpen
+            onClose={props.onClose}
+            title="Widget settings"
+            description="Configure tile details and which session recordings appear on this dashboard."
+            width={680}
+            footer={
+                <>
+                    <div className="flex-1" />
+                    <LemonButton type="secondary" onClick={props.onClose} disabled={saving}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        loading={saving}
+                        disabledReason={saveDisabledReason}
+                        onClick={() => submit()}
+                    >
+                        Save
+                    </LemonButton>
+                </>
+            }
+        >
+            <div className="flex flex-col gap-4">
+                {props.onSaveMetadata && (
+                    <section className="flex flex-col gap-3">
+                        <h5 className="text-sm font-semibold m-0">Tile details</h5>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <LemonField.Pure
+                                className={widgetSettingsFieldFullWidthClass}
+                                label="Title"
+                                help="Shown on the tile. Leave empty to use the default title."
+                            >
+                                <LemonInput
+                                    value={tileName}
+                                    onChange={setTileName}
+                                    placeholder={defaultTitle}
+                                    maxLength={400}
+                                    disabled={saving}
+                                />
+                            </LemonField.Pure>
+                            <LemonField.Pure
+                                className={widgetSettingsFieldFullWidthClass}
+                                label="Description"
+                                help="Shown under the tile title. Supports markdown. Leave empty to hide."
+                            >
+                                <LemonTextArea
+                                    value={tileDescription}
+                                    onChange={setTileDescription}
+                                    placeholder="Enter description (optional)"
+                                    minRows={2}
+                                    disabled={saving}
+                                />
+                            </LemonField.Pure>
+                        </div>
+                    </section>
+                )}
+                <>
+                    {props.onSaveMetadata && <LemonDivider className="my-0" />}
+                    <section className="flex flex-col gap-3">
+                        <h5 className="text-sm font-semibold m-0">Filters</h5>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div className={widgetSettingsFieldFullWidthClass}>
+                                <TestAccountFilter
+                                    size="small"
+                                    filters={{ filter_test_accounts: filterTestAccounts }}
+                                    onChange={({ filter_test_accounts }) =>
+                                        setFilterTestAccounts(filter_test_accounts ?? false)
+                                    }
+                                    disabledReason={saving ? 'Saving…' : undefined}
+                                />
+                            </div>
+                        </div>
+                    </section>
+                    <LemonDivider className="my-0" />
+                    <section className="flex flex-col gap-3">
+                        <h5 className="text-sm font-semibold m-0">{catalogEntry.groupLabel}</h5>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <LemonField.Pure
+                                label="Date range"
+                                help="Only include recordings started in this period."
+                                error={activeFieldErrors.dateFrom}
+                            >
+                                <LemonSelect
+                                    fullWidth
+                                    value={dateFrom}
+                                    onChange={(value) => {
+                                        setDateFrom(value)
+                                        clearFieldError('dateFrom')
+                                    }}
+                                    options={WIDGET_DATE_RANGE_SELECT_OPTIONS}
+                                />
+                            </LemonField.Pure>
+                            <LemonField.Pure
+                                label="Number of recordings"
+                                help="Show up to 25 recordings on the tile."
+                                error={activeFieldErrors.limit}
+                            >
+                                <LemonInput
+                                    type="number"
+                                    min={1}
+                                    max={25}
+                                    fullWidth
+                                    value={limit}
+                                    onChange={(value) => {
+                                        setLimit(Number(value))
+                                        clearFieldError('limit')
+                                    }}
+                                />
+                            </LemonField.Pure>
+                            <LemonField.Pure
+                                className={widgetSettingsFieldFullWidthClass}
+                                label="Sort by"
+                                help="Order recordings by this metric within the date range."
+                                error={activeFieldErrors.orderBy}
+                            >
+                                <LemonSelect
+                                    fullWidth
+                                    value={orderBy}
+                                    onChange={(value) => {
+                                        setOrderBy(value)
+                                        clearFieldError('orderBy')
+                                    }}
+                                    options={[...SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS]}
+                                />
+                            </LemonField.Pure>
+                        </div>
+                    </section>
+                </>
+            </div>
+        </LemonModal>
+    )
+}
+
+export function EditSessionReplayWidgetModal({
+    isOpen,
+    ...formProps
+}: DashboardWidgetEditModalProps): JSX.Element | null {
+    if (!isOpen) {
+        return null
+    }
+
+    return (
+        <BindLogic logic={editSessionReplayWidgetModalLogic} props={formProps}>
+            <EditSessionReplayWidgetModalForm {...formProps} />
+        </BindLogic>
+    )
+}

--- a/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.stories.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ReactNode } from 'react'
+
+import { DashboardPlacement } from '~/types'
+
+import { WidgetCard } from '../../components/WidgetCard/WidgetCard'
+import { WidgetCardBody } from '../../components/WidgetCard/WidgetCardBody'
+import { WidgetCardHeader, widgetCardShouldHideMoreButton } from '../../components/WidgetCard/WidgetCardHeader'
+import {
+    mockMoreOverlay,
+    widgetTileFrameDecorator,
+    withSessionReplayProjectState,
+} from '../../components/WidgetCard/widgetCardStoryFixtures'
+import { sessionReplaySampleRecordings } from '../../components/WidgetCard/widgetOverviewStoryFixtures'
+import { WidgetRuntimeAvailabilityGuard } from '../../components/WidgetRuntimeAvailabilityGuard/WidgetRuntimeAvailabilityGuard'
+import { getDashboardWidgetCatalogEntry } from '../../widget_types/catalog'
+import type { DashboardWidgetComponentProps } from '../registry'
+import { SessionReplayWidget } from './SessionReplayWidget'
+
+const SESSION_REPLAY_CATALOG = getDashboardWidgetCatalogEntry('session_replay_list')!
+const DEFAULT_CONFIG = SESSION_REPLAY_CATALOG.defaultConfig as Record<string, unknown>
+
+type SessionReplayWidgetTileStoryProps = DashboardWidgetComponentProps & {
+    title?: string
+    description?: string
+    showDescription?: boolean
+    body?: ReactNode
+}
+
+function SessionReplayWidgetTileStory({
+    title = '',
+    description = 'Recent session recordings you can open in the replay player.',
+    showDescription = true,
+    body,
+    ...widgetProps
+}: SessionReplayWidgetTileStoryProps): JSX.Element {
+    const widgetTypeLabel = SESSION_REPLAY_CATALOG.groupLabel ?? 'Session replay'
+    const defaultTitle = SESSION_REPLAY_CATALOG.headerTitle ?? SESSION_REPLAY_CATALOG.label
+
+    return (
+        <WidgetCard className="h-full">
+            <WidgetCardHeader
+                layout={SESSION_REPLAY_CATALOG.headerLayout}
+                title={title}
+                defaultTitle={defaultTitle}
+                titleHref={SESSION_REPLAY_CATALOG.titleHref}
+                widgetTypeLabel={widgetTypeLabel}
+                config={widgetProps.config}
+                headerMeta={SESSION_REPLAY_CATALOG.headerMeta}
+                description={description}
+                showDescription={showDescription}
+                loading={widgetProps.loading}
+                shouldHideMoreButton={widgetCardShouldHideMoreButton(DashboardPlacement.Dashboard, false)}
+                moreButtonOverlay={mockMoreOverlay}
+            />
+            <WidgetCardBody>{body ?? <SessionReplayWidget {...widgetProps} />}</WidgetCardBody>
+        </WidgetCard>
+    )
+}
+
+const meta: Meta<typeof SessionReplayWidgetTileStory> = {
+    title: 'Dashboards/Dashboard Widgets/Widget types/Session replay/Recent recordings',
+    component: SessionReplayWidgetTileStory,
+    parameters: {
+        layout: 'padded',
+    },
+    decorators: [...widgetTileFrameDecorator],
+    args: {
+        tileId: 1,
+        config: DEFAULT_CONFIG,
+        loading: false,
+        result: null,
+        onUpdateConfig: () => undefined,
+        onRefresh: () => undefined,
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof SessionReplayWidgetTileStory>
+
+export const Populated: Story = {
+    decorators: [withSessionReplayProjectState(true)],
+    args: {
+        title: 'Recent recordings',
+        config: { ...DEFAULT_CONFIG, orderBy: 'start_time' },
+        loading: false,
+        result: {
+            results: sessionReplaySampleRecordings,
+            hasMore: true,
+            limit: 10,
+        },
+    },
+}
+
+export const Loading: Story = {
+    decorators: [withSessionReplayProjectState(true)],
+    args: {
+        title: 'Recent recordings',
+        config: DEFAULT_CONFIG,
+        loading: true,
+        result: null,
+    },
+}
+
+export const Empty: Story = {
+    decorators: [withSessionReplayProjectState(true)],
+    args: {
+        title: 'Recent recordings',
+        config: DEFAULT_CONFIG,
+        loading: false,
+        result: { results: [] },
+    },
+}
+
+export const SetupUnavailable: Story = {
+    decorators: [withSessionReplayProjectState(false)],
+    render: (args) => (
+        <SessionReplayWidgetTileStory
+            {...args}
+            body={
+                <WidgetRuntimeAvailabilityGuard availability={SESSION_REPLAY_CATALOG.availability}>
+                    <SessionReplayWidget {...args} />
+                </WidgetRuntimeAvailabilityGuard>
+            }
+        />
+    ),
+    args: {
+        title: 'Recent recordings',
+        config: DEFAULT_CONFIG,
+        loading: false,
+        result: null,
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Uses catalog `session_replay_enabled` availability via `WidgetRuntimeAvailabilityGuard` when session replay is disabled.',
+            },
+        },
+    },
+}

--- a/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.stories.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.stories.tsx
@@ -115,7 +115,7 @@ export const Empty: Story = {
 
 export const SetupUnavailable: Story = {
     decorators: [withSessionReplayProjectState(false)],
-    render: (args) => (
+    render: (args: SessionReplayWidgetTileStoryProps) => (
         <SessionReplayWidgetTileStory
             {...args}
             body={

--- a/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.stories.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../components/WidgetCard/widgetCardStoryFixtures'
 import { sessionReplaySampleRecordings } from '../../components/WidgetCard/widgetOverviewStoryFixtures'
 import { WidgetRuntimeAvailabilityGuard } from '../../components/WidgetRuntimeAvailabilityGuard/WidgetRuntimeAvailabilityGuard'
-import { getDashboardWidgetCatalogEntry } from '../../widget_types/catalog'
+import { getDashboardWidgetCatalogEntry, getDashboardWidgetGroupLabel } from '../../widget_types/catalog'
 import type { DashboardWidgetComponentProps } from '../registry'
 import { SessionReplayWidget } from './SessionReplayWidget'
 
@@ -34,7 +34,7 @@ function SessionReplayWidgetTileStory({
     body,
     ...widgetProps
 }: SessionReplayWidgetTileStoryProps): JSX.Element {
-    const widgetTypeLabel = SESSION_REPLAY_CATALOG.groupLabel ?? 'Session replay'
+    const widgetTypeLabel = getDashboardWidgetGroupLabel(SESSION_REPLAY_CATALOG.groupId)
     const defaultTitle = SESSION_REPLAY_CATALOG.headerTitle ?? SESSION_REPLAY_CATALOG.label
 
     return (
@@ -100,6 +100,9 @@ export const Loading: Story = {
         config: DEFAULT_CONFIG,
         loading: true,
         result: null,
+    },
+    parameters: {
+        testOptions: { waitForLoadersToDisappear: false },
     },
 }
 

--- a/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.test.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.test.tsx
@@ -1,0 +1,61 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import '@testing-library/jest-dom'
+
+import { render, screen, cleanup } from '@testing-library/react'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import { SessionReplayWidget } from './SessionReplayWidget'
+
+jest.mock('scenes/session-recordings/playlist/SessionRecordingPreview', () => ({
+    SessionRecordingPreview: ({ recording }: { recording: { id: string } }): JSX.Element => (
+        <div data-attr="session-recording-preview">{recording.id}</div>
+    ),
+    SessionRecordingPreviewSkeleton: (): JSX.Element => <div data-attr="session-recording-preview-skeleton" />,
+}))
+
+describe('SessionReplayWidget', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    beforeEach(() => {
+        initKeaTests(true, { ...MOCK_DEFAULT_TEAM, session_recording_opt_in: true })
+        teamLogic.mount()
+    })
+
+    const recording = {
+        id: 'recording-1',
+        viewed: false,
+        viewers: [],
+        recording_duration: 120,
+        start_time: '2026-05-26T08:00:00.000Z',
+        end_time: '2026-05-26T08:02:00.000Z',
+        snapshot_source: 'web' as const,
+    }
+
+    it('renders recording rows from the widget result payload', () => {
+        render(
+            <SessionReplayWidget
+                tileId={1}
+                config={{ limit: 10 }}
+                loading={false}
+                result={{ results: [recording], hasMore: false, limit: 10 }}
+            />
+        )
+
+        expect(screen.getByText('recording-1')).toBeInTheDocument()
+    })
+
+    it('renders an empty state when there are no recordings', () => {
+        const { container } = render(
+            <SessionReplayWidget tileId={1} config={{ limit: 10 }} loading={false} result={{ results: [] }} />
+        )
+
+        expect(container.querySelector('[data-attr="session-replay-widget-empty-state"]')).toBeInTheDocument()
+        expect(screen.getByText('No recordings yet')).toBeInTheDocument()
+    })
+})

--- a/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.tsx
@@ -16,11 +16,7 @@ import type { SessionRecordingType } from '~/types'
 
 import { WidgetCardBodyMessage, WidgetCardContent } from '../../components/WidgetCard'
 import type { DashboardWidgetComponentProps } from '../registry'
-import {
-    getWidgetRecordingOrder,
-    SESSION_REPLAY_WIDGET_LOADING_SKELETON_ROW_COUNT,
-    type SessionReplayWidgetResult,
-} from './utils'
+import { getWidgetRecordingOrder, type SessionReplayWidgetResult } from './utils'
 
 function SessionReplayWidgetRecordingRow({
     recording,
@@ -61,7 +57,7 @@ export function SessionReplayWidget({ result, loading, config }: DashboardWidget
     if (loading) {
         return (
             <WidgetCardContent>
-                {Array.from({ length: SESSION_REPLAY_WIDGET_LOADING_SKELETON_ROW_COUNT }, (_, index) => (
+                {Array.from({ length: 4 }, (_, index) => (
                     <div key={index} className="border-b">
                         <SessionRecordingPreviewSkeleton />
                     </div>

--- a/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.tsx
@@ -1,0 +1,101 @@
+import { useActions } from 'kea'
+import { useEffect } from 'react'
+
+import { FilmCameraHog } from 'lib/components/hedgehogs'
+import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
+import 'scenes/session-recordings/playlist/SessionRecordingPreview.scss'
+import {
+    SessionRecordingPreview,
+    SessionRecordingPreviewSkeleton,
+} from 'scenes/session-recordings/playlist/SessionRecordingPreview'
+import { sessionRecordingsListPropertiesLogic } from 'scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic'
+import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
+
+import type { RecordingsQuery } from '~/queries/schema/schema-general'
+import type { SessionRecordingType } from '~/types'
+
+import { WidgetCardBodyMessage, WidgetCardContent } from '../../components/WidgetCard'
+import type { DashboardWidgetComponentProps } from '../registry'
+import {
+    getWidgetRecordingOrder,
+    SESSION_REPLAY_WIDGET_LOADING_SKELETON_ROW_COUNT,
+    type SessionReplayWidgetResult,
+} from './utils'
+
+function SessionReplayWidgetRecordingRow({
+    recording,
+    order,
+}: {
+    recording: SessionRecordingType
+    order: RecordingsQuery['order']
+}): JSX.Element {
+    const { openSessionPlayer } = useActions(sessionPlayerModalLogic)
+    const { reportRecordingOpenedFromRecentRecordingList } = useActions(sessionRecordingEventUsageLogic)
+
+    return (
+        <div
+            className="border-b"
+            onClick={() => {
+                openSessionPlayer({ id: recording.id })
+                reportRecordingOpenedFromRecentRecordingList()
+            }}
+        >
+            <SessionRecordingPreview recording={recording} order={order} />
+        </div>
+    )
+}
+
+export function SessionReplayWidget({ result, loading, config }: DashboardWidgetComponentProps): JSX.Element {
+    const { maybeLoadPropertiesForSessions } = useActions(sessionRecordingsListPropertiesLogic)
+
+    const payload = result as SessionReplayWidgetResult | null | undefined
+    const recordings = payload?.results ?? []
+    const order = getWidgetRecordingOrder(config)
+
+    useEffect(() => {
+        if (recordings.length > 0) {
+            maybeLoadPropertiesForSessions(recordings)
+        }
+    }, [recordings, maybeLoadPropertiesForSessions])
+
+    if (loading) {
+        return (
+            <WidgetCardContent>
+                {Array.from({ length: SESSION_REPLAY_WIDGET_LOADING_SKELETON_ROW_COUNT }, (_, index) => (
+                    <div key={index} className="border-b">
+                        <SessionRecordingPreviewSkeleton />
+                    </div>
+                ))}
+            </WidgetCardContent>
+        )
+    }
+
+    if (recordings.length === 0) {
+        return (
+            <WidgetCardContent>
+                <WidgetCardBodyMessage>
+                    <div
+                        className="flex max-w-xs flex-col items-center gap-2 px-2 text-balance"
+                        data-attr="session-replay-widget-empty-state"
+                    >
+                        <FilmCameraHog className="size-20 shrink-0" />
+                        <p className="m-0 text-base font-semibold text-primary">No recordings yet</p>
+                        <p className="m-0 text-sm text-muted">
+                            No session recordings matched your filters for this date range.
+                        </p>
+                    </div>
+                </WidgetCardBodyMessage>
+            </WidgetCardContent>
+        )
+    }
+
+    return (
+        <WidgetCardContent>
+            <div className="flex flex-col">
+                {recordings.map((recording) => (
+                    <SessionReplayWidgetRecordingRow key={recording.id} recording={recording} order={order} />
+                ))}
+            </div>
+        </WidgetCardContent>
+    )
+}

--- a/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/SessionReplayWidget.tsx
@@ -1,5 +1,4 @@
 import { useActions } from 'kea'
-import { useEffect } from 'react'
 
 import { FilmCameraHog } from 'lib/components/hedgehogs'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
@@ -8,7 +7,6 @@ import {
     SessionRecordingPreview,
     SessionRecordingPreviewSkeleton,
 } from 'scenes/session-recordings/playlist/SessionRecordingPreview'
-import { sessionRecordingsListPropertiesLogic } from 'scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic'
 import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
 
 import type { RecordingsQuery } from '~/queries/schema/schema-general'
@@ -16,7 +14,13 @@ import type { SessionRecordingType } from '~/types'
 
 import { WidgetCardBodyMessage, WidgetCardContent } from '../../components/WidgetCard'
 import type { DashboardWidgetComponentProps } from '../registry'
-import { getWidgetRecordingOrder, type SessionReplayWidgetResult } from './utils'
+import { parseSessionReplayWidgetConfig } from './sessionReplayWidgetConfigValidation'
+
+type SessionReplayWidgetResult = {
+    results?: SessionRecordingType[]
+    hasMore?: boolean
+    limit?: number
+}
 
 function SessionReplayWidgetRecordingRow({
     recording,
@@ -42,17 +46,9 @@ function SessionReplayWidgetRecordingRow({
 }
 
 export function SessionReplayWidget({ result, loading, config }: DashboardWidgetComponentProps): JSX.Element {
-    const { maybeLoadPropertiesForSessions } = useActions(sessionRecordingsListPropertiesLogic)
-
     const payload = result as SessionReplayWidgetResult | null | undefined
     const recordings = payload?.results ?? []
-    const order = getWidgetRecordingOrder(config)
-
-    useEffect(() => {
-        if (recordings.length > 0) {
-            maybeLoadPropertiesForSessions(recordings)
-        }
-    }, [recordings, maybeLoadPropertiesForSessions])
+    const order = parseSessionReplayWidgetConfig(config).orderBy as RecordingsQuery['order']
 
     if (loading) {
         return (

--- a/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
@@ -4,6 +4,12 @@ import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/fil
 
 import { isWidgetConfigValidationError } from '../../utils'
 import { resolveWidgetFilterTestAccounts, type SessionReplayWidgetConfig } from '../../widget_types/configSchemas'
+import {
+    widgetEditModalSavingReducers,
+    widgetEditModalTileActions,
+    widgetEditModalTileReducers,
+} from '../editWidgetModalTileBuilders'
+import { getWidgetEditModalTileDefaults, saveWidgetTileMetadataAfterConfig } from '../editWidgetModalTileUtils'
 import type { DashboardWidgetEditModalProps } from '../registry'
 import type { editSessionReplayWidgetModalLogicType } from './editSessionReplayWidgetModalLogicType'
 import {
@@ -32,11 +38,10 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
     }),
 
     actions({
+        ...widgetEditModalTileActions,
         setLimit: (limit: number) => ({ limit }),
         setOrderBy: (orderBy: string) => ({ orderBy }),
         setDateFrom: (dateFrom: string) => ({ dateFrom }),
-        setTileName: (tileName: string) => ({ tileName }),
-        setTileDescription: (tileDescription: string) => ({ tileDescription }),
         setFilterTestAccounts: (filterTestAccounts: boolean) => ({ filterTestAccounts }),
         setFieldErrors: (fieldErrors: SessionReplayWidgetFieldErrors) => ({ fieldErrors }),
         clearFieldError: (field: keyof SessionReplayWidgetFieldErrors) => ({ field }),
@@ -46,6 +51,8 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
     }),
 
     reducers({
+        ...widgetEditModalTileReducers,
+        ...widgetEditModalSavingReducers,
         limit: [
             10,
             {
@@ -62,18 +69,6 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
             '-7d',
             {
                 setDateFrom: (_, { dateFrom }) => dateFrom,
-            },
-        ],
-        tileName: [
-            '',
-            {
-                setTileName: (_, { tileName }) => tileName,
-            },
-        ],
-        tileDescription: [
-            '',
-            {
-                setTileDescription: (_, { tileDescription }) => tileDescription,
             },
         ],
         filterTestAccounts: [
@@ -94,14 +89,6 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
                     delete next[field]
                     return next
                 },
-            },
-        ],
-        saving: [
-            false,
-            {
-                submit: () => true,
-                submitSuccess: () => false,
-                submitFailure: () => false,
             },
         ],
     }),
@@ -152,11 +139,10 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
         const baseConfig = parseSessionReplayWidgetConfig(props.config)
 
         return {
+            ...getWidgetEditModalTileDefaults(props),
             limit: baseConfig.limit,
             orderBy: baseConfig.orderBy,
             dateFrom: baseConfig.dateRange?.date_from ?? '-7d',
-            tileName: props.name ?? '',
-            tileDescription: props.description ?? '',
             filterTestAccounts: resolveWidgetFilterTestAccounts(
                 baseConfig.filterTestAccounts,
                 values.filterTestAccountsDefault
@@ -173,7 +159,7 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
                 orderBy: values.orderBy,
                 dateFrom: values.dateFrom,
                 filterTestAccounts: values.filterTestAccounts,
-                baseConfig: props.config,
+                baseConfig: values.widgetConfig,
             })
 
             if (!result.success) {
@@ -182,24 +168,8 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
             }
 
             try {
-                const trimmedName = values.tileName.trim()
-                const trimmedDescription = values.tileDescription.trim()
-                const nameChanged = trimmedName !== (props.name ?? '').trim()
-                const descriptionChanged = trimmedDescription !== (props.description ?? '').trim()
-
                 await props.onSave(result.config)
-                if (props.onSaveMetadata) {
-                    const metadata: { name?: string; description?: string } = {}
-                    if (nameChanged) {
-                        metadata.name = trimmedName === (props.defaultTitle ?? 'Untitled').trim() ? '' : trimmedName
-                    }
-                    if (descriptionChanged) {
-                        metadata.description = trimmedDescription
-                    }
-                    if (Object.keys(metadata).length > 0) {
-                        await props.onSaveMetadata(metadata)
-                    }
-                }
+                await saveWidgetTileMetadataAfterConfig(props, values.tileName, values.tileDescription)
                 actions.setFieldErrors({})
                 props.onClose()
                 actions.submitSuccess()

--- a/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
@@ -5,9 +5,17 @@ import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/fil
 import { isWidgetConfigValidationError } from '../../utils'
 import { resolveWidgetFilterTestAccounts, type SessionReplayWidgetConfig } from '../../widget_types/configSchemas'
 import {
+    widgetEditModalFieldErrorsActions,
+    widgetEditModalFieldErrorsReducers,
+    widgetEditModalFilterTestAccountsActions,
+    widgetEditModalFilterTestAccountsReducers,
+    widgetEditModalListFieldActions,
+    widgetEditModalListFieldReducers,
+    widgetEditModalPropSelectors,
     widgetEditModalSavingReducers,
     widgetEditModalTileActions,
     widgetEditModalTileReducers,
+    widgetEditModalValidationSelectors,
 } from '../editWidgetModalBuilders'
 import { getWidgetEditModalTileDefaults, saveWidgetTileMetadataAfterConfig } from '../editWidgetModalTileUtils'
 import type { DashboardWidgetEditModalProps } from '../registry'
@@ -38,59 +46,31 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
     }),
 
     actions({
+        setOrderBy: (orderBy: SessionReplayWidgetConfig['orderBy']) => ({ orderBy }),
+        ...widgetEditModalListFieldActions,
         ...widgetEditModalTileActions,
-        setLimit: (limit: number) => ({ limit }),
-        setOrderBy: (orderBy: string) => ({ orderBy }),
-        setDateFrom: (dateFrom: string) => ({ dateFrom }),
-        setFilterTestAccounts: (filterTestAccounts: boolean) => ({ filterTestAccounts }),
-        setFieldErrors: (fieldErrors: SessionReplayWidgetFieldErrors) => ({ fieldErrors }),
-        clearFieldError: (field: keyof SessionReplayWidgetFieldErrors) => ({ field }),
+        ...widgetEditModalFilterTestAccountsActions,
+        ...widgetEditModalFieldErrorsActions,
         submit: true,
         submitSuccess: true,
         submitFailure: true,
     }),
 
     reducers({
-        ...widgetEditModalTileReducers,
-        ...widgetEditModalSavingReducers,
-        limit: [
-            10,
-            {
-                setLimit: (_, { limit }) => limit,
-            },
-        ],
         orderBy: [
-            'start_time',
+            'start_time' as SessionReplayWidgetConfig['orderBy'],
             {
-                setOrderBy: (_, { orderBy }) => orderBy,
+                setOrderBy: (
+                    _: SessionReplayWidgetConfig['orderBy'],
+                    { orderBy }: { orderBy: SessionReplayWidgetConfig['orderBy'] }
+                ) => orderBy,
             },
         ],
-        dateFrom: [
-            '-7d',
-            {
-                setDateFrom: (_, { dateFrom }) => dateFrom,
-            },
-        ],
-        filterTestAccounts: [
-            false,
-            {
-                setFilterTestAccounts: (_, { filterTestAccounts }) => filterTestAccounts,
-            },
-        ],
-        fieldErrors: [
-            {} as SessionReplayWidgetFieldErrors,
-            {
-                setFieldErrors: (_, { fieldErrors }) => fieldErrors,
-                clearFieldError: (state, { field }) => {
-                    if (!state[field]) {
-                        return state
-                    }
-                    const next = { ...state }
-                    delete next[field]
-                    return next
-                },
-            },
-        ],
+        ...widgetEditModalListFieldReducers,
+        ...widgetEditModalTileReducers,
+        ...widgetEditModalFilterTestAccountsReducers,
+        ...widgetEditModalFieldErrorsReducers,
+        ...widgetEditModalSavingReducers,
     }),
 
     selectors({
@@ -98,9 +78,7 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
             (_, p) => [p.config],
             (config): SessionReplayWidgetConfig => parseSessionReplayWidgetConfig(config),
         ],
-        onClose: [(_, p) => [p.onClose], (onClose) => onClose],
-        defaultTitle: [(_, p) => [p.defaultTitle], (defaultTitle) => defaultTitle ?? 'Untitled'],
-        onSaveMetadata: [(_, p) => [p.onSaveMetadata], (onSaveMetadata) => onSaveMetadata],
+        ...widgetEditModalPropSelectors,
         validation: [
             (s) => [s.limit, s.orderBy, s.dateFrom, s.filterTestAccounts, s.widgetConfig],
             (limit, orderBy, dateFrom, filterTestAccounts, widgetConfig) =>
@@ -112,27 +90,7 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
                     baseConfig: widgetConfig,
                 }),
         ],
-        activeFieldErrors: [
-            (s) => [s.validation, s.fieldErrors],
-            (validation, fieldErrors): SessionReplayWidgetFieldErrors => {
-                if (!validation.success) {
-                    return { ...validation.fieldErrors, ...fieldErrors }
-                }
-                return fieldErrors
-            },
-        ],
-        saveDisabledReason: [
-            (s) => [s.saving, s.validation],
-            (saving, validation): string | undefined => {
-                if (saving) {
-                    return 'Saving…'
-                }
-                if (!validation.success) {
-                    return 'Fix validation errors to save'
-                }
-                return undefined
-            },
-        ],
+        ...widgetEditModalValidationSelectors,
     }),
 
     defaults(({ props, values }) => {

--- a/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
@@ -3,10 +3,11 @@ import { actions, connect, defaults, kea, listeners, path, props, reducers, sele
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
 
 import { isWidgetConfigValidationError } from '../../utils'
-import { resolveWidgetFilterTestAccounts } from '../../widget_types/configSchemas'
+import { resolveWidgetFilterTestAccounts, type SessionReplayWidgetConfig } from '../../widget_types/configSchemas'
 import type { DashboardWidgetEditModalProps } from '../registry'
 import type { editSessionReplayWidgetModalLogicType } from './editSessionReplayWidgetModalLogicType'
 import {
+    parseSessionReplayWidgetConfig,
     validateSessionReplayWidgetConfigInput,
     type SessionReplayWidgetFieldErrors,
 } from './sessionReplayWidgetConfigValidation'
@@ -105,7 +106,13 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
     }),
 
     selectors({
-        widgetConfig: [(_, p) => [p.config], (config): Record<string, unknown> => config],
+        widgetConfig: [
+            (_, p) => [p.config],
+            (config): SessionReplayWidgetConfig => parseSessionReplayWidgetConfig(config),
+        ],
+        onClose: [(_, p) => [p.onClose], (onClose) => onClose],
+        defaultTitle: [(_, p) => [p.defaultTitle], (defaultTitle) => defaultTitle ?? 'Untitled'],
+        onSaveMetadata: [(_, p) => [p.onSaveMetadata], (onSaveMetadata) => onSaveMetadata],
         validation: [
             (s) => [s.limit, s.orderBy, s.dateFrom, s.filterTestAccounts, s.widgetConfig],
             (limit, orderBy, dateFrom, filterTestAccounts, widgetConfig) =>
@@ -138,20 +145,19 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
                 return undefined
             },
         ],
-        defaultTitle: [(_, p) => [p.defaultTitle], (defaultTitle): string => defaultTitle ?? 'Untitled'],
     }),
 
     defaults(({ props, values }) => {
-        const dateFrom = (props.config.dateRange as { date_from?: string } | undefined)?.date_from ?? '-7d'
+        const baseConfig = parseSessionReplayWidgetConfig(props.config)
 
         return {
-            limit: (props.config.limit as number) ?? 10,
-            orderBy: (props.config.orderBy as string) ?? 'start_time',
-            dateFrom,
+            limit: baseConfig.limit,
+            orderBy: baseConfig.orderBy,
+            dateFrom: baseConfig.dateRange?.date_from ?? '-7d',
             tileName: props.name ?? '',
             tileDescription: props.description ?? '',
             filterTestAccounts: resolveWidgetFilterTestAccounts(
-                props.config.filterTestAccounts as boolean | undefined,
+                baseConfig.filterTestAccounts,
                 values.filterTestAccountsDefault
             ),
             fieldErrors: {},

--- a/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
@@ -14,7 +14,7 @@ import {
     widgetEditModalPropSelectors,
     widgetEditModalTileActions,
 } from '../editWidgetModalBuilders'
-import { getWidgetEditModalTileDefaults, saveWidgetTileMetadataAfterConfig } from '../editWidgetModalTileUtils'
+import { buildWidgetTileMetadataPatch, getWidgetEditModalTileDefaults } from '../editWidgetModalTileUtils'
 import type { DashboardWidgetEditModalProps } from '../registry'
 import type { editSessionReplayWidgetModalLogicType } from './editSessionReplayWidgetModalLogicType'
 import {
@@ -32,7 +32,6 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
         config: {},
         onSave: async () => {},
         onClose: () => {},
-        onSaveMetadata: undefined,
         name: '',
         defaultTitle: 'Untitled',
         description: '',
@@ -199,8 +198,10 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
             }
 
             try {
-                await props.onSave(result.config)
-                await saveWidgetTileMetadataAfterConfig(props, values.tileName, values.tileDescription)
+                await props.onSave(
+                    result.config,
+                    buildWidgetTileMetadataPatch(props, values.tileName, values.tileDescription)
+                )
                 actions.setFieldErrors({})
                 props.onClose()
                 actions.submitSuccess()

--- a/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
@@ -21,6 +21,7 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
         config: {},
         onSave: async () => {},
         onClose: () => {},
+        onSaveMetadata: undefined,
         name: '',
         defaultTitle: 'Untitled',
         description: '',

--- a/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
@@ -3,19 +3,16 @@ import { actions, connect, defaults, kea, listeners, path, props, reducers, sele
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
 
 import { isWidgetConfigValidationError } from '../../utils'
-import { resolveWidgetFilterTestAccounts, type SessionReplayWidgetConfig } from '../../widget_types/configSchemas'
 import {
-    widgetEditModalFieldErrorsActions,
-    widgetEditModalFieldErrorsReducers,
+    resolveWidgetFilterTestAccounts,
+    type SessionReplayWidgetConfig,
+    type WidgetDateFromValue,
+} from '../../widget_types/configSchemas'
+import {
     widgetEditModalFilterTestAccountsActions,
-    widgetEditModalFilterTestAccountsReducers,
     widgetEditModalListFieldActions,
-    widgetEditModalListFieldReducers,
     widgetEditModalPropSelectors,
-    widgetEditModalSavingReducers,
     widgetEditModalTileActions,
-    widgetEditModalTileReducers,
-    widgetEditModalValidationSelectors,
 } from '../editWidgetModalBuilders'
 import { getWidgetEditModalTileDefaults, saveWidgetTileMetadataAfterConfig } from '../editWidgetModalTileUtils'
 import type { DashboardWidgetEditModalProps } from '../registry'
@@ -46,11 +43,12 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
     }),
 
     actions({
-        setOrderBy: (orderBy: SessionReplayWidgetConfig['orderBy']) => ({ orderBy }),
+        setOrderBy: (orderBy: string) => ({ orderBy }),
         ...widgetEditModalListFieldActions,
         ...widgetEditModalTileActions,
         ...widgetEditModalFilterTestAccountsActions,
-        ...widgetEditModalFieldErrorsActions,
+        setFieldErrors: (fieldErrors: SessionReplayWidgetFieldErrors) => ({ fieldErrors }),
+        clearFieldError: (field: keyof SessionReplayWidgetFieldErrors) => ({ field }),
         submit: true,
         submitSuccess: true,
         submitFailure: true,
@@ -62,15 +60,70 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
             {
                 setOrderBy: (
                     _: SessionReplayWidgetConfig['orderBy'],
-                    { orderBy }: { orderBy: SessionReplayWidgetConfig['orderBy'] }
-                ) => orderBy,
+                    { orderBy }: { orderBy: string }
+                ): SessionReplayWidgetConfig['orderBy'] => orderBy as SessionReplayWidgetConfig['orderBy'],
             },
         ],
-        ...widgetEditModalListFieldReducers,
-        ...widgetEditModalTileReducers,
-        ...widgetEditModalFilterTestAccountsReducers,
-        ...widgetEditModalFieldErrorsReducers,
-        ...widgetEditModalSavingReducers,
+        limit: [
+            10,
+            {
+                setLimit: (_: number, { limit }: { limit: number }) => limit,
+            },
+        ],
+        dateFrom: [
+            '-7d',
+            {
+                setDateFrom: (_: WidgetDateFromValue, { dateFrom }: { dateFrom: string }): WidgetDateFromValue =>
+                    dateFrom as WidgetDateFromValue,
+            },
+        ],
+        tileName: [
+            '',
+            {
+                setTileName: (_: string, { tileName }: { tileName: string }) => tileName,
+            },
+        ],
+        tileDescription: [
+            '',
+            {
+                setTileDescription: (_: string, { tileDescription }: { tileDescription: string }) => tileDescription,
+            },
+        ],
+        filterTestAccounts: [
+            false,
+            {
+                setFilterTestAccounts: (_: boolean, { filterTestAccounts }: { filterTestAccounts: boolean }) =>
+                    filterTestAccounts,
+            },
+        ],
+        fieldErrors: [
+            {} as SessionReplayWidgetFieldErrors,
+            {
+                setFieldErrors: (
+                    _: SessionReplayWidgetFieldErrors,
+                    { fieldErrors }: { fieldErrors: SessionReplayWidgetFieldErrors }
+                ) => fieldErrors,
+                clearFieldError: (
+                    state: SessionReplayWidgetFieldErrors,
+                    { field }: { field: keyof SessionReplayWidgetFieldErrors }
+                ) => {
+                    if (!state[field]) {
+                        return state
+                    }
+                    const next = { ...state }
+                    delete next[field]
+                    return next
+                },
+            },
+        ],
+        saving: [
+            false,
+            {
+                submit: (_state: boolean, _payload: { value: true }) => true,
+                submitSuccess: (_state: boolean, _payload: { value: true }) => false,
+                submitFailure: (_state: boolean, _payload: { value: true }) => false,
+            },
+        ],
     }),
 
     selectors({
@@ -90,17 +143,37 @@ export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModa
                     baseConfig: widgetConfig,
                 }),
         ],
-        ...widgetEditModalValidationSelectors,
+        activeFieldErrors: [
+            (s) => [s.validation, s.fieldErrors],
+            (validation, fieldErrors): SessionReplayWidgetFieldErrors => {
+                if (!validation.success) {
+                    return { ...validation.fieldErrors, ...fieldErrors }
+                }
+                return fieldErrors
+            },
+        ],
+        saveDisabledReason: [
+            (s) => [s.saving, s.validation],
+            (saving, validation): string | undefined => {
+                if (saving) {
+                    return 'Saving…'
+                }
+                if (!validation.success) {
+                    return 'Fix validation errors to save'
+                }
+                return undefined
+            },
+        ],
     }),
 
     defaults(({ props, values }) => {
         const baseConfig = parseSessionReplayWidgetConfig(props.config)
 
         return {
-            ...getWidgetEditModalTileDefaults(props),
             limit: baseConfig.limit,
             orderBy: baseConfig.orderBy,
             dateFrom: baseConfig.dateRange?.date_from ?? '-7d',
+            ...getWidgetEditModalTileDefaults(props),
             filterTestAccounts: resolveWidgetFilterTestAccounts(
                 baseConfig.filterTestAccounts,
                 values.filterTestAccountsDefault

--- a/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
@@ -1,0 +1,209 @@
+import { actions, connect, defaults, kea, listeners, path, props, reducers, selectors } from 'kea'
+
+import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
+
+import { isWidgetConfigValidationError } from '../../utils'
+import { resolveWidgetFilterTestAccounts } from '../../widget_types/configSchemas'
+import type { DashboardWidgetEditModalProps } from '../registry'
+import type { editSessionReplayWidgetModalLogicType } from './editSessionReplayWidgetModalLogicType'
+import {
+    validateSessionReplayWidgetConfigInput,
+    type SessionReplayWidgetFieldErrors,
+} from './sessionReplayWidgetConfigValidation'
+
+export type EditSessionReplayWidgetModalLogicProps = Omit<DashboardWidgetEditModalProps, 'isOpen'>
+
+export const editSessionReplayWidgetModalLogic = kea<editSessionReplayWidgetModalLogicType>([
+    path(['products', 'dashboards', 'widgets', 'session_replay', 'editSessionReplayWidgetModalLogic']),
+
+    props({
+        config: {},
+        onSave: async () => {},
+        onClose: () => {},
+        name: '',
+        defaultTitle: 'Untitled',
+        description: '',
+    } as EditSessionReplayWidgetModalLogicProps),
+
+    connect({
+        values: [filterTestAccountsDefaultsLogic, ['filterTestAccountsDefault']],
+    }),
+
+    actions({
+        setLimit: (limit: number) => ({ limit }),
+        setOrderBy: (orderBy: string) => ({ orderBy }),
+        setDateFrom: (dateFrom: string) => ({ dateFrom }),
+        setTileName: (tileName: string) => ({ tileName }),
+        setTileDescription: (tileDescription: string) => ({ tileDescription }),
+        setFilterTestAccounts: (filterTestAccounts: boolean) => ({ filterTestAccounts }),
+        setFieldErrors: (fieldErrors: SessionReplayWidgetFieldErrors) => ({ fieldErrors }),
+        clearFieldError: (field: keyof SessionReplayWidgetFieldErrors) => ({ field }),
+        submit: true,
+        submitSuccess: true,
+        submitFailure: true,
+    }),
+
+    reducers({
+        limit: [
+            10,
+            {
+                setLimit: (_, { limit }) => limit,
+            },
+        ],
+        orderBy: [
+            'start_time',
+            {
+                setOrderBy: (_, { orderBy }) => orderBy,
+            },
+        ],
+        dateFrom: [
+            '-7d',
+            {
+                setDateFrom: (_, { dateFrom }) => dateFrom,
+            },
+        ],
+        tileName: [
+            '',
+            {
+                setTileName: (_, { tileName }) => tileName,
+            },
+        ],
+        tileDescription: [
+            '',
+            {
+                setTileDescription: (_, { tileDescription }) => tileDescription,
+            },
+        ],
+        filterTestAccounts: [
+            false,
+            {
+                setFilterTestAccounts: (_, { filterTestAccounts }) => filterTestAccounts,
+            },
+        ],
+        fieldErrors: [
+            {} as SessionReplayWidgetFieldErrors,
+            {
+                setFieldErrors: (_, { fieldErrors }) => fieldErrors,
+                clearFieldError: (state, { field }) => {
+                    if (!state[field]) {
+                        return state
+                    }
+                    const next = { ...state }
+                    delete next[field]
+                    return next
+                },
+            },
+        ],
+        saving: [
+            false,
+            {
+                submit: () => true,
+                submitSuccess: () => false,
+                submitFailure: () => false,
+            },
+        ],
+    }),
+
+    selectors({
+        widgetConfig: [(_, p) => [p.config], (config): Record<string, unknown> => config],
+        validation: [
+            (s) => [s.limit, s.orderBy, s.dateFrom, s.filterTestAccounts, s.widgetConfig],
+            (limit, orderBy, dateFrom, filterTestAccounts, widgetConfig) =>
+                validateSessionReplayWidgetConfigInput({
+                    limit,
+                    orderBy,
+                    dateFrom,
+                    filterTestAccounts,
+                    baseConfig: widgetConfig,
+                }),
+        ],
+        activeFieldErrors: [
+            (s) => [s.validation, s.fieldErrors],
+            (validation, fieldErrors): SessionReplayWidgetFieldErrors => {
+                if (!validation.success) {
+                    return { ...validation.fieldErrors, ...fieldErrors }
+                }
+                return fieldErrors
+            },
+        ],
+        saveDisabledReason: [
+            (s) => [s.saving, s.validation],
+            (saving, validation): string | undefined => {
+                if (saving) {
+                    return 'Saving…'
+                }
+                if (!validation.success) {
+                    return 'Fix validation errors to save'
+                }
+                return undefined
+            },
+        ],
+        defaultTitle: [(_, p) => [p.defaultTitle], (defaultTitle): string => defaultTitle ?? 'Untitled'],
+    }),
+
+    defaults(({ props, values }) => {
+        const dateFrom = (props.config.dateRange as { date_from?: string } | undefined)?.date_from ?? '-7d'
+
+        return {
+            limit: (props.config.limit as number) ?? 10,
+            orderBy: (props.config.orderBy as string) ?? 'start_time',
+            dateFrom,
+            tileName: props.name ?? '',
+            tileDescription: props.description ?? '',
+            filterTestAccounts: resolveWidgetFilterTestAccounts(
+                props.config.filterTestAccounts as boolean | undefined,
+                values.filterTestAccountsDefault
+            ),
+            fieldErrors: {},
+            saving: false,
+        }
+    }),
+
+    listeners(({ actions, props, values }) => ({
+        submit: async () => {
+            const result = validateSessionReplayWidgetConfigInput({
+                limit: values.limit,
+                orderBy: values.orderBy,
+                dateFrom: values.dateFrom,
+                filterTestAccounts: values.filterTestAccounts,
+                baseConfig: props.config,
+            })
+
+            if (!result.success) {
+                actions.setFieldErrors(result.fieldErrors)
+                return
+            }
+
+            try {
+                const trimmedName = values.tileName.trim()
+                const trimmedDescription = values.tileDescription.trim()
+                const nameChanged = trimmedName !== (props.name ?? '').trim()
+                const descriptionChanged = trimmedDescription !== (props.description ?? '').trim()
+
+                await props.onSave(result.config)
+                if (props.onSaveMetadata) {
+                    const metadata: { name?: string; description?: string } = {}
+                    if (nameChanged) {
+                        metadata.name = trimmedName === (props.defaultTitle ?? 'Untitled').trim() ? '' : trimmedName
+                    }
+                    if (descriptionChanged) {
+                        metadata.description = trimmedDescription
+                    }
+                    if (Object.keys(metadata).length > 0) {
+                        await props.onSaveMetadata(metadata)
+                    }
+                }
+                actions.setFieldErrors({})
+                props.onClose()
+                actions.submitSuccess()
+            } catch (error) {
+                actions.submitFailure()
+                if (isWidgetConfigValidationError(error)) {
+                    actions.setFieldErrors(error.fieldErrors as SessionReplayWidgetFieldErrors)
+                    return
+                }
+                throw error
+            }
+        },
+    })),
+])

--- a/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/session_replay/editSessionReplayWidgetModalLogic.ts
@@ -8,7 +8,7 @@ import {
     widgetEditModalSavingReducers,
     widgetEditModalTileActions,
     widgetEditModalTileReducers,
-} from '../editWidgetModalTileBuilders'
+} from '../editWidgetModalBuilders'
 import { getWidgetEditModalTileDefaults, saveWidgetTileMetadataAfterConfig } from '../editWidgetModalTileUtils'
 import type { DashboardWidgetEditModalProps } from '../registry'
 import type { editSessionReplayWidgetModalLogicType } from './editSessionReplayWidgetModalLogicType'

--- a/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.test.ts
+++ b/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.test.ts
@@ -1,0 +1,74 @@
+import { ApiError } from 'lib/api-error'
+
+import { sessionReplayWidgetConfigSchema } from '../../widget_types/configSchemas'
+import {
+    parseSessionReplayWidgetConfigApiError,
+    validateSessionReplayWidgetConfigInput,
+} from './sessionReplayWidgetConfigValidation'
+
+describe('validateSessionReplayWidgetConfigInput', () => {
+    it('rejects limit above 25 with inline-friendly message', () => {
+        const result = validateSessionReplayWidgetConfigInput({
+            limit: 30,
+            orderBy: 'start_time',
+            dateFrom: '-7d',
+            filterTestAccounts: true,
+            baseConfig: sessionReplayWidgetConfigSchema.parse({}),
+        })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+            expect(result.fieldErrors.limit).toBe('Must be an integer between 1 and 25.')
+        }
+    })
+
+    it('accepts valid config', () => {
+        const result = validateSessionReplayWidgetConfigInput({
+            limit: 10,
+            orderBy: 'start_time',
+            dateFrom: '-7d',
+            filterTestAccounts: true,
+            baseConfig: sessionReplayWidgetConfigSchema.parse({}),
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+            expect(result.config.limit).toBe(10)
+            expect(result.config.dateRange).toEqual({ date_from: '-7d' })
+            expect(result.config.filterTestAccounts).toBe(true)
+        }
+    })
+
+    it('accepts short date range', () => {
+        const result = validateSessionReplayWidgetConfigInput({
+            limit: 10,
+            orderBy: 'start_time',
+            dateFrom: '-1h',
+            filterTestAccounts: true,
+            baseConfig: sessionReplayWidgetConfigSchema.parse({}),
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+            expect(result.config.dateRange).toEqual({ date_from: '-1h' })
+        }
+    })
+})
+
+describe('parseSessionReplayWidgetConfigApiError', () => {
+    it('maps invalid config to zod field errors', () => {
+        const error = new ApiError('limit must be an integer between 1 and 25.', 400, undefined, {
+            config: 'limit must be an integer between 1 and 25.',
+        })
+
+        expect(
+            parseSessionReplayWidgetConfigApiError(error, {
+                limit: 30,
+                orderBy: 'start_time',
+                dateRange: { date_from: '-7d' },
+            })
+        ).toEqual({
+            limit: 'Must be an integer between 1 and 25.',
+        })
+    })
+})

--- a/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
@@ -1,0 +1,86 @@
+import type { ZodError } from 'zod'
+
+import { ApiError } from 'lib/api-error'
+
+import { sessionReplayWidgetConfigSchema } from '../../widget_types/configSchemas'
+
+export type SessionReplayWidgetFieldErrors = {
+    limit?: string
+    orderBy?: string
+    dateFrom?: string
+}
+
+function zodIssuesToFieldErrors(error: ZodError): SessionReplayWidgetFieldErrors {
+    const fieldErrors: SessionReplayWidgetFieldErrors = {}
+
+    for (const issue of error.issues) {
+        if (issue.path[0] === 'dateRange' && issue.path[1] === 'date_from') {
+            fieldErrors.dateFrom ??= issue.message
+            continue
+        }
+
+        if (issue.path[0] === 'limit') {
+            fieldErrors.limit ??= issue.message
+        } else if (issue.path[0] === 'orderBy') {
+            fieldErrors.orderBy ??= issue.message
+        }
+    }
+
+    return fieldErrors
+}
+
+export function buildSessionReplayWidgetConfigInput({
+    limit,
+    orderBy,
+    dateFrom,
+    filterTestAccounts,
+    baseConfig,
+}: {
+    limit: number
+    orderBy: string
+    dateFrom: string
+    filterTestAccounts: boolean
+    baseConfig: Record<string, unknown>
+}): Record<string, unknown> {
+    return {
+        ...baseConfig,
+        limit,
+        orderBy,
+        filterTestAccounts,
+        dateRange: { date_from: dateFrom },
+    }
+}
+
+export function validateSessionReplayWidgetConfigInput(input: {
+    limit: number
+    orderBy: string
+    dateFrom: string
+    filterTestAccounts: boolean
+    baseConfig: Record<string, unknown>
+}):
+    | { success: true; config: Record<string, unknown> }
+    | { success: false; fieldErrors: SessionReplayWidgetFieldErrors } {
+    const parsed = sessionReplayWidgetConfigSchema.safeParse(buildSessionReplayWidgetConfigInput(input))
+
+    if (parsed.success) {
+        return { success: true, config: parsed.data as Record<string, unknown> }
+    }
+
+    return { success: false, fieldErrors: zodIssuesToFieldErrors(parsed.error) }
+}
+
+export function parseSessionReplayWidgetConfigApiError(
+    error: unknown,
+    config: Record<string, unknown>
+): SessionReplayWidgetFieldErrors | null {
+    if (!(error instanceof ApiError)) {
+        return null
+    }
+
+    const parsed = sessionReplayWidgetConfigSchema.safeParse(config)
+    if (!parsed.success) {
+        return zodIssuesToFieldErrors(parsed.error)
+    }
+
+    return null
+}

--- a/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
@@ -1,54 +1,51 @@
-import type { ZodError } from 'zod'
+import { z, type ZodError } from 'zod'
 
 import { ApiError } from 'lib/api-error'
 
-import { sessionReplayWidgetConfigSchema } from '../../widget_types/configSchemas'
+import {
+    sessionReplayWidgetConfigSchema,
+    type SessionReplayWidgetConfig,
+    widgetDateFromSchema,
+    widgetLimitFieldSchema,
+} from '../../widget_types/configSchemas'
 
-export type SessionReplayWidgetFieldErrors = {
-    limit?: string
-    orderBy?: string
-    dateFrom?: string
+export type SessionReplayWidgetFieldErrors = Partial<Record<keyof SessionReplayWidgetFormInput, string>>
+
+export const sessionReplayWidgetFormSchema = z.object({
+    limit: widgetLimitFieldSchema,
+    orderBy: sessionReplayWidgetConfigSchema.shape.orderBy,
+    dateFrom: widgetDateFromSchema,
+    filterTestAccounts: z.boolean(),
+})
+
+export type SessionReplayWidgetFormInput = z.infer<typeof sessionReplayWidgetFormSchema>
+
+function fieldErrorsFromZodError(error: ZodError): SessionReplayWidgetFieldErrors {
+    const { fieldErrors } = z.flattenError(error)
+
+    return Object.fromEntries(
+        Object.entries(fieldErrors).flatMap(([field, messages]) =>
+            messages.length > 0 ? [[field, messages[0] as string]] : []
+        )
+    )
 }
 
-function zodIssuesToFieldErrors(error: ZodError): SessionReplayWidgetFieldErrors {
-    const fieldErrors: SessionReplayWidgetFieldErrors = {}
-
-    for (const issue of error.issues) {
-        if (issue.path[0] === 'dateRange' && issue.path[1] === 'date_from') {
-            fieldErrors.dateFrom ??= issue.message
-            continue
-        }
-
-        if (issue.path[0] === 'limit') {
-            fieldErrors.limit ??= issue.message
-        } else if (issue.path[0] === 'orderBy') {
-            fieldErrors.orderBy ??= issue.message
-        }
-    }
-
-    return fieldErrors
+export function parseSessionReplayWidgetConfig(config: Record<string, unknown>): SessionReplayWidgetConfig {
+    const parsed = sessionReplayWidgetConfigSchema.safeParse(config)
+    return parsed.success ? parsed.data : sessionReplayWidgetConfigSchema.parse({})
 }
 
-export function buildSessionReplayWidgetConfigInput({
-    limit,
-    orderBy,
-    dateFrom,
-    filterTestAccounts,
-    baseConfig,
-}: {
-    limit: number
-    orderBy: string
-    dateFrom: string
-    filterTestAccounts: boolean
-    baseConfig: Record<string, unknown>
-}): Record<string, unknown> {
-    return {
+export function buildSessionReplayWidgetConfig(
+    formInput: SessionReplayWidgetFormInput,
+    baseConfig: SessionReplayWidgetConfig
+): SessionReplayWidgetConfig {
+    return sessionReplayWidgetConfigSchema.parse({
         ...baseConfig,
-        limit,
-        orderBy,
-        filterTestAccounts,
-        dateRange: { date_from: dateFrom },
-    }
+        limit: formInput.limit,
+        orderBy: formInput.orderBy,
+        filterTestAccounts: formInput.filterTestAccounts,
+        dateRange: { date_from: formInput.dateFrom },
+    })
 }
 
 export function validateSessionReplayWidgetConfigInput(input: {
@@ -56,17 +53,25 @@ export function validateSessionReplayWidgetConfigInput(input: {
     orderBy: string
     dateFrom: string
     filterTestAccounts: boolean
-    baseConfig: Record<string, unknown>
+    baseConfig: SessionReplayWidgetConfig
 }):
-    | { success: true; config: Record<string, unknown> }
+    | { success: true; config: SessionReplayWidgetConfig }
     | { success: false; fieldErrors: SessionReplayWidgetFieldErrors } {
-    const parsed = sessionReplayWidgetConfigSchema.safeParse(buildSessionReplayWidgetConfigInput(input))
+    const parsed = sessionReplayWidgetFormSchema.safeParse({
+        limit: input.limit,
+        orderBy: input.orderBy,
+        dateFrom: input.dateFrom,
+        filterTestAccounts: input.filterTestAccounts,
+    })
 
-    if (parsed.success) {
-        return { success: true, config: parsed.data as Record<string, unknown> }
+    if (!parsed.success) {
+        return { success: false, fieldErrors: fieldErrorsFromZodError(parsed.error) }
     }
 
-    return { success: false, fieldErrors: zodIssuesToFieldErrors(parsed.error) }
+    return {
+        success: true,
+        config: buildSessionReplayWidgetConfig(parsed.data, input.baseConfig),
+    }
 }
 
 export function parseSessionReplayWidgetConfigApiError(
@@ -77,10 +82,21 @@ export function parseSessionReplayWidgetConfigApiError(
         return null
     }
 
-    const parsed = sessionReplayWidgetConfigSchema.safeParse(config)
-    if (!parsed.success) {
-        return zodIssuesToFieldErrors(parsed.error)
+    const parsedConfig = sessionReplayWidgetConfigSchema.safeParse(config)
+    if (parsedConfig.success) {
+        return null
     }
 
-    return null
+    const formInput: SessionReplayWidgetFormInput = {
+        limit: (config.limit as number) ?? 0,
+        orderBy: (config.orderBy as SessionReplayWidgetFormInput['orderBy']) ?? 'start_time',
+        dateFrom: (config.dateRange as { date_from?: string } | undefined)?.date_from ?? '-7d',
+        filterTestAccounts: (config.filterTestAccounts as boolean) ?? false,
+    }
+    const parsedForm = sessionReplayWidgetFormSchema.safeParse(formInput)
+    if (!parsedForm.success) {
+        return fieldErrorsFromZodError(parsedForm.error)
+    }
+
+    return fieldErrorsFromZodError(parsedConfig.error)
 }

--- a/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
@@ -4,28 +4,20 @@ import { ApiError } from 'lib/api-error'
 
 import {
     sessionReplayWidgetConfigSchema,
+    sessionReplayWidgetFormSchema,
     type SessionReplayWidgetConfig,
-    widgetDateFromSchema,
-    widgetLimitFieldSchema,
 } from '../../widget_types/configSchemas'
 
-export type SessionReplayWidgetFieldErrors = Partial<Record<keyof SessionReplayWidgetFormInput, string>>
+type SessionReplayWidgetFormField = keyof z.infer<typeof sessionReplayWidgetFormSchema>
 
-export const sessionReplayWidgetFormSchema = z.object({
-    limit: widgetLimitFieldSchema,
-    orderBy: sessionReplayWidgetConfigSchema.shape.orderBy,
-    dateFrom: widgetDateFromSchema,
-    filterTestAccounts: z.boolean(),
-})
-
-export type SessionReplayWidgetFormInput = z.infer<typeof sessionReplayWidgetFormSchema>
+export type SessionReplayWidgetFieldErrors = Partial<Record<SessionReplayWidgetFormField, string>>
 
 function fieldErrorsFromZodError(error: ZodError): SessionReplayWidgetFieldErrors {
     const { fieldErrors } = z.flattenError(error)
 
     return Object.fromEntries(
-        Object.entries(fieldErrors).flatMap(([field, messages]) =>
-            messages.length > 0 ? [[field, messages[0] as string]] : []
+        (Object.entries(fieldErrors) as [string, string[]][]).flatMap(([field, messages]) =>
+            messages.length > 0 ? [[field, messages[0]]] : []
         )
     )
 }
@@ -36,7 +28,7 @@ export function parseSessionReplayWidgetConfig(config: Record<string, unknown>):
 }
 
 export function buildSessionReplayWidgetConfig(
-    formInput: SessionReplayWidgetFormInput,
+    formInput: z.infer<typeof sessionReplayWidgetFormSchema>,
     baseConfig: SessionReplayWidgetConfig
 ): SessionReplayWidgetConfig {
     return sessionReplayWidgetConfigSchema.parse({
@@ -87,9 +79,9 @@ export function parseSessionReplayWidgetConfigApiError(
         return null
     }
 
-    const formInput: SessionReplayWidgetFormInput = {
+    const formInput = {
         limit: (config.limit as number) ?? 0,
-        orderBy: (config.orderBy as SessionReplayWidgetFormInput['orderBy']) ?? 'start_time',
+        orderBy: (config.orderBy as SessionReplayWidgetConfig['orderBy']) ?? 'start_time',
         dateFrom: (config.dateRange as { date_from?: string } | undefined)?.date_from ?? '-7d',
         filterTestAccounts: (config.filterTestAccounts as boolean) ?? false,
     }

--- a/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
@@ -1,43 +1,30 @@
-import { z, type ZodError } from 'zod'
-
-import { ApiError } from 'lib/api-error'
+import { z } from 'zod'
 
 import {
     sessionReplayWidgetConfigSchema,
     sessionReplayWidgetFormSchema,
     type SessionReplayWidgetConfig,
 } from '../../widget_types/configSchemas'
+import {
+    buildWidgetConfigFromForm,
+    parseWidgetConfig,
+    parseWidgetConfigApiError,
+    validateWidgetConfigInput as validateWidgetConfigInputShared,
+} from '../widgetConfigValidation'
 
 type SessionReplayWidgetFormField = keyof z.infer<typeof sessionReplayWidgetFormSchema>
 
 export type SessionReplayWidgetFieldErrors = Partial<Record<SessionReplayWidgetFormField, string>>
 
-function fieldErrorsFromZodError(error: ZodError): SessionReplayWidgetFieldErrors {
-    const { fieldErrors } = z.flattenError(error)
-
-    return Object.fromEntries(
-        (Object.entries(fieldErrors) as [string, string[]][]).flatMap(([field, messages]) =>
-            messages.length > 0 ? [[field, messages[0]]] : []
-        )
-    )
-}
-
 export function parseSessionReplayWidgetConfig(config: Record<string, unknown>): SessionReplayWidgetConfig {
-    const parsed = sessionReplayWidgetConfigSchema.safeParse(config)
-    return parsed.success ? parsed.data : sessionReplayWidgetConfigSchema.parse({})
+    return parseWidgetConfig(sessionReplayWidgetConfigSchema, config)
 }
 
 export function buildSessionReplayWidgetConfig(
     formInput: z.infer<typeof sessionReplayWidgetFormSchema>,
     baseConfig: SessionReplayWidgetConfig
 ): SessionReplayWidgetConfig {
-    return sessionReplayWidgetConfigSchema.parse({
-        ...baseConfig,
-        limit: formInput.limit,
-        orderBy: formInput.orderBy,
-        filterTestAccounts: formInput.filterTestAccounts,
-        dateRange: { date_from: formInput.dateFrom },
-    })
+    return buildWidgetConfigFromForm(sessionReplayWidgetConfigSchema, formInput, baseConfig)
 }
 
 export function validateSessionReplayWidgetConfigInput(input: {
@@ -49,46 +36,22 @@ export function validateSessionReplayWidgetConfigInput(input: {
 }):
     | { success: true; config: SessionReplayWidgetConfig }
     | { success: false; fieldErrors: SessionReplayWidgetFieldErrors } {
-    const parsed = sessionReplayWidgetFormSchema.safeParse({
-        limit: input.limit,
-        orderBy: input.orderBy,
-        dateFrom: input.dateFrom,
-        filterTestAccounts: input.filterTestAccounts,
+    return validateWidgetConfigInputShared({
+        formSchema: sessionReplayWidgetFormSchema,
+        buildConfig: buildSessionReplayWidgetConfig,
+        input,
     })
-
-    if (!parsed.success) {
-        return { success: false, fieldErrors: fieldErrorsFromZodError(parsed.error) }
-    }
-
-    return {
-        success: true,
-        config: buildSessionReplayWidgetConfig(parsed.data, input.baseConfig),
-    }
 }
 
 export function parseSessionReplayWidgetConfigApiError(
     error: unknown,
     config: Record<string, unknown>
 ): SessionReplayWidgetFieldErrors | null {
-    if (!(error instanceof ApiError)) {
-        return null
-    }
-
-    const parsedConfig = sessionReplayWidgetConfigSchema.safeParse(config)
-    if (parsedConfig.success) {
-        return null
-    }
-
-    const formInput = {
-        limit: (config.limit as number) ?? 0,
-        orderBy: (config.orderBy as SessionReplayWidgetConfig['orderBy']) ?? 'start_time',
-        dateFrom: (config.dateRange as { date_from?: string } | undefined)?.date_from ?? '-7d',
-        filterTestAccounts: (config.filterTestAccounts as boolean) ?? false,
-    }
-    const parsedForm = sessionReplayWidgetFormSchema.safeParse(formInput)
-    if (!parsedForm.success) {
-        return fieldErrorsFromZodError(parsedForm.error)
-    }
-
-    return fieldErrorsFromZodError(parsedConfig.error)
+    return parseWidgetConfigApiError({
+        error,
+        config,
+        configSchema: sessionReplayWidgetConfigSchema,
+        formSchema: sessionReplayWidgetFormSchema,
+        defaultOrderBy: 'start_time',
+    })
 }

--- a/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/session_replay/sessionReplayWidgetConfigValidation.ts
@@ -9,6 +9,7 @@ import {
     buildWidgetConfigFromForm,
     parseWidgetConfig,
     parseWidgetConfigApiError,
+    type WidgetListFormInput,
     validateWidgetConfigInput as validateWidgetConfigInputShared,
 } from '../widgetConfigValidation'
 
@@ -21,7 +22,7 @@ export function parseSessionReplayWidgetConfig(config: Record<string, unknown>):
 }
 
 export function buildSessionReplayWidgetConfig(
-    formInput: z.infer<typeof sessionReplayWidgetFormSchema>,
+    formInput: WidgetListFormInput,
     baseConfig: SessionReplayWidgetConfig
 ): SessionReplayWidgetConfig {
     return buildWidgetConfigFromForm(sessionReplayWidgetConfigSchema, formInput, baseConfig)

--- a/products/dashboards/frontend/widgets/session_replay/utils.ts
+++ b/products/dashboards/frontend/widgets/session_replay/utils.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_RECORDING_FILTERS_ORDER_BY } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
-
 import type { RecordingsQuery } from '~/queries/schema/schema-general'
 import type { SessionRecordingType } from '~/types'
+
+import { sessionReplayWidgetConfigSchema } from '../../widget_types/configSchemas'
 
 export type SessionReplayWidgetResult = {
     results?: SessionRecordingType[]
@@ -21,12 +21,6 @@ export const SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS = [
 ] as const
 
 export function getWidgetRecordingOrder(config: Record<string, unknown>): RecordingsQuery['order'] {
-    const orderBy = config.orderBy
-    if (
-        typeof orderBy === 'string' &&
-        SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS.some((option) => option.value === orderBy)
-    ) {
-        return orderBy as RecordingsQuery['order']
-    }
-    return DEFAULT_RECORDING_FILTERS_ORDER_BY
+    const parsed = sessionReplayWidgetConfigSchema.safeParse(config)
+    return parsed.success ? parsed.data.orderBy : 'start_time'
 }

--- a/products/dashboards/frontend/widgets/session_replay/utils.ts
+++ b/products/dashboards/frontend/widgets/session_replay/utils.ts
@@ -1,0 +1,32 @@
+import { DEFAULT_RECORDING_FILTERS_ORDER_BY } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
+
+import type { RecordingsQuery } from '~/queries/schema/schema-general'
+import type { SessionRecordingType } from '~/types'
+
+export type SessionReplayWidgetResult = {
+    results?: SessionRecordingType[]
+    hasMore?: boolean
+    limit?: number
+}
+
+/** Recording rows that fit in the default h:5 tile without clipping. */
+export const SESSION_REPLAY_WIDGET_LOADING_SKELETON_ROW_COUNT = 4
+
+export const SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS = [
+    { value: 'start_time', label: 'Start time' },
+    { value: 'activity_score', label: 'Activity score' },
+    { value: 'recording_duration', label: 'Duration' },
+    { value: 'click_count', label: 'Clicks' },
+    { value: 'console_error_count', label: 'Console errors' },
+] as const
+
+export function getWidgetRecordingOrder(config: Record<string, unknown>): RecordingsQuery['order'] {
+    const orderBy = config.orderBy
+    if (
+        typeof orderBy === 'string' &&
+        SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS.some((option) => option.value === orderBy)
+    ) {
+        return orderBy as RecordingsQuery['order']
+    }
+    return DEFAULT_RECORDING_FILTERS_ORDER_BY
+}

--- a/products/dashboards/frontend/widgets/session_replay/utils.ts
+++ b/products/dashboards/frontend/widgets/session_replay/utils.ts
@@ -9,9 +9,6 @@ export type SessionReplayWidgetResult = {
     limit?: number
 }
 
-/** Recording rows that fit in the default h:5 tile without clipping. */
-export const SESSION_REPLAY_WIDGET_LOADING_SKELETON_ROW_COUNT = 4
-
 export const SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS = [
     { value: 'start_time', label: 'Start time' },
     { value: 'activity_score', label: 'Activity score' },

--- a/products/dashboards/frontend/widgets/session_replay/utils.ts
+++ b/products/dashboards/frontend/widgets/session_replay/utils.ts
@@ -1,14 +1,3 @@
-import type { RecordingsQuery } from '~/queries/schema/schema-general'
-import type { SessionRecordingType } from '~/types'
-
-import { sessionReplayWidgetConfigSchema } from '../../widget_types/configSchemas'
-
-export type SessionReplayWidgetResult = {
-    results?: SessionRecordingType[]
-    hasMore?: boolean
-    limit?: number
-}
-
 export const SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS = [
     { value: 'start_time', label: 'Start time' },
     { value: 'activity_score', label: 'Activity score' },
@@ -16,8 +5,3 @@ export const SESSION_REPLAY_WIDGET_ORDER_BY_OPTIONS = [
     { value: 'click_count', label: 'Clicks' },
     { value: 'console_error_count', label: 'Console errors' },
 ] as const
-
-export function getWidgetRecordingOrder(config: Record<string, unknown>): RecordingsQuery['order'] {
-    const parsed = sessionReplayWidgetConfigSchema.safeParse(config)
-    return parsed.success ? parsed.data.orderBy : 'start_time'
-}

--- a/products/dashboards/frontend/widgets/widgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/widgetConfigValidation.ts
@@ -1,0 +1,101 @@
+import { z, type ZodError, type ZodType } from 'zod'
+
+import { ApiError } from 'lib/api-error'
+
+export function fieldErrorsFromZodError<TField extends string>(error: ZodError): Partial<Record<TField, string>> {
+    const { fieldErrors } = z.flattenError(error)
+
+    return Object.fromEntries(
+        (Object.entries(fieldErrors) as [string, string[]][]).flatMap(([field, messages]) =>
+            messages.length > 0 ? [[field, messages[0]]] : []
+        )
+    ) as Partial<Record<TField, string>>
+}
+
+export function parseWidgetConfig<T>(configSchema: ZodType<T>, config: Record<string, unknown>): T {
+    const parsed = configSchema.safeParse(config)
+    return parsed.success ? parsed.data : configSchema.parse({})
+}
+
+export type WidgetListFormInput = {
+    limit: number
+    orderBy: string
+    dateFrom: string
+    filterTestAccounts: boolean
+}
+
+export function buildWidgetConfigFromForm<TConfig>(
+    configSchema: ZodType<TConfig>,
+    formInput: WidgetListFormInput,
+    baseConfig: TConfig
+): TConfig {
+    return configSchema.parse({
+        ...baseConfig,
+        limit: formInput.limit,
+        orderBy: formInput.orderBy,
+        filterTestAccounts: formInput.filterTestAccounts,
+        dateRange: { date_from: formInput.dateFrom },
+    })
+}
+
+export function validateWidgetConfigInput<TField extends string, TConfig>({
+    formSchema,
+    buildConfig,
+    input,
+}: {
+    formSchema: ZodType<WidgetListFormInput>
+    buildConfig: (formInput: WidgetListFormInput, baseConfig: TConfig) => TConfig
+    input: WidgetListFormInput & { baseConfig: TConfig }
+}): { success: true; config: TConfig } | { success: false; fieldErrors: Partial<Record<TField, string>> } {
+    const parsed = formSchema.safeParse({
+        limit: input.limit,
+        orderBy: input.orderBy,
+        dateFrom: input.dateFrom,
+        filterTestAccounts: input.filterTestAccounts,
+    })
+
+    if (!parsed.success) {
+        return { success: false, fieldErrors: fieldErrorsFromZodError<TField>(parsed.error) }
+    }
+
+    return {
+        success: true,
+        config: buildConfig(parsed.data, input.baseConfig),
+    }
+}
+
+export function parseWidgetConfigApiError<TField extends string, TConfig>({
+    error,
+    config,
+    configSchema,
+    formSchema,
+    defaultOrderBy,
+}: {
+    error: unknown
+    config: Record<string, unknown>
+    configSchema: ZodType<TConfig>
+    formSchema: ZodType<WidgetListFormInput>
+    defaultOrderBy: string
+}): Partial<Record<TField, string>> | null {
+    if (!(error instanceof ApiError)) {
+        return null
+    }
+
+    const parsedConfig = configSchema.safeParse(config)
+    if (parsedConfig.success) {
+        return null
+    }
+
+    const formInput: WidgetListFormInput = {
+        limit: (config.limit as number) ?? 0,
+        orderBy: (config.orderBy as string) ?? defaultOrderBy,
+        dateFrom: (config.dateRange as { date_from?: string } | undefined)?.date_from ?? '-7d',
+        filterTestAccounts: (config.filterTestAccounts as boolean) ?? false,
+    }
+    const parsedForm = formSchema.safeParse(formInput)
+    if (!parsedForm.success) {
+        return fieldErrorsFromZodError<TField>(parsedForm.error)
+    }
+
+    return fieldErrorsFromZodError<TField>(parsedConfig.error)
+}

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3766,126 +3766,6 @@ export namespace Schemas {
       version?: number | null;
     }
 
-    /**
-     * * `last_seen` - last_seen
-    * `first_seen` - first_seen
-    * `occurrences` - occurrences
-    * `users` - users
-    * `sessions` - sessions
-     */
-    export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
-
-
-    export const ErrorTrackingIssueOrderByEnum = {
-      LastSeen: 'last_seen',
-      FirstSeen: 'first_seen',
-      Occurrences: 'occurrences',
-      Users: 'users',
-      Sessions: 'sessions',
-    } as const;
-
-    /**
-     * * `ASC` - ASC
-    * `DESC` - DESC
-     */
-    export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
-
-
-    export const OrderDirectionEnum = {
-      Asc: 'ASC',
-      Desc: 'DESC',
-    } as const;
-
-    /**
-     * * `archived` - archived
-    * `active` - active
-    * `resolved` - resolved
-    * `pending_release` - pending_release
-    * `suppressed` - suppressed
-    * `all` - all
-     */
-    export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
-
-
-    export const ErrorTrackingIssueStatusEnum = {
-      Archived: 'archived',
-      Active: 'active',
-      Resolved: 'resolved',
-      PendingRelease: 'pending_release',
-      Suppressed: 'suppressed',
-      All: 'all',
-    } as const;
-
-    /**
-     * * `-14d` - -14d
-    * `-1h` - -1h
-    * `-24h` - -24h
-    * `-30d` - -30d
-    * `-3h` - -3h
-    * `-7d` - -7d
-    * `-90d` - -90d
-     */
-    export type DateFromEnum = typeof DateFromEnum[keyof typeof DateFromEnum];
-
-
-    export const DateFromEnum = {
-      '14d': '-14d',
-      '1h': '-1h',
-      '24h': '-24h',
-      '30d': '-30d',
-      '3h': '-3h',
-      '7d': '-7d',
-      '90d': '-90d',
-    } as const;
-
-    export interface WidgetDateRange {
-      /** Relative lookback window (for example '-7d'). Omit to use the project default range.
-
-      * `-14d` - -14d
-      * `-1h` - -1h
-      * `-24h` - -24h
-      * `-30d` - -30d
-      * `-3h` - -3h
-      * `-7d` - -7d
-      * `-90d` - -90d */
-      date_from?: DateFromEnum | null;
-    }
-
-    export interface ErrorTrackingListWidgetConfig {
-      /**
-         * Maximum number of issues to return.
-         * @minimum 1
-         * @maximum 25
-         */
-      limit?: number;
-      /** Issue ranking column.
-
-      * `first_seen` - first_seen
-      * `last_seen` - last_seen
-      * `occurrences` - occurrences
-      * `sessions` - sessions
-      * `users` - users */
-      orderBy?: ErrorTrackingIssueOrderByEnum;
-      /** Sort direction for orderBy.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
-      orderDirection?: OrderDirectionEnum;
-      /** Issue status filter.
-
-      * `archived` - archived
-      * `active` - active
-      * `resolved` - resolved
-      * `pending_release` - pending_release
-      * `suppressed` - suppressed
-      * `all` - all */
-      status?: ErrorTrackingIssueStatusEnum;
-      /** Optional relative date range override. */
-      dateRange?: WidgetDateRange | null;
-      /** When omitted, follows the project default for filtering test accounts. */
-      filterTestAccounts?: boolean;
-    }
-
     export interface TileLayoutBox {
       /** Column position in the dashboard grid (0-indexed). */
       x?: number;
@@ -3910,8 +3790,8 @@ export namespace Schemas {
          * @maxLength 64
          */
       widget_type: string;
-      /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for other types. For error_tracking_list, use the schema below (currently the only supported type: error_tracking_list, session_replay_list). */
-      config: ErrorTrackingListWidgetConfig;
+      /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for config_schema_hints. Supported types: error_tracking_list, session_replay_list. */
+      config: unknown;
       /**
          * Optional custom display name for the widget tile.
          * @maxLength 400
@@ -6806,6 +6686,126 @@ export namespace Schemas {
       style?: StyleEnum;
       readonly last_modified_at: string;
       team: number;
+    }
+
+    /**
+     * * `last_seen` - last_seen
+    * `first_seen` - first_seen
+    * `occurrences` - occurrences
+    * `users` - users
+    * `sessions` - sessions
+     */
+    export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
+
+
+    export const ErrorTrackingIssueOrderByEnum = {
+      LastSeen: 'last_seen',
+      FirstSeen: 'first_seen',
+      Occurrences: 'occurrences',
+      Users: 'users',
+      Sessions: 'sessions',
+    } as const;
+
+    /**
+     * * `ASC` - ASC
+    * `DESC` - DESC
+     */
+    export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
+
+
+    export const OrderDirectionEnum = {
+      Asc: 'ASC',
+      Desc: 'DESC',
+    } as const;
+
+    /**
+     * * `archived` - archived
+    * `active` - active
+    * `resolved` - resolved
+    * `pending_release` - pending_release
+    * `suppressed` - suppressed
+    * `all` - all
+     */
+    export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
+
+
+    export const ErrorTrackingIssueStatusEnum = {
+      Archived: 'archived',
+      Active: 'active',
+      Resolved: 'resolved',
+      PendingRelease: 'pending_release',
+      Suppressed: 'suppressed',
+      All: 'all',
+    } as const;
+
+    /**
+     * * `-14d` - -14d
+    * `-1h` - -1h
+    * `-24h` - -24h
+    * `-30d` - -30d
+    * `-3h` - -3h
+    * `-7d` - -7d
+    * `-90d` - -90d
+     */
+    export type DateFromEnum = typeof DateFromEnum[keyof typeof DateFromEnum];
+
+
+    export const DateFromEnum = {
+      '14d': '-14d',
+      '1h': '-1h',
+      '24h': '-24h',
+      '30d': '-30d',
+      '3h': '-3h',
+      '7d': '-7d',
+      '90d': '-90d',
+    } as const;
+
+    export interface WidgetDateRange {
+      /** Relative lookback window (for example '-7d'). Omit to use the project default range.
+
+      * `-14d` - -14d
+      * `-1h` - -1h
+      * `-24h` - -24h
+      * `-30d` - -30d
+      * `-3h` - -3h
+      * `-7d` - -7d
+      * `-90d` - -90d */
+      date_from?: DateFromEnum | null;
+    }
+
+    export interface ErrorTrackingListWidgetConfig {
+      /**
+         * Maximum number of issues to return.
+         * @minimum 1
+         * @maximum 25
+         */
+      limit?: number;
+      /** Issue ranking column.
+
+      * `first_seen` - first_seen
+      * `last_seen` - last_seen
+      * `occurrences` - occurrences
+      * `sessions` - sessions
+      * `users` - users */
+      orderBy?: ErrorTrackingIssueOrderByEnum;
+      /** Sort direction for orderBy.
+
+      * `ASC` - ASC
+      * `DESC` - DESC */
+      orderDirection?: OrderDirectionEnum;
+      /** Issue status filter.
+
+      * `archived` - archived
+      * `active` - active
+      * `resolved` - resolved
+      * `pending_release` - pending_release
+      * `suppressed` - suppressed
+      * `all` - all */
+      status?: ErrorTrackingIssueStatusEnum;
+      /** Optional relative date range override. */
+      dateRange?: WidgetDateRange | null;
+      /** When omitted, follows the project default for filtering test accounts. */
+      filterTestAccounts?: boolean;
     }
 
     export interface DashboardWidget {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3766,6 +3766,175 @@ export namespace Schemas {
       version?: number | null;
     }
 
+    /**
+     * * `last_seen` - last_seen
+    * `first_seen` - first_seen
+    * `occurrences` - occurrences
+    * `users` - users
+    * `sessions` - sessions
+     */
+    export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
+
+
+    export const ErrorTrackingIssueOrderByEnum = {
+      LastSeen: 'last_seen',
+      FirstSeen: 'first_seen',
+      Occurrences: 'occurrences',
+      Users: 'users',
+      Sessions: 'sessions',
+    } as const;
+
+    /**
+     * * `ASC` - ASC
+    * `DESC` - DESC
+     */
+    export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
+
+
+    export const OrderDirectionEnum = {
+      Asc: 'ASC',
+      Desc: 'DESC',
+    } as const;
+
+    /**
+     * * `archived` - archived
+    * `active` - active
+    * `resolved` - resolved
+    * `pending_release` - pending_release
+    * `suppressed` - suppressed
+    * `all` - all
+     */
+    export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
+
+
+    export const ErrorTrackingIssueStatusEnum = {
+      Archived: 'archived',
+      Active: 'active',
+      Resolved: 'resolved',
+      PendingRelease: 'pending_release',
+      Suppressed: 'suppressed',
+      All: 'all',
+    } as const;
+
+    /**
+     * * `-14d` - -14d
+    * `-1h` - -1h
+    * `-24h` - -24h
+    * `-30d` - -30d
+    * `-3h` - -3h
+    * `-7d` - -7d
+    * `-90d` - -90d
+     */
+    export type DateFromEnum = typeof DateFromEnum[keyof typeof DateFromEnum];
+
+
+    export const DateFromEnum = {
+      '14d': '-14d',
+      '1h': '-1h',
+      '24h': '-24h',
+      '30d': '-30d',
+      '3h': '-3h',
+      '7d': '-7d',
+      '90d': '-90d',
+    } as const;
+
+    export interface WidgetDateRange {
+      /** Relative lookback window (for example '-7d'). Omit to use the project default range.
+
+      * `-14d` - -14d
+      * `-1h` - -1h
+      * `-24h` - -24h
+      * `-30d` - -30d
+      * `-3h` - -3h
+      * `-7d` - -7d
+      * `-90d` - -90d */
+      date_from?: DateFromEnum | null;
+    }
+
+    export interface ErrorTrackingListWidgetConfig {
+      /**
+         * Maximum number of issues to return.
+         * @minimum 1
+         * @maximum 25
+         */
+      limit?: number;
+      /** Issue ranking column.
+
+      * `first_seen` - first_seen
+      * `last_seen` - last_seen
+      * `occurrences` - occurrences
+      * `sessions` - sessions
+      * `users` - users */
+      orderBy?: ErrorTrackingIssueOrderByEnum;
+      /** Sort direction for orderBy.
+
+      * `ASC` - ASC
+      * `DESC` - DESC */
+      orderDirection?: OrderDirectionEnum;
+      /** Issue status filter.
+
+      * `archived` - archived
+      * `active` - active
+      * `resolved` - resolved
+      * `pending_release` - pending_release
+      * `suppressed` - suppressed
+      * `all` - all */
+      status?: ErrorTrackingIssueStatusEnum;
+      /** Optional relative date range override. */
+      dateRange?: WidgetDateRange | null;
+      /** When omitted, follows the project default for filtering test accounts. */
+      filterTestAccounts?: boolean;
+    }
+
+    /**
+     * * `activity_score` - activity_score
+    * `click_count` - click_count
+    * `console_error_count` - console_error_count
+    * `duration` - duration
+    * `recording_duration` - recording_duration
+    * `start_time` - start_time
+     */
+    export type SessionReplayListWidgetConfigOrderByEnum = typeof SessionReplayListWidgetConfigOrderByEnum[keyof typeof SessionReplayListWidgetConfigOrderByEnum];
+
+
+    export const SessionReplayListWidgetConfigOrderByEnum = {
+      ActivityScore: 'activity_score',
+      ClickCount: 'click_count',
+      ConsoleErrorCount: 'console_error_count',
+      Duration: 'duration',
+      RecordingDuration: 'recording_duration',
+      StartTime: 'start_time',
+    } as const;
+
+    export interface SessionReplayListWidgetConfig {
+      /**
+         * Maximum number of recordings to return.
+         * @minimum 1
+         * @maximum 25
+         */
+      limit?: number;
+      /** Recording ranking column.
+
+      * `activity_score` - activity_score
+      * `click_count` - click_count
+      * `console_error_count` - console_error_count
+      * `duration` - duration
+      * `recording_duration` - recording_duration
+      * `start_time` - start_time */
+      orderBy?: SessionReplayListWidgetConfigOrderByEnum;
+      /** Sort direction for orderBy.
+
+      * `ASC` - ASC
+      * `DESC` - DESC */
+      orderDirection?: OrderDirectionEnum;
+      /** Optional relative date range override. */
+      dateRange?: WidgetDateRange | null;
+      /** When omitted, follows the project default for filtering test accounts. */
+      filterTestAccounts?: boolean;
+    }
+
+    export type DashboardWidgetConfig = ErrorTrackingListWidgetConfig | SessionReplayListWidgetConfig;
+
     export interface TileLayoutBox {
       /** Column position in the dashboard grid (0-indexed). */
       x?: number;
@@ -3791,7 +3960,7 @@ export namespace Schemas {
          */
       widget_type: string;
       /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for config_schema_hints. Supported types: error_tracking_list, session_replay_list. */
-      config: unknown;
+      config: DashboardWidgetConfig;
       /**
          * Optional custom display name for the widget tile.
          * @maxLength 400
@@ -6688,126 +6857,6 @@ export namespace Schemas {
       team: number;
     }
 
-    /**
-     * * `last_seen` - last_seen
-    * `first_seen` - first_seen
-    * `occurrences` - occurrences
-    * `users` - users
-    * `sessions` - sessions
-     */
-    export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
-
-
-    export const ErrorTrackingIssueOrderByEnum = {
-      LastSeen: 'last_seen',
-      FirstSeen: 'first_seen',
-      Occurrences: 'occurrences',
-      Users: 'users',
-      Sessions: 'sessions',
-    } as const;
-
-    /**
-     * * `ASC` - ASC
-    * `DESC` - DESC
-     */
-    export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
-
-
-    export const OrderDirectionEnum = {
-      Asc: 'ASC',
-      Desc: 'DESC',
-    } as const;
-
-    /**
-     * * `archived` - archived
-    * `active` - active
-    * `resolved` - resolved
-    * `pending_release` - pending_release
-    * `suppressed` - suppressed
-    * `all` - all
-     */
-    export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
-
-
-    export const ErrorTrackingIssueStatusEnum = {
-      Archived: 'archived',
-      Active: 'active',
-      Resolved: 'resolved',
-      PendingRelease: 'pending_release',
-      Suppressed: 'suppressed',
-      All: 'all',
-    } as const;
-
-    /**
-     * * `-14d` - -14d
-    * `-1h` - -1h
-    * `-24h` - -24h
-    * `-30d` - -30d
-    * `-3h` - -3h
-    * `-7d` - -7d
-    * `-90d` - -90d
-     */
-    export type DateFromEnum = typeof DateFromEnum[keyof typeof DateFromEnum];
-
-
-    export const DateFromEnum = {
-      '14d': '-14d',
-      '1h': '-1h',
-      '24h': '-24h',
-      '30d': '-30d',
-      '3h': '-3h',
-      '7d': '-7d',
-      '90d': '-90d',
-    } as const;
-
-    export interface WidgetDateRange {
-      /** Relative lookback window (for example '-7d'). Omit to use the project default range.
-
-      * `-14d` - -14d
-      * `-1h` - -1h
-      * `-24h` - -24h
-      * `-30d` - -30d
-      * `-3h` - -3h
-      * `-7d` - -7d
-      * `-90d` - -90d */
-      date_from?: DateFromEnum | null;
-    }
-
-    export interface ErrorTrackingListWidgetConfig {
-      /**
-         * Maximum number of issues to return.
-         * @minimum 1
-         * @maximum 25
-         */
-      limit?: number;
-      /** Issue ranking column.
-
-      * `first_seen` - first_seen
-      * `last_seen` - last_seen
-      * `occurrences` - occurrences
-      * `sessions` - sessions
-      * `users` - users */
-      orderBy?: ErrorTrackingIssueOrderByEnum;
-      /** Sort direction for orderBy.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
-      orderDirection?: OrderDirectionEnum;
-      /** Issue status filter.
-
-      * `archived` - archived
-      * `active` - active
-      * `resolved` - resolved
-      * `pending_release` - pending_release
-      * `suppressed` - suppressed
-      * `all` - all */
-      status?: ErrorTrackingIssueStatusEnum;
-      /** Optional relative date range override. */
-      dateRange?: WidgetDateRange | null;
-      /** When omitted, follows the project default for filtering test accounts. */
-      filterTestAccounts?: boolean;
-    }
-
     export interface DashboardWidget {
       readonly id: string;
       readonly created_by: UserBasic;
@@ -6826,7 +6875,7 @@ export namespace Schemas {
       /** Optional markdown description shown on the dashboard tile when enabled. */
       description?: string;
       /** Widget-specific configuration JSON for this widget type. */
-      config?: ErrorTrackingListWidgetConfig;
+      config?: DashboardWidgetConfig;
       readonly dashboard_tiles: readonly DashboardTileBasic[];
       readonly last_modified_at: string;
       team: number;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3906,11 +3906,11 @@ export namespace Schemas {
 
     export interface AddDashboardWidgetRequest {
       /**
-         * Widget type identifier. Supported values: error_tracking_list. Use dashboard-widget-catalog-list for config_schema_hints per type.
+         * Widget type identifier. Supported values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for config_schema_hints per type.
          * @maxLength 64
          */
       widget_type: string;
-      /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for other types. For error_tracking_list, use the schema below (currently the only supported type: error_tracking_list). */
+      /** Widget-specific configuration. Shape depends on widget_type; see dashboard-widget-catalog-list for other types. For error_tracking_list, use the schema below (currently the only supported type: error_tracking_list, session_replay_list). */
       config: ErrorTrackingListWidgetConfig;
       /**
          * Optional custom display name for the widget tile.


### PR DESCRIPTION
## Problem

Session recordings belong on dashboards alongside error tracking. This PR adds the second list-style widget (`session_replay_list`) and generalizes backend config handling so multiple widget types can share the same create/update/run paths.

This PR is **9/11** in the dashboard widgets Graphite stack.

**Depends on:** PR 8 (#60524 — error tracking dashboard widget + shared tile orchestration)

## Changes

- **`session_replay_list`** **widget** — backend runner (reuses session recording list query + serializer shim), catalog/registry, config schema, preview, and frontend tile (component, edit modal, stories, tests)
- **Setup gating** — catalog `availability` (`session_replay_enabled`) via `WidgetRuntimeAvailabilityGuard` + stacked vertical setup prompt when replay is disabled
- **Generic widget config API** — replace error-tracking-only request serializers with `JSONField` + catalog schema hints so ET and SR configs don't cross-pollinate
- **`run_widgets`** **replay throttling** — apply existing replay listing rate limits when batch-running session replay tiles (via `get_replay_listing_throttle_error`)
- **Shared frontend patterns with ET** — edit modal uses shared tile builders/filter sections; config validation and form schemas deduped into shared helpers (`widgetConfigValidation`, `widgetListFormSchema`)
- **Single-patch save** — session replay edit modal submits config + tile metadata in one `onSave(config, buildWidgetTileMetadataPatch(...))` call, matching #60524
- **Backend validation parity** — shared list-widget validators (limit, order, date range) with tests in `test_run_widgets`
- **Review follow-ups** — aligned SR structure with ET (catalog defaults, kea typegen-safe modal logic, removed redundant property prefetch)

## How did you test this code?

- Agent: Jest for session replay widget, edit modal, preview, registry, and config validation
- Agent: backend `test_run_widgets` for session replay runner and config validation cases
- Verified preview renders with shared session recording Storybook fixtures

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [x] Alert Sales and Marketing teams?

## Docs update

Add the `skip-inkeep-docs` label — no user-facing docs yet (feature flagged). Agent skill/docs land in #60516.

## 🤖 Agent context

- Restacked onto #60524 after #60495 was closed; branch name still references batch add API but batch create already exists on master — this PR is the session replay widget + multi-type config generalization
- Load-more pagination intentionally omitted from widgets per product decision
- Cursor agent assisted on review alignment, CI fixes, and single-patch save parity with ET