### PR TITLE
feat(data-warehouse): open custom source to all teams

### DIFF
--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -2,8 +2,6 @@ import json
 from typing import Any, Literal, Optional, cast
 from urllib.parse import urlparse
 
-from django.conf import settings
-
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 from requests import Response
 from urllib3.util.retry import Retry
@@ -60,17 +58,6 @@ MAX_MANIFEST_RESOURCES = 50
 # Upper bound on the number of custom sources a single team/project may create.
 # Enforced in the external_data_source create endpoint.
 MAX_CUSTOM_SOURCES_PER_TEAM = 5
-
-
-def is_custom_source_available_for_team(team_id: int | None) -> bool:
-    # While the custom source is in development it is restricted to a single
-    # pilot team on PostHog Cloud US. The wizard listing is gated client-side by
-    # the `dwh_custom_source` feature flag; this is the server-side enforcement
-    # that rejects creation from anywhere else (other cloud regions, self-hosted).
-    # Temporary: remove this gate once SSRF protection for arbitrary user-supplied
-    # URLs is enabled, after which the source can open up to all teams.
-    allowed_team_id = 2
-    return settings.CLOUD_DEPLOYMENT == "US" and team_id == allowed_team_id
 
 
 class ManifestValidationError(ValueError):

--- a/posthog/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_custom_source.py
@@ -17,7 +17,6 @@ from posthog.temporal.data_imports.sources.custom.source import (
     CustomSource,
     ManifestValidationError,
     _read_capped_text,
-    is_custom_source_available_for_team,
     manifest_request_hosts,
     validate_manifest,
     validate_manifest_urls,
@@ -690,22 +689,6 @@ class TestManifestRequestHosts(SimpleTestCase):
     @parameterized.expand([("not json", "{nope}"), ("non_string", 123), ("none", None), ("json_array", "[1, 2]")])
     def test_unparseable_returns_empty(self, _name, raw):
         assert manifest_request_hosts(raw) == frozenset()
-
-
-class TestIsCustomSourceAvailableForTeam(SimpleTestCase):
-    @override_settings(CLOUD_DEPLOYMENT="US")
-    def test_allows_pilot_team_on_us_cloud(self):
-        assert is_custom_source_available_for_team(2) is True
-
-    @parameterized.expand([("EU",), ("DEV",), ("E2E",), ("",), (None,)])
-    def test_rejects_non_us_deployment(self, deployment):
-        with override_settings(CLOUD_DEPLOYMENT=deployment):
-            assert is_custom_source_available_for_team(2) is False
-
-    @parameterized.expand([(1,), (3,), (999,), (None,)])
-    @override_settings(CLOUD_DEPLOYMENT="US")
-    def test_rejects_other_teams_even_on_us(self, team_id):
-        assert is_custom_source_available_for_team(team_id) is False
 
 
 class TestCustomSourceSourceForPipeline(SimpleTestCase):

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -49,11 +49,7 @@ from posthog.temporal.data_imports.sources.common.config import Config
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.common.sql import filter_dwh_columns_by_enabled_columns, sql_schema_metadata
 from posthog.temporal.data_imports.sources.common.sql.base import SQLSource
-from posthog.temporal.data_imports.sources.custom.source import (
-    MAX_CUSTOM_SOURCES_PER_TEAM,
-    is_custom_source_available_for_team,
-    manifest_request_hosts,
-)
+from posthog.temporal.data_imports.sources.custom.source import MAX_CUSTOM_SOURCES_PER_TEAM, manifest_request_hosts
 from posthog.temporal.data_imports.sources.postgres.cdc.slot_manager import cdc_pg_connection
 from posthog.temporal.data_imports.sources.postgres.postgres import get_primary_key_columns, source_requires_ssl
 from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
@@ -1147,11 +1143,6 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 if isinstance(value, str):
                     payload[key] = value.strip()
         source_type_model = ExternalDataSourceType(source_type)
-        if source_type_model == ExternalDataSourceType.CUSTOM and not is_custom_source_available_for_team(self.team_id):
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={"message": "Custom REST source is not available for this team."},
-            )
         if (
             source_type_model == ExternalDataSourceType.CUSTOM
             and count_active_custom_sources(self.team_id) >= MAX_CUSTOM_SOURCES_PER_TEAM

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -5665,36 +5665,6 @@ class TestExternalDataSource(APIBaseTest):
         assert response.status_code == 200
         assert payload is not None
 
-    def test_create_custom_source_rejected_when_team_ineligible(self):
-        response = self.client.post(
-            f"/api/environments/{self.team.pk}/external_data_sources/",
-            data={
-                "source_type": "Custom",
-                "prefix": "custom_",
-                "payload": {"manifest_json": "{}"},
-            },
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json()["message"] == "Custom REST source is not available for this team."
-
-    def test_create_custom_source_allowed_when_team_eligible(self):
-        with patch(
-            "products.data_warehouse.backend.api.external_data_source.is_custom_source_available_for_team",
-            return_value=True,
-        ):
-            response = self.client.post(
-                f"/api/environments/{self.team.pk}/external_data_sources/",
-                data={
-                    "source_type": "Custom",
-                    "prefix": "custom_",
-                    "payload": {"manifest_json": "{}"},
-                },
-            )
-        # Past the team gate, the request fails later on the (empty) manifest rather
-        # than on availability — i.e. the eligibility check no longer blocks it.
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json()["message"] != "Custom REST source is not available for this team."
-
     @parameterized.expand(
         [
             # name, seed sources soft-deleted?, seed for a different team?, expect the limit error
@@ -5720,21 +5690,17 @@ class TestExternalDataSource(APIBaseTest):
                 deleted=deleted,
             )
 
-        with patch(
-            "products.data_warehouse.backend.api.external_data_source.is_custom_source_available_for_team",
-            return_value=True,
-        ):
-            response = self.client.post(
-                f"/api/environments/{self.team.pk}/external_data_sources/",
-                data={
-                    "source_type": "Custom",
-                    "prefix": "custom_new_",
-                    "payload": {"manifest_json": "{}"},
-                },
-            )
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/",
+            data={
+                "source_type": "Custom",
+                "prefix": "custom_new_",
+                "payload": {"manifest_json": "{}"},
+            },
+        )
 
         # Every case 400s; only the at-limit case is blocked *by the per-team limit* — the
-        # excluded cases pass the gate and fail later on the (empty) manifest instead.
+        # excluded cases stay under the limit and fail later on the (empty) manifest instead.
         limit_message = f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         if expect_blocked:


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
