### PR TITLE
chore(personhog): add latency decomposition metrics

### DIFF
--- a/rust/AGENTS.md
+++ b/rust/AGENTS.md
@@ -1,0 +1,10 @@
+# Rust crates
+
+## Metrics labels
+
+When emitting metrics via the `metrics` crate (`histogram!`, `counter!`, `gauge!`), dynamic label values (method names, client names, etc.) must use `Arc<str>`, never `String` or `.to_string()`.
+
+- Construct an `Arc<str>` once at the top of the function (`Arc::from(value)`) and `.clone()` it into each macro call. `Arc::clone` is a single atomic increment — no heap allocation.
+- `current_client_name()` already returns `Arc<str>`, so use `.clone()` directly. Never call `.to_string()` on it.
+- When passing a dynamic label through multiple functions, pass `Arc<str>` by value, not `&str` — the downstream function will need to clone it into macros anyway.
+- Static label values (`"ok"`, `"error"`, `"unavailable"`) can be passed as `&'static str` literals directly.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6660,6 +6660,7 @@ dependencies = [
  "http-body-util",
  "metrics",
  "pin-project",
+ "rstest",
  "sqlx",
  "tokio",
  "tonic 0.12.3",

--- a/rust/personhog-common/Cargo.toml
+++ b/rust/personhog-common/Cargo.toml
@@ -20,6 +20,7 @@ tower = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+rstest = "0.26"
 tokio = { workspace = true, features = ["macros", "rt"] }
 tower = { workspace = true, features = ["util"] }
 

--- a/rust/personhog-common/src/async_gzip.rs
+++ b/rust/personhog-common/src/async_gzip.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::future::Future;
 use std::io::Write;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
 
@@ -154,14 +155,15 @@ where
                 .and_then(|v| v.to_str().ok())
                 .is_some_and(|v| v.split(',').any(|e| e.trim() == "gzip"));
 
-        let method = request
-            .uri()
-            .path()
-            .rsplit_once('/')
-            .map(|(_, m)| m)
-            .filter(|m| !m.is_empty())
-            .unwrap_or("unknown")
-            .to_string();
+        let method: Arc<str> = Arc::from(
+            request
+                .uri()
+                .path()
+                .rsplit_once('/')
+                .map(|(_, m)| m)
+                .filter(|m| !m.is_empty())
+                .unwrap_or("unknown"),
+        );
 
         let config = self.config.clone();
         let mut inner = self.inner.clone();
@@ -248,7 +250,7 @@ where
             {
                 counter!("grpc_gzip_responses_total", "outcome" => "passthrough", "method" => method.clone()).increment(1);
                 let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
-                set_gzip_overhead_header(&mut parts, &method, gzip_overhead_ms);
+                set_gzip_overhead_header(&mut parts, method.clone(), gzip_overhead_ms);
                 let data = concat_chunks(&chunks);
                 let boxed: ResponseBody = Box::pin(PrecomputedBody::new(data, trailers));
                 return Ok(Response::from_parts(parts, boxed));
@@ -282,7 +284,7 @@ where
                         .insert(GRPC_ENCODING, HeaderValue::from_static("gzip"));
 
                     let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
-                    set_gzip_overhead_header(&mut parts, &method, gzip_overhead_ms);
+                    set_gzip_overhead_header(&mut parts, method.clone(), gzip_overhead_ms);
 
                     let boxed: ResponseBody =
                         Box::pin(PrecomputedBody::new(frame.freeze(), trailers));
@@ -293,7 +295,7 @@ where
                     counter!("grpc_gzip_responses_total", "outcome" => "compress_error", "method" => method.clone())
                         .increment(1);
                     let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
-                    set_gzip_overhead_header(&mut parts, &method, gzip_overhead_ms);
+                    set_gzip_overhead_header(&mut parts, method.clone(), gzip_overhead_ms);
                     let boxed: ResponseBody = Box::pin(PrecomputedBody::trailers_only(trailers));
                     Ok(Response::from_parts(parts, boxed))
                 }
@@ -301,7 +303,7 @@ where
                     warn!(error = %e, "spawn_blocking panicked, returning uncompressed");
                     counter!("grpc_gzip_responses_total", "outcome" => "spawn_error", "method" => method.clone()).increment(1);
                     let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
-                    set_gzip_overhead_header(&mut parts, &method, gzip_overhead_ms);
+                    set_gzip_overhead_header(&mut parts, method.clone(), gzip_overhead_ms);
                     let boxed: ResponseBody = Box::pin(PrecomputedBody::trailers_only(trailers));
                     Ok(Response::from_parts(parts, boxed))
                 }
