### PR TITLE
feat(data-warehouse): hogql access control for warehouse tables and views

### DIFF
--- a/posthog/hogql/context.py
+++ b/posthog/hogql/context.py
@@ -36,6 +36,13 @@ class HogQLContext:
     # User making the queries - used for access control on system tables
     user: Optional["User"] = None
 
+    # SECURITY-SENSITIVE: opt-in bypass for HogQL access control on system and warehouse tables.
+    # Set ONLY when running in a context with no human owner (e.g. data import pipeline internals,
+    # schema introspection, sharing-token-authenticated reads). Every call site that sets this MUST
+    # include an inline comment explaining why. `grep -r "bypass_access_control=True"` returns the
+    # complete audit list in one shot.
+    bypass_access_control: bool = False
+
     # Virtual database we're querying, will be populated from team_id if not present
     database: Optional["Database"] = None
     # Metadata discovered for a direct Postgres connection, if one is selected

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -367,7 +367,11 @@ class Database(BaseModel):
         self._warehouse_table_names = []
         self._warehouse_self_managed_table_names = []
         self._view_table_names = []
-        self._denied_tables = set()
+        self._denied_tables: set[str] = set()
+        # Per-resource deny set populated by the warehouse filter methods. Read by
+        # QueryRunner._get_object_access_restrictions so changes to warehouse grants
+        # invalidate cached query results. Keys: "warehouse_table", "warehouse_view".
+        self._denied_resource_ids_by_scope: dict[str, set[str]] = {}
         self._connection_id = None
         self._direct_connection_metadata = None
         self._direct_access_warehouse_table_names = set()
@@ -594,7 +598,8 @@ class Database(BaseModel):
         from posthog.models import OrganizationMembership
         from posthog.rbac.user_access_control import NO_ACCESS_LEVEL, UserAccessControl
 
-        self.user_access_control = UserAccessControl(user=user, team=team)
+        if self.user_access_control is None:
+            self.user_access_control = UserAccessControl(user=user, team=team)
 
         org_membership = self.user_access_control._organization_membership
         if org_membership and org_membership.level >= OrganizationMembership.Level.ADMIN:
@@ -604,7 +609,6 @@ class Database(BaseModel):
         if not system_node or not hasattr(system_node, "children"):
             return
 
-        denied: set[str] = set()
         for table_node in list(system_node.children.values()):
             table = table_node.table
             if not isinstance(table, PostgresTable) or table.access_scope is None:
@@ -616,9 +620,7 @@ class Database(BaseModel):
 
             # No access - remove from schema
             del system_node.children[table_node.name]
-            denied.add(f"system.{table_node.name}")
-
-        self._denied_tables = denied
+            self._denied_tables.add(f"system.{table_node.name}")
 
     def _filter_all_scoped_system_tables(self) -> None:
         """Remove ALL access-controlled system tables"""
@@ -626,16 +628,89 @@ class Database(BaseModel):
         if not system_node or not hasattr(system_node, "children"):
             return
 
-        denied: set[str] = set()
         for table_node in list(system_node.children.values()):
             table = table_node.table
             if not isinstance(table, PostgresTable) or table.access_scope is None:
                 continue  # Not access-controlled, keep it
 
             del system_node.children[table_node.name]
-            denied.add(f"system.{table_node.name}")
+            self._denied_tables.add(f"system.{table_node.name}")
 
-        self._denied_tables = denied
+    def _denied_warehouse_table_ids_for_user(
+        self,
+        user: "User",
+        team: "Team",
+        tables: list["DataWarehouseTable"],
+    ) -> set[str]:
+        """Per-object access decision for the warehouse_table resource.
+
+        Uses the same precedence chain (specific role/member grants > resource defaults >
+        creator/admin shortcuts) as the warehouse_table REST API — one preload DB query
+        for N tables, then in-memory check_access_level_for_object per table. Org admins
+        bypass with empty deny set.
+
+        Also writes the deny set into self._denied_resource_ids_by_scope["warehouse_table"]
+        so QueryRunner cache fingerprints include the warehouse grants.
+        """
+        from posthog.models import OrganizationMembership
+        from posthog.rbac.user_access_control import UserAccessControl
+
+        if self.user_access_control is None:
+            self.user_access_control = UserAccessControl(user=user, team=team)
+        uac = self.user_access_control
+
+        org_membership = uac._organization_membership
+        if org_membership and org_membership.level >= OrganizationMembership.Level.ADMIN:
+            return set()
+
+        if not tables:
+            return set()
+
+        uac.preload_object_access_controls(list(tables))
+        denied = {
+            str(t.id)
+            for t in tables
+            if not uac.check_access_level_for_object(t, required_level="viewer")
+        }
+        if denied:
+            self._denied_resource_ids_by_scope.setdefault("warehouse_table", set()).update(denied)
+        return denied
+
+    def _denied_warehouse_view_ids_for_user(
+        self,
+        user: "User",
+        team: "Team",
+        saved_queries: list[Any],
+    ) -> set[str]:
+        """Per-object access decision for the warehouse_view resource (saved queries).
+
+        Same shape as `_denied_warehouse_table_ids_for_user`. Closes the
+        saved-query-as-backdoor gap — without this, a user denied access to a warehouse
+        table could SELECT through a view that references the same table.
+        """
+        from posthog.models import OrganizationMembership
+        from posthog.rbac.user_access_control import UserAccessControl
+
+        if self.user_access_control is None:
+            self.user_access_control = UserAccessControl(user=user, team=team)
+        uac = self.user_access_control
+
+        org_membership = uac._organization_membership
+        if org_membership and org_membership.level >= OrganizationMembership.Level.ADMIN:
+            return set()
+
+        if not saved_queries:
+            return set()
+
+        uac.preload_object_access_controls(list(saved_queries))
+        denied = {
+            str(sq.id)
+            for sq in saved_queries
+            if not uac.check_access_level_for_object(sq, required_level="viewer")
+        }
+        if denied:
+            self._denied_resource_ids_by_scope.setdefault("warehouse_view", set()).update(denied)
+        return denied
 
     def serialize(
         self,
@@ -875,6 +950,7 @@ class Database(BaseModel):
         modifiers: HogQLQueryModifiers | None = None,
         timings: HogQLTimings | None = None,
         connection_id: str | None = None,
+        bypass_access_control: bool = False,
     ) -> "Database":
         if timings is None:
             timings = HogQLTimings()
