### PR TITLE
chore(kafka): fix misleading cooperative-sticky migration comment

### DIFF
--- a/rust/common/kafka/src/config.rs
+++ b/rust/common/kafka/src/config.rs
@@ -81,8 +81,9 @@ pub struct ConsumerConfig {
     pub kafka_consumer_group_instance_id: Option<String>,
 
     // Override partition assignment strategy, e.g. "cooperative-sticky" for
-    // incremental rebalancing instead of the default eager "range" protocol.
-    // During migration, use "range,cooperative-sticky" then drop "range".
+    // incremental rebalancing instead of the default eager "range". librdkafka
+    // rejects mixing protocol types in one list, so migrate the whole group to
+    // cooperative-sticky in a single cutover, not a "range,cooperative-sticky" phase.
     pub kafka_consumer_partition_strategy: Option<String>,
 
     // WarpStream recommends "0" so the kernel auto-tunes TCP buffers.


### PR DESCRIPTION
## Problem

The doc comment on `kafka_consumer_partition_strategy` recommends the Java client's `range,cooperative-sticky` two-phase migration. librdkafka (what all our Rust and Node consumers use) rejects mixing eager and cooperative assignors in one list, failing with "All partition.assignment.strategy assignors must have the same protocol type, online migration between assignors with different protocol types is not supported". Following the comment crash-loops the consumer at startup.

See [librdkafka #3589](https://github.com/confluentinc/librdkafka/issues/3589) and [#4368](https://github.com/confluentinc/librdkafka/issues/4368).

## Changes

Correct the comment to reflect librdkafka behavior: do not list both, migrate the whole group to `cooperative-sticky` in a single cutover.

## How did you test this code?

Comment-only change, no behavior change. I am an agent and ran no tests; CI compiles the crate.

## Publish to changelog?

no

## 🤖 Agent context

Caught while writing a prod-us chart change for property-vals-rs: the comment led to setting `KAFKA_CONSUMER_PARTITION_STRATEGY=range,cooperative-sticky`, which would have crash-looped the pods on librdkafka. Verified the restriction against the two librdkafka issues linked above. The correct migration is a single cutover to `cooperative-sticky` (drain or restart the group), since librdkafka cannot do the Java-style online two-phase.
