### PR TITLE
chore(taxonomic-filter): three pre-existing cleanups

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/recentPinnedTabDefinitions.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/recentPinnedTabDefinitions.ts
@@ -1,0 +1,37 @@
+import { recentTaxonomicFiltersLogic } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
+import { taxonomicFilterPinnedPropertiesLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
+import {
+    TaxonomicDefinitionTypes,
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterValue,
+} from 'lib/components/TaxonomicFilter/types'
+
+export const RECENT_PINNED_TAB_DEFINITIONS = [
+    {
+        name: 'Recent',
+        searchPlaceholder: 'recent',
+        type: TaxonomicFilterGroupType.RecentFilters,
+        isLocalOnly: true,
+        isMetaGroup: true,
+        logic: recentTaxonomicFiltersLogic,
+        value: 'recentFilterItems',
+        getName: (item: TaxonomicDefinitionTypes) => ('name' in item ? item.name : '') || '',
+        getValue: (item: TaxonomicDefinitionTypes): TaxonomicFilterValue =>
+            'name' in item ? (item.name ?? null) : null,
+        getPopoverHeader: () => 'Recent',
+    },
+    {
+        name: 'Pinned',
+        searchPlaceholder: 'pinned',
+        type: TaxonomicFilterGroupType.PinnedFilters,
+        isLocalOnly: true,
+        isMetaGroup: true,
+        logic: taxonomicFilterPinnedPropertiesLogic,
+        value: 'pinnedFilterItems',
+        getName: (item: TaxonomicDefinitionTypes) => ('name' in item ? item.name : '') || '',
+        getValue: (item: TaxonomicDefinitionTypes): TaxonomicFilterValue =>
+            'name' in item ? (item.name ?? null) : null,
+        getPopoverHeader: () => 'Pinned',
+    },
+] as const satisfies readonly TaxonomicFilterGroup[]

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -30,10 +30,7 @@ import {
     recentTaxonomicFiltersLogic,
     stripRecentContext,
 } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
-import {
-    hasPinnedContext,
-    taxonomicFilterPinnedPropertiesLogic,
-} from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
+import { hasPinnedContext } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
 import {
     DataWarehousePopoverField,
     ExcludedProperties,
@@ -109,6 +106,7 @@ import { HogFlowTaxonomicFilters } from 'products/workflows/frontend/Workflows/h
 
 import { PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE } from '../PropertyFilters/utils'
 import { InlineHogQLEditor } from './InlineHogQLEditor'
+import { RECENT_PINNED_TAB_DEFINITIONS } from './recentPinnedTabDefinitions'
 import type { taxonomicFilterLogicType } from './taxonomicFilterLogicType'
 
 const PROPERTY_TAXONOMIC_GROUP_TYPES = new Set(Object.values(PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE))
@@ -922,7 +920,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                                         o.value
                                     )
                             ),
