### PR TITLE
chore: update mcp oauth URLs

### DIFF
--- a/products/mcp_store/backend/oauth.py
+++ b/products/mcp_store/backend/oauth.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 import requests
 import structlog
+import tldextract
 
 from posthog.security.url_validation import is_url_allowed
 
@@ -36,21 +37,48 @@ def _validate_url(url: str) -> None:
 
 
 def _fetch_auth_server_metadata(auth_server_url: str) -> dict:
+    # MCP Authorization §2.3 mandates this exact ordered chain of well-known URLs.
+    # https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-server-metadata-discovery
     parsed = urlparse(auth_server_url)
-    metadata_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server"
-    if parsed.path and parsed.path != "/":
-        metadata_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server{parsed.path}"
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    has_path = parsed.path and parsed.path != "/"
+    path = parsed.path.rstrip("/") if has_path else ""
 
-    _validate_url(metadata_url)
-    metadata_resp = requests.get(metadata_url, timeout=TIMEOUT)
-    metadata_resp.raise_for_status()
-    metadata = metadata_resp.json()
+    if path:
+        candidates = [
+            f"{origin}/.well-known/oauth-authorization-server{path}",
+            f"{origin}/.well-known/openid-configuration{path}",
+            f"{origin}{path}/.well-known/openid-configuration",
+        ]
+    else:
+        candidates = [
+            f"{origin}/.well-known/oauth-authorization-server",
+            f"{origin}/.well-known/openid-configuration",
+        ]
 
-    for field in ("authorization_endpoint", "token_endpoint"):
-        if field not in metadata:
-            raise ValueError(f"Missing required field '{field}' in authorization server metadata")
+    # Only fall back on "endpoint not implemented" — transient errors must surface as-is.
+    FALLBACK_STATUSES = {404, 405}
+    last_exc: Exception = RuntimeError("no discovery candidates were attempted")
+    for metadata_url in candidates:
+        _validate_url(metadata_url)
+        metadata_resp = requests.get(metadata_url, timeout=TIMEOUT)
+        if metadata_resp.status_code in FALLBACK_STATUSES:
+            last_exc = requests.HTTPError(response=metadata_resp)
+            continue
+        metadata_resp.raise_for_status()
+        metadata = metadata_resp.json()
+        for field in ("authorization_endpoint", "token_endpoint"):
+            if field not in metadata:
+                raise ValueError(f"Missing required field '{field}' in authorization server metadata")
+        if metadata_url != candidates[0]:
+            logger.info(
+                "OAuth auth-server metadata discovered via fallback URL",
+                auth_server_url=auth_server_url,
+                tried_url=metadata_url,
+            )
+        return metadata
 
-    return metadata
+    raise last_exc
 
 
 # When the origin declares a cross-origin issuer (e.g. Atlassian → Cloudflare),
@@ -76,13 +104,26 @@ def _resolve_issuer(metadata: dict, expected_issuer: str) -> dict:
     return metadata
 
 
+def _registrable_domain(hostname: str) -> str | None:
+    """Return the eTLD+1 (registrable domain) for a hostname, e.g. `auth.example.co.uk` -> `example.co.uk`."""
+    extracted = tldextract.extract(hostname)
+    if not extracted.domain or not extracted.suffix:
+        return None
+    return f"{extracted.domain}.{extracted.suffix}".lower()
+
+
 def _validate_endpoints_bound_to_issuer(metadata: dict) -> None:
-    """Reject metadata where OAuth endpoints don't share the issuer's origin.
+    """Reject metadata where OAuth endpoints live on an unrelated registrable domain from the issuer.
 
     Without this, a malicious metadata source can mix endpoints from a real
     provider with an attacker-controlled token_endpoint, exfiltrating
     authorization codes, PKCE verifiers, and DCR-minted client_secrets while
     the user authorizes against the legitimate provider.
