### PR TITLE
chore(personhog): enforce 250-ID limit on batch person lookup RPCs

### DIFF
--- a/nodejs/src/ingestion/personhog/persons.test.ts
+++ b/nodejs/src/ingestion/personhog/persons.test.ts
@@ -91,25 +91,38 @@ function createOperations(overrides: Partial<ServiceImpl<typeof PersonHogService
 }
 
 describe('PersonHogPersonOperations', () => {
-    describe('fetchPersonsByDistinctIds batching', () => {
+    describe.each([
+        {
+            method: 'fetchPersonsByDistinctIds' as const,
+            handler: 'getPersonsByDistinctIds' as const,
+            makeItem: (i: number) => ({ teamId: 1, distinctId: `d-${i}` }),
+        },
+        {
+            method: 'fetchPersonsByPersonIds' as const,
+            handler: 'getPersonsByUuids' as const,
+            makeItem: (i: number) => ({ teamId: 1, personId: `uuid-${i}` }),
+        },
+    ])('$method batching', ({ method, handler, makeItem }) => {
         it('sends a single RPC when under the batch limit', async () => {
             const { ops, handlers } = createOperations()
-            const items = Array.from({ length: 10 }, (_, i) => ({ teamId: 1, distinctId: `d-${i}` }))
-
-            await ops.fetchPersonsByDistinctIds(items)
-
-            expect(handlers.getPersonsByDistinctIds).toHaveBeenCalledTimes(1)
+            await ops[method](Array.from({ length: 10 }, (_, i) => makeItem(i)))
+            expect(handlers[handler]).toHaveBeenCalledTimes(1)
         })
 
         it('splits into multiple RPCs when over the batch limit', async () => {
             const { ops, handlers } = createOperations()
-            const items = Array.from({ length: 400 }, (_, i) => ({ teamId: 1, distinctId: `d-${i}` }))
-
-            await ops.fetchPersonsByDistinctIds(items)
-
-            expect(handlers.getPersonsByDistinctIds).toHaveBeenCalledTimes(2)
+            await ops[method](Array.from({ length: 400 }, (_, i) => makeItem(i)))
+            expect(handlers[handler]).toHaveBeenCalledTimes(2)
         })
 
+        it('handles exact batch boundary without duplicating or dropping', async () => {
+            const { ops, handlers } = createOperations()
+            await ops[method](Array.from({ length: 250 }, (_, i) => makeItem(i)))
+            expect(handlers[handler]).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('fetchPersonsByDistinctIds', () => {
         it('merges results from multiple batches', async () => {
             const handler = jest.fn()
             let callCount = 0
@@ -135,42 +148,9 @@ describe('PersonHogPersonOperations', () => {
             expect(handler).toHaveBeenCalledTimes(2)
             expect(results).toHaveLength(300)
         })
-
-        it('handles exact batch boundary without duplicating or dropping', async () => {
-            const { ops, handlers } = createOperations()
-            const items = Array.from({ length: 250 }, (_, i) => ({ teamId: 1, distinctId: `d-${i}` }))
-
-            await ops.fetchPersonsByDistinctIds(items)
-
-            expect(handlers.getPersonsByDistinctIds).toHaveBeenCalledTimes(1)
-        })
     })
 
-    describe('fetchPersonsByPersonIds batching', () => {
-        it('sends a single RPC per team when under the batch limit', async () => {
-            const { ops, handlers } = createOperations()
-            const items = Array.from({ length: 10 }, (_, i) => ({
-                teamId: 1,
-                personId: `uuid-${i}`,
-            }))
-
-            await ops.fetchPersonsByPersonIds(items)
-
-            expect(handlers.getPersonsByUuids).toHaveBeenCalledTimes(1)
-        })
-
-        it('splits into multiple RPCs per team when over the batch limit', async () => {
-            const { ops, handlers } = createOperations()
-            const items = Array.from({ length: 400 }, (_, i) => ({
-                teamId: 1,
-                personId: `uuid-${i}`,
-            }))
-
-            await ops.fetchPersonsByPersonIds(items)
-
-            expect(handlers.getPersonsByUuids).toHaveBeenCalledTimes(2)
-        })
-
+    describe('fetchPersonsByPersonIds', () => {
         it('merges results from multiple batches across teams', async () => {
             const handler = jest.fn()
             handler.mockImplementation((req: GetPersonsByUuidsRequest) => ({
@@ -188,18 +168,6 @@ describe('PersonHogPersonOperations', () => {
             // team 1: 2 batches (250 + 50), team 2: 1 batch (100)
             expect(handler).toHaveBeenCalledTimes(3)
             expect(results).toHaveLength(400)
-        })
-
-        it('handles exact batch boundary without duplicating or dropping', async () => {
-            const { ops, handlers } = createOperations()
-            const items = Array.from({ length: 250 }, (_, i) => ({
-                teamId: 1,
-                personId: `uuid-${i}`,
-            }))
-
-            await ops.fetchPersonsByPersonIds(items)
-
-            expect(handlers.getPersonsByUuids).toHaveBeenCalledTimes(1)
         })
     })
 })

--- a/nodejs/src/ingestion/personhog/persons.test.ts
+++ b/nodejs/src/ingestion/personhog/persons.test.ts
@@ -1,0 +1,205 @@
+import { type ServiceImpl, create } from '@bufbuild/protobuf'
+import { createClient, createRouterTransport } from '@connectrpc/connect'
+
+import { PersonHogService } from '../../generated/personhog/personhog/service/v1/service_pb'
+import { PersonSchema } from '../../generated/personhog/personhog/types/v1/person_pb'
+import type {
+    GetPersonsByDistinctIdsRequest,
+    GetPersonsByUuidsRequest,
+} from '../../generated/personhog/personhog/types/v1/person_pb'
+import { PersonHogPersonOperations } from './persons'
+
+const textEncoder = new TextEncoder()
+
+function jsonBytes(obj: unknown): Uint8Array {
+    return textEncoder.encode(JSON.stringify(obj))
+}
+
+function makeProtoPerson(id: number, uuid: string, teamId: number) {
+    return create(PersonSchema, {
+        id: BigInt(id),
+        uuid,
+        teamId: BigInt(teamId),
+        properties: jsonBytes({ name: `person-${id}` }),
+        propertiesLastUpdatedAt: jsonBytes({}),
+        propertiesLastOperation: jsonBytes({}),
+        createdAt: BigInt(Date.now()),
+        version: 1n,
+        isIdentified: true,
+    })
+}
+
+const SERVICE_DEFAULTS: ServiceImpl<typeof PersonHogService> = {
+    getGroup: () => ({}),
+    getGroups: () => ({ groups: [], missingGroups: [] }),
+    getGroupsBatch: () => ({ results: [] }),
+    listGroups: () => ({ groups: [], hasMore: false }),
+    getGroupTypeMappingsByTeamId: () => ({ mappings: [] }),
+    getGroupTypeMappingsByTeamIds: () => ({ results: [] }),
+    getGroupTypeMappingsByProjectId: () => ({ mappings: [] }),
+    getGroupTypeMappingsByProjectIds: () => ({ results: [] }),
+    getGroupTypeMappingByDashboardId: () => ({}),
+    createGroup: () => ({}),
+    updateGroup: () => ({ updated: false }),
+    deleteGroupsBatchForTeam: () => ({ deletedCount: 0n }),
+    updateGroupTypeMapping: () => ({}),
+    deleteGroupTypeMapping: () => ({ deleted: false }),
+    deleteGroupTypeMappingsBatchForTeam: () => ({ deletedCount: 0n }),
+    getPerson: () => ({}),
+    getPersons: () => ({ persons: [] }),
+    getPersonByUuid: () => ({}),
+    getPersonsByUuids: () => ({ persons: [] }),
+    getPersonByDistinctId: () => ({}),
+    getPersonsByDistinctIdsInTeam: () => ({ results: [] }),
+    getPersonsByDistinctIds: () => ({ results: [] }),
+    getDistinctIdsForPerson: () => ({ distinctIds: [] }),
+    getDistinctIdsForPersons: () => ({ personDistinctIds: [] }),
+    getHashKeyOverrideContext: () => ({ results: [] }),
+    upsertHashKeyOverrides: () => ({}),
+    deleteHashKeyOverridesByTeams: () => ({}),
+    checkCohortMembership: () => ({ memberships: [] }),
+    countCohortMembers: () => ({ count: 0n }),
+    deleteCohortMember: () => ({ deleted: false }),
+    deleteCohortMembersBulk: () => ({ deletedCount: 0n }),
+    insertCohortMembers: () => ({ insertedCount: 0n }),
+    listCohortMemberIds: () => ({ personIds: [], nextCursor: 0n }),
+    updatePersonProperties: () => ({}),
+    deletePersons: () => ({ deletedCount: 0n }),
+    deletePersonsBatchForTeam: () => ({ deletedCount: 0n }),
+}
+
+function createOperations(overrides: Partial<ServiceImpl<typeof PersonHogService>> = {}): {
+    ops: PersonHogPersonOperations
+    handlers: { getPersonsByDistinctIds: jest.Mock; getPersonsByUuids: jest.Mock }
+} {
+    const handlers = {
+        getPersonsByDistinctIds: jest.fn(() => ({ results: [] })),
+        getPersonsByUuids: jest.fn(() => ({ persons: [] })),
+    }
+
+    const transport = createRouterTransport(({ service }) => {
+        service(PersonHogService, {
+            ...SERVICE_DEFAULTS,
+            ...handlers,
+            ...overrides,
+        })
+    })
+
+    const client = createClient(PersonHogService, transport)
+    const ops = new PersonHogPersonOperations(client)
+    return { ops, handlers }
+}
+
+describe('PersonHogPersonOperations', () => {
+    describe('fetchPersonsByDistinctIds batching', () => {
+        it('sends a single RPC when under the batch limit', async () => {
+            const { ops, handlers } = createOperations()
+            const items = Array.from({ length: 10 }, (_, i) => ({ teamId: 1, distinctId: `d-${i}` }))
+
+            await ops.fetchPersonsByDistinctIds(items)
+
+            expect(handlers.getPersonsByDistinctIds).toHaveBeenCalledTimes(1)
+        })
+
+        it('splits into multiple RPCs when over the batch limit', async () => {
+            const { ops, handlers } = createOperations()
+            const items = Array.from({ length: 400 }, (_, i) => ({ teamId: 1, distinctId: `d-${i}` }))
+
+            await ops.fetchPersonsByDistinctIds(items)
+
+            expect(handlers.getPersonsByDistinctIds).toHaveBeenCalledTimes(2)
+        })
+
+        it('merges results from multiple batches', async () => {
+            const handler = jest.fn()
+            let callCount = 0
+            handler.mockImplementation((req: GetPersonsByDistinctIdsRequest) => {
+                callCount++
+                return {
+                    results: req.teamDistinctIds.map((td) => ({
+                        key: { teamId: td.teamId, distinctId: td.distinctId },
+                        person: makeProtoPerson(
+                            callCount * 1000 + Number(td.teamId),
+                            `uuid-${td.distinctId}`,
+                            Number(td.teamId)
+                        ),
+                    })),
+                }
+            })
+
+            const { ops } = createOperations({ getPersonsByDistinctIds: handler })
+            const items = Array.from({ length: 300 }, (_, i) => ({ teamId: 1, distinctId: `d-${i}` }))
+
+            const results = await ops.fetchPersonsByDistinctIds(items)
+
+            expect(handler).toHaveBeenCalledTimes(2)
+            expect(results).toHaveLength(300)
+        })
+
+        it('handles exact batch boundary without duplicating or dropping', async () => {
+            const { ops, handlers } = createOperations()
+            const items = Array.from({ length: 250 }, (_, i) => ({ teamId: 1, distinctId: `d-${i}` }))
+
+            await ops.fetchPersonsByDistinctIds(items)
+
+            expect(handlers.getPersonsByDistinctIds).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('fetchPersonsByPersonIds batching', () => {
+        it('sends a single RPC per team when under the batch limit', async () => {
+            const { ops, handlers } = createOperations()
+            const items = Array.from({ length: 10 }, (_, i) => ({
+                teamId: 1,
+                personId: `uuid-${i}`,
+            }))
+
+            await ops.fetchPersonsByPersonIds(items)
+
+            expect(handlers.getPersonsByUuids).toHaveBeenCalledTimes(1)
+        })
+
+        it('splits into multiple RPCs per team when over the batch limit', async () => {
+            const { ops, handlers } = createOperations()
+            const items = Array.from({ length: 400 }, (_, i) => ({
+                teamId: 1,
+                personId: `uuid-${i}`,
+            }))
+
+            await ops.fetchPersonsByPersonIds(items)
+
+            expect(handlers.getPersonsByUuids).toHaveBeenCalledTimes(2)
+        })
+
+        it('merges results from multiple batches across teams', async () => {
+            const handler = jest.fn()
+            handler.mockImplementation((req: GetPersonsByUuidsRequest) => ({
+                persons: req.uuids.map((uuid, i) => makeProtoPerson(i, uuid, Number(req.teamId))),
+            }))
+
+            const { ops } = createOperations({ getPersonsByUuids: handler })
+            const items = [
+                ...Array.from({ length: 300 }, (_, i) => ({ teamId: 1, personId: `uuid-t1-${i}` })),
+                ...Array.from({ length: 100 }, (_, i) => ({ teamId: 2, personId: `uuid-t2-${i}` })),
+            ]
+
+            const results = await ops.fetchPersonsByPersonIds(items)
+
+            // team 1: 2 batches (250 + 50), team 2: 1 batch (100)
+            expect(handler).toHaveBeenCalledTimes(3)
+            expect(results).toHaveLength(400)
+        })
+
+        it('handles exact batch boundary without duplicating or dropping', async () => {
+            const { ops, handlers } = createOperations()
+            const items = Array.from({ length: 250 }, (_, i) => ({
+                teamId: 1,
+                personId: `uuid-${i}`,
+            }))
+
+            await ops.fetchPersonsByPersonIds(items)
+
+            expect(handlers.getPersonsByUuids).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/nodejs/src/ingestion/personhog/persons.test.ts
+++ b/nodejs/src/ingestion/personhog/persons.test.ts
@@ -1,5 +1,5 @@
-import { type ServiceImpl, create } from '@bufbuild/protobuf'
-import { createClient, createRouterTransport } from '@connectrpc/connect'
+import { create } from '@bufbuild/protobuf'
+import { type ServiceImpl, createClient, createRouterTransport } from '@connectrpc/connect'
 
 import { PersonHogService } from '../../generated/personhog/personhog/service/v1/service_pb'
 import { PersonSchema } from '../../generated/personhog/personhog/types/v1/person_pb'
@@ -103,21 +103,24 @@ describe('PersonHogPersonOperations', () => {
             makeItem: (i: number) => ({ teamId: 1, personId: `uuid-${i}` }),
         },
     ])('$method batching', ({ method, handler, makeItem }) => {
+        const invoke = (ops: PersonHogPersonOperations, count: number): Promise<any> =>
+            (ops[method] as any)(Array.from({ length: count }, (_, i) => makeItem(i)))
+
         it('sends a single RPC when under the batch limit', async () => {
             const { ops, handlers } = createOperations()
-            await ops[method](Array.from({ length: 10 }, (_, i) => makeItem(i)))
+            await invoke(ops, 10)
             expect(handlers[handler]).toHaveBeenCalledTimes(1)
         })
 
         it('splits into multiple RPCs when over the batch limit', async () => {
             const { ops, handlers } = createOperations()
-            await ops[method](Array.from({ length: 400 }, (_, i) => makeItem(i)))
+            await invoke(ops, 400)
             expect(handlers[handler]).toHaveBeenCalledTimes(2)
         })
 
         it('handles exact batch boundary without duplicating or dropping', async () => {
             const { ops, handlers } = createOperations()
-            await ops[method](Array.from({ length: 250 }, (_, i) => makeItem(i)))
+            await invoke(ops, 250)
             expect(handlers[handler]).toHaveBeenCalledTimes(1)
         })
     })

--- a/nodejs/src/ingestion/personhog/persons.ts
+++ b/nodejs/src/ingestion/personhog/persons.ts
@@ -28,6 +28,8 @@ function protoPersonToDomain(proto: ProtoPerson): InternalPerson {
     }
 }
 
+const PERSONHOG_BATCH_SIZE = 250
+
 export class PersonHogPersonOperations {
     constructor(private client: Client<typeof PersonHogService>) {}
 
@@ -38,24 +40,27 @@ export class PersonHogPersonOperations {
             return []
         }
 
-        const response = await this.client.getPersonsByDistinctIds(
-            create(GetPersonsByDistinctIdsRequestSchema, {
-                teamDistinctIds: teamPersons.map(({ teamId, distinctId }) =>
-                    create(TeamDistinctIdSchema, {
-                        teamId: BigInt(teamId),
-                        distinctId,
-                    })
-                ),
-                readOptions: eventualReadOptions(),
-            })
-        )
-
         const results: InternalPersonWithDistinctId[] = []
-        for (const result of response.results) {
-            if (result.person && result.key) {
-                const person = protoPersonToDomain(result.person) as InternalPersonWithDistinctId
-                person.distinct_id = result.key.distinctId
-                results.push(person)
+        for (let i = 0; i < teamPersons.length; i += PERSONHOG_BATCH_SIZE) {
+            const batch = teamPersons.slice(i, i + PERSONHOG_BATCH_SIZE)
+            const response = await this.client.getPersonsByDistinctIds(
+                create(GetPersonsByDistinctIdsRequestSchema, {
+                    teamDistinctIds: batch.map(({ teamId, distinctId }) =>
+                        create(TeamDistinctIdSchema, {
+                            teamId: BigInt(teamId),
+                            distinctId,
+                        })
+                    ),
+                    readOptions: eventualReadOptions(),
+                })
+            )
+
+            for (const result of response.results) {
+                if (result.person && result.key) {
+                    const person = protoPersonToDomain(result.person) as InternalPersonWithDistinctId
+                    person.distinct_id = result.key.distinctId
+                    results.push(person)
+                }
             }
         }
         return results
@@ -66,10 +71,6 @@ export class PersonHogPersonOperations {
             return []
         }
 
-        // Group by team_id since GetPersonsByUuids is a single-team RPC.
-        // In practice callers (e.g. CDP PersonsManager) almost always pass a single team,
-        // so multiple RPCs here is an edge case. If metrics show frequent multi-team batches,
-        // consider adding a cross-team UUID RPC (similar to GetPersonsByDistinctIds).
         const byTeam = new Map<number, string[]>()
         for (const { teamId, personId } of teamPersons) {
             const uuids = byTeam.get(teamId) ?? []
@@ -79,14 +80,19 @@ export class PersonHogPersonOperations {
 
         const allPersons = await Promise.all(
             [...byTeam].map(async ([teamId, uuids]) => {
-                const response = await this.client.getPersonsByUuids(
-                    create(GetPersonsByUuidsRequestSchema, {
-                        teamId: BigInt(teamId),
-                        uuids,
-                        readOptions: eventualReadOptions(),
-                    })
-                )
-                return response.persons.map(protoPersonToDomain)
+                const batchResults: InternalPerson[] = []
+                for (let i = 0; i < uuids.length; i += PERSONHOG_BATCH_SIZE) {
+                    const batch = uuids.slice(i, i + PERSONHOG_BATCH_SIZE)
+                    const response = await this.client.getPersonsByUuids(
+                        create(GetPersonsByUuidsRequestSchema, {
+                            teamId: BigInt(teamId),
+                            uuids: batch,
+                            readOptions: eventualReadOptions(),
+                        })
+                    )
+                    batchResults.push(...response.persons.map(protoPersonToDomain))
+                }
+                return batchResults
             })
         )
         return allPersons.flat()

--- a/proto/personhog/types/v1/person.proto
+++ b/proto/personhog/types/v1/person.proto
@@ -54,6 +54,7 @@ message GetPersonResponse {
 
 message GetPersonsRequest {
   int64 team_id = 1;
+  // Max 250 per request.
   repeated int64 person_ids = 2;
   ReadOptions read_options = 3;
 }
@@ -71,6 +72,7 @@ message GetPersonByUuidRequest {
 
 message GetPersonsByUuidsRequest {
   int64 team_id = 1;
+  // Max 250 per request.
   repeated string uuids = 2;
   ReadOptions read_options = 3;
 }
@@ -83,6 +85,7 @@ message GetPersonByDistinctIdRequest {
 
 message GetPersonsByDistinctIdsInTeamRequest {
   int64 team_id = 1;
+  // Max 250 per request.
   repeated string distinct_ids = 2;
   ReadOptions read_options = 3;
 }
@@ -92,6 +95,7 @@ message PersonsByDistinctIdsInTeamResponse {
 }
 
 message GetPersonsByDistinctIdsRequest {
+  // Max 250 per request.
   repeated TeamDistinctId team_distinct_ids = 1;
   ReadOptions read_options = 2;
 }

--- a/rust/personhog-replica/src/service/mod.rs
+++ b/rust/personhog-replica/src/service/mod.rs
@@ -44,6 +44,7 @@ use uuid::Uuid;
 
 use crate::storage::{self, FullStorage};
 
+const MAX_BATCH_LOOKUP_SIZE: usize = 250;
 const MAX_BATCH_DELETE_SIZE: i64 = 50_000;
 const MAX_LIST_COHORT_MEMBER_IDS_LIMIT: i32 = 10_000;
 const MAX_LIST_GROUPS_LIMIT: i32 = 1_000;
@@ -95,6 +96,12 @@ impl PersonHogReplica for PersonHogReplicaService {
     ) -> Result<Response<PersonsResponse>, Status> {
         let req = request.into_inner();
         reject_strong_consistency(&req.read_options)?;
+
+        if req.person_ids.len() > MAX_BATCH_LOOKUP_SIZE {
+            return Err(Status::invalid_argument(format!(
+                "Maximum {MAX_BATCH_LOOKUP_SIZE} person IDs per request"
+            )));
+        }
 
         let include_props = person_needs_properties(&req.read_options);
         let persons = self
@@ -149,6 +156,12 @@ impl PersonHogReplica for PersonHogReplicaService {
     ) -> Result<Response<PersonsResponse>, Status> {
         let req = request.into_inner();
         reject_strong_consistency(&req.read_options)?;
+
+        if req.uuids.len() > MAX_BATCH_LOOKUP_SIZE {
+            return Err(Status::invalid_argument(format!(
+                "Maximum {MAX_BATCH_LOOKUP_SIZE} UUIDs per request"
+            )));
+        }
 
         let uuids: Vec<Uuid> = req
             .uuids
@@ -205,6 +218,12 @@ impl PersonHogReplica for PersonHogReplicaService {
         let req = request.into_inner();
         reject_strong_consistency(&req.read_options)?;
 
+        if req.distinct_ids.len() > MAX_BATCH_LOOKUP_SIZE {
+            return Err(Status::invalid_argument(format!(
+                "Maximum {MAX_BATCH_LOOKUP_SIZE} distinct IDs per request"
+            )));
+        }
+
         let include_props = person_needs_properties(&req.read_options);
         let results = self
             .storage
@@ -236,6 +255,12 @@ impl PersonHogReplica for PersonHogReplicaService {
     ) -> Result<Response<PersonsByDistinctIdsResponse>, Status> {
         let req = request.into_inner();
         reject_strong_consistency(&req.read_options)?;
+
+        if req.team_distinct_ids.len() > MAX_BATCH_LOOKUP_SIZE {
+            return Err(Status::invalid_argument(format!(
+                "Maximum {MAX_BATCH_LOOKUP_SIZE} distinct IDs per request"
+            )));
+        }
 
         let include_props = person_needs_properties(&req.read_options);
         let team_distinct_ids: Vec<(i64, String)> = req


### PR DESCRIPTION
## Problem

Personhog batch person lookup RPCs (`GetPersonsByDistinctIdsInTeam`, `GetPersonsByUuids`, `GetPersonsByDistinctIds`, `GetPersons`) accept unbounded ID lists, leading to large gRPC response payloads. These large responses increase memory pressure on the personhog-replica pods and risk hitting gRPC message size limits.

## Changes

**Server-side validation (Rust):**
- Added `MAX_BATCH_LOOKUP_SIZE = 250` constant in `personhog-replica`
- Added `Status::invalid_argument` validation on 4 batch read RPCs: `get_persons`, `get_persons_by_uuids`, `get_persons_by_distinct_ids_in_team`, `get_persons_by_distinct_ids`
- Follows the same pattern as the existing `delete_persons` validation (max 1000)

**Proto documentation:**
- Added `// Max 250 per request.` comments on the repeated ID fields for the 4 affected request messages

**Node.js client-side batching (CDP/plugin-server):**
- Added `PERSONHOG_BATCH_SIZE = 250` chunking to `PersonHogPersonOperations.fetchPersonsByDistinctIds()` and `fetchPersonsByPersonIds()`
- Previously these methods sent all IDs in a single unbounded RPC call
- Verified via Grafana metrics that current CDP traffic is well under the limit (~44 rows at p99.9), so this is a defensive measure

**Note:** The Python Django client already had client-side batching (previously 500, reduced to 250 in a prior change on branch `nick/person-fetch-call-limit-reduction`). `GetDistinctIdsForPersons` is intentionally excluded from the limit since it returns lightweight responses (distinct ID strings, no properties).

## How did you test this code?

Agent-authored. Automated tests only:
- `cargo check -p personhog-replica` — Rust compiles clean
- `npx jest src/ingestion/personhog/persons.test.ts` — 8 new tests covering batching behavior (single batch, multi-batch splits, result merging, exact boundary handling) for both `fetchPersonsByDistinctIds` and `fetchPersonsByPersonIds`

## 🤖 Agent context

- **Tools/agent:** Claude Code (Opus), Grafana MCP (prod-eu, prod-us)
- **Decisions:**
  - Chose 250 as the limit to match the Python client-side batch size already in use
  - Excluded `GetDistinctIdsForPersons` from the limit after verifying via Grafana that its response sizes are modest (~253 KB at p99.9 vs 14 MB for `GetPersonsByDistinctIdsInTeam`) because it doesn't return the properties blob
  - Confirmed `GetPersons` (integer PK lookup) has zero traffic in both prod-us and prod-eu, so the limit there is harmless
  - Confirmed CDP callers (`cdp-cyclotron-worker`, `cdp-cyclotron-worker-hogflow`) are well under the 250 limit today via `rows_returned` metrics (~44 at p99.9)