-                        getIcon: (option: PropertyDefinition): JSX.Element => getRevenueAnalyticsDefinitionIcon(option),
+                        getIcon: getRevenueAnalyticsDefinitionIcon,
                         getName: (option: PropertyDefinition) => {
                             const coreDefinition = getCoreFilterDefinition(
                                 option.id,
@@ -1275,28 +1273,13 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                             <IconFlag className={clsx('size-4', !featureFlag.active && 'text-muted-alt opacity-50')} />
                         ),
                         getIsDisabled: (featureFlag: FeatureFlagType) => !featureFlag.active,
-                        localItemsSearch: (
-                            items: TaxonomicDefinitionTypes[],
-                            query: string
-                        ): TaxonomicDefinitionTypes[] => {
-                            // Note: This function doesn't have direct access to the current value
-                            // The actual filtering logic needs to be implemented in the infinite list logic
-                            // For now, just handle search filtering
+                        localItemsSearch: (items, query) => {
                             if (!query) {
                                 return items
                             }
-
-                            return items.filter((item: TaxonomicDefinitionTypes) => {
-                                // Type guard for FeatureFlagType
-                                if ('key' in item && 'name' in item) {
-                                    const flag = item as unknown as FeatureFlagType
-                                    return (flag.key || flag.name || '').toLowerCase().includes(query.toLowerCase())
-                                }
-                                // For other types, check if they have a name property
-                                if ('name' in item) {
-                                    return (item.name || '').toLowerCase().includes(query.toLowerCase())
-                                }
-                                return true
+                            return items.filter((item) => {
+                                const flag = item as unknown as FeatureFlagType
+                                return (flag.key || flag.name || '').toLowerCase().includes(query.toLowerCase())
                             })
                         },
                         excludedProperties:
@@ -1462,32 +1445,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                             'name' in item ? (item.name ?? null) : null,
                         getPopoverHeader: () => suggestedFiltersLabel ?? 'Suggested filters',
                     },
-                    {
-                        name: 'Recent',
-                        searchPlaceholder: 'recent',
-                        type: TaxonomicFilterGroupType.RecentFilters,
-                        isLocalOnly: true,
-                        isMetaGroup: true,
-                        logic: recentTaxonomicFiltersLogic,
-                        value: 'recentFilterItems',
-                        getName: (item: TaxonomicDefinitionTypes) => ('name' in item ? item.name : '') || '',
-                        getValue: (item: TaxonomicDefinitionTypes): TaxonomicFilterValue =>
-                            'name' in item ? (item.name ?? null) : null,
-                        getPopoverHeader: () => 'Recent',
-                    } as TaxonomicFilterGroup,
-                    {
-                        name: 'Pinned',
-                        searchPlaceholder: 'pinned',
-                        type: TaxonomicFilterGroupType.PinnedFilters,
-                        isLocalOnly: true,
-                        isMetaGroup: true,
-                        logic: taxonomicFilterPinnedPropertiesLogic,
-                        value: 'pinnedFilterItems',
-                        getName: (item: TaxonomicDefinitionTypes) => ('name' in item ? item.name : '') || '',
-                        getValue: (item: TaxonomicDefinitionTypes): TaxonomicFilterValue =>
-                            'name' in item ? (item.name ?? null) : null,
-                        getPopoverHeader: () => 'Pinned',
-                    } as TaxonomicFilterGroup,
+                    ...RECENT_PINNED_TAB_DEFINITIONS,
                     ...groupAnalyticsTaxonomicGroups,
                     ...groupAnalyticsTaxonomicGroupNames,
                 ]

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -7,8 +7,7 @@ import {
     buildAutocaptureSeriesShortcuts,
     buildEventTypeFilterShortcuts,
 } from 'lib/components/TaxonomicFilter/eventTypeShortcuts'
-import { recentTaxonomicFiltersLogic } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
-import { taxonomicFilterPinnedPropertiesLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
+import { RECENT_PINNED_TAB_DEFINITIONS } from 'lib/components/TaxonomicFilter/recentPinnedTabDefinitions'
 import {
     DataWarehousePopoverField,
     SimpleOption,
@@ -1001,32 +1000,7 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
                 'name' in item ? (item.name ?? null) : null,
             getPopoverHeader: () => suggestedFiltersLabel ?? 'Suggested filters',
         },
-        {
-            name: 'Recent',
-            searchPlaceholder: 'recent',
-            type: TaxonomicFilterGroupType.RecentFilters,
-            isLocalOnly: true,
-            isMetaGroup: true,
-            logic: recentTaxonomicFiltersLogic,
-            value: 'recentFilterItems',
-            getName: (item: TaxonomicDefinitionTypes) => ('name' in item ? item.name : '') || '',
-            getValue: (item: TaxonomicDefinitionTypes): TaxonomicFilterValue =>
-                'name' in item ? (item.name ?? null) : null,
-            getPopoverHeader: () => 'Recent',
-        } as TaxonomicFilterGroup,
-        {
-            name: 'Pinned',
-            searchPlaceholder: 'pinned',
-            type: TaxonomicFilterGroupType.PinnedFilters,
-            isLocalOnly: true,
-            isMetaGroup: true,
-            logic: taxonomicFilterPinnedPropertiesLogic,
-            value: 'pinnedFilterItems',
-            getName: (item: TaxonomicDefinitionTypes) => ('name' in item ? item.name : '') || '',
-            getValue: (item: TaxonomicDefinitionTypes): TaxonomicFilterValue =>
-                'name' in item ? (item.name ?? null) : null,
-            getPopoverHeader: () => 'Pinned',
-        } as TaxonomicFilterGroup,
+        ...RECENT_PINNED_TAB_DEFINITIONS,
         ...groupAnalyticsTaxonomicGroups,
         ...groupAnalyticsTaxonomicGroupNames,
     ]

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -469,7 +469,7 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
                 .filter(
                     (o) => !excludedProperties[TaxonomicFilterGroupType.RevenueAnalyticsProperties]?.includes(o.value)
                 ),
-            getIcon: (option: PropertyDefinition): JSX.Element => getRevenueAnalyticsDefinitionIcon(option),
+            getIcon: getRevenueAnalyticsDefinitionIcon,
             getName: (option: PropertyDefinition) => {
                 const coreDefinition = getCoreFilterDefinition(
                     option.id,


### PR DESCRIPTION
## Problem

Three small pre-existing issues in `taxonomicFilterLogic.tsx` (and one consumer) that were surfaced during the now-reverted extraction effort (#60485). Each one stands on its own without the extraction context.

## Changes

1. **`localItemsSearch` for the Feature Flags tab** — dropped a defensive `'key' in item && 'name' in item` type guard and a `return true` fallback. The group only ever receives `FeatureFlagType` items so both branches were unreachable; the simplified filter agrees with `getName` two lines above.

2. **Recent / Pinned tab definitions extracted to a shared const** — `taxonomicFilterLogic.tsx` and `utils/buildTaxonomicGroups.tsx` each had identical ~13-line object literals for the two tabs. Both now spread `RECENT_PINNED_TAB_DEFINITIONS` from the new `recentPinnedTabDefinitions.ts`. Typed `as const satisfies readonly TaxonomicFilterGroup[]` so a future caller can't mutate one consumer's view through the shared reference.

3. **revenueAnalytics `getIcon`** — `getIcon: (option) => getRevenueAnalyticsDefinitionIcon(option)` collapsed to `getIcon: getRevenueAnalyticsDefinitionIcon`. Identical signature, no behaviour change, stable module-level reference instead of a fresh arrow per recompute.

No behaviour change in any of the three.

## How did you test this code?

I'm an agent (PostHog Code / Claude Opus). Ran `hogli test frontend/src/lib/components/TaxonomicFilter/` against this branch — all 16 test suites / 362 tests pass. Did not click through the picker in a browser.

## Publish to changelog?

no

## 🤖 Agent context

These three cleanups originated in #59848 (closed) while it sat on top of the abandoned extraction stack. After #60485 reverted the stack, each fix was re-verified to apply to the pre-extraction code on master and lifted to its own PR. No new design decisions — each change is mechanical and behaviour-preserving.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*