### PR TITLE
chore: hide invite link from members

### DIFF
--- a/frontend/src/scenes/settings/organization/Invites.tsx
+++ b/frontend/src/scenes/settings/organization/Invites.tsx
@@ -110,7 +110,12 @@ export function InvitesTable(): JSX.Element {
             title: 'Invite Link',
             dataIndex: 'id',
             key: 'link',
-            render: (_, invite) => InviteLinkComponent(invite.id, invite),
+            render: (_, invite) =>
+                restrictionReason ? (
+                    <i className="text-secondary">Only organization admins can view invite links</i>
+                ) : (
+                    InviteLinkComponent(invite.id, invite)
+                ),
         },
         {
             title: '',

--- a/frontend/src/scenes/settings/organization/Invites.tsx
+++ b/frontend/src/scenes/settings/organization/Invites.tsx
@@ -65,13 +65,11 @@ function makeActionsComponent(
 export function InvitesTable(): JSX.Element {
     const { invites, invitesLoading } = useValues(inviteLogic)
     const { deleteInvite } = useActions(inviteLogic)
-    const { currentOrganization } = useValues(organizationLogic)
 
     const restrictionReason = useRestrictedArea({
         minimumAccessLevel: OrganizationMembershipLevel.Admin,
         scope: RestrictionScope.Organization,
     })
-    const canViewInviteLinks = !restrictionReason || !!currentOrganization?.members_can_invite
 
     const columns: LemonTableColumns<OrganizationInviteType> = [
         {
@@ -112,12 +110,7 @@ export function InvitesTable(): JSX.Element {
             title: 'Invite Link',
             dataIndex: 'id',
             key: 'link',
-            render: (_, invite) =>
-                canViewInviteLinks ? (
-                    InviteLinkComponent(invite.id, invite)
-                ) : (
-                    <i className="text-secondary">Only organization admins can view invite links</i>
-                ),
+            render: (_, invite) => InviteLinkComponent(invite.id, invite),
         },
         {
             title: '',
@@ -158,7 +151,7 @@ export function Invites(): JSX.Element {
                 type="primary"
                 onClick={showInviteModal}
                 data-attr="invite-teammate-button"
-                disabledReason={userCannotInvite && "You don't have permissions to invite others."}
+                disabledReason={userCannotInvite && "You can't invite other members or view invites"}
             >
                 Invite team member
             </LemonButton>

--- a/frontend/src/scenes/settings/organization/Invites.tsx
+++ b/frontend/src/scenes/settings/organization/Invites.tsx
@@ -65,11 +65,13 @@ function makeActionsComponent(
 export function InvitesTable(): JSX.Element {
     const { invites, invitesLoading } = useValues(inviteLogic)
     const { deleteInvite } = useActions(inviteLogic)
+    const { currentOrganization } = useValues(organizationLogic)
 
     const restrictionReason = useRestrictedArea({
         minimumAccessLevel: OrganizationMembershipLevel.Admin,
         scope: RestrictionScope.Organization,
     })
+    const canViewInviteLinks = !restrictionReason || !!currentOrganization?.members_can_invite
 
     const columns: LemonTableColumns<OrganizationInviteType> = [
         {
@@ -111,10 +113,10 @@ export function InvitesTable(): JSX.Element {
             dataIndex: 'id',
             key: 'link',
             render: (_, invite) =>
-                restrictionReason ? (
-                    <i className="text-secondary">Only organization admins can view invite links</i>
-                ) : (
+                canViewInviteLinks ? (
                     InviteLinkComponent(invite.id, invite)
+                ) : (
+                    <i className="text-secondary">Only organization admins can view invite links</i>
                 ),
         },
         {

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -405,7 +405,26 @@ class OrganizationInviteViewSet(
         raise NotImplementedError()
 
     def safely_get_queryset(self, queryset):
-        return queryset.select_related("created_by").order_by(self.ordering)
+        queryset = queryset.select_related("created_by").order_by(self.ordering)
+
+        if self.action != "list":
+            return queryset
+
+        user = self.request.user
+        if not user.is_authenticated:
+            return queryset.none()
+
+        try:
+            membership = OrganizationMembership.objects.select_related("organization").get(
+                organization_id=self.organization_id, user=user
+            )
+        except OrganizationMembership.DoesNotExist:
+            return queryset.none()
+
+        if membership.level < OrganizationMembership.Level.ADMIN and not membership.organization.members_can_invite:
+            return queryset.none()
+
+        return queryset.filter(level__lte=membership.level)
 
     def get_throttles(self):
         # Apply invite-specific throttles only to actions that create invites,

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -66,6 +66,90 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json(), self.permission_denied_response())
 
+    def test_member_cannot_list_invites_when_members_can_invite_false(self):
+        member_user = self._create_user("member@posthog.com")
+        self.client.force_login(member_user)
+
+        self.organization.available_product_features = [
+            *(self.organization.available_product_features or []),
+            {"key": AvailableFeature.ORGANIZATION_INVITE_SETTINGS},
+        ]
+        self.organization.members_can_invite = False
+        self.organization.save()
+
+        OrganizationInvite.objects.create(
+            organization=self.organization,
+            target_email="hidden@posthog.com",
+            level=OrganizationMembership.Level.MEMBER,
+        )
+
+        response = self.client.get(f"/api/organizations/{self.organization.id}/invites/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["results"], [])
+
+    def test_member_can_list_invites_when_members_can_invite_true(self):
+        member_user = self._create_user("member@posthog.com")
+        self.client.force_login(member_user)
+
+        self.organization.members_can_invite = True
+        self.organization.save()
+
+        invite = OrganizationInvite.objects.create(
+            organization=self.organization,
+            target_email="visible@posthog.com",
+            level=OrganizationMembership.Level.MEMBER,
+        )
+
+        response = self.client.get(f"/api/organizations/{self.organization.id}/invites/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [row["id"] for row in response.json()["results"]]
+        self.assertIn(str(invite.id), ids)
+
+    def test_member_cannot_list_invites_for_higher_levels(self):
+        member_user = self._create_user("member@posthog.com")
+        self.client.force_login(member_user)
+
+        self.organization.members_can_invite = True
+        self.organization.save()
+
+        member_invite = OrganizationInvite.objects.create(
+            organization=self.organization,
+            target_email="peer@posthog.com",
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        admin_invite = OrganizationInvite.objects.create(
+            organization=self.organization,
+            target_email="future-admin@posthog.com",
+            level=OrganizationMembership.Level.ADMIN,
+        )
+
+        response = self.client.get(f"/api/organizations/{self.organization.id}/invites/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [row["id"] for row in response.json()["results"]]
+        self.assertIn(str(member_invite.id), ids)
+        self.assertNotIn(str(admin_invite.id), ids)
+
+    def test_admin_can_list_invites_for_all_levels(self):
+        admin_user = self._create_user("admin@posthog.com", level=OrganizationMembership.Level.ADMIN)
+        self.client.force_login(admin_user)
+
+        member_invite = OrganizationInvite.objects.create(
+            organization=self.organization,
+            target_email="peer@posthog.com",
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        admin_invite = OrganizationInvite.objects.create(
+            organization=self.organization,
+            target_email="another-admin@posthog.com",
+            level=OrganizationMembership.Level.ADMIN,
+        )
+
+        response = self.client.get(f"/api/organizations/{self.organization.id}/invites/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [row["id"] for row in response.json()["results"]]
+        self.assertIn(str(member_invite.id), ids)
+        self.assertIn(str(admin_invite.id), ids)
+
     # Creating invites
 
     @patch("posthoganalytics.capture")


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Members probably shouldn't be able to see this link. Admin access should be required to see it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

If the "members can invite" setting is enabled:  anyone can see the invite links
Otherwise: admin+ acecss is required to view invite links

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manually
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
<!-- Add the `skip-migration-service-check` label if every migration here is DB-noop (e.g. `SeparateDatabaseAndState` with empty `database_operations`, or pure `RunPython`) and it's safe to ship alongside service code. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
