### PR TITLE
fix(team): invalidate team metadata cache on org and project rename

### DIFF
--- a/posthog/tasks/team_metadata.py
+++ b/posthog/tasks/team_metadata.py
@@ -15,6 +15,8 @@ from django.dispatch import receiver
 import structlog
 from celery import shared_task
 
+from posthog.models.organization import Organization
+from posthog.models.project import Project
 from posthog.models.team import Team
 from posthog.scoping_audit import skip_team_scope_audit
 from posthog.storage.hypercache_manager import HYPERCACHE_SIGNAL_UPDATE_COUNTER
@@ -52,6 +54,28 @@ def update_team_metadata_cache_task(team_id: int) -> None:
     HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
         namespace="team_metadata", operation="update", result="success" if success else "failure"
     ).inc()
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
+@skip_team_scope_audit
+def update_related_teams_metadata_cache_task(organization_id: int | None = None, project_id: int | None = None) -> None:
+    """
+    Refresh team metadata caches for every team under a changed organization or project.
+
+    Organization and project names are denormalized into each team's cached metadata, so renaming
+    either must refresh every dependent team. Fanning out here keeps the originating request O(1):
+    the signal enqueues a single task no matter how many teams the org or project owns, and each
+    per-team update runs as its own task so the work spreads across workers.
+    """
+    if organization_id is not None:
+        team_ids = Team.objects.filter(organization_id=organization_id).values_list("id", flat=True)
+    elif project_id is not None:
+        team_ids = Team.objects.filter(project_id=project_id).values_list("id", flat=True)
+    else:
+        return
+
+    for team_id in team_ids:
+        update_team_metadata_cache_task.delay(team_id)
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
@@ -117,9 +141,7 @@ def update_team_metadata_cache_on_save(sender: type[Team], instance: Team, creat
         try:
             update_team_metadata_cache_task.delay(instance.id)
         except Exception as e:
-            HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
-                namespace="team_metadata", operation="enqueue", result="failure"
-            ).inc()
+            _record_enqueue_failure()
             logger.exception(
                 "Failed to enqueue cache update task",
                 team_id=instance.id,
@@ -140,6 +162,60 @@ def clear_team_metadata_cache_on_delete(sender: type[Team], instance: Team, **kw
     # NB: For unit tests, only clear Redis to avoid S3 timestamp issues with frozen time
     kinds = ["redis"] if settings.TEST else None
     clear_team_metadata_cache(instance, kinds=kinds)
+
+
+def _record_enqueue_failure() -> None:
+    HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="team_metadata", operation="enqueue", result="failure").inc()
+
+
+def _name_may_have_changed(update_fields: frozenset[str] | None) -> bool:
+    """Whether a save could have touched the `name` field.
+
+    A `None` update_fields means a full save, where we can't tell, so we assume it might have.
+    """
+    return update_fields is None or "name" in update_fields
+
+
+def _enqueue_related_team_metadata_fanout(*, organization_id: int | None = None, project_id: int | None = None) -> None:
+    try:
+        update_related_teams_metadata_cache_task.delay(organization_id=organization_id, project_id=project_id)
+    except Exception as e:
+        _record_enqueue_failure()
+        logger.exception(
+            "Failed to enqueue related team metadata fan-out",
+            organization_id=organization_id,
+            project_id=project_id,
+            error=str(e),
+        )
+
+
+# Organization and project names are denormalized into team metadata, but only the Team signal
+# refreshes the cache. These receivers cover org/project renames, which never touch the Team row.
+# Deletes need no receiver: both FKs cascade to Team, firing the Team pre_delete handler above.
+@receiver(post_save, sender=Organization)
+def update_team_metadata_cache_on_organization_save(
+    sender: type[Organization], instance: Organization, created: bool, **kwargs: Any
+) -> None:
+    """Refresh dependent team metadata caches when an organization is renamed."""
+    if created or not settings.FLAGS_REDIS_URL:
+        return
+    if not _name_may_have_changed(kwargs.get("update_fields")):
+        return
+
+    transaction.on_commit(lambda: _enqueue_related_team_metadata_fanout(organization_id=instance.id))
+
+
+@receiver(post_save, sender=Project)
+def update_team_metadata_cache_on_project_save(
+    sender: type[Project], instance: Project, created: bool, **kwargs: Any
+) -> None:
+    """Refresh dependent team metadata caches when a project is renamed."""
+    if created or not settings.FLAGS_REDIS_URL:
+        return
+    if not _name_may_have_changed(kwargs.get("update_fields")):
+        return
+
+    transaction.on_commit(lambda: _enqueue_related_team_metadata_fanout(project_id=instance.id))
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -133,6 +133,7 @@
     'posthog.tasks.team_access_cache_tasks.invalidate_user_tokens_task',
     'posthog.tasks.team_metadata.cleanup_stale_expiry_tracking_task',
     'posthog.tasks.team_metadata.refresh_expiring_team_metadata_cache_entries',
+    'posthog.tasks.team_metadata.update_related_teams_metadata_cache_task',
     'posthog.tasks.team_metadata.update_team_metadata_cache_task',
     'posthog.tasks.usage_report.capture_report',
     'posthog.tasks.usage_report.send_all_org_usage_reports',

--- a/posthog/tasks/test/test_team_metadata_signals.py
+++ b/posthog/tasks/test/test_team_metadata_signals.py
@@ -10,7 +10,7 @@ from posthog.tasks.team_metadata import update_related_teams_metadata_cache_task
 
 @override_settings(FLAGS_REDIS_URL="redis://localhost:6379")
 class TestTeamMetadataInvalidationSignals(BaseTest):
-    def test_organization_rename_enqueues_fanout(self):
+    def test_organization_rename_enqueues_fanout(self) -> None:
         with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
             with self.captureOnCommitCallbacks(execute=True):
                 self.organization.name = "Renamed org"
@@ -18,7 +18,7 @@ class TestTeamMetadataInvalidationSignals(BaseTest):
 
         mock_task.delay.assert_called_once_with(organization_id=self.organization.id, project_id=None)
 
-    def test_project_rename_enqueues_fanout(self):
+    def test_project_rename_enqueues_fanout(self) -> None:
         with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
             with self.captureOnCommitCallbacks(execute=True):
                 self.project.name = "Renamed project"
@@ -26,7 +26,7 @@ class TestTeamMetadataInvalidationSignals(BaseTest):
 
         mock_task.delay.assert_called_once_with(organization_id=None, project_id=self.project.id)
 
-    def test_save_with_name_in_update_fields_enqueues(self):
+    def test_save_with_name_in_update_fields_enqueues(self) -> None:
         with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
             with self.captureOnCommitCallbacks(execute=True):
                 self.organization.name = "Renamed via update_fields"
@@ -34,7 +34,7 @@ class TestTeamMetadataInvalidationSignals(BaseTest):
 
         mock_task.delay.assert_called_once_with(organization_id=self.organization.id, project_id=None)
 
-    def test_save_without_name_in_update_fields_does_not_enqueue(self):
+    def test_save_without_name_in_update_fields_does_not_enqueue(self) -> None:
         with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
             with self.captureOnCommitCallbacks(execute=True):
                 self.organization.is_member_join_email_enabled = False
@@ -42,7 +42,7 @@ class TestTeamMetadataInvalidationSignals(BaseTest):
 
         mock_task.delay.assert_not_called()
 
-    def test_creating_does_not_enqueue(self):
+    def test_creating_does_not_enqueue(self) -> None:
         with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
             with self.captureOnCommitCallbacks(execute=True):
                 Organization.objects.create(name="Brand new org")
@@ -53,7 +53,7 @@ class TestTeamMetadataInvalidationSignals(BaseTest):
         mock_task.delay.assert_not_called()
 
     @override_settings(FLAGS_REDIS_URL="")
-    def test_no_fanout_when_flags_redis_url_unset(self):
+    def test_no_fanout_when_flags_redis_url_unset(self) -> None:
         with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
             with self.captureOnCommitCallbacks(execute=True):
                 self.organization.name = "Renamed org"
@@ -66,7 +66,7 @@ class TestTeamMetadataInvalidationSignals(BaseTest):
 
 @override_settings(FLAGS_REDIS_URL="redis://localhost:6379")
 class TestRelatedTeamsMetadataFanoutTask(BaseTest):
-    def test_organization_fanout_enqueues_every_team(self):
+    def test_organization_fanout_enqueues_every_team(self) -> None:
         _, second_team = Project.objects.create_with_team(
             organization=self.organization, initiating_user=self.user, name="Second project"
         )
@@ -77,14 +77,14 @@ class TestRelatedTeamsMetadataFanoutTask(BaseTest):
         enqueued_team_ids = {call.args[0] for call in mock_update.delay.call_args_list}
         self.assertEqual(enqueued_team_ids, {self.team.id, second_team.id})
 
-    def test_project_fanout_enqueues_project_team(self):
+    def test_project_fanout_enqueues_project_team(self) -> None:
         with patch("posthog.tasks.team_metadata.update_team_metadata_cache_task") as mock_update:
             update_related_teams_metadata_cache_task(project_id=self.project.id)
 
         enqueued_team_ids = {call.args[0] for call in mock_update.delay.call_args_list}
         self.assertEqual(enqueued_team_ids, {self.team.id})
 
-    def test_fanout_is_noop_without_ids(self):
+    def test_fanout_is_noop_without_ids(self) -> None:
         with patch("posthog.tasks.team_metadata.update_team_metadata_cache_task") as mock_update:
             update_related_teams_metadata_cache_task()
 
@@ -93,7 +93,7 @@ class TestRelatedTeamsMetadataFanoutTask(BaseTest):
 
 @override_settings(FLAGS_REDIS_URL="redis://localhost:6379")
 class TestOrgProjectDeleteCascadesToTeamClear(BaseTest):
-    def test_deleting_project_clears_team_metadata_via_cascade(self):
+    def test_deleting_project_clears_team_metadata_via_cascade(self) -> None:
         project, team = Project.objects.create_with_team(
             organization=self.organization, initiating_user=self.user, name="Doomed project"
         )

--- a/posthog/tasks/test/test_team_metadata_signals.py
+++ b/posthog/tasks/test/test_team_metadata_signals.py
@@ -1,0 +1,111 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from posthog.models.organization import Organization
+from posthog.models.project import Project
+from posthog.tasks.team_metadata import update_related_teams_metadata_cache_task
+
+
+@override_settings(FLAGS_REDIS_URL="redis://localhost:6379")
+class TestTeamMetadataInvalidationSignals(BaseTest):
+    def test_organization_rename_enqueues_fanout(self):
+        with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
+            with self.captureOnCommitCallbacks(execute=True):
+                self.organization.name = "Renamed org"
+                self.organization.save()
+
+        mock_task.delay.assert_called_once_with(organization_id=self.organization.id, project_id=None)
+
+    def test_project_rename_enqueues_fanout(self):
+        with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
+            with self.captureOnCommitCallbacks(execute=True):
+                self.project.name = "Renamed project"
+                self.project.save()
+
+        mock_task.delay.assert_called_once_with(organization_id=None, project_id=self.project.id)
+
+    def test_save_with_name_in_update_fields_enqueues(self):
+        with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
+            with self.captureOnCommitCallbacks(execute=True):
+                self.organization.name = "Renamed via update_fields"
+                self.organization.save(update_fields=["name"])
+
+        mock_task.delay.assert_called_once_with(organization_id=self.organization.id, project_id=None)
+
+    def test_save_without_name_in_update_fields_does_not_enqueue(self):
+        with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
+            with self.captureOnCommitCallbacks(execute=True):
+                self.organization.is_member_join_email_enabled = False
+                self.organization.save(update_fields=["is_member_join_email_enabled"])
+
+        mock_task.delay.assert_not_called()
+
+    def test_creating_does_not_enqueue(self):
+        with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
+            with self.captureOnCommitCallbacks(execute=True):
+                Organization.objects.create(name="Brand new org")
+                Project.objects.create_with_team(
+                    organization=self.organization, initiating_user=self.user, name="Brand new project"
+                )
+
+        mock_task.delay.assert_not_called()
+
+    @override_settings(FLAGS_REDIS_URL="")
+    def test_no_fanout_when_flags_redis_url_unset(self):
+        with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
+            with self.captureOnCommitCallbacks(execute=True):
+                self.organization.name = "Renamed org"
+                self.organization.save()
+                self.project.name = "Renamed project"
+                self.project.save()
+
+        mock_task.delay.assert_not_called()
+
+
+@override_settings(FLAGS_REDIS_URL="redis://localhost:6379")
+class TestRelatedTeamsMetadataFanoutTask(BaseTest):
+    def test_organization_fanout_enqueues_every_team(self):
+        _, second_team = Project.objects.create_with_team(
+            organization=self.organization, initiating_user=self.user, name="Second project"
+        )
+
+        with patch("posthog.tasks.team_metadata.update_team_metadata_cache_task") as mock_update:
+            update_related_teams_metadata_cache_task(organization_id=self.organization.id)
+
+        enqueued_team_ids = {call.args[0] for call in mock_update.delay.call_args_list}
+        self.assertEqual(enqueued_team_ids, {self.team.id, second_team.id})
+
+    def test_project_fanout_enqueues_project_team(self):
+        with patch("posthog.tasks.team_metadata.update_team_metadata_cache_task") as mock_update:
+            update_related_teams_metadata_cache_task(project_id=self.project.id)
+
+        enqueued_team_ids = {call.args[0] for call in mock_update.delay.call_args_list}
+        self.assertEqual(enqueued_team_ids, {self.team.id})
+
+    def test_fanout_is_noop_without_ids(self):
+        with patch("posthog.tasks.team_metadata.update_team_metadata_cache_task") as mock_update:
+            update_related_teams_metadata_cache_task()
+
+        mock_update.delay.assert_not_called()
+
+
+@override_settings(FLAGS_REDIS_URL="redis://localhost:6379")
+class TestOrgProjectDeleteCascadesToTeamClear(BaseTest):
+    def test_deleting_project_clears_team_metadata_via_cascade(self):
+        project, team = Project.objects.create_with_team(
+            organization=self.organization, initiating_user=self.user, name="Doomed project"
+        )
+        team_id = team.id
+
+        # Capture ids at call time: the delete collector nulls each instance's pk after deletion,
+        # so reading instance.id after project.delete() returns would see None.
+        cleared_team_ids: set[int] = set()
+        with patch(
+            "posthog.tasks.team_metadata.clear_team_metadata_cache",
+            side_effect=lambda instance, **kwargs: cleared_team_ids.add(instance.id),
+        ):
+            project.delete()
+
+        self.assertIn(team_id, cleared_team_ids)


### PR DESCRIPTION
## Problem

The team_metadata HyperCache denormalizes organization_name and project_name onto each cached team entry, but invalidation only fires on Team save and delete. Renaming an organization or project never touches the Team row, so no signal fires and the cache keeps serving the old name until the 7-day TTL expires or the hourly refresh job happens to pick it up. The hypercache verifier sees the cached name differ from the database and reports it as recurring drift, which it then "fixes" every cycle.

This is genuine staleness, not a phantom race: the flags service reads the wrong org/project name in the meantime.

## Changes

Add post_save receivers for Organization and Project that refresh every dependent team's cached metadata.

The fan-out runs inside a Celery task rather than the request. The signal enqueues exactly one task regardless of how many teams the org or project owns, and that task enqueues an independent per-team update so each retries in isolation. This keeps the originating web request O(1) and avoids a task-queue stampede when a large org is renamed.

An update_fields guard skips saves that demonstrably did not touch name (for example the billing sync that saves with update_fields=["available_product_features"]). Full saves, which is how renames go through DRF, pass update_fields=None and fan out. A full non-name save still fans out, which is harmless: the per-team task just rewrites identical cache data.

No delete receiver is needed. Both Team.organization and Team.project are on_delete=CASCADE, so deleting an org or project deletes its teams, and Django fires pre_delete for those cascaded teams, which the existing Team handler already uses to clear the cache.

This depends on no schema changes and can ship independently. The grace-period side of this work (so the verifier does not flag teams mid-refresh) is tracked separately and needs Project.updated_at, which lands in its own PR first.

## How did you test this code?

Automated tests:

- New `posthog/tasks/test/test_team_metadata_signals.py` covering: org rename enqueues the fan-out, project rename enqueues the fan-out, name in update_fields enqueues, non-name update_fields does not, creation does not, no fan-out when FLAGS_REDIS_URL is unset, the fan-out task enqueues every team under an org and only the project's team for a project, the task is a noop without ids, and that deleting a project clears its team's cache via the cascade.
- `hogli test posthog/tasks/test/test_team_metadata_signals.py posthog/storage/test/test_team_metadata_cache.py` (41 passed) and `posthog/tasks/test/test_hypercache_verification.py` (24 passed).
- ruff check and ruff format clean; lint-staged Python type check passed on commit.

Manual testing (agent-assisted, run against the local dev stack with `FLAGS_REDIS_URL` set):

- Warmed a team's metadata cache, renamed its organization, and confirmed the Redis-backed cache read (`get_team_metadata`) returned the new `organization_name`. Repeated for project rename and `project_name`. Both refreshed end-to-end through the real path: post_save receiver → `transaction.on_commit` → fan-out task → per-team `update_team_metadata_cache` → Redis write → read back.
- Confirmed the receivers register via Celery app finalization (`on_after_finalize` → `scheduled.py` → `team_metadata`), the same mechanism the pre-existing Team receiver relies on. This finalizes early in web processes since they dispatch Celery tasks continuously, so renames go through with the receivers registered.

## Docs update

No docs changes needed.
