### PR TITLE
DUPED CLOSED

### DIFF
--- a/.agents/skills/dashboard-widgets/SKILL.md
+++ b/.agents/skills/dashboard-widgets/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: dashboard-widgets
+description: >
+  Agent playbook for PostHog dashboard widget types — add new types or update existing ones
+  (config, edit modal, catalog layout mins, run_widgets, stories). Covers backend WIDGET_REGISTRY,
+  frontend catalog/registry, WidgetCard composition, permissions, and dashboard scene glue.
+  Load when adding or modifying dashboard widget types, changing tile min/default size, WIDGET_REGISTRY,
+  DASHBOARD_WIDGET_CATALOG, WidgetCard, run_widgets, edit/settings modals, or dashboard tile widget glue.
+---
+
+# Managing dashboard widgets
+
+Add new embeddable types **or update existing ones** (config, layout mins, edit modal, query, stories).
+
+Embeddable dashboard content types backed by `DashboardWidget` + `run_widgets`.
+Overview: [`products/dashboards/CONTRIBUTING.md`](../../../products/dashboards/CONTRIBUTING.md)
+
+Reference implementation: `products/dashboards/frontend/widgets/error_tracking/`
+
+**Out of scope:** insight tiles, text cards, button tiles — separate models today.
+
+## Pattern index
+
+| You want to… | Read |
+| ------------ | ---- |
+| **Add** a new widget type (`widget_type` + JSON `config`) | [checklist-new-widget-type.md](references/checklist-new-widget-type.md) end-to-end |
+| **Update** an existing type (config, modal, mins, query, stories) | [managing-existing-widgets.md](references/managing-existing-widgets.md) |
+| Change tile **min/default size** on the dashboard grid | [layout-and-ux.md](references/layout-and-ux.md) § Tile min/max size |
+| Add a second variant in an existing product group | [checklist-new-widget-type.md](references/checklist-new-widget-type.md) §4b (variant pattern) |
+| Understand tile/widget model or registries | [architecture.md](references/architecture.md) |
+| Compose WidgetCard, loading, RGL, headers | [composition.md](references/composition.md) |
+| Wire RBAC, copy/move, or shared dashboards | [permissions-and-sharing.md](references/permissions-and-sharing.md) |
+| Gate on project setup or show setup prompts | [availability-and-gating.md](references/availability-and-gating.md) |
+| Set grid sizing, menus, or undo remove | [layout-and-ux.md](references/layout-and-ux.md) |
+| Debug a bug | [pitfalls.md](references/pitfalls.md) |
+| Add type N — what grows vs stays generic | [scaling.md](references/scaling.md) |
+| Expose widgets via MCP / agent tools | [mcp.md](references/mcp.md) |
+| Find the right file to edit | [file-paths.md](references/file-paths.md) |
+
+## Unbreakable rules
+
+1. **Product RBAC is registry-driven** — set `required_product_access` on each `WIDGET_REGISTRY` entry (and matching `productAccess` on FE catalog). Extend `DashboardWidgetProductAccess` in `types.ts` and the `userHasWidgetProductAccess` switch in `DashboardWidgetItem.tsx`. `get_widget_product_access_error` handles `run_widgets` and tile mutations. **Never** add per-type `if widget_type == …` in `dashboard.py`. `required_scopes` is documentation only.
+2. **Catalog + registry must match** — catalog drives add modal, layouts, headers, previews; `DASHBOARD_WIDGET_REGISTRY` uses `satisfies Record<DashboardWidgetCatalogKey, …>`. Each variant needs a unique `widget_type`; variants in the same product area share `groupId`/`groupLabel` (see [architecture.md](references/architecture.md)).
+3. **Compound `WidgetCard`** — thin shell only; compose `WidgetCardHeader` + `WidgetCardBody` at the callsite (`DashboardWidgetItem`, stories). Widget content goes in `WidgetCardBody`; RGL resize handles go in `gridChildren`. Loading lives in the widget `Component`, not the shell.
+4. **Cross-dashboard copy/move deep-clones widgets** — copy creates a new `DashboardWidget` row; move reassigns the tile row. Dashboard duplication always deep-clones widget rows.
+5. **Title, description, and filters live in the widget settings modal** — compose `WidgetSettingsModalSection` blocks inside `WidgetSettingsModalSections` (Tile details / Filters / type-specific). Not inline on the card header; `filterTestAccounts` is not in the ⋯ menu. Full-width fields: `WIDGET_SETTINGS_FIELD_FULL_WIDTH_CLASS` on the **grid child** (`LemonField.Pure`), not the inner input — see [managing-existing-widgets.md](references/managing-existing-widgets.md).
+6. **Tile min/max size is catalog → `tileLayouts.ts`** — set `defaultLayout.minH` / `minW` in `catalog.ts`; do not try to fix resize floors in the widget component. See [layout-and-ux.md](references/layout-and-ux.md) § Tile min/max size.
+7. **New `widget_type` strings need no migration** — register backend + frontend + both catalogs; invoke `django-migrations` only for schema changes.
+8. **No product-specific glue** — validate/run live in `backend/widgets/<type>.py`; UI in `frontend/widgets/<product>/`. Do not hardcode product names in `DashboardWidgetItem`, `WidgetCard`, or `run_widgets`.
+
+## Mandatory companion skills
+
+Invoke **before** editing their files:
+
+| Skill | Files |
+| ----- | ----- |
+| `improving-drf-endpoints` | `products/dashboards/backend/api/dashboard.py` serializers/actions |
+| `writing-kea-logics` | `frontend/src/scenes/dashboard/dashboardLogic.tsx` |
+| `django-migrations` | `DashboardWidget` / `DashboardTile` schema changes only |
+| `implementing-mcp-tools` | `products/dashboards/mcp/tools.yaml`, widget MCP endpoints |
+| `adopting-generated-api-types` | Migrating manual API client calls |
+
+## Architecture (sketch)
+
+```text
+DashboardTile (layout) → widget_id → DashboardWidget (team-scoped)
+  widget_type + config  →  WIDGET_REGISTRY (BE)  →  run_widgets
+                        →  DASHBOARD_WIDGET_CATALOG + registry.tsx (FE)
+                        →  tileLayouts.ts (defaultLayout → RGL minW/minH)
+```
+
+Full layer table and registry shapes: [architecture.md](references/architecture.md)
+
+## Pre-change checklist
+
+**Adding a type**
+
+- [ ] Read [checklist-new-widget-type.md](references/checklist-new-widget-type.md)
+- [ ] Mirror `error_tracking_list` unless you have a strong reason not to
+- [ ] Set explicit `defaultLayout.minW` / `minH` on the catalog entry (do not rely on `MIN_WIDGET_TILE_HEIGHT_ROWS = 4` fallback)
+
+**Updating a type**
+
+- [ ] Read [managing-existing-widgets.md](references/managing-existing-widgets.md) for the change class (config vs mins vs modal vs query)
+- [ ] If changing mins: catalog + `tileLayouts.test.ts` — not the widget component
+- [ ] If changing edit modal: mirror `EditErrorTrackingWidgetModal.tsx` grid layout
+
+**Always**
+
+- [ ] Backend: `widgets/<widget_type>.py` + `required_product_access` on registry entry (not manual checks in `dashboard.py`)
+- [ ] Frontend: `registry.tsx` entry + catalog entry + `widgetPreviews` + `DashboardWidgetProductAccess` union + `userHasWidgetProductAccess` case when RBAC-gated
+- [ ] After serializer changes: `hogli build:openapi` (do not edit generated files)
+- [ ] Run backend + frontend tests in **Verify** below
+
+## Verify
+
+```bash
+# Backend
+hogli test products/dashboards/backend/api/test/test_dashboard_widgets.py
+hogli test products/dashboards/backend/api/test/test_run_widgets.py
+hogli test products/dashboards/backend/api/test/test_widget_access.py
+
+# Frontend
+hogli test products/dashboards/frontend/widgets/
+hogli test frontend/src/scenes/dashboard/tileLayouts.test.ts
+hogli test products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.test.tsx
+hogli test products/dashboards/frontend/components/WidgetCard/
+
+# Storybook (widget loading / empty / populated / minimum size states)
+pnpm storybook
+```
+
+Schema migrations chain after `0006_migrate_product_analytics_models` (`products/dashboards/backend/migrations/`).

--- a/.agents/skills/dashboard-widgets/references/architecture.md
+++ b/.agents/skills/dashboard-widgets/references/architecture.md
@@ -1,0 +1,125 @@
+# Dashboard widgets architecture
+
+## Mental model
+
+```text
+Dashboard
+  └── DashboardTile (layout, color, placement)
+        └── widget_id → DashboardWidget (team-scoped content entity)
+              ├── widget_type: str  # no DB enum — validated in registry/serializer; typed as DashboardWidgetType in Python
+              ├── config: JSON
+              ├── name, description, audit fields
+              └── team FK (tenant isolation)
+```
+
+| Layer | Location | Role |
+| ----- | -------- | ---- |
+| Persistence | `products/dashboards/backend/models/dashboard_widget.py`, `dashboard_tile.py` | Exactly one content FK per tile: insight \| text \| button_tile \| widget (DB CHECK) |
+| Backend runtime | `products/dashboards/backend/widgets/<type>.py` + `widget_registry.py` | Per-type validate/run; aggregator registry |
+| Backend access | `products/dashboards/backend/widget_access.py` | `required_product_access` → RBAC check |
+| Backend catalog | `products/dashboards/backend/widget_catalog.py` | Labels, grouping, `config_schema_hints` for REST/MCP |
+| Data fetch | `GET .../dashboards/:id/run_widgets?tile_ids=` in `dashboard.py` | Batched per-tile results + per-tile errors (generic loop) |
+| Frontend dispatch | `widgets/registry.tsx` | `DASHBOARD_WIDGET_REGISTRY` → `Component` + `EditModal` |
+| Catalog / layout | `frontend/widget_types/` | Add modal, defaults, headers, RBAC map, grid sizing |
+| Scene glue | `frontend/src/scenes/dashboard/` | Fetch, CRUD, copy/move, undo remove |
+
+**New `widget_type` strings need no migration** — register in both backend and frontend registries + catalog.
+
+## Backend registry entry shape
+
+Files: `products/dashboards/backend/widgets/<widget_type>.py` + `widget_registry.py`
+
+```python
+# widgets/your_type.py — validate + run for one widget_type
+# widget_registry.py — aggregator only
+WIDGET_REGISTRY: dict[str, WidgetRegistryEntry] = {
+    "your_type": {
+        "validate_config": validate_your_type_config,
+        "query_fn": run_your_type_widget,
+        "required_scopes": ["your_product:read"],  # documentation only
+        "required_product_access": "your_product",  # RBAC gate via widget_access.py
+    },
+}
+```
+
+- `validate_<type>_config` / `run_<type>_widget` live in `widgets/<widget_type>.py` — call the **same** query runner the standalone product uses
+- `required_product_access` drives `get_widget_product_access_error` in `run_widgets` and tile mutations — do not add per-type checks in `dashboard.py`
+- Add type to `EXPECTED_WIDGET_TYPES` (must equal `WIDGET_REGISTRY.keys()` — enforced in tests)
+- Extend `DashboardWidgetType` (`Literal[...]`) — canonical types only; used in typed Python call sites
+- Extend `DashboardWidgetTypeInput` when API/tests accept alternate type aliases (`WIDGET_TYPE_ALIASES`)
+- Shared date-range validation: `widgets.config.validate_widget_date_range`
+
+## Frontend registry entry shape
+
+File: `products/dashboards/frontend/widgets/registry.tsx`
+
+```typescript
+import { YourWidget } from './your_product/YourWidget'
+import { EditYourWidgetModal } from './your_product/EditYourWidgetModal'
+
+export const DASHBOARD_WIDGET_REGISTRY = {
+    your_type: {
+        Component: YourWidget,
+        EditModal: EditYourWidgetModal,
+        productAccess: 'your_product',
+    },
+} satisfies Record<DashboardWidgetCatalogKey, DashboardWidgetDefinition>
+```
+
+Catalog entry in `widget_types/catalog.ts` drives add modal, layouts, headers, and previews — registry alone is not enough.
+
+Optional catalog `availability` declares project setup prerequisites (exception autocapture, etc.). Gating runs at **tile render** via `WidgetRuntimeAvailabilityGuard`, not in the add modal — see [availability-and-gating.md](availability-and-gating.md).
+
+## Widget type vs catalog group
+
+| Field | Role |
+| ----- | ---- |
+| `widget_type` | Unique ID everywhere: catalog key, `WIDGET_REGISTRY` key, DB column, `DASHBOARD_WIDGET_REGISTRY` key |
+| `groupId` / `groupLabel` | Product area section in add-widget modal — **multiple `widget_type` entries share one group** (e.g. `error_tracking_list` + a future `error_tracking_<variant>` both use `groupId: 'error_tracking'`, `groupLabel: 'Error tracking'`) |
+| `label` | Variant name within the group ("Top issues", "Trend chart"); fallback card title |
+
+`getDashboardWidgetCatalogGroups()` in `AddWidgetModal.tsx` builds grouped picker sections from catalog entries. Card headers use `groupLabel` for the product type chip (`DashboardWidgetItem` → `WidgetCardHeader`).
+
+Adding a second variant in an existing group still requires a full new `widget_type` stack — only `groupId`/`groupLabel` are reused. See checklist §4b and [scaling.md](scaling.md).
+
+## Scaling
+
+Many widget types: platform glue stays generic; each type adds product-local files. See [scaling.md](scaling.md).
+
+## Scene integration (usually no changes for new types)
+
+Only touch when the new type needs special fetch/CRUD behavior:
+
+| File | Widget-related behavior |
+| ---- | ----------------------- |
+| `dashboardLogic.tsx` | `addWidgetTiles` (multi-tile add via dashboard PATCH), `refreshDashboardWidgets`, `updateWidgetTileConfig`, `widgetResultsByTileId`, `dashboardWidgetsEnabled`, copy/move |
+| `DashboardItems.tsx` | Renders `DashboardWidgetItem`; passes refresh/results |
+| `DashboardHeaderActions.tsx` | Add widget entry |
+| `DashboardModals.tsx` | `AddWidgetModal` (multi-select) |
+| `tileLayouts.ts` | Widget default/min layout from catalog |
+| `widgetFetchUtils.ts` | Batched `run_widgets` fetch (15 min client TTL) |
+| `dashboardUtils.ts` | `getDashboardWidgetType`, template helpers |
+
+## Add widget flows
+
+| Surface | Mechanism |
+| ------- | --------- |
+| UI add modal | `AddWidgetModal` multi-select → `addWidgetTiles` → PATCH dashboard with multiple new tile payloads |
+| REST / MCP single add | `POST .../dashboards/:id/widgets/` — one tile (`widget_type` + `config`). See [mcp.md](mcp.md) |
+
+## Analytics
+
+First-time widget tile insert fires `dashboard tile added` with `tile_type: "widget"`, `widget_type`, and `dashboard_id` via `_report_dashboard_tile_added` in `dashboard.py`:
+
+- PATCH dashboard `tiles[]` (UI `addWidgetTiles`)
+- POST `.../widgets/` (REST/MCP)
+
+Config updates do not re-fire the event.
+
+## Copy, move, duplicate
+
+Cross-project transfer, cross-dashboard copy/move, and dashboard duplication all deep-clone widget rows (move reassigns the tile only). Details: [permissions-and-sharing.md](permissions-and-sharing.md).
+
+## Reference implementation
+
+Mirror `products/dashboards/frontend/widgets/error_tracking/` for end-to-end patterns.

