### PR TITLE
chore(ci): commit foss-sync changes via GitHub API

### DIFF
--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -57,10 +57,18 @@ jobs:
                   cd .github/workflows
                   ls | grep -v foss-release-image-publish.yml | xargs rm
 
+            - name: Remove enterprise code and dependabot config
+              run: rm -rf ee/ .github/dependabot.yml
+
+            # Commit via the GitHub API so the commit is signed by GitHub's key
+            # (required once posthog-foss enforces signed commits). ghcommit-action
+            # detects modified and deleted tracked files and applies them through
+            # createCommitOnBranch.
             - name: Commit "Sync and remove all non-FOSS parts"
-              uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
+              uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
               with:
-                  message: 'Sync and remove all non-FOSS parts'
-                  remove: '-r ee/ .github/dependabot.yml'
-                  default_author: github_actions
-                  github_token: ${{ steps.app-token.outputs.token }}
+                  commit_message: 'Sync and remove all non-FOSS parts'
+                  repo: posthog/posthog-foss
+                  branch: master
+              env:
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Replace the EndBug/add-and-commit step with planetscale/ghcommit-action so the posthog-foss sync commit is created through GitHub's GraphQL API. The enterprise/dependabot removals previously handled by the action's `remove` input are now explicit working-tree deletions, which ghcommit-action detects and applies.
