### PR TITLE
feat(property-vals): label worker metrics by worker

### DIFF
--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -150,6 +150,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         events_producer,
         events_handle.clone(),
         move |e: &Event| fan_out(e, &excluded_events),
+        "events",
     ));
     tokio::spawn(worker_loop::<GroupIdentify, _, _>(
         shared_config.clone(),
@@ -157,6 +158,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         groups_producer,
         groups_handle.clone(),
         move |g: &GroupIdentify| fan_out_group(g, &excluded_groups),
+        "groups",
     ));
     tokio::spawn(worker_loop::<PropertyValueMessage, _, _>(
         shared_config.clone(),
@@ -164,6 +166,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         merger_producer,
         merger_handle.clone(),
         |m: &PropertyValueMessage| extract_tuple(m),
+        "merger",
     ));
     drop(events_handle);
     drop(groups_handle);

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -24,6 +24,7 @@ pub async fn worker_loop<E, P, F>(
     producer: P,
     handle: lifecycle::Handle,
     fan_out_fn: F,
+    worker: &'static str,
 ) where
     E: IngestableEvent,
     P: Producer,
@@ -45,7 +46,7 @@ pub async fn worker_loop<E, P, F>(
         tokio::select! {
             _ = handle.shutdown_recv() => {
                 info!("worker received shutdown; draining final flush");
-                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_SHUTDOWN).await;
+                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_SHUTDOWN, worker).await;
                 if let Err(e) = consumer.commit() {
                     warn!(error = %e, "kafka sync commit at shutdown failed; falling back to broker auto-commit");
                 }
@@ -53,22 +54,22 @@ pub async fn worker_loop<E, P, F>(
             }
             _ = flush_timer.tick() => {
                 handle.report_healthy();
-                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_TIMER).await;
+                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_TIMER, worker).await;
             }
             recv = consumer.json_recv::<E>() => {
                 handle.report_healthy();
                 match recv {
                     Ok((event, offset)) => {
-                        metrics::counter!(EVENTS_RECEIVED).increment(1);
+                        metrics::counter!(EVENTS_RECEIVED, "worker" => worker).increment(1);
 
                         if config.should_process(event.team_id()) {
                             let tuples = fan_out_fn(&event);
-                            metrics::counter!(TUPLES_AGGREGATED).increment(tuples.len() as u64);
+                            metrics::counter!(TUPLES_AGGREGATED, "worker" => worker).increment(tuples.len() as u64);
                             for (t, count) in tuples {
                                 aggregator.add(t, count);
                             }
                         } else {
-                            metrics::counter!(EVENTS_FILTERED).increment(1);
+                            metrics::counter!(EVENTS_FILTERED, "worker" => worker).increment(1);
                         }
 
                         pending_offsets.insert(offset.partition(), offset);
@@ -79,6 +80,7 @@ pub async fn worker_loop<E, P, F>(
                                 &mut pending_offsets,
                                 &producer,
                                 FLUSH_REASON_BACKPRESSURE,
+                                worker,
                             ).await;
                         }
                     }
@@ -86,7 +88,7 @@ pub async fn worker_loop<E, P, F>(
                         // SingleTopicConsumer auto-stores poison-pill offsets.
                     }
                     Err(RecvErr::Kafka(e)) => {
-                        metrics::counter!(KAFKA_RECV_ERRORS).increment(1);
+                        metrics::counter!(KAFKA_RECV_ERRORS, "worker" => worker).increment(1);
                         warn!(error = %e, "kafka recv error");
                     }
                 }