@@ -943,6 +1019,7 @@ class Database(BaseModel):
                 if direct_source is not None:
                     database._direct_connection_metadata = direct_source.connection_metadata
 
+        is_hogql_warehouse_access_control_enabled = False
         with timings.measure("filter_system_tables_for_user", emit_span=True):
             if team is not None:
                 is_hogql_access_control_enabled = posthoganalytics.feature_enabled(
@@ -955,11 +1032,28 @@ class Database(BaseModel):
                     },
                     send_feature_flag_events=False,
                 )
-                if is_hogql_access_control_enabled:
+                if is_hogql_access_control_enabled and not bypass_access_control:
                     if user is not None:
                         database._filter_system_tables_for_user(user, team)
                     else:
                         database._filter_all_scoped_system_tables()
+
+                # Separate FF for the data warehouse ACL — same shape (off-by-default rollout) but
+                # independent of the system-table FF (which is already at 100%). Used inside the
+                # warehouse tables and saved-query loops below to filter out inaccessible objects.
+                is_hogql_warehouse_access_control_enabled = posthoganalytics.feature_enabled(
+                    "hogql-warehouse-access-control",
+                    str(team.uuid),
+                    groups={"organization": str(team.organization_id), "project": str(team.id)},
+                    group_properties={
+                        "organization": {"id": str(team.organization_id)},
+                        "project": {"id": str(team.id)},
+                    },
+                    send_feature_flag_events=False,
+                )
+        warehouse_acl_active = (
+            is_hogql_warehouse_access_control_enabled and not bypass_access_control and team is not None
+        )
 
         with timings.measure("modifiers", emit_span=True):
             modifiers = create_default_modifiers_for_team(team, modifiers)
@@ -1092,8 +1186,26 @@ class Database(BaseModel):
 
                     saved_queries = list(queryset)
 
+                # Warehouse ACL: compute deny set once before the loop. When user is None,
+                # fail closed (deny all) — call sites that legitimately need warehouse data
+                # without a user must opt in via bypass_access_control=True.
+                denied_view_ids: set[str] = set()
+                deny_all_views = False
+                if warehouse_acl_active:
+                    if user is not None:
+                        denied_view_ids = database._denied_warehouse_view_ids_for_user(user, team, saved_queries)
+                    else:
+                        deny_all_views = True
+
                 for saved_query in saved_queries:
                     with timings.measure(f"saved_query_{saved_query.name}"):
+                        if deny_all_views or str(saved_query.id) in denied_view_ids:
+                            # Mark every name this saved query would have occupied so a later
+                            # Database.get_table(name) raises the "You don't have access" error
+                            # via the existing _denied_tables path.
+                            for name_part in (saved_query.name, ".".join(saved_query.name.split("."))):
+                                database._denied_tables.add(name_part)
+                            continue
                         views.add_child(
                             TableNode.create_nested_for_chain(
                                 saved_query.name.split("."),
@@ -1182,12 +1294,36 @@ class Database(BaseModel):
                         )
                     ]
             sync_warnings_now = datetime.now(UTC)
+
+            # Warehouse ACL: compute deny set once before the loop. Mirrors the saved-query
+            # branch above. Without a user we fail closed; opt-in bypass_access_control=True
+            # is the only way to use warehouse data in a userless context.
+            denied_table_ids: set[str] = set()
+            deny_all_tables = False
+            if warehouse_acl_active:
+                if user is not None:
+                    denied_table_ids = database._denied_warehouse_table_ids_for_user(user, team, tables)
+                else:
+                    deny_all_tables = True
+
             for table in tables:
                 if (
                     not database._is_direct_query()
                     and table.external_data_source
                     and table.external_data_source.access_method == ExternalDataSource.AccessMethod.DIRECT
                 ):
