### PR TITLE
feat(property-vals): add per-tuple count distribution metric at flush

### DIFF
--- a/rust/property-vals-rs/src/metrics_consts.rs
+++ b/rust/property-vals-rs/src/metrics_consts.rs
@@ -2,6 +2,7 @@ pub const EVENTS_RECEIVED: &str = "property_vals_rs_events_received_total";
 pub const EVENTS_FILTERED: &str = "property_vals_rs_events_filtered_total";
 pub const TUPLES_AGGREGATED: &str = "property_vals_rs_tuples_aggregated_total";
 pub const FLUSH_TUPLES: &str = "property_vals_rs_flush_tuples";
+pub const FLUSH_TUPLE_COUNT: &str = "property_vals_rs_flush_tuple_count";
 pub const FLUSH_TOTAL: &str = "property_vals_rs_flushes_total";
 pub const FLUSH_REASON_TIMER: &str = "timer";
 pub const FLUSH_REASON_BACKPRESSURE: &str = "backpressure";

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -117,9 +117,6 @@ pub(crate) async fn flush<P: Producer>(
     metrics::counter!(FLUSH_TOTAL, "reason" => reason, "worker" => worker).increment(1);
     metrics::histogram!(FLUSH_TUPLES, "worker" => worker).record(snapshot.len() as f64);
 
-    // Distribution of per-tuple counts in this flush. avg (sum/count) near 1
-    // means the volume is unique-value cardinality; a higher avg means values
-    // are actually aggregating.
     for (_, count) in &snapshot {
         metrics::histogram!(FLUSH_TUPLE_COUNT, "worker" => worker).record(*count as f64);
     }

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -117,6 +117,13 @@ pub(crate) async fn flush<P: Producer>(
     metrics::counter!(FLUSH_TOTAL, "reason" => reason, "worker" => worker).increment(1);
     metrics::histogram!(FLUSH_TUPLES, "worker" => worker).record(snapshot.len() as f64);
 
+    // Distribution of per-tuple counts in this flush. avg (sum/count) near 1
+    // means the volume is unique-value cardinality; a higher avg means values
+    // are actually aggregating.
+    for (_, count) in &snapshot {
+        metrics::histogram!(FLUSH_TUPLE_COUNT, "worker" => worker).record(*count as f64);
+    }
+
     if let Err(e) = producer.produce(snapshot.clone()).await {
         metrics::counter!(PRODUCER_FLUSH_FAILED, "worker" => worker).increment(1);
         error!(error = %e, "produce failed; restoring counts, retrying next flush");


### PR DESCRIPTION
## Problem

We can see distinct-tuples-per-flush (`flush_tuples`) but not the distribution of per-tuple counts, so there's no real-time way to tell whether output volume is driven by unique-value cardinality (every tuple seen once) versus values that actually aggregate. That distinction is what decides whether the lever is dropping high-cardinality keys or something else.

A ClickHouse query on `property_values` confirms the volume is cardinality: over a recent window the median `property_count` per tuple is 1 (half of all distinct tuples seen once), with the mean dragged to ~32 by a small elephant tail. But that is cumulative and ad-hoc; this adds the precise per-flush view as a service metric.

## Changes

Add a `property_vals_rs_flush_tuple_count` histogram, labeled by `worker`, recorded once per tuple at flush. From it:

- avg count per tuple: `rate(..._sum) / rate(..._count)`
- percentiles (p50/p90/p99) from the histogram

Splitting by worker also shows how much the two-stage collapse buys: the merger's per-flush counts are post-collapse and should sit above the events worker's.

Recorded in the loop that already walks the snapshot, so the cost is negligible.

## How did you test this code?

I am an agent. Automated only:
- `cargo test -p property-vals-rs` (42 pass)
- `cargo clippy -p property-vals-rs --no-deps --all-targets` clean
- `cargo fmt -p property-vals-rs --check` clean

## Publish to changelog?

no

## 🤖 Agent context

Follow-up to the worker-label metric (merged). Added while investigating output volume at higher rollout: the count-per-tuple distribution is the cardinality-vs-aggregation signal, and p50=1 in production confirmed the volume is the unique long tail, which is what motivates the top-K / singleton-gate direction.
