### PR TITLE
fix(flags): apply grace period to flag definitions cache verification

### DIFF
--- a/products/feature_flags/backend/flags_cache.py
+++ b/products/feature_flags/backend/flags_cache.py
@@ -773,7 +773,7 @@ def get_teams_with_flags_queryset() -> "QuerySet[Team]":
     return Team.objects.filter(Exists(has_flags))
 
 
-def _get_team_ids_with_recently_updated_flags(team_ids: list[int]) -> set[int]:
+def get_team_ids_with_recently_updated_flags(team_ids: list[int]) -> set[int]:
     """
     Batch check which teams have active flags updated within the grace period.
 
@@ -810,7 +810,7 @@ FLAGS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
     update_fn=update_flags_cache,
     cache_name="flags",
     get_teams_queryset_fn=get_teams_with_flags_queryset,
-    get_team_ids_to_skip_fix_fn=_get_team_ids_with_recently_updated_flags,
+    get_team_ids_to_skip_fix_fn=get_team_ids_with_recently_updated_flags,
 )
 
 

--- a/products/feature_flags/backend/local_evaluation.py
+++ b/products/feature_flags/backend/local_evaluation.py
@@ -43,7 +43,11 @@ from posthog.person_db_router import PERSONS_DB_FOR_READ
 from posthog.storage.hypercache import HyperCache, emit_cache_sync_metrics
 from posthog.storage.hypercache_manager import HyperCacheManagementConfig
 
-from products.feature_flags.backend.flags_cache import _compare_flag_fields, get_teams_with_flags_queryset
+from products.feature_flags.backend.flags_cache import (
+    _compare_flag_fields,
+    get_team_ids_with_recently_updated_flags,
+    get_teams_with_flags_queryset,
+)
 from products.feature_flags.backend.models.evaluation_context import EvaluationContext, FeatureFlagEvaluationContext
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.feature_flags.backend.types import FlagFilters, FlagProperty, PropertyFilterType
@@ -701,6 +705,7 @@ FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
     update_fn=_update_flag_definitions_with_cohorts,
     cache_name="flag_definitions",
     get_teams_queryset_fn=get_teams_with_flags_queryset,
+    get_team_ids_to_skip_fix_fn=get_team_ids_with_recently_updated_flags,
 )
 
 FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
@@ -708,6 +713,7 @@ FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementC
     update_fn=_update_flag_definitions_without_cohorts,
     cache_name="flag_definitions_no_cohorts",
     get_teams_queryset_fn=get_teams_with_flags_queryset,
+    get_team_ids_to_skip_fix_fn=get_team_ids_with_recently_updated_flags,
 )
 
 

--- a/products/feature_flags/backend/test/test_flags_cache.py
+++ b/products/feature_flags/backend/test/test_flags_cache.py
@@ -34,12 +34,12 @@ from products.feature_flags.backend.flags_cache import (
     _get_feature_flags_for_service,
     _get_feature_flags_for_teams_batch,
     _get_referenced_cohorts,
-    _get_team_ids_with_recently_updated_flags,
     _serialize_cohort,
     _strip_null_values,
     clear_flags_cache,
     flags_hypercache,
     get_flags_from_cache,
+    get_team_ids_with_recently_updated_flags,
     get_teams_with_flags_queryset,
     update_flags_cache,
 )
@@ -2559,11 +2559,11 @@ class TestServiceFlagsGuards(BaseTest):
 
 @override_settings(FLAGS_REDIS_URL="redis://test", FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES=5)
 class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
-    """Test _get_team_ids_with_recently_updated_flags batch helper for grace period logic."""
+    """Test get_team_ids_with_recently_updated_flags batch helper for grace period logic."""
 
     def test_returns_empty_set_for_team_with_no_flags(self):
         """Test returns empty set for team with no flags."""
-        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        result = get_team_ids_with_recently_updated_flags([self.team.id])
         assert result == set()
 
     def test_returns_team_id_for_recently_updated_flag(self):
@@ -2575,7 +2575,7 @@ class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
             filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
         )
 
-        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        result = get_team_ids_with_recently_updated_flags([self.team.id])
         assert result == {self.team.id}
 
     def test_returns_empty_set_for_old_flag(self):
@@ -2593,7 +2593,7 @@ class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
         # Manually set updated_at to outside grace period
         FeatureFlag.objects.filter(id=flag.id).update(updated_at=timezone.now() - timedelta(minutes=10))
 
-        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        result = get_team_ids_with_recently_updated_flags([self.team.id])
         assert result == set()
 
     @override_settings(FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES=0)
@@ -2606,12 +2606,12 @@ class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
             filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
         )
 
-        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        result = get_team_ids_with_recently_updated_flags([self.team.id])
         assert result == set()
 
     def test_returns_empty_set_for_empty_team_ids_list(self):
         """Test returns empty set when given empty list of team IDs."""
-        result = _get_team_ids_with_recently_updated_flags([])
+        result = get_team_ids_with_recently_updated_flags([])
         assert result == set()
 
     def test_returns_team_id_if_any_flag_is_recent(self):
@@ -2638,7 +2638,7 @@ class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
         )
 
         # Should return team ID because at least one flag is recent
-        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        result = get_team_ids_with_recently_updated_flags([self.team.id])
         assert result == {self.team.id}
 
     def test_batch_returns_only_teams_with_recent_flags(self):
@@ -2668,7 +2668,7 @@ class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
         FeatureFlag.objects.filter(id=old_flag.id).update(updated_at=timezone.now() - timedelta(minutes=10))
 
         # Query both teams - should only return team 1
-        result = _get_team_ids_with_recently_updated_flags([self.team.id, team2.id])
+        result = get_team_ids_with_recently_updated_flags([self.team.id, team2.id])
         assert result == {self.team.id}
 
     def test_ignores_recently_deleted_flags(self):
@@ -2687,7 +2687,7 @@ class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
         # Ensure updated_at is recent (within grace period)
         assert flag.updated_at is not None
 
-        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        result = get_team_ids_with_recently_updated_flags([self.team.id])
         assert result == set()
 
     def test_ignores_recently_deactivated_flags(self):
@@ -2708,7 +2708,7 @@ class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
         # Ensure updated_at is recent (within grace period)
         assert flag.updated_at is not None
 
-        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        result = get_team_ids_with_recently_updated_flags([self.team.id])
         assert result == set()
 
 

--- a/products/feature_flags/backend/test/test_local_evaluation.py
+++ b/products/feature_flags/backend/test/test_local_evaluation.py
@@ -13,6 +13,7 @@ from posthog.models.tag import Tag
 from posthog.models.team.team import Team
 from posthog.test.test_utils import create_group_type_mapping_without_created_at
 
+from products.feature_flags.backend.flags_cache import get_team_ids_with_recently_updated_flags
 from products.feature_flags.backend.local_evaluation import (
     FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG,
     FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG,
@@ -1171,11 +1172,15 @@ class TestFlagDefinitionsCache(BaseTest):
         assert config1.cache_name == "flag_definitions"
         assert config1.hypercache == flag_definitions_hypercache
         assert config1.update_fn == _update_flag_definitions_with_cohorts
+        # Grace-period skip prevents the verifier from flagging caches whose
+        # underlying flags were just updated and whose async rebuild is still in flight.
+        assert config1.get_team_ids_to_skip_fix_fn == get_team_ids_with_recently_updated_flags
 
         config2 = FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG
         assert config2.cache_name == "flag_definitions_no_cohorts"
         assert config2.hypercache == flag_definitions_without_cohorts_hypercache
         assert config2.update_fn == _update_flag_definitions_without_cohorts
+        assert config2.get_team_ids_to_skip_fix_fn == get_team_ids_with_recently_updated_flags
 
     def test_update_flag_definitions_cache_returns_false_on_partial_failure(self):
         FeatureFlag.objects.create(


### PR DESCRIPTION
## Problem

The HyperCache verifier compares cached flag definitions against the database and "fixes" any drift it detects. Both `FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG` and `FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG` were missing `get_team_ids_to_skip_fix_fn`, so the verifier had no way to know a flag had just been updated and the async cache rebuild was still in flight. The result was a steady stream of phantom drift reports for teams whose caches were already on their way to being refreshed.

The `flags` cache already has this protection via `_get_team_ids_with_recently_updated_flags` in `flags_cache.py`. The two flag-definitions configs just weren't wired to it.

## Changes

- Renames `_get_team_ids_with_recently_updated_flags` to `get_team_ids_with_recently_updated_flags` so it can be shared across modules.
- Passes it as `get_team_ids_to_skip_fix_fn` on both flag-definitions HyperCache configs in `local_evaluation.py`.
- Adds assertions in the existing config tests to verify both configs now have the skip function wired in.

## How did you test this code?

Test coverage.