### PR TITLE
feat(personhog): use field mask to skip properties in batch person lookups

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -438,7 +438,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         from posthog.personhog_client.gate import use_personhog
 
         if use_personhog():
-            persons = get_persons_by_distinct_ids(team_id, list(distinct_ids))
+            persons = get_persons_by_distinct_ids(team_id, list(distinct_ids), include_properties=False)
             return [str(person.uuid) for person in persons]
 
         # ORM path: lightweight values_list queries — no full model instantiation
@@ -823,7 +823,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         from posthog.models.person.sql import PERSON_STATIC_COHORT_TABLE
         from posthog.models.person.util import get_persons_by_uuids
 
-        persons = get_persons_by_uuids(team_id, batch)
+        persons = get_persons_by_uuids(team_id, batch, include_properties=False)
         if not persons:
             return
 

--- a/posthog/models/person/test/test_batched_personhog_helpers.py
+++ b/posthog/models/person/test/test_batched_personhog_helpers.py
@@ -101,6 +101,28 @@ class TestBatchedGetPersonsByUuids(SimpleTestCase):
             assert len(result) == 1
             assert result[0].uuid == "uuid-1"
 
+    def test_read_options_forwarded_to_request(self):
+        from posthog.personhog_client import READ_OPTIONS_WITHOUT_PROPERTIES
+
+        mock_client = MagicMock()
+        mock_client.get_persons_by_uuids.return_value = person_pb2.PersonsResponse(persons=[])
+
+        with patch("posthog.models.person.util._get_client", return_value=mock_client):
+            _batched_get_persons_by_uuids(1, ["uuid-1"], "test", read_options=READ_OPTIONS_WITHOUT_PROPERTIES)
+
+        request = mock_client.get_persons_by_uuids.call_args[0][0]
+        assert list(request.read_options.field_mask) == list(READ_OPTIONS_WITHOUT_PROPERTIES.field_mask)
+
+    def test_read_options_none_leaves_default(self):
+        mock_client = MagicMock()
+        mock_client.get_persons_by_uuids.return_value = person_pb2.PersonsResponse(persons=[])
+
+        with patch("posthog.models.person.util._get_client", return_value=mock_client):
+            _batched_get_persons_by_uuids(1, ["uuid-1"], "test")
+
+        request = mock_client.get_persons_by_uuids.call_args[0][0]
+        assert list(request.read_options.field_mask) == []
+
 
 class TestBatchedGetPersonsByDistinctIds(SimpleTestCase):
     @parameterized.expand(
@@ -179,6 +201,20 @@ class TestBatchedGetPersonsByDistinctIds(SimpleTestCase):
             result = _batched_get_persons_by_distinct_ids(1, ["did-1", "did-missing"], "test")
 
             assert len(result) == 1
+
+    def test_read_options_forwarded_to_request(self):
+        from posthog.personhog_client import READ_OPTIONS_WITHOUT_PROPERTIES
+
+        mock_client = MagicMock()
+        mock_client.get_persons_by_distinct_ids_in_team.return_value = person_pb2.PersonsByDistinctIdsInTeamResponse(
+            results=[]
+        )
+
+        with patch("posthog.models.person.util._get_client", return_value=mock_client):
+            _batched_get_persons_by_distinct_ids(1, ["did-1"], "test", read_options=READ_OPTIONS_WITHOUT_PROPERTIES)
+
+        request = mock_client.get_persons_by_distinct_ids_in_team.call_args[0][0]
+        assert list(request.read_options.field_mask) == list(READ_OPTIONS_WITHOUT_PROPERTIES.field_mask)
 
 
 class TestBatchedGetDistinctIdsForPersons(SimpleTestCase):

--- a/posthog/models/person/test/test_util_personhog_routing.py
+++ b/posthog/models/person/test/test_util_personhog_routing.py
@@ -324,7 +324,7 @@ class TestGetPersonsByUuidsRouting(SimpleTestCase):
 
         if personhog_data is not None and gate_on:
             assert result == personhog_data
-            mock_fetch_personhog.assert_called_once_with(team_id, uuids)
+            mock_fetch_personhog.assert_called_once_with(team_id, uuids, read_options=None)
             mock_objects.db_manager.assert_not_called()
         else:
             assert result == mock_qs

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -45,6 +45,7 @@ from posthog.personhog_client.proto import (
     GetPersonRequest,
     GetPersonsByDistinctIdsInTeamRequest,
     GetPersonsByUuidsRequest,
+    ReadOptions,
 )
 from posthog.settings import TEST
 
@@ -70,12 +71,16 @@ def _batched_get_persons_by_uuids(
     team_id: int,
     uuids: list[str],
     operation: str,
+    read_options: ReadOptions | None = None,
 ) -> list[person_pb2.Person]:
     client = _get_client()
     valid_persons: list[person_pb2.Person] = []
     for i in range(0, len(uuids), PERSONHOG_BATCH_SIZE):
         batch = uuids[i : i + PERSONHOG_BATCH_SIZE]
-        resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=batch))
+        request = GetPersonsByUuidsRequest(team_id=team_id, uuids=batch)
+        if read_options is not None:
+            request.read_options.CopyFrom(read_options)
+        resp = client.get_persons_by_uuids(request)
 
         present_persons = [p for p in resp.persons if p.id]
         batch_valid = [p for p in present_persons if p.team_id == team_id]
