### PR TITLE
fix(sources): Convex is using regions in their deployment urls, lets support those

### DIFF
--- a/posthog/temporal/data_imports/sources/convex/convex.py
+++ b/posthog/temporal/data_imports/sources/convex/convex.py
@@ -24,7 +24,7 @@ class ConvexResumeConfig:
     snapshot: int | None = None
 
 
-_CONVEX_CLOUD_HOST_RE = re.compile(r"^[a-z0-9][a-z0-9-]*\.convex\.cloud$")
+_CONVEX_CLOUD_HOST_RE = re.compile(r"^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)?\.convex\.cloud$")
 
 
 class InvalidDeployUrlError(Exception):
@@ -48,7 +48,10 @@ def validate_deploy_url(deploy_url: str) -> str:
 
     host = (parsed.hostname or "").lower()
     if not host or not _CONVEX_CLOUD_HOST_RE.match(host):
-        raise InvalidDeployUrlError(f"Deployment URL host must match <deployment-name>.convex.cloud, got: {host!r}.")
+        raise InvalidDeployUrlError(
+            f"Deployment URL host must match <deployment-name>.convex.cloud or "
+            f"<deployment-name>.<region>.convex.cloud, got: {host!r}."
+        )
 
     if parsed.query:
         raise InvalidDeployUrlError("Deployment URL must not contain query parameters.")

--- a/posthog/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/posthog/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -43,12 +43,22 @@ class TestValidateDeployUrl:
             ("uppercase", "HTTPS://Swift-Lemur-123.CONVEX.CLOUD", "https://swift-lemur-123.convex.cloud"),
             ("leading_space", "  https://swift-lemur-123.convex.cloud", "https://swift-lemur-123.convex.cloud"),
             ("with_path", "https://swift-lemur-123.convex.cloud/some/path", "https://swift-lemur-123.convex.cloud"),
+            (
+                "regional_eu_west_1",
+                "https://breezy-otter-42.eu-west-1.convex.cloud",
+                "https://breezy-otter-42.eu-west-1.convex.cloud",
+            ),
+            (
+                "regional_us_east_1",
+                "https://clever-falcon-77.us-east-1.convex.cloud",
+                "https://clever-falcon-77.us-east-1.convex.cloud",
+            ),
             # invalid — should raise
             ("http", "http://swift-lemur-123.convex.cloud", None),
             ("ftp", "ftp://swift-lemur-123.convex.cloud", None),
             ("no_scheme", "swift-lemur-123.convex.cloud", None),
             ("wrong_tld", "https://swift-lemur-123.convex.io", None),
-            ("extra_subdomain", "https://extra.swift-lemur-123.convex.cloud", None),
+            ("two_extra_subdomains", "https://extra.foo.swift-lemur-123.convex.cloud", None),
             ("lookalike", "https://convex.cloud.evil.com", None),
             ("bare_domain", "https://convex.cloud", None),
             ("ip_literal", "https://1.2.3.4", None),


### PR DESCRIPTION


## Problem

Seems that convex is using regions in their deployment urls, our current regex check fails valid urls. 

## Changes

- Added an optional region subdomain check to the regex
- Added tests

## How did you test this code?

- Created tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update


## 🤖 Agent context