--- a/.agents/skills/dashboard-widgets/references/availability-and-gating.md
+++ b/.agents/skills/dashboard-widgets/references/availability-and-gating.md
@@ -1,0 +1,106 @@
+# Widget availability and gating
+
+Project setup prerequisites (exception autocapture, future ingestion flags, etc.) — **not** RBAC. Product access (`productAccess`) is separate: it gates who can see widget data via `run_widgets` and locked tiles; availability gates whether the project is configured to produce data.
+
+## Product rule: gate at render, never at add
+
+Users **always** pick and add widgets in `AddWidgetModal` — no filtering, disabling, or hiding catalog entries based on availability.
+
+When a prerequisite is unmet, the **dashboard tile body** shows setup UI instead of widget content. The tile still exists (header, layout, edit/remove menus work).
+
+Do **not**:
+
+- Hide or disable variants in the add-widget picker
+- Block `POST .../widgets/` or dashboard PATCH add paths
+- Show availability checks only in the edit modal
+
+## Two patterns (pick one per widget type)
+
+| Pattern | When | Catalog `availability` | Tile render |
+| ------- | ---- | ---------------------- | ----------- |
+| **Catalog-driven guard** | Single team flag checkable in `widgetAvailability.ts` | Required | `WidgetRuntimeAvailabilityGuard` wraps `Component` (always wired in `DashboardWidgetItem`) |
+| **Widget-layer setup gate** | Richer rules (multi-signal, ingestion polling, product logic) | **Omit** — guard is a no-op | Inline in widget `Component` (private gate + setup UI) |
+
+Do not set catalog `availability` when the widget handles setup internally — the guard would use the wrong (simpler) check and double-gate.
+
+Error tracking uses inline setup gating in `ErrorTrackingWidget.tsx` — checks `exceptionIngestionLogic` (events received **or** autocapture enabled), not just `autocapture_exceptions_opt_in`.
+
+## Catalog `availability` shape
+
+File: `products/dashboards/frontend/widget_types/catalog.ts`
+
+```typescript
+availability?: {
+    requirement: WidgetAvailabilityRequirementId  // e.g. 'exception_autocapture'
+    unavailableTitle: string
+    unavailableReason: string
+    setupActionLabel: string
+    docsHref?: string
+}
+```
+
+Types and evaluators: `products/dashboards/frontend/widget_types/widgetAvailability.ts`
+
+- `WidgetAvailabilityRequirementId` — extend here when adding a new generic requirement
+- `isWidgetAvailabilityRequirementMet(requirement, team)` — exhaustive switch on team fields
+- `getWidgetAvailabilityStatus(config, team)` / `useWidgetAvailability(config)` — `{ isAvailable, config }`
+
+No `availability` key → guard renders children unchanged.
+
+## `WidgetRuntimeAvailabilityGuard` flow
+
+File: `products/dashboards/frontend/components/WidgetRuntimeAvailabilityGuard/WidgetRuntimeAvailabilityGuard.tsx`
+
+Always wraps the widget `Component` in `DashboardWidgetItem`:
+
+```text
+catalogEntry.availability
+  → useWidgetAvailability()
+  → isAvailable? render children (widget Component)
+  → else render unavailableContentFallback ?? WidgetAvailabilitySetupPrompt
+```
+
+Props:
+
+- `availability` — from `getDashboardWidgetCatalogEntry(widget_type)?.availability`
+- `unavailableContentFallback` — optional override from `DashboardWidgetDefinition.unavailableContentFallback`
+- `children` — widget `Component`
+
+Default setup UI: `WidgetAvailabilitySetupPrompt` — generic `WidgetCardProductIntroduction` + CTA per `requirement` (admin-gated enable actions, docs link, product intent capture). Extend its `switch (availability.requirement)` when adding a new `WidgetAvailabilityRequirementId`.
+
+## Widget-layer setup gate
+
+When catalog `availability` is omitted, handle setup gating inside the widget `Component` as private subcomponents (e.g. `ErrorTrackingWidgetSetupGate` in `ErrorTrackingWidget.tsx`).
+
+**Do not** modify product `SetupPrompt`, `ProductIntroduction`, or other shared lib components for widget layout. Reuse product **logic** (e.g. `exceptionIngestionLogic`) from the widget wrapper; compose `WidgetCardProductIntroduction` for tile-friendly setup UI.
+
+## Error tracking reference implementation
+
+| Piece | Path | Role |
+| ----- | ---- | ---- |
+| Widget | `widgets/error_tracking/ErrorTrackingWidget.tsx` | Setup gate + body + empty/loading states |
+| Product prompt (reference only) | `products/error_tracking/frontend/components/SetupPrompt/SetupPrompt.tsx` | Standalone product surface — **do not import or extend for dashboard tiles** |
+| Generic prompt (catalog guard) | `components/WidgetAvailabilitySetupPrompt/WidgetAvailabilitySetupPrompt.tsx` | Catalog-driven enable-exception-autocapture UI |
+| Widget tile layout wrapper | `components/WidgetCardProductIntroduction/WidgetCardProductIntroduction.tsx` | Container-query responsive layout for setup prompts inside `WidgetCardBody` |
+
+Loading state renders **outside** the setup wrapper so skeletons show while fetching.
+
+## Adding a new generic requirement
+
+1. Add id to `WidgetAvailabilityRequirementId` in `widgetAvailability.ts`
+2. Implement check in `isWidgetAvailabilityRequirementMet` (team field or helper)
+3. Add UI branch in `WidgetAvailabilitySetupPrompt` (enable action, docs, intents)
+4. Set `availability` on catalog entry
+5. Test: `widgetAvailability.test.ts`, `WidgetRuntimeAvailabilityGuard.test.tsx`
+
+## Checklist: widget type needs setup gating
+
+- [ ] **Simple team flag?** Set catalog `availability` + evaluator in `widgetAvailability.ts` + prompt branch in `WidgetAvailabilitySetupPrompt`. Optional `unavailableContentFallback` on registry for custom setup UI.
+- [ ] **Richer product rules?** Omit catalog `availability`; add private setup gate + prompt UI inside `widgets/<product>/<Component>.tsx` (reuse product logic; do not modify product SetupPrompt)
+- [ ] Confirm add modal still lists the widget unconditionally
+- [ ] Setup UI replaces tile **body** only — header/menus unchanged
+- [ ] Loading skeleton bypasses setup prompt
+- [ ] Admin restriction on destructive enable actions (`useRestrictedArea`)
+- [ ] Tests for met/unmet requirement at render time
+
+See also: [checklist-new-widget-type.md](checklist-new-widget-type.md) §4 (catalog `availability` bullet), [composition.md](composition.md) (loading ownership).

