### PR TITLE
chore: Bump flags-project-board workflow pin to latest

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
     call-flags-project:
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@b6cef416551ce8e557d57e1bb4f6766da7389b4e
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
         # Only on PostHog/posthog, as there's no GitHub token on forks
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         with:


### PR DESCRIPTION
Re-pins the reusable `flags-project-board.yml` workflow to the latest `main` (`d8b55d0`).

This pulls in:
- The team→board mapping moving to a runtime config file (`.github/flags-boards.json`), so future board-list edits no longer require callers to re-pin.
- Removal of the dead direct `pull_request_review` trigger in the `.github` repo (no behavior change for callers).

No input contract changes — `pr_number`, `pr_node_id`, `is_draft`, and `secrets: inherit` are unchanged.