### PR TITLE
feat(web-analytics): Add new AI summarization to Web Analytics

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -495,6 +495,7 @@ export const FEATURE_FLAGS = {
     UX_REMOVE_SIDEPANEL: 'ux-remove-sidepanel', // owner: #team-surveys
     VISUAL_REVIEW: 'visual-review', // owner: #team-devex
     WAREHOUSE_SOURCE_WEBHOOKS: 'warehouse-source-webhooks', // owner: #team-warehouse-sources @Gilbert09
+    WEB_ANALYTICS_AI_SUMMARY: 'web-analytics-ai-summary', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_BOT_ANALYSIS: 'web-analytics-bot-analysis', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_CONVERSION_GOAL_PREAGG: 'web-analytics-conversion-goal-preagg', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_DRAG_TO_ZOOM: 'web-analytics-drag-to-zoom', // owner: @jordanm-posthog #team-web-analytics

--- a/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.tsx
+++ b/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.tsx
@@ -116,7 +116,7 @@ export function EventFilterScene(): JSX.Element {
                 }
             }
         },
-        [filterForm.filter_tree, updateTreeNode, setFilterFormValue]
+        [filterForm.filter_tree, updateTreeNode, setFilterFormValue, nodeIds]
     )
 
     const activeNode = activeId ? getNodeAtPath(filterForm.filter_tree, nodeIds.pathOf(activeId) ?? []) : null