--- a/.agents/skills/dashboard-widgets/references/checklist-new-widget-type.md
+++ b/.agents/skills/dashboard-widgets/references/checklist-new-widget-type.md
@@ -1,0 +1,188 @@
+# Checklist: new dashboard widget type
+
+Work in order. Do not skip backend permission wiring (step 2).
+
+Reference implementation: `products/dashboards/frontend/widgets/error_tracking/`
+
+## 1. Backend registry
+
+Files: `products/dashboards/backend/widgets/<widget_type>.py` + `widget_registry.py`
+
+- [ ] `validate_<type>_config(config) -> dict` in `widgets/<widget_type>.py` — normalize defaults; reject bad input with `DRFValidationError`
+- [ ] Merge `merge_base_widget_config_fields(config)` for shared fields (`filterTestAccounts`)
+- [ ] `run_<type>_widget(team, config) -> dict` — call the **same** query runner the standalone product uses (no parallel query path); pass `resolve_filter_test_accounts(config)` when the query supports it
+- [ ] Register in `WIDGET_REGISTRY` with `required_scopes` (docs only) and `required_product_access` when RBAC-gated (must match catalog `required_product_access`)
+- [ ] Add type to `EXPECTED_WIDGET_TYPES` (must equal `WIDGET_REGISTRY.keys()` — enforced in tests)
+- [ ] Extend `DashboardWidgetType` (`Literal[...]`) with the new canonical `widget_type` string
+- [ ] Extend `DashboardWidgetTypeInput` only if the API accepts alternate type aliases for that widget (see `WIDGET_TYPE_ALIASES`)
+- [ ] Pass through time-scoped fields (`dateRange`) when the query is date-filtered — use `validate_widget_date_range` from `widgets/config.py`
+
+See [architecture.md](architecture.md) for registry entry shape.
+
+## 2. Backend `run_widgets` permissions — critical
+
+`run_widgets` and widget tile mutations call `get_widget_product_access_error(registry_entry, user_access_control)` from `widget_access.py`.
+
+- [ ] Set `required_product_access` on the `WIDGET_REGISTRY` entry — **do not** add per-type `if widget_type == …` checks in `dashboard.py`
+- [ ] Add a friendly denial message to `PRODUCT_ACCESS_DENIED_MESSAGES` in `widget_access.py` only when the generic fallback copy is not good enough — do not pre-populate messages for unshipped types
+- [ ] **`required_scopes` is documentation only** — RBAC is driven by `required_product_access`
+- [ ] Return per-tile `{ tile_id, error }` — do not fail the whole request for one bad tile
+- [ ] Catch query exceptions → per-tile error in response (see existing `dashboard_run_widgets_failed` logging)
+
+## 3. Backend catalog
+
+File: `products/dashboards/backend/widget_catalog.py`
+
+- [ ] Add entry to `WIDGET_CATALOG` with `group_id`, `group_label`, `label`, `description`, `config_schema_hints`, `required_product_access`
+- [ ] Keeps REST/MCP catalog in sync with frontend defaults; agents call `dashboard-widget-catalog-list` / `GET .../widget_catalog/`
+
+## 4. Frontend catalog + config schema
+
+- [ ] `widget_types/configSchemas.ts` — extend `baseWidgetConfigSchema` for shared fields (`filterTestAccounts`); use `.parse()` for `defaultConfig`
+- [ ] `widget_types/catalog.ts` — add entry to `DASHBOARD_WIDGET_CATALOG` (catalog key = `widget_type`):
+  - **`groupId`, `groupLabel`** — required; product area for add-modal grouping. Multiple catalog keys share one group (e.g. `error_tracking_list` and a future variant both use `groupId: 'error_tracking'`, `groupLabel: 'Error tracking'`)
+  - **`label`, `description`** — required; variant name within the group (e.g. "Top issues", "Trend chart")
+  - `defaultLayout` (`w`, `h`, `minW`, `minH`)
+  - `headerLayout`: prefer `'dashboard_tile'` for new widgets (insight-tile parity)
+  - Optional: `headerMeta`, `headerTitle`, `titleHref`, `productAccess`
+  - Optional: `availability` — simple team-flag prerequisite for `WidgetRuntimeAvailabilityGuard` (omit when the widget handles richer setup gating inline). Gate at **tile render** only (never in add modal). See [availability-and-gating.md](availability-and-gating.md).
+- [ ] `widgets/<product>/<type>WidgetConfigValidation.ts` — map Zod errors to edit-modal fields; export API error parser for `utils.ts`
+
+No change to `AddWidgetModal` grouping for normal adds — `getDashboardWidgetCatalogGroups()` derives groups from catalog entries automatically.
+
+### 4b. Adding a variant to an existing group
+
+Use when the product area already has a widget and you need another visualization (e.g. a chart alongside a list widget in the same group).
+
+- [ ] New **unique** catalog key / `widget_type` (e.g. `error_tracking_trends`) — not a config fork of the existing type
+- [ ] Reuse sibling **`groupId` and `groupLabel`** exactly
+- [ ] Distinct **`label`**, **`description`**, **`defaultConfig`**, **`defaultLayout`** (and usually `headerTitle`)
+- [ ] Full backend stack: new `widgets/<widget_type>.py`, `WIDGET_REGISTRY` entry with `required_product_access`, `EXPECTED_WIDGET_TYPES`, extend `DashboardWidgetType`
+- [ ] Full frontend stack: new component (same `widgets/<product>/` dir), edit modal, preview in `widgetPreviews.tsx`, registry entry in `registry.tsx`, extend `DashboardWidgetProductAccess` + `userHasWidgetProductAccess` case when RBAC-gated
+- [ ] Tests: assert shared `groupId` in `registry.test.tsx` like existing ET variants
+
+## 5. Frontend widget component
+
+Directory: `products/dashboards/frontend/widgets/<product>/` (snake_case product area — e.g. `error_tracking/` for `error_tracking_list`)
+
+- [ ] Implement `Component` with `DashboardWidgetComponentProps` (`tileId`, `config`, `result`, `loading`, `error`, `onRefresh`, `onUpdateConfig`)
+- [ ] Setup gating: catalog `availability` for simple team-flag checks, or private setup gate inside the widget `Component` for richer rules — do not modify product `SetupPrompt`
+- [ ] **Own loading UI** — early-return with `WidgetLoadingState` (typed skeleton as `children` when helpful)
+- [ ] Use `WidgetCardContent` for scrollable lists/tables; `WidgetCardBodyMessage` for empty states
+- [ ] Do **not** render card chrome — `DashboardWidgetItem` + catalog handle headers/menus
+
+Minimal skeleton:
+
+```tsx
+export function YourWidget({ result, loading, config }: DashboardWidgetComponentProps): JSX.Element {
+    if (loading) {
+        return (
+            <WidgetLoadingState>
+                <YourTypedSkeleton />
+            </WidgetLoadingState>
+        )
+    }
+    const rows = (result as YourResult)?.results ?? []
+    if (rows.length === 0) {
+        return <WidgetCardBodyMessage>No data found.</WidgetCardBodyMessage>
+    }
+    return (
+        <WidgetCardContent>
+            <YourList data={rows} />
+        </WidgetCardContent>
+    )
+}
+```
+
+See [composition.md](composition.md) for WidgetCard rules.
+
+## 5b. Storybook
+
+File: `products/dashboards/frontend/widgets/<product>/<YourWidget>.stories.tsx`
+
+Reference: `products/dashboards/frontend/widgets/error_tracking/ErrorTrackingWidget.stories.tsx`
+
+- [ ] Storybook meta: **string literal** `title: 'Dashboards/Dashboard Widgets/Widget types/<groupLabel>/<label>'` (must match catalog — CSF rejects function calls), `layout: 'padded'`, `WidgetTileFrame` decorator (see `ErrorTrackingWidget.stories.tsx`; platform primitives in `WidgetCard.stories.tsx`)
+- [ ] Compose stories with `WidgetCard` + `WidgetCardHeader` + `WidgetCardBody` + catalog header metadata — not the bare widget component
+- [ ] Export Kea seed decorators from the primary `*.stories.tsx` when multiple story files need them — no separate `*StoryDecorators.tsx` until shared across products
+- [ ] Mock `DashboardWidgetComponentProps` via `args` — no Kea, no `run_widgets` fetch
+- [ ] Export stories for each visual state the tile can show:
+  - **Populated** — realistic `result` payload (shape matches `run_*` output)
+  - **Loading** — `loading: true`, `result: null`
+  - **Empty** — `loading: false`, empty `result` (e.g. `{ results: [] }`)
+  - **Error** — when the component renders `error` (pass a string or error-shaped prop your component expects)
+- [ ] Include `tileId`, `config` (defaults from catalog), and stub `onUpdateConfig` / `onRefresh` where the component needs them
+
+Run locally:
+
+```sh
+pnpm storybook
+```
+
+Repo rule: presentational widget components belong in Storybook (see `.cursor/rules/react-typescript.mdc`).
+
+## 6. Edit modal + add-widget preview
+
+- [ ] `EditModal` — Zod validate → `LemonField` errors; disable save while `saving` / invalid
+- [ ] Compose `WidgetSettingsModalSections` + `WidgetSettingsModalSection` (+ `WidgetSettingsModalDivider` between sections): **Tile details** (`name`, `description`), **Filters** (`TestAccountFilter` when query honors `filterTestAccounts`), type-specific section titled with `groupLabel`
+- [ ] Date-filtered widgets: date range select from `WIDGET_DATE_RANGE_SELECT_OPTIONS` in `widgetDateRangeOptions.ts` (`-1h`, `-3h`, `-24h`, `-7d`, …)
+- [ ] Wire `parseWidgetConfigApiError` in `frontend/utils.ts` when inline tile config updates should surface field errors
+- [ ] Preview in `widgets/previews/`; register in `widgetPreviews.tsx` for `AddWidgetModal`
+
+## 7. Frontend registry
+
+File: `products/dashboards/frontend/widgets/registry.tsx`
+
+```typescript
+import { EditYourWidgetModal } from './your_product/EditYourWidgetModal'
+import { YourWidget } from './your_product/YourWidget'
+
+export const DASHBOARD_WIDGET_REGISTRY = {
+    your_type: {
+        Component: YourWidget,
+        EditModal: EditYourWidgetModal,
+        productAccess: 'your_product',
+    },
+} satisfies Record<DashboardWidgetCatalogKey, DashboardWidgetDefinition>
+```
+
+- [ ] When RBAC-gated: set `productAccess` on the registry entry (must match catalog), extend `DashboardWidgetProductAccess` in `types.ts`, and add a `case` to `userHasWidgetProductAccess` in `DashboardWidgetItem.tsx`
+
+## 8. Tests
+
+Backend:
+
+```sh
+hogli test products/dashboards/backend/api/test/test_dashboard_widgets.py
+hogli test products/dashboards/backend/api/test/test_run_widgets.py
+hogli test products/dashboards/backend/api/test/test_widget_access.py
+```
+
+Frontend:
+
+```sh
+hogli test products/dashboards/frontend/widgets/registry.test.tsx
+hogli test products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.test.tsx
+hogli test products/dashboards/frontend/widgets/<product>/
+hogli test products/dashboards/frontend/components/WidgetCard/
+pnpm storybook   # manual: loading / empty / error (if applicable) / populated stories
+```
+
+- [ ] Assert `EXPECTED_WIDGET_TYPES == WIDGET_REGISTRY.keys()`
+- [ ] `registry.test.tsx`: every catalog key registered; unknown types report once via `registry.tsx`
+- [ ] Test create/update config validation, activity logging, permission denial in `run_widgets`
+- [ ] Registry test: component, edit modal, catalog defaults, header layout
+- [ ] Analytics: first insert fires `dashboard tile added` with `widget_type` on PATCH and POST add paths (`test_dashboard_widgets.py`)
+- [ ] No empty test scaffolds — every `.test.tsx` must assert real behavior
+
+## 9. OpenAPI / generated types
+
+After serializer changes in `dashboard.py`:
+
+```sh
+hogli build:openapi
+```
+
+Regenerates `products/dashboards/frontend/generated/api.ts`, `api.schemas.ts`. Do not edit generated files.
+
+Invoke `improving-drf-endpoints` before editing serializers. Invoke `adopting-generated-api-types` when migrating manual API calls.

