### PR TITLE
fix(search): guard cmd+k shift+enter href against javascript: URLs

### DIFF
--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -1000,9 +1000,6 @@ function SearchFooter({ children }: SearchFooterProps): JSX.Element {
                     <span>
                         <KeyboardShortcut enter /> to activate
                     </span>
-                    <span>
-                        <KeyboardShortcut shift enter /> to open in new tab
-                    </span>
                     {searchValue.trim() && (
                         <span>
                             <KeyboardShortcut tab /> to ask AI

--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -665,7 +665,7 @@ function SearchInput({ autoFocus, className }: SearchInputProps): JSX.Element {
                 e.preventDefault()
                 e.stopPropagation()
                 const item = highlightedItemRef.current
-                if (item?.href) {
+                if (item?.href && item.href.startsWith('/') && !item.href.startsWith('//')) {
                     window.open(item.href, '_blank', 'noopener,noreferrer')
                 }
             }

--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -4,7 +4,6 @@ import { capitalizeFirstLetter } from 'kea-forms'
 import { router } from 'kea-router'
 import {
     Fragment,
-    type MutableRefObject,
     type ReactNode,
     type RefObject,
     createContext,
@@ -27,7 +26,6 @@ import { ContextMenu, ContextMenuContent, ContextMenuGroup, ContextMenuTrigger }
 import { Label } from 'lib/ui/Label/Label'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { cn } from 'lib/utils/css-classes'
-import { newInternalTab } from 'lib/utils/newInternalTab'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -224,7 +222,6 @@ interface SearchContextValue {
     handleItemClick: (item: SearchItem) => void
     showAskAiLink: boolean
     onAskAiClick?: () => void
-    highlightedItemRef: MutableRefObject<SearchItem | null>
 }
 
 const SearchContext = createContext<SearchContextValue | null>(null)
@@ -414,7 +411,6 @@ function SearchRoot({
 
     const inputRef = useRef<HTMLInputElement>(null!)
     const actionsRef = useRef<Autocomplete.Root.Actions>(null)
-    const highlightedItemRef = useRef<SearchItem | null>(null)
 
     const allItems = useMemo(() => {
         const items: SearchItem[] = []
@@ -601,7 +597,6 @@ function SearchRoot({
             handleItemClick,
             showAskAiLink,
             onAskAiClick,
-            highlightedItemRef,
         }),
         [
             logicKey,
@@ -648,8 +643,7 @@ export interface SearchInputProps {
 }
 
 function SearchInput({ autoFocus, className }: SearchInputProps): JSX.Element {
-    const { searchValue, setSearchValue, isActive, inputRef, highlightedItemRef, showAskAiLink, onAskAiClick } =
-        useSearchContext()
+    const { searchValue, setSearchValue, isActive, inputRef, showAskAiLink, onAskAiClick } = useSearchContext()
 
     const { text: placeholderText, isVisible: placeholderVisible } = useRotatingPlaceholder(isActive && !searchValue)
 
@@ -662,21 +656,13 @@ function SearchInput({ autoFocus, className }: SearchInputProps): JSX.Element {
 
     const handleInputKeyDown = useCallback(
         (e: React.KeyboardEvent) => {
-            if (e.key === 'Enter' && e.shiftKey) {
-                e.preventDefault()
-                e.stopPropagation()
-                const item = highlightedItemRef.current
-                if (item?.href) {
-                    newInternalTab(item.href)
-                }
-            }
             if (e.key === 'Tab' && showAskAiLink && searchValue.trim()) {
                 e.preventDefault()
                 onAskAiClick?.()
                 router.actions.push(urls.ai(undefined, searchValue.trim()))
             }
         },
-        [highlightedItemRef, showAskAiLink, searchValue, onAskAiClick]
+        [showAskAiLink, searchValue, onAskAiClick]
     )
 
     useEffect(() => {
@@ -813,7 +799,7 @@ function SearchResults({
     listClassName?: string
     groupLabelClassName?: string
 }): JSX.Element {
-    const { groupedItems, handleItemClick, highlightedItemRef, isSearching, searchValue } = useSearchContext()
+    const { groupedItems, handleItemClick, isSearching, searchValue } = useSearchContext()
 
     // Don't show "no results" while any category is still loading
     const isAnyLoading = groupedItems.some((g) => g.isLoading)
@@ -884,13 +870,6 @@ function SearchResults({
                                                                 handleItemClick(item)
                                                             }}
                                                             render={(props) => {
-                                                                const isHighlighted =
-                                                                    (props as Record<string, unknown>)[
-                                                                        'data-highlighted'
-                                                                    ] === ''
-                                                                if (isHighlighted) {
-                                                                    highlightedItemRef.current = item
-                                                                }
                                                                 return (
                                                                     <div className="px-2">
                                                                         <Link

--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -1000,7 +1000,7 @@ function SearchFooter({ children }: SearchFooterProps): JSX.Element {
                         <KeyboardShortcut enter /> to activate
                     </span>
                     <span>
-                        <KeyboardShortcut shift enter /> to open in new browser tab
+                        <KeyboardShortcut shift enter /> to open in new tab
                     </span>
                     {searchValue.trim() && (
                         <span>

--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -4,6 +4,7 @@ import { capitalizeFirstLetter } from 'kea-forms'
 import { router } from 'kea-router'
 import {
     Fragment,
+    type MutableRefObject,
     type ReactNode,
     type RefObject,
     createContext,
@@ -222,6 +223,7 @@ interface SearchContextValue {
     handleItemClick: (item: SearchItem) => void
     showAskAiLink: boolean
     onAskAiClick?: () => void
+    highlightedItemRef: MutableRefObject<SearchItem | null>
 }
 
 const SearchContext = createContext<SearchContextValue | null>(null)
@@ -411,6 +413,7 @@ function SearchRoot({
 
     const inputRef = useRef<HTMLInputElement>(null!)
     const actionsRef = useRef<Autocomplete.Root.Actions>(null)
+    const highlightedItemRef = useRef<SearchItem | null>(null)
 
     const allItems = useMemo(() => {
         const items: SearchItem[] = []
@@ -597,6 +600,7 @@ function SearchRoot({
             handleItemClick,
             showAskAiLink,
             onAskAiClick,
+            highlightedItemRef,
         }),
         [
             logicKey,
@@ -643,7 +647,8 @@ export interface SearchInputProps {
 }
 
 function SearchInput({ autoFocus, className }: SearchInputProps): JSX.Element {
-    const { searchValue, setSearchValue, isActive, inputRef, showAskAiLink, onAskAiClick } = useSearchContext()
+    const { searchValue, setSearchValue, isActive, inputRef, highlightedItemRef, showAskAiLink, onAskAiClick } =
+        useSearchContext()
 
     const { text: placeholderText, isVisible: placeholderVisible } = useRotatingPlaceholder(isActive && !searchValue)
 
@@ -656,13 +661,21 @@ function SearchInput({ autoFocus, className }: SearchInputProps): JSX.Element {
 
     const handleInputKeyDown = useCallback(
         (e: React.KeyboardEvent) => {
+            if (e.key === 'Enter' && e.shiftKey) {
+                e.preventDefault()
+                e.stopPropagation()
+                const item = highlightedItemRef.current
+                if (item?.href) {
+                    window.open(item.href, '_blank', 'noopener,noreferrer')
+                }
+            }
             if (e.key === 'Tab' && showAskAiLink && searchValue.trim()) {
                 e.preventDefault()
                 onAskAiClick?.()
                 router.actions.push(urls.ai(undefined, searchValue.trim()))
             }
         },
-        [showAskAiLink, searchValue, onAskAiClick]
+        [highlightedItemRef, showAskAiLink, searchValue, onAskAiClick]
     )
 
     useEffect(() => {
@@ -799,7 +812,7 @@ function SearchResults({
     listClassName?: string
     groupLabelClassName?: string
 }): JSX.Element {
-    const { groupedItems, handleItemClick, isSearching, searchValue } = useSearchContext()
+    const { groupedItems, handleItemClick, highlightedItemRef, isSearching, searchValue } = useSearchContext()
 
     // Don't show "no results" while any category is still loading
     const isAnyLoading = groupedItems.some((g) => g.isLoading)
@@ -870,6 +883,13 @@ function SearchResults({
                                                                 handleItemClick(item)
                                                             }}
                                                             render={(props) => {
+                                                                const isHighlighted =
+                                                                    (props as Record<string, unknown>)[
+                                                                        'data-highlighted'
+                                                                    ] === ''
+                                                                if (isHighlighted) {
+                                                                    highlightedItemRef.current = item
+                                                                }
                                                                 return (
                                                                     <div className="px-2">
                                                                         <Link
@@ -978,6 +998,9 @@ function SearchFooter({ children }: SearchFooterProps): JSX.Element {
                     )}
                     <span>
                         <KeyboardShortcut enter /> to activate
+                    </span>
+                    <span>
+                        <KeyboardShortcut shift enter /> to open in new browser tab
                     </span>
                     {searchValue.trim() && (
                         <span>


### PR DESCRIPTION
## Summary

Addresses the Veria AI review comment on #60525.

`item.href` in the cmd+k command palette comes from `FileSystem` records, whose `href` is accepted through the API. An authenticated user could create a search result with a `javascript:` href; when another user highlights it and presses Shift+Enter, the raw value was passed to `window.open` and would execute.

This PR guards the `window.open` call so it only fires when `item.href` is an internal absolute path (starts with `/`, but not protocol-relative `//`).

## Changes

`frontend/src/lib/components/Search/Search.tsx`:

- Tightened the Shift+Enter handler from `if (item?.href)` to `if (item?.href && item.href.startsWith('/') && !item.href.startsWith('//'))` before calling `window.open(item.href, '_blank', 'noopener,noreferrer')`.

## Test plan

- [ ] Highlight a normal internal search result and press Shift+Enter — opens in a new tab
- [ ] Confirm Shift+Enter on a result with a non-internal `href` (e.g. `javascript:alert(1)`, `https://evil.example`, `//evil.example`) does nothing

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*