### PR TITLE
fix(dashboards): preserve task order in runWithLimit

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardUtils.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.test.ts
@@ -3,6 +3,7 @@ import { dayjs } from 'lib/dayjs'
 import {
     parseURLFilters,
     parseURLVariables,
+    runWithLimit,
     SEARCH_PARAM_FILTERS_KEY,
     SEARCH_PARAM_QUERY_VARIABLES_KEY,
     shouldSharedDashboardAutoForceForStaleTime,
@@ -88,5 +89,48 @@ describe('shouldSharedDashboardAutoForceForStaleTime', () => {
         ])('when %s, returns expected result', (_, isoTime, expected) => {
             expect(shouldSharedDashboardAutoForceForStaleTime(dayjs(isoTime))).toBe(expected)
         })
+    })
+})
+
+describe('runWithLimit', () => {
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    it('preserves task order in returned array when later tasks resolve first', async () => {
+        jest.useFakeTimers()
+        const p = runWithLimit(
+            [
+                () => new Promise<string>((resolve) => setTimeout(() => resolve('slow-first'), 30)),
+                () => new Promise<string>((resolve) => setTimeout(() => resolve('fast-second'), 5)),
+                () => new Promise<string>((resolve) => setTimeout(() => resolve('mid-third'), 10)),
+            ],
+            3
+        )
+        await jest.advanceTimersByTimeAsync(5)
+        await jest.advanceTimersByTimeAsync(5)
+        await jest.advanceTimersByTimeAsync(20)
+        await expect(p).resolves.toEqual(['slow-first', 'fast-second', 'mid-third'])
+    })
+
+    it('respects concurrency limit', async () => {
+        let concurrent = 0
+        let maxConcurrent = 0
+        const out = await runWithLimit(
+            [0, 1, 2, 3].map(
+                (i) => () =>
+                    new Promise<number>((resolve) => {
+                        concurrent += 1
+                        maxConcurrent = Math.max(maxConcurrent, concurrent)
+                        setTimeout(() => {
+                            concurrent -= 1
+                            resolve(i)
+                        }, 5)
+                    })
+            ),
+            2
+        )
+        expect(maxConcurrent).toBeLessThanOrEqual(2)
+        expect(out).toEqual([0, 1, 2, 3])
     })
 })

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -151,14 +151,14 @@ const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(
  * @returns A promise that resolves to an array of results from the tasks.
  */
 export async function runWithLimit<T>(tasks: (() => Promise<T>)[], limit: number): Promise<T[]> {
-    const results: T[] = []
+    const results: T[] = new Array(tasks.length)
     const activePromises: Set<Promise<void>> = new Set()
-    const remainingTasks = [...tasks]
+    const remaining = tasks.map((task, index) => ({ task, index }))
 
-    const startTask = async (task: () => Promise<T>): Promise<void> => {
+    const startTask = async (task: () => Promise<T>, index: number): Promise<void> => {
         const promise = task()
             .then((result) => {
-                results.push(result)
+                results[index] = result
             })
             .catch((error) => {
                 console.error('Error executing task:', error)
@@ -170,9 +170,10 @@ export async function runWithLimit<T>(tasks: (() => Promise<T>)[], limit: number
         await promise
     }
 
-    while (remainingTasks.length > 0 || activePromises.size > 0) {
-        if (activePromises.size < limit && remainingTasks.length > 0) {
-            void startTask(remainingTasks.shift()!)
+    while (remaining.length > 0 || activePromises.size > 0) {
+        if (activePromises.size < limit && remaining.length > 0) {
+            const { task, index } = remaining.shift()!
+            void startTask(task, index)
         } else {
             await Promise.race(activePromises)
         }


### PR DESCRIPTION
## Problem

`runWithLimit` in `dashboardUtils.ts` fans out async tasks under a concurrency cap and returns the collected results. The current implementation appends results via `Array.prototype.push` inside the `.then()` callback of each task — so results end up ordered by **resolution time** rather than **input position**.

Callers that read the returned array positionally currently receive misaligned data whenever one task happens to resolve before another that was scheduled earlier:

- `frontend/src/scenes/dashboard/dashboardLogic.tsx:2168` — dashboard insight tile loading
- `frontend/src/scenes/experiments/experimentLogic.tsx:513` — experiment metric queries
- `frontend/src/scenes/experiments/legacy/legacyExperimentLogic.tsx:308` — legacy experiment metrics
- `frontend/src/scenes/experiments/ExperimentView/ExperimentExecutionPathComparison.tsx:363` — execution path comparison

In practice the order only diverges when queries have very different latencies, which is exactly what happens against ClickHouse with a mix of cheap and expensive insights — so the misalignment is rare-looking but real.

## Changes

- Allocate `results` as a fixed-length array up front and assign by the task's original index instead of appending.
- The surrounding control flow (the `activePromises` set, `Promise.race`, the concurrency check) is unchanged, so the rate-limiting contract is preserved.
- Added two Jest cases in `dashboardUtils.test.ts`:
  1. `preserves task order in returned array when later tasks resolve first` — uses `jest.useFakeTimers()` to force a deterministic out-of-order resolution and asserts the returned order matches input order.
  2. `respects concurrency limit` — asserts the active count never exceeds the configured limit.

## How did you test this code?

Reverted only `dashboardUtils.ts` back to current `master` while keeping the new tests, then ran `hogli test frontend/src/scenes/dashboard/dashboardUtils.test.ts`. The new ordering test fails against `master` exactly the way the bug predicts:

```
runWithLimit
  ✕ preserves task order in returned array when later tasks resolve first

Expected: ["slow-first", "fast-second", "mid-third"]
Received: ["fast-second", "mid-third", "slow-first"]
```

With the fix applied, all 16 tests in the file pass in ~3s. The pre-existing `parseURLVariables`, `parseURLFilters`, and `shouldSharedDashboardAutoForceForStaleTime` cases remain green, so this change doesn't regress anything in the surrounding utilities.

I did not exercise the four callers through the UI — reproducing the race visually would need multiple insights seeded with different query latencies and is non-deterministic. The unit test exercises the exact failure mode and will catch any future regression to push semantics.

## Publish to changelog?

no

## Docs update

n/a — internal utility, no public-facing behavior change.

## 🤖 Agent context

Authored with assistance from PostHog Code (Claude). Flow:

- The agent walked me through the existing `runWithLimit` implementation and made the push-vs-index semantics explicit, including which callers actually depend on returned-array order. I confirmed each caller (dashboards, experiments, execution-path comparison) reads the returned array positionally before agreeing to the change — the bug only matters because those consumers treat position as identity.
- The fix itself is intentionally minimal: pre-allocate the array and swap `results.push(result)` for `results[index] = result`. The concurrency control around it is untouched, so the risk surface is just "indexed assignment vs push" — easy to reason about, easy to revert if something downstream secretly relied on resolution-order semantics (I don't believe anything does, based on the four callers I looked at).
- The two new tests are written to demonstrate the bug mechanically. The ordering test will fail again the moment `runWithLimit` regresses to push semantics, which makes this cheap to lock in.
- Before opening the PR I reverted only the source file (keeping the new tests) and reproduced the failure against current `master` myself — the test output above is from that run. That's the artifact I personally inspected to decide the change is correct.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*