### PR TITLE
chore(ci): make foss/private sync atomic and faster

### DIFF
--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -28,26 +28,26 @@ jobs:
                   owner: PostHog
                   repositories: posthog-foss
 
-            - name: Sync repositories 1 to 1 - master branch
-              uses: PostHog/git-sync@29d9a6756e8646d0715d5caa9c66438be7e32a1f # v3
-              with:
-                  source_repo: 'https://x-access-token:${{ github.token }}@github.com/posthog/posthog.git'
-                  source_branch: 'master'
-                  destination_repo: 'https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/posthog/posthog-foss.git'
-                  destination_branch: 'master'
-            - name: Sync repositories 1 to 1 – tags
-              uses: PostHog/git-sync@29d9a6756e8646d0715d5caa9c66438be7e32a1f # v3
-              with:
-                  source_repo: 'https://x-access-token:${{ github.token }}@github.com/posthog/posthog.git'
-                  source_branch: 'refs/tags/*'
-                  destination_repo: 'https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/posthog/posthog-foss.git'
-                  destination_branch: 'refs/tags/*'
-            - name: Checkout posthog-foss
+            # blob:none skips historical blobs (avoids a full-history clone); the full
+            # commit graph keeps pushes connected. Lazy blob fetches need origin auth,
+            # so persist-credentials stays default-on.
+            - name: Checkout posthog
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  repository: 'posthog/posthog-foss'
-                  ref: master
-                  token: ${{ steps.app-token.outputs.token }}
+                  fetch-depth: 0
+                  filter: blob:none
+                  fetch-tags: true
+
+            # Stage on a branch, not master, so master never momentarily exposes raw
+            # posthog (ee/, non-MIT LICENSE) before the FOSS cleanup commit lands.
+            - name: Push master tip to staging branch and sync tags
+              env:
+                  FOSS_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: |
+                  git remote add foss "https://x-access-token:${FOSS_TOKEN}@github.com/posthog/posthog-foss.git"
+                  git push foss "HEAD:refs/heads/foss-sync-staging" --force
+                  git push foss "refs/tags/*:refs/tags/*" --force
+
             - name: Change LICENSE to pure MIT
               run: |
                   sed -i -e '/PostHog Inc\./,/Permission is hereby granted/c\Copyright (c) 2020-2021 PostHog Inc\.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy' LICENSE
@@ -60,15 +60,28 @@ jobs:
             - name: Remove enterprise code and dependabot config
               run: rm -rf ee/ .github/dependabot.yml
 
-            # Commit via the GitHub API so the commit is signed by GitHub's key
-            # (required once posthog-foss enforces signed commits). ghcommit-action
-            # detects modified and deleted tracked files and applies them through
-            # createCommitOnBranch.
+            # Commit via the API (ghcommit-action) so it's signed by GitHub — required
+            # once posthog-foss enforces signed commits. Picks up modified + deleted files.
             - name: Commit "Sync and remove all non-FOSS parts"
+              id: foss-commit
               uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
               with:
                   commit_message: 'Sync and remove all non-FOSS parts'
                   repo: posthog/posthog-foss
-                  branch: master
+                  branch: foss-sync-staging
               env:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+            # Atomically repoint master to the signed commit (clean tip -> clean tip),
+            # then drop staging.
+            - name: Promote staging to master and clean up
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  FOSS_SHA: ${{ steps.foss-commit.outputs.commit-hash }}
+              run: |
+                  if gh api repos/posthog/posthog-foss/git/ref/heads/master >/dev/null 2>&1; then
+                    gh api -X PATCH repos/posthog/posthog-foss/git/refs/heads/master -f sha="$FOSS_SHA" -F force=true
+                  else
+                    gh api repos/posthog/posthog-foss/git/refs -f ref=refs/heads/master -f sha="$FOSS_SHA"
+                  fi
+                  gh api -X DELETE repos/posthog/posthog-foss/git/refs/heads/foss-sync-staging || true

--- a/.github/workflows/private-sync.yml
+++ b/.github/workflows/private-sync.yml
@@ -27,18 +27,22 @@ jobs:
                   owner: PostHog
                   repositories: posthog-private
 
-            - name: Sync repositories 1 to 1 - master branch
-              uses: PostHog/git-sync@29d9a6756e8646d0715d5caa9c66438be7e32a1f # v3
+            # blob:none skips historical blobs (avoids a full-history clone); the full
+            # commit graph keeps pushes connected. Lazy blob fetches need origin auth,
+            # so persist-credentials stays default-on.
+            - name: Checkout posthog
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  source_repo: 'https://x-access-token:${{ github.token }}@github.com/posthog/posthog.git'
-                  source_branch: 'master'
-                  destination_repo: 'https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/posthog/posthog-private.git'
-                  destination_branch: 'master'
+                  fetch-depth: 0
+                  filter: blob:none
+                  fetch-tags: true
 
-            - name: Sync repositories 1 to 1 – tags
-              uses: PostHog/git-sync@29d9a6756e8646d0715d5caa9c66438be7e32a1f # v3
-              with:
-                  source_repo: 'https://x-access-token:${{ github.token }}@github.com/posthog/posthog.git'
-                  source_branch: 'refs/tags/*'
-                  destination_repo: 'https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/posthog/posthog-private.git'
-                  destination_branch: 'refs/tags/*'
+            # 1:1 mirror: replays posthog's existing signed commits — no new commit, so
+            # signing enforcement on posthog-private is unaffected.
+            - name: Mirror master and tags to posthog-private
+              env:
+                  PRIVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: |
+                  git remote add private "https://x-access-token:${PRIVATE_TOKEN}@github.com/posthog/posthog-private.git"
+                  git push private "HEAD:refs/heads/master" --force
+                  git push private "refs/tags/*:refs/tags/*" --force


### PR DESCRIPTION
The current `PostHog/git-sync` action has two issues:

- It's slow as hell, usually taking between 6 and 12 minutes, because it copies the entire 4GiB+ history every time
- It's not atomic. The `ee/` directory and our proprietary license are copied over first and then the removal/license change happens at some later point. The workflow could fail between the two steps, leaving posthog-foss with a non-MIT license.

This PR replaces `PostHog/git-sync` with a `blob:none` partial-clone checkout plus a direct push. The full commit graph keeps pushes connected while historical blobs are fetched lazily, so runs no longer re-download the whole repo.

foss-sync also now builds the signed FOSS commit on a staging branch via the GitHub API and then atomically repoints master, so `posthog-foss/master` is never momentarily left as raw posthog (with `ee/` present).