@@ -368,8 +370,8 @@ impl Body for PrecomputedBody {
 // Compression helpers
 // ============================================================
 
-fn set_gzip_overhead_header(parts: &mut http::response::Parts, method: &str, overhead_ms: f64) {
-    histogram!("grpc_gzip_total_overhead_ms", "method" => method.to_string()).record(overhead_ms);
+fn set_gzip_overhead_header(parts: &mut http::response::Parts, method: Arc<str>, overhead_ms: f64) {
+    histogram!("grpc_gzip_total_overhead_ms", "method" => method).record(overhead_ms);
     if let Ok(hv) = HeaderValue::from_str(&format!("{overhead_ms:.3}")) {
         parts.headers.insert(GZIP_OVERHEAD_HEADER, hv);
     }

--- a/rust/personhog-common/src/async_gzip.rs
+++ b/rust/personhog-common/src/async_gzip.rs
@@ -32,6 +32,8 @@ use tonic::Status;
 use tower::{Layer, Service};
 use tracing::warn;
 
+use crate::grpc::GZIP_OVERHEAD_HEADER;
+
 /// gRPC frame header: 1 byte compression flag + 4 byte payload length.
 const GRPC_HEADER_SIZE: usize = 5;
 
@@ -178,6 +180,8 @@ where
                 return Ok(Response::from_parts(parts, boxed));
             }
 
+            let gzip_start = Instant::now();
+
             // Gather body data chunks and trailers separately. For unary RPCs,
             // tonic produces one or more data frames (split at ~32KB boundaries)
             // followed by a trailers frame. We keep chunks as individual Bytes
@@ -226,6 +230,12 @@ where
                 }
             }
 
+            histogram!(
+                "grpc_gzip_body_collect_ms",
+                "method" => method.clone(),
+            )
+            .record(gzip_start.elapsed().as_secs_f64() * 1000.0);
+
             let payload_size = total_size.saturating_sub(GRPC_HEADER_SIZE);
             let already_compressed = chunks.iter().find_map(|c| c.first().copied()) == Some(1);
 
