### PR TITLE
refactor(growth): render sdk doctor from backend report

### DIFF
--- a/frontend/src/scenes/health/components/HealthTables.stories.tsx
+++ b/frontend/src/scenes/health/components/HealthTables.stories.tsx
@@ -194,9 +194,12 @@ const SDK_OUTDATED_ISSUE: HealthIssue = createMockIssue('sdk-1', {
         sdk_name: 'web',
         latest_version: '1.142.0',
         current_version: '1.142.0',
+        is_outdated: true,
+        is_old: false,
         // The latest in-use version already matches latest, but an older version is still
         // serving a significant share of traffic — the reason explains both.
         reason: 'Latest in-use version 1.142.0 matches latest 1.142.0. Outdated versions still handling >= 20% of traffic: 1.130.0.',
+        banners: ['Version 1.130.0 of the Web SDK has captured more than 20% of events in the last 7 days.'],
         usage: [
             {
                 lib_version: '1.142.0',

--- a/frontend/src/scenes/onboarding/sdks/SdkDoctorComponents.tsx
+++ b/frontend/src/scenes/onboarding/sdks/SdkDoctorComponents.tsx
@@ -1,5 +1,4 @@
 import { useValues } from 'kea'
-import { combineUrl } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { IconInfo } from '@posthog/icons'
@@ -9,92 +8,11 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { urls } from 'scenes/urls'
 
-import { ActivityTab } from '~/types'
-
 import { SDK_DOCS_LINKS, SDK_TYPE_READABLE_NAME } from './sdkConstants'
 import { AugmentedTeamSdkVersionsInfoRelease, type SdkType, sdkDoctorLogic } from './sdkDoctorLogic'
 
-// NOTE: this SQL query, the activity page URL builder below, and the three tooltip
-// messages further down are mirrored in products/growth/backend/sdk_health.py so the
-// SDK Doctor MCP tool returns the same strings. Keep them in sync when editing here.
-const queryForSdkVersion = (sdkType: SdkType, version: string): string => {
-    return `SELECT * FROM events WHERE timestamp >= NOW() - INTERVAL 7 DAY AND properties.$lib = '${sdkType}' AND properties.$lib_version = '${version}' ORDER BY timestamp DESC LIMIT 50`
-}
-
-// Matches the Activity explore page's DataTableNode format
-const activityPageUrlForSdkVersion = (sdkType: SdkType, version: string): string => {
-    const query = {
-        kind: 'DataTableNode',
-        columns: [
-            '*',
-            'event',
-            'person_display_name -- Person',
-            'coalesce(properties.$current_url, properties.$screen_name) -- Url / Screen',
-            'properties.$lib',
-            'timestamp',
-        ],
-        hiddenColumns: [],
-        pinnedColumns: [],
-        source: {
-            kind: 'EventsQuery',
-            select: [
-                '*',
-                'timestamp',
-                'properties.$lib',
-                'properties.$lib_version',
-                'event',
-                'person_display_name -- Person',
-                'coalesce(properties.$current_url, properties.$screen_name) -- Url / Screen',
-            ],
-            orderBy: ['timestamp DESC'],
-            after: '-7d',
-            properties: [
-                {
-                    key: '$lib',
-                    value: [sdkType],
-                    operator: 'exact',
-                    type: 'event',
-                },
-                {
-                    key: '$lib_version',
-                    value: [version],
-                    operator: 'exact',
-                    type: 'event',
-                },
-            ],
-        },
-        context: { type: 'team_columns' },
-        allowSorting: true,
-        embedded: false,
-        expandable: true,
-        full: true,
-        propertiesViaUrl: true,
-        showActions: true,
-        showColumnConfigurator: true,
-        showCount: false,
-        showDateRange: true,
-        showElapsedTime: false,
-        showEventFilter: true,
-        showEventsFilter: false,
-        showExport: true,
-        showHogQLEditor: true,
-        showOpenEditorButton: true,
-        showPersistentColumnConfigurator: true,
-        showPropertyFilter: true,
-        showRecordingColumn: false,
-        showReload: true,
-        showResultsTable: true,
-        showSavedFilters: false,
-        showSavedQueries: true,
-        showSearch: true,
-        showSourceQueryOptions: true,
-        showTableViews: false,
-        showTestAccountFilters: true,
-        showTimings: false,
-    }
-    return combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: query }).url
-}
-
+// The version drill-in SQL and Activity page URL are computed by the backend (sql_query /
+// activity_page_url on each release) so the UI and the SDK Doctor MCP tool stay in lockstep.
 const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
     {
         title: (
@@ -121,26 +39,24 @@ const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
                         items={[
                             {
                                 label: 'Events on Activity page',
+                                disabledReason: record.activityPageUrl ? undefined : 'Unavailable for this version',
                                 onClick: () => {
                                     posthog.capture('sdk doctor view events', {
                                         sdkType: record.type,
                                         destination: 'activity_page',
                                     })
-                                    newInternalTab(activityPageUrlForSdkVersion(record.type, record.version))
+                                    newInternalTab(record.activityPageUrl)
                                 },
                             },
                             {
                                 label: 'SQL query',
+                                disabledReason: record.sqlQuery ? undefined : 'Unavailable for this version',
                                 onClick: () => {
                                     posthog.capture('sdk doctor view events', {
                                         sdkType: record.type,
                                         destination: 'sql_editor',
                                     })
-                                    newInternalTab(
-                                        urls.sqlEditor({
-                                            query: queryForSdkVersion(record.type, record.version),
-                                        })
-                                    )
+                                    newInternalTab(urls.sqlEditor({ query: record.sqlQuery }))
                                 },
                             },
                         ]}
@@ -150,48 +66,19 @@ const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
                         </code>
                     </LemonMenu>
                     {record.isOutdated ? (
-                        <Tooltip
-                            placement="right"
-                            title={
-                                record.releasedAgo
-                                    ? `Released ${record.releasedAgo}. Upgrade recommended.`
-                                    : 'Upgrade recommended'
-                            }
-                        >
+                        <Tooltip placement="right" title={record.statusReason}>
                             <LemonTag type="danger" className="shrink-0 cursor-help">
                                 Outdated
                             </LemonTag>
                         </Tooltip>
                     ) : record.isCurrentOrNewer ? (
-                        <Tooltip
-                            placement="right"
-                            title={
-                                <>
-                                    You have the latest available.
-                                    <br />
-                                    Click 'Releases ↗' above to check for any since.
-                                </>
-                            }
-                        >
+                        <Tooltip placement="right" title={record.statusReason}>
                             <LemonTag type="success" className="shrink-0 cursor-help">
                                 Current
                             </LemonTag>
                         </Tooltip>
                     ) : (
-                        <Tooltip
-                            placement="right"
-                            title={
-                                record.releasedAgo ? (
-                                    <>
-                                        Released {record.releasedAgo}.
-                                        <br />
-                                        Upgrading is a good idea, but it's not urgent yet.
-                                    </>
-                                ) : (
-                                    "Upgrading is a good idea, but it's not urgent yet"
-                                )
-                            }
-                        >
+                        <Tooltip placement="right" title={record.statusReason}>
                             <LemonTag type="warning" className="shrink-0 cursor-help">
                                 Recent
                             </LemonTag>
@@ -225,7 +112,7 @@ const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
 ]
 
 export function SdkSection({ sdkType }: { sdkType: SdkType }): JSX.Element {
-    const { augmentedData, rawDataLoading: loading } = useValues(sdkDoctorLogic)
+    const { augmentedData, reportLoading: loading } = useValues(sdkDoctorLogic)
 
     const sdk = augmentedData[sdkType]!
     const links = SDK_DOCS_LINKS[sdkType]

--- a/frontend/src/scenes/onboarding/sdks/SdkDoctorScene.tsx
+++ b/frontend/src/scenes/onboarding/sdks/SdkDoctorScene.tsx
@@ -15,9 +15,8 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
-import { SDK_TYPE_READABLE_NAME } from './sdkConstants'
 import { SdkSection } from './SdkDoctorComponents'
-import { type OutdatedTrafficAlert, SdkType, sdkDoctorLogic } from './sdkDoctorLogic'
+import { SdkType, sdkDoctorLogic } from './sdkDoctorLogic'
 import { sdkDoctorSceneLogic } from './sdkDoctorSceneLogic'
 
 export const scene: SceneExport = {
@@ -28,7 +27,7 @@ export const scene: SceneExport = {
 export function SdkDoctorScene(): JSX.Element {
     const {
         augmentedData,
-        rawDataLoading: loading,
+        reportLoading: loading,
         needsUpdatingCount,
         hasErrors,
         snoozedUntil,
@@ -37,7 +36,7 @@ export function SdkDoctorScene(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const healthAlertsEnabled = !!featureFlags[FEATURE_FLAGS.HEALTH_ALERTS]
 
-    const { loadRawData, snoozeSdkDoctor } = useActions(sdkDoctorLogic)
+    const { loadReport, snoozeSdkDoctor } = useActions(sdkDoctorLogic)
 
     useOnMountEffect(() => {
         posthog.capture('sdk doctor loaded', { needsUpdatingCount })
@@ -45,7 +44,7 @@ export function SdkDoctorScene(): JSX.Element {
 
     const scanEvents = (): void => {
         posthog.capture('sdk doctor scan events')
-        loadRawData({ forceRefresh: true })
+        loadReport({ forceRefresh: true })
     }
 
     const snoozeWarning = (): void => {
@@ -138,11 +137,9 @@ export function SdkDoctorScene(): JSX.Element {
                             }}
                         >
                             {Object.entries(augmentedData).flatMap(([sdkType, sdk]) =>
-                                sdk.outdatedTrafficAlerts.map((alert: OutdatedTrafficAlert) => (
-                                    <p key={`${sdkType}-${alert.version}`} className="text-sm mb-1">
-                                        Version <code className="text-xs font-mono">{alert.version}</code> of the{' '}
-                                        {SDK_TYPE_READABLE_NAME[sdkType as SdkType]} SDK has captured more than{' '}
-                                        {alert.thresholdPercent}% of events in the last 7 days.
+                                sdk.banners.map((banner, index) => (
+                                    <p key={`${sdkType}-${index}`} className="text-sm mb-1">
+                                        {banner}
                                     </p>
                                 ))
                             )}

--- a/frontend/src/scenes/onboarding/sdks/sdkDoctorLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdkDoctorLogic.tsx
@@ -1,5 +1,6 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -154,6 +155,11 @@ export const sdkDoctorLogic = kea<sdkDoctorLogicType>([
             null as SdkHealthReportResponse | null,
             {
                 loadReport: async (options?: { forceRefresh?: boolean }): Promise<SdkHealthReportResponse | null> => {
+                    // Skip while the team is still loading — firing against /projects/null/ 404s and
+                    // would leave the scene stuck in an error state with no automatic retry.
+                    if (!values.currentTeamId) {
+                        return null
+                    }
                     try {
                         const base = `api/projects/${values.currentTeamId}/sdk_doctor/report/`
                         const endpoint = options?.forceRefresh === true ? `${base}?force_refresh=true` : base
@@ -247,6 +253,18 @@ export const sdkDoctorLogic = kea<sdkDoctorLogicType>([
             lemonToast.success('SDK Doctor snoozed for 30 days')
         },
     }),
+
+    subscriptions(({ actions, values }) => ({
+        // If the team was still loading when the scene mounted (currentTeamId null), afterMount's
+        // loadReport bailed early — retry once the team id arrives. `oldTeamId === null` targets that
+        // real null→id transition specifically, so a fresh mount with the team already present never
+        // double-loads.
+        currentTeamId: (currentTeamId, oldTeamId) => {
+            if (currentTeamId && oldTeamId === null && values.isCloudOrDev) {
+                actions.loadReport()
+            }
+        },
+    })),
 
     afterMount(({ actions, values }) => {
         if (!values.isCloudOrDev) {

--- a/frontend/src/scenes/onboarding/sdks/sdkDoctorLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdkDoctorLogic.tsx
@@ -4,9 +4,8 @@ import { loaders } from 'kea-loaders'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { dayjs } from 'lib/dayjs'
-import { SemanticVersion, diffVersions, parseVersion, versionToString } from 'lib/utils/semver'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { teamLogic } from 'scenes/teamLogic'
 
 import type { sdkDoctorLogicType } from './sdkDoctorLogicType'
 
@@ -28,44 +27,65 @@ export type SdkType =
 // Small helper to define what our versions look like
 export type SdkVersion = `${string}.${string}.${string}`
 
-// For a team we have a map of SDK types to all of the versions we say in recent times
-// This is what we receive from the backend, we then do some calculations in the UI to determine
-// what we should be displaying in the UI
-export type TeamSdkUsageEntry = {
-    lib_version: SdkVersion
-    count: number
-    is_latest: boolean
-    max_timestamp: string
-    release_date: string | undefined
-}
+/**
+ * Overall health status for SDK version monitoring
+ */
+export type SdkHealthStatus = 'danger' | 'warning' | 'success'
 
-export type SdkDoctorResponse = {
-    [key in SdkType]?: {
-        latest_version: SdkVersion
-        usage: TeamSdkUsageEntry[]
-    }
-}
+// --- Backend report shape (mirrors SdkHealthReportSerializer in posthog/api/sdk_doctor.py) ---
+//
+// All outdatedness heuristics (device thresholds, grace periods, traffic-share rules, severity
+// escalation) live in products/growth/backend/sdk_health.py and are surfaced pre-computed here.
+// The frontend renders these fields directly — it does NOT recompute health.
 
-// This is the final data used to display in the UI
 export type OutdatedTrafficAlert = {
-    version: SdkVersion
+    version: string
     thresholdPercent: number
 }
 
-export type AugmentedTeamSdkVersionsInfo = {
-    [key in SdkType]?: {
-        isOutdated: boolean
-        isOld: boolean
-        needsUpdating: boolean
-        currentVersion: SdkVersion
-        allReleases: AugmentedTeamSdkVersionsInfoRelease[]
-        outdatedTrafficAlerts: OutdatedTrafficAlert[]
-    }
+export type SdkReleaseAssessmentResponse = {
+    version: string
+    count: number
+    max_timestamp: string
+    release_date: string | null
+    days_since_release: number | null
+    released_ago: string | null
+    is_outdated: boolean
+    is_old: boolean
+    needs_updating: boolean
+    is_current_or_newer: boolean
+    status_reason: string
+    sql_query: string
+    activity_page_url: string
 }
+
+export type SdkAssessmentResponse = {
+    lib: SdkType
+    readable_name: string
+    latest_version: string
+    needs_updating: boolean
+    is_outdated: boolean
+    is_old: boolean
+    severity: 'none' | 'warning' | 'danger'
+    reason: string
+    banners: string[]
+    releases: SdkReleaseAssessmentResponse[]
+    outdated_traffic_alerts: { version: string; threshold_percent: number }[]
+}
+
+export type SdkHealthReportResponse = {
+    overall_health: 'healthy' | 'needs_attention'
+    health: SdkHealthStatus
+    needs_updating_count: number
+    team_sdk_count: number
+    sdks: SdkAssessmentResponse[]
+}
+
+// --- Camel-cased shapes the UI components consume (adapted from the backend report) ----------
 
 export type AugmentedTeamSdkVersionsInfoRelease = {
     type: SdkType
-    version: SdkVersion
+    version: string
     maxTimestamp: string
     count: number
     latestVersion: string
@@ -76,54 +96,41 @@ export type AugmentedTeamSdkVersionsInfoRelease = {
     isOld: boolean
     needsUpdating: boolean
     isCurrentOrNewer: boolean
+    statusReason: string
+    sqlQuery: string
+    activityPageUrl: string
 }
 
-/**
- * Overall health status for SDK version monitoring
- */
-export type SdkHealthStatus = 'danger' | 'warning' | 'success'
+export type AugmentedTeamSdkVersionsInfo = {
+    [key in SdkType]?: {
+        isOutdated: boolean
+        isOld: boolean
+        needsUpdating: boolean
+        currentVersion: string
+        severity: 'none' | 'warning' | 'danger'
+        banners: string[]
+        allReleases: AugmentedTeamSdkVersionsInfoRelease[]
+        outdatedTrafficAlerts: OutdatedTrafficAlert[]
+    }
+}
 
 /**
  * SDK Doctor - PostHog SDK Health Monitoring
  *
- * Detects installed SDKs and their versions across a team's events.
- * Provides smart version outdatedness detection.
+ * Detects installed SDKs and their versions across a team's events and surfaces a pre-digested
+ * health report computed entirely by the backend (see products/growth/backend/sdk_health.py).
  *
- * Architecture:
- * - Backend detection: Team SDK detections cached server-side (72h Redis, refreshed every 12 hours)
- * - Version checking: Per-SDK GitHub API queries cached server-side (72h Redis, refreshed every 6 hours)
- * - Smart semver: Contextual thresholds
+ * Data flow:
+ * - Team SDK detections + GitHub latest versions are cached server-side and refreshed by the
+ *   Temporal `sdk_outdated` health check.
+ * - The `report` endpoint applies the outdatedness heuristics and returns the assessment below.
  */
-
-const DEVICE_CONTEXT_CONFIG = {
-    mobileSDKs: ['posthog-ios', 'posthog-android', 'posthog-flutter', 'posthog-react-native'] as SdkType[],
-    desktopSDKs: [
-        'web',
-        'posthog-node',
-        'posthog-python',
-        'posthog-php',
-        'posthog-ruby',
-        'posthog-go',
-        'posthog-dotnet',
-        'posthog-elixir',
-    ] as SdkType[],
-    // Age-based outdated detection depends on mobile/desktop
-    // We're more lenient with mobile versions because it's harder to keep them up to date
-    // Arbitrary threshold for now, 4 months for desktop, 6 months for mobile
-    ageThresholds: { desktop: 16, mobile: 24 },
-} as const
-
-// Threshold for considering an outdated version's traffic "significant"
-// Web SDK ships very frequently, so we use a higher threshold (20% vs 10%)
-// to avoid over-alerting when old versions linger in the 7-day event window
-const SIGNIFICANT_TRAFFIC_THRESHOLD_WEB = 0.2
-const SIGNIFICANT_TRAFFIC_THRESHOLD_DEFAULT = 0.1
 
 export const sdkDoctorLogic = kea<sdkDoctorLogicType>([
     path(['scenes', 'onboarding', 'sdks', 'sdkDoctorLogic']),
 
     connect(() => ({
-        values: [preflightLogic, ['isCloudOrDev']],
+        values: [preflightLogic, ['isCloudOrDev'], teamLogic, ['currentTeamId']],
     })),
 
     actions({
@@ -142,19 +149,17 @@ export const sdkDoctorLogic = kea<sdkDoctorLogicType>([
         ],
     })),
 
-    loaders(() => ({
-        rawData: [
-            null as SdkDoctorResponse | null,
+    loaders(({ values }) => ({
+        report: [
+            null as SdkHealthReportResponse | null,
             {
-                loadRawData: async (options?: { forceRefresh?: boolean }): Promise<SdkDoctorResponse | null> => {
+                loadReport: async (options?: { forceRefresh?: boolean }): Promise<SdkHealthReportResponse | null> => {
                     try {
-                        const endpoint =
-                            options?.forceRefresh === true ? 'api/sdk_doctor/?force_refresh=true' : 'api/sdk_doctor/'
-                        const response = await api.get<SdkDoctorResponse>(endpoint)
-
-                        return response
+                        const base = `api/projects/${values.currentTeamId}/sdk_doctor/report/`
+                        const endpoint = options?.forceRefresh === true ? `${base}?force_refresh=true` : base
+                        return await api.get<SdkHealthReportResponse>(endpoint)
                     } catch (error) {
-                        console.error('Error loading SDK doctor data', error)
+                        console.error('Error loading SDK doctor report', error)
                         return null
                     }
                 },
@@ -164,130 +169,75 @@ export const sdkDoctorLogic = kea<sdkDoctorLogicType>([
 
     selectors({
         augmentedData: [
-            (s) => [s.rawData],
-            (rawData: SdkDoctorResponse): AugmentedTeamSdkVersionsInfo => {
-                if (!rawData) {
+            (s) => [s.report],
+            (report: SdkHealthReportResponse | null): AugmentedTeamSdkVersionsInfo => {
+                if (!report) {
                     return {}
                 }
 
                 return Object.fromEntries(
-                    Object.entries(rawData).map(([sdkType, teamSdkUsage]) => {
-                        const isSingleVersion = teamSdkUsage.usage.length === 1
-                        const releasesInfo = teamSdkUsage.usage.map((usageEntry) =>
-                            computeAugmentedInfoRelease(
-                                sdkType as SdkType,
-                                usageEntry,
-                                parseVersion(teamSdkUsage.latest_version),
-                                isSingleVersion
-                            )
-                        )
-
-                        // Calculate total events across all versions of this SDK
-                        const totalEvents = releasesInfo.reduce((sum, r) => sum + r.count, 0)
-
-                        // Check if any outdated version handles significant traffic
-                        // Web SDK uses 20% threshold (ships frequently), others use 10%
-                        // Skip for mobile SDKs - users don't auto-update apps, so outdated versions are expected
-                        const isMobileSdk = DEVICE_CONTEXT_CONFIG.mobileSDKs.includes(sdkType as SdkType)
-                        const trafficThreshold =
-                            sdkType === 'web'
-                                ? SIGNIFICANT_TRAFFIC_THRESHOLD_WEB
-                                : SIGNIFICANT_TRAFFIC_THRESHOLD_DEFAULT
-                        const thresholdPercent = trafficThreshold * 100
-
-                        // Find outdated versions exceeding the traffic threshold
-                        const outdatedTrafficAlerts: OutdatedTrafficAlert[] =
-                            !isMobileSdk && totalEvents > 0
-                                ? releasesInfo
-                                      .filter((r) => r.isOutdated && r.count / totalEvents >= trafficThreshold)
-                                      .map((r) => ({ version: r.version, thresholdPercent }))
-                                : []
-
-                        const hasSignificantOutdatedTraffic = outdatedTrafficAlerts.length > 0
-
-                        // SDK is outdated if most recent version is outdated OR any outdated version has significant traffic
-                        // Safe: backend only includes SDKs with at least one usage entry
-                        const isOutdated = releasesInfo[0]!.isOutdated || hasSignificantOutdatedTraffic
-
-                        return [
-                            sdkType,
-                            {
-                                isOutdated,
-                                isOld: releasesInfo[0]!.isOld,
-                                needsUpdating: isOutdated || releasesInfo[0]!.isOld,
-                                currentVersion: teamSdkUsage.latest_version,
-                                allReleases: releasesInfo,
-                                outdatedTrafficAlerts,
-                            },
-                        ]
-                    })
+                    report.sdks.map((sdk) => [
+                        sdk.lib,
+                        {
+                            isOutdated: sdk.is_outdated,
+                            isOld: sdk.is_old,
+                            needsUpdating: sdk.needs_updating,
+                            currentVersion: sdk.latest_version,
+                            severity: sdk.severity,
+                            banners: sdk.banners,
+                            outdatedTrafficAlerts: sdk.outdated_traffic_alerts.map((alert) => ({
+                                version: alert.version,
+                                thresholdPercent: alert.threshold_percent,
+                            })),
+                            allReleases: sdk.releases.map(
+                                (release): AugmentedTeamSdkVersionsInfoRelease => ({
+                                    type: sdk.lib,
+                                    version: release.version,
+                                    maxTimestamp: release.max_timestamp,
+                                    count: release.count,
+                                    latestVersion: sdk.latest_version,
+                                    releaseDate: release.release_date ?? undefined,
+                                    releasedAgo: release.released_ago ?? undefined,
+                                    daysSinceRelease: release.days_since_release ?? undefined,
+                                    isOutdated: release.is_outdated,
+                                    isOld: release.is_old,
+                                    needsUpdating: release.needs_updating,
+                                    isCurrentOrNewer: release.is_current_or_newer,
+                                    statusReason: release.status_reason,
+                                    sqlQuery: release.sql_query,
+                                    activityPageUrl: release.activity_page_url,
+                                })
+                            ),
+                        },
+                    ])
                 )
             },
         ],
 
         needsUpdatingCount: [
-            (s) => [s.augmentedData],
-            (augmentedData: AugmentedTeamSdkVersionsInfo): number => {
-                return Object.values(augmentedData).filter((sdk) => sdk.needsUpdating).length
-            },
+            (s) => [s.report],
+            (report: SdkHealthReportResponse | null): number => report?.needs_updating_count ?? 0,
         ],
 
         needsAttention: [
-            (s) => [s.augmentedData, s.needsUpdatingCount, s.snoozedUntil],
-            (
-                augmentedData: AugmentedTeamSdkVersionsInfo,
-                needsUpdatingCount: number,
-                snoozedUntil: string | null
-            ): boolean => {
-                // If snoozed, we don't need attention to this
+            (s) => [s.report, s.snoozedUntil],
+            (report: SdkHealthReportResponse | null, snoozedUntil: string | null): boolean => {
                 if (snoozedUntil !== null) {
                     return false
                 }
-
-                // If there are no SDKs - unlikely, but it happens just after onboarding - we don't need attention at all
-                const teamSdkCount = Object.values(augmentedData).length
-                if (teamSdkCount === 0) {
-                    return false
-                }
-
-                // Let's call their attention if at least half of their SDKs are outdated
-                // It's unlikely for people to have more than 3 SDKs, but let's be safe
-                // and handle it very generically.
-                //
-                // | Outdated SDKs \ Total SDKs |  1  |  2  |  3  |  4  |  5  |
-                // |----------------------------|-----|-----|-----|-----|-----|
-                // |                0           |  NO |  NO |  NO |  NO |  NO |
-                // |                1           | YES | YES |  NO |  NO |  NO |
-                // |                2           |     | YES | YES | YES |  NO |
-                // |                3           |     |     | YES | YES | YES |
-                // |                4           |     |     |     | YES | YES |
-                // |                5           |     |     |     |     | YES |
-                return needsUpdatingCount >= Math.ceil(teamSdkCount / 2)
+                return report?.overall_health === 'needs_attention'
             },
         ],
 
         sdkHealth: [
-            (s) => [s.needsAttention, s.needsUpdatingCount],
-            (needsAttention: boolean, needsUpdatingCount: number): SdkHealthStatus => {
-                // If there's need for attention, then it's automatically marked as danger
-                if (needsAttention) {
-                    return 'danger'
-                }
-
-                // If there's no need for attention, but there are outdated SDKs, then it's marked as warning
-                if (needsUpdatingCount >= 1) {
-                    return 'warning'
-                }
-
-                // Else, we're in a healthy state
-                return 'success'
-            },
+            (s) => [s.report],
+            (report: SdkHealthReportResponse | null): SdkHealthStatus => report?.health ?? 'success',
         ],
 
         hasErrors: [
-            (s) => [s.rawData, s.rawDataLoading],
-            (rawData: SdkDoctorResponse | null, rawDataLoading: boolean): boolean => {
-                return !rawDataLoading && rawData === null
+            (s) => [s.report, s.reportLoading],
+            (report: SdkHealthReportResponse | null, reportLoading: boolean): boolean => {
+                return !reportLoading && report === null
             },
         ],
     }),
@@ -303,198 +253,10 @@ export const sdkDoctorLogic = kea<sdkDoctorLogicType>([
             return
         }
 
-        actions.loadRawData()
+        actions.loadReport()
 
         if (values.snoozedUntil && new Date(values.snoozedUntil) < new Date()) {
             actions.unsnooze()
         }
     }),
 ])
-
-/**
- * Smart semver detection with age-based thresholds.
- *
- * This is the core version comparison logic that determines if an SDK version is outdated.
- * It applies contextual rules based on semantic versioning and release age to avoid false positives.
- *
- * Detection thresholds:
- * - **Grace period**: Versions <7 days old are NEVER flagged (even if major version behind)
- * - **Major**: Always flag if major version behind (1.x → 2.x) OR >1 year old
- * - **Minor**: Flag if 3+ minors behind OR >6 months old
- *
- * The grace period prevents nagging teams about brand-new releases they haven't had time to upgrade to.
- * The age-based thresholds catch abandoned projects using very old versions.
- *
- * @param type - SDK type to check (e.g., 'web', 'python', 'node')
- * @param version - Current version string to evaluate
- * @param latestVersionsData - Version data from GitHub API including:
- *   - latestVersion: Most recent version string
- *   - versions: All versions in descending order
- *   - releaseDates: Map of version -> ISO date for time-based checks
- * @returns Object containing:
- *   - isOutdated: Whether version should be flagged (uses smart semver logic)
- *   - releasesAhead: Number of releases between current and latest
- *   - latestVersion: The most recent version available
- *   - releaseDate: ISO date when current version was released
- *   - daysSinceRelease: Age of current version in days
- *   - isOld: Whether version is outdated by age alone (for "Old" badge)
- *   - deviceContext: Device platform category (mobile/desktop/mixed)
- *   - error: Error message if version parsing fails
- */
-function computeAugmentedInfoRelease(
-    type: SdkType,
-    usageEntry: TeamSdkUsageEntry,
-    latestVersion: SemanticVersion,
-    isSingleVersion: boolean = false
-): AugmentedTeamSdkVersionsInfoRelease {
-    try {
-        // Parse versions for comparison
-        const currentVersion = parseVersion(usageEntry.lib_version)
-
-        // Check if versions differ
-        const diff = diffVersions(latestVersion, currentVersion)
-
-        // Check if current version is equal to or newer than cached latest
-        // This handles the case where events show a newer version than what's cached from GitHub
-        // diff === null means versions are equal; diff.diff <= 0 means current >= latest
-        const isCurrentOrNewer = diff === null || diff.diff <= 0
-
-        // Count number of versions behind by estimating based on semantic version difference
-        let releasesBehind = 0
-        if (diff) {
-            if (diff.kind === 'major') {
-                releasesBehind = diff.diff * 100 // Major version differences are significant
-            } else if (diff.kind === 'minor') {
-                releasesBehind = diff.diff * 10 // Minor versions represent normal releases
-            } else if (diff.kind === 'patch') {
-                releasesBehind = diff.diff
-            }
-        }
-
-        // Age-based analysis
-        let daysSinceRelease: number | undefined
-        let isOld = false
-
-        if (usageEntry.release_date) {
-            daysSinceRelease = calculateVersionAge(usageEntry.release_date)
-            const weeksOld = daysSinceRelease / 7
-
-            // Age-based outdated detection depends on mobile/desktop
-            // We're more lenient with mobile versions because it's harder to keep them up to date
-            const deviceContext = determineDeviceContext(type)
-
-            const ageThreshold =
-                deviceContext === 'desktop'
-                    ? DEVICE_CONTEXT_CONFIG.ageThresholds.desktop
-                    : DEVICE_CONTEXT_CONFIG.ageThresholds.mobile
-
-            isOld = releasesBehind > 0 && weeksOld > ageThreshold
-        }
-
-        // Grace period: Don't flag versions released within the grace period (even if major version behind)
-        // This gives our team time to fix any issues with recent releases before we nag them about new releases
-        // Web SDK ships very frequently, so it gets a longer grace period (14 days vs 7 days)
-        //
-        // NOTE: If daysSinceRelease is undefined (e.g., failed releases not in GitHub),
-        // we continue with release count logic only - this is intentional
-        let isRecentRelease = false
-        const GRACE_PERIOD_DAYS = type === 'web' ? 14 : 7
-
-        if (daysSinceRelease !== undefined) {
-            isRecentRelease = daysSinceRelease < GRACE_PERIOD_DAYS
-        }
-
-        // Smart version detection based on semver difference
-        let isOutdated = false
-
-        // Single version case: only warn if >30 days old to avoid false positives after upgrades
-        // When a user upgrades, old events from the previous version are still in the 7-day window
-        // but no new events with the new version exist yet, causing confusing "Outdated" warnings
-        const SINGLE_VERSION_GRACE_PERIOD_DAYS = 30
-
-        if (isSingleVersion && diff && diff.kind !== 'patch' && daysSinceRelease !== undefined) {
-            isOutdated = daysSinceRelease > SINGLE_VERSION_GRACE_PERIOD_DAYS
-        } else if (isRecentRelease) {
-            // Apply grace period - don't flag anything <7 days old
-            isOutdated = false
-        } else if (diff) {
-            switch (diff.kind) {
-                case 'major':
-                    // Major version behind (e.g. 1.x -> 2.x): Always flag as outdated
-                    isOutdated = true
-                    break
-                case 'minor':
-                    // Minor version behind (e.g. 1.2.x -> 1.5.x): Flag if 3+ minors behind OR >6 months old
-                    const sixMonthsInDays = 180
-                    const isMinorOutdatedByCount = diff.diff >= 3
-                    const isMinorOutdatedByAge = daysSinceRelease !== undefined && daysSinceRelease > sixMonthsInDays
-                    isOutdated = isMinorOutdatedByCount || isMinorOutdatedByAge
-                    break
-                case 'patch':
-                    // Patch version behind (e.g. 1.2.3 -> 1.2.7) is never outdated
-                    isOutdated = false
-                    break
-            }
-        }
-
-        return {
-            type,
-            version: usageEntry.lib_version,
-            maxTimestamp: usageEntry.max_timestamp,
-            count: usageEntry.count,
-            isOutdated,
-            isOld, // Returned separately for "Old" badge in UI
-            needsUpdating: isOutdated || isOld,
-            isCurrentOrNewer,
-            releaseDate: usageEntry.release_date,
-            releasedAgo: usageEntry.release_date ? dayjs(usageEntry.release_date).fromNow() : undefined,
-            daysSinceRelease,
-            latestVersion: versionToString(latestVersion),
-        }
-    } catch {
-        // If we can't parse the versions, return error state
-        return {
-            type,
-            version: usageEntry.lib_version,
-            maxTimestamp: usageEntry.max_timestamp,
-            count: usageEntry.count,
-            isOutdated: false,
-            isOld: false,
-            needsUpdating: false,
-            isCurrentOrNewer: false,
-            releaseDate: undefined,
-            releasedAgo: undefined,
-            daysSinceRelease: undefined,
-            latestVersion: versionToString(latestVersion),
-        }
-    }
-}
-
-/**
- * Calculate the age of a version in days based on its release date
- *
- * @param releaseDate - ISO date string when the version was released
- * @returns Number of days since the release
- */
-function calculateVersionAge(releaseDate: string): number {
-    const release = new Date(releaseDate)
-    const now = new Date()
-    return Math.floor((now.getTime() - release.getTime()) / (1000 * 60 * 60 * 24))
-}
-
-/**
- * Determine the device context (mobile/desktop/mixed) for an SDK type
- *
- * @param sdkType - The SDK type to categorize
- * @returns 'mobile', 'desktop', or 'mixed' based on SDK type
- */
-function determineDeviceContext(sdkType: SdkType): 'mobile' | 'desktop' | 'mixed' {
-    if (DEVICE_CONTEXT_CONFIG.mobileSDKs.includes(sdkType)) {
-        return 'mobile'
-    }
-    if (DEVICE_CONTEXT_CONFIG.desktopSDKs.includes(sdkType)) {
-        return 'desktop'
-    }
-
-    return 'mixed'
-}


### PR DESCRIPTION
## Problem

The SDK Doctor scene re-implemented the entire SDK outdatedness heuristic suite in the browser (device thresholds, grace periods, traffic-share rules, severity escalation) against a raw, un-digested endpoint — duplicating logic that already lives in the backend (`products/growth/backend/sdk_health.py`). The two copies had to be kept in sync by hand.

## Changes

- `sdkDoctorLogic` now fetches the pre-digested `SdkHealthReport` from `api/projects/{id}/sdk_doctor/report/` and exposes the backend-computed fields through a thin adapter (`augmentedData` is preserved for `surveysSdkLogic`). All client-side heuristics, thresholds, and the `computeAugmentedInfoRelease` helper are deleted.
- `SdkDoctorComponents` renders the backend-provided `sqlQuery`, `activityPageUrl`, and `statusReason` directly instead of rebuilding them client-side.
- `SdkDoctorScene` renders the backend `banners` strings verbatim.
- The unified Health scene's `SdkOutdatedRenderer` shows accurate per-version status from the new backend payload fields.

No behaviour change for users — the same numbers and copy, now computed once on the backend.

## How did you test this code?

I'm an agent. Automated checks I ran locally:

- `pnpm --filter=@posthog/frontend typegen:write:no-cache` then `typescript:check:tsgo` — no type errors.
- `oxlint` and `oxfmt --check` — clean on all touched files.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The backend report endpoint and the `SdkHealthReport` serializer already existed (built for the MCP tool); this PR points the UI at it. I kept the camel-cased `AugmentedTeamSdkVersionsInfo` shape as an adapter rather than rewriting every consumer, because `surveysSdkLogic` depends on it. The legacy flat `api/sdk_doctor/` endpoint is intentionally left in place — its helpers are shared with the report viewset and it has its own tests. Stacked on the backend-heuristics PR, whose enriched payload feeds `SdkOutdatedRenderer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>