+                    continue
+
+                if deny_all_tables or str(table.id) in denied_table_ids:
+                    # Mark every public name this table would have occupied so get_table()
+                    # raises the "You don't have access" error rather than "Unknown table".
+                    # Mirrors the name registration done by the add_child branch below.
+                    database._denied_tables.add(table.name)
+                    if table.external_data_source:
+                        for table_key in _get_warehouse_table_keys(
+                            table, direct_query=database._is_direct_query()
+                        ):
+                            database._denied_tables.add(table_key)
                     continue
 
                 with timings.measure(f"table_{table.name}"):

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -667,11 +667,7 @@ class Database(BaseModel):
             return set()
 
         uac.preload_object_access_controls(list(tables))
-        denied = {
-            str(t.id)
-            for t in tables
-            if not uac.check_access_level_for_object(t, required_level="viewer")
-        }
+        denied = {str(t.id) for t in tables if not uac.check_access_level_for_object(t, required_level="viewer")}
         if denied:
             self._denied_resource_ids_by_scope.setdefault("warehouse_table", set()).update(denied)
         return denied
@@ -704,9 +700,7 @@ class Database(BaseModel):
 
         uac.preload_object_access_controls(list(saved_queries))
         denied = {
-            str(sq.id)
-            for sq in saved_queries
-            if not uac.check_access_level_for_object(sq, required_level="viewer")
+            str(sq.id) for sq in saved_queries if not uac.check_access_level_for_object(sq, required_level="viewer")
         }
         if denied:
             self._denied_resource_ids_by_scope.setdefault("warehouse_view", set()).update(denied)
@@ -1320,9 +1314,7 @@ class Database(BaseModel):
                     # Mirrors the name registration done by the add_child branch below.
                     database._denied_tables.add(table.name)
                     if table.external_data_source:
-                        for table_key in _get_warehouse_table_keys(
-                            table, direct_query=database._is_direct_query()
-                        ):
+                        for table_key in _get_warehouse_table_keys(table, direct_query=database._is_direct_query()):
                             database._denied_tables.add(table_key)
                     continue
 

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -207,3 +207,304 @@ class TestAccessControlIntegration(BaseTest):
         sql = self._compile_select("SELECT id, name FROM system.cohorts", context)
         assert "id" in sql
         assert "name" in sql
