### PR TITLE
fix(visual-review): Block client-supplied github_check_run_id

### DIFF
--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -34,6 +34,7 @@ _RESERVED_RUN_METADATA_KEYS = frozenset(
         "github_comment_id",
         "baseline_commit_sha",
         "baseline_healed_from_merge_base",
+        "github_check_run_id",
     }
 )
 

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1148,7 +1148,11 @@ def _rerun_github_job(run: Run, check_run_id: str) -> tuple[bool, str | None]:
     if check_run_response.status_code != 200:
         return False, f"Could not fetch check run details (status {check_run_response.status_code})"
 
-    check_run_data = check_run_response.json()
+    try:
+        check_run_data = check_run_response.json()
+    except Exception:
+        return False, "Failed to parse check run response"
+
     if check_run_data.get("head_sha") != run.commit_sha:
         logger.warning(
             "visual_review.ci_rerun_sha_mismatch",

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1136,6 +1136,30 @@ def _rerun_github_job(run: Run, check_run_id: str) -> tuple[bool, str | None]:
         return False, "Repo has no GitHub full name configured"
 
     try:
+        check_run_response = _github_api_request(
+            "GET",
+            repo,
+            f"check-runs/{check_run_id}",
+            timeout=10,
+        )
+    except Exception:
+        return False, "Failed to verify check run ownership"
+
+    if check_run_response.status_code != 200:
+        return False, f"Could not fetch check run details (status {check_run_response.status_code})"
+
+    check_run_data = check_run_response.json()
+    if check_run_data.get("head_sha") != run.commit_sha:
+        logger.warning(
+            "visual_review.ci_rerun_sha_mismatch",
+            run_id=str(run.id),
+            check_run_id=check_run_id,
+            expected_sha=run.commit_sha,
+            actual_sha=check_run_data.get("head_sha"),
+        )
+        return False, "Check run does not belong to this commit"
+
+    try:
         response = _github_api_request(
             "POST",
             repo,

--- a/products/visual_review/backend/tests/test_api.py
+++ b/products/visual_review/backend/tests/test_api.py
@@ -124,6 +124,7 @@ class TestRunAPI:
                     "github_comment_id": 99999,
                     "baseline_commit_sha": "deadbeef",
                     "baseline_healed_from_merge_base": 1,
+                    "github_check_run_id": "72855643533",
                 },
             ),
             team_id=repo.team_id,

--- a/products/visual_review/backend/tests/test_logic.py
+++ b/products/visual_review/backend/tests/test_logic.py
@@ -1592,6 +1592,78 @@ class TestRecomputeRun:
 
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
+class TestRerunGithubJob:
+    """Tests for _rerun_github_job SHA validation."""
+
+    @pytest.fixture
+    def repo(self, team):
+        return logic.create_repo(team_id=team.id, repo_external_id=55555, repo_full_name="org/test-repo")
+
+    def _make_run(self, repo: "Repo", commit_sha: str = "abc123def456") -> "Run":
+        run, _ = logic.create_run(
+            repo_id=repo.id,
+            team_id=repo.team_id,
+            run_type=RunType.STORYBOOK,
+            commit_sha=commit_sha,
+            branch="feature",
+            pr_number=1,
+            snapshots=[],
+            metadata={"github_check_run_id": "72855643533"},
+        )
+        return run
+
+    def test_rejects_non_digit_check_run_id(self, repo):
+        run = self._make_run(repo)
+        success, error = logic._rerun_github_job(run, "not-a-number")
+        assert success is False
+        assert error == "Invalid check run ID"
+
+    def test_rejects_when_sha_does_not_match(self, repo, mocker):
+        run = self._make_run(repo, commit_sha="abc123")
+        mock_response = mocker.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"head_sha": "different_sha_entirely"}
+        mocker.patch("products.visual_review.backend.logic._github_api_request", return_value=mock_response)
+
+        success, error = logic._rerun_github_job(run, "72855643533")
+
+        assert success is False
+        assert error == "Check run does not belong to this commit"
+
+    def test_rejects_when_check_run_fetch_fails(self, repo, mocker):
+        run = self._make_run(repo)
+        mock_response = mocker.MagicMock()
+        mock_response.status_code = 404
+        mocker.patch("products.visual_review.backend.logic._github_api_request", return_value=mock_response)
+
+        success, error = logic._rerun_github_job(run, "72855643533")
+
+        assert success is False
+        assert "404" in error
+
+    def test_triggers_rerun_when_sha_matches(self, repo, mocker):
+        commit_sha = "abc123def456"
+        run = self._make_run(repo, commit_sha=commit_sha)
+
+        check_run_response = mocker.MagicMock()
+        check_run_response.status_code = 200
+        check_run_response.json.return_value = {"head_sha": commit_sha}
+
+        rerun_response = mocker.MagicMock()
+        rerun_response.status_code = 201
+
+        mocker.patch(
+            "products.visual_review.backend.logic._github_api_request",
+            side_effect=[check_run_response, rerun_response],
+        )
+
+        success, error = logic._rerun_github_job(run, "72855643533")
+
+        assert success is True
+        assert error is None
+
+
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
 class TestMergeBaseBaselineHealing:
     """Tests for _resolve_baselines_with_merge_base healing rebase-corrupted baselines."""
 

--- a/products/visual_review/backend/tests/test_logic.py
+++ b/products/visual_review/backend/tests/test_logic.py
@@ -1639,6 +1639,7 @@ class TestRerunGithubJob:
         success, error = logic._rerun_github_job(run, "72855643533")
 
         assert success is False
+        assert error is not None
         assert "404" in error
 
     def test_triggers_rerun_when_sha_matches(self, repo, mocker):


### PR DESCRIPTION
## Changes

Two layered fixes:

**`products/visual_review/backend/facade/api.py`** — Added `github_check_run_id` to `_RESERVED_RUN_METADATA_KEYS`. The facade's `_sanitize_run_metadata` now strips this key from all client-supplied metadata before it reaches the DB, so the only way `github_check_run_id` can enter `run.metadata` is via server-side code (the CI workflow integration).

**`products/visual_review/backend/logic.py`** — Added commit SHA ownership check in `_rerun_github_job`. Before issuing the `POST actions/jobs/{id}/rerun` request, the function now calls `GET check-runs/{id}` on the GitHub API and verifies that `head_sha` matches `run.commit_sha`. A mismatch returns an error and emits a structured warning log

## How did you test this code?

Agent-authored. Automated tests only — no manual testing.

- Updated `TestRunAPI::test_create_run_strips_reserved_metadata_keys` to assert `github_check_run_id` is stripped alongside the other reserved keys.
- Added `TestRerunGithubJob` (4 cases): invalid ID format rejected, SHA mismatch rejected, GitHub fetch failure (404) rejected, successful rerun when SHA matches.
- All 5 tests pass (`hogli test`), existing `TestRecomputeRun` tests unaffected (they mock `_rerun_github_job` directly).