--- a/.agents/skills/dashboard-widgets/references/composition.md
+++ b/.agents/skills/dashboard-widgets/references/composition.md
@@ -1,0 +1,137 @@
+# WidgetCard composition
+
+Symptom/fix tables: [pitfalls.md](pitfalls.md).
+
+Follow the Quill `Card` pattern: **thin shell + compound subcomponents composed at the callsite**. `WidgetCard` is chrome only — no header/body props.
+
+| File / export | Role |
+| ------------- | ---- |
+| `WidgetCard` | Thin tile shell: decorative resize handles, edit-mode edge overlay, RGL slot. **No product/header/body props** |
+| `WidgetCardHeader` (+ internal title/actions helpers) | Layout router: `simple` vs `dashboard_tile`; exports `widgetCardShouldHideMoreButton` |
+| `WidgetCardBody.tsx` | Body slot; locked/error shell states. Also exports `WidgetCardContent`, `WidgetCardBodyMessage`, `WidgetLoadingState`, `WidgetCardBodySkeleton` |
+| `WidgetCardContent` | Scrollable column + optional footer (list/table widgets) — from `WidgetCardBody.tsx` |
+| `WidgetCardBodyMessage` | Empty / inline status text — from `WidgetCardBody.tsx` |
+| `WidgetLoadingState` / `WidgetCardBodySkeleton` | Widget-owned loading UI — from `WidgetCardBody.tsx` |
+| `DashboardWidgetItem` | Production callsite — composes header + body, wires ⋯ menu, edit modal portal, product RBAC lock |
+
+`WidgetCardHeaderDescription` is exported from `WidgetCardHeader.tsx` for tests only. Widget `Component`s never render card chrome — only body content primitives (`WidgetCardContent`, `WidgetCardBodyMessage`, …).
+
+## Compound pattern
+
+```tsx
+<WidgetCard
+    ref={ref}
+    className={className}
+    style={style}
+    showResizeHandles={showResizeHandles}
+    canEnterEditModeFromEdge={canEnterEditModeFromEdge}
+    onEnterEditModeFromEdge={onEnterEditModeFromEdge}
+    gridChildren={rglHandles} // react-grid-layout injects these
+>
+    <WidgetCardHeader
+        layout={headerLayout}
+        title={title}
+        defaultTitle={defaultTitle}
+        // …catalog-driven header fields
+        shouldHideMoreButton={widgetCardShouldHideMoreButton(placement, showEditingControls)}
+        moreButtonOverlay={…}
+    />
+    <WidgetCardBody locked={locked} error={error}>
+        <WidgetComponent … />
+    </WidgetCardBody>
+</WidgetCard>
+```
+
+Render order inside `WidgetCard` (matches `InsightCard`):
+
+1. `children` — composed header + body
+2. `DashboardResizeHandles` when `showResizeHandles`
+3. `EditModeEdgeOverlay` when edge-enter-edit is enabled
+4. `gridChildren` — RGL `.react-resizable-handle` nodes
+
+## Do
+
+- Keep `WidgetCard` as the outermost node in `DashboardWidgetItem` — RGL injects `className`/`style` via `ref` on the card root
+- Compose `WidgetCardHeader` + `WidgetCardBody` in `DashboardWidgetItem` (or story wrappers) — not inside `WidgetCard`
+- Pass RGL handles via `gridChildren`, not `children`
+- Let the widget `Component` decide skeleton vs content from `loading` prop
+- Use `min-w-0` + `overflow-auto` chain (`WidgetCardContent` already scrolls vertically)
+- Store time period in `config.dateRange` — options, edit modal, and header display: [layout-and-ux.md](layout-and-ux.md)
+- Prefer `headerLayout: 'dashboard_tile'` — Refresh data as direct ⋯ menu item via `DashboardTileRefreshDataButton` (matches insight tiles; no flyout submenu)
+- Edit title/description in the widget settings modal only (`WidgetSettingsModalSections` Tile details) — card header is read-only display
+
+## Don't
+
+- Add header/body props back to `WidgetCard` — that defeats the compound pattern
+- Put loading placeholders in `WidgetCard` shell — breaks resize/empty-state behavior
+- Put widget body content in `gridChildren` — RGL owns that slot for resize handles only
+- Duplicate headers, menus, card chrome, or filter toggles inside the widget component — filters belong in the settings modal, not the ⋯ menu
+- Register in `registry.tsx` without a matching `DASHBOARD_WIDGET_CATALOG` entry
+
+## Header layouts (`catalog.ts`)
+
+| Layout | Behavior |
+| ------ | -------- |
+| `simple` | Single title row — prefer `dashboard_tile` for new types. Refresh via tile ⋯ menu only |
+| `dashboard_tile` | Compact `CardMeta` style: type • date range + title + divider; Refresh in ⋯ menu |
+
+Date range display is derived in `WidgetCardHeader` from `config.dateRange` + catalog `headerMeta` (via `dateFilterToText`).
+
+## Loading ownership
+
+The widget `Component` receives `loading` from scene logic and must early-return with `WidgetLoadingState`. The shell (`DashboardWidgetItem` → composed `WidgetCardBody`) does not show skeletons for widget body content.
+
+## RGL and overflow
+
+- Widget content lives inside composed `WidgetCardBody`
+- `gridChildren` is reserved for react-grid-layout resize handles only
+- Wide tables: horizontal scroll **inside** `WidgetCardContent`, not the dashboard grid
+
+## Storybook
+
+Platform primitives under **Dashboards/Dashboard Widgets/**:
+
+- `WidgetCard/` — `WidgetCard.stories.tsx` (header + body composition patterns)
+- `Overview/` — `DashboardWidgetsOverview.stories.tsx` (all catalog types)
+
+Shared frame/mocks: `widgetCardStoryFixtures.tsx`.
+
+Per-type stories: `widgets/<product>/<Component>.stories.tsx` under **Widget types/<groupLabel>/<label>/**.
+
+- Meta `title` must be a **string literal** derived from catalog `groupLabel` / `label` (CSF rejects dynamic titles)
+- Compose with `WidgetCard` + `WidgetCardHeader` + `WidgetCardBody` + catalog header metadata — see `ErrorTrackingWidget.stories.tsx`
+- Product setup state: Kea seed helpers live in `errorTrackingWidgetStoryDecorators.tsx` — do not export decorators from `*.stories.tsx` (Storybook treats exports as stories)
+- Stack decorators carefully: story-level `withErrorTrackingProjectState(false)` must not be overridden by a meta decorator that seeds `true`
+
+## Widget settings modal
+
+Same compound pattern as `WidgetCard` — thin shell, sections composed in each `Edit*WidgetModal`.
+
+| Export | Role |
+| ------ | ---- |
+| `WidgetSettingsModalSections` | Outer `flex flex-col gap-4` wrapper only |
+| `WidgetSettingsModalSection` | Titled section + 2-column form grid |
+| `WidgetSettingsModalDivider` | `LemonDivider` between sections — insert at callsite when needed |
+| `WIDGET_SETTINGS_FORM_GRID_CLASS` / `WIDGET_SETTINGS_FIELD_FULL_WIDTH_CLASS` | Grid layout helpers for fields inside a section |
+
+```tsx
+<WidgetSettingsModalSections>
+    {onSaveMetadata && (
+        <WidgetSettingsModalSection title="Tile details">{/* name, description */}</WidgetSettingsModalSection>
+    )}
+    {showFilters && (
+        <>
+            {onSaveMetadata && <WidgetSettingsModalDivider />}
+            <WidgetSettingsModalSection title="Filters">{/* TestAccountFilter */}</WidgetSettingsModalSection>
+        </>
+    )}
+    {showTypeFields && (
+        <>
+            {(onSaveMetadata || showFilters) && <WidgetSettingsModalDivider />}
+            <WidgetSettingsModalSection title={catalogEntry.groupLabel}>{/* type-specific fields */}</WidgetSettingsModalSection>
+        </>
+    )}
+</WidgetSettingsModalSections>
+```
+
+Reference: `EditErrorTrackingWidgetModal.tsx`. Omit sections you do not need — do not pass optional slot props to the shell.

--- a/.agents/skills/dashboard-widgets/references/file-paths.md
+++ b/.agents/skills/dashboard-widgets/references/file-paths.md
@@ -1,0 +1,59 @@
+# Dashboard widgets file paths
+
+Open these paths; do not guess locations.
+
+## Naming
+
+| Context | Convention | Example |
+| ------- | ---------- | ------- |
+| Product widget dirs under `widgets/` | `snake_case` | `widgets/error_tracking/` |
+| Catalog keys / `widget_type` / registry keys | `snake_case` | `error_tracking_list` |
+| Shared `widget_types/` modules | `snake_case` filenames | `widgetDateRangeOptions.ts` |
+| React component dirs under `components/` | `PascalCase` | `WidgetCard/`, `DashboardWidgetItem/` |
+| MCP tool names | `kebab-case` | `dashboard-widgets-run` |
+
+Do not scaffold empty `hooks/`, `logic/`, or abandoned component dirs — colocate widget code in `widgets/<product>/` until a kea logic is actually needed.
+
+| Path | Edit when |
+| ---- | --------- |
+| `products/dashboards/backend/widgets/<widget_type>.py` | Per-type `validate_*` + `run_*` (call standalone product query runners) |
+| `products/dashboards/backend/widget_registry.py` | **Aggregator only** — `WIDGET_REGISTRY` keys, `EXPECTED_WIDGET_TYPES`, `DashboardWidgetType` / `DashboardWidgetTypeInput`, `WIDGET_TYPE_ALIASES` |
+| `products/dashboards/backend/widget_access.py` | `get_widget_product_access_error`; optional `PRODUCT_ACCESS_DENIED_MESSAGES` entry per shipped gated type (fallback copy is fine until then) |
+| `products/dashboards/backend/widgets/config.py` | Shared config: `filterTestAccounts`, `MAX_WIDGET_CONFIG_LIMIT`, `dateRange` validation, merge/resolve helpers |
+| `products/dashboards/backend/widget_catalog.py` | Backend catalog entries + config schema hints for MCP/API |
+| `products/dashboards/backend/api/dashboard.py` | Generic `run_widgets` loop, `widgets` (single add), `update_widget`, `widget_catalog`, tile CRUD — **no per-type branches** |
+| `products/dashboards/backend/api/test/test_dashboard_widgets.py` | Widget CRUD, copy/duplicate, config validation, analytics tests |
+| `products/dashboards/backend/api/test/test_run_widgets.py` | `run_widgets` + permission denial tests |
+| `products/dashboards/backend/api/test/test_widget_access.py` | `get_widget_product_access_error` unit tests |
+| `products/dashboards/mcp/tools.yaml` | MCP tool descriptions for widget endpoints (regenerate MCP after changes) |
+| `products/dashboards/frontend/widget_types/configSchemas.ts` | Zod config schema (`baseWidgetConfigSchema` + per-type extend) |
+| `products/dashboards/frontend/widget_types/widgetDateRangeOptions.ts` | Allowed `date_from` values + edit-modal select options (`-1h`, `-3h`, `-24h`, …) |
+| `products/dashboards/frontend/widgets/WidgetSettingsModalSections.tsx` | Compound edit-modal shell: `WidgetSettingsModalSections`, `WidgetSettingsModalSection`, `WidgetSettingsModalDivider`, grid class constants |
+| `products/dashboards/frontend/types.ts` | `DashboardWidgetProductAccess` union — extend when adding RBAC-gated types |
+| `products/dashboards/frontend/utils.ts` | `updateDashboardWidgetTileConfig`; wire per-type API error parsing in `parseWidgetConfigApiError` |
+| `products/dashboards/frontend/widgets/constants.ts` | Modal width, fetch error copy, `getDashboardWidgetFetchDisplayError` |
+| `products/dashboards/frontend/widget_types/catalog.ts` | Catalog entry (`groupId`, `groupLabel`, `label`, layout, headers, defaults, optional `availability`) |
+| `products/dashboards/frontend/widget_types/widgetAvailability.ts` | Requirement ids, team checks, `useWidgetAvailability` hook |
+| `products/dashboards/frontend/components/WidgetRuntimeAvailabilityGuard/WidgetRuntimeAvailabilityGuard.tsx` | Catalog-driven setup gate at tile render (no-op when catalog omits `availability`) |
+| `products/dashboards/frontend/components/WidgetAvailabilitySetupPrompt/WidgetAvailabilitySetupPrompt.tsx` | Default setup UI for catalog `availability` requirements |
+| `products/dashboards/frontend/widget_types/widgetConfigValidation.ts` | Shared `WidgetConfigValidationError` + type guard |
+| `products/dashboards/frontend/widgets/<product>/<type>WidgetConfigValidation.ts` | Per-type edit-modal Zod + API error mapping (e.g. `errorTrackingWidgetConfigValidation.ts`) |
+| `products/dashboards/frontend/widgets/AddWidgetModal.tsx` | Multi-select add-widget modal; catalog grouping via `getDashboardWidgetCatalogGroups()` |
+| `products/dashboards/frontend/widgets/WidgetTypePickerCard.tsx` | Catalog variant picker card in add modal |
+| `products/dashboards/frontend/widgets/<product>/` | Widget `Component` (+ private subcomponents), `utils.ts`, `EditModal`, tests, stories (export shared story decorators from primary `*.stories.tsx` when needed) |
+| `products/dashboards/frontend/widgets/previews/` + `widgetPreviews.tsx` | Add-widget preview |
+| `products/dashboards/frontend/widgets/registry.tsx` | `DASHBOARD_WIDGET_REGISTRY`, `getDashboardWidgetDefinition`, types — import components here per `widget_type` |
+| `products/dashboards/frontend/components/WidgetCard/` | Compound family: thin `WidgetCard.tsx` (chrome), `WidgetCardHeader.tsx`, `WidgetCardBody.tsx` (+ `index.ts`, exports `widgetCardShouldHideMoreButton`). Platform Storybook: `WidgetCard.stories.tsx`, `DashboardWidgetsOverview.stories.tsx`; shared mocks in `widgetCardStoryFixtures.tsx` |
+| `products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx` | Production tile glue — composes `WidgetCard` + header/body, ⋯ menu, RBAC lock (`userHasWidgetProductAccess`), copy/move |
+| `frontend/src/scenes/dashboard/dashboardLogic.tsx` | `addWidgetTiles`, fetch, config update, copy/move |
+| `frontend/src/scenes/dashboard/DashboardItems.tsx` | Renders widget tiles |
+| `frontend/src/scenes/dashboard/DashboardHeaderActions.tsx` | Add widget entry; `LemonMenu` item uses `tag: 'new'` |
+| `frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx` | Empty-state add menu; inline `LemonTag` "NEW" on Widget item |
+| `frontend/src/scenes/dashboard/DashboardModals.tsx` | `AddWidgetModal` |
+| `frontend/src/scenes/dashboard/tileLayouts.ts` | **Dashboard min/max tile size** — `calculateLayouts` reads catalog `defaultLayout.minW`/`minH`; test in `tileLayouts.test.ts` |
+| `frontend/src/scenes/dashboard/widgetFetchUtils.ts` | Batched `run_widgets` (15 min client TTL) |
+| `frontend/src/scenes/dashboard/dashboardUtils.ts` | `getDashboardWidgetType`, helpers |
+| `posthog/models/resource_transfer/visitors/dashboard_widget.py` | Cross-project dashboard copy — `DashboardWidgetVisitor` (`user_facing=True`) |
+| `products/dashboards/frontend/generated/api.ts`, `api.schemas.ts` | **Generated** — run `hogli build:openapi` after serializer changes |
+
+MCP tool reference: [mcp.md](mcp.md)

--- a/.agents/skills/dashboard-widgets/references/layout-and-ux.md
+++ b/.agents/skills/dashboard-widgets/references/layout-and-ux.md
@@ -1,0 +1,141 @@
+# Layout and UX
+
+## Grid sizing (overview)
+
+- Defaults: catalog `defaultLayout` → `tileLayouts.ts` (`minW`/`minH`)
+- Widgets use wider mins than insights (`MIN_WIDGET_TILE_WIDTH_COLS`)
+- Set realistic `minH` — RGL won't shrink below it
+- Wide tables: horizontal scroll **inside** widget body (`WidgetCardContent`), not the dashboard grid
+
+Catalog fields in `widget_types/catalog.ts`:
+
+- `defaultLayout.w`, `defaultLayout.h` — initial placement size when a tile is added
+- `defaultLayout.minW`, `defaultLayout.minH` — resize floor in dashboard edit mode
+
+## Tile min/max size (grid rows & columns)
+
+Changing minimum tile size is **catalog + `tileLayouts.ts`**, not the widget `Component`. Agents often look in the wrong layer first — use this section.
+
+### Mental model
+
+```text
+DASHBOARD_WIDGET_CATALOG[].defaultLayout     ← you edit this
+        ↓
+tileLayouts.ts :: calculateLayouts()         ← reads catalog per tile.widget.widget_type
+        ↓
+react-grid-layout minW / minH on each item   ← enforced while resizing in edit mode
+```
+
+- Grid is **12 columns** wide (`w` / `minW` are column counts).
+- Height is in **row units** (`h` / `minH`), not columns — users may say “3 rows tall” or “3 grid rows”.
+- **Row height:** `BASE_ROW_HEIGHT = 80` px in `frontend/src/scenes/dashboard/DashboardItems.tsx`. Example: `minH: 3` → 240 px minimum tile height (plus margins).
+
+### Single source of truth
+
+Set mins on the catalog entry only:
+
+```typescript
+// products/dashboards/frontend/widget_types/catalog.ts
+defaultLayout: { w: 6, h: 5, minW: 6, minH: 3 },
+```
+
+| Field | Meaning |
+| ----- | ------- |
+| `w`, `h` | Default size when **adding** a widget (`dashboardLogic.addWidgetTiles` reads these) |
+| `minW`, `minH` | Smallest size allowed when **resizing** on the dashboard |
+
+### How mins reach the grid
+
+1. `calculateLayouts(tiles)` in `frontend/src/scenes/dashboard/tileLayouts.ts` runs on every dashboard load / tile change.
+2. For widget tiles it calls `getWidgetCatalogLayout(widget_type)` → `DASHBOARD_WIDGET_CATALOG[key].defaultLayout`.
+3. `getTileMinDimensions()` sets RGL `minW` / `minH` on each layout item.
+
+**Persisted tile JSON** (`tile.layouts.sm`) stores `x`, `y`, `w`, `h` — not mins. Mins are **recomputed** from catalog each time, so a catalog `minH` change applies to existing dashboards without a migration.
+
+### Fallbacks (when catalog omits mins)
+
+| Constant | Value | Used when |
+| -------- | ----- | --------- |
+| `MIN_WIDGET_TILE_WIDTH_COLS` | 6 | Widget tile, catalog has no `minW` |
+| `MIN_WIDGET_TILE_HEIGHT_ROWS` | 4 | Widget tile, catalog has no `minH` |
+| `MIN_TILE_HEIGHT_ROWS` | 2 | Insight tiles |
+| `MIN_TEXT_TILE_HEIGHT_ROWS` | 1 | Text tiles |
+
+If a new widget type omits `minH`, users can only shrink to **4 rows**, not 3. Always set explicit `minH` / `minW` on the catalog entry.
+
+### What does **not** control dashboard min size
+
+| Location | Why it’s unrelated |
+| -------- | ------------------- |
+| Widget `Component` / SCSS | Body layout only; RGL sizes the outer tile |
+| `widget_catalog.py` `get_default_widget_layouts()` | Backend add helper — returns `w`/`h` only, no mins |
+| Storybook `widgetCardStoryFixtures` `TILE_HEIGHT` | Fixed frame for stories, not RGL |
+| `DashboardWidgetsOverview.stories.tsx` heights | Overview showcase scale, separate from live mins |
+| Changing `MIN_WIDGET_TILE_HEIGHT_ROWS` globally | Affects **unknown** widget types only; prefer per-type catalog `minH` |
+
+### Change checklist
+
+1. Edit `defaultLayout.minH` / `minW` in `widget_types/catalog.ts` for the `widget_type`.
+2. Extend `frontend/src/scenes/dashboard/tileLayouts.test.ts` — parameterized case with `expectedMinH` / `expectedMinW` for that `widget_type` (see `error_tracking_list` / `session_replay_list` examples).
+3. Run `hogli test frontend/src/scenes/dashboard/tileLayouts.test.ts`.
+4. Manually resize the tile in dashboard **edit mode** to confirm the floor.
+5. Optional: add a `MinimumSize` story — frame height `minH * 80` px, limit demo data so content fits.
+
+### Storybook vs dashboard
+
+- **Dashboard:** mins from catalog → `tileLayouts.ts` → RGL.
+- **Storybook tile stories:** optional fixed frame (`widgetCardStoryFixtures` or per-story wrapper). A `MinimumSize` story documents the floor; it does not change production behavior.
+
+## Add widget modal
+
+- Title: **Add widget**; description: **Bring context from your different PostHog products into one dashboard.**
+- `AddWidgetModal` supports **multi-select** — pick one or more catalog variants, then "Add N widgets"
+- `dashboardLogic.addWidgetTiles` PATCHes the dashboard with multiple new tile payloads in one request
+- REST/MCP single add: `POST .../widgets/` with `widget_type` + `config`. See [mcp.md](mcp.md)
+
+## NEW badge (Add menu)
+
+Surface the Widget entry as new in the Add menu:
+
+- Populated dashboard: `DashboardHeaderActions` — `LemonMenu` item `tag: 'new'`
+- Empty dashboard: `EmptyDashboardComponent` — inline `<LemonTag type="success" size="small">NEW</LemonTag>` on the Widget menu item
+
+Do not add NEW badges on individual catalog variants inside `AddWidgetModal`.
+
+## Config updates
+
+- `updateWidgetTileConfig` in `dashboardLogic` → PATCH tiles → refresh widget data
+- Widget settings modal: Zod validate → `LemonField` errors; disable save while `saving` / invalid
+- Title, description, `filterTestAccounts`, and type-specific fields all live in the settings modal (`WidgetSettingsModalSections`) — not inline on the card
+
+## Remove and undo
+
+- Remove: no confirm dialog — undo toast (`removeTileSuccess` in `dashboardLogic.tsx`)
+- Copy: "widget removed" + Undo
+
+## ⋯ menu parity (`DashboardWidgetItem`)
+
+- View (if `titleHref`)
+- Edit (opens widget settings modal)
+- Duplicate
+- Show/hide description (toggle visibility; edit text in settings modal)
+- Dashboard section: copy/move to another dashboard, remove
+- Refresh data — direct click with optional "Last computed" subtitle (`dashboard_tile` header layout; not a submenu)
+
+## Header layout choice
+
+Prefer `headerLayout: 'dashboard_tile'` for new widgets — matches insight tile chrome; Refresh data is a direct ⋯ menu item (optional "Last computed" subtitle), same as insight tiles.
+
+See [composition.md](composition.md) for header layout details.
+
+## Date range in config
+
+Store time period in `config.dateRange` (insight-shaped `{ date_from, date_to?, explicitDate? }`).
+
+Supported relative `date_from` values (shortest first): `-1h`, `-3h`, `-24h`, `-7d`, `-14d`, `-30d`, `-90d` — defined in `widgetDateRangeOptions.ts`.
+
+Format for display via `WidgetCardHeader` — reads `config.dateRange` + catalog `headerMeta` and formats with `dateFilterToText`.
+
+## Description display
+
+When `show_description` is enabled, the card header renders markdown under the title (`WidgetCardHeader` / `CardMeta`) with `max-h-24 overflow-y-auto`.

--- a/.agents/skills/dashboard-widgets/references/managing-existing-widgets.md
+++ b/.agents/skills/dashboard-widgets/references/managing-existing-widgets.md
@@ -1,0 +1,60 @@
+# Managing existing dashboard widgets
+
+Use this when **changing** a shipped widget type — not only when adding a new one.
+
+Reference implementation for patterns: `products/dashboards/frontend/widgets/error_tracking/` (`error_tracking_list`).
+
+## What kind of change?
+
+| Goal | Primary files | Also check |
+| ---- | ------------- | ---------- |
+| Widget query / `run_widgets` payload | `backend/widgets/<widget_type>.py`, `widget_registry.py` | `test_run_widgets.py`, frontend `Component` types |
+| Config fields (filters, limits, sort) | `configSchemas.ts`, `<type>WidgetConfigValidation.ts`, `Edit*WidgetModal.tsx`, backend `validate_*_config` | `utils.ts` API error parser, `hogli build:openapi` if serializers change |
+| Tile name / description UX | `Edit*WidgetModal.tsx`, `WidgetSettingsModalSections.tsx` | Mirror `EditErrorTrackingWidgetModal.tsx` field layout |
+| Default size when **adding** a tile | `catalog.ts` `defaultLayout.w` / `.h` | `dashboardLogic.addWidgetTiles` (reads catalog defaults) |
+| **Min/max resize** on dashboard grid | `catalog.ts` `defaultLayout.minW` / `.minH` | [layout-and-ux.md](layout-and-ux.md) § Tile min/max size — **`tileLayouts.ts`**, `tileLayouts.test.ts` |
+| Card header / date range display | `catalog.ts` (`headerLayout`, `headerMeta`, `headerTitle`) | `WidgetCardHeader`, stories |
+| Setup / availability gate | `catalog.ts` `availability`, `widgetAvailability.ts` | `WidgetRuntimeAvailabilityGuard` |
+| RBAC lock on tile | `widget_registry.py` `required_product_access`, FE `catalog.ts` `productAccess` | `types.ts`, `DashboardWidgetItem.tsx` `userHasWidgetProductAccess` |
+| Add-modal preview | `widgets/previews/`, `widgetPreviews.tsx` | Storybook variant stories |
+| Storybook / overview fixtures | `WidgetCard/*.stories.tsx`, `widgetOverviewStoryFixtures.ts` | `getWidgetOverviewDemoState` switch per catalog key |
+
+## Config update flow (runtime)
+
+1. User opens ⋯ → **Edit** → `Edit*WidgetModal` validates with Zod → `onSave` / `onSaveMetadata`
+2. `dashboardLogic.updateWidgetTileConfig` / `updateWidgetTileMetadata` → PATCH dashboard tile
+3. `refreshDashboardWidgets` re-runs `run_widgets` for that tile
+
+Guard saves with `loading` / `disabledReason` on Save — never leave the button clickable mid-mutation.
+
+## Edit modal layout
+
+`WidgetSettingsModalSection` renders a **2-column CSS grid** (`sm:grid-cols-2`).
+
+- Full-width fields (name, description, test-account filter): put `WIDGET_SETTINGS_FIELD_FULL_WIDTH_CLASS` (`sm:col-span-2`) on the **grid child** — `LemonField.Pure` or a wrapper `<div>` — **not** on the inner `LemonInput` / `LemonTextArea`.
+- Half-width fields (date range, sort, limit): omit `col-span-2`; use `fullWidth` on `LemonSelect` where needed.
+
+Copy `EditErrorTrackingWidgetModal.tsx` Tile details + Filters sections when wiring a new edit modal.
+
+## Changing min/max tile size
+
+**Do not** hunt for a single “min height constant” in the widget component — mins are catalog-driven and applied in `tileLayouts.ts`. See [layout-and-ux.md](layout-and-ux.md) § Tile min/max size.
+
+Quick checklist:
+
+1. Set `defaultLayout.minH` / `minW` on the catalog entry in `widget_types/catalog.ts`
+2. Add or extend a case in `frontend/src/scenes/dashboard/tileLayouts.test.ts` (`expectedMinH` / `expectedMinW`)
+3. Optional: `MinimumSize` story in `<Widget>.stories.tsx` at `minH * 80` px frame height
+4. Verify in dashboard **edit mode** by resizing the tile — RGL enforces `minH`/`minW` from `calculateLayouts`, not from persisted tile JSON alone
+
+Changing catalog mins affects **all** tiles of that type on the next layout pass; it does not rewrite stored `h`/`w` in Postgres.
+
+## Verify (updates)
+
+Same as add — run targeted tests for the files you touched:
+
+```bash
+hogli test products/dashboards/backend/api/test/test_run_widgets.py   # backend query/config
+hogli test frontend/src/scenes/dashboard/tileLayouts.test.ts        # grid mins
+hogli test products/dashboards/frontend/widgets/<product>/          # modal + component
+```

--- a/.agents/skills/dashboard-widgets/references/mcp.md
+++ b/.agents/skills/dashboard-widgets/references/mcp.md
@@ -1,0 +1,49 @@
+# Dashboard widgets MCP tools
+
+Agents manage dashboard widget tiles through atomic MCP tools.
+
+Tool config: `products/dashboards/mcp/tools.yaml` — regenerate MCP handlers after endpoint changes (`implementing-mcp-tools` skill).
+
+## Tool map
+
+| Goal | MCP tool | Notes |
+| ---- | -------- | ----- |
+| Discover widget types + config hints | `dashboard-widget-catalog-list` | Read-only catalog |
+| Read dashboard tiles + widget config | `dashboard-get` | Widget tiles have `widget.widget_type` and `widget.config`; no live data |
+| Add widget tile | `dashboard-widget-add` | Single tile via `POST .../widgets/` |
+| Add multiple widget tiles | `dashboard-widgets-batch-add` | Atomic batch via `POST .../widgets/batch/` |
+| Update widget tile | `dashboard-widget-update` | Path: dashboard ID + `tile_id` from dashboard-get |
+| Run widget queries | `dashboard-widgets-run` | Query: `tile_ids` comma-separated from dashboard-get |
+| Copy widget tile to another dashboard | `dashboard-tile-copy` | Deep-clones widget; destination is path dashboard ID |
+| Move widget tile between dashboards | `dashboards-move-tile-partial-update` | Reassigns tile row; source is path dashboard ID |
+
+## Typical agent flow
+
+1. `dashboard-widget-catalog-list` — pick `widget_type`, build `config` from `config_schema_hints`
+2. `dashboard-widget-add` or `dashboard-widgets-batch-add` — add one tile or up to 10 atomically
+3. `dashboard-get` — confirm tile ID(s) and layout
+4. `dashboard-widgets-run` — fetch live widget data for `tile_ids`
+
+For updates: `dashboard-widget-update` then `dashboard-widgets-run`.
+
+Multi-tile add from the UI uses `POST .../widgets/batch/` (`addWidgetTiles`), same as MCP batch add.
+
+## REST equivalents
+
+| MCP tool | Endpoint |
+| -------- | -------- |
+| `dashboard-widget-catalog-list` | `GET .../dashboards/widget_catalog/` |
+| `dashboard-widget-add` | `POST .../dashboards/:id/widgets/` (single tile) |
+| `dashboard-widgets-batch-add` | `POST .../dashboards/:id/widgets/batch/` (1–10 tiles, atomic) |
+| `dashboard-widget-update` | `PATCH .../dashboards/:id/widgets/:tile_id/` |
+| `dashboard-widgets-run` | `GET .../dashboards/:id/run_widgets/?tile_ids=` |
+| `dashboard-tile-copy` | `POST .../dashboards/:id/copy_tile/` |
+| `dashboards-move-tile-partial-update` | `PATCH .../dashboards/:id/move_tile/` |
+
+UI multi-select add uses `POST .../widgets/batch/` (not PATCH dashboard `tiles[]`).
+
+## Permissions
+
+- Dashboard edit scope for add/update/copy/move
+- Dashboard read scope for get, catalog, run
+- Each widget type may require additional product access — check `required_product_access` on `dashboard-widget-catalog-list`; denied tiles return per-tile errors from run/add/update paths

--- a/.agents/skills/dashboard-widgets/references/permissions-and-sharing.md
+++ b/.agents/skills/dashboard-widgets/references/permissions-and-sharing.md
@@ -1,0 +1,47 @@
+# Permissions and sharing
+
+## Team scoping
+
+- `DashboardWidget.team` required — all reads/writes filter by `team_id`
+- Tile upsert validates existing widget IDs belong to the dashboard's team
+
+## Two access layers (both must pass)
+
+| Layer | Check |
+| ----- | ----- |
+| Dashboard RBAC | `dashboard:read` / `dashboard:write`; access level on dashboard object |
+| Product RBAC | Can user see the underlying data? Frontend: `userHasDashboardWidgetProductAccess(definition.productAccess)` in `DashboardWidgetItem`. Backend: `required_product_access` on `WIDGET_REGISTRY` → `get_widget_product_access_error` in `run_widgets` and tile mutations |
+
+**Frontend `locked` alone is insufficient** — set `required_product_access` on the registry entry so backend enforces the same gate.
+
+## Copy / move / duplicate
+
+| Action | Widget support |
+| ------ | -------------- |
+| Duplicate within same dashboard | Deep-clones widget row |
+| Copy to another dashboard | Deep-clones widget row + tile on destination (name gets ` (Copy)` when set) |
+| Move to another dashboard | Moves tile row; same `DashboardWidget` FK (widgets are not shared across dashboards) |
+| Duplicate entire dashboard | Always deep-clones widget rows (even when `duplicate_tiles: false` for insights) |
+
+Button tiles still cannot be copied or moved between dashboards.
+
+## Cross-project copy
+
+Transferring a dashboard between projects deep-clones widget rows. `DashboardWidgetVisitor` (`posthog/models/resource_transfer/visitors/dashboard_widget.py`) is `user_facing=True` (default) so widgets appear in transfer preview dependencies with `display_name` from widget `name` when set. `DashboardTile` visitor stays `user_facing=False`. Tests: `posthog/api/test/test_resource_transfer.py` (`test_preview_returns_dashboard_with_widget_tiles`).
+
+## Shared / public / subscriptions
+
+- `placement === DashboardPlacement.Public` hides edit controls and ⋯ menu
+- `titleHref` suppressed on public dashboards
+- Widget tiles are not rendered on shared/public/export placements (`isWidgetTileVisibleOnPlacement` in `DashboardItems.tsx`)
+- Subscriptions and snapshots render read-only — no edit modal, no mutations from tile chrome
+
+## Activity logging
+
+- `DashboardWidget` uses `ModelActivityMixin`; scope `"DashboardWidget"`
+- `handle_dashboard_widget_change` in `dashboard.py` logs create/update/delete
+- Do not store secrets in `config` — changes are logged
+
+## `required_scopes` and `required_product_access`
+
+`required_scopes` on `WIDGET_REGISTRY` entries is documentation only. RBAC is driven by `required_product_access` — `widget_access.get_widget_product_access_error` handles `run_widgets` and tile mutations. Do not add per-type checks in `dashboard.py`.

--- a/.agents/skills/dashboard-widgets/references/pitfalls.md
+++ b/.agents/skills/dashboard-widgets/references/pitfalls.md
@@ -1,0 +1,63 @@
+# Pitfalls and troubleshooting
+
+See also: [architecture.md](architecture.md), [permissions-and-sharing.md](permissions-and-sharing.md), [composition.md](composition.md).
+
+## Common mistakes
+
+| Symptom | Fix |
+| ------- | --- |
+| Data leaks despite frontend `locked` | Set `required_product_access` on the registry entry — backend uses `get_widget_product_access_error` |
+| Assumed `required_scopes` is enforced | Registry field is documentation only — RBAC uses `required_product_access` + `widget_access.py` |
+| Skeleton in wrong layer | Loading belongs in widget `Component`, not `WidgetCard` shell |
+| Body in `gridChildren` | Widget content belongs in composed `WidgetCardBody`; `gridChildren` is RGL resize handles only |
+| Fat props on `WidgetCard` | Compose `WidgetCardHeader` + `WidgetCardBody` at callsite — shell is chrome only |
+| Add modal missing type | Registry without catalog entry — catalog drives add modal, layouts, headers, previews |
+| Backend catalog out of sync | New type needs entries in both `widget_catalog.py` (BE) and `catalog.ts` (FE) |
+| Confused `groupId` with `widget_type` | `groupId` groups add-modal UI only; backend/DB need a unique `widget_type` per variant |
+| Reused `widget_type` for a new variant | Each variant needs its own catalog key + BE/FE registry entry — do not overload an existing type |
+| Inconsistent `groupLabel` within a group | All entries sharing a `groupId` must use the same `groupLabel` |
+| CI fails on widget types | Keep `EXPECTED_WIDGET_TYPES` in sync with `WIDGET_REGISTRY`; extend `DashboardWidgetType` when adding a canonical type |
+| Frontend types drift | Run `hogli build:openapi` after serializer changes |
+| Filter toggle in ⋯ menu | `filterTestAccounts` belongs in settings modal Filters section — wire `TestAccountFilter` (or equivalent) in a `WidgetSettingsModalSection`; baked into `baseWidgetConfigSchema` / `merge_base_widget_config_fields` |
+| Inline title/description edit on card | Title and description edit only in widget settings modal Tile details section |
+| Storybook "CSF: unexpected dynamic title" | Meta `title` must be a string literal matching catalog `groupLabel` / `label` — no helper function in CSF |
+| Unknown `widget_type` crashes render | Every supported type needs a registry entry; unsupported types should not reach render |
+| Unknown `widget_type` renders empty tile | `getDashboardWidgetDefinition` dedupes a PostHog `captureException` per canonical type — add the registry entry (and keep catalog in sync) |
+| Widget CRUD tests fail with validation errors | Copy the setUp patch pattern from existing widget test modules |
+| Empty test file scaffold | Do not commit `.test.tsx` files with only `@testing-library/jest-dom` import — add real assertions or omit the file |
+| Modified product SetupPrompt for widgets | Add setup gate UI inside `widgets/<product>/<Component>.tsx` instead |
+| Added widget props to `ProductIntroduction` | Use `WidgetCardProductIntroduction` in the dashboard widget layer instead |
+| Hardcoded product check in `DashboardWidgetItem` | Extend `userHasWidgetProductAccess` switch + `DashboardWidgetProductAccess` union — one `case` per gated product |
+| Hardcoded product check in `dashboard.py` | Set `required_product_access` on registry entry — use `widget_access.py` |
+| Missing FE RBAC map entry | Extend `DashboardWidgetProductAccess` union + `DASHBOARD_WIDGET_PRODUCT_ACCESS_RESOURCES` |
+| Fetch error shows raw API string | Add passthrough prefix in `constants.ts` (`getDashboardWidgetFetchDisplayError`) or rely on generic message |
+| Resize floor stuck at 4 rows | Catalog entry missing `minH` — `tileLayouts.ts` falls back to `MIN_WIDGET_TILE_HEIGHT_ROWS` (4). Set explicit `defaultLayout.minH` in `catalog.ts` + test in `tileLayouts.test.ts` |
+| Changed min size in widget component / SCSS | Mins are **catalog → `tileLayouts.ts` → RGL**, not the widget body. See [layout-and-ux.md](layout-and-ux.md) § Tile min/max size |
+| Description/name half-width in edit modal | `WIDGET_SETTINGS_FIELD_FULL_WIDTH_CLASS` must be on `LemonField.Pure` (grid child), not on inner `LemonInput`/`LemonTextArea` — copy `EditErrorTrackingWidgetModal.tsx` |
+| `TestAccountFilter` crashes edit modal | Pass `filters={{ filter_test_accounts }}` and `onChange={({ filter_test_accounts }) => …}` — not `checked`/`onChange(boolean)` |
+
+See [scaling.md](scaling.md) for what should vs should not grow per widget type.
+
+## "If you change X, also check Y"
+
+| Change | Verify |
+| ------ | ------ |
+| New `widget_type` in backend registry | Frontend registry + catalog + preview + `EXPECTED_WIDGET_TYPES` test |
+| New variant in existing product group | Unique `widget_type`; reuse `groupId`/`groupLabel`; distinct `label`/`defaultConfig`/`defaultLayout`; full BE+FE stack still required |
+| `run_widgets` permission logic | `required_product_access` on registry entry; `test_run_widgets.py` + `test_widget_access.py`; `DashboardWidgetItem.test.tsx` for FE lock state |
+| Storybook setup states all look the same | Check decorator stacking — meta-level `withErrorTrackingProjectState(true)` overrides story-level `false`; seed per story |
+| Serializer field on `DashboardWidget` | `hogli build:openapi`; generated types; activity logging |
+| Catalog `defaultLayout` | `tileLayouts.ts` min/max; `tileLayouts.test.ts` case for `expectedMinH`/`minW`; RGL resize in edit mode; optional Storybook `MinimumSize` story |
+| Widget `Component` loading path | Skeleton in component only; shell still resizes correctly |
+| Copy/move tile logic | Widget copy deep-clones; move reassigns tile. Button tiles still blocked cross-dashboard |
+| Date range options | Keep `widgetDateRangeOptions.ts`, Zod schema, and edit-modal select in sync |
+| Multi-tile add (UI / MCP) | `addWidgetTiles` → `POST .../widgets/batch/` |
+| REST/MCP single add | `POST .../widgets/` creates one tile per request |
+
+## `run_widgets` permission pattern
+
+The `required_scopes` field on registry entries documents expected scopes. RBAC is enforced via `required_product_access` on each `WIDGET_REGISTRY` entry — `get_widget_product_access_error` in `widget_access.py` handles `run_widgets` and tile mutations. Do not add per-type `if widget_type == …` branches in `dashboard.py`.
+
+## Out of scope
+
+Insight tiles, text cards, and button tiles use separate models. Widgets are the path for **new** embeddable content types only.

--- a/.agents/skills/dashboard-widgets/references/scaling.md
+++ b/.agents/skills/dashboard-widgets/references/scaling.md
@@ -1,0 +1,46 @@
+# Scaling to many widget types
+
+Platform glue stays product-agnostic. Each new type adds files under product-specific paths — not branches in shared dispatch code.
+
+## Per-type touch list (typical add)
+
+| Layer | Add / extend |
+| ----- | ------------ |
+| BE runtime | `backend/widgets/<widget_type>.py` — `validate_*`, `run_*` |
+| BE registry | `widget_registry.py` — one `WIDGET_REGISTRY` key + `DashboardWidgetType` |
+| BE catalog | `widget_catalog.py` — one `WIDGET_CATALOG` entry |
+| BE access | `widget_access.py` — denial message in `PRODUCT_ACCESS_DENIED_MESSAGES` (optional) |
+| FE catalog | `widget_types/catalog.ts` — one key (`satisfies` forces registry sync) |
+| FE config | `configSchemas.ts` — per-type Zod schema (split into `configSchemas/<product>.ts` when file grows) |
+| FE registry | `widgets/registry.tsx` — import `Component` / `EditModal` from `widgets/<product>/`; one keyed entry per `widget_type` |
+| FE RBAC | `types.ts` `DashboardWidgetProductAccess` union + new `case` in `userHasWidgetProductAccess` (`DashboardWidgetItem.tsx`) |
+| FE preview | `widgets/previews/` + `widgetPreviews.tsx` key |
+| FE widget | `widgets/<product>/` — Component, EditModal, stories, tests |
+| FE overview demo | `widgetOverviewStoryFixtures.ts` — one `case` in exhaustive switch |
+
+## Files that should **not** grow per type
+
+| File | Role |
+| ---- | ---- |
+| `dashboard.py` `run_widgets` | Generic loop — uses `get_widget_registry_entry` + `get_widget_product_access_error` |
+| `DashboardWidgetItem.tsx` | Generic shell — composes `WidgetCard` + header/body; extend `userHasWidgetProductAccess` switch only when adding a new gated product |
+| `WidgetCard.tsx` | Thin chrome shell only — no product imports, no header/body props |
+| `WidgetCardHeader.tsx` / `WidgetCardBody.tsx` | Shared compound parts — no product imports |
+| `dashboardLogic.tsx` | Generic fetch/CRUD — no `widget_type` switches for data |
+| `widgetFetchUtils.ts` | Batched `run_widgets` only |
+
+## Type-safety nets (CI)
+
+- BE: `EXPECTED_WIDGET_TYPES == WIDGET_REGISTRY.keys()`
+- FE: `DASHBOARD_WIDGET_REGISTRY satisfies Record<DashboardWidgetCatalogKey, …>`
+- FE: `DASHBOARD_WIDGET_PREVIEWS` keyed by `DashboardWidgetCatalogKey`
+- FE: `registry.test.tsx` — every catalog key has a definition
+- Runtime: `getDashboardWidgetDefinition` → PostHog `captureException` on miss (deploy skew)
+
+## Variants in the same product group
+
+Multiple `widget_type` entries share `groupId` / `groupLabel` in catalog only. `AddWidgetModal` groups by `groupId` inline — no separate grouping module. Each variant still gets the full per-type stack above — **no** shared `if widget_type in (...)` permission or query branches in platform code.
+
+## Registry imports
+
+Import `Component` and `EditModal` directly in `registry.tsx` (no `React.lazy`, no per-type `definition.ts`). `DashboardWidgetItem` renders components directly — widget-owned `WidgetLoadingState` handles data-fetch loading.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 
 **Invoke when in the area:**
 
+- `/dashboard-widgets` — adding or updating dashboard widget types (catalog, edit modal, layout mins, config, run_widgets), WIDGET_REGISTRY, WidgetCard, or dashboard tile widget glue
 - `/implementing-mcp-tools` — adding/modifying endpoints or `tools.yaml`
 - `/modifying-taxonomic-filter` — any TaxonomicFilter change
 - `/sending-notifications` — adding notification support

--- a/products/dashboards/CONTRIBUTING.md
+++ b/products/dashboards/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Dashboard widgets
+
+Embeddable dashboard tiles backed by `DashboardWidget` and rendered through the product-local frontend registry in `products/dashboards/frontend/`.
+
+**In scope:** widget tiles (`widget_id` on `DashboardTile`).
+**Out of scope:** insight tiles, text cards, and button tiles — separate models today.
+
+Reference implementation: `products/dashboards/frontend/widgets/error_tracking/` (`error_tracking_list`).
+
+## Architecture (sketch)
+
+```text
+DashboardTile (layout) → widget_id → DashboardWidget (team-scoped)
+  widget_type + config  →  WIDGET_REGISTRY (BE)  →  run_widgets
+                        →  DASHBOARD_WIDGET_CATALOG + registry.tsx (FE)
+```
+
+New `widget_type` strings need **no migration** — register backend + frontend + both catalogs.
+Schema changes on `DashboardWidget` / `DashboardTile` use the dashboards migration chain (`0007+` after `0006_migrate_product_analytics_models`).
+
+Layer table, registry shapes, copy/move, analytics, and typing details: [`.agents/skills/dashboard-widgets/references/architecture.md`](../../.agents/skills/dashboard-widgets/references/architecture.md)
+
+## Playbook
+
+**Canonical guide:** [`.agents/skills/dashboard-widgets/`](../../.agents/skills/dashboard-widgets/) (also loaded by agents via `/dashboard-widgets` — covers **add and update**).
+
+| Task | Doc |
+| ---- | --- |
+| Add a new widget type | [`references/checklist-new-widget-type.md`](../../.agents/skills/dashboard-widgets/references/checklist-new-widget-type.md) |
+| Update an existing widget type | [`references/managing-existing-widgets.md`](../../.agents/skills/dashboard-widgets/references/managing-existing-widgets.md) |
+| Tile min/max size on dashboard grid | [`references/layout-and-ux.md`](../../.agents/skills/dashboard-widgets/references/layout-and-ux.md) (§ Tile min/max size) |
+| WidgetCard, loading, headers | [`references/composition.md`](../../.agents/skills/dashboard-widgets/references/composition.md) |
+| RBAC, copy/move, shared dashboards | [`references/permissions-and-sharing.md`](../../.agents/skills/dashboard-widgets/references/permissions-and-sharing.md) |
+| Scaling to many widget types | [`references/scaling.md`](../../.agents/skills/dashboard-widgets/references/scaling.md) |
+| MCP / REST | [`references/mcp.md`](../../.agents/skills/dashboard-widgets/references/mcp.md) |
+| Pitfalls | [`references/pitfalls.md`](../../.agents/skills/dashboard-widgets/references/pitfalls.md) |
+| File index | [`references/file-paths.md`](../../.agents/skills/dashboard-widgets/references/file-paths.md) |
+
+**Critical rule:** set `required_product_access` / `productAccess` only when the widget reads gated product data — omit both when no extra product RBAC is needed. Platform glue stays generic. `required_scopes` is documentation only.
+
+## Frontend / backend parity
+
+Three registries must stay aligned for every shipped `widget_type`:
+
+| Registry | Location |
+| -------- | -------- |
+| `EXPECTED_WIDGET_TYPES` | `backend/widget_registry.py` |
+| `WIDGET_CATALOG` | `backend/widget_catalog.py` |
+| `DASHBOARD_WIDGET_CATALOG` | `frontend/widget_types/catalog.ts` |
+
+Each catalog key equals the canonical `widget_type` string. On the frontend,
+`DASHBOARD_WIDGET_REGISTRY` uses `satisfies Record<DashboardWidgetCatalogKey, …>`
+so a missing registry entry fails TypeScript. `registry.test.tsx` asserts catalog
+keys match `EXPECTED_DASHBOARD_WIDGET_TYPES` (keep in sync with the Python
+constant). Backend tests assert `WIDGET_REGISTRY`, `WIDGET_CATALOG`, and
+`EXPECTED_WIDGET_TYPES` match. After adding a type, run both backend and frontend
+widget tests in **Verify** below.
+
+## Adding a widget type
+
+Full step-by-step: [checklist-new-widget-type.md](../../.agents/skills/dashboard-widgets/references/checklist-new-widget-type.md).
+
+Each registry below grows with one entry per `widget_type`. Inline comments in code point here instead of repeating the list.
+
+| Location | What to add |
+| -------- | ----------- |
+| `backend/widgets/<widget_type>.py` | `validate_*` + `run_*` for the type |
+| `backend/widget_registry.py` | `WIDGET_REGISTRY` key, `EXPECTED_WIDGET_TYPES`, `DashboardWidgetType`, optional `WIDGET_TYPE_ALIASES` / `DashboardWidgetTypeInput` |
+| `backend/widget_catalog.py` | `WIDGET_CATALOG` key |
+| `backend/widget_access.py` | Optional friendly `PRODUCT_ACCESS_DENIED_MESSAGES` entry per shipped gated type |
+| `frontend/widget_types/catalog.ts` | `DASHBOARD_WIDGET_CATALOG` key; optional `DASHBOARD_WIDGET_TYPE_ALIASES` |
+| `frontend/widget_types/configSchemas.ts` | Per-type Zod schema (used by catalog `defaultConfig`) |
+| `frontend/widget_types/widgetConfigValidation.ts` | Shared validation error type |
+| `frontend/widgets/<product>/*WidgetConfigValidation.ts` | Per-type edit-modal validation |
+| `frontend/types.ts` | `DashboardWidgetProductAccess` union member (if RBAC-gated) |
+| `frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx` | `userHasWidgetProductAccess` case (if RBAC-gated) |
+| `frontend/widgets/registry.tsx` | `DASHBOARD_WIDGET_REGISTRY` key |
+| `frontend/widgets/previews/widgetPreviews.tsx` | Preview component + map entry |
+| `frontend/components/WidgetCard/widgetOverviewStoryFixtures.ts` | `getWidgetOverviewDemoState` switch case |
+| `frontend/widget_types/widgetAvailability.ts` | `WidgetAvailabilityRequirementId` + evaluator (if catalog uses `availability`) |
+| `frontend/components/WidgetAvailabilitySetupPrompt/` | Setup UI branch for new requirement id |
+
+Auto-derived from catalog (no manual list edit): add-widget modal grouping, overview story tile list, `DashboardWidgetCatalogKey` type.
+
+## Verify
+
+```bash
+hogli test products/dashboards/backend/api/test/test_dashboard_widgets.py
+hogli test products/dashboards/backend/api/test/test_run_widgets.py
+hogli test products/dashboards/backend/api/test/test_widget_access.py
+hogli test products/dashboards/frontend/widgets/
+hogli test products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.test.tsx
+hogli test products/dashboards/frontend/components/WidgetCard/
+```
+
+After serializer changes: `hogli build:openapi` (do not edit `products/dashboards/frontend/generated/`).

--- a/products/dashboards/frontend/widgets/error_tracking/EditErrorTrackingWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/error_tracking/EditErrorTrackingWidgetModal.tsx
@@ -1,26 +1,23 @@
-import { useEffect, useMemo, useState } from 'react'
 import { useValues } from 'kea'
+import { useEffect, useMemo, useState } from 'react'
+
+import { LemonTextArea } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
-import { LemonTextArea } from '@posthog/lemon-ui'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { exceptionIngestionLogic } from 'products/error_tracking/frontend/components/SetupPrompt/exceptionIngestionLogic'
 
-import { resolveWidgetFilterTestAccounts } from '../../widget_types/configSchemas'
-import { WIDGET_DATE_RANGE_SELECT_OPTIONS } from '../../widget_types/widgetDateRangeOptions'
-import {
-    validateErrorTrackingWidgetConfigInput,
-    type ErrorTrackingWidgetFieldErrors,
-} from './errorTrackingWidgetConfigValidation'
-import { isWidgetConfigValidationError } from '../../widget_types/widgetConfigValidation'
 import { DASHBOARD_WIDGET_CATALOG } from '../../widget_types/catalog'
+import { resolveWidgetFilterTestAccounts } from '../../widget_types/configSchemas'
+import { isWidgetConfigValidationError } from '../../widget_types/widgetConfigValidation'
+import { WIDGET_DATE_RANGE_SELECT_OPTIONS } from '../../widget_types/widgetDateRangeOptions'
 import { DASHBOARD_WIDGET_MODAL_WIDTH } from '../constants'
 import type { DashboardWidgetEditModalProps } from '../registry'
 import {
@@ -30,9 +27,10 @@ import {
     WidgetSettingsModalSections,
 } from '../WidgetSettingsModalSections'
 import {
-    canConfigureErrorTrackingWidgetIssues,
-    ERROR_TRACKING_WIDGET_ORDER_BY_OPTIONS,
-} from './utils'
+    validateErrorTrackingWidgetConfigInput,
+    type ErrorTrackingWidgetFieldErrors,
+} from './errorTrackingWidgetConfigValidation'
+import { canConfigureErrorTrackingWidgetIssues, ERROR_TRACKING_WIDGET_ORDER_BY_OPTIONS } from './utils'
 
 export function EditErrorTrackingWidgetModal({
     isOpen,
@@ -57,7 +55,7 @@ export function EditErrorTrackingWidgetModal({
     const [dateFrom, setDateFrom] = useState<string>(initialDateRange)
     const [tileName, setTileName] = useState<string>(name)
     const [tileDescription, setTileDescription] = useState<string>(description)
-    const [filterTestAccounts, setFilterTestAccounts] = useState<boolean>(
+    const [filterTestAccounts, setFilterTestAccounts] = useState<boolean>(() =>
         resolveWidgetFilterTestAccounts(config.filterTestAccounts as boolean | undefined, filterTestAccountsDefault)
     )
     const [fieldErrors, setFieldErrors] = useState<ErrorTrackingWidgetFieldErrors>({})
@@ -175,11 +173,7 @@ export function EditErrorTrackingWidgetModal({
                         type="primary"
                         loading={saving}
                         disabledReason={
-                            saving
-                                ? 'Saving…'
-                                : !validation.success
-                                  ? 'Fix validation errors to save'
-                                  : undefined
+                            saving ? 'Saving…' : !validation.success ? 'Fix validation errors to save' : undefined
                         }
                         onClick={() => void handleSave()}
                     >
@@ -235,9 +229,7 @@ export function EditErrorTrackingWidgetModal({
                             </div>
                         </WidgetSettingsModalSection>
                         <WidgetSettingsModalDivider />
-                        <WidgetSettingsModalSection
-                            title={DASHBOARD_WIDGET_CATALOG.error_tracking_list.groupLabel}
-                        >
+                        <WidgetSettingsModalSection title={DASHBOARD_WIDGET_CATALOG.error_tracking_list.groupLabel}>
                             <LemonField.Pure
                                 label="Date range"
                                 help="Only include issues seen in this period."

--- a/products/dashboards/frontend/widgets/error_tracking/errorTrackingWidgetConfigValidation.test.ts
+++ b/products/dashboards/frontend/widgets/error_tracking/errorTrackingWidgetConfigValidation.test.ts
@@ -22,7 +22,7 @@ describe('validateErrorTrackingWidgetConfigInput', () => {
         }
     })
 
-    it('accepts valid config', () => {
+    it('accepts valid config without filterTestAccounts', () => {
         const result = validateErrorTrackingWidgetConfigInput({
             limit: 10,
             orderBy: 'occurrences',

--- a/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/session_replay/EditSessionReplayWidgetModal.tsx
@@ -1,19 +1,20 @@
-import { useEffect, useMemo, useState } from 'react'
 import { useValues } from 'kea'
+import { useEffect, useMemo, useState } from 'react'
+
+import { LemonTextArea } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
-import { LemonTextArea } from '@posthog/lemon-ui'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
 
-import { resolveWidgetFilterTestAccounts } from '../../widget_types/configSchemas'
-import { WIDGET_DATE_RANGE_SELECT_OPTIONS } from '../../widget_types/widgetDateRangeOptions'
-import { isWidgetConfigValidationError } from '../../widget_types/widgetConfigValidation'
 import { DASHBOARD_WIDGET_CATALOG } from '../../widget_types/catalog'
+import { resolveWidgetFilterTestAccounts } from '../../widget_types/configSchemas'
+import { isWidgetConfigValidationError } from '../../widget_types/widgetConfigValidation'
+import { WIDGET_DATE_RANGE_SELECT_OPTIONS } from '../../widget_types/widgetDateRangeOptions'
 import { DASHBOARD_WIDGET_MODAL_WIDTH } from '../constants'
 import type { DashboardWidgetEditModalProps } from '../registry'
 import {
@@ -45,7 +46,7 @@ export function EditSessionReplayWidgetModal({
     const [dateFrom, setDateFrom] = useState<string>(initialDateRange)
     const [tileName, setTileName] = useState<string>(name)
     const [tileDescription, setTileDescription] = useState<string>(description)
-    const [filterTestAccounts, setFilterTestAccounts] = useState<boolean>(
+    const [filterTestAccounts, setFilterTestAccounts] = useState<boolean>(() =>
         resolveWidgetFilterTestAccounts(config.filterTestAccounts as boolean | undefined, filterTestAccountsDefault)
     )
     const [fieldErrors, setFieldErrors] = useState<SessionReplayWidgetFieldErrors>({})
@@ -175,20 +176,10 @@ export function EditSessionReplayWidgetModal({
         >
             <WidgetSettingsModalSections>
                 <WidgetSettingsModalSection title="Tile details">
-                    <LemonField.Pure
-                        className={WIDGET_SETTINGS_FIELD_FULL_WIDTH_CLASS}
-                        label="Name"
-                    >
-                        <LemonInput
-                            value={tileName}
-                            onChange={setTileName}
-                            placeholder={defaultTitle}
-                        />
+                    <LemonField.Pure className={WIDGET_SETTINGS_FIELD_FULL_WIDTH_CLASS} label="Name">
+                        <LemonInput value={tileName} onChange={setTileName} placeholder={defaultTitle} />
                     </LemonField.Pure>
-                    <LemonField.Pure
-                        className={WIDGET_SETTINGS_FIELD_FULL_WIDTH_CLASS}
-                        label="Description"
-                    >
+                    <LemonField.Pure className={WIDGET_SETTINGS_FIELD_FULL_WIDTH_CLASS} label="Description">
                         <LemonTextArea
                             value={tileDescription}
                             onChange={setTileDescription}


### PR DESCRIPTION
## Problem

Future agents and contributors need documented conventions for adding dashboard widget types.

This PR is **10/10** in the dashboard widgets Graphite stack.

**Depends on:** PR 9 (full feature complete)

## Changes

- `.agents/skills/dashboard-widgets/` — skill + reference docs for widget development
- `products/dashboards/CONTRIBUTING.md` — contributor guide for the dashboards product
- `AGENTS.md` — mandatory skill invocation entry for dashboard widgets

## How did you test this code?

- Agent: documentation-only change; no runtime tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

skip-inkeep-docs (agent/contributor docs, not user-facing product docs)

## 🤖 Agent context

- Final stack PR — docs/skills only, safe to merge anytime after feature PRs
- Closes out the dashboard widgets Graphite stack