+
+
+@patch("posthoganalytics.feature_enabled", new=Mock(return_value=True))
+class TestWarehouseTableAccessControl(BaseTest):
+    """Per-object access control for warehouse tables.
+
+    Each DataWarehouseTable row is treated as an object of the warehouse_table
+    resource (with warehouse_objects as the inheritance parent). The HogQL
+    decision uses the same UserAccessControl.check_access_level_for_object
+    primitive as the warehouse_table REST API.
+    """
+
+    resource = "warehouse_objects"
+
+    def setUp(self):
+        super().setUp()
+        from posthog.constants import AvailableFeature
+
+        from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+        from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.MEMBER
+        membership.save()
+
+        self.credential = DataWarehouseCredential.objects.create(
+            access_key="blah", access_secret="blah", team=self.team
+        )
+        self.allowed_table = DataWarehouseTable.objects.create(
+            name="allowed_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=self.credential,
+            url_pattern="s3://bucket/allowed/*",
+            columns={"id": "String"},
+        )
+        self.denied_table = DataWarehouseTable.objects.create(
+            name="denied_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=self.credential,
+            url_pattern="s3://bucket/denied/*",
+            columns={"id": "String"},
+        )
+
+    def _create_ac(self, *, resource, access_level, resource_id=None, role=None, member=None):
+        from ee.models.rbac.access_control import AccessControl
+
+        return AccessControl.objects.create(
+            team=self.team,
+            resource=resource,
+            resource_id=resource_id,
+            access_level=access_level,
+            organization_member=member,
+            role=role,
+        )
+
+    def _membership(self):
+        return OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+
+    def test_explicit_object_level_deny_marks_table(self):
+        # Member-scoped per-object deny on denied_table; allowed_table should still resolve.
+        self._create_ac(
+            resource="warehouse_table",
+            resource_id=str(self.denied_table.id),
+            access_level="none",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "denied_table" in database._denied_tables
+        assert "allowed_table" not in database._denied_tables
+        assert str(self.denied_table.id) in database._denied_resource_ids_by_scope.get("warehouse_table", set())
+
+    def test_warehouse_objects_resource_none_denies_all_tables(self):
+        self._create_ac(resource="warehouse_objects", access_level="none")
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        # Both tables become inaccessible because warehouse_table inherits warehouse_objects
+        assert "denied_table" in database._denied_tables
+        assert "allowed_table" in database._denied_tables
+
+    def test_warehouse_objects_resource_none_plus_specific_member_grant(self):
+        # User has no warehouse_objects access, but has explicit viewer on allowed_table.
+        self._create_ac(resource="warehouse_objects", access_level="none")
+        self._create_ac(
+            resource="warehouse_table",
+            resource_id=str(self.allowed_table.id),
+            access_level="viewer",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        # Specific grant wins: allowed_table is reachable, denied_table is not.
+        assert "allowed_table" not in database._denied_tables
+        assert "denied_table" in database._denied_tables
+
+    def test_org_admin_bypasses_warehouse_acl(self):
+        membership = self._membership()
+        membership.level = OrganizationMembership.Level.ADMIN
+        membership.save()
+
+        # Even with a deny row, org admins keep access
+        self._create_ac(
+            resource="warehouse_table",
+            resource_id=str(self.denied_table.id),
+            access_level="none",
+            member=membership,
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "denied_table" not in database._denied_tables
+        assert "allowed_table" not in database._denied_tables
+
+    def test_no_user_fails_closed_for_warehouse_tables(self):
+        database = Database.create_for(team=self.team, user=None)
+
+        assert "denied_table" in database._denied_tables
+        assert "allowed_table" in database._denied_tables
+
+    def test_bypass_access_control_skips_warehouse_acl(self):
+        self._create_ac(
+            resource="warehouse_table",
+            resource_id=str(self.denied_table.id),
+            access_level="none",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user, bypass_access_control=True)
+
+        assert "denied_table" not in database._denied_tables
+        assert "allowed_table" not in database._denied_tables
+
+    def test_bypass_access_control_skips_warehouse_acl_without_user(self):
+        # The classic background-job case: no user, but the caller explicitly opts in.
+        database = Database.create_for(team=self.team, user=None, bypass_access_control=True)
+
+        assert "denied_table" not in database._denied_tables
+        assert "allowed_table" not in database._denied_tables
+
+    def test_denied_table_lookup_raises_access_error(self):
+        from posthog.hogql.errors import QueryError
+
+        self._create_ac(
+            resource="warehouse_table",
+            resource_id=str(self.denied_table.id),
+            access_level="none",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        with self.assertRaises(QueryError) as cm:
+            database.get_table("denied_table")
+        assert "don't have access" in str(cm.exception)
+        assert "Unknown" not in str(cm.exception)
+
+
+class TestWarehouseTableAccessControlFlagOff(BaseTest):
+    """Regression guard: with hogql-warehouse-access-control off, nothing is filtered."""
+
+    def setUp(self):
+        super().setUp()
+        from posthog.constants import AvailableFeature
+
+        from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+        from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+        ]
+        self.organization.save()
+
+        credential = DataWarehouseCredential.objects.create(access_key="blah", access_secret="blah", team=self.team)
+        self.table = DataWarehouseTable.objects.create(
+            name="some_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=credential,
+            url_pattern="s3://bucket/some_table/*",
+            columns={"id": "String"},
+        )
+
+    @patch("posthoganalytics.feature_enabled", new=Mock(return_value=False))
+    def test_warehouse_table_acl_off_keeps_all_tables(self):
+        from ee.models.rbac.access_control import AccessControl
+
+        # Even an explicit deny row should be ignored when the FF is off.
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        AccessControl.objects.create(
+            team=self.team,
+            resource="warehouse_table",
+            resource_id=str(self.table.id),
+            access_level="none",
+            organization_member=membership,
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "some_table" not in database._denied_tables
+        assert not database._denied_resource_ids_by_scope.get("warehouse_table")
+
+
+@patch("posthoganalytics.feature_enabled", new=Mock(return_value=True))
+class TestWarehouseViewAccessControl(BaseTest):
+    """Per-object access control for warehouse saved queries (DataWarehouseSavedQuery)."""
+
+    def setUp(self):
+        super().setUp()
+        from posthog.constants import AvailableFeature
+
+        from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.MEMBER
+        membership.save()
+
+        self.allowed_view = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="allowed_view",
+            query={"kind": "HogQLQuery", "query": "SELECT 1 AS id"},
+            columns={"id": "String"},
+        )
+        self.denied_view = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="denied_view",
+            query={"kind": "HogQLQuery", "query": "SELECT 1 AS id"},
+            columns={"id": "String"},
+        )
+
+    def _create_ac(self, *, resource, access_level, resource_id=None, role=None, member=None):
+        from ee.models.rbac.access_control import AccessControl
+
+        return AccessControl.objects.create(
+            team=self.team,
+            resource=resource,
+            resource_id=resource_id,
+            access_level=access_level,
+            organization_member=member,
+            role=role,
+        )
+
+    def _membership(self):
+        return OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+
+    def test_explicit_object_level_deny_marks_saved_query(self):
+        self._create_ac(
+            resource="warehouse_view",
+            resource_id=str(self.denied_view.id),
+            access_level="none",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "denied_view" in database._denied_tables
+        assert "allowed_view" not in database._denied_tables
+        assert str(self.denied_view.id) in database._denied_resource_ids_by_scope.get("warehouse_view", set())
+
+    def test_warehouse_objects_resource_none_denies_all_views(self):
+        self._create_ac(resource="warehouse_objects", access_level="none")
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "denied_view" in database._denied_tables
+        assert "allowed_view" in database._denied_tables
+
+    def test_no_user_fails_closed_for_warehouse_views(self):
+        database = Database.create_for(team=self.team, user=None)
+
+        assert "denied_view" in database._denied_tables
+        assert "allowed_view" in database._denied_tables
+
+    def test_bypass_access_control_skips_warehouse_view_acl(self):
+        self._create_ac(
+            resource="warehouse_view",
+            resource_id=str(self.denied_view.id),
+            access_level="none",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user, bypass_access_control=True)
+
+        assert "denied_view" not in database._denied_tables
+        assert "allowed_view" not in database._denied_tables

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -421,6 +421,98 @@ class TestWarehouseTableAccessControlFlagOff(BaseTest):
 
 
 @patch("posthoganalytics.feature_enabled", new=Mock(return_value=True))
+class TestWarehouseAccessControlEndToEnd(BaseTest):
+    """End-to-end: execute_hogql_query (the SQL editor path) raises QueryError
+    on a denied warehouse table without ever reaching ClickHouse."""
+
+    def setUp(self):
+        super().setUp()
+        from posthog.constants import AvailableFeature
+
+        from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+        from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.MEMBER
+        membership.save()
+
+        self.membership = membership
+        credential = DataWarehouseCredential.objects.create(access_key="k", access_secret="s", team=self.team)
+        self.denied_table = DataWarehouseTable.objects.create(
+            name="denied_warehouse_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=credential,
+            url_pattern="s3://bucket/denied/*",
+            columns={"id": "String"},
+        )
+
+    def test_execute_hogql_query_raises_on_denied_warehouse_table(self):
+        from posthog.hogql.errors import QueryError
+        from posthog.hogql.query import execute_hogql_query
+
+        from ee.models.rbac.access_control import AccessControl
+
+        AccessControl.objects.create(
+            team=self.team,
+            resource="warehouse_table",
+            resource_id=str(self.denied_table.id),
+            access_level="none",
+            organization_member=self.membership,
+        )
+
+        with self.assertRaises(QueryError) as cm:
+            execute_hogql_query(
+                query="SELECT id FROM denied_warehouse_table",
+                team=self.team,
+                user=self.user,
+            )
+        assert "don't have access" in str(cm.exception)
+        assert "denied_warehouse_table" in str(cm.exception)
+
+    def test_execute_hogql_query_bypass_access_control_skips_denial(self):
+        """bypass_access_control opt-in should let the query past the ACL gate
+        (downstream may still fail because there's no real S3 data, but the
+        ACL gate must not block it)."""
+        from posthog.hogql.context import HogQLContext
+        from posthog.hogql.errors import QueryError
+        from posthog.hogql.query import execute_hogql_query
+
+        from ee.models.rbac.access_control import AccessControl
+
+        AccessControl.objects.create(
+            team=self.team,
+            resource="warehouse_table",
+            resource_id=str(self.denied_table.id),
+            access_level="none",
+            organization_member=self.membership,
+        )
+
+        context = HogQLContext(team_id=self.team.pk, team=self.team, user=self.user, bypass_access_control=True)
+        try:
+            execute_hogql_query(
+                query="SELECT id FROM denied_warehouse_table",
+                team=self.team,
+                user=self.user,
+                context=context,
+            )
+        except QueryError as e:
+            # ACL deny would say "don't have access". Any other error is fine for this test
+            # — we just want to confirm we didn't trip the ACL gate.
+            assert "don't have access" not in str(e), f"bypass was not honored: {e}"
+        except Exception:
+            # Downstream errors (missing S3, etc.) are expected and irrelevant
+            # to whether ACL was bypassed.
+            pass
+
+
+@patch("posthoganalytics.feature_enabled", new=Mock(return_value=True))
 class TestWarehouseViewAccessControl(BaseTest):
     """Per-object access control for warehouse saved queries (DataWarehouseSavedQuery)."""
 

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -83,6 +83,7 @@ def prepare_ast_for_printing(
                 team=context.team,
                 user=context.user,
                 timings=context.timings,
+                bypass_access_control=context.bypass_access_control,
             )
     if context.direct_postgres_connection_metadata is None and context.database is not None:
         context.direct_postgres_connection_metadata = getattr(context.database, "_direct_connection_metadata", None)

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -261,6 +261,8 @@ class HogQLQueryExecutor:
     connection_id: Optional[str] = None
     send_raw_query: bool = False
     user: Optional[User] = None
+    # SECURITY-SENSITIVE: opt-in bypass for HogQL access control. See HogQLContext.bypass_access_control.
+    bypass_access_control: bool = False
 
     __uninitialized_context: ClassVar[HogQLContext] = HogQLContext()
 
@@ -273,7 +275,9 @@ class HogQLQueryExecutor:
     @tracer.start_as_current_span("HogQLQueryExecutor.__post_init__")
     def __post_init__(self):
         if self.context is self.__uninitialized_context:
-            self.context = HogQLContext(team_id=self.team.pk, user=self.user)
+            self.context = HogQLContext(
+                team_id=self.team.pk, user=self.user, bypass_access_control=self.bypass_access_control
+            )
 
         self.query_modifiers = create_default_modifiers_for_team(self.team, self.modifiers)
         self.debug = self.modifiers is not None and self.modifiers.debug
@@ -328,6 +332,7 @@ class HogQLQueryExecutor:
                         user=self.user,
                         modifiers=self.query_modifiers,
                         timings=self.timings,
+                        bypass_access_control=self.context.bypass_access_control,
                     )
                 self.select_query = replace_filters(
                     self.select_query, self.filters, self.team, database=self.context.database
@@ -388,6 +393,7 @@ class HogQLQueryExecutor:
                 modifiers=self.query_modifiers,
                 timings=self.timings,
                 connection_id=self.connection_id,
+                bypass_access_control=self.context.bypass_access_control,
             )
 
         # Reset between executions: the resolver appends per query, and dataclasses.replace below

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1846,6 +1846,12 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         if restricted:
             payload["restricted_properties"] = restricted
 
+        # Include warehouse object-level access control restrictions in the cache key
+        # so that users with different warehouse grants get separate cache entries.
+        restricted_objects = self._get_object_access_restrictions()
+        if restricted_objects:
+            payload["restricted_objects"] = restricted_objects
+
         return payload
 
     def _get_property_access_restrictions(self) -> list[tuple[str, int]] | None:
@@ -1861,6 +1867,23 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         if not restricted:
             return None
         return sorted(restricted)
+
+    def _get_object_access_restrictions(self) -> dict[str, list[str]] | None:
+        """Returns a sorted {resource: [ids]} mapping of restricted resource IDs for the current user, or None if no restrictions.
+
+        Reads ``Database._denied_resource_ids_by_scope`` — the warehouse_table /
+        warehouse_view deny set computed by the new filter methods in
+        ``Database.create_for`` using the full ``check_access_level_for_object``
+        precedence chain. Skipped without user since fail-closed Database.create_for
+        produces the right behavior without needing a cache-key contribution.
+        """
+        if self.user is None or self.database is None:
+            return None
+
+        blocked = self.database._denied_resource_ids_by_scope
+        if not blocked:
+            return None
+        return {resource: sorted(ids) for resource, ids in sorted(blocked.items()) if ids}
 
     def get_cache_key(self) -> str:
         return generate_cache_key(self.team.pk, f"query_{bytes.decode(to_json(self.get_cache_payload()))}")

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1876,11 +1876,17 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         ``Database.create_for`` using the full ``check_access_level_for_object``
         precedence chain. Skipped without user since fail-closed Database.create_for
         produces the right behavior without needing a cache-key contribution.
+
+        Only ``QueryRunnerWithHogQLContext`` subclasses have a ``database``
+        attribute, so non-HogQL runners always return None.
         """
-        if self.user is None or self.database is None:
+        if self.user is None:
+            return None
+        database = getattr(self, "database", None)
+        if database is None:
             return None
 
-        blocked = self.database._denied_resource_ids_by_scope
+        blocked = database._denied_resource_ids_by_scope
         if not blocked:
             return None
         return {resource: sorted(ids) for resource, ids in sorted(blocked.items()) if ids}

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -44,6 +44,7 @@ from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQuer
 from posthog.hogql_queries.query_runner import (
     ExecutionMode,
     QueryRunner,
+    QueryRunnerWithHogQLContext,
     get_query_runner,
     shared_insights_execution_mode,
 )
@@ -325,6 +326,63 @@ class TestQueryRunner(BaseTest):
 
         cache_key = runner.get_cache_key()
         assert cache_key == "cache_42_473689ec17cc982383519776503e498bd0e44f16e6b6f0073412599254a69aba"
+
+    @mock.patch("posthoganalytics.feature_enabled", new=mock.Mock(return_value=True))
+    def test_cache_key_differs_when_warehouse_grants_change(self):
+        """Warehouse table / view deny set is merged into the cache fingerprint.
+
+        Warehouse ACL uses Database._denied_resource_ids_by_scope (populated by
+        the new filter methods in Database.create_for). The fingerprint must
+        include it so warehouse grant changes invalidate cached results.
+        """
+        from posthog.models import OrganizationMembership
+
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.MEMBER
+        membership.save()
+
+        # Only QueryRunnerWithHogQLContext subclasses have a `database` attribute;
+        # build one inline so we don't need to depend on a `base=` parameter on the
+        # `setup_test_query_runner_class` helper.
+        class TestHogQLRunner(QueryRunnerWithHogQLContext):
+            query: TheTestQuery
+            cached_response: TheTestCachedBasicQueryResponse
+
+            def _calculate(self):
+                return TheTestBasicQueryResponse(results=[])
+
+            def _refresh_frequency(self) -> timedelta:
+                return timedelta(minutes=4)
+
+            def _is_stale(self, last_refresh: Optional[datetime], lazy: bool = False, *args, **kwargs) -> bool:
+                return False
+
+            def to_query(self):
+                return self.query
+
+        baseline_runner = TestHogQLRunner(query={"some_attr": "bla"}, team=self.team, user=self.user)
+        baseline_key = baseline_runner.get_cache_key()
+        assert "restricted_objects" not in baseline_runner.get_cache_payload()
+
+        # Simulate the result of the warehouse filter methods having populated the deny set.
+        restricted_runner = TestHogQLRunner(query={"some_attr": "bla"}, team=self.team, user=self.user)
+        restricted_runner.database._denied_resource_ids_by_scope["warehouse_table"] = {
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        }
+        restricted_runner.database._denied_resource_ids_by_scope["warehouse_view"] = {
+            "33333333-3333-3333-3333-333333333333",
+        }
+        restricted_payload = restricted_runner.get_cache_payload()
+
+        assert restricted_payload["restricted_objects"]["warehouse_table"] == [
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        ]
+        assert restricted_payload["restricted_objects"]["warehouse_view"] == [
+            "33333333-3333-3333-3333-333333333333",
+        ]
+        assert restricted_runner.get_cache_key() != baseline_key
 
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`SELECT` queries against Data warehouse tables in HogQL ignore the per-object access control configured for warehouse tables via the REST API. A user who can't see `stripe.customers` via `GET /api/projects/<id>/warehouse_tables/<id>/` (because their role has an explicit deny on it) can still `SELECT * FROM stripe.customers` from the SQL editor.

This is iteration 1 of a multi-PR effort. It lands the base mechanics gated behind a new feature flag at 0% rollout so it is safe to merge without migrating the existing background call sites that touch warehouse data without a user. Iteration 2 will migrate those call sites (pass `created_by` where possible, mark truly authorless paths with `bypass_access_control=True`); iteration 3 rolls the flag out.

## Changes

- New feature flag `hogql-warehouse-access-control` (separate from `hogql-access-control`, which is already at 100% rollout for system tables). Default off, 0% rollout.
- `Database._denied_warehouse_table_ids_for_user(user, team, tables)` and `_denied_warehouse_view_ids_for_user(user, team, saved_queries)`: pure ACL decision methods returning `set[str]` of denied UUIDs. Each warehouse table is treated as an object of the `warehouse_table` resource and each saved query as an object of `warehouse_view`. The decision uses `UserAccessControl.check_access_level_for_object` after a single `preload_object_access_controls` call — same primitive the warehouse REST API uses, so HogQL and the API stay in lockstep on access semantics.
- Wired into the existing warehouse-tables loop in `Database.create_for` and into the `data_warehouse_saved_query` loop. Denied tables / views are skipped and every public name they would have registered is added to `Database._denied_tables`, so `Database.get_table(name)` raises the existing `"You don't have access to table `…`."` `QueryError` instead of `"Unknown table"`.
- `HogQLContext.bypass_access_control: bool` and `Database.create_for(..., *, bypass_access_control=False)` keyword-only. Documented escape hatch for legitimately userless contexts (data import pipeline internals, schema introspection, sharing-token-authenticated reads). Plumbed through `prepare_ast_for_printing` and `HogQLQueryExecutor` so most call sites only touch `HogQLContext`. `grep -r "bypass_access_control=True"` returns the complete audit list in one shot.
- `Database._denied_resource_ids_by_scope: dict[str, set[str]]` populated by the new filter methods. New `QueryRunner._get_object_access_restrictions` hook reads it and adds a `restricted_objects` entry to the cache payload so warehouse grant changes invalidate cached query results. Implementation tolerates non-HogQL runners that don't have a `database` attribute.
- Existing `_filter_system_tables_for_user` / `_filter_all_scoped_system_tables` updated to add to `_denied_tables` rather than overwrite it (the warehouse path may have populated it first), and to reuse an already-constructed `UserAccessControl` instance instead of always creating a new one.

## Known UAC quirks documented in the plan but not addressed here

Each of these affects every `RESOURCE_INHERITANCE_MAP` child (dashboards, etc.), not just warehouse, and warrants its own RBAC PR rather than a warehouse-specific patch. All three are spelled out in the plan file alongside the conditions under which they bite:

1. `warehouse_table` resource-level rows (`resource_id=None`) are silently ignored because `access_level_for_resource("warehouse_table")` short-circuits to `warehouse_objects` via inheritance.
2. Team-wide per-object grants (`role=None, member=None`) are masked by a resource-level "none" because `get_user_access_level` returns at tier 2 without reaching tier 3.
3. `access_level_for_resource` takes the MAX over team-wide / member / role rows, so a role-scoped "none" at the resource level is silently masked by any permissive team default. Asymmetric with `filter_queryset_by_access_level`, which DOES apply explicit-beats-default precedence for per-object rules.

Shipping symmetric with the REST API means when those underlying RBAC issues are fixed, HogQL picks up the fix for free.

## How did you test this code?

I'm an agent and these are the automated tests I ran. No GUI walkthrough — the sandbox environment doesn't have a usable PostHog frontend; manual GUI testing was deferred to whoever picks up iteration 2/3 (where the FF will actually be flipped on for a test team). I did run the SQL-editor entry point end-to-end via `execute_hogql_query`, which is the same call path the SQL editor takes.

**`posthog/hogql/printer/test/test_hogql_access_control.py`** (24 passing — 15 new, 9 pre-existing):

- `TestWarehouseTableAccessControl` (8 tests): explicit object-level deny marks table; `warehouse_objects` resource none denies all tables; resource-none plus specific member grant lets the granted table through and blocks the rest; org-admin bypass; fail-closed without user; `bypass_access_control=True` skips ACL with and without user; denied-table `get_table()` raises access error (not "Unknown table").
- `TestWarehouseTableAccessControlFlagOff` (1 test): regression guard — FF off leaves all tables visible even with explicit deny rows present.
- `TestWarehouseAccessControlEndToEnd` (2 tests): full `execute_hogql_query` path raises `QueryError` for a denied table without ever reaching ClickHouse; `bypass_access_control=True` lets the query past the ACL gate.
- `TestWarehouseViewAccessControl` (4 tests): equivalent matrix for `DataWarehouseSavedQuery` on the `warehouse_view` resource.

**`posthog/hogql_queries/test/test_query_runner.py`** (1 new): `test_cache_key_differs_when_warehouse_grants_change` verifies `Database._denied_resource_ids_by_scope` for `warehouse_table` and `warehouse_view` flows into the cache fingerprint and changes the resulting cache key.

**Regression smoke test**: 37 warehouse-related tests in `posthog/hogql/database/test/test_database.py` still pass.

Commands run (sandbox lab has an unrelated `HogQLParserShadowMismatch` regression in master that fires on every parse, so I monkey-patched `_shadow_sample_rate = lambda: 0.0` for the local runs — CI will exercise the same tests without that workaround):

- ✅ `pytest posthog/hogql/printer/test/test_hogql_access_control.py` (24 passed)
- ✅ `pytest posthog/hogql_queries/test/test_query_runner.py::TestQueryRunner::test_cache_key_differs_when_warehouse_grants_change` (1 passed)
- ✅ `pytest posthog/hogql/database/test/test_database.py -k 'warehouse or s3'` (37 passed, no regressions; run pre-rebase before the unrelated parser shadow issue manifested in this branch)
- ✅ `ruff check` and `ruff format --check` on all touched files

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Cursor cloud agent.
- The pre-implementation design discussion went through several iterations before settling on the current shape. The high-level decisions captured in the plan file (and worth re-reading if you want context for code-review questions):
  - **Hook point**: schema build time in `Database.create_for`, not print/SQL time. The whole table is either accessible or not (warehouse tables are referenced by name, not joined by PK), so the system-table object-level pattern of injecting a `id NOT IN (...)` SQL guard doesn't apply.
  - **Primitive choice**: `UserAccessControl.check_access_level_for_object` rather than the `blocked_resource_ids_by_scope` shortcut the system-table guard uses. The shortcut only finds explicit deny rows — it would silently miss the common warehouse pattern of "default-deny on `warehouse_objects`, grant specific tables to specific roles" and compute zero accessible tables. Using `check_access_level_for_object` keeps HogQL and the warehouse REST API symmetric.
  - **No new helper for name-marking**: the deny branch in the warehouse loop inlines `table.name` + `_get_warehouse_table_keys(...)` — the same two calls the registration branch uses 30 lines further down. Zero drift risk and no extract-method refactor needed.
  - **`bypass_access_control` as `bool`, not a justification string**: the bool was the user's pick. Convention is an inline comment justifying every set site so code review can audit grep results.
  - **New FF (`hogql-warehouse-access-control`) instead of reusing `hogql-access-control`**: the existing flag is at 100% rollout, so reusing it would silently enable warehouse ACL for every team the moment this lands. The new flag gives an independent ramp.
  - **Views in scope for iteration 1**: shipping warehouse-table ACL without warehouse-view ACL leaves a trivial backdoor — define a saved query that `SELECT *` from a locked-down table and share the view name.
- Plan file (not committed): `/opt/cursor/artifacts/plans/hogql_warehouse_table_acl_3a50bd16.plan.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f333e764-2826-4637-b5d0-61c5520301c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f333e764-2826-4637-b5d0-61c5520301c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