+
+    Many auth setups (Keycloak, Auth0, Okta, and apps that delegate auth
+    to a dedicated subdomain) publish the issuer on one subdomain and the
+    actual OAuth endpoints on a sibling subdomain — e.g. issuer at
+    `mcp.example.com/oauth` with endpoints on `auth.example.com`.
     """
     issuer = (metadata.get("issuer") or "").rstrip("/")
     if not issuer:
@@ -91,21 +132,35 @@ def _validate_endpoints_bound_to_issuer(metadata: dict) -> None:
     parsed_issuer = urlparse(issuer)
     if not parsed_issuer.scheme or not parsed_issuer.netloc:
         raise ValueError("OAuth metadata issuer is not an absolute URL")
-    issuer_origin = (parsed_issuer.scheme, parsed_issuer.netloc)
+
+    issuer_domain = _registrable_domain(parsed_issuer.hostname or "")
+    if issuer_domain is None:
+        raise ValueError("OAuth metadata issuer has no registrable domain")
 
     for field in ("authorization_endpoint", "token_endpoint", "registration_endpoint"):
         url = metadata.get(field)
         if not url:
             continue
         parsed = urlparse(url)
-        if (parsed.scheme, parsed.netloc) != issuer_origin:
+        if parsed.scheme != parsed_issuer.scheme:
             logger.warning(
-                "OAuth endpoint origin does not match issuer",
+                "OAuth endpoint scheme does not match issuer",
                 issuer=issuer,
                 field=field,
                 endpoint=url,
             )
-            raise ValueError(f"OAuth endpoint '{field}' origin does not match issuer")
+            raise ValueError(f"OAuth endpoint '{field}' scheme does not match issuer")
+        endpoint_domain = _registrable_domain(parsed.hostname or "")
+        if endpoint_domain != issuer_domain:
+            logger.warning(
+                "OAuth endpoint registrable domain does not match issuer",
+                issuer=issuer,
+                field=field,
+                endpoint=url,
+                issuer_domain=issuer_domain,
+                endpoint_domain=endpoint_domain,
+            )
+            raise ValueError(f"OAuth endpoint '{field}' is on an unrelated domain from issuer")
 
 
 def discover_oauth_metadata(server_url: str) -> dict:

--- a/products/mcp_store/backend/test/test_oauth.py
+++ b/products/mcp_store/backend/test/test_oauth.py
@@ -218,6 +218,21 @@ class TestIssuerValidation(TestCase):
             return f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server{parsed.path}"
         return f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server"
 
+    def _auth_metadata_chain(self, auth_server_url: str) -> list[str]:
+        parsed = urlparse(auth_server_url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        if parsed.path and parsed.path != "/":
+            path = parsed.path.rstrip("/")
+            return [
+                f"{origin}/.well-known/oauth-authorization-server{path}",
+                f"{origin}/.well-known/openid-configuration{path}",
+                f"{origin}{path}/.well-known/openid-configuration",
+            ]
+        return [
+            f"{origin}/.well-known/oauth-authorization-server",
+            f"{origin}/.well-known/openid-configuration",
+        ]
+
     @parameterized.expand(
         [
             (
@@ -318,9 +333,11 @@ class TestIssuerValidation(TestCase):
         if needs_cross_validation:
             if cross_val_metadata is not None:
                 responses.append(self._make_response(json_data=cross_val_metadata))
+                expected_urls.append(self._auth_metadata_url(declared_issuer))
             else:
-                responses.append(self._make_response(ok=False, status_code=404))
-            expected_urls.append(self._auth_metadata_url(declared_issuer))
+                chain = self._auth_metadata_chain(declared_issuer)
+                responses.extend(self._make_response(ok=False, status_code=404) for _ in chain)
+                expected_urls.extend(chain)
 
         mock_get.side_effect = responses
 
@@ -435,9 +452,11 @@ class TestIssuerValidation(TestCase):
         if needs_cross_validation:
             if cross_val_metadata is not None:
                 responses.append(self._make_response(json_data=cross_val_metadata))
+                expected_urls.append(self._auth_metadata_url(declared_issuer))
             else:
-                responses.append(self._make_response(ok=False, status_code=404))
-            expected_urls.append(self._auth_metadata_url(declared_issuer))
+                chain = self._auth_metadata_chain(declared_issuer)
+                responses.extend(self._make_response(ok=False, status_code=404) for _ in chain)
+                expected_urls.extend(chain)
 
         mock_get.side_effect = responses
 
@@ -490,6 +509,172 @@ class TestIssuerValidation(TestCase):
 
         with self.assertRaises(ValueError):
             discover_oauth_metadata("https://mcp.legit.com/mcp")
+
+
+class TestAuthServerMetadataDiscoveryChain(TestCase):
+    """Verifies the MCP-spec-mandated discovery chain for authorization server metadata.
+
+    Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
+    §2.3 "Authorization Server Metadata Discovery".
+    """
+
+    def _make_response(self, *, ok=True, status_code=200, json_data=None):
+        resp = MagicMock()
+        resp.ok = ok
+        resp.status_code = status_code
+        resp.json.return_value = json_data or {}
+        resp.raise_for_status = MagicMock()
+        if status_code >= 400:
+            resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+        return resp
+
+    def _valid_metadata(self, issuer: str) -> dict:
+        return {
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+        }
+
+    @patch("products.mcp_store.backend.oauth.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.oauth.requests.get")
+    def test_variant_1_success_makes_no_fallback_calls(self, mock_get, _allow):
+        """Regression guard: when variant 1 succeeds, the loop stops — no fallback URLs are tried."""
+        mcp_url = "https://mcp.example.com"
+        auth_server_url = "https://mcp.example.com/oauth"
+        resource_resp = self._make_response(json_data={"authorization_servers": [auth_server_url]})
+        auth_resp = self._make_response(json_data=self._valid_metadata(auth_server_url))
+
+        mock_get.side_effect = [resource_resp, auth_resp]
+
+        metadata = discover_oauth_metadata(mcp_url)
+        assert metadata["issuer"] == auth_server_url
+
+        expected_urls = [
+            "https://mcp.example.com/.well-known/oauth-protected-resource",
+            "https://mcp.example.com/.well-known/oauth-authorization-server/oauth",
+        ]
+        assert mock_get.call_count == len(expected_urls)
+        for index, expected_url in enumerate(expected_urls):
+            assert mock_get.call_args_list[index].args[0] == expected_url
+
+    @patch("products.mcp_store.backend.oauth.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.oauth.requests.get")
+    def test_auth_server_with_path_falls_back_to_oidc_path_insertion(self, mock_get, _allow):
+        """Variant 1 404s, variant 2 (OIDC path insertion) succeeds."""
+        mcp_url = "https://mcp.example.com"
+        auth_server_url = "https://mcp.example.com/oauth"
+        resource_resp = self._make_response(json_data={"authorization_servers": [auth_server_url]})
+        not_found = self._make_response(ok=False, status_code=404)
+        auth_resp = self._make_response(json_data=self._valid_metadata(auth_server_url))
+
+        mock_get.side_effect = [resource_resp, not_found, auth_resp]
+
+        metadata = discover_oauth_metadata(mcp_url)
+        assert metadata["issuer"] == auth_server_url
+
+        expected_urls = [
+            "https://mcp.example.com/.well-known/oauth-protected-resource",
+            "https://mcp.example.com/.well-known/oauth-authorization-server/oauth",
+            "https://mcp.example.com/.well-known/openid-configuration/oauth",
+        ]
+        assert mock_get.call_count == len(expected_urls)
+        for index, expected_url in enumerate(expected_urls):
+            assert mock_get.call_args_list[index].args[0] == expected_url
+
+    @patch("products.mcp_store.backend.oauth.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.oauth.requests.get")
+    def test_auth_server_with_path_falls_back_to_oidc_path_append(self, mock_get, _allow):
+        """Variants 1 and 2 404, variant 3 (OIDC path append) succeeds — the BuildBetter case."""
+        mcp_url = "https://mcp.example.com"
+        auth_server_url = "https://mcp.example.com/oauth"
+        resource_resp = self._make_response(json_data={"authorization_servers": [auth_server_url]})
+        not_found = self._make_response(ok=False, status_code=404)
+        auth_resp = self._make_response(json_data=self._valid_metadata(auth_server_url))
+
+        mock_get.side_effect = [resource_resp, not_found, not_found, auth_resp]
+
+        metadata = discover_oauth_metadata(mcp_url)
+        assert metadata["issuer"] == auth_server_url
+
+        expected_urls = [
+            "https://mcp.example.com/.well-known/oauth-protected-resource",
+            "https://mcp.example.com/.well-known/oauth-authorization-server/oauth",
+            "https://mcp.example.com/.well-known/openid-configuration/oauth",
+            "https://mcp.example.com/oauth/.well-known/openid-configuration",
+        ]
+        assert mock_get.call_count == len(expected_urls)
+        for index, expected_url in enumerate(expected_urls):
+            assert mock_get.call_args_list[index].args[0] == expected_url
+
+    @patch("products.mcp_store.backend.oauth.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.oauth.requests.get")
+    def test_auth_server_without_path_falls_back_to_oidc(self, mock_get, _allow):
+        """Root auth-server URL: oauth-authorization-server 404, openid-configuration 200."""
+        mcp_url = "https://mcp.example.com"
+        auth_server_url = "https://auth.example.com"
+        resource_resp = self._make_response(json_data={"authorization_servers": [auth_server_url]})
+        not_found = self._make_response(ok=False, status_code=404)
+        auth_resp = self._make_response(json_data=self._valid_metadata(auth_server_url))
+
+        mock_get.side_effect = [resource_resp, not_found, auth_resp]
+
+        metadata = discover_oauth_metadata(mcp_url)
+        assert metadata["issuer"] == auth_server_url
+
+        expected_urls = [
+            "https://mcp.example.com/.well-known/oauth-protected-resource",
+            "https://auth.example.com/.well-known/oauth-authorization-server",
+            "https://auth.example.com/.well-known/openid-configuration",
+        ]
+        assert mock_get.call_count == len(expected_urls)
+        for index, expected_url in enumerate(expected_urls):
+            assert mock_get.call_args_list[index].args[0] == expected_url
+
+    @patch("products.mcp_store.backend.oauth.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.oauth.requests.get")
+    def test_all_discovery_candidates_fail_raises(self, mock_get, _allow):
+        """When every spec-mandated candidate returns 404, discovery raises and the view layer surfaces the 400."""
+        mcp_url = "https://mcp.example.com"
+        auth_server_url = "https://mcp.example.com/oauth"
+        resource_resp = self._make_response(json_data={"authorization_servers": [auth_server_url]})
+        not_found = self._make_response(ok=False, status_code=404)
+
+        mock_get.side_effect = [resource_resp, not_found, not_found, not_found]
+
+        with self.assertRaises(requests.HTTPError):
+            discover_oauth_metadata(mcp_url)
+
+    @patch("products.mcp_store.backend.oauth.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.oauth.requests.get")
+    def test_variant_1_malformed_metadata_does_not_fall_back(self, mock_get, _allow):
+        """A 200 with malformed metadata is a real misconfiguration — surface it instead of probing fallbacks."""
+        mcp_url = "https://mcp.example.com"
+        auth_server_url = "https://mcp.example.com/oauth"
+        resource_resp = self._make_response(json_data={"authorization_servers": [auth_server_url]})
+        malformed = self._make_response(json_data={"issuer": auth_server_url})
+
+        mock_get.side_effect = [resource_resp, malformed]
+
+        with self.assertRaises(ValueError):
+            discover_oauth_metadata(mcp_url)
+
+        assert mock_get.call_count == 2
+
+    @patch("products.mcp_store.backend.oauth.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.oauth.requests.get")
+    def test_variant_1_server_error_does_not_fall_back(self, mock_get, _allow):
+        """A 500 is a transient failure, not 'endpoint not implemented' — surface it without retrying variants."""
+        mcp_url = "https://mcp.example.com"
+        auth_server_url = "https://mcp.example.com/oauth"
+        resource_resp = self._make_response(json_data={"authorization_servers": [auth_server_url]})
+        server_error = self._make_response(ok=False, status_code=500)
+
+        mock_get.side_effect = [resource_resp, server_error]
+
+        with self.assertRaises(requests.HTTPError):
+            discover_oauth_metadata(mcp_url)
+
+        assert mock_get.call_count == 2
 
 
 class TestSSRFProtection(TestCase):
@@ -548,6 +733,31 @@ class TestValidateEndpointsBoundToIssuer(TestCase):
                     "token_endpoint": "https://auth.example.com/token",
                 },
             ),
+            (
+                "sibling_subdomain_endpoints_accepted",
+                {
+                    "issuer": "https://auth.example.com",
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://token.example.com/token",
+                },
+            ),
+            (
+                "buildbetter_shape_endpoints_on_dedicated_auth_subdomain",
+                {
+                    "issuer": "https://mcp.buildbetter.app/oauth",
+                    "authorization_endpoint": "https://auth.buildbetter.app/realms/buildbetter/protocol/openid-connect/auth",
+                    "token_endpoint": "https://auth.buildbetter.app/realms/buildbetter/protocol/openid-connect/token",
+                    "registration_endpoint": "https://mcp.buildbetter.app/register",
+                },
+            ),
+            (
+                "non_standard_port_in_issuer_does_not_break_registrable_domain_extraction",
+                {
+                    "issuer": "https://auth.example.com:8443",
+                    "authorization_endpoint": "https://auth.example.com:8443/authorize",
+                    "token_endpoint": "https://auth.example.com:8443/token",
+                },
+            ),
         ]
     )
     def test_accepts_aligned_metadata(self, _name, metadata):
@@ -593,11 +803,11 @@ class TestValidateEndpointsBoundToIssuer(TestCase):
                 "token_endpoint",
             ),
             (
-                "subdomain_mismatch",
+                "unrelated_registrable_domain_co_uk_lookalike",
                 {
                     "issuer": "https://auth.example.com",
                     "authorization_endpoint": "https://auth.example.com/authorize",
-                    "token_endpoint": "https://token.example.com/token",
+                    "token_endpoint": "https://auth.evil.co.uk/token",
                 },
                 "token_endpoint",
             ),


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

1. posthog mcp oauth only tries one URL for metadata, `/.well-known/oauth-authorization-server`
    1. the mcp spec says we need to be checking more: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
    2. this was discovered when trying to add the buildbetter mcp
2. we strictly require issuer endpoint to match auth endpoint, which fails in cases like buildbetter using `mcp.buildbetter.com` and `auth.buildbetter.com`

closes https://github.com/posthog/code/issues/2417

## Changes

1. updates mcp oauth flow to adhere to the spec, checking these 3 URLs in this order:

```
/.well-known/oauth-authorization-server
/.well-known/openid-configuration
/.well-known/openid-configuration
```

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

1. relaxes the domain checks by allowing same root domain, not strictly same subdomain (e.g. buildbetter uses `mcp.buildbetter.com` but auth lives on `auth.buildbetter.com`)

## How did you test this code?

- ran posthog locally
- signed in to posthog code w/ local posthog instance
- successfully added buildbetter as a custom mcp server in posthog code
    - mcp url: https://mcp.buildbetter.app with oauth

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- Add the `skip-migration-service-check` label if every migration here is DB-noop (e.g. `SeparateDatabaseAndState` with empty `database_operations`, or pure `RunPython`) and it's safe to ship alongside service code. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->