@@ -95,6 +100,7 @@ def _batched_get_persons_by_distinct_ids(
     distinct_ids: list[str],
     operation: str,
     deduplicate_by_person: bool = True,
+    read_options: ReadOptions | None = None,
 ) -> list[person_pb2.PersonWithDistinctIds]:
     client = _get_client()
     seen_person_ids: set[int] = set()
@@ -102,9 +108,10 @@ def _batched_get_persons_by_distinct_ids(
 
     for i in range(0, len(distinct_ids), PERSONHOG_BATCH_SIZE):
         batch = distinct_ids[i : i + PERSONHOG_BATCH_SIZE]
-        resp = client.get_persons_by_distinct_ids_in_team(
-            GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=batch)
-        )
+        request = GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=batch)
+        if read_options is not None:
+            request.read_options.CopyFrom(read_options)
+        resp = client.get_persons_by_distinct_ids_in_team(request)
 
         present_results = [r for r in resp.results if r.person and r.person.id]
         batch_valid = [r for r in present_results if r.person.team_id == team_id]
@@ -310,9 +317,15 @@ def create_person_distinct_id(
 
 
 def _fetch_persons_by_distinct_ids_via_personhog(
-    team_id: int, distinct_ids: list[str], *, distinct_id_limit: int | None = None
+    team_id: int,
+    distinct_ids: list[str],
+    *,
+    distinct_id_limit: int | None = None,
+    read_options: ReadOptions | None = None,
 ) -> list[Person]:
-    valid_results = _batched_get_persons_by_distinct_ids(team_id, distinct_ids, "get_persons_by_distinct_ids")
+    valid_results = _batched_get_persons_by_distinct_ids(
+        team_id, distinct_ids, "get_persons_by_distinct_ids", read_options=read_options
+    )
 
     person_ids = [r.person.id for r in valid_results]
     if not person_ids:
@@ -367,18 +380,27 @@ def get_persons_by_distinct_ids(
     *,
     operation: str = "get_persons_by_distinct_ids",
     distinct_id_limit: int | None = None,
+    include_properties: bool = True,
 ) -> list[Person]:
+    read_options: ReadOptions | None = None
+    if not include_properties:
+        from posthog.personhog_client import READ_OPTIONS_WITHOUT_PROPERTIES
+
+        read_options = READ_OPTIONS_WITHOUT_PROPERTIES
+
     def orm_fn() -> list[Person]:
         did_queryset = PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS).filter(team_id=team_id).order_by("id")
 