@@ -104,6 +106,7 @@ pub(crate) async fn flush<P: Producer>(
     pending_offsets: &mut HashMap<i32, Offset>,
     producer: &P,
     reason: &'static str,
+    worker: &'static str,
 ) {
     if aggregator.is_empty() && pending_offsets.is_empty() {
         return;
@@ -111,11 +114,11 @@ pub(crate) async fn flush<P: Producer>(
 
     let snapshot: Vec<(TupleKey, u64)> = aggregator.drain().into_iter().collect();
 
-    metrics::counter!(FLUSH_TOTAL, "reason" => reason).increment(1);
-    metrics::histogram!(FLUSH_TUPLES).record(snapshot.len() as f64);
+    metrics::counter!(FLUSH_TOTAL, "reason" => reason, "worker" => worker).increment(1);
+    metrics::histogram!(FLUSH_TUPLES, "worker" => worker).record(snapshot.len() as f64);
 
     if let Err(e) = producer.produce(snapshot.clone()).await {
-        metrics::counter!(PRODUCER_FLUSH_FAILED).increment(1);
+        metrics::counter!(PRODUCER_FLUSH_FAILED, "worker" => worker).increment(1);
         error!(error = %e, "produce failed; restoring counts, retrying next flush");
         for (tuple, count) in snapshot {
             aggregator.add(tuple, count);
@@ -128,7 +131,7 @@ pub(crate) async fn flush<P: Producer>(
     // within ~5s; shutdown forces a sync commit.
     for (_partition, offset) in pending_offsets.drain() {
         if let Err(e) = offset.store() {
-            metrics::counter!(OFFSET_STORE_FAILED).increment(1);
+            metrics::counter!(OFFSET_STORE_FAILED, "worker" => worker).increment(1);
             warn!(error = %e, "failed to store offset; auto-commit will be a no-op for this partition until the next successful flush");
         }
     }
@@ -225,7 +228,14 @@ mod tests {
 
         let mut pending: HashMap<i32, Offset> = HashMap::new();
         let producer = MockProducer::new();
-        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+        )
+        .await;
 
         assert!(agg.is_empty());
         assert_eq!(producer.call_count(), 1);
@@ -239,7 +249,14 @@ mod tests {
 
         let mut pending: HashMap<i32, Offset> = HashMap::new();
         let producer = MockProducer::new().fail_on(1);
-        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+        )
+        .await;
 
         assert_eq!(
             agg.len(),
@@ -256,10 +273,24 @@ mod tests {
         let mut pending: HashMap<i32, Offset> = HashMap::new();
         let producer = MockProducer::new().fail_on(1);
 
-        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+        )
+        .await;
         assert!(!agg.is_empty());
 
-        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+        )
+        .await;
         assert!(agg.is_empty());
         assert_eq!(producer.call_count(), 2);
     }
@@ -269,7 +300,14 @@ mod tests {
         let mut agg = Aggregator::new();
         let mut pending: HashMap<i32, Offset> = HashMap::new();
         let producer = MockProducer::new();
-        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+        )
+        .await;
         assert_eq!(producer.call_count(), 0);
     }
 
@@ -280,11 +318,25 @@ mod tests {
 
         let mut pending: HashMap<i32, Offset> = HashMap::new();
         let producer = MockProducer::new().fail_on(1);
-        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+        )
+        .await;
 
         agg.add(tuple(2, "k1", "v1"), 1);
 
-        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+        )
+        .await;
 
         let batch = producer.last_items();
         assert_eq!(batch.len(), 1);
@@ -300,7 +352,14 @@ mod tests {
         let producer = MockProducer::new().fail_on(1).fail_on(2).fail_on(3);
 
         for _ in 0..3 {
-            flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
+            flush(
+                &mut agg,
+                &mut pending,
+                &producer,
+                FLUSH_REASON_TIMER,
+                "test",
+            )
+            .await;
         }
 
         assert_eq!(agg.len(), 1);
@@ -373,6 +432,7 @@ mod tests {
                             &mut pending,
                             &producer,
                             FLUSH_REASON_TIMER,
+                            "test",
                         ));
                     }
                 }


### PR DESCRIPTION
## Problem

The events, groups, and merger workers all share one `worker_loop` and increment the same unlabeled metrics counters. So `property_vals_rs_events_received_total` conflated the all-teams event firehose (events worker) with the merger consuming the internal `property_vals_intermediate` topic. This made the throughput panels unreadable: raising the rollout pushed "received" up purely from extra merger consumption, while the real firehose stayed flat, and there was no way to tell the two apart.

## Changes

Add a `worker` label (`events` | `groups` | `merger`) to the per-worker counters and histograms in `worker_loop` and `flush`: received, filtered, tuples_aggregated, flushes_total, flush_tuples, producer_flush_failed, offset_store_failed, kafka_recv_errors.

After this, `received{worker="events"}` is the true all-teams firehose (flat across rollout changes), separable from `received{worker="merger"}` (the internal shuffle traffic that scales with rollout). Existing `sum(rate(...))` panel queries keep working since they aggregate over the new label.

## How did you test this code?

I am an agent. Automated only:
- `cargo test -p property-vals-rs` (42 pass)
- `cargo clippy -p property-vals-rs --no-deps --all-targets` clean
- `cargo fmt -p property-vals-rs` no-op

## Publish to changelog?

no

## 🤖 Agent context

Follow-up to the two-stage merger (#60309, merged). Diagnosed while investigating why the "Events received / filtered" Grafana panel showed received rising on a rollout bump even though the events worker consumes the whole firehose regardless of rollout: the rise was the merger's intermediate-topic consumption landing in the same counter. The dashboard panels will be updated to use `worker="events"` once this image deploys.
