### PR TITLE
feat(data-warehouse): make destination UI warehouse-table aware

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionTest.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionTest.tsx
@@ -153,7 +153,9 @@ export const HogFunctionTestEditor = ({
 }
 
 export function HogFunctionTest(): JSX.Element {
-    const { logicProps, canLoadSampleGlobals, hogFunction, template } = useValues(hogFunctionConfigurationLogic)
+    const { logicProps, canLoadSampleGlobals, hogFunction, template, configuration } =
+        useValues(hogFunctionConfigurationLogic)
+    const isDataWarehouse = configuration?.filters?.source === 'data-warehouse-table'
     const {
         isTestInvocationSubmitting,
         testResult,
@@ -199,7 +201,9 @@ export function HogFunctionTest(): JSX.Element {
                         <h2 className="flex gap-2 items-center mb-0">
                             <span>Testing</span>
                         </h2>
-                        {inactive ? <p>Click here to test your function with an example event</p> : null}
+                        {inactive ? (
+                            <p>Click here to test your function with an example {isDataWarehouse ? 'row' : 'event'}</p>
+                        ) : null}
                     </div>
 
                     {inactive ? (

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -141,7 +141,9 @@ export function HogFunctionFilters({
         return types
     }, [isTransformation, groupsTaxonomicTypes, isDataWarehouse])
 
-    const showMasking = type === 'destination' && !isLegacyPlugin && showTriggerOptions
+    // Masking trigger options are event/person based (hashes of person.id / event.event and
+    // event-count thresholds), so they don't apply to data-warehouse row triggers.
+    const showMasking = type === 'destination' && !isLegacyPlugin && showTriggerOptions && !isDataWarehouse
 
     if (type === 'internal_destination') {
         return <HogFunctionFiltersInternal />
@@ -173,8 +175,8 @@ export function HogFunctionFilters({
                             <br />
                             <b>Person updates</b> will trigger whenever a Person is created, updated or deleted.
                             <br />
-                            <b>Data warehouse</b> will trigger whenever a new row has been synced into the data
-                            warehouse.
+                            <b>Warehouse table</b> will trigger whenever a new row is synced into a data warehouse
+                            table.
                         </>
                     }
                 >
@@ -187,7 +189,7 @@ export function HogFunctionFilters({
                                         ? [{ value: 'person-updates', label: 'Person updates' }]
                                         : []),
                                     ...(cdpDwhTableSourceEnabled
-                                        ? [{ value: 'data-warehouse-table', label: 'Data warehouse' }]
+                                        ? [{ value: 'data-warehouse-table', label: 'Warehouse table' }]
                                         : []),
                                 ]}
                                 value={value?.source ?? 'events'}


### PR DESCRIPTION
## Problem

The hog function destination configuration UI assumes an events/persons trigger everywhere. For the data-warehouse table source (gated behind the existing `cdp-dwh-table-source` flag) some of this is misleading: the source is labelled "Data warehouse", the masking/trigger-options block offers event/person-based hashing and event-count thresholds that don't apply to row syncs, and the test panel talks about "events".

## Changes

UI polish for the data-warehouse table source. Everything keys off `filters.source === 'data-warehouse-table'`, which is only selectable when the flag is on, so it's transitively gated.

- Rename the source label **"Data warehouse" → "Warehouse table"** and reword the tooltip. The stored `data-warehouse-table` identifier is unchanged (no migration).
- Hide the masking / "Trigger options" block for warehouse sources — its hashes (`person.id` / `event.event`) and event-count thresholds aren't meaningful per-row.
- Use "example row" instead of "example event" in the test panel copy for warehouse sources.

This is a small follow-up to #60538 (the `record` global). It touches different files and can merge independently in either order.

## How did you test this code?

I'm an agent (Claude Code). I ran `oxlint` on the changed files (clean). These are copy/conditional-rendering changes gated on the warehouse source. I could not run the full frontend `tsc` locally (pre-existing missing generated types on my machine) — CI will typecheck. No manual UI testing was performed by me.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus). Split out from the core `record` global change (#60538) so the functional change and the UX polish can be reviewed separately. Requires human review; not self-merged.