### PR TITLE
fix(llma): drop deprecated gemini-3-pro-preview from supported models

### DIFF
--- a/products/ai_observability/backend/llm/providers/gemini.py
+++ b/products/ai_observability/backend/llm/providers/gemini.py
@@ -41,7 +41,6 @@ class GeminiConfig:
 
     SUPPORTED_MODELS: list[str] = [
         "gemini-3.1-pro-preview",
-        "gemini-3-pro-preview",
         "gemini-3-flash-preview",
         "gemini-2.5-flash",
         "gemini-2.5-flash-lite",


### PR DESCRIPTION
## Problem

Google retired `models/gemini-3-pro-preview`. Any eval or playground call in AI Observability that picks it now fails with:

```
This model models/gemini-3-pro-preview is no longer available. Please update your code to use a newer model for the latest features and improvements.
```

`gemini-3.1-pro-preview` is the successor and is already in `GeminiConfig.SUPPORTED_MODELS`.

## Changes

- `products/ai_observability/backend/llm/providers/gemini.py`: remove `"gemini-3-pro-preview"` from `SUPPORTED_MODELS`. It wasn't in `TRIAL_MODELS`, so the trial path is unaffected.

The retired model is referenced in two other places that don't need changes:
- `services/llm-gateway/tests/test_openai.py` uses it only as a fixture for unsupported-model rejection tests, no live call.
- `services/llm-gateway/src/llm_gateway/api/handler.py:53` is a docstring example.

## How did you test this code?

Agent-authored PR; no manual playground or eval run.

- Automated coverage in this area is small. `products/ai_observability/backend/llm/providers/test/test_gemini_adapter.py::test_recommended_models_equals_supported_models` keeps passing since `recommended_models()` is derived from `SUPPORTED_MODELS`.
- `products/ai_observability/backend/api/test/test_proxy.py` enforces `TRIAL_MODELS ⊆ SUPPORTED_MODELS`; unaffected (the removed model wasn't in `TRIAL_MODELS`).

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7), background session.
- User flagged an eval failure citing `models/gemini-3-pro-preview is no longer available.`. The agent located the surviving reference in `GeminiConfig.SUPPORTED_MODELS`, cross-checked Google's Gemini API model status page (it lists `gemini-3-pro-preview` as Shut down and `gemini-3.1-pro-preview` as the recommended successor), and confirmed `gemini-3.1-pro-preview` is already in the list.
- Considered also bumping `posthog/temporal/data_imports/signals/pipeline.py` (currently pinned to `models/gemini-3-flash-preview`). Skipped at user direction since that model is still served as Preview by Google.
