### PR TITLE
feat(auth): add passkey-2fa toggle to user admin

### DIFF
--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -49,6 +49,14 @@ class UserChangeForm(DjangoUserChangeForm):
 
         return is_staff
 
+    def clean_passkeys_enabled_for_2fa(self):
+        # Mirror the API-side guard in UserSerializer.validate_passkeys_enabled_for_2fa:
+        # only allow enabling if the user has a verified passkey.
+        value = bool(self.cleaned_data.get("passkeys_enabled_for_2fa", False))
+        if value and not WebauthnCredential.objects.filter(user=self.instance, verified=True).exists():
+            raise ValidationError("Cannot enable passkeys for 2FA — this user has no verified passkey.")
+        return value
+
 
 @admin.register(User)
 class UserAdmin(DjangoUserAdmin):
@@ -81,6 +89,7 @@ class UserAdmin(DjangoUserAdmin):
                     "strapi_id",
                     "revoke_sessions_link",
                     "two_factor_status",
+                    "passkeys_enabled_for_2fa",
                     "allow_impersonation",
                 )
             },

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -12,7 +12,6 @@ from posthog.admin.inlines.organization_member_inline import OrganizationMemberF
 from posthog.admin.inlines.plugin_attachment_inline import PluginAttachmentInline
 from posthog.models import User
 from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig
-from posthog.models.webauthn_credential import WebauthnCredential
 
 
 class TestOAuthSidebarRegrouping(BaseTest):
@@ -111,18 +110,6 @@ class TestUserAdmin(BaseTest):
 
         assert self.search_user_ids("missing-distinct-id") == []
 
-    def _make_passkey(self, user: User, *, verified: bool) -> None:
-        WebauthnCredential.objects.create(
-            user=user,
-            credential_id=b"cred",
-            label="Test passkey",
-            public_key=b"pk",
-            algorithm=-7,
-            counter=0,
-            transports=["internal"],
-            verified=verified,
-        )
-
     def test_clean_passkeys_enabled_for_2fa_rejects_when_user_has_no_verified_passkey(self) -> None:
         from django.core.exceptions import ValidationError
 
@@ -130,26 +117,6 @@ class TestUserAdmin(BaseTest):
         form.cleaned_data = {"passkeys_enabled_for_2fa": True}
         with self.assertRaises(ValidationError):
             form.clean_passkeys_enabled_for_2fa()
-
-    def test_clean_passkeys_enabled_for_2fa_rejects_when_only_unverified_passkey_exists(self) -> None:
-        from django.core.exceptions import ValidationError
-
-        self._make_passkey(self.user, verified=False)
-        form = UserChangeForm(instance=self.user)
-        form.cleaned_data = {"passkeys_enabled_for_2fa": True}
-        with self.assertRaises(ValidationError):
-            form.clean_passkeys_enabled_for_2fa()
-
-    def test_clean_passkeys_enabled_for_2fa_allows_enable_when_verified_passkey_exists(self) -> None:
-        self._make_passkey(self.user, verified=True)
-        form = UserChangeForm(instance=self.user)
-        form.cleaned_data = {"passkeys_enabled_for_2fa": True}
-        assert form.clean_passkeys_enabled_for_2fa() is True
-
-    def test_clean_passkeys_enabled_for_2fa_allows_disable_regardless_of_passkey_state(self) -> None:
-        form = UserChangeForm(instance=self.user)
-        form.cleaned_data = {"passkeys_enabled_for_2fa": False}
-        assert form.clean_passkeys_enabled_for_2fa() is False
 
 
 class TestPluginAttachmentInline(BaseTest):

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -7,11 +7,12 @@ from django.test import RequestFactory
 
 from posthog.admin import _OAUTH_ADMIN_MODEL_NAMES, install_admin_app_list_overrides
 from posthog.admin.admins.event_ingestion_restriction_config import EventIngestionRestrictionConfigAdmin
-from posthog.admin.admins.user_admin import UserAdmin
+from posthog.admin.admins.user_admin import UserAdmin, UserChangeForm
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberForUserInline, OrganizationMemberInline
 from posthog.admin.inlines.plugin_attachment_inline import PluginAttachmentInline
 from posthog.models import User
 from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig
+from posthog.models.webauthn_credential import WebauthnCredential
 
 
 class TestOAuthSidebarRegrouping(BaseTest):
@@ -109,6 +110,46 @@ class TestUserAdmin(BaseTest):
         )
 
         assert self.search_user_ids("missing-distinct-id") == []
+
+    def _make_passkey(self, user: User, *, verified: bool) -> None:
+        WebauthnCredential.objects.create(
+            user=user,
+            credential_id=b"cred",
+            label="Test passkey",
+            public_key=b"pk",
+            algorithm=-7,
+            counter=0,
+            transports=["internal"],
+            verified=verified,
+        )
+
+    def test_clean_passkeys_enabled_for_2fa_rejects_when_user_has_no_verified_passkey(self) -> None:
+        from django.core.exceptions import ValidationError
+
+        form = UserChangeForm(instance=self.user)
+        form.cleaned_data = {"passkeys_enabled_for_2fa": True}
+        with self.assertRaises(ValidationError):
+            form.clean_passkeys_enabled_for_2fa()
+
+    def test_clean_passkeys_enabled_for_2fa_rejects_when_only_unverified_passkey_exists(self) -> None:
+        from django.core.exceptions import ValidationError
+
+        self._make_passkey(self.user, verified=False)
+        form = UserChangeForm(instance=self.user)
+        form.cleaned_data = {"passkeys_enabled_for_2fa": True}
+        with self.assertRaises(ValidationError):
+            form.clean_passkeys_enabled_for_2fa()
+
+    def test_clean_passkeys_enabled_for_2fa_allows_enable_when_verified_passkey_exists(self) -> None:
+        self._make_passkey(self.user, verified=True)
+        form = UserChangeForm(instance=self.user)
+        form.cleaned_data = {"passkeys_enabled_for_2fa": True}
+        assert form.clean_passkeys_enabled_for_2fa() is True
+
+    def test_clean_passkeys_enabled_for_2fa_allows_disable_regardless_of_passkey_state(self) -> None:
+        form = UserChangeForm(instance=self.user)
+        form.cleaned_data = {"passkeys_enabled_for_2fa": False}
+        assert form.clean_passkeys_enabled_for_2fa() is False
 
 
 class TestPluginAttachmentInline(BaseTest):


### PR DESCRIPTION
## Problem

Follow-up to #60503. While debugging that one, I had to flip `passkeys_enabled_for_2fa` for a stuck user via the prod Django shell — impersonation blocks all `/api/users/` writes, and the toggle wasn't surfaced anywhere in admin. Adding it so support can unblock similar cases.

## Changes

- Expose `passkeys_enabled_for_2fa` as an editable field on `UserAdmin`.
- Mirror the API-side guard (`UserSerializer.validate_passkeys_enabled_for_2fa`) in `UserChangeForm.clean_passkeys_enabled_for_2fa`: refuse to enable when the user has no verified passkey.

<img width="1138" height="221" alt="Screenshot 2026-05-29 at 00 09 30" src="https://github.com/user-attachments/assets/f9dfa3bb-90df-4cd3-bd9d-092a58ea016f" />

<img width="1044" height="115" alt="Screenshot 2026-05-29 at 00 09 38" src="https://github.com/user-attachments/assets/9baf7d3c-1101-46e1-ba38-3c8dccfd74fd" />


## Publish to changelog?

no