--- a/frontend/src/scenes/web-analytics/WebAnalyticsAISummaryBanner.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsAISummaryBanner.tsx
@@ -1,0 +1,104 @@
+import { useActions, useValues } from 'kea'
+
+import { IconChevronDown, IconCopy, IconMagicWand } from '@posthog/icons'
+import { LemonBanner, LemonButton, Spinner } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+
+import { webAnalyticsAISummaryLogic } from './webAnalyticsAISummaryLogic'
+
+export function WebAnalyticsAISummaryBanner(): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { summary, summaryLoading, errorMessage, isExpanded } = useValues(webAnalyticsAISummaryLogic)
+    const { generateSummary, setExpanded } = useActions(webAnalyticsAISummaryLogic)
+
+    if (!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_AI_SUMMARY]) {
+        return null
+    }
+
+    const hasContent = !!summary || summaryLoading || !!errorMessage
+
+    return (
+        <div
+            className="border rounded bg-surface-primary mb-2 overflow-hidden"
+            data-attr="web-analytics-ai-summary-banner"
+        >
+            <div className="flex items-center justify-between h-11 px-3">
+                <div className="flex items-center gap-2 font-semibold">
+                    <IconMagicWand className="text-primary" fontSize="18" />
+                    <span>AI summary</span>
+                    {summary && (
+                        <span className="text-secondary text-xs font-normal">
+                            Generated <TZLabel time={summary.created_at} />
+                        </span>
+                    )}
+                </div>
+                <div className="flex items-center gap-1">
+                    {!hasContent && (
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            icon={<IconMagicWand />}
+                            onClick={() => generateSummary()}
+                            loading={summaryLoading}
+                            data-attr="web-analytics-ai-summary-generate"
+                        >
+                            Generate AI summary
+                        </LemonButton>
+                    )}
+                    {summary && (
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            icon={<IconCopy />}
+                            tooltip="Copy summary to clipboard"
+                            aria-label="Copy summary to clipboard"
+                            onClick={() => {
+                                void copyToClipboard(summary.summary_text, 'AI summary')
+                            }}
+                            data-attr="web-analytics-ai-summary-copy"
+                        />
+                    )}
+                    {hasContent && (
+                        <LemonButton
+                            size="small"
+                            icon={<IconChevronDown className={isExpanded ? '' : 'rotate-180'} />}
+                            onClick={() => setExpanded(!isExpanded)}
+                            tooltip={isExpanded ? 'Collapse' : 'Expand'}
+                            aria-label={isExpanded ? 'Collapse summary' : 'Expand summary'}
+                        />
+                    )}
+                </div>
+            </div>
+            {isExpanded && hasContent && (
+                <div className="px-3 pb-3 border-t pt-2">
+                    {summaryLoading ? (
+                        <div className="flex items-center gap-2 text-sm text-secondary">
+                            <Spinner /> Analyzing your data...
+                        </div>
+                    ) : errorMessage ? (
+                        <LemonBanner
+                            type="error"
+                            action={{
+                                children: 'Try again',
+                                onClick: () => generateSummary(),
+                            }}
+                        >
+                            <div className="text-sm font-normal">
+                                <strong>Summary failed.</strong> {errorMessage}
+                            </div>
+                        </LemonBanner>
+                    ) : summary ? (
+                        <LemonMarkdown lowKeyHeadings className="text-sm leading-relaxed">
+                            {summary.summary_text}
+                        </LemonMarkdown>
+                    ) : null}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -60,6 +60,7 @@ import { botAnalyticsLogic } from './botAnalyticsLogic'
 import { HealthStatusTab, webAnalyticsHealthLogic } from './health'
 import { LiveBotTiles } from './LiveMetricsDashboard/LiveBotTiles'
 import { LiveWebAnalyticsMetrics } from './LiveMetricsDashboard/LiveWebAnalyticsMetrics'
+import { WebAnalyticsAISummaryBanner } from './WebAnalyticsAISummaryBanner'
 import { WebAnalyticsExport } from './WebAnalyticsExport'
 import { WebAnalyticsFilters } from './WebAnalyticsFilters'
 import { webAnalyticsModalLogic } from './webAnalyticsModalLogic'
@@ -644,6 +645,14 @@ const Filters = ({ tabs }: { tabs: JSX.Element }): JSX.Element | null => {
     }
 }
 
+const AnalyticsTabBanners = (): JSX.Element | null => {
+    const { productTab } = useValues(webAnalyticsLogic)
+    if (productTab !== ProductTab.ANALYTICS) {
+        return null
+    }
+    return <WebAnalyticsAISummaryBanner />
+}
+
 const MainContent = (): JSX.Element => {
     const { productTab } = useValues(webAnalyticsLogic)
 
@@ -790,6 +799,7 @@ export const WebAnalyticsDashboard = (): JSX.Element => {
                         <Filters tabs={<></>} />
 
                         <WebAnalyticsHealthCheck />
+                        <AnalyticsTabBanners />
                         <MainContent />
                     </>
                 </SceneContent>

--- a/frontend/src/scenes/web-analytics/webAnalyticsAISummaryLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsAISummaryLogic.ts
@@ -45,7 +45,6 @@ export const webAnalyticsAISummaryLogic = kea<webAnalyticsAISummaryLogicType>([
                 generateSummarySuccess: (_, { summary }) => summary,
             },
         ],
-        // Only the LLM-invoking generate path drives the visible loading state; the cache check is silent.
         summaryLoading: [
             false,
             {
@@ -103,7 +102,6 @@ export const webAnalyticsAISummaryLogic = kea<webAnalyticsAISummaryLogicType>([
     }),
     listeners(({ values, actions }) => ({
         loadCachedSummary: async (_, breakpoint) => {
-            // Debounce: filterSpec changes can fire in rapid bursts as the user adjusts filters.
             await breakpoint(300)
             if (!values.currentProjectId) {
                 return
@@ -114,11 +112,9 @@ export const webAnalyticsAISummaryLogic = kea<webAnalyticsAISummaryLogicType>([
                     check: true,
                 })
             } catch {
-                // A failed silent cache check must not disrupt the dashboard — leave the current summary in place.
                 return
             }
             breakpoint()
-            // Cache hit → show it; miss (HTTP 204 → void) → clear so the banner reflects the current filters.
             actions.setSummary(result?.summary_text ? result : null)
         },
         generateSummary: async () => {
@@ -133,8 +129,9 @@ export const webAnalyticsAISummaryLogic = kea<webAnalyticsAISummaryLogicType>([
                 } else {
                     actions.generateSummaryFailure('Failed to generate summary')
                 }
-            } catch (error: any) {
-                actions.generateSummaryFailure(error?.detail || error?.message || 'Failed to generate summary')
+            } catch (error) {
+                const { detail, message } = (error ?? {}) as { detail?: string; message?: string }
+                actions.generateSummaryFailure(detail || message || 'Failed to generate summary')
             }
         },
     })),

--- a/frontend/src/scenes/web-analytics/webAnalyticsAISummaryLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsAISummaryLogic.ts
@@ -1,0 +1,146 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { subscriptions } from 'kea-subscriptions'
+
+import { projectLogic } from 'scenes/projectLogic'
+import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
+
+import { webAnalyticsAiSummary } from 'products/web_analytics/frontend/generated/api'
+import type {
+    AISummaryFilterSpecApi,
+    AISummaryResponseApi,
+} from 'products/web_analytics/frontend/generated/api.schemas'
+
+import type { webAnalyticsAISummaryLogicType } from './webAnalyticsAISummaryLogicType'
+
+export const webAnalyticsAISummaryLogic = kea<webAnalyticsAISummaryLogicType>([
+    path(['scenes', 'web-analytics', 'webAnalyticsAISummaryLogic']),
+    connect(() => ({
+        values: [
+            projectLogic,
+            ['currentProjectId'],
+            webAnalyticsLogic,
+            [
+                'dateFilter',
+                'compareFilter',
+                'webAnalyticsFilters',
+                'conversionGoal',
+                'shouldFilterTestAccounts',
+                'isPathCleaningEnabled',
+            ],
+        ],
+    })),
+    actions({
+        loadCachedSummary: true,
+        setSummary: (summary: AISummaryResponseApi | null) => ({ summary }),
+        generateSummary: true,
+        generateSummarySuccess: (summary: AISummaryResponseApi) => ({ summary }),
+        generateSummaryFailure: (error: string) => ({ error }),
+        setExpanded: (expanded: boolean) => ({ expanded }),
+    }),
+    reducers({
+        summary: [
+            null as AISummaryResponseApi | null,
+            {
+                setSummary: (_, { summary }) => summary,
+                generateSummarySuccess: (_, { summary }) => summary,
+            },
+        ],
+        // Only the LLM-invoking generate path drives the visible loading state; the cache check is silent.
+        summaryLoading: [
+            false,
+            {
+                generateSummary: () => true,
+                generateSummarySuccess: () => false,
+                generateSummaryFailure: () => false,
+            },
+        ],
+        errorMessage: [
+            null as string | null,
+            {
+                generateSummary: () => null,
+                generateSummaryFailure: (_, { error }) => error,
+            },
+        ],
+        isExpanded: [true, { setExpanded: (_, { expanded }) => expanded }],
+    }),
+    selectors({
+        filterSpec: [
+            (s) => [
+                s.dateFilter,
+                s.compareFilter,
+                s.webAnalyticsFilters,
+                s.conversionGoal,
+                s.shouldFilterTestAccounts,
+                s.isPathCleaningEnabled,
+            ],
+            (
+                dateFilter,
+                compareFilter,
+                webAnalyticsFilters,
+                conversionGoal,
+                shouldFilterTestAccounts,
+                isPathCleaningEnabled
+            ): AISummaryFilterSpecApi => {
+                let conversion_goal: AISummaryFilterSpecApi['conversion_goal'] = null
+                if (conversionGoal) {
+                    if ('actionId' in conversionGoal) {
+                        conversion_goal = { actionId: conversionGoal.actionId }
+                    } else if ('customEventName' in conversionGoal) {
+                        conversion_goal = { customEventName: conversionGoal.customEventName }
+                    }
+                }
+                return {
+                    date_from: dateFilter.dateFrom ?? '-7d',
+                    date_to: dateFilter.dateTo ?? null,
+                    compare: !!compareFilter?.compare,
+                    properties: webAnalyticsFilters as AISummaryFilterSpecApi['properties'],
+                    conversion_goal,
+                    filter_test_accounts: shouldFilterTestAccounts,
+                    do_path_cleaning: isPathCleaningEnabled,
+                }
+            },
+        ],
+    }),
+    listeners(({ values, actions }) => ({
+        loadCachedSummary: async (_, breakpoint) => {
+            // Debounce: filterSpec changes can fire in rapid bursts as the user adjusts filters.
+            await breakpoint(300)
+            if (!values.currentProjectId) {
+                return
+            }
+            let result: AISummaryResponseApi | void
+            try {
+                result = await webAnalyticsAiSummary(String(values.currentProjectId), values.filterSpec, {
+                    check: true,
+                })
+            } catch {
+                // A failed silent cache check must not disrupt the dashboard — leave the current summary in place.
+                return
+            }
+            breakpoint()
+            // Cache hit → show it; miss (HTTP 204 → void) → clear so the banner reflects the current filters.
+            actions.setSummary(result?.summary_text ? result : null)
+        },
+        generateSummary: async () => {
+            if (!values.currentProjectId) {
+                actions.generateSummaryFailure('No project selected')
+                return
+            }
+            try {
+                const result = await webAnalyticsAiSummary(String(values.currentProjectId), values.filterSpec)
+                if (result?.summary_text) {
+                    actions.generateSummarySuccess(result)
+                } else {
+                    actions.generateSummaryFailure('Failed to generate summary')
+                }
+            } catch (error: any) {
+                actions.generateSummaryFailure(error?.detail || error?.message || 'Failed to generate summary')
+            }
+        },
+    })),
+    subscriptions(({ actions }) => ({
+        filterSpec: () => {
+            actions.loadCachedSummary()
+        },
+    })),
+])

--- a/products/web_analytics/backend/ai_summary.py
+++ b/products/web_analytics/backend/ai_summary.py
@@ -1,12 +1,13 @@
 import json
 import hashlib
 from datetime import datetime, timedelta
+from typing import cast
 from zoneinfo import ZoneInfo
 
 from django.core.cache import cache
 
-import structlog
 from langchain_core.messages import HumanMessage
+from langchain_core.outputs import ChatGeneration
 
 from posthog.schema import DateRange
 
@@ -17,9 +18,6 @@ from posthog.utils import relative_date_parse
 from products.web_analytics.backend.weekly_digest import DigestFilterSpec
 
 from ee.hogai.llm import MaxChatAnthropic
-
-logger = structlog.get_logger(__name__)
-
 
 MODEL_ID = "claude-haiku-4-5"
 LIVE_RANGE_TTL = timedelta(hours=1)
@@ -42,8 +40,6 @@ def _normalize_spec(spec: DigestFilterSpec) -> dict:
 
 
 def compute_cache_key(spec: DigestFilterSpec, *, team: Team) -> tuple[str, dict]:
-    # The key is built from the raw (unresolved) spec — relative tokens like '-7d' stay as-is so the
-    # key is stable over time and freshness is governed solely by the TTL, not by a wall-clock hour.
     normalized = _normalize_spec(spec)
     payload = json.dumps(normalized, sort_keys=True, default=str)
     digest = hashlib.sha256(payload.encode()).hexdigest()
@@ -61,7 +57,6 @@ def _range_contains_now(date_range: DateRange, *, team: Team, now: datetime) -> 
 
 
 def cache_ttl_for(spec: DigestFilterSpec, *, team: Team, now: datetime | None = None) -> timedelta:
-    # Live ranges (ending at/after now) churn, so expire quickly; closed past ranges are stable.
     now = now or datetime.now(ZoneInfo(team.timezone))
     return LIVE_RANGE_TTL if _range_contains_now(spec.date_range, team=team, now=now) else PAST_RANGE_TTL
 
@@ -158,6 +153,6 @@ def generate_web_analytics_summary(*, team: Team, normalized_spec: dict, digest:
         posthog_properties={"ai_product": "web_analytics", "ai_feature": "dashboard-summary"},
     )
     result = llm.generate([[HumanMessage(content=prompt)]])
-    message = result.generations[0][0].message  # type: ignore[union-attr]
+    message = cast(ChatGeneration, result.generations[0][0]).message
     content = message.content if isinstance(message.content, str) else "".join(str(c) for c in message.content)
     return content.strip()

--- a/products/web_analytics/backend/ai_summary.py
+++ b/products/web_analytics/backend/ai_summary.py
@@ -1,0 +1,163 @@
+import json
+import hashlib
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from django.core.cache import cache
+
+import structlog
+from langchain_core.messages import HumanMessage
+
+from posthog.schema import DateRange
+
+from posthog.models import Team
+from posthog.models.user import User
+from posthog.utils import relative_date_parse
+
+from products.web_analytics.backend.weekly_digest import DigestFilterSpec
+
+from ee.hogai.llm import MaxChatAnthropic
+
+logger = structlog.get_logger(__name__)
+
+
+MODEL_ID = "claude-haiku-4-5"
+LIVE_RANGE_TTL = timedelta(hours=1)
+PAST_RANGE_TTL = timedelta(hours=24)
+MAX_SUMMARY_WORDS = 150
+MAX_OUTPUT_TOKENS = 700
+CACHE_KEY_PREFIX = "web_analytics_ai_summary"
+
+
+def _normalize_spec(spec: DigestFilterSpec) -> dict:
+    return {
+        "date_from": spec.date_range.date_from,
+        "date_to": spec.date_range.date_to,
+        "compare": spec.compare,
+        "properties": sorted(spec.properties, key=lambda p: json.dumps(p, sort_keys=True, default=str)),
+        "conversion_goal": spec.conversion_goal.model_dump() if spec.conversion_goal is not None else None,
+        "filter_test_accounts": spec.filter_test_accounts,
+        "do_path_cleaning": spec.do_path_cleaning,
+    }
+
+
+def compute_cache_key(spec: DigestFilterSpec, *, team: Team) -> tuple[str, dict]:
+    # The key is built from the raw (unresolved) spec — relative tokens like '-7d' stay as-is so the
+    # key is stable over time and freshness is governed solely by the TTL, not by a wall-clock hour.
+    normalized = _normalize_spec(spec)
+    payload = json.dumps(normalized, sort_keys=True, default=str)
+    digest = hashlib.sha256(payload.encode()).hexdigest()
+    return f"{CACHE_KEY_PREFIX}:{team.pk}:{digest}", normalized
+
+
+def _range_contains_now(date_range: DateRange, *, team: Team, now: datetime) -> bool:
+    if date_range.date_to is None:
+        return True
+    try:
+        resolved = relative_date_parse(date_range.date_to, ZoneInfo(team.timezone), now=now, increase=True)
+    except Exception:
+        return True
+    return resolved >= now
+
+
+def cache_ttl_for(spec: DigestFilterSpec, *, team: Team, now: datetime | None = None) -> timedelta:
+    # Live ranges (ending at/after now) churn, so expire quickly; closed past ranges are stable.
+    now = now or datetime.now(ZoneInfo(team.timezone))
+    return LIVE_RANGE_TTL if _range_contains_now(spec.date_range, team=team, now=now) else PAST_RANGE_TTL
+
+
+def get_cached_summary(cache_key: str) -> dict | None:
+    return cache.get(cache_key)
+
+
+def cache_summary(cache_key: str, *, summary_text: str, ttl: timedelta, now: datetime | None = None) -> dict:
+    payload = {
+        "summary_text": summary_text,
+        "model_id": MODEL_ID,
+        "created_at": now or datetime.now(ZoneInfo("UTC")),
+    }
+    cache.set(cache_key, payload, timeout=int(ttl.total_seconds()))
+    return payload
+
+
+def _format_filter_context_for_prompt(normalized: dict) -> str:
+    lines = []
+    date_from = normalized.get("date_from") or "(beginning of available data)"
+    date_to = normalized.get("date_to") or "(now)"
+    lines.append(f"- Date range: {date_from} to {date_to}")
+    lines.append(f"- Period comparison: {'on (vs prior equal-length period)' if normalized['compare'] else 'off'}")
+    lines.append(f"- Filter test accounts: {normalized['filter_test_accounts']}")
+    lines.append(f"- Path cleaning: {normalized['do_path_cleaning']}")
+    if normalized.get("conversion_goal"):
+        lines.append(f"- Conversion goal: {json.dumps(normalized['conversion_goal'], default=str)}")
+    if normalized.get("properties"):
+        lines.append(f"- Property filters: {json.dumps(normalized['properties'], default=str)}")
+    else:
+        lines.append("- Property filters: none")
+    return "\n".join(lines)
+
+
+def _format_context_events_for_prompt(events: list[dict]) -> str:
+    lines = []
+    for event in events:
+        date = (event.get("date") or "")[:10] or "unknown date"
+        kind = (event.get("kind") or "event").replace("_", " ")
+        name = event.get("name") or "(unnamed)"
+        summary = event.get("summary") or ""
+        suffix = f" — {summary}" if summary else ""
+        lines.append(f"- {date} · {kind}: `{name}`{suffix}")
+    return "\n".join(lines)
+
+
+def _build_prompt(normalized_spec: dict, digest: dict) -> str:
+    filter_context = _format_filter_context_for_prompt(normalized_spec)
+    context_events = digest.get("context_events") or []
+    context_section = ""
+    if context_events:
+        context_section = (
+            "Recent project events (use to add explanatory color for metric changes when timing plausibly aligns):\n"
+            f"{_format_context_events_for_prompt(context_events)}\n\n"
+        )
+    return (
+        "You are a web analytics expert summarizing a project's web traffic for a busy operator.\n\n"
+        "Filter context:\n"
+        f"{filter_context}\n\n"
+        f"{context_section}"
+        "Data (period-over-period change present when available):\n"
+        f"{json.dumps(digest, default=str)}\n\n"
+        "Style rules:\n"
+        "- Format the output as GitHub-flavored markdown.\n"
+        "- 4-6 concise bullet points using `-` for list items.\n"
+        "- Lead with the single most notable change (spike, drop, anomaly).\n"
+        "- Use `**bold**` to highlight the metric or entity each bullet is about (e.g. `**Visitors:** ...`).\n"
+        "- Quantify every claim with absolute numbers and percentage change "
+        '(e.g., "+15% to 12,453 visitors", "bounce rate dropped from 4.2% to 2.1%").\n'
+        "- Wrap specific page paths and source names in backticks (e.g. `` `/pricing` ``, `` `google.com` ``).\n"
+        "- When a metric change plausibly aligns in time with a listed project event, you may mention it "
+        '(use phrasing like "coincides with" or "following"). Never assert causation.\n'
+        "- At most one event mention per bullet. Do not list events that have no plausible link to a metric.\n"
+        "- If nothing notable changed, say so in one sentence.\n"
+        "- Do not use headings (no `#`). Do not wrap the whole response in code fences.\n"
+        f"- Stay under {MAX_SUMMARY_WORDS} words total.\n"
+    )
+
+
+def generate_web_analytics_summary(*, team: Team, normalized_spec: dict, digest: dict, user: User) -> str:
+    prompt = _build_prompt(normalized_spec, digest)
+    llm = MaxChatAnthropic(
+        model=MODEL_ID,
+        user=user,
+        team=team,
+        billable=False,
+        inject_context=False,
+        max_retries=2,
+        temperature=0,
+        max_tokens=MAX_OUTPUT_TOKENS,
+        stream_usage=False,
+        disable_streaming=True,
+        posthog_properties={"ai_product": "web_analytics", "ai_feature": "dashboard-summary"},
+    )
+    result = llm.generate([[HumanMessage(content=prompt)]])
+    message = result.generations[0][0].message  # type: ignore[union-attr]
+    content = message.content if isinstance(message.content, str) else "".join(str(c) for c in message.content)
+    return content.strip()

--- a/products/web_analytics/backend/api/api.py
+++ b/products/web_analytics/backend/api/api.py
@@ -1,18 +1,36 @@
+from typing import cast
+
+import structlog
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
-from rest_framework import serializers, viewsets
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_field
+from rest_framework import exceptions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.schema import ActionConversionGoal, CustomEventConversionGoal, DateRange
 
+from posthog.api.documentation import PropertyItemSerializer
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models.user import User
+from posthog.rate_limit import AIBurstRateThrottle, AISustainedRateThrottle
+
+from products.web_analytics.backend.ai_summary import (
+    MODEL_ID,
+    cache_summary,
+    cache_ttl_for,
+    compute_cache_key,
+    generate_web_analytics_summary,
+    get_cached_summary,
+)
 from products.web_analytics.backend.serializers import WeeklyDigestResponseSerializer
-from products.web_analytics.backend.weekly_digest import build_team_digest
+from products.web_analytics.backend.weekly_digest import DigestFilterSpec, build_digest_from_spec, build_team_digest
 
 MIN_DAYS = 1
 MAX_DAYS = 90
 DEFAULT_DAYS = 7
+
+logger = structlog.get_logger(__name__)
 
 
 class _DigestQuerySerializer(serializers.Serializer):
@@ -20,10 +38,107 @@ class _DigestQuerySerializer(serializers.Serializer):
     compare = serializers.BooleanField(required=False, default=True)
 
 
+@extend_schema_field(
+    {
+        "type": "object",
+        "description": (
+            "Conversion goal. Either {actionId: number} for an action goal "
+            "or {customEventName: string} for a custom event goal."
+        ),
+        "properties": {
+            "actionId": {"type": "integer", "description": "ID of the action used as conversion goal."},
+            "customEventName": {"type": "string", "description": "Custom event name used as conversion goal."},
+        },
+        "additionalProperties": True,
+    }
+)
+class _ConversionGoalField(serializers.DictField):
+    pass
+
+
+class AISummaryFilterSpecSerializer(serializers.Serializer):
+    date_from = serializers.CharField(
+        help_text="Start of the analysis window. Accepts a relative spec like '-7d' or an ISO date like '2026-01-01'."
+    )
+    date_to = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="End of the analysis window. Accepts the same formats as date_from, or null for an open-ended range up to now.",
+    )
+    compare = serializers.BooleanField(
+        required=False,
+        default=True,
+        help_text="When true, include period-over-period change for each metric against the prior equal-length period.",
+    )
+    properties = PropertyItemSerializer(
+        many=True,
+        required=False,
+        default=list,
+        help_text="Property filters applied to all underlying queries.",
+    )
+    conversion_goal = _ConversionGoalField(
+        required=False,
+        allow_null=True,
+        help_text="Optional conversion goal — either ActionConversionGoal ({actionId}) or CustomEventConversionGoal ({customEventName}).",
+    )
+    filter_test_accounts = serializers.BooleanField(
+        required=False, default=True, help_text="Whether to exclude internal/test-account events from the analysis."
+    )
+    do_path_cleaning = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="When true, apply the team's path-cleaning rules before bucketing by page path.",
+    )
+
+
+class AISummaryResponseSerializer(serializers.Serializer):
+    summary_text = serializers.CharField(help_text="LLM-generated plain-text summary, up to ~150 words.")
+    created_at = serializers.DateTimeField(help_text="When the summary was generated.")
+    model_id = serializers.CharField(help_text="LLM model identifier used to generate this summary.")
+    cached = serializers.BooleanField(
+        help_text="True when this summary was reused from the cache; false when freshly generated."
+    )
+
+
+def _spec_from_validated(data: dict) -> DigestFilterSpec:
+    conversion_goal: ActionConversionGoal | CustomEventConversionGoal | None = None
+    raw_goal = data.get("conversion_goal")
+    if raw_goal:
+        if "actionId" in raw_goal:
+            conversion_goal = ActionConversionGoal(actionId=raw_goal["actionId"])
+        elif "customEventName" in raw_goal:
+            conversion_goal = CustomEventConversionGoal(customEventName=raw_goal["customEventName"])
+    return DigestFilterSpec(
+        date_range=DateRange(date_from=data["date_from"], date_to=data.get("date_to") or None),
+        compare=data.get("compare", True),
+        properties=list(data.get("properties") or []),
+        conversion_goal=conversion_goal,
+        filter_test_accounts=data.get("filter_test_accounts", True),
+        do_path_cleaning=data.get("do_path_cleaning", False),
+    )
+
+
+def _is_check_request(request: "Request") -> bool:
+    return request.query_params.get("check", "").lower() in ("1", "true", "yes")
+
+
+class _AISummaryGenerationFailed(exceptions.APIException):
+    status_code = status.HTTP_502_BAD_GATEWAY
+    default_detail = "Failed to generate AI summary. Please try again."
+    default_code = "ai_summary_failed"
+
+
 class WebAnalyticsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "web_analytics"
     scope_object_read_actions = ["weekly_digest"]
+    scope_object_write_actions = ["ai_summary"]
     serializer_class = WeeklyDigestResponseSerializer
+
+    def get_throttles(self):
+        if self.action == "ai_summary" and not _is_check_request(self.request):
+            return [AIBurstRateThrottle(), AISustainedRateThrottle()]
+        return super().get_throttles()
 
     @extend_schema(
         operation_id="web_analytics_weekly_digest",
@@ -67,3 +182,68 @@ class WebAnalyticsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         digest = build_team_digest(self.team, days=params["days"], compare=params["compare"])
         serializer = self.get_serializer(instance=digest)
         return Response(serializer.data)
+
+    @extend_schema(
+        operation_id="web_analytics_ai_summary",
+        summary="Generate AI summary of web analytics",
+        description=(
+            "Returns an AI summary of the team's web analytics for the supplied filter spec. "
+            "If a fresh summary is cached it is returned as-is. Otherwise, when check=true the call returns "
+            "HTTP 204 without invoking the LLM; when check is omitted/false the LLM is invoked, the result "
+            "is cached, and returned. The generate path is rate-limited per user."
+        ),
+        request=AISummaryFilterSpecSerializer,
+        parameters=[
+            OpenApiParameter(
+                name="check",
+                type=OpenApiTypes.BOOL,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                default=False,
+                description=(
+                    "When true, only return a cached summary if one is fresh (HTTP 204 on a miss) and never "
+                    "invoke the LLM. Used by the dashboard to hydrate a cached summary without incurring cost."
+                ),
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(response=AISummaryResponseSerializer),
+            204: OpenApiResponse(description="check=true and no fresh cached summary exists for this filter spec."),
+            502: OpenApiResponse(description="LLM call failed."),
+        },
+        tags=["web_analytics"],
+    )
+    @action(detail=False, methods=["post"], url_path="ai_summary")
+    def ai_summary(self, request: "Request", **kwargs: object) -> Response:
+        serializer = AISummaryFilterSpecSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        spec = _spec_from_validated(serializer.validated_data)
+        cache_key, normalized = compute_cache_key(spec, team=self.team)
+
+        cached = get_cached_summary(cache_key)
+        if cached is not None:
+            return Response({**cached, "cached": True})
+
+        if _is_check_request(request):
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        if not request.user.is_authenticated:
+            raise exceptions.NotAuthenticated()
+        user = cast(User, request.user)
+
+        digest = build_digest_from_spec(self.team, spec, include_context_events=True)
+
+        try:
+            summary_text = generate_web_analytics_summary(
+                team=self.team,
+                normalized_spec=normalized,
+                digest=digest,
+                user=user,
+            )
+        except Exception:
+            logger.exception("web_analytics_ai_summary_failed", team_id=self.team.pk, model_id=MODEL_ID)
+            raise _AISummaryGenerationFailed()
+
+        ttl = cache_ttl_for(spec, team=self.team)
+        payload = cache_summary(cache_key, summary_text=summary_text, ttl=ttl)
+        return Response({**payload, "cached": False})

--- a/products/web_analytics/backend/context_events.py
+++ b/products/web_analytics/backend/context_events.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from typing import Any
+
+import structlog
+
+from posthog.models import Team
+from posthog.models.annotation import Annotation
+
+logger = structlog.get_logger(__name__)
+
+
+MAX_CONTEXT_EVENTS = 5
+ANNOTATION_PREVIEW_CHARS = 140
+
+
+def _preview(content: str | None) -> str:
+    if not content:
+        return ""
+    stripped = content.strip()
+    if len(stripped) <= ANNOTATION_PREVIEW_CHARS:
+        return stripped
+    return stripped[: ANNOTATION_PREVIEW_CHARS - 1].rstrip() + "…"
+
+
+def gather_context_events(
+    team: Team, date_from: datetime, date_to: datetime, limit: int = MAX_CONTEXT_EVENTS
+) -> list[dict[str, Any]]:
+    """Collect a small ranked list of project events within the digest window for the AI summary prompt.
+
+    Events are purely additive context; on any internal failure this returns an empty list so summary
+    generation can still proceed. Sourced from manual annotations — the lowest-risk, highest-signal
+    timeline markers.
+    """
+    try:
+        rows = Annotation.objects.filter(
+            team_id=team.pk,
+            deleted=False,
+            date_marker__gte=date_from,
+            date_marker__lte=date_to,
+        ).order_by("-date_marker")[:limit]
+    except Exception:
+        logger.exception("failed to load annotations for context events", team_id=team.pk)
+        return []
+
+    events: list[dict[str, Any]] = []
+    for row in rows:
+        preview = _preview(row.content)
+        if not preview:
+            continue
+        events.append(
+            {
+                "kind": "annotation",
+                "name": preview,
+                "date": row.date_marker.isoformat() if row.date_marker else None,
+                "summary": "manual annotation",
+            }
+        )
+    return events

--- a/products/web_analytics/backend/context_events.py
+++ b/products/web_analytics/backend/context_events.py
@@ -25,12 +25,6 @@ def _preview(content: str | None) -> str:
 def gather_context_events(
     team: Team, date_from: datetime, date_to: datetime, limit: int = MAX_CONTEXT_EVENTS
 ) -> list[dict[str, Any]]:
-    """Collect a small ranked list of project events within the digest window for the AI summary prompt.
-
-    Events are purely additive context; on any internal failure this returns an empty list so summary
-    generation can still proceed. Sourced from manual annotations — the lowest-risk, highest-signal
-    timeline markers.
-    """
     try:
         rows = Annotation.objects.filter(
             team_id=team.pk,

--- a/products/web_analytics/backend/test/test_ai_summary.py
+++ b/products/web_analytics/backend/test/test_ai_summary.py
@@ -84,8 +84,6 @@ class TestComputeCacheKey(APIBaseTest):
         assert key_a == key_b
 
     def test_key_does_not_rotate_over_time(self):
-        # Regression: the key must not embed the current wall-clock, or a summary cached at one hour
-        # would never be found at the next, defeating the TTL.
         with freeze_time("2026-05-28 11:55:00"):
             key_early, _ = compute_cache_key(_spec(), team=self.team)
         with freeze_time("2026-05-28 12:05:00"):

--- a/products/web_analytics/backend/test/test_ai_summary.py
+++ b/products/web_analytics/backend/test/test_ai_summary.py
@@ -1,0 +1,130 @@
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest
+
+from posthog.schema import DateRange
+
+from products.web_analytics.backend.ai_summary import (
+    LIVE_RANGE_TTL,
+    PAST_RANGE_TTL,
+    _build_prompt,
+    cache_ttl_for,
+    compute_cache_key,
+)
+from products.web_analytics.backend.weekly_digest import DigestFilterSpec
+
+
+def _spec(date_from="-7d", date_to=None, **kwargs) -> DigestFilterSpec:
+    return DigestFilterSpec(date_range=DateRange(date_from=date_from, date_to=date_to), **kwargs)
+
+
+def _empty_digest(extra=None) -> dict:
+    digest = {
+        "visitors": {"current": 100, "previous": 80, "change": {"delta": 25.0}},
+        "top_pages": [],
+        "top_sources": [],
+        "goals": [],
+        "context_events": [],
+    }
+    if extra:
+        digest.update(extra)
+    return digest
+
+
+class TestBuildPrompt(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.cache_key, self.normalized = compute_cache_key(_spec(), team=self.team)
+
+    def test_prompt_omits_context_section_when_no_events(self):
+        prompt = _build_prompt(self.normalized, _empty_digest())
+        assert "Recent project events" not in prompt
+        assert "Filter context:" in prompt
+
+    def test_prompt_includes_context_section_when_events_present(self):
+        digest = _empty_digest(
+            {
+                "context_events": [
+                    {
+                        "kind": "annotation",
+                        "name": "deployed v3.4",
+                        "date": "2026-05-25T10:00:00+00:00",
+                        "summary": "manual annotation",
+                    },
+                ]
+            }
+        )
+        prompt = _build_prompt(self.normalized, digest)
+        assert "Recent project events" in prompt
+        assert "annotation" in prompt
+        assert "deployed v3.4" in prompt
+        assert "2026-05-25" in prompt
+
+    def test_prompt_includes_correlation_style_rule_when_events_present(self):
+        digest = _empty_digest(
+            {
+                "context_events": [
+                    {
+                        "kind": "annotation",
+                        "name": "deployed v3.4",
+                        "date": "2026-05-25T10:00:00+00:00",
+                        "summary": "manual annotation",
+                    }
+                ]
+            }
+        )
+        prompt = _build_prompt(self.normalized, digest)
+        assert "coincides with" in prompt
+        assert "Never assert causation" in prompt
+
+
+class TestComputeCacheKey(APIBaseTest):
+    def test_key_is_stable_for_same_spec(self):
+        key_a, _ = compute_cache_key(_spec(), team=self.team)
+        key_b, _ = compute_cache_key(_spec(), team=self.team)
+        assert key_a == key_b
+
+    def test_key_does_not_rotate_over_time(self):
+        # Regression: the key must not embed the current wall-clock, or a summary cached at one hour
+        # would never be found at the next, defeating the TTL.
+        with freeze_time("2026-05-28 11:55:00"):
+            key_early, _ = compute_cache_key(_spec(), team=self.team)
+        with freeze_time("2026-05-28 12:05:00"):
+            key_later, _ = compute_cache_key(_spec(), team=self.team)
+        assert key_early == key_later
+
+    def test_key_changes_with_date_range(self):
+        key_7d, _ = compute_cache_key(_spec(date_from="-7d"), team=self.team)
+        key_30d, _ = compute_cache_key(_spec(date_from="-30d"), team=self.team)
+        assert key_7d != key_30d
+
+    def test_key_changes_with_filter_options(self):
+        key_a, _ = compute_cache_key(_spec(filter_test_accounts=True), team=self.team)
+        key_b, _ = compute_cache_key(_spec(filter_test_accounts=False), team=self.team)
+        assert key_a != key_b
+
+    def test_key_is_scoped_to_team(self):
+        other_team = self.organization.teams.create(name="Other team")
+        key_self, _ = compute_cache_key(_spec(), team=self.team)
+        key_other, _ = compute_cache_key(_spec(), team=other_team)
+        assert key_self != key_other
+
+    def test_key_independent_of_property_order(self):
+        props_a = [{"key": "a", "value": "1"}, {"key": "b", "value": "2"}]
+        props_b = [{"key": "b", "value": "2"}, {"key": "a", "value": "1"}]
+        key_a, _ = compute_cache_key(_spec(properties=props_a), team=self.team)
+        key_b, _ = compute_cache_key(_spec(properties=props_b), team=self.team)
+        assert key_a == key_b
+
+
+class TestCacheTTL(APIBaseTest):
+    def test_open_ended_range_is_live(self):
+        with freeze_time("2026-05-28 12:00:00"):
+            assert cache_ttl_for(_spec(date_from="-7d", date_to=None), team=self.team) == LIVE_RANGE_TTL
+
+    def test_range_ending_now_is_live(self):
+        with freeze_time("2026-05-28 12:00:00"):
+            assert cache_ttl_for(_spec(date_from="-7d", date_to="0d"), team=self.team) == LIVE_RANGE_TTL
+
+    def test_closed_past_range_uses_long_ttl(self):
+        with freeze_time("2026-05-28 12:00:00"):
+            assert cache_ttl_for(_spec(date_from="2026-01-01", date_to="2026-01-31"), team=self.team) == PAST_RANGE_TTL

--- a/products/web_analytics/backend/test/test_api.py
+++ b/products/web_analytics/backend/test/test_api.py
@@ -3,7 +3,9 @@ from urllib.parse import urlparse
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
+from unittest.mock import patch
 
+from django.core.cache import cache
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -275,3 +277,91 @@ class TestWebAnalyticsDigestAPI(ClickhouseTestMixin, APIBaseTest):
         dashboard_url = response.json()["dashboard_url"]
         assert f"/project/{self.team.id}/web" in dashboard_url
         assert "utm_source=" in dashboard_url
+
+
+_SUMMARY_PATH = "products.web_analytics.backend.api.api.generate_web_analytics_summary"
+
+
+class TestWebAnalyticsAISummaryAPI(ClickhouseTestMixin, APIBaseTest):
+    ENDPOINT = "/api/environments/{team_id}/web_analytics/ai_summary/"
+
+    def setUp(self):
+        super().setUp()
+        # Summaries are cached in Redis/Django cache by team + filter spec — isolate cache state per test.
+        cache.clear()
+
+    def _url(self, team_id=None, check=False):
+        url = self.ENDPOINT.format(team_id=team_id or self.team.id)
+        return f"{url}?check=true" if check else url
+
+    def _post(self, check=False, team_id=None, **kwargs):
+        return self.client.post(self._url(team_id=team_id, check=check), {"date_from": "-7d"}, format="json", **kwargs)
+
+    def test_check_returns_204_when_no_cached_summary(self):
+        with patch(_SUMMARY_PATH) as mock_generate:
+            response = self._post(check=True)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_generate.assert_not_called()
+
+    def test_generate_returns_summary_and_caches_it(self):
+        with patch(_SUMMARY_PATH, return_value="**Visitors:** up 25%") as mock_generate:
+            first = self._post()
+            assert first.status_code == status.HTTP_200_OK
+            body = first.json()
+            assert body["summary_text"] == "**Visitors:** up 25%"
+            assert body["cached"] is False
+            assert body["model_id"]
+            assert mock_generate.call_count == 1
+
+            # Repeated generate hits the cache without invoking the LLM again.
+            second = self._post()
+            assert second.status_code == status.HTTP_200_OK
+            assert second.json()["cached"] is True
+            assert mock_generate.call_count == 1
+
+            # check=true now returns the cached summary.
+            peek = self._post(check=True)
+            assert peek.status_code == status.HTTP_200_OK
+            assert peek.json()["cached"] is True
+            assert mock_generate.call_count == 1
+
+    def test_generate_failure_returns_502(self):
+        with patch(_SUMMARY_PATH, side_effect=Exception("llm down")):
+            response = self._post()
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+    def test_cannot_summarize_other_teams_data(self):
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+
+        with patch(_SUMMARY_PATH, return_value="leaked"):
+            response = self._post(team_id=other_team.id, check=True)
+
+        assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
+
+    def test_unauthenticated_request_rejected(self):
+        self.client.logout()
+
+        response = self._post(check=True)
+
+        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+    @parameterized.expand(
+        [
+            (["feature_flag:read"], status.HTTP_403_FORBIDDEN),
+            (["web_analytics:read"], status.HTTP_403_FORBIDDEN),
+            (["web_analytics:write"], status.HTTP_204_NO_CONTENT),
+        ]
+    )
+    def test_personal_api_key_requires_write_scope(self, scopes, expected_status):
+        api_key = self.create_personal_api_key_with_scopes(scopes)
+        self.client.logout()
+
+        with patch(_SUMMARY_PATH):
+            response = self.client.post(
+                self._url(check=True), {"date_from": "-7d"}, format="json", HTTP_AUTHORIZATION=f"Bearer {api_key}"
+            )
+
+        assert response.status_code == expected_status

--- a/products/web_analytics/backend/test/test_api.py
+++ b/products/web_analytics/backend/test/test_api.py
@@ -287,7 +287,6 @@ class TestWebAnalyticsAISummaryAPI(ClickhouseTestMixin, APIBaseTest):
 
     def setUp(self):
         super().setUp()
-        # Summaries are cached in Redis/Django cache by team + filter spec — isolate cache state per test.
         cache.clear()
 
     def _url(self, team_id=None, check=False):
@@ -314,13 +313,11 @@ class TestWebAnalyticsAISummaryAPI(ClickhouseTestMixin, APIBaseTest):
             assert body["model_id"]
             assert mock_generate.call_count == 1
 
-            # Repeated generate hits the cache without invoking the LLM again.
             second = self._post()
             assert second.status_code == status.HTTP_200_OK
             assert second.json()["cached"] is True
             assert mock_generate.call_count == 1
 
-            # check=true now returns the cached summary.
             peek = self._post(check=True)
             assert peek.status_code == status.HTTP_200_OK
             assert peek.json()["cached"] is True

--- a/products/web_analytics/backend/test/test_context_events.py
+++ b/products/web_analytics/backend/test/test_context_events.py
@@ -1,0 +1,82 @@
+from datetime import UTC, datetime, timedelta
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from posthog.models.annotation import Annotation
+
+from products.web_analytics.backend.context_events import MAX_CONTEXT_EVENTS, gather_context_events
+
+
+def _aware(year, month, day, hour=12):
+    return datetime(year, month, day, hour, tzinfo=UTC)
+
+
+class TestGatherContextEvents(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.window_from = _aware(2026, 5, 1)
+        self.window_to = _aware(2026, 5, 31, 23)
+
+    def _annotation(self, content, when, team=None):
+        return Annotation.objects.create(
+            team=team or self.team,
+            content=content,
+            date_marker=when,
+            created_by=self.user,
+        )
+
+    def test_returns_empty_when_no_data(self):
+        assert gather_context_events(self.team, self.window_from, self.window_to) == []
+
+    def test_annotation_within_window(self):
+        self._annotation("deployed v3.4 with new checkout", _aware(2026, 5, 15))
+        events = gather_context_events(self.team, self.window_from, self.window_to)
+        assert len(events) == 1
+        assert events[0]["kind"] == "annotation"
+        assert events[0]["name"] == "deployed v3.4 with new checkout"
+        assert events[0]["summary"] == "manual annotation"
+        assert events[0]["date"].startswith("2026-05-15")
+
+    def test_annotation_outside_window_excluded(self):
+        self._annotation("before window", _aware(2026, 4, 30))
+        self._annotation("after window", _aware(2026, 6, 1))
+        assert gather_context_events(self.team, self.window_from, self.window_to) == []
+
+    def test_annotation_truncated_when_long(self):
+        self._annotation("a" * 500, _aware(2026, 5, 15))
+        events = gather_context_events(self.team, self.window_from, self.window_to)
+        ann = next(e for e in events if e["kind"] == "annotation")
+        assert ann["name"].endswith("…")
+        assert len(ann["name"]) <= 200
+
+    def test_annotation_with_empty_content_skipped(self):
+        self._annotation("", _aware(2026, 5, 15))
+        self._annotation(None, _aware(2026, 5, 16))
+        assert gather_context_events(self.team, self.window_from, self.window_to) == []
+
+    def test_respects_limit(self):
+        for i in range(MAX_CONTEXT_EVENTS + 3):
+            self._annotation(f"annotation {i}", _aware(2026, 5, 10) + timedelta(hours=i))
+        events = gather_context_events(self.team, self.window_from, self.window_to)
+        assert len(events) == MAX_CONTEXT_EVENTS
+
+    def test_results_sorted_descending_and_capped(self):
+        self._annotation("late annotation", _aware(2026, 5, 25))
+        self._annotation("early annotation", _aware(2026, 5, 5))
+        events = gather_context_events(self.team, self.window_from, self.window_to, limit=1)
+        assert len(events) == 1
+        assert events[0]["name"] == "late annotation"
+
+    def test_query_failure_returns_empty(self):
+        self._annotation("annotation", _aware(2026, 5, 15))
+        with patch(
+            "products.web_analytics.backend.context_events.Annotation.objects.filter",
+            side_effect=Exception("db down"),
+        ):
+            assert gather_context_events(self.team, self.window_from, self.window_to) == []
+
+    def test_other_team_data_excluded(self):
+        other_team = self.organization.teams.create(name="Other team")
+        self._annotation("other team annotation", _aware(2026, 5, 15), team=other_team)
+        assert gather_context_events(self.team, self.window_from, self.window_to) == []

--- a/products/web_analytics/backend/test/test_weekly_digest.py
+++ b/products/web_analytics/backend/test/test_weekly_digest.py
@@ -13,15 +13,20 @@ from posthog.models.utils import uuid7
 from products.actions.backend.models.action import Action
 from products.web_analytics.backend.weekly_digest import (
     _format_duration,
+    _goals_from_spec,
+    _overview_from_spec,
+    _spec_for_days,
+    _top_pages_from_spec,
+    _top_sources_from_spec,
     auto_select_project_for_user,
     build_team_digest,
-    get_goals_for_team,
-    get_overview_for_team,
-    get_top_pages,
-    get_top_sources,
 )
 
 QUERY_TIMESTAMP = "2025-01-29"
+
+
+def _default_spec():
+    return _spec_for_days(7, True)
 
 
 def _create_pageview(
@@ -115,7 +120,7 @@ class TestGetOverviewForTeam(ClickhouseTestMixin, APIBaseTest):
                 _create_pageview(self.team, distinct_id="user_1", session_id=session_id, timestamp="2025-01-25")
             flush_persons_and_events()
 
-            result = get_overview_for_team(self.team)
+            result = _overview_from_spec(self.team, _default_spec())
 
         assert "visitors" in result
         assert result["visitors"]["current"] > 0
@@ -127,7 +132,7 @@ class TestGetOverviewForTeam(ClickhouseTestMixin, APIBaseTest):
 
     def test_returns_zero_values_for_team_with_no_events(self):
         with freeze_time(QUERY_TIMESTAMP):
-            result = get_overview_for_team(self.team)
+            result = _overview_from_spec(self.team, _default_spec())
 
         assert result == {
             "visitors": {"current": 0, "previous": None, "change": None},
@@ -175,7 +180,7 @@ class TestGetTopPages(ClickhouseTestMixin, APIBaseTest):
             )
             flush_persons_and_events()
 
-            result = get_top_pages(self.team)
+            result = _top_pages_from_spec(self.team, _default_spec())
 
         assert len(result) >= 2
         assert result[0]["visitors"] >= result[-1]["visitors"]
@@ -197,13 +202,13 @@ class TestGetTopPages(ClickhouseTestMixin, APIBaseTest):
                 )
             flush_persons_and_events()
 
-            result = get_top_pages(self.team, limit=2)
+            result = _top_pages_from_spec(self.team, _default_spec(), limit=2)
 
         assert len(result) <= 2
 
     def test_returns_empty_for_no_events(self):
         with freeze_time(QUERY_TIMESTAMP):
-            result = get_top_pages(self.team)
+            result = _top_pages_from_spec(self.team, _default_spec())
         assert result == []
 
 
@@ -222,7 +227,7 @@ class TestGetTopSources(ClickhouseTestMixin, APIBaseTest):
             )
             flush_persons_and_events()
 
-            result = get_top_sources(self.team)
+            result = _top_sources_from_spec(self.team, _default_spec())
 
         sources = [r["name"] for r in result]
         assert sources == ["google.com"]
@@ -243,20 +248,20 @@ class TestGetTopSources(ClickhouseTestMixin, APIBaseTest):
             )
             flush_persons_and_events()
 
-            result = get_top_sources(self.team)
+            result = _top_sources_from_spec(self.team, _default_spec())
 
         assert all(r["name"] != "" for r in result)
 
     def test_returns_empty_for_no_events(self):
         with freeze_time(QUERY_TIMESTAMP):
-            result = get_top_sources(self.team)
+            result = _top_sources_from_spec(self.team, _default_spec())
         assert result == []
 
 
 class TestGetGoalsForTeam(ClickhouseTestMixin, APIBaseTest):
     def test_returns_empty_when_no_actions(self):
         with freeze_time(QUERY_TIMESTAMP):
-            result = get_goals_for_team(self.team)
+            result = _goals_from_spec(self.team, _default_spec())
         assert result == []
 
     def test_returns_goals_with_conversions(self):
@@ -279,7 +284,7 @@ class TestGetGoalsForTeam(ClickhouseTestMixin, APIBaseTest):
             )
             flush_persons_and_events()
 
-            result = get_goals_for_team(self.team)
+            result = _goals_from_spec(self.team, _default_spec())
 
         assert len(result) >= 1
         goal = next(g for g in result if g["name"] == "Signed Up")

--- a/products/web_analytics/backend/weekly_digest.py
+++ b/products/web_analytics/backend/weekly_digest.py
@@ -1,9 +1,16 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
 from django.conf import settings
 
 import structlog
 
 from posthog.schema import (
+    ActionConversionGoal,
     CompareFilter,
+    CustomEventConversionGoal,
     DateRange,
     ProductKey,
     WebAnalyticsOrderByDirection,
@@ -18,12 +25,27 @@ from posthog.clickhouse.query_tagging import tag_queries
 from posthog.models import Team
 from posthog.models.user import User
 from posthog.tasks.email_utils import compute_week_over_week_change
+from posthog.utils import relative_date_parse
 
+from products.web_analytics.backend.context_events import gather_context_events
 from products.web_analytics.backend.hogql_queries.stats_table import WebStatsTableQueryRunner
 from products.web_analytics.backend.hogql_queries.web_goals import NoActionsError, WebGoalsQueryRunner
 from products.web_analytics.backend.hogql_queries.web_overview import WebOverviewQueryRunner
 
 logger = structlog.get_logger(__name__)
+
+
+ConversionGoalT = ActionConversionGoal | CustomEventConversionGoal | None
+
+
+@dataclass(frozen=True)
+class DigestFilterSpec:
+    date_range: DateRange
+    compare: bool = True
+    properties: list[dict[str, Any]] = field(default_factory=list)
+    conversion_goal: ConversionGoalT = None
+    filter_test_accounts: bool = True
+    do_path_cleaning: bool = False
 
 
 def _default_overview() -> dict:
@@ -36,16 +58,18 @@ def _default_overview() -> dict:
     }
 
 
-def get_overview_for_team(team: Team, days: int = 7, compare: bool = True) -> dict:
+def _overview_from_spec(team: Team, spec: DigestFilterSpec) -> dict:
     tag_queries(product=ProductKey.WEB_ANALYTICS, team_id=team.pk, name="weekly_digest:web_overview")
     result = _default_overview()
 
     try:
         query = WebOverviewQuery(
-            dateRange=DateRange(date_from=f"-{days}d"),
-            compareFilter=CompareFilter(compare=compare),
-            filterTestAccounts=True,
-            properties=[],
+            dateRange=spec.date_range,
+            compareFilter=CompareFilter(compare=spec.compare),
+            filterTestAccounts=spec.filter_test_accounts,
+            properties=spec.properties,
+            conversionGoal=spec.conversion_goal,
+            doPathCleaning=spec.do_path_cleaning,
         )
         runner = WebOverviewQueryRunner(team=team, query=query)
         response = runner.calculate()
@@ -93,7 +117,7 @@ def get_overview_for_team(team: Team, days: int = 7, compare: bool = True) -> di
         prev_duration = duration_item.previous
         result["avg_session_duration"] = {
             "current": _format_duration(current_duration),
-            "previous": _format_duration(prev_duration) if compare else None,
+            "previous": _format_duration(prev_duration) if spec.compare else None,
             "change": compute_week_over_week_change(
                 current_duration,
                 prev_duration,
@@ -105,7 +129,6 @@ def get_overview_for_team(team: Team, days: int = 7, compare: bool = True) -> di
 
 
 def _format_duration(seconds: float | None) -> str:
-    """Format seconds into a human-readable string like '2m 34s'."""
     if seconds is None or seconds <= 0:
         return "0s"
     total = int(seconds)
@@ -118,17 +141,19 @@ def _format_duration(seconds: float | None) -> str:
     return f"{minutes}m {secs}s"
 
 
-def get_top_pages(team: Team, limit: int = 5, days: int = 7) -> list[dict]:
+def _top_pages_from_spec(team: Team, spec: DigestFilterSpec, limit: int = 5) -> list[dict]:
     tag_queries(product=ProductKey.WEB_ANALYTICS, team_id=team.pk, name="weekly_digest:top_pages")
 
     try:
         query = WebStatsTableQuery(
             breakdownBy=WebStatsBreakdown.PAGE,
-            dateRange=DateRange(date_from=f"-{days}d"),
+            dateRange=spec.date_range,
             limit=limit,
             orderBy=[WebAnalyticsOrderByFields.VISITORS, WebAnalyticsOrderByDirection.DESC],
-            filterTestAccounts=True,
-            properties=[],
+            filterTestAccounts=spec.filter_test_accounts,
+            properties=spec.properties,
+            conversionGoal=spec.conversion_goal,
+            doPathCleaning=spec.do_path_cleaning,
         )
         runner = WebStatsTableQueryRunner(team=team, query=query)
         response = runner.calculate()
@@ -150,17 +175,19 @@ def get_top_pages(team: Team, limit: int = 5, days: int = 7) -> list[dict]:
         return []
 
 
-def get_top_sources(team: Team, limit: int = 5, days: int = 7) -> list[dict]:
+def _top_sources_from_spec(team: Team, spec: DigestFilterSpec, limit: int = 5) -> list[dict]:
     tag_queries(product=ProductKey.WEB_ANALYTICS, team_id=team.pk, name="weekly_digest:top_sources")
 
     try:
         query = WebStatsTableQuery(
             breakdownBy=WebStatsBreakdown.INITIAL_REFERRING_DOMAIN,
-            dateRange=DateRange(date_from=f"-{days}d"),
+            dateRange=spec.date_range,
             limit=limit,
             orderBy=[WebAnalyticsOrderByFields.VISITORS, WebAnalyticsOrderByDirection.DESC],
-            filterTestAccounts=True,
-            properties=[],
+            filterTestAccounts=spec.filter_test_accounts,
+            properties=spec.properties,
+            conversionGoal=spec.conversion_goal,
+            doPathCleaning=spec.do_path_cleaning,
         )
         runner = WebStatsTableQueryRunner(team=team, query=query)
         response = runner.calculate()
@@ -182,14 +209,16 @@ def get_top_sources(team: Team, limit: int = 5, days: int = 7) -> list[dict]:
         return []
 
 
-def get_goals_for_team(team: Team, limit: int = 5, days: int = 7, compare: bool = True) -> list[dict]:
+def _goals_from_spec(team: Team, spec: DigestFilterSpec, limit: int = 5) -> list[dict]:
     tag_queries(product=ProductKey.WEB_ANALYTICS, team_id=team.pk, name="weekly_digest:goals")
 
     try:
         query = WebGoalsQuery(
-            dateRange=DateRange(date_from=f"-{days}d"),
-            compareFilter=CompareFilter(compare=compare),
-            properties=[],
+            dateRange=spec.date_range,
+            compareFilter=CompareFilter(compare=spec.compare),
+            properties=spec.properties,
+            filterTestAccounts=spec.filter_test_accounts,
+            doPathCleaning=spec.do_path_cleaning,
         )
         runner = WebGoalsQueryRunner(team=team, query=query)
         response = runner.calculate()
@@ -216,18 +245,57 @@ def get_goals_for_team(team: Team, limit: int = 5, days: int = 7, compare: bool 
     return results
 
 
-def build_team_digest(team: Team, days: int = 7, compare: bool = True) -> dict:
-    overview = get_overview_for_team(team, days=days, compare=compare)
-    top_pages = get_top_pages(team, days=days)
-    top_sources = get_top_sources(team, days=days)
-    goals = get_goals_for_team(team, days=days, compare=compare)
+def _resolve_window(team: Team, spec: DigestFilterSpec) -> tuple[datetime, datetime] | None:
+    if spec.date_range.date_from is None:
+        return None
+    tz = ZoneInfo(team.timezone)
+    now = datetime.now(tz)
+    try:
+        date_from = relative_date_parse(spec.date_range.date_from, tz, now=now, increase=False)
+        date_to = (
+            relative_date_parse(spec.date_range.date_to, tz, now=now, increase=True) if spec.date_range.date_to else now
+        )
+    except Exception:
+        logger.exception("failed to resolve digest window for context events", team_id=team.pk)
+        return None
+    if date_from > date_to:
+        return None
+    return date_from, date_to
+
+
+def _context_events_from_spec(team: Team, spec: DigestFilterSpec) -> list[dict[str, Any]]:
+    window = _resolve_window(team, spec)
+    if window is None:
+        return []
+    return gather_context_events(team, window[0], window[1])
+
+
+def build_digest_from_spec(team: Team, spec: DigestFilterSpec, *, include_context_events: bool = False) -> dict:
+    overview = _overview_from_spec(team, spec)
+    top_pages = _top_pages_from_spec(team, spec)
+    top_sources = _top_sources_from_spec(team, spec)
+    goals = _goals_from_spec(team, spec)
+    context_events = _context_events_from_spec(team, spec) if include_context_events else []
 
     return {
-        "team": team,
         **overview,
         "top_pages": top_pages,
         "top_sources": top_sources,
         "goals": goals,
+        "context_events": context_events,
+    }
+
+
+def _spec_for_days(days: int, compare: bool) -> DigestFilterSpec:
+    return DigestFilterSpec(date_range=DateRange(date_from=f"-{days}d"), compare=compare)
+
+
+def build_team_digest(team: Team, days: int = 7, compare: bool = True) -> dict:
+    spec = _spec_for_days(days, compare)
+    digest = build_digest_from_spec(team, spec)
+    return {
+        "team": team,
+        **digest,
         "dashboard_url": f"{settings.SITE_URL}/project/{team.pk}/web?utm_source=web_analytics_weekly_digest&utm_medium=email",
     }
 

--- a/products/web_analytics/frontend/generated/api.schemas.ts
+++ b/products/web_analytics/frontend/generated/api.schemas.ts
@@ -8,6 +8,170 @@
  * OpenAPI spec version: 1.0.0
  */
 /**
+ * Optional conversion goal — either ActionConversionGoal ({actionId}) or CustomEventConversionGoal ({customEventName}).
+ * @nullable
+ */
+export type AISummaryFilterSpecApiConversionGoal = {
+    /** ID of the action used as conversion goal. */
+    actionId?: number
+    /** Custom event name used as conversion goal. */
+    customEventName?: string
+    [key: string]: unknown
+} | null
+
+/**
+ * * `exact` - exact
+ * `is_not` - is_not
+ * `icontains` - icontains
+ * `not_icontains` - not_icontains
+ * `regex` - regex
+ * `not_regex` - not_regex
+ * `gt` - gt
+ * `lt` - lt
+ * `gte` - gte
+ * `lte` - lte
+ * `is_set` - is_set
+ * `is_not_set` - is_not_set
+ * `is_date_exact` - is_date_exact
+ * `is_date_after` - is_date_after
+ * `is_date_before` - is_date_before
+ * `in` - in
+ * `not_in` - not_in
+ */
+export type PropertyItemOperatorEnumApi = (typeof PropertyItemOperatorEnumApi)[keyof typeof PropertyItemOperatorEnumApi]
+
+export const PropertyItemOperatorEnumApi = {
+    Exact: 'exact',
+    IsNot: 'is_not',
+    Icontains: 'icontains',
+    NotIcontains: 'not_icontains',
+    Regex: 'regex',
+    NotRegex: 'not_regex',
+    Gt: 'gt',
+    Lt: 'lt',
+    Gte: 'gte',
+    Lte: 'lte',
+    IsSet: 'is_set',
+    IsNotSet: 'is_not_set',
+    IsDateExact: 'is_date_exact',
+    IsDateAfter: 'is_date_after',
+    IsDateBefore: 'is_date_before',
+    In: 'in',
+    NotIn: 'not_in',
+} as const
+
+export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
+
+export const BlankEnumApi = {
+    '': '',
+} as const
+
+/**
+ * * `event` - event
+ * `event_metadata` - event_metadata
+ * `feature` - feature
+ * `person` - person
+ * `cohort` - cohort
+ * `element` - element
+ * `static-cohort` - static-cohort
+ * `dynamic-cohort` - dynamic-cohort
+ * `precalculated-cohort` - precalculated-cohort
+ * `group` - group
+ * `recording` - recording
+ * `log_entry` - log_entry
+ * `behavioral` - behavioral
+ * `session` - session
+ * `hogql` - hogql
+ * `data_warehouse` - data_warehouse
+ * `data_warehouse_person_property` - data_warehouse_person_property
+ * `error_tracking_issue` - error_tracking_issue
+ * `log` - log
+ * `log_attribute` - log_attribute
+ * `log_resource_attribute` - log_resource_attribute
+ * `span` - span
+ * `span_attribute` - span_attribute
+ * `span_resource_attribute` - span_resource_attribute
+ * `revenue_analytics` - revenue_analytics
+ * `flag` - flag
+ * `workflow_variable` - workflow_variable
+ */
+export type PropertyFilterTypeEnumApi = (typeof PropertyFilterTypeEnumApi)[keyof typeof PropertyFilterTypeEnumApi]
+
+export const PropertyFilterTypeEnumApi = {
+    Event: 'event',
+    EventMetadata: 'event_metadata',
+    Feature: 'feature',
+    Person: 'person',
+    Cohort: 'cohort',
+    Element: 'element',
+    StaticCohort: 'static-cohort',
+    DynamicCohort: 'dynamic-cohort',
+    PrecalculatedCohort: 'precalculated-cohort',
+    Group: 'group',
+    Recording: 'recording',
+    LogEntry: 'log_entry',
+    Behavioral: 'behavioral',
+    Session: 'session',
+    Hogql: 'hogql',
+    DataWarehouse: 'data_warehouse',
+    DataWarehousePersonProperty: 'data_warehouse_person_property',
+    ErrorTrackingIssue: 'error_tracking_issue',
+    Log: 'log',
+    LogAttribute: 'log_attribute',
+    LogResourceAttribute: 'log_resource_attribute',
+    Span: 'span',
+    SpanAttribute: 'span_attribute',
+    SpanResourceAttribute: 'span_resource_attribute',
+    RevenueAnalytics: 'revenue_analytics',
+    Flag: 'flag',
+    WorkflowVariable: 'workflow_variable',
+} as const
+
+export const PropertyItemApiType = { ...PropertyFilterTypeEnumApi, ...BlankEnumApi } as const
+export interface PropertyItemApi {
+    /** Key of the property you're filtering on. For example `email` or `$current_url` */
+    key: string
+    /** Value of your filter. For example `test@example.com` or `https://example.com/test/`. Can be an array for an OR query, like `["test@example.com","ok@example.com"]` */
+    value: string | number | boolean | (string | number)[]
+    operator?: PropertyItemOperatorEnumApi | BlankEnumApi | null
+    type?: (typeof PropertyItemApiType)[keyof typeof PropertyItemApiType]
+}
+
+export interface AISummaryFilterSpecApi {
+    /** Start of the analysis window. Accepts a relative spec like '-7d' or an ISO date like '2026-01-01'. */
+    date_from: string
+    /**
+     * End of the analysis window. Accepts the same formats as date_from, or null for an open-ended range up to now.
+     * @nullable
+     */
+    date_to?: string | null
+    /** When true, include period-over-period change for each metric against the prior equal-length period. */
+    compare?: boolean
+    /** Property filters applied to all underlying queries. */
+    properties?: PropertyItemApi[]
+    /**
+     * Optional conversion goal — either ActionConversionGoal ({actionId}) or CustomEventConversionGoal ({customEventName}).
+     * @nullable
+     */
+    conversion_goal?: AISummaryFilterSpecApiConversionGoal
+    /** Whether to exclude internal/test-account events from the analysis. */
+    filter_test_accounts?: boolean
+    /** When true, apply the team's path-cleaning rules before bucketing by page path. */
+    do_path_cleaning?: boolean
+}
+
+export interface AISummaryResponseApi {
+    /** LLM-generated plain-text summary, up to ~150 words. */
+    summary_text: string
+    /** When the summary was generated. */
+    created_at: string
+    /** LLM model identifier used to generate this summary. */
+    model_id: string
+    /** True when this summary was reused from the cache; false when freshly generated. */
+    cached: boolean
+}
+
+/**
  * * `Up` - Up
  * `Down` - Down
  */
@@ -129,12 +293,6 @@ export const RoleAtOrganizationEnumApi = {
     Marketing: 'marketing',
     Sales: 'sales',
     Other: 'other',
-} as const
-
-export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
-
-export const BlankEnumApi = {
-    '': '',
 } as const
 
 /**
@@ -319,6 +477,13 @@ export interface PatchedHeatmapScreenshotResponseApi {
     readonly updated_at?: string
     /** @nullable */
     readonly exception?: string | null
+}
+
+export type WebAnalyticsAiSummaryParams = {
+    /**
+     * When true, only return a cached summary if one is fresh (HTTP 204 on a miss) and never invoke the LLM. Used by the dashboard to hydrate a cached summary without incurring cost.
+     */
+    check?: boolean
 }
 
 export type WebAnalyticsWeeklyDigestParams = {

--- a/products/web_analytics/frontend/generated/api.ts
+++ b/products/web_analytics/frontend/generated/api.ts
@@ -9,6 +9,8 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    AISummaryFilterSpecApi,
+    AISummaryResponseApi,
     HeatmapScreenshotResponseApi,
     HeatmapsListParams,
     PaginatedHeatmapScreenshotResponseListApi,
@@ -17,6 +19,7 @@ import type {
     PatchedHeatmapScreenshotResponseApi,
     PatchedWebAnalyticsFilterPresetApi,
     SavedListParams,
+    WebAnalyticsAiSummaryParams,
     WebAnalyticsFilterPresetApi,
     WebAnalyticsFilterPresetsListParams,
     WebAnalyticsWeeklyDigestParams,
@@ -39,6 +42,40 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
           [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
       }
     : DistributeReadOnlyOverUnions<T>
+
+export const getWebAnalyticsAiSummaryUrl = (projectId: string, params?: WebAnalyticsAiSummaryParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/environments/${projectId}/web_analytics/ai_summary/?${stringifiedParams}`
+        : `/api/environments/${projectId}/web_analytics/ai_summary/`
+}
+
+/**
+ * Returns an AI summary of the team's web analytics for the supplied filter spec. If a fresh summary is cached it is returned as-is. Otherwise, when check=true the call returns HTTP 204 without invoking the LLM; when check is omitted/false the LLM is invoked, the result is cached, and returned. The generate path is rate-limited per user.
+ * @summary Generate AI summary of web analytics
+ */
+export const webAnalyticsAiSummary = async (
+    projectId: string,
+    aISummaryFilterSpecApi: AISummaryFilterSpecApi,
+    params?: WebAnalyticsAiSummaryParams,
+    options?: RequestInit
+): Promise<AISummaryResponseApi | void> => {
+    return apiMutator<AISummaryResponseApi | void>(getWebAnalyticsAiSummaryUrl(projectId, params), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(aISummaryFilterSpecApi),
+    })
+}
 
 export const getWebAnalyticsWeeklyDigestUrl = (projectId: string, params?: WebAnalyticsWeeklyDigestParams) => {
     const normalizedParams = new URLSearchParams()

--- a/products/web_analytics/frontend/generated/api.zod.ts
+++ b/products/web_analytics/frontend/generated/api.zod.ts
@@ -9,6 +9,138 @@
  */
 import * as zod from 'zod'
 
+/**
+ * Returns an AI summary of the team's web analytics for the supplied filter spec. If a fresh summary is cached it is returned as-is. Otherwise, when check=true the call returns HTTP 204 without invoking the LLM; when check is omitted/false the LLM is invoked, the result is cached, and returned. The generate path is rate-limited per user.
+ * @summary Generate AI summary of web analytics
+ */
+export const webAnalyticsAiSummaryBodyCompareDefault = true
+export const webAnalyticsAiSummaryBodyPropertiesItemOperatorDefault = `exact`
+export const webAnalyticsAiSummaryBodyPropertiesItemTypeDefault = `event`
+export const webAnalyticsAiSummaryBodyFilterTestAccountsDefault = true
+export const webAnalyticsAiSummaryBodyDoPathCleaningDefault = false
+
+export const WebAnalyticsAiSummaryBody = /* @__PURE__ */ zod.object({
+    date_from: zod
+        .string()
+        .describe("Start of the analysis window. Accepts a relative spec like '-7d' or an ISO date like '2026-01-01'."),
+    date_to: zod
+        .string()
+        .nullish()
+        .describe(
+            'End of the analysis window. Accepts the same formats as date_from, or null for an open-ended range up to now.'
+        ),
+    compare: zod
+        .boolean()
+        .default(webAnalyticsAiSummaryBodyCompareDefault)
+        .describe(
+            'When true, include period-over-period change for each metric against the prior equal-length period.'
+        ),
+    properties: zod
+        .array(
+            zod.object({
+                key: zod
+                    .string()
+                    .describe("Key of the property you're filtering on. For example `email` or `$current_url`"),
+                value: zod
+                    .union([
+                        zod.string(),
+                        zod.number(),
+                        zod.boolean(),
+                        zod.array(zod.union([zod.string(), zod.number()])),
+                    ])
+                    .describe(
+                        'Value of your filter. For example `test@example.com` or `https:\/\/example.com\/test\/`. Can be an array for an OR query, like `[\"test@example.com\",\"ok@example.com\"]`'
+                    ),
+                operator: zod
+                    .union([
+                        zod
+                            .enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'lt',
+                                'gte',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_after',
+                                'is_date_before',
+                                'in',
+                                'not_in',
+                            ])
+                            .describe(
+                                '\* `exact` - exact\n\* `is_not` - is_not\n\* `icontains` - icontains\n\* `not_icontains` - not_icontains\n\* `regex` - regex\n\* `not_regex` - not_regex\n\* `gt` - gt\n\* `lt` - lt\n\* `gte` - gte\n\* `lte` - lte\n\* `is_set` - is_set\n\* `is_not_set` - is_not_set\n\* `is_date_exact` - is_date_exact\n\* `is_date_after` - is_date_after\n\* `is_date_before` - is_date_before\n\* `in` - in\n\* `not_in` - not_in'
+                            ),
+                        zod.enum(['']),
+                        zod.null(),
+                    ])
+                    .default(webAnalyticsAiSummaryBodyPropertiesItemOperatorDefault),
+                type: zod
+                    .union([
+                        zod
+                            .enum([
+                                'event',
+                                'event_metadata',
+                                'feature',
+                                'person',
+                                'cohort',
+                                'element',
+                                'static-cohort',
+                                'dynamic-cohort',
+                                'precalculated-cohort',
+                                'group',
+                                'recording',
+                                'log_entry',
+                                'behavioral',
+                                'session',
+                                'hogql',
+                                'data_warehouse',
+                                'data_warehouse_person_property',
+                                'error_tracking_issue',
+                                'log',
+                                'log_attribute',
+                                'log_resource_attribute',
+                                'span',
+                                'span_attribute',
+                                'span_resource_attribute',
+                                'revenue_analytics',
+                                'flag',
+                                'workflow_variable',
+                            ])
+                            .describe(
+                                '\* `event` - event\n\* `event_metadata` - event_metadata\n\* `feature` - feature\n\* `person` - person\n\* `cohort` - cohort\n\* `element` - element\n\* `static-cohort` - static-cohort\n\* `dynamic-cohort` - dynamic-cohort\n\* `precalculated-cohort` - precalculated-cohort\n\* `group` - group\n\* `recording` - recording\n\* `log_entry` - log_entry\n\* `behavioral` - behavioral\n\* `session` - session\n\* `hogql` - hogql\n\* `data_warehouse` - data_warehouse\n\* `data_warehouse_person_property` - data_warehouse_person_property\n\* `error_tracking_issue` - error_tracking_issue\n\* `log` - log\n\* `log_attribute` - log_attribute\n\* `log_resource_attribute` - log_resource_attribute\n\* `span` - span\n\* `span_attribute` - span_attribute\n\* `span_resource_attribute` - span_resource_attribute\n\* `revenue_analytics` - revenue_analytics\n\* `flag` - flag\n\* `workflow_variable` - workflow_variable'
+                            ),
+                        zod.enum(['']),
+                    ])
+                    .default(webAnalyticsAiSummaryBodyPropertiesItemTypeDefault),
+            })
+        )
+        .optional()
+        .describe('Property filters applied to all underlying queries.'),
+    conversion_goal: zod
+        .object({
+            actionId: zod.number().optional().describe('ID of the action used as conversion goal.'),
+            customEventName: zod.string().optional().describe('Custom event name used as conversion goal.'),
+        })
+        .nullish()
+        .describe(
+            'Optional conversion goal — either ActionConversionGoal ({actionId}) or CustomEventConversionGoal ({customEventName}).'
+        ),
+    filter_test_accounts: zod
+        .boolean()
+        .default(webAnalyticsAiSummaryBodyFilterTestAccountsDefault)
+        .describe('Whether to exclude internal\/test-account events from the analysis.'),
+    do_path_cleaning: zod
+        .boolean()
+        .default(webAnalyticsAiSummaryBodyDoPathCleaningDefault)
+        .describe("When true, apply the team's path-cleaning rules before bucketing by page path."),
+})
+
 export const webAnalyticsFilterPresetsCreateBodyNameMax = 400
 
 export const WebAnalyticsFilterPresetsCreateBody = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -32,6 +32,173 @@ export namespace Schemas {
     } as const;
 
     /**
+     * Optional conversion goal — either ActionConversionGoal ({actionId}) or CustomEventConversionGoal ({customEventName}).
+     * @nullable
+     */
+    export type AISummaryFilterSpecConversionGoal = {
+      /** ID of the action used as conversion goal. */
+      actionId?: number;
+      /** Custom event name used as conversion goal. */
+      customEventName?: string;
+      [key: string]: unknown;
+     } | null;
+
+    /**
+     * * `exact` - exact
+    * `is_not` - is_not
+    * `icontains` - icontains
+    * `not_icontains` - not_icontains
+    * `regex` - regex
+    * `not_regex` - not_regex
+    * `gt` - gt
+    * `lt` - lt
+    * `gte` - gte
+    * `lte` - lte
+    * `is_set` - is_set
+    * `is_not_set` - is_not_set
+    * `is_date_exact` - is_date_exact
+    * `is_date_after` - is_date_after
+    * `is_date_before` - is_date_before
+    * `in` - in
+    * `not_in` - not_in
+     */
+    export type PropertyItemOperatorEnum = typeof PropertyItemOperatorEnum[keyof typeof PropertyItemOperatorEnum];
+
+
+    export const PropertyItemOperatorEnum = {
+      Exact: 'exact',
+      IsNot: 'is_not',
+      Icontains: 'icontains',
+      NotIcontains: 'not_icontains',
+      Regex: 'regex',
+      NotRegex: 'not_regex',
+      Gt: 'gt',
+      Lt: 'lt',
+      Gte: 'gte',
+      Lte: 'lte',
+      IsSet: 'is_set',
+      IsNotSet: 'is_not_set',
+      IsDateExact: 'is_date_exact',
+      IsDateAfter: 'is_date_after',
+      IsDateBefore: 'is_date_before',
+      In: 'in',
+      NotIn: 'not_in',
+    } as const;
+
+    export type BlankEnum = typeof BlankEnum[keyof typeof BlankEnum];
+
+
+    export const BlankEnum = {
+      '': '',
+    } as const;
+
+    /**
+     * * `event` - event
+    * `event_metadata` - event_metadata
+    * `feature` - feature
+    * `person` - person
+    * `cohort` - cohort
+    * `element` - element
+    * `static-cohort` - static-cohort
+    * `dynamic-cohort` - dynamic-cohort
+    * `precalculated-cohort` - precalculated-cohort
+    * `group` - group
+    * `recording` - recording
+    * `log_entry` - log_entry
+    * `behavioral` - behavioral
+    * `session` - session
+    * `hogql` - hogql
+    * `data_warehouse` - data_warehouse
+    * `data_warehouse_person_property` - data_warehouse_person_property
+    * `error_tracking_issue` - error_tracking_issue
+    * `log` - log
+    * `log_attribute` - log_attribute
+    * `log_resource_attribute` - log_resource_attribute
+    * `span` - span
+    * `span_attribute` - span_attribute
+    * `span_resource_attribute` - span_resource_attribute
+    * `revenue_analytics` - revenue_analytics
+    * `flag` - flag
+    * `workflow_variable` - workflow_variable
+     */
+    export type PropertyFilterTypeEnum = typeof PropertyFilterTypeEnum[keyof typeof PropertyFilterTypeEnum];
+
+
+    export const PropertyFilterTypeEnum = {
+      Event: 'event',
+      EventMetadata: 'event_metadata',
+      Feature: 'feature',
+      Person: 'person',
+      Cohort: 'cohort',
+      Element: 'element',
+      StaticCohort: 'static-cohort',
+      DynamicCohort: 'dynamic-cohort',
+      PrecalculatedCohort: 'precalculated-cohort',
+      Group: 'group',
+      Recording: 'recording',
+      LogEntry: 'log_entry',
+      Behavioral: 'behavioral',
+      Session: 'session',
+      Hogql: 'hogql',
+      DataWarehouse: 'data_warehouse',
+      DataWarehousePersonProperty: 'data_warehouse_person_property',
+      ErrorTrackingIssue: 'error_tracking_issue',
+      Log: 'log',
+      LogAttribute: 'log_attribute',
+      LogResourceAttribute: 'log_resource_attribute',
+      Span: 'span',
+      SpanAttribute: 'span_attribute',
+      SpanResourceAttribute: 'span_resource_attribute',
+      RevenueAnalytics: 'revenue_analytics',
+      Flag: 'flag',
+      WorkflowVariable: 'workflow_variable',
+    } as const;
+
+    export const PropertyItemType = {...PropertyFilterTypeEnum,...BlankEnum,} as const
+    export interface PropertyItem {
+      /** Key of the property you're filtering on. For example `email` or `$current_url` */
+      key: string;
+      /** Value of your filter. For example `test@example.com` or `https://example.com/test/`. Can be an array for an OR query, like `["test@example.com","ok@example.com"]` */
+      value: string | number | boolean | (string | number)[];
+      operator?: PropertyItemOperatorEnum | BlankEnum | null;
+      type?: typeof PropertyItemType[keyof typeof PropertyItemType];
+    }
+
+    export interface AISummaryFilterSpec {
+      /** Start of the analysis window. Accepts a relative spec like '-7d' or an ISO date like '2026-01-01'. */
+      date_from: string;
+      /**
+         * End of the analysis window. Accepts the same formats as date_from, or null for an open-ended range up to now.
+         * @nullable
+         */
+      date_to?: string | null;
+      /** When true, include period-over-period change for each metric against the prior equal-length period. */
+      compare?: boolean;
+      /** Property filters applied to all underlying queries. */
+      properties?: PropertyItem[];
+      /**
+         * Optional conversion goal — either ActionConversionGoal ({actionId}) or CustomEventConversionGoal ({customEventName}).
+         * @nullable
+         */
+      conversion_goal?: AISummaryFilterSpecConversionGoal;
+      /** Whether to exclude internal/test-account events from the analysis. */
+      filter_test_accounts?: boolean;
+      /** When true, apply the team's path-cleaning rules before bucketing by page path. */
+      do_path_cleaning?: boolean;
+    }
+
+    export interface AISummaryResponse {
+      /** LLM-generated plain-text summary, up to ~150 words. */
+      summary_text: string;
+      /** When the summary was generated. */
+      created_at: string;
+      /** LLM model identifier used to generate this summary. */
+      model_id: string;
+      /** True when this summary was reused from the cache; false when freshly generated. */
+      cached: boolean;
+    }
+
+    /**
      * * `read_write` - read_write
     * `read` - read
     * `none` - none
@@ -145,13 +312,6 @@ export namespace Schemas {
       Other: 'other',
     } as const;
 
-    export type BlankEnum = typeof BlankEnum[keyof typeof BlankEnum];
-
-
-    export const BlankEnum = {
-      '': '',
-    } as const;
-
     /**
      * @nullable
      */
@@ -199,68 +359,6 @@ export namespace Schemas {
       readonly last_modified_at: string;
       readonly last_modified_by: UserBasic;
     }
-
-    /**
-     * * `event` - event
-    * `event_metadata` - event_metadata
-    * `feature` - feature
-    * `person` - person
-    * `cohort` - cohort
-    * `element` - element
-    * `static-cohort` - static-cohort
-    * `dynamic-cohort` - dynamic-cohort
-    * `precalculated-cohort` - precalculated-cohort
-    * `group` - group
-    * `recording` - recording
-    * `log_entry` - log_entry
-    * `behavioral` - behavioral
-    * `session` - session
-    * `hogql` - hogql
-    * `data_warehouse` - data_warehouse
-    * `data_warehouse_person_property` - data_warehouse_person_property
-    * `error_tracking_issue` - error_tracking_issue
-    * `log` - log
-    * `log_attribute` - log_attribute
-    * `log_resource_attribute` - log_resource_attribute
-    * `span` - span
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
-    * `revenue_analytics` - revenue_analytics
-    * `flag` - flag
-    * `workflow_variable` - workflow_variable
-     */
-    export type PropertyFilterTypeEnum = typeof PropertyFilterTypeEnum[keyof typeof PropertyFilterTypeEnum];
-
-
-    export const PropertyFilterTypeEnum = {
-      Event: 'event',
-      EventMetadata: 'event_metadata',
-      Feature: 'feature',
-      Person: 'person',
-      Cohort: 'cohort',
-      Element: 'element',
-      StaticCohort: 'static-cohort',
-      DynamicCohort: 'dynamic-cohort',
-      PrecalculatedCohort: 'precalculated-cohort',
-      Group: 'group',
-      Recording: 'recording',
-      LogEntry: 'log_entry',
-      Behavioral: 'behavioral',
-      Session: 'session',
-      Hogql: 'hogql',
-      DataWarehouse: 'data_warehouse',
-      DataWarehousePersonProperty: 'data_warehouse_person_property',
-      ErrorTrackingIssue: 'error_tracking_issue',
-      Log: 'log',
-      LogAttribute: 'log_attribute',
-      LogResourceAttribute: 'log_resource_attribute',
-      Span: 'span',
-      SpanAttribute: 'span_attribute',
-      SpanResourceAttribute: 'span_resource_attribute',
-      RevenueAnalytics: 'revenue_analytics',
-      Flag: 'flag',
-      WorkflowVariable: 'workflow_variable',
-    } as const;
 
     /**
      * * `exact` - exact
@@ -14344,58 +14442,6 @@ export namespace Schemas {
       impact?: ErrorTrackingImpact;
       /** Optional compact occurrence sparkline. */
       sparkline?: number[];
-    }
-
-    /**
-     * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
-    * `gt` - gt
-    * `lt` - lt
-    * `gte` - gte
-    * `lte` - lte
-    * `is_set` - is_set
-    * `is_not_set` - is_not_set
-    * `is_date_exact` - is_date_exact
-    * `is_date_after` - is_date_after
-    * `is_date_before` - is_date_before
-    * `in` - in
-    * `not_in` - not_in
-     */
-    export type PropertyItemOperatorEnum = typeof PropertyItemOperatorEnum[keyof typeof PropertyItemOperatorEnum];
-
-
-    export const PropertyItemOperatorEnum = {
-      Exact: 'exact',
-      IsNot: 'is_not',
-      Icontains: 'icontains',
-      NotIcontains: 'not_icontains',
-      Regex: 'regex',
-      NotRegex: 'not_regex',
-      Gt: 'gt',
-      Lt: 'lt',
-      Gte: 'gte',
-      Lte: 'lte',
-      IsSet: 'is_set',
-      IsNotSet: 'is_not_set',
-      IsDateExact: 'is_date_exact',
-      IsDateAfter: 'is_date_after',
-      IsDateBefore: 'is_date_before',
-      In: 'in',
-      NotIn: 'not_in',
-    } as const;
-
-    export const PropertyItemType = {...PropertyFilterTypeEnum,...BlankEnum,} as const
-    export interface PropertyItem {
-      /** Key of the property you're filtering on. For example `email` or `$current_url` */
-      key: string;
-      /** Value of your filter. For example `test@example.com` or `https://example.com/test/`. Can be an array for an OR query, like `["test@example.com","ok@example.com"]` */
-      value: string | number | boolean | (string | number)[];
-      operator?: PropertyItemOperatorEnum | BlankEnum | null;
-      type?: typeof PropertyItemType[keyof typeof PropertyItemType];
     }
 
     /**
@@ -41778,6 +41824,13 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    };
+
+    export type WebAnalyticsAiSummaryParams = {
+    /**
+     * When true, only return a cached summary if one is fresh (HTTP 204 on a miss) and never invoke the LLM. Used by the dashboard to hydrate a cached summary without incurring cost.
+     */
+    check?: boolean;
     };
 
     export type WebAnalyticsWeeklyDigestParams = {


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
There is no way to quickly review important Web Analytics changes
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a new AI driven Web Analytics summary. Summaries are cached on two different schedules:
  - Live ranges (range ends at or after "now"): 1 hour 
  - Closed past ranges (range ends before "now"): 24 hours
  
  
https://github.com/user-attachments/assets/626edae2-10e8-4989-93e7-59a055e438a0


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
<!-- Add the `skip-migration-service-check` label if every migration here is DB-noop (e.g. `SeparateDatabaseAndState` with empty `database_operations`, or pure `RunPython`) and it's safe to ship alongside service code. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