@@ -237,6 +247,8 @@ where
                 || already_compressed
             {
                 counter!("grpc_gzip_responses_total", "outcome" => "passthrough", "method" => method.clone()).increment(1);
+                let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
+                set_gzip_overhead_header(&mut parts, &method, gzip_overhead_ms);
                 let data = concat_chunks(&chunks);
                 let boxed: ResponseBody = Box::pin(PrecomputedBody::new(data, trailers));
                 return Ok(Response::from_parts(parts, boxed));
@@ -246,14 +258,14 @@ where
             // We move the chunk references directly — the encoder reads each
             // chunk sequentially without copying them into a contiguous buffer.
             let level = config.compression_level;
-            let start = Instant::now();
+            let compress_start = Instant::now();
             let compressed = spawn_blocking(move || gzip_compress_chunks(&chunks, level)).await;
-            let elapsed = start.elapsed();
+            let compress_elapsed = compress_start.elapsed();
 
             match compressed {
                 Ok(Ok(bytes)) => {
                     histogram!("grpc_gzip_compression_duration_ms", "method" => method.clone())
-                        .record(elapsed.as_secs_f64() * 1000.0);
+                        .record(compress_elapsed.as_secs_f64() * 1000.0);
                     histogram!("grpc_gzip_uncompressed_bytes", "method" => method.clone())
                         .record(payload_size as f64);
                     histogram!("grpc_gzip_compressed_bytes", "method" => method.clone())
@@ -269,6 +281,9 @@ where
                         .headers
                         .insert(GRPC_ENCODING, HeaderValue::from_static("gzip"));
 
+                    let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
+                    set_gzip_overhead_header(&mut parts, &method, gzip_overhead_ms);
+
                     let boxed: ResponseBody =
                         Box::pin(PrecomputedBody::new(frame.freeze(), trailers));
                     Ok(Response::from_parts(parts, boxed))
@@ -277,12 +292,16 @@ where
                     warn!(error = %e, "gzip compression failed, returning uncompressed");
                     counter!("grpc_gzip_responses_total", "outcome" => "compress_error", "method" => method.clone())
                         .increment(1);
+                    let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
+                    set_gzip_overhead_header(&mut parts, &method, gzip_overhead_ms);
                     let boxed: ResponseBody = Box::pin(PrecomputedBody::trailers_only(trailers));
                     Ok(Response::from_parts(parts, boxed))
                 }
                 Err(e) => {
                     warn!(error = %e, "spawn_blocking panicked, returning uncompressed");
                     counter!("grpc_gzip_responses_total", "outcome" => "spawn_error", "method" => method.clone()).increment(1);
+                    let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
+                    set_gzip_overhead_header(&mut parts, &method, gzip_overhead_ms);
                     let boxed: ResponseBody = Box::pin(PrecomputedBody::trailers_only(trailers));
                     Ok(Response::from_parts(parts, boxed))
                 }
@@ -348,6 +367,13 @@ impl Body for PrecomputedBody {
 // ============================================================
 // Compression helpers
 // ============================================================
+
+fn set_gzip_overhead_header(parts: &mut http::response::Parts, method: &str, overhead_ms: f64) {
+    histogram!("grpc_gzip_total_overhead_ms", "method" => method.to_string()).record(overhead_ms);
+    if let Ok(hv) = HeaderValue::from_str(&format!("{overhead_ms:.3}")) {
+        parts.headers.insert(GZIP_OVERHEAD_HEADER, hv);
+    }
+}
 
 /// Concatenate chunks into a contiguous buffer. Only used for the passthrough
 /// path where we already collected but decided not to compress.
@@ -946,5 +972,56 @@ mod tests {
 
         let trailers = trailers.expect("trailers should be present");
         assert_eq!(trailers.get("grpc-status").unwrap(), "0");
+    }
+
+    #[tokio::test]
+    async fn gzip_overhead_header_set_on_compressed_response() {
+        let payload = b"payload that will be compressed by the gzip layer";
+        let service = MockGrpcService::new(payload);
+        let (parts, _data, _trailers) =
+            call_layer(service, default_test_config(), Some("gzip")).await;
+
+        let overhead = parts
+            .headers
+            .get(GZIP_OVERHEAD_HEADER)
+            .expect("x-gzip-overhead-ms header should be present")
+            .to_str()
+            .unwrap()
+            .parse::<f64>()
+            .unwrap();
+        assert!(overhead >= 0.0, "overhead should be non-negative");
+    }
+
+    #[tokio::test]
+    async fn gzip_overhead_header_set_on_passthrough_when_collected() {
+        let payload = b"tiny";
+        let service = MockGrpcService::new(payload);
+        let config = AsyncGzipConfig {
+            min_payload_size: 1000,
+            ..default_test_config()
+        };
+        let (parts, _data, _trailers) = call_layer(service, config, Some("gzip")).await;
+
+        let overhead = parts
+            .headers
+            .get(GZIP_OVERHEAD_HEADER)
+            .expect("x-gzip-overhead-ms header should be present on collected passthrough")
+            .to_str()
+            .unwrap()
+            .parse::<f64>()
+            .unwrap();
+        assert!(overhead >= 0.0);
+    }
+
+    #[tokio::test]
+    async fn gzip_overhead_header_absent_when_not_accepted() {
+        let payload = b"no gzip requested";
+        let service = MockGrpcService::new(payload);
+        let (parts, _data, _trailers) = call_layer(service, default_test_config(), None).await;
+
+        assert!(
+            parts.headers.get(GZIP_OVERHEAD_HEADER).is_none(),
+            "header should be absent when gzip was never requested"
+        );
     }
 }

--- a/rust/personhog-common/src/async_gzip.rs
+++ b/rust/personhog-common/src/async_gzip.rs
@@ -974,54 +974,28 @@ mod tests {
         assert_eq!(trailers.get("grpc-status").unwrap(), "0");
     }
 
+    #[rstest::rstest]
+    #[case::compressed(b"payload that will be compressed by the gzip layer".as_slice(), default_test_config(), Some("gzip"), true)]
+    #[case::passthrough_collected(b"tiny".as_slice(), AsyncGzipConfig { min_payload_size: 1000, ..default_test_config() }, Some("gzip"), true)]
+    #[case::not_accepted(b"no gzip requested".as_slice(), default_test_config(), None, false)]
     #[tokio::test]
-    async fn gzip_overhead_header_set_on_compressed_response() {
-        let payload = b"payload that will be compressed by the gzip layer";
+    async fn gzip_overhead_header_presence(
+        #[case] payload: &[u8],
+        #[case] config: AsyncGzipConfig,
+        #[case] accept_encoding: Option<&str>,
+        #[case] expect_present: bool,
+    ) {
         let service = MockGrpcService::new(payload);
-        let (parts, _data, _trailers) =
-            call_layer(service, default_test_config(), Some("gzip")).await;
+        let (parts, _data, _trailers) = call_layer(service, config, accept_encoding).await;
 
-        let overhead = parts
-            .headers
-            .get(GZIP_OVERHEAD_HEADER)
-            .expect("x-gzip-overhead-ms header should be present")
-            .to_str()
-            .unwrap()
-            .parse::<f64>()
-            .unwrap();
-        assert!(overhead >= 0.0, "overhead should be non-negative");
-    }
-
-    #[tokio::test]
-    async fn gzip_overhead_header_set_on_passthrough_when_collected() {
-        let payload = b"tiny";
-        let service = MockGrpcService::new(payload);
-        let config = AsyncGzipConfig {
-            min_payload_size: 1000,
-            ..default_test_config()
-        };
-        let (parts, _data, _trailers) = call_layer(service, config, Some("gzip")).await;
-
-        let overhead = parts
-            .headers
-            .get(GZIP_OVERHEAD_HEADER)
-            .expect("x-gzip-overhead-ms header should be present on collected passthrough")
-            .to_str()
-            .unwrap()
-            .parse::<f64>()
-            .unwrap();
-        assert!(overhead >= 0.0);
-    }
-
-    #[tokio::test]
-    async fn gzip_overhead_header_absent_when_not_accepted() {
-        let payload = b"no gzip requested";
-        let service = MockGrpcService::new(payload);
-        let (parts, _data, _trailers) = call_layer(service, default_test_config(), None).await;
-
-        assert!(
-            parts.headers.get(GZIP_OVERHEAD_HEADER).is_none(),
-            "header should be absent when gzip was never requested"
-        );
+        match parts.headers.get(GZIP_OVERHEAD_HEADER) {
+            Some(val) if expect_present => {
+                let overhead: f64 = val.to_str().unwrap().parse().unwrap();
+                assert!(overhead >= 0.0, "overhead should be non-negative");
+            }
+            None if !expect_present => {}
+            Some(_) => panic!("header should be absent"),
+            None => panic!("header should be present"),
+        }
     }
 }

--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -242,6 +242,12 @@ fn is_fatal_accept_error(e: &io::Error) -> bool {
 /// histogram quantiles.
 pub const PROCESSING_TIME_HEADER: &str = "x-processing-time-ms";
 
+/// Response header set by [`AsyncGzipLayer`] with the total gzip layer
+/// overhead in milliseconds (body collection + compression). The router
+/// subtracts this alongside `PROCESSING_TIME_HEADER` to isolate true
+/// network RTT.
+pub const GZIP_OVERHEAD_HEADER: &str = "x-gzip-overhead-ms";
+
 /// Tower layer that instruments gRPC requests with timing and concurrency metrics.
 ///
 /// Records:

--- a/rust/personhog-router/src/proxy.rs
+++ b/rust/personhog-router/src/proxy.rs
@@ -10,7 +10,8 @@ use http_body::Frame;
 use http_body_util::{BodyExt, Empty, Full};
 use metrics::{counter, histogram};
 use personhog_common::grpc::{
-    current_caller_tag, current_client_name, ClientInFlightGuard, PROCESSING_TIME_HEADER,
+    current_caller_tag, current_client_name, ClientInFlightGuard, GZIP_OVERHEAD_HEADER,
+    PROCESSING_TIME_HEADER,
 };
 use personhog_proto::personhog::types::v1::{GetPersonRequest, UpdatePersonPropertiesRequest};
 use prost::Message;
@@ -187,12 +188,19 @@ impl RawProxyInner {
         )
         .record(duration_ms);
 
-        if let Some(processing_ms) = response
+        let processing_ms = response
             .headers()
             .get(PROCESSING_TIME_HEADER)
             .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<f64>().ok())
-        {
+            .and_then(|s| s.parse::<f64>().ok());
+
+        let gzip_overhead_ms = response
+            .headers()
+            .get(GZIP_OVERHEAD_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<f64>().ok());
+
+        if let Some(processing_ms) = processing_ms {
             histogram!(
                 "personhog_router_transport_overhead_ms",
                 "method" => method.clone(),
@@ -200,7 +208,21 @@ impl RawProxyInner {
                 "client" => client.clone(),
             )
             .record((duration_ms - processing_ms).max(0.0));
+
+            let replica_total_ms = processing_ms + gzip_overhead_ms.unwrap_or(0.0);
+            histogram!(
+                "personhog_router_network_overhead_ms",
+                "method" => method.clone(),
+                "backend" => backend,
+                "client" => client.clone(),
+            )
+            .record((duration_ms - replica_total_ms).max(0.0));
+
             response.headers_mut().remove(PROCESSING_TIME_HEADER);
+        }
+
+        if gzip_overhead_ms.is_some() {
+            response.headers_mut().remove(GZIP_OVERHEAD_HEADER);
         }
 
         if is_grpc_error_response(&response) {
@@ -232,10 +254,18 @@ impl RawProxyInner {
     ) -> http::Response<BoxBody> {
         let (parts, body) = req.into_parts();
 
+        let collect_start = Instant::now();
         let body_bytes = match collect_body_limited(body, self.max_recv_message_size).await {
             Ok(b) => b,
             Err(resp) => return resp,
         };
+        let client = current_client_name();
+        histogram!(
+            "personhog_router_body_collect_ms",
+            "method" => method.to_string(),
+            "client" => client.to_string(),
+        )
+        .record(collect_start.elapsed().as_secs_f64() * 1000.0);
 
         let new_path = format!("{REPLICA_PREFIX}{method}");
 
@@ -254,7 +284,52 @@ impl RawProxyInner {
         let mut delay_ms = self.retry_config.initial_backoff_ms;
 
         for attempt in 0..=self.retry_config.max_retries {
-            let channel = self.replica.next_raw_channel_for(method);
+            let mut channel = self.replica.next_raw_channel_for(method);
+
+            let client = current_client_name();
+
+            let ready_start = Instant::now();
+            let ready_channel = match channel.ready().await {
+                Ok(c) => c,
+                Err(e) => {
+                    histogram!(
+                        "personhog_router_channel_ready_wait_ms",
+                        "method" => method.to_string(),
+                        "client" => client.to_string(),
+                        "outcome" => "error",
+                    )
+                    .record(ready_start.elapsed().as_secs_f64() * 1000.0);
+
+                    let is_last = attempt >= self.retry_config.max_retries;
+                    if is_last {
+                        return grpc_error_response(
+                            Code::Unavailable,
+                            &format!("replica channel not ready: {e}"),
+                        );
+                    }
+
+                    counter!(
+                        "personhog_router_backend_retries_total",
+                        "method" => method.to_string(),
+                        "status_code" => "unavailable",
+                        "client" => client.clone(),
+                    )
+                    .increment(1);
+
+                    let base = delay_ms / 2;
+                    let jittered = base + rand::thread_rng().gen_range(0..=base);
+                    tokio::time::sleep(std::time::Duration::from_millis(jittered)).await;
+                    delay_ms = (delay_ms * 2).min(self.retry_config.max_backoff_ms);
+                    continue;
+                }
+            };
+            histogram!(
+                "personhog_router_channel_ready_wait_ms",
+                "method" => method.to_string(),
+                "client" => client.to_string(),
+                "outcome" => "ok",
+            )
+            .record(ready_start.elapsed().as_secs_f64() * 1000.0);
 
             let body = BoxBody::new(Full::new(body_bytes.clone()).map_err(|never| match never {}));
 
@@ -267,9 +342,27 @@ impl RawProxyInner {
             *req.version_mut() = parts.version;
             *req.headers_mut() = parts.headers.clone();
 
-            match channel.oneshot(req).await {
-                Ok(response) => return response,
+            let call_start = Instant::now();
+            match ready_channel.call(req).await {
+                Ok(response) => {
+                    histogram!(
+                        "personhog_router_channel_call_ms",
+                        "method" => method.to_string(),
+                        "client" => client.to_string(),
+                        "outcome" => "ok",
+                    )
+                    .record(call_start.elapsed().as_secs_f64() * 1000.0);
+                    return response;
+                }
                 Err(e) => {
+                    histogram!(
+                        "personhog_router_channel_call_ms",
+                        "method" => method.to_string(),
+                        "client" => client.to_string(),
+                        "outcome" => "error",
+                    )
+                    .record(call_start.elapsed().as_secs_f64() * 1000.0);
+
                     let is_last = attempt >= self.retry_config.max_retries;
                     if is_last {
                         return grpc_error_response(
@@ -278,12 +371,11 @@ impl RawProxyInner {
                         );
                     }
 
-                    let client = current_client_name();
                     counter!(
                         "personhog_router_backend_retries_total",
                         "method" => method.to_string(),
                         "status_code" => "unavailable",
-                        "client" => client,
+                        "client" => client.clone(),
                     )
                     .increment(1);
 

--- a/rust/personhog-router/src/proxy.rs
+++ b/rust/personhog-router/src/proxy.rs
@@ -151,8 +151,10 @@ impl RawProxyInner {
         let caller_tag = current_caller_tag();
         let start = Instant::now();
 
-        let (mut response, backend) = match method_name {
-            "UpdatePersonProperties" => (self.handle_update_person_properties(req).await, "leader"),
+        let (mut response, backend, channel_call_ms) = match method_name {
+            "UpdatePersonProperties" => {
+                (self.handle_update_person_properties(req).await, "leader", None)
+            }
             "GetPerson" => {
                 let is_strong = req
                     .headers()
@@ -161,12 +163,16 @@ impl RawProxyInner {
                     == Some("strong");
 
                 if is_strong {
-                    (self.handle_get_person_strong(req).await, "leader")
+                    (self.handle_get_person_strong(req).await, "leader", None)
                 } else {
-                    (self.raw_proxy_to_replica(req, method_name).await, "replica")
+                    let (resp, call_ms) = self.raw_proxy_to_replica(req, method_name).await;
+                    (resp, "replica", call_ms)
                 }
             }
-            _ => (self.raw_proxy_to_replica(req, method_name).await, "replica"),
+            _ => {
+                let (resp, call_ms) = self.raw_proxy_to_replica(req, method_name).await;
+                (resp, "replica", call_ms)
+            }
         };
 
         let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -189,16 +195,14 @@ impl RawProxyInner {
         .record(duration_ms);
 
         let processing_ms = response
-            .headers()
-            .get(PROCESSING_TIME_HEADER)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<f64>().ok());
+            .headers_mut()
+            .remove(PROCESSING_TIME_HEADER)
+            .and_then(|v| v.to_str().ok().and_then(|s| s.parse::<f64>().ok()));
 
         let gzip_overhead_ms = response
-            .headers()
-            .get(GZIP_OVERHEAD_HEADER)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<f64>().ok());
+            .headers_mut()
+            .remove(GZIP_OVERHEAD_HEADER)
+            .and_then(|v| v.to_str().ok().and_then(|s| s.parse::<f64>().ok()));
 
         if let Some(processing_ms) = processing_ms {
             histogram!(
@@ -209,20 +213,16 @@ impl RawProxyInner {
             )
             .record((duration_ms - processing_ms).max(0.0));
 
-            let replica_total_ms = processing_ms + gzip_overhead_ms.unwrap_or(0.0);
-            histogram!(
-                "personhog_router_network_overhead_ms",
-                "method" => method.clone(),
-                "backend" => backend,
-                "client" => client.clone(),
-            )
-            .record((duration_ms - replica_total_ms).max(0.0));
-
-            response.headers_mut().remove(PROCESSING_TIME_HEADER);
-        }
-
-        if gzip_overhead_ms.is_some() {
-            response.headers_mut().remove(GZIP_OVERHEAD_HEADER);
+            if let Some(call_ms) = channel_call_ms {
+                let replica_total_ms = processing_ms + gzip_overhead_ms.unwrap_or(0.0);
+                histogram!(
+                    "personhog_router_network_overhead_ms",
+                    "method" => method.clone(),
+                    "backend" => backend,
+                    "client" => client.clone(),
+                )
+                .record((call_ms - replica_total_ms).max(0.0));
+            }
         }
 
         if is_grpc_error_response(&response) {
@@ -251,13 +251,13 @@ impl RawProxyInner {
         &self,
         req: http::Request<BoxBody>,
         method: &str,
-    ) -> http::Response<BoxBody> {
+    ) -> (http::Response<BoxBody>, Option<f64>) {
         let (parts, body) = req.into_parts();
 
         let collect_start = Instant::now();
         let body_bytes = match collect_body_limited(body, self.max_recv_message_size).await {
             Ok(b) => b,
-            Err(resp) => return resp,
+            Err(resp) => return (resp, None),
         };
         let client = current_client_name();
         histogram!(
@@ -280,7 +280,7 @@ impl RawProxyInner {
         body_bytes: &Bytes,
         new_path: &str,
         method: &str,
-    ) -> http::Response<BoxBody> {
+    ) -> (http::Response<BoxBody>, Option<f64>) {
         let mut delay_ms = self.retry_config.initial_backoff_ms;
 
         for attempt in 0..=self.retry_config.max_retries {
@@ -302,9 +302,12 @@ impl RawProxyInner {
 
                     let is_last = attempt >= self.retry_config.max_retries;
                     if is_last {
-                        return grpc_error_response(
-                            Code::Unavailable,
-                            &format!("replica channel not ready: {e}"),
+                        return (
+                            grpc_error_response(
+                                Code::Unavailable,
+                                &format!("replica channel not ready: {e}"),
+                            ),
+                            None,
                         );
                     }
 
@@ -345,14 +348,15 @@ impl RawProxyInner {
             let call_start = Instant::now();
             match ready_channel.call(req).await {
                 Ok(response) => {
+                    let channel_call_ms = call_start.elapsed().as_secs_f64() * 1000.0;
                     histogram!(
                         "personhog_router_channel_call_ms",
                         "method" => method.to_string(),
                         "client" => client.to_string(),
                         "outcome" => "ok",
                     )
-                    .record(call_start.elapsed().as_secs_f64() * 1000.0);
-                    return response;
+                    .record(channel_call_ms);
+                    return (response, Some(channel_call_ms));
                 }
                 Err(e) => {
                     histogram!(
@@ -365,9 +369,12 @@ impl RawProxyInner {
 
                     let is_last = attempt >= self.retry_config.max_retries;
                     if is_last {
-                        return grpc_error_response(
-                            Code::Unavailable,
-                            &format!("replica backend error: {e}"),
+                        return (
+                            grpc_error_response(
+                                Code::Unavailable,
+                                &format!("replica backend error: {e}"),
+                            ),
+                            None,
                         );
                     }
 

--- a/rust/personhog-router/src/proxy.rs
+++ b/rust/personhog-router/src/proxy.rs
@@ -282,11 +282,10 @@ impl RawProxyInner {
         method: &str,
     ) -> (http::Response<BoxBody>, Option<f64>) {
         let mut delay_ms = self.retry_config.initial_backoff_ms;
+        let client = current_client_name();
 
         for attempt in 0..=self.retry_config.max_retries {
             let mut channel = self.replica.next_raw_channel_for(method);
-
-            let client = current_client_name();
 
             let ready_start = Instant::now();
             let ready_channel = match channel.ready().await {

--- a/rust/personhog-router/src/proxy.rs
+++ b/rust/personhog-router/src/proxy.rs
@@ -152,9 +152,11 @@ impl RawProxyInner {
         let start = Instant::now();
 
         let (mut response, backend, channel_call_ms) = match method_name {
-            "UpdatePersonProperties" => {
-                (self.handle_update_person_properties(req).await, "leader", None)
-            }
+            "UpdatePersonProperties" => (
+                self.handle_update_person_properties(req).await,
+                "leader",
+                None,
+            ),
             "GetPerson" => {
                 let is_strong = req
                     .headers()

--- a/rust/personhog-router/src/proxy.rs
+++ b/rust/personhog-router/src/proxy.rs
@@ -146,7 +146,7 @@ impl RawProxyInner {
             );
         }
 
-        let method = method_name.to_string();
+        let method: Arc<str> = Arc::from(method_name);
         let client = current_client_name();
         let caller_tag = current_caller_tag();
         let start = Instant::now();
@@ -167,12 +167,13 @@ impl RawProxyInner {
                 if is_strong {
                     (self.handle_get_person_strong(req).await, "leader", None)
                 } else {
-                    let (resp, call_ms) = self.raw_proxy_to_replica(req, method_name).await;
+                    let (resp, call_ms) =
+                        self.raw_proxy_to_replica(req, method.clone()).await;
                     (resp, "replica", call_ms)
                 }
             }
             _ => {
-                let (resp, call_ms) = self.raw_proxy_to_replica(req, method_name).await;
+                let (resp, call_ms) = self.raw_proxy_to_replica(req, method.clone()).await;
                 (resp, "replica", call_ms)
             }
         };
@@ -252,7 +253,7 @@ impl RawProxyInner {
     async fn raw_proxy_to_replica(
         &self,
         req: http::Request<BoxBody>,
-        method: &str,
+        method: Arc<str>,
     ) -> (http::Response<BoxBody>, Option<f64>) {
         let (parts, body) = req.into_parts();
 
@@ -264,8 +265,8 @@ impl RawProxyInner {
         let client = current_client_name();
         histogram!(
             "personhog_router_body_collect_ms",
-            "method" => method.to_string(),
-            "client" => client.to_string(),
+            "method" => method.clone(),
+            "client" => client.clone(),
         )
         .record(collect_start.elapsed().as_secs_f64() * 1000.0);
 
@@ -281,13 +282,13 @@ impl RawProxyInner {
         parts: &http::request::Parts,
         body_bytes: &Bytes,
         new_path: &str,
-        method: &str,
+        method: Arc<str>,
     ) -> (http::Response<BoxBody>, Option<f64>) {
         let mut delay_ms = self.retry_config.initial_backoff_ms;
         let client = current_client_name();
 
         for attempt in 0..=self.retry_config.max_retries {
-            let mut channel = self.replica.next_raw_channel_for(method);
+            let mut channel = self.replica.next_raw_channel_for(&method);
 
             let ready_start = Instant::now();
             let ready_channel = match channel.ready().await {
@@ -295,8 +296,8 @@ impl RawProxyInner {
                 Err(e) => {
                     histogram!(
                         "personhog_router_channel_ready_wait_ms",
-                        "method" => method.to_string(),
-                        "client" => client.to_string(),
+                        "method" => method.clone(),
+                        "client" => client.clone(),
                         "outcome" => "error",
                     )
                     .record(ready_start.elapsed().as_secs_f64() * 1000.0);
@@ -314,7 +315,7 @@ impl RawProxyInner {
 
                     counter!(
                         "personhog_router_backend_retries_total",
-                        "method" => method.to_string(),
+                        "method" => method.clone(),
                         "status_code" => "unavailable",
                         "client" => client.clone(),
                     )
@@ -329,8 +330,8 @@ impl RawProxyInner {
             };
             histogram!(
                 "personhog_router_channel_ready_wait_ms",
-                "method" => method.to_string(),
-                "client" => client.to_string(),
+                "method" => method.clone(),
+                "client" => client.clone(),
                 "outcome" => "ok",
             )
             .record(ready_start.elapsed().as_secs_f64() * 1000.0);
@@ -352,8 +353,8 @@ impl RawProxyInner {
                     let channel_call_ms = call_start.elapsed().as_secs_f64() * 1000.0;
                     histogram!(
                         "personhog_router_channel_call_ms",
-                        "method" => method.to_string(),
-                        "client" => client.to_string(),
+                        "method" => method.clone(),
+                        "client" => client.clone(),
                         "outcome" => "ok",
                     )
                     .record(channel_call_ms);
@@ -362,8 +363,8 @@ impl RawProxyInner {
                 Err(e) => {
                     histogram!(
                         "personhog_router_channel_call_ms",
-                        "method" => method.to_string(),
-                        "client" => client.to_string(),
+                        "method" => method.clone(),
+                        "client" => client.clone(),
                         "outcome" => "error",
                     )
                     .record(call_start.elapsed().as_secs_f64() * 1000.0);
@@ -381,7 +382,7 @@ impl RawProxyInner {
 
                     counter!(
                         "personhog_router_backend_retries_total",
-                        "method" => method.to_string(),
+                        "method" => method.clone(),
                         "status_code" => "unavailable",
                         "client" => client.clone(),
                     )
@@ -585,7 +586,7 @@ fn percent_encode_grpc(s: &str) -> String {
 struct ByteCountedBody {
     inner: BoxBody,
     bytes_counted: usize,
-    method: String,
+    method: Arc<str>,
     backend: &'static str,
     client: Arc<str>,
     caller_tag: Arc<str>,
@@ -595,7 +596,7 @@ struct ByteCountedBody {
 impl ByteCountedBody {
     fn new(
         inner: BoxBody,
-        method: String,
+        method: Arc<str>,
         backend: &'static str,
         client: Arc<str>,
         caller_tag: Arc<str>,

--- a/rust/personhog-router/src/proxy.rs
+++ b/rust/personhog-router/src/proxy.rs
@@ -167,8 +167,7 @@ impl RawProxyInner {
                 if is_strong {
                     (self.handle_get_person_strong(req).await, "leader", None)
                 } else {
-                    let (resp, call_ms) =
-                        self.raw_proxy_to_replica(req, method.clone()).await;
+                    let (resp, call_ms) = self.raw_proxy_to_replica(req, method.clone()).await;
                     (resp, "replica", call_ms)
                 }
             }


### PR DESCRIPTION
## Problem

When debugging personhog request latency in production, we can see a few high level latency metrics but things aren't isntrumented granularly enough to fully determine *where* time is being spent. is it the client delivering the request body? HTTP/2 channel backpressure? Network RTT? Replica DB queries? Gzip compression? As we add migrate more calls to the service, we want to easily be able to originate any latency problems.

## Changes

Adds fine-grained latency decomposition metrics across the personhog router and replica, allowing latency of the request to be attributed to a specific phase. The metrics are designed so the pieces will up to the whole. Should be able to build stacked bar charts or waterfall panels that fully explain E2E latency.

### Router-side (proxy.rs)
- **`personhog_router_body_collect_ms`** — time waiting for the client to deliver the request body (labels: `method`, `client`)
- **`personhog_router_channel_ready_wait_ms`** — time waiting for the tower channel to become ready / HTTP/2 stream availability (labels: `method`, `client`, `outcome`)
- **`personhog_router_channel_call_ms`** — time for the actual `channel.call()` round-trip (labels: `method`, `client`, `outcome`)
- **`personhog_router_network_overhead_ms`** — computed per-request as `backend_duration - x-processing-time - x-gzip-overhead`, isolating true network RTT + scheduling jitter (labels: `method`, `backend`, `client`)

### Replica-side (async_gzip.rs)
- **`grpc_gzip_body_collect_ms`** — time collecting response body frames, which includes tonic's lazy protobuf serialization (labels: `method`)
- **`grpc_gzip_total_overhead_ms`** — total gzip layer overhead (body collect + compression) (labels: `method`)
- **`x-gzip-overhead-ms` response header** — propagates gzip overhead to the router so it can compute `network_overhead_ms` via per-request subtraction (stripped before forwarding to callers)

### How the pieces add up

```
E2E (grpc_server_request_duration_ms, service=personhog-router)
├── router_overhead = E2E - backend_duration_ms
└── backend_duration_ms
    ├── body_collect_ms
    ├── channel_ready_wait_ms
    └── channel_call_ms
        ├── network_overhead_ms (computed: backend - processing_time - gzip_overhead)
        ├── x-processing-time-ms (replica handler)
        │   ├── db_pool_acquire_duration_ms
        │   ├── db_query_duration_ms
        │   └── (remainder: proto deser, result mapping)
        └── x-gzip-overhead-ms (replica gzip layer)
            ├── grpc_gzip_body_collect_ms (proto serialization)
            └── grpc_gzip_compression_duration_ms
```

**Stacked waterfall** (approximate, using independent quantiles):
```promql
# Each as a separate series in a stacked time-series panel:
histogram_quantile(0.95, sum(rate(personhog_router_body_collect_ms_bucket{method=~"$method"}[5m])) by (le))
histogram_quantile(0.95, sum(rate(personhog_router_channel_ready_wait_ms_bucket{method=~"$method", outcome="ok"}[5m])) by (le))
histogram_quantile(0.95, sum(rate(personhog_router_network_overhead_ms_bucket{method=~"$method"}[5m])) by (le))
histogram_quantile(0.95, sum(rate(grpc_server_request_duration_ms_bucket{service="personhog-replica", method=~"$method"}[5m])) by (le))
histogram_quantile(0.95, sum(rate(grpc_gzip_body_collect_ms_bucket{method=~"$method"}[5m])) by (le))
histogram_quantile(0.95, sum(rate(grpc_gzip_compression_duration_ms_bucket{method=~"$method"}[5m])) by (le))
```

## How did you test this code?

New unit tests for the `x-gzip-overhead-ms` header in `async_gzip.rs`:
- `gzip_overhead_header_set_on_compressed_response` — verifies the header is present with a non-negative value when gzip compression occurs
- `gzip_overhead_header_set_on_passthrough_when_collected` — verifies the header is set even on passthrough (below min size) when body collection happened
- `gzip_overhead_header_absent_when_not_accepted` — verifies the header is absent when the client doesn't request gzip