### PR TITLE
feat(flags): strip non-allowlisted $feature_flag_called properties at ingestion

### DIFF
--- a/nodejs/src/ingestion/common/metrics.ts
+++ b/nodejs/src/ingestion/common/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter, Summary } from 'prom-client'
+import { Counter, Histogram, Summary } from 'prom-client'
 
 export const pipelineStepErrorCounter = new Counter({
     name: 'events_pipeline_step_error_total',
@@ -48,4 +48,21 @@ export const droppedBloatPropertyCounter = new Counter({
     name: 'ingestion_dropped_bloat_property_total',
     help: 'Count of deprecated posthog-js persistence-cache properties stripped from event payloads before ClickHouse write (see strip-bloat-properties.ts BLOAT_PROPERTIES).',
     labelNames: ['property'],
+})
+
+export const strippedFeatureFlagCalledPropertyCounter = new Counter({
+    name: 'ingestion_stripped_feature_flag_called_property_total',
+    help: 'Count of non-whitelisted properties stripped from $feature_flag_called events before ClickHouse write (see strip-bloat-properties.ts FEATURE_FLAG_CALLED_KEEP). Unlabelled: stripped key names are user-controlled and would create unbounded Prometheus label cardinality.',
+})
+
+export const featureFlagCalledPropertyCountHistogram = new Histogram({
+    name: 'ingestion_feature_flag_called_property_count',
+    help: 'Number of properties present on a $feature_flag_called event before stripping. Surfaces property-count outliers driving per-event strip cost (see strip-bloat-properties.ts stripFeatureFlagCalledProperties).',
+    buckets: [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, Infinity],
+})
+
+export const featureFlagCalledStripOutcomeCounter = new Counter({
+    name: 'ingestion_feature_flag_called_strip_outcome_total',
+    help: 'Per-event outcome of $feature_flag_called property stripping. outcome="stripped" when the allowlist strip ran; outcome="kept_multivariate" when stripping was skipped because $feature_flag_response is a variant string (a potential experiment exposure, see strip-bloat-properties.ts).',
+    labelNames: ['outcome'],
 })

--- a/nodejs/src/ingestion/common/steps/event-processing/event-pipeline-options.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/event-pipeline-options.ts
@@ -1,3 +1,5 @@
+import { ValueMatcher } from '~/types'
+
 export interface EventPipelineRunnerOptions {
     SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
     PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
@@ -10,4 +12,7 @@ export interface EventPipelineRunnerOptions {
     PERSON_PROPERTIES_UPDATE_ALL: boolean
     /** Teams whose $feature_flag_called events default to personless: '*' for all, '' to disable, or comma-separated team IDs */
     FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: string
+    // Teams opted out of `$feature_flag_called` property stripping. Built once at
+    // startup so the matcher isn't rebuilt per event.
+    stripFeatureFlagCalledExcludedTeams: ValueMatcher<number>
 }

--- a/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.test.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon'
 import { Message } from 'node-rdkafka'
 
+import { featureFlagCalledPropertyCountHistogram } from '~/ingestion/common/metrics'
 import { parseEventTimestamp } from '~/ingestion/common/timestamps'
 import { PipelineResultType } from '~/ingestion/framework/results'
 import { PluginEvent } from '~/plugin-scaffold'
@@ -28,14 +29,20 @@ type TestInput = {
 describe('createPrepareEventStep', () => {
     let mockEvent: PluginEvent
     let mockTeam: Team
+    let observeHistogram: jest.SpyInstance
 
     beforeEach(() => {
         jest.clearAllMocks()
 
         mockEvent = createTestPluginEvent({ properties: { key: 'value' } })
         mockTeam = createTestTeam()
+        observeHistogram = jest.spyOn(featureFlagCalledPropertyCountHistogram, 'observe').mockImplementation()
 
         jest.mocked(parseEventTimestamp).mockReturnValue(DateTime.fromISO('2023-01-01T00:00:00.000Z'))
+    })
+
+    afterEach(() => {
+        observeHistogram.mockRestore()
     })
 
     const createInput = (overrides: Partial<TestInput> = {}): TestInput => ({
@@ -131,6 +138,161 @@ describe('createPrepareEventStep', () => {
         if (result.type === PipelineResultType.OK) {
             expect(result.value.preparedEvent.properties).toEqual({ other: 'kept' })
         }
+    })
+
+    it('should strip non-whitelisted properties on $feature_flag_called events with a non-variant response', async () => {
+        const event = createTestPluginEvent({
+            event: '$feature_flag_called',
+            properties: {
+                $feature_flag: 'my-flag',
+                $feature_flag_response: false,
+                '$feature/my-flag': false,
+                environment: 'production',
+                plan: 'pro',
+                $active_feature_flags: ['flag-a'],
+            },
+        })
+
+        const step = createPrepareEventStep<TestInput>()
+        const result = await step(createInput({ normalizedEvent: event }))
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.preparedEvent.properties).toEqual({
+                $feature_flag: 'my-flag',
+                $feature_flag_response: false,
+                '$feature/my-flag': false,
+                $active_feature_flags: ['flag-a'],
+            })
+        }
+    })
+
+    it('keeps all properties on $feature_flag_called events with a variant response (experiment exposure)', async () => {
+        const event = createTestPluginEvent({
+            event: '$feature_flag_called',
+            properties: {
+                $feature_flag: 'my-flag',
+                $feature_flag_response: 'test',
+                '$feature/my-flag': 'test',
+                environment: 'production',
+                plan: 'pro',
+                $active_feature_flags: ['flag-a'],
+            },
+        })
+
+        const step = createPrepareEventStep<TestInput>()
+        const result = await step(createInput({ normalizedEvent: event }))
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.preparedEvent.properties).toEqual({
+                $feature_flag: 'my-flag',
+                $feature_flag_response: 'test',
+                '$feature/my-flag': 'test',
+                environment: 'production',
+                plan: 'pro',
+                $active_feature_flags: ['flag-a'],
+            })
+        }
+    })
+
+    it('should strip both bloat and non-whitelisted properties on $feature_flag_called events', async () => {
+        const event = createTestPluginEvent({
+            event: '$feature_flag_called',
+            properties: {
+                $feature_flag: 'my-flag',
+                ph_product_tours: { heavy: 'cache-blob' },
+                $product_tours_activated: true,
+                environment: 'production',
+            },
+        })
+
+        const step = createPrepareEventStep<TestInput>()
+        const result = await step(createInput({ normalizedEvent: event }))
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.preparedEvent.properties).toEqual({ $feature_flag: 'my-flag' })
+        }
+    })
+
+    it.each([
+        {
+            desc: 'keeps all properties for an opted-out team',
+            teamId: 42,
+            expected: { $feature_flag: 'my-flag', environment: 'production', $active_feature_flags: ['flag-a'] },
+        },
+        {
+            desc: 'strips non-whitelisted properties for a team not in the opt-out list',
+            teamId: 7,
+            expected: { $feature_flag: 'my-flag', $active_feature_flags: ['flag-a'] },
+        },
+    ])('$desc on $feature_flag_called events', async ({ teamId, expected }) => {
+        const event = createTestPluginEvent({
+            event: '$feature_flag_called',
+            properties: { $feature_flag: 'my-flag', environment: 'production', $active_feature_flags: ['flag-a'] },
+        })
+
+        const step = createPrepareEventStep<TestInput>((id) => id === 42)
+        const result = await step(createInput({ normalizedEvent: event, team: createTestTeam({ id: teamId }) }))
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.preparedEvent.properties).toEqual(expected)
+        }
+    })
+
+    it('should not strip properties on non $feature_flag_called events', async () => {
+        const event = createTestPluginEvent({
+            event: '$pageview',
+            properties: {
+                environment: 'production',
+                plan: 'pro',
+                $active_feature_flags: ['flag-a'],
+                custom: 'kept',
+            },
+        })
+
+        const step = createPrepareEventStep<TestInput>()
+        const result = await step(createInput({ normalizedEvent: event }))
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.preparedEvent.properties).toEqual({
+                environment: 'production',
+                plan: 'pro',
+                $active_feature_flags: ['flag-a'],
+                custom: 'kept',
+            })
+        }
+    })
+
+    it.each([
+        { desc: 'a stripped team', excludedTeams: undefined },
+        { desc: 'an opted-out team', excludedTeams: (teamId: number) => teamId === 42 },
+    ])('observes the pre-strip property count on $feature_flag_called events for $desc', async ({ excludedTeams }) => {
+        const event = createTestPluginEvent({
+            event: '$feature_flag_called',
+            properties: { $feature_flag: 'my-flag', environment: 'production', plan: 'pro' },
+        })
+
+        const step = createPrepareEventStep<TestInput>(excludedTeams)
+        await step(createInput({ normalizedEvent: event, team: createTestTeam({ id: 42 }) }))
+
+        expect(observeHistogram).toHaveBeenCalledTimes(1)
+        expect(observeHistogram).toHaveBeenCalledWith(3)
+    })
+
+    it('does not observe the property count on non $feature_flag_called events', async () => {
+        const event = createTestPluginEvent({
+            event: '$pageview',
+            properties: { environment: 'production', plan: 'pro' },
+        })
+
+        const step = createPrepareEventStep<TestInput>()
+        await step(createInput({ normalizedEvent: event }))
+
+        expect(observeHistogram).not.toHaveBeenCalled()
     })
 
     it('should only strip exact matches, not substring matches', async () => {

--- a/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.ts
@@ -1,10 +1,6 @@
-
 import { sanitizeEventName } from '~/common/utils/db/utils'
 import { IngestionWarningType } from '~/ingestion/common/ingestion-warnings'
-import {
-    featureFlagCalledPropertyCountHistogram,
-    invalidTimestampCounter,
-} from '~/ingestion/common/metrics'
+import { featureFlagCalledPropertyCountHistogram, invalidTimestampCounter } from '~/ingestion/common/metrics'
 import { parseEventTimestamp } from '~/ingestion/common/timestamps'
 import { PipelineWarning } from '~/ingestion/framework/pipeline.interface'
 import { ok } from '~/ingestion/framework/results'

--- a/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.ts
@@ -1,14 +1,22 @@
+
 import { sanitizeEventName } from '~/common/utils/db/utils'
 import { IngestionWarningType } from '~/ingestion/common/ingestion-warnings'
-import { invalidTimestampCounter } from '~/ingestion/common/metrics'
+import {
+    featureFlagCalledPropertyCountHistogram,
+    invalidTimestampCounter,
+} from '~/ingestion/common/metrics'
 import { parseEventTimestamp } from '~/ingestion/common/timestamps'
 import { PipelineWarning } from '~/ingestion/framework/pipeline.interface'
 import { ok } from '~/ingestion/framework/results'
 import { ProcessingStep } from '~/ingestion/framework/steps'
 import { PluginEvent } from '~/plugin-scaffold'
-import { EventHeaders, ISOTimestamp, PreIngestionEvent, Team } from '~/types'
+import { EventHeaders, ISOTimestamp, PreIngestionEvent, Team, ValueMatcher } from '~/types'
 
-import { stripBloatProperties } from './strip-bloat-properties'
+import {
+    FEATURE_FLAG_CALLED_EVENT,
+    stripBloatProperties,
+    stripFeatureFlagCalledProperties,
+} from './strip-bloat-properties'
 
 export type PrepareEventStepInput = {
     normalizedEvent: PluginEvent
@@ -22,10 +30,12 @@ export type PrepareEventStepResult<TInput> = Omit<TInput, 'normalizedEvent'> & {
     historicalMigration: boolean
 }
 
-export function createPrepareEventStep<TInput extends PrepareEventStepInput>(): ProcessingStep<
-    TInput,
-    PrepareEventStepResult<TInput>
-> {
+export function createPrepareEventStep<TInput extends PrepareEventStepInput>(
+    // Teams opted out of `$feature_flag_called` property stripping. Built once at
+    // startup via buildIntegerMatcher; `*` disables stripping globally. Defaults
+    // to no exclusions so every team is stripped.
+    stripFeatureFlagCalledExcludedTeams: ValueMatcher<number> = () => false
+): ProcessingStep<TInput, PrepareEventStepResult<TInput>> {
     return function prepareEventStep(input: TInput) {
         const { normalizedEvent, ...rest } = input
 
@@ -43,6 +53,13 @@ export function createPrepareEventStep<TInput extends PrepareEventStepInput>(): 
         }
 
         stripBloatProperties(properties)
+
+        if (sanitizedEventName === FEATURE_FLAG_CALLED_EVENT) {
+            const propertyCount = stripFeatureFlagCalledExcludedTeams(input.team.id)
+                ? Object.keys(properties).length
+                : stripFeatureFlagCalledProperties(properties)
+            featureFlagCalledPropertyCountHistogram.observe(propertyCount)
+        }
 
         const timestamp = parseEventTimestamp(normalizedEvent, invalidTimestampCallback)
 

--- a/nodejs/src/ingestion/common/steps/event-processing/strip-bloat-properties.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/strip-bloat-properties.test.ts
@@ -1,14 +1,31 @@
-import { droppedBloatPropertyCounter } from '~/ingestion/common/metrics'
+import {
+    droppedBloatPropertyCounter,
+    featureFlagCalledStripOutcomeCounter,
+    strippedFeatureFlagCalledPropertyCounter,
+} from '~/ingestion/common/metrics'
 
-import { BLOAT_PROPERTIES, stripBloatProperties } from './strip-bloat-properties'
+import {
+    BLOAT_PROPERTIES,
+    FEATURE_FLAG_CALLED_KEEP,
+    stripBloatProperties,
+    stripFeatureFlagCalledProperties,
+} from './strip-bloat-properties'
 
 jest.mock('~/ingestion/common/metrics', () => ({
     droppedBloatPropertyCounter: {
         labels: jest.fn().mockReturnValue({ inc: jest.fn() }),
     },
+    strippedFeatureFlagCalledPropertyCounter: {
+        inc: jest.fn(),
+    },
+    featureFlagCalledStripOutcomeCounter: {
+        labels: jest.fn().mockReturnValue({ inc: jest.fn() }),
+    },
 }))
 
-const mockLabels = jest.mocked(droppedBloatPropertyCounter.labels)
+const mockBloatLabels = jest.mocked(droppedBloatPropertyCounter.labels)
+const mockFlagInc = jest.mocked(strippedFeatureFlagCalledPropertyCounter.inc)
+const mockOutcomeLabels = jest.mocked(featureFlagCalledStripOutcomeCounter.labels)
 
 describe('stripBloatProperties', () => {
     beforeEach(() => {
@@ -22,8 +39,8 @@ describe('stripBloatProperties', () => {
 
         expect(properties).not.toHaveProperty(bloatKey)
         expect(properties).toEqual({ other: 'kept' })
-        expect(mockLabels).toHaveBeenCalledTimes(1)
-        expect(mockLabels).toHaveBeenCalledWith(bloatKey)
+        expect(mockBloatLabels).toHaveBeenCalledTimes(1)
+        expect(mockBloatLabels).toHaveBeenCalledWith(bloatKey)
     })
 
     it('strips every bloat property present and increments the counter once per stripped key', () => {
@@ -33,9 +50,9 @@ describe('stripBloatProperties', () => {
         stripBloatProperties(properties)
 
         expect(properties).toEqual({ other: 'kept' })
-        expect(mockLabels).toHaveBeenCalledTimes(BLOAT_PROPERTIES.size)
+        expect(mockBloatLabels).toHaveBeenCalledTimes(BLOAT_PROPERTIES.size)
         for (const key of BLOAT_PROPERTIES) {
-            expect(mockLabels).toHaveBeenCalledWith(key)
+            expect(mockBloatLabels).toHaveBeenCalledWith(key)
         }
     })
 
@@ -45,7 +62,7 @@ describe('stripBloatProperties', () => {
         stripBloatProperties(properties)
 
         expect(properties).toEqual({ other: 'kept', another: 'also-kept' })
-        expect(mockLabels).not.toHaveBeenCalled()
+        expect(mockBloatLabels).not.toHaveBeenCalled()
     })
 
     it('only strips exact matches, not substring matches', () => {
@@ -64,6 +81,233 @@ describe('stripBloatProperties', () => {
             $product_tours_activated_at: 'kept',
             my_$override_feature_flag_payloads: 'kept',
         })
-        expect(mockLabels).not.toHaveBeenCalled()
+        expect(mockBloatLabels).not.toHaveBeenCalled()
+    })
+})
+
+describe('stripFeatureFlagCalledProperties', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it.each([
+        '$feature_flag',
+        '$feature_flag_response',
+        '$feature_flag_id',
+        '$feature_flag_version',
+        '$feature_flag_request_id',
+        '$set',
+        '$groups',
+        '$group_0',
+        '$group_1',
+        '$group_2',
+        '$group_3',
+        '$group_4',
+        '$lib',
+        '$lib_version',
+    ])('keeps business-critical whitelist key %s pinned in FEATURE_FLAG_CALLED_KEEP', (key) => {
+        expect(FEATURE_FLAG_CALLED_KEEP.has(key)).toBe(true)
+    })
+
+    it.each([...FEATURE_FLAG_CALLED_KEEP])('preserves whitelisted key %s', (key) => {
+        const properties: Record<string, any> = { [key]: 'value' }
+
+        stripFeatureFlagCalledProperties(properties)
+
+        expect(properties).toEqual({ [key]: 'value' })
+        expect(mockFlagInc).not.toHaveBeenCalled()
+    })
+
+    it.each(['$feature/my-flag', '$feature/another-flag', '$feature/flag-with-many-dashes-in-name', '$feature/'])(
+        'preserves $feature/ prefixed key %s',
+        (key) => {
+            const properties: Record<string, any> = { [key]: 'variant-a' }
+
+            stripFeatureFlagCalledProperties(properties)
+
+            expect(properties).toEqual({ [key]: 'variant-a' })
+            expect(mockFlagInc).not.toHaveBeenCalled()
+        }
+    )
+
+    it.each([
+        '$initial_current_url',
+        '$initial_referrer',
+        '$initial_utm_source',
+        '$initial_os',
+        '$initial_geoip_country_code',
+        '$session_entry_url',
+        '$session_entry_utm_campaign',
+        '$session_entry_referring_domain',
+    ])('preserves first-touch / session-entry prefixed key %s', (key) => {
+        const properties: Record<string, any> = { [key]: 'value' }
+
+        stripFeatureFlagCalledProperties(properties)
+
+        expect(properties).toEqual({ [key]: 'value' })
+        expect(mockFlagInc).not.toHaveBeenCalled()
+    })
+
+    it.each([
+        'utm_source',
+        '$referrer',
+        '$referring_domain',
+        '$raw_user_agent',
+        '$os_name',
+        '$device_manufacturer',
+        '$channel_type',
+        '$user_id',
+        '$active_feature_flags',
+    ])('preserves standard PostHog auto-captured property %s', (key) => {
+        const properties: Record<string, any> = { [key]: 'value' }
+
+        stripFeatureFlagCalledProperties(properties)
+
+        expect(properties).toEqual({ [key]: 'value' })
+        expect(mockFlagInc).not.toHaveBeenCalled()
+    })
+
+    it.each(['environment', 'platform', 'amount', 'plan', 'revenue', 'variant', 'random_key'])(
+        'strips non-whitelisted key %s and increments the counter',
+        (key) => {
+            const properties: Record<string, any> = { [key]: 'leaked', $feature_flag: 'kept' }
+
+            stripFeatureFlagCalledProperties(properties)
+
+            expect(properties).not.toHaveProperty(key)
+            expect(properties).toEqual({ $feature_flag: 'kept' })
+            expect(mockFlagInc).toHaveBeenCalledTimes(1)
+            expect(mockFlagInc).toHaveBeenCalledWith(1)
+        }
+    )
+
+    it('preserves whitelisted and $feature/ keys while stripping the rest', () => {
+        const properties: Record<string, any> = {
+            $feature_flag: 'flag-key',
+            $feature_flag_response: true,
+            '$feature/my-flag': 'variant-a',
+            '$feature/another-flag': false,
+            $lib: 'web',
+            $current_url: 'https://example.com',
+            $group_0: 'org-123',
+            $groups: { organization: 'acme' },
+            $set: { plan: 'pro' },
+            environment: 'production',
+            plan: 'pro',
+            $active_feature_flags: ['flag-a', 'flag-b'],
+        }
+
+        stripFeatureFlagCalledProperties(properties)
+
+        expect(properties).toEqual({
+            $feature_flag: 'flag-key',
+            $feature_flag_response: true,
+            '$feature/my-flag': 'variant-a',
+            '$feature/another-flag': false,
+            $lib: 'web',
+            $current_url: 'https://example.com',
+            $group_0: 'org-123',
+            $groups: { organization: 'acme' },
+            $set: { plan: 'pro' },
+            $active_feature_flags: ['flag-a', 'flag-b'],
+        })
+        expect(mockFlagInc).toHaveBeenCalledTimes(1)
+        expect(mockFlagInc).toHaveBeenCalledWith(2)
+    })
+
+    it('leaves properties empty when every key is non-whitelisted', () => {
+        const properties: Record<string, any> = { environment: 'prod', plan: 'pro', custom: 'x' }
+
+        stripFeatureFlagCalledProperties(properties)
+
+        expect(properties).toEqual({})
+        expect(mockFlagInc).toHaveBeenCalledTimes(1)
+        expect(mockFlagInc).toHaveBeenCalledWith(3)
+    })
+
+    it('is a no-op on empty properties', () => {
+        const properties: Record<string, any> = {}
+
+        stripFeatureFlagCalledProperties(properties)
+
+        expect(properties).toEqual({})
+        expect(mockFlagInc).not.toHaveBeenCalled()
+    })
+
+    it('only matches the $feature/ prefix at the start of the key, not as a substring', () => {
+        const properties: Record<string, any> = {
+            'has_$feature/in_middle': 'stripped',
+            'feature/no-dollar': 'stripped',
+        }
+
+        stripFeatureFlagCalledProperties(properties)
+
+        expect(properties).toEqual({})
+        expect(mockFlagInc).toHaveBeenCalledTimes(1)
+        expect(mockFlagInc).toHaveBeenCalledWith(2)
+    })
+
+    it.each([
+        { desc: 'empty', properties: {}, expected: 0 },
+        { desc: 'all kept', properties: { $feature_flag: 'f', $lib: 'web' }, expected: 2 },
+        { desc: 'all stripped', properties: { environment: 'prod', plan: 'pro', custom: 'x' }, expected: 3 },
+        { desc: 'mixed', properties: { $feature_flag: 'f', '$feature/x': 1, environment: 'prod' }, expected: 3 },
+    ])('returns the pre-strip property count ($desc)', ({ properties, expected }) => {
+        expect(stripFeatureFlagCalledProperties({ ...properties })).toBe(expected)
+    })
+
+    it.each([
+        { desc: 'variant "control"', response: 'control' },
+        { desc: 'variant "test"', response: 'test' },
+        { desc: 'empty-string variant', response: '' },
+    ])(
+        'keeps all properties when $feature_flag_response is a variant string ($desc, experiment exposure)',
+        ({ response }) => {
+            const properties: Record<string, any> = {
+                $feature_flag: 'flag-key',
+                $feature_flag_response: response,
+                environment: 'production',
+                plan: 'pro',
+                $active_feature_flags: ['flag-a', 'flag-b'],
+                custom_breakdown_prop: 'mobile',
+            }
+            const unchanged = { ...properties }
+
+            stripFeatureFlagCalledProperties(properties)
+
+            expect(properties).toEqual(unchanged)
+            expect(mockFlagInc).not.toHaveBeenCalled()
+            expect(mockOutcomeLabels).toHaveBeenCalledWith('kept_multivariate')
+        }
+    )
+
+    it.each([
+        { desc: 'boolean true', response: true },
+        { desc: 'boolean false', response: false },
+        { desc: 'null', response: null },
+        { desc: 'number', response: 30 },
+        { desc: 'payload object', response: { enabled: false } },
+    ])('strips non-whitelisted keys when $feature_flag_response is not a variant string ($desc)', ({ response }) => {
+        const properties: Record<string, any> = {
+            $feature_flag: 'flag-key',
+            $feature_flag_response: response,
+            environment: 'production',
+        }
+
+        stripFeatureFlagCalledProperties(properties)
+
+        expect(properties).toEqual({ $feature_flag: 'flag-key', $feature_flag_response: response })
+        expect(mockFlagInc).toHaveBeenCalledWith(1)
+        expect(mockOutcomeLabels).toHaveBeenCalledWith('stripped')
+    })
+
+    it('strips non-whitelisted keys when $feature_flag_response is absent', () => {
+        const properties: Record<string, any> = { $feature_flag: 'flag-key', environment: 'production' }
+
+        stripFeatureFlagCalledProperties(properties)
+
+        expect(properties).toEqual({ $feature_flag: 'flag-key' })
+        expect(mockFlagInc).toHaveBeenCalledWith(1)
+        expect(mockOutcomeLabels).toHaveBeenCalledWith('stripped')
     })
 })

--- a/nodejs/src/ingestion/common/steps/event-processing/strip-bloat-properties.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/strip-bloat-properties.ts
@@ -1,4 +1,9 @@
-import { droppedBloatPropertyCounter } from '~/ingestion/common/metrics'
+import { eventToPersonProperties } from '~/common/persons/person-property-utils'
+import {
+    droppedBloatPropertyCounter,
+    featureFlagCalledStripOutcomeCounter,
+    strippedFeatureFlagCalledPropertyCounter,
+} from '~/ingestion/common/metrics'
 
 // Persistence cache keys that leak from older posthog-js versions into event
 // payloads. The SDK stopped sending these in posthog-js#3392; this server-side
@@ -17,4 +22,155 @@ export function stripBloatProperties(properties: Record<string, any>): void {
             droppedBloatPropertyCounter.labels(key).inc()
         }
     }
+}
+
+export const FEATURE_FLAG_CALLED_EVENT = '$feature_flag_called' as const
+
+// Prefixes whose keys are always preserved on `$feature_flag_called`. Each names
+// an open-ended PostHog property family: `$feature/<flag-key>` (one per evaluated
+// flag, server SDKs), `$initial_<prop>` (first-touch super-properties), and
+// `$session_entry_<prop>` (session entry-point context).
+export const FEATURE_FLAG_CALLED_KEEP_PREFIXES: readonly string[] = ['$feature/', '$initial_', '$session_entry_']
+
+// Allowed property keys on `$feature_flag_called` events. The event is
+// SDK-emitted with a fixed schema, but SDKs' cross-cutting methods (`register`,
+// super-properties) leak unrelated keys onto it. PostHog owns this event's
+// schema, so we strip non-whitelisted keys before ClickHouse persistence.
+// Compiled from auditing all PostHog SDKs, a `system.query_log` audit of
+// actively-used insights/cohorts referencing `$feature_flag_called`, and the CDP
+// legacy-plugin destination/transformation property mappings.
+export const FEATURE_FLAG_CALLED_KEEP: ReadonlySet<string> = new Set<string>([
+    // Flag-specific (SDK audit)
+    '$feature_flag',
+    '$feature_flag_response',
+    '$feature_flag_id',
+    '$feature_flag_version',
+    '$feature_flag_reason',
+    '$feature_flag_request_id',
+    '$feature_flag_evaluated_at',
+    '$feature_flag_error',
+    '$feature_flag_payload',
+    '$feature_flag_definitions_loaded_at',
+    'locally_evaluated',
+    '$feature_flag_bootstrapped_response',
+    '$feature_flag_bootstrapped_payload',
+    '$used_bootstrap_value',
+    '$feature_flag_original_response',
+    '$feature_flag_original_payload',
+
+    // SDK identification
+    '$lib',
+    '$lib_version',
+
+    // Active feature flags — CDP destinations (e.g. rudderstack-posthog,
+    // posthog-laudspeaker) map this onto `context.active_feature_flags`, so it must
+    // survive on `$feature_flag_called` events forwarded to those destinations.
+    '$active_feature_flags',
+
+    // Person/group writes consumed downstream — `$set` is mirrored into the
+    // event row's `person_properties` column by createEvent; `$groups` is
+    // consumed by processGroupsStep (the step immediately after prepareEvent)
+    // to populate the `$group_0..$group_4` columns. `$set_once`/`$unset`
+    // travel with `$set` for symmetry, and `$insert_id`/`$sent_at` are
+    // consumed by downstream destinations.
+    '$set',
+    '$set_once',
+    '$unset',
+    '$groups',
+    '$insert_id',
+    '$sent_at',
+
+    // Device / session identity
+    '$device_id',
+    '$session_id',
+    '$window_id',
+    '$is_identified',
+
+    // URL / page / screen context
+    '$current_url',
+    '$pathname',
+    '$host',
+    '$screen_name',
+
+    // Platform / device
+    '$device_type',
+    '$os',
+    '$browser',
+    '$app_version',
+
+    // GeoIP family
+    '$ip',
+    '$geoip_country_code',
+    '$geoip_country_name',
+    '$geoip_city_name',
+    '$geoip_continent_code',
+    '$geoip_continent_name',
+    '$geoip_latitude',
+    '$geoip_longitude',
+    '$geoip_postal_code',
+    '$geoip_time_zone',
+    '$geoip_subdivision_1_code',
+    '$geoip_subdivision_1_name',
+    '$geoip_subdivision_2_code',
+    '$geoip_subdivision_2_name',
+
+    // Groups
+    '$group_0',
+    '$group_1',
+    '$group_2',
+    '$group_3',
+    '$group_4',
+
+    // Standard PostHog auto-captured / super-properties (campaign + UTM, web and
+    // mobile device, OS, referrer, screen/viewport, raw user agent). Reused from
+    // the canonical person-property mapping list so the two stay in sync. Their
+    // `$initial_*` first-touch variants are kept via FEATURE_FLAG_CALLED_KEEP_PREFIXES.
+    ...eventToPersonProperties,
+
+    // Standard properties not in the person-mapping list above.
+    '$user_id',
+    '$anon_distinct_id',
+    '$device',
+    '$device_name',
+    '$device_model',
+    '$device_manufacturer',
+    '$channel_type',
+    '$event_type',
+    '$session_duration',
+    '$start_timestamp',
+    '$entry_current_url',
+    '$pageview_id',
+])
+
+// A variant-string `$feature_flag_response` marks a multivariate flag evaluation —
+// a possible experiment exposure whose breakdown/exposure properties must survive.
+// Every other response type (boolean, null, number, object, or absent) is stripped.
+function isMultivariateFlagResponse(properties: Record<string, any>): boolean {
+    return typeof properties['$feature_flag_response'] === 'string'
+}
+
+// Strips non-whitelisted keys and returns the property count seen before stripping.
+export function stripFeatureFlagCalledProperties(properties: Record<string, any>): number {
+    if (isMultivariateFlagResponse(properties)) {
+        featureFlagCalledStripOutcomeCounter.labels('kept_multivariate').inc()
+        return Object.keys(properties).length
+    }
+
+    const keys = Object.keys(properties)
+    let stripped = 0
+    for (const key of keys) {
+        if (FEATURE_FLAG_CALLED_KEEP.has(key)) {
+            continue
+        }
+        if (FEATURE_FLAG_CALLED_KEEP_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+            continue
+        }
+        delete properties[key]
+        stripped++
+    }
+    if (stripped > 0) {
+        strippedFeatureFlagCalledPropertyCounter.inc(stripped)
+    }
+    featureFlagCalledStripOutcomeCounter.labels('stripped').inc()
+    return keys.length
 }

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -189,10 +189,12 @@ export type IngestionConsumerConfig = {
     KAFKA_BATCH_START_LOGGING_ENABLED: boolean
     /** Teams whose $feature_flag_called events default to personless: '*' for all, '' to disable, or comma-separated team IDs */
     FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: string
+    /** Teams opted out of `$feature_flag_called` property stripping: '*' to disable globally, or comma-separated team IDs. Empty strips every team. */
+    STRIP_FEATURE_FLAG_CALLED_PROPERTIES_EXCLUDED_TEAMS: string
 
     // $feature_flag_called keep-first dedup config
-    /** 'disabled' | 'shadow' (claim + count, never drop) | 'drop' */
-    INGESTION_FEATURE_FLAG_CALLED_DEDUP_MODE: string
+/** 'disabled' | 'shadow' (claim + count, never drop) | 'drop' */
+INGESTION_FEATURE_FLAG_CALLED_DEDUP_MODE: string
     /** '*' for all teams, or comma-separated team IDs */
     INGESTION_FEATURE_FLAG_CALLED_DEDUP_TEAMS: string
     /** Comma-separated team IDs never deduped, even when TEAMS is '*' */
@@ -305,9 +307,12 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         EVENT_SCHEMA_ENFORCEMENT_ENABLED: true,
         KAFKA_BATCH_START_LOGGING_ENABLED: false,
         FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: DEFAULT_FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS,
+        // '*' disables stripping for everyone; the charts repo enables it by setting this
+        // to '' (all teams) or a comma-separated team list (all teams except those).
+        STRIP_FEATURE_FLAG_CALLED_PROPERTIES_EXCLUDED_TEAMS: '*',
 
         // $feature_flag_called keep-first dedup config
-        INGESTION_FEATURE_FLAG_CALLED_DEDUP_MODE: 'disabled',
+    INGESTION_FEATURE_FLAG_CALLED_DEDUP_MODE: 'disabled',
 
         INGESTION_FEATURE_FLAG_CALLED_DEDUP_TEAMS: '',
 

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -193,8 +193,8 @@ export type IngestionConsumerConfig = {
     STRIP_FEATURE_FLAG_CALLED_PROPERTIES_EXCLUDED_TEAMS: string
 
     // $feature_flag_called keep-first dedup config
-/** 'disabled' | 'shadow' (claim + count, never drop) | 'drop' */
-INGESTION_FEATURE_FLAG_CALLED_DEDUP_MODE: string
+    /** 'disabled' | 'shadow' (claim + count, never drop) | 'drop' */
+    INGESTION_FEATURE_FLAG_CALLED_DEDUP_MODE: string
     /** '*' for all teams, or comma-separated team IDs */
     INGESTION_FEATURE_FLAG_CALLED_DEDUP_TEAMS: string
     /** Comma-separated team IDs never deduped, even when TEAMS is '*' */
@@ -312,7 +312,7 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         STRIP_FEATURE_FLAG_CALLED_PROPERTIES_EXCLUDED_TEAMS: '*',
 
         // $feature_flag_called keep-first dedup config
-    INGESTION_FEATURE_FLAG_CALLED_DEDUP_MODE: 'disabled',
+        INGESTION_FEATURE_FLAG_CALLED_DEDUP_MODE: 'disabled',
 
         INGESTION_FEATURE_FLAG_CALLED_DEDUP_TEAMS: '',
 

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -584,6 +584,77 @@ describe('IngestionConsumer', () => {
         })
     })
 
+    describe('$feature_flag_called property stripping', () => {
+        beforeEach(async () => {
+            // Stripping defaults to disabled globally ('*'); enable it for every team
+            // so these tests exercise the strip behavior rather than the kill switch.
+            infra.config.STRIP_FEATURE_FLAG_CALLED_PROPERTIES_EXCLUDED_TEAMS = ''
+            ingester = await createIngestionConsumer(infra)
+        })
+
+        const propertiesOf = (event: string) => {
+            const messages = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
+            const message = messages.find((m) => (m.value as any).event === event)
+            return message ? parseJSON((message.value as any).properties) : undefined
+        }
+
+        const mixedProperties = {
+            $feature_flag: 'my-flag',
+            '$feature/my-flag': 'variant-a',
+            $lib: 'posthog-python',
+            $active_feature_flags: ['flag-a'],
+            environment: 'production',
+            my_custom_prop: 'leaked',
+        }
+
+        it('strips non-whitelisted properties from $feature_flag_called events but not from other events', async () => {
+            await ingester.handleKafkaBatch(
+                createKafkaMessages([
+                    createEvent({ event: '$feature_flag_called', properties: mixedProperties }),
+                    createEvent({ event: '$pageview', properties: mixedProperties }),
+                ])
+            )
+
+            const ffCalledProperties = propertiesOf('$feature_flag_called')
+            expect(ffCalledProperties).toMatchObject({
+                $feature_flag: 'my-flag',
+                '$feature/my-flag': 'variant-a',
+                $lib: 'posthog-python',
+                $active_feature_flags: ['flag-a'],
+            })
+            expect(ffCalledProperties).not.toHaveProperty('environment')
+            expect(ffCalledProperties).not.toHaveProperty('my_custom_prop')
+
+            // The same leaked keys survive on a non-$feature_flag_called event.
+            expect(propertiesOf('$pageview')).toMatchObject({
+                $active_feature_flags: ['flag-a'],
+                environment: 'production',
+                my_custom_prop: 'leaked',
+            })
+        })
+
+        it('keeps non-whitelisted properties on $feature_flag_called events with a variant response', async () => {
+            await ingester.handleKafkaBatch(
+                createKafkaMessages([
+                    createEvent({
+                        event: '$feature_flag_called',
+                        properties: { ...mixedProperties, $feature_flag_response: 'test' },
+                    }),
+                ])
+            )
+
+            // A variant response marks a multivariate flag — a potential experiment
+            // exposure — so the strip is skipped and breakdown properties survive.
+            expect(propertiesOf('$feature_flag_called')).toMatchObject({
+                $feature_flag: 'my-flag',
+                $feature_flag_response: 'test',
+                $active_feature_flags: ['flag-a'],
+                environment: 'production',
+                my_custom_prop: 'leaked',
+            })
+        })
+    })
+
     describe('dropping events', () => {
         it('should DLQ $exception events (wrong consumer)', async () => {
             const messages = createKafkaMessages([

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -2,6 +2,7 @@ import { Message } from 'node-rdkafka'
 import { Gauge, Histogram } from 'prom-client'
 
 import { CommonConfig } from '~/common/config'
+import { buildIntegerMatcher } from '~/common/config/config'
 import { GroupTypeManager } from '~/common/groups/group-type-manager'
 import { ClickhouseGroupRepository } from '~/common/groups/repositories/clickhouse-group-repository'
 import { GroupRepository } from '~/common/groups/repositories/group-repository.interface'
@@ -286,6 +287,10 @@ export class IngestionConsumer {
                 PERSON_JSONB_SIZE_ESTIMATE_ENABLE: this.config.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
                 PERSON_PROPERTIES_UPDATE_ALL: this.config.PERSON_PROPERTIES_UPDATE_ALL,
                 FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: this.config.FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS,
+                stripFeatureFlagCalledExcludedTeams: buildIntegerMatcher(
+                    this.config.STRIP_FEATURE_FLAG_CALLED_PROPERTIES_EXCLUDED_TEAMS,
+                    true
+                ),
             },
             concurrentBatches: this.config.INGESTION_WORKER_CONCURRENT_BATCHES,
         }

--- a/nodejs/src/ingestion/pipelines/ai/pipelines/ai-event-subpipeline.ts
+++ b/nodejs/src/ingestion/pipelines/ai/pipelines/ai-event-subpipeline.ts
@@ -78,7 +78,7 @@ export function createAiEventSubpipeline<TInput extends AiEventSubpipelineInput,
             ]),
             { retry: { tries: 5, sleepMs: 100, name: 'process_persons' } }
         )
-        .pipe(createPrepareEventStep())
+        .pipe(createPrepareEventStep(options.stripFeatureFlagCalledExcludedTeams))
         .pipe(createProcessGroupsStep(teamManager, groupTypeManager, options), {
             retry: { tries: 5, sleepMs: 100, name: 'process_groups' },
         })

--- a/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
@@ -135,7 +135,7 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
             ]),
             { retry: { tries: 5, sleepMs: 100, name: 'process_persons' } }
         )
-        .pipe(createPrepareEventStep())
+        .pipe(createPrepareEventStep(options.stripFeatureFlagCalledExcludedTeams))
         .pipe(
             topHog(createProcessGroupsStep(teamManager, groupTypeManager, options), [
                 timer('process_groups_time', (input) => ({

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -3,7 +3,7 @@ import { Counter, Gauge, Histogram } from 'prom-client'
 
 import { IntegrationManagerService } from '~/cdp/services/managers/integration-manager.service'
 import { initializePrometheusLabels } from '~/common/api/router'
-import { defaultConfig, overrideConfigWithEnv } from '~/common/config/config'
+import { buildIntegerMatcher, defaultConfig, overrideConfigWithEnv } from '~/common/config/config'
 import {
     createCookielessRedisConnectionConfig,
     createFeatureFlagCalledDedupRedisConnectionConfig,
@@ -392,6 +392,10 @@ export class IngestionApiServer implements NodeServer {
                 PERSON_JSONB_SIZE_ESTIMATE_ENABLE: this.config.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
                 PERSON_PROPERTIES_UPDATE_ALL: this.config.PERSON_PROPERTIES_UPDATE_ALL,
                 FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: this.config.FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS,
+                stripFeatureFlagCalledExcludedTeams: buildIntegerMatcher(
+                    this.config.STRIP_FEATURE_FLAG_CALLED_PROPERTIES_EXCLUDED_TEAMS,
+                    true
+                ),
             },
             concurrentBatches: this.config.INGESTION_WORKER_CONCURRENT_BATCHES,
         }

--- a/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
+++ b/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
@@ -52,6 +52,7 @@ describe('createProcessPersonsStep', () => {
         PERSON_JSONB_SIZE_ESTIMATE_ENABLE: 0,
         PERSON_PROPERTIES_UPDATE_ALL: false,
         FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: '*',
+        stripFeatureFlagCalledExcludedTeams: () => false,
     }
 
     beforeEach(async () => {

--- a/nodejs/tests/ingestion/pipelines/ai/pipelines/ai-event-subpipeline.integration.test.ts
+++ b/nodejs/tests/ingestion/pipelines/ai/pipelines/ai-event-subpipeline.integration.test.ts
@@ -100,6 +100,7 @@ function buildPipeline(configOverrides: Partial<AiEventSubpipelineConfig> = {}) 
             PERSON_JSONB_SIZE_ESTIMATE_ENABLE: 0,
             PERSON_PROPERTIES_UPDATE_ALL: false,
             FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: '*',
+            stripFeatureFlagCalledExcludedTeams: () => false,
         },
         outputs: mockOutputs,
         teamManager: {


### PR DESCRIPTION
## Problem

`$feature_flag_called` is a system event. The SDKs emit it automatically with a fixed set of properties, it's billing-exempt (it doesn't count against a customer's event volume), and we own its schema. Since nobody's paying for these events, there's no reason for arbitrary properties to ride along on them, but they do. SDK methods like `register` and super properties leak unrelated properties onto every event, and a few client-side persistence caches have dumped large blobs onto them too. The result is ClickHouse storage filled with data that has no meaning on this particular event.

posthog-js #3392 and #3393 fixed the persistence-cache leak, but that fix only takes effect once customers upgrade their SDK. This strips the properties server-side, so it works no matter what version a client is pinned to.

## Changes

The ingestion `prepareEventStep` now enforces an allowlist (`FEATURE_FLAG_CALLED_KEEP`). Anything not on the list gets removed before the event hits ClickHouse. Keys prefixed with `$feature/`, `$initial_`, or `$session_entry_` are kept, along with the standard PostHog auto-captured and super properties. `$active_feature_flags` is also kept, because some CDP legacy-plugin destinations (rudderstack-posthog, posthog-laudspeaker) map it onto `context.active_feature_flags` and dropping it would break them.

There's one important exception. When `$feature_flag_response` is a string variant, which only happens for multivariate flags (the kind experiments run on), we keep everything. Experiment breakdowns and custom exposure criteria filter on arbitrary event properties, so stripping there would quietly break them. Boolean, null, numeric, object, and missing responses all get stripped.

Stripping is gated per team through `STRIP_FEATURE_FLAG_CALLED_PROPERTIES_EXCLUDED_TEAMS` (a comma-separated list of team IDs, with `*` as a global kill switch). It defaults to `*`, so stripping is off everywhere until we're ready to ramp it.

One bug worth calling out: the testing subpipelines (`testing-event-subpipeline`, `testing-per-distinct-id-pipeline`, and the rest) were calling `createPrepareEventStep()` without passing the matcher through. That meant the kill switch was ignored and stripping ran unconditionally in testing mode, regardless of config. The matcher now threads through all of them, so testing mode behaves like production.

For visibility once this rolls out, there's a histogram of the property count per event before stripping, and a counter that records whether each event was kept (`kept_multivariate`) or stripped.

The existing `stripBloatProperties` denylist (the posthog-js persistence-cache keys) hasn't changed and still runs on every event.

## How did you test this code?

Unit tests cover the strip logic, the allowlist and the three prefixes, the multivariate gate (string variant keeps everything; boolean, null, numeric, object, and missing all strip), the per-team opt-out, the global kill switch, the histogram (including that it still fires for opted-out teams), and the per-event counter. There's also an ingestion-consumer integration test that runs a `$feature_flag_called` event and a `$pageview` control through the real consumer and checks that the leaked keys are gone from the flag event and untouched on the pageview.

I also exercised the full path by hand on a local stack, sending events through capture, Kafka, and ingestion and reading the persisted rows back out of ClickHouse.

<details>
<summary>Manual end-to-end checklist</summary>

- [x] `$feature_flag_called`, boolean response, stripping on → junk properties stripped; allowlist and the `$feature/` / `$initial_` / `$session_entry_` prefixes kept
- [x] `$feature_flag_called`, string-variant response → all properties kept (multivariate gate)
- [x] `STRIP_..._EXCLUDED_TEAMS=*` → boolean event kept (global kill switch disables stripping)
- [x] Excluded-teams list containing the team → kept (per-team opt-out)
- [x] Excluded-teams list without the team → stripped (a non-empty list still strips everyone not named)
- [x] `$pageview` carrying the same junk properties while stripping active → kept (strip only applies to `$feature_flag_called`)

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change.

## Additional Context

Comms plan: https://github.com/PostHog/requests-for-comments-public/issues/553