### PR TITLE
chore(legacy-webhook-service): move group fetch out of the event loop

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -411,8 +411,18 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
             })
 
             return await instrumentFn('cdpLegacyConsumer.handleEachBatch', async () => {
+                // Phase 1: Filter webhook events and warm the group type cache
+                // sequentially, before the parallel storm starts. This ensures
+                // the gRPC call for group types completes while the event loop
+                // is clear — otherwise Track 2's thousands of concurrent
+                // promises delay HTTP/2 DATA frame flushes by ~400ms.
+                const webhookEvents = await this.legacyWebhookService.filterAndPrefetchGroups(messages)
+
+                // Phase 2: Run enrichment + webhooks and plugin processing in
+                // parallel. The group type cache is warm, so no gRPC calls
+                // happen during the microtask storm.
                 const [webhookBatch, pluginBatch] = await Promise.all([
-                    this.legacyWebhookService.processBatch(messages),
+                    this.legacyWebhookService.enrichAndProcess(webhookEvents),
                     this._parseKafkaBatch(messages).then((invocations) => this.processBatch(invocations)),
                 ])
                 return {

--- a/nodejs/src/cdp/legacy-webhooks/legacy-webhook-service.test.ts
+++ b/nodejs/src/cdp/legacy-webhooks/legacy-webhook-service.test.ts
@@ -96,6 +96,11 @@ describe('LegacyWebhookService', () => {
         jest.clearAllMocks()
     })
 
+    async function processBatch(svc: LegacyWebhookService, messages: Message[]) {
+        const events = await svc.filterAndPrefetchGroups(messages)
+        return svc.enrichAndProcess(events)
+    }
+
     describe('processBatch', () => {
         it('should parse events for teams with both webhooks and zapier', async () => {
             service['actionMatcher'].hasWebhooks = jest.fn().mockReturnValue(true)
@@ -103,7 +108,7 @@ describe('LegacyWebhookService', () => {
 
             const messages: Message[] = [createKafkaMessage(createIncomingEvent(team.id, { event: '$pageview' }))]
 
-            const result = await service.processBatch(messages)
+            const result = await processBatch(service, messages)
             await result.backgroundTask
 
             expect(service['actionMatcher'].hasWebhooks).toHaveBeenCalledWith(team.id)
@@ -119,7 +124,7 @@ describe('LegacyWebhookService', () => {
                 createKafkaMessage(createIncomingEvent(team2.id, { event: '$pageview' })),
             ]
 
-            const result = await service.processBatch(messages)
+            const result = await processBatch(service, messages)
             await result.backgroundTask
 
             expect(service.processEvent).not.toHaveBeenCalled()
@@ -132,7 +137,7 @@ describe('LegacyWebhookService', () => {
 
             const messages: Message[] = [createKafkaMessage(createIncomingEvent(team.id, { event: '$pageview' }))]
 
-            const result = await service.processBatch(messages)
+            const result = await processBatch(service, messages)
             await result.backgroundTask
 
             expect(service.processEvent).not.toHaveBeenCalled()
@@ -145,7 +150,7 @@ describe('LegacyWebhookService', () => {
 
             const messages: Message[] = [createKafkaMessage(createIncomingEvent(team.id, { event: '$pageview' }))]
 
-            const result = await service.processBatch(messages)
+            const result = await processBatch(service, messages)
             await result.backgroundTask
 
             expect(service.processEvent).not.toHaveBeenCalled()
@@ -161,7 +166,7 @@ describe('LegacyWebhookService', () => {
                 createKafkaMessage(createIncomingEvent(team2.id, { event: '$pageview' })),
             ]
 
-            const result = await service.processBatch(messages)
+            const result = await processBatch(service, messages)
             await result.backgroundTask
 
             expect(service.processEvent).toHaveBeenCalledTimes(1)
@@ -193,7 +198,7 @@ describe('LegacyWebhookService', () => {
                 ),
             ]
 
-            const result = await service.processBatch(messages)
+            const result = await processBatch(service, messages)
             await result.backgroundTask
 
             expect(processEventSpy).toHaveBeenCalledTimes(1)
@@ -223,7 +228,7 @@ describe('LegacyWebhookService', () => {
                 ),
             ]
 
-            const result = await service.processBatch(messages)
+            const result = await processBatch(service, messages)
             await result.backgroundTask
 
             expect(processEventSpy).toHaveBeenCalledTimes(1)
@@ -256,7 +261,7 @@ describe('LegacyWebhookService', () => {
                 ),
             ]
 
-            const result = await service.processBatch(messages)
+            const result = await processBatch(service, messages)
             await result.backgroundTask
 
             expect(processEventSpy).toHaveBeenCalledTimes(2)
@@ -510,7 +515,7 @@ describe('LegacyWebhookService', () => {
                 ),
             ]
 
-            const result = await personhogService.processBatch(messages)
+            const result = await processBatch(personhogService, messages)
             await result.backgroundTask
 
             expect(processEventSpy).toHaveBeenCalledTimes(1)

--- a/nodejs/src/cdp/legacy-webhooks/legacy-webhook-service.ts
+++ b/nodejs/src/cdp/legacy-webhooks/legacy-webhook-service.ts
@@ -98,28 +98,62 @@ export class LegacyWebhookService {
         )
     }
 
-    public async processBatch(messages: Message[]): Promise<{ backgroundTask: Promise<any> }> {
-        const eventsWithoutGroups: PostIngestionEvent[] = []
+    /**
+     * Filter messages to webhook-eligible events and warm the group type
+     * cache. This runs sequentially to avoid flooding the microtask queue —
+     * both checks (hasWebhooks, hasAvailableFeature) are sync or cached, and
+     * the gRPC call for group types needs a clear event loop to flush its
+     * HTTP/2 DATA frame promptly.
+     */
+    public async filterAndPrefetchGroups(messages: Message[]): Promise<PostIngestionEvent[]> {
+        const events: PostIngestionEvent[] = []
 
-        await Promise.all(
-            messages.map(async (message) => {
-                try {
-                    const clickHouseEvent = parseJSON(message.value!.toString()) as RawClickHouseEvent
+        for (const message of messages) {
+            try {
+                const clickHouseEvent = parseJSON(message.value!.toString()) as RawClickHouseEvent
 
-                    if (
-                        !this.actionMatcher.hasWebhooks(clickHouseEvent.team_id) ||
-                        !(await this.teamManager.hasAvailableFeature(clickHouseEvent.team_id, 'zapier'))
-                    ) {
-                        return
-                    }
-
-                    eventsWithoutGroups.push(convertToPostIngestionEvent(clickHouseEvent))
-                } catch (e) {
-                    logger.error('Error parsing message', e)
-                    counterParseError.labels({ error: e.message }).inc()
+                if (
+                    !this.actionMatcher.hasWebhooks(clickHouseEvent.team_id) ||
+                    !(await this.teamManager.hasAvailableFeature(clickHouseEvent.team_id, 'zapier'))
+                ) {
+                    continue
                 }
-            })
-        )
+
+                events.push(convertToPostIngestionEvent(clickHouseEvent))
+            } catch (e) {
+                logger.error('Error parsing message', e)
+                counterParseError.labels({ error: e.message }).inc()
+            }
+        }
+
+        if (events.length > 0) {
+            // Warm the group type cache so the enrichment step hits cache
+            // instead of making gRPC calls during the parallel processing storm.
+            // Best-effort: if this fails, enrichAndProcess will retry and handle
+            // the error with its own fallback logic.
+            try {
+                const projectIds = new Set(events.map((e) => e.projectId))
+                await this.groupTypeManager.fetchGroupTypesForProjects(projectIds)
+            } catch (e) {
+                logger.warn('Group type prefetch failed, enrichment will retry', e)
+            }
+        }
+
+        return events
+    }
+
+    /**
+     * Enrich filtered events with group properties and fire webhooks.
+     * Designed to run in parallel with other batch processing — the group
+     * type cache was warmed by filterAndPrefetchGroups, so no gRPC calls
+     * are made here.
+     */
+    public async enrichAndProcess(
+        eventsWithoutGroups: PostIngestionEvent[]
+    ): Promise<{ backgroundTask: Promise<any> }> {
+        if (eventsWithoutGroups.length === 0) {
+            return { backgroundTask: Promise.resolve() }
+        }
 
         let events: PostIngestionEvent[]
         try {

--- a/nodejs/src/cdp/legacy-webhooks/legacy-webhook-service.ts
+++ b/nodejs/src/cdp/legacy-webhooks/legacy-webhook-service.ts
@@ -14,7 +14,7 @@ import { GroupRepository } from '../../worker/ingestion/groups/repositories/grou
 import { counterParseError } from '../consumers/metrics'
 import { ActionManager } from '../legacy-webhooks/action-manager'
 import { ActionMatcher } from '../legacy-webhooks/action-matcher'
-import { addGroupPropertiesToPostIngestionEventsBatch } from '../legacy-webhooks/utils'
+import { addGroupPropertiesToPostIngestionEventsBatch, getProjectIdsWithGroupAnalytics } from '../legacy-webhooks/utils'
 import { cdpTrackedFetch } from '../services/hog-executor.service'
 
 export class LegacyWebhookService {
@@ -127,12 +127,12 @@ export class LegacyWebhookService {
         }
 
         if (events.length > 0) {
-            // Warm the group type cache so the enrichment step hits cache
-            // instead of making gRPC calls during the parallel processing storm.
-            // Best-effort: if this fails, enrichAndProcess will retry and handle
-            // the error with its own fallback logic.
+            // Warm the group type cache before the parallel processing storm.
+            // Uses the same filter as addGroupPropertiesToPostIngestionEventsBatch
+            // so we only prefetch for teams that will actually use the data.
+            // Best-effort: if this fails, enrichAndProcess will retry.
             try {
-                const projectIds = new Set(events.map((e) => e.projectId))
+                const projectIds = await getProjectIdsWithGroupAnalytics(events, this.teamManager)
                 await this.groupTypeManager.fetchGroupTypesForProjects(projectIds)
             } catch (e) {
                 logger.warn('Group type prefetch failed, enrichment will retry', e)
@@ -144,9 +144,10 @@ export class LegacyWebhookService {
 
     /**
      * Enrich filtered events with group properties and fire webhooks.
-     * Designed to run in parallel with other batch processing — the group
-     * type cache was warmed by filterAndPrefetchGroups, so no gRPC calls
-     * are made here.
+     * Designed to run in parallel with other batch processing. The group
+     * type cache is typically warm from filterAndPrefetchGroups, though
+     * if the prefetch failed the enrichment will fall back to fetching
+     * on demand.
      */
     public async enrichAndProcess(
         eventsWithoutGroups: PostIngestionEvent[]

--- a/nodejs/src/cdp/legacy-webhooks/utils.test.ts
+++ b/nodejs/src/cdp/legacy-webhooks/utils.test.ts
@@ -72,7 +72,7 @@ describe('addGroupPropertiesToPostIngestionEventsBatch', () => {
         )
 
         expect(result).toEqual(events)
-        expect(mockGroupTypeManager.fetchGroupTypesForProjects).not.toHaveBeenCalled()
+        expect(mockGroupTypeManager.fetchGroupTypesForProjects).toHaveBeenCalledWith(new Set())
         expect(mockGroupRepository.fetchGroupsByKeys).not.toHaveBeenCalled()
     })
 

--- a/nodejs/src/cdp/legacy-webhooks/utils.ts
+++ b/nodejs/src/cdp/legacy-webhooks/utils.ts
@@ -57,6 +57,31 @@ function makeGroupLookupKey(teamId: number, groupTypeIndex: number, groupKey: st
     return `${teamId}:${groupTypeIndex}:${groupKey}`
 }
 
+/**
+ * Returns the set of project IDs whose teams have group analytics enabled.
+ * Used by both the prefetch path and the enrichment path.
+ */
+export async function getProjectIdsWithGroupAnalytics(
+    events: PostIngestionEvent[],
+    teamManager: TeamManager
+): Promise<Set<ProjectId>> {
+    const checkedTeams = new Map<number, boolean>()
+    const projectIds = new Set<ProjectId>()
+
+    for (const event of events) {
+        const cached = checkedTeams.get(event.teamId)
+        const hasFeature = cached ?? (await teamManager.hasAvailableFeature(event.teamId, 'group_analytics'))
+        if (cached === undefined) {
+            checkedTeams.set(event.teamId, hasFeature)
+        }
+        if (hasFeature) {
+            projectIds.add(event.projectId)
+        }
+    }
+
+    return projectIds
+}
+
 export async function addGroupPropertiesToPostIngestionEventsBatch(
     events: PostIngestionEvent[],
     groupTypeManager: GroupTypeManager,
@@ -67,26 +92,7 @@ export async function addGroupPropertiesToPostIngestionEventsBatch(
         return []
     }
 
-    const uniqueTeamIds = [...new Set(events.map((e) => e.teamId))]
-    const teamHasGroupAnalytics = new Map<number, boolean>()
-    await Promise.all(
-        uniqueTeamIds.map(async (teamId) => {
-            const has = await teamManager.hasAvailableFeature(teamId, 'group_analytics')
-            teamHasGroupAnalytics.set(teamId, has)
-        })
-    )
-
-    const projectIdsNeedingGroups = new Set<ProjectId>()
-    for (const event of events) {
-        if (teamHasGroupAnalytics.get(event.teamId)) {
-            projectIdsNeedingGroups.add(event.projectId)
-        }
-    }
-
-    if (projectIdsNeedingGroups.size === 0) {
-        return events
-    }
-
+    const projectIdsNeedingGroups = await getProjectIdsWithGroupAnalytics(events, teamManager)
     const groupTypesByProject = await groupTypeManager.fetchGroupTypesForProjects(projectIdsNeedingGroups)
 
     const allTeamIds: TeamId[] = []
@@ -98,7 +104,7 @@ export async function addGroupPropertiesToPostIngestionEventsBatch(
     const eventGroupNeeds: (EventGroupNeed[] | null)[] = []
 
     for (const event of events) {
-        if (!teamHasGroupAnalytics.get(event.teamId)) {
+        if (!projectIdsNeedingGroups.has(event.projectId)) {
             eventGroupNeeds.push(null)
             continue
         }

--- a/nodejs/src/worker/ingestion/group-type-manager.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.ts
@@ -91,7 +91,11 @@ export class GroupTypeManager {
     }
 
     public async fetchGroupTypesForProjects(projectIds: ProjectId[] | Set<ProjectId>): Promise<GroupTypesByProjectId> {
-        const results = await this.loader.getMany(Array.from(projectIds).map((id) => id.toString()))
+        const ids = Array.from(projectIds)
+        if (ids.length === 0) {
+            return {}
+        }
+        const results = await this.loader.getMany(ids.map((id) => id.toString()))
 
         return Object.fromEntries(
             Object.entries(results).map(([projectId, groupTypes]) => [projectId, groupTypes ?? {}])


### PR DESCRIPTION
## Problem

I'm not attached to this at all - but figured I'd take a quick pass at it in case we wanted it. Group fetches to personhog are currently taking up to almost 500ms for small fetches - this comes down to the fact that the underlying http call is multi part and asynchronous, so when called on a busy event loop, can be fairly latent in completing the request. If we move the synchronous part of the legacy processing outside of the event loop, we can prefetch the groups quite quickly, then resume the rest in parallel. I totally understand this latency is probably not an issue on the cdp side, I am really just being anal in wanting clean personhog latency metrics (so, totally fine if someone tells me to close this and go away).

## Changes

- Split legacy webhook service process batch into two steps:
    - filterAndPrefetchGroups: done in sync, just filters events and warms the groups cache
    - enrichAndProcess: the actual processing part, happens on the event loop with the rest