+        qs = Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(
+            team_id=team_id,
+            persondistinctid__team_id=team_id,
+            persondistinctid__distinct_id__in=distinct_ids,
+        )
+        if not include_properties:
+            qs = qs.defer("properties")
+
         persons = list(
-            Person.objects.db_manager(READ_DB_FOR_PERSONS)
-            .filter(
-                team_id=team_id,
-                persondistinctid__team_id=team_id,
-                persondistinctid__distinct_id__in=distinct_ids,
-            )
-            .prefetch_related(
+            qs.prefetch_related(
                 Prefetch(
                     "persondistinctid_set",
                     queryset=did_queryset,
@@ -396,7 +418,7 @@ def get_persons_by_distinct_ids(
     return _personhog_routed(
         operation,
         lambda: _fetch_persons_by_distinct_ids_via_personhog(
-            team_id, distinct_ids, distinct_id_limit=distinct_id_limit
+            team_id, distinct_ids, distinct_id_limit=distinct_id_limit, read_options=read_options
         ),
         orm_fn,
         team_id=team_id,
@@ -447,8 +469,12 @@ def get_persons_mapped_by_distinct_id(
     )
 
 
-def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> list[Person]:
-    valid_persons = _batched_get_persons_by_uuids(team_id, uuids, "get_persons_by_uuids")
+def _fetch_persons_by_uuids_via_personhog(
+    team_id: int,
+    uuids: list[str],
+    read_options: ReadOptions | None = None,
+) -> list[Person]:
+    valid_persons = _batched_get_persons_by_uuids(team_id, uuids, "get_persons_by_uuids", read_options=read_options)
 
     person_ids = [p.id for p in valid_persons]
     if not person_ids:
@@ -459,11 +485,28 @@ def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> lis
     return [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in valid_persons]
 
 
-def get_persons_by_uuids(team_id: int, uuids: list[str]) -> QuerySet | list[Person]:
-    personhog_fn: Callable[[], QuerySet | list[Person]] = lambda: _fetch_persons_by_uuids_via_personhog(team_id, uuids)
-    orm_fn: Callable[[], QuerySet | list[Person]] = lambda: Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(
-        team_id=team_id, uuid__in=uuids
+def get_persons_by_uuids(
+    team_id: int,
+    uuids: list[str],
+    *,
+    include_properties: bool = True,
+) -> QuerySet | list[Person]:
+    read_options: ReadOptions | None = None
+    if not include_properties:
+        from posthog.personhog_client import READ_OPTIONS_WITHOUT_PROPERTIES
+
+        read_options = READ_OPTIONS_WITHOUT_PROPERTIES
+
+    personhog_fn: Callable[[], QuerySet | list[Person]] = lambda: _fetch_persons_by_uuids_via_personhog(
+        team_id, uuids, read_options=read_options
     )
+
+    def orm_fn() -> QuerySet | list[Person]:
+        qs = Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(team_id=team_id, uuid__in=uuids)
+        if not include_properties:
+            qs = qs.defer("properties")
+        return qs
+
     return _personhog_routed(
         "get_persons_by_uuids",
         personhog_fn,
@@ -586,9 +629,13 @@ def get_person_by_pk_or_uuid(team_id: int, key: str) -> Optional[Person]:
 
 
 def _validate_uuids_via_personhog(team_id: int, uuids: list[str]) -> list[str]:
+    from posthog.personhog_client import READ_OPTIONS_WITHOUT_PROPERTIES
+
     # _batched_get_persons_by_uuids also filters out persons with id == 0 (server "not found" sentinel),
     # which the previous single-RPC implementation did not do. This is intentionally more correct.
-    valid_persons = _batched_get_persons_by_uuids(team_id, uuids, "validate_person_uuids_exist")
+    valid_persons = _batched_get_persons_by_uuids(
+        team_id, uuids, "validate_person_uuids_exist", read_options=READ_OPTIONS_WITHOUT_PROPERTIES
+    )
     return [p.uuid for p in valid_persons]
 
 

--- a/posthog/personhog_client/__init__.py
+++ b/posthog/personhog_client/__init__.py
@@ -1,18 +1,13 @@
 from typing import Literal
 
-from posthog.personhog_client.proto import CONSISTENCY_LEVEL_EVENTUAL, CONSISTENCY_LEVEL_STRONG, ReadOptions
+from posthog.personhog_client.proto import CONSISTENCY_LEVEL_EVENTUAL, CONSISTENCY_LEVEL_STRONG, Person, ReadOptions
 
 ReadConsistency = Literal["strong", "eventual"]
 
+_PERSON_PROPERTIES_FIELDS = frozenset({"properties", "properties_last_updated_at", "properties_last_operation"})
+
 PERSON_FIELDS_WITHOUT_PROPERTIES: list[str] = [
-    "id",
-    "uuid",
-    "team_id",
-    "created_at",
-    "version",
-    "is_identified",
-    "is_user_id",
-    "last_seen_at",
+    f.name for f in Person.DESCRIPTOR.fields if f.name not in _PERSON_PROPERTIES_FIELDS
 ]
 
 READ_OPTIONS_WITHOUT_PROPERTIES = ReadOptions(field_mask=PERSON_FIELDS_WITHOUT_PROPERTIES)

--- a/posthog/personhog_client/__init__.py
+++ b/posthog/personhog_client/__init__.py
@@ -4,6 +4,19 @@ from posthog.personhog_client.proto import CONSISTENCY_LEVEL_EVENTUAL, CONSISTEN
 
 ReadConsistency = Literal["strong", "eventual"]
 
+PERSON_FIELDS_WITHOUT_PROPERTIES: list[str] = [
+    "id",
+    "uuid",
+    "team_id",
+    "created_at",
+    "version",
+    "is_identified",
+    "is_user_id",
+    "last_seen_at",
+]
+
+READ_OPTIONS_WITHOUT_PROPERTIES = ReadOptions(field_mask=PERSON_FIELDS_WITHOUT_PROPERTIES)
+
 
 def consistency_to_read_options(consistency: ReadConsistency) -> ReadOptions:
     level = CONSISTENCY_LEVEL_STRONG if consistency == "strong" else CONSISTENCY_LEVEL_EVENTUAL


### PR DESCRIPTION
## Problem

The personhog field masking feature (shipped in #60284) allows callers to specify which proto fields they need in batch/list RPCs. When all properties-related fields are excluded from the mask, the server skips fetching them in SELECT clauses — avoiding deserializing and transmitting potentially large JSON blobs over gRPC.

Several Django call sites fetch persons via batch RPCs but never access `person.properties`. Today they pay the full cost of serializing/deserializing properties anyway.

## Changes

- **`posthog/personhog_client/__init__.py`** — Added `PERSON_FIELDS_WITHOUT_PROPERTIES` constant (the include-list of all Person proto fields except `properties`, `properties_last_updated_at`, `properties_last_operation`) and a pre-built `READ_OPTIONS_WITHOUT_PROPERTIES` instance.

- **`posthog/models/person/util.py`** — Threaded `read_options` through the internal batch functions (`_batched_get_persons_by_uuids`, `_batched_get_persons_by_distinct_ids`, and their `_fetch_*` wrappers). Added `include_properties=True` kwarg to the public `get_persons_by_uuids()` and `get_persons_by_distinct_ids()` functions. When `False`, the personhog path sends the field mask and the ORM fallback uses `.defer("properties")`. `_validate_uuids_via_personhog()` always sends the mask since it only returns UUID strings.

- **`posthog/models/cohort/cohort.py`** — Two call sites updated to pass `include_properties=False`:
  - `insert_users_by_list` — only extracts `.uuid` from returned persons
  - `insert_static_cohort_batch` — only uses `.id` and `.uuid`

**Why only these call sites?** The field mask is only honored by batch/list RPCs (per the proto definition). Single-entity RPCs (`GetPerson`, `GetPersonByUuid`, `GetPersonByDistinctId`) always return all fields. Among the batch-RPC callers, all other sites need properties for serialization or direct property access (e.g. `.properties.get("email")`).

## How did you test this code?

Agent-authored. Automated tests only:
- 3 new unit tests in `test_batched_personhog_helpers.py` verify that `read_options` is correctly forwarded to proto requests and that omitting it leaves the default (empty mask = all fields)
- All existing tests pass: batched helpers (29), routing (67), cohort personhog (104), cohort model (20), cohort API personhog (8)

## 🤖 Agent context

- **Agent:** Claude Code (Opus)
- **Approach:** Traced all personhog batch-RPC call sites to determine which never access `person.properties`. Three call sites qualified: `validate_person_uuids_exist` (returns only UUID strings), `insert_static_cohort_batch` (uses only `.id`/`.uuid`), and `insert_users_by_list` (uses only `.uuid`). The field mask is an include-list, so `PERSON_FIELDS_WITHOUT_PROPERTIES` lists every Person field except the three properties-related ones. The ORM fallback path mirrors this with Django's `.defer("properties")`.