### PR TITLE
fix(data-warehouse): redact API key credentials from request logs

### DIFF
--- a/posthog/temporal/data_imports/sources/common/http/observer.py
+++ b/posthog/temporal/data_imports/sources/common/http/observer.py
@@ -32,7 +32,12 @@ from posthog.temporal.data_imports.sources.common.http.metrics import (
     status_class,
 )
 from posthog.temporal.data_imports.sources.common.http.sampling import maybe_capture
-from posthog.temporal.data_imports.sources.common.http.url_utils import host_of, scrub_url, url_template
+from posthog.temporal.data_imports.sources.common.http.url_utils import (
+    host_of,
+    redact_literal_values,
+    scrub_url,
+    url_template,
+)
 
 logger = structlog.get_logger(__name__)
 _fallback_logger = logging.getLogger(__name__)
@@ -83,12 +88,19 @@ def record_request(
     *,
     started_at_monotonic: float,
     exception: BaseException | None = None,
+    redact_values: tuple[str, ...] = (),
 ) -> None:
-    """Log + meter a single outbound request. Never raises."""
+    """Log + meter a single outbound request. Never raises.
+
+    `redact_values` are credential strings masked from the logged URL and the
+    captured sample, on top of the name-based scrubbers.
+    """
     elapsed_ms = max(0, int((time.monotonic() - started_at_monotonic) * 1000))
     method = (request.method or "GET").upper()
     raw_url = request.url or ""
     scrubbed_url = scrub_url(raw_url)
+    if redact_values:
+        scrubbed_url = redact_literal_values(scrubbed_url, redact_values)
     template = url_template(raw_url)
     host = host_of(raw_url)
     status_code = response.status_code if response is not None else None
@@ -109,7 +121,7 @@ def record_request(
     ctx = current_job_context()
     _emit_log(record, host=host, url_template=template, ctx=ctx)
     _emit_metrics(record, host=host, ctx=ctx)
-    _maybe_capture_sample(request, response, record=record, ctx=ctx, exception=exception)
+    _maybe_capture_sample(request, response, record=record, ctx=ctx, exception=exception, redact_values=redact_values)
 
 
 def _emit_log(
@@ -165,10 +177,11 @@ def _maybe_capture_sample(
     record: RequestRecord,
     ctx: JobContext | None,
     exception: BaseException | None,
+    redact_values: tuple[str, ...] = (),
 ) -> None:
     if ctx is None or exception is not None:
         return
     try:
-        maybe_capture(request=request, response=response, record=record, ctx=ctx)
+        maybe_capture(request=request, response=response, record=record, ctx=ctx, redact_values=redact_values)
     except Exception:
         _fallback_logger.debug("Failed to capture HTTP sample", exc_info=True)

--- a/posthog/temporal/data_imports/sources/common/http/sampling.py
+++ b/posthog/temporal/data_imports/sources/common/http/sampling.py
@@ -42,7 +42,11 @@ from django.conf import settings
 from posthog.redis import get_client
 from posthog.storage import object_storage
 from posthog.temporal.data_imports.sources.common.http.context import JobContext
-from posthog.temporal.data_imports.sources.common.http.url_utils import _REDACT_PARAM_NAMES, scrub_url
+from posthog.temporal.data_imports.sources.common.http.url_utils import (
+    _REDACT_PARAM_NAMES,
+    redact_literal_values,
+    scrub_url,
+)
 
 if TYPE_CHECKING:
     from requests import PreparedRequest, Response
@@ -216,8 +220,13 @@ def maybe_capture(
     response: Response | None,
     record: RequestRecord,
     ctx: JobContext,
+    redact_values: tuple[str, ...] = (),
 ) -> None:
-    """Entry point used by the observer. No-op when no rule matches."""
+    """Entry point used by the observer. No-op when no rule matches.
+
+    `redact_values` are credential strings masked from the captured sample on
+    top of the name-based header/URL/body scrubbers.
+    """
     if response is None:
         return
 
@@ -240,6 +249,11 @@ def maybe_capture(
         return
 
     payload = _build_sample_payload(request=request, response=response, record=record, ctx=ctx)
+    if redact_values:
+        # Final value-based pass over the fully serialized sample: catches the
+        # credential wherever it landed (query param, custom header, cookie,
+        # body) regardless of the name-based scrubbers above.
+        payload = redact_literal_values(payload, redact_values)
     sequence = _next_sequence(config.capture_id, ctx.source_type)
     key = _sample_object_key(config.capture_id, ctx.source_type, sequence)
     bucket = settings.OBJECT_STORAGE_BUCKET

--- a/posthog/temporal/data_imports/sources/common/http/transport.py
+++ b/posthog/temporal/data_imports/sources/common/http/transport.py
@@ -40,7 +40,16 @@ class TrackedHTTPAdapter(HTTPAdapter):
     `send()` is the lowest synchronous hook in the requests stack — it sees
     the fully-prepared request and the raw response, exception or not, with
     no SDK-specific framing on top.
+
+    `redact_values` are credential strings to mask wherever they appear in the
+    logged URL or captured sample — value-based masking that complements the
+    name-based denylists for auth injected under an unpredictable param/header
+    name (e.g. an API key in a query param).
     """
+
+    def __init__(self, *args: Any, redact_values: tuple[str, ...] = (), **kwargs: Any) -> None:
+        self._redact_values = redact_values
+        super().__init__(*args, **kwargs)
 
     def send(
         self,
@@ -74,6 +83,7 @@ class TrackedHTTPAdapter(HTTPAdapter):
                     response,
                     started_at_monotonic=started,
                     exception=exception,
+                    redact_values=self._redact_values,
                 )
             except Exception:
                 # Belt-and-braces: record_request should never raise, but if
@@ -81,31 +91,38 @@ class TrackedHTTPAdapter(HTTPAdapter):
                 pass
 
 
-def make_tracked_adapter(retry: Retry | None = None, **kwargs: Any) -> TrackedHTTPAdapter:
+def make_tracked_adapter(
+    retry: Retry | None = None, redact_values: tuple[str, ...] = (), **kwargs: Any
+) -> TrackedHTTPAdapter:
     """Construct a `TrackedHTTPAdapter`.
 
     `retry=None` (the default) uses the built-in `DEFAULT_RETRY` policy. To
     truly opt out of retries, pass `retry=Retry(total=0)`. To override with
     different retry settings, pass a custom `Retry` instance. Any extra
-    kwargs are forwarded to `HTTPAdapter.__init__`.
+    kwargs are forwarded to `HTTPAdapter.__init__`. `redact_values` are
+    credential strings to mask in logged URLs and captured samples.
     """
     if retry is None:
         retry = DEFAULT_RETRY
-    return TrackedHTTPAdapter(max_retries=retry, **kwargs)
+    return TrackedHTTPAdapter(max_retries=retry, redact_values=redact_values, **kwargs)
 
 
 def make_tracked_session(
     *,
     retry: Retry | None = None,
     headers: dict[str, str] | None = None,
+    redact_values: tuple[str, ...] = (),
 ) -> requests.Session:
     """Return a fresh `requests.Session` with tracked HTTP/HTTPS adapters.
 
     See `make_tracked_adapter` for the `retry` parameter semantics — `None`
     uses `DEFAULT_RETRY`; pass `Retry(total=0)` to disable retries.
+    `redact_values` are credential strings to mask in logged URLs and captured
+    samples — for auth injected under a param/header name the denylist can't
+    predict (e.g. an API key in a query param).
     """
     session = requests.Session()
-    adapter = make_tracked_adapter(retry=retry)
+    adapter = make_tracked_adapter(retry=retry, redact_values=redact_values)
     session.mount("https://", adapter)
     session.mount("http://", adapter)
     if headers:

--- a/posthog/temporal/data_imports/sources/common/http/url_utils.py
+++ b/posthog/temporal/data_imports/sources/common/http/url_utils.py
@@ -14,8 +14,9 @@ group-by.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from typing import Final
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, quote, quote_plus, urlencode, urlsplit, urlunsplit
 
 _REDACT_PARAM_NAMES: Final[frozenset[str]] = frozenset(
     {
@@ -49,6 +50,29 @@ _REDACT_PARAM_NAMES: Final[frozenset[str]] = frozenset(
 )
 
 _REDACTED: Final[str] = "REDACTED"
+
+# Below this length a credential is too short to redact by value without risking
+# mangling unrelated log text; real API keys/tokens are far longer.
+_MIN_REDACT_VALUE_LEN: Final[int] = 4
+
+
+def redact_literal_values(text: str, values: Iterable[str]) -> str:
+    """Replace known secret values (and their URL-encoded forms) with REDACTED.
+
+    Complements the name-based `scrub_url`/header denylists: when a manifest puts
+    a credential in a query param, header, or cookie whose name we can't predict,
+    the value is still masked here because we know the exact credential string.
+    This is value-based masking (cf. Airbyte) — it covers any injection location
+    and any param name. Both the raw and percent-encoded forms are matched since
+    a query value is URL-encoded by the time it reaches the logged URL.
+    """
+    for value in values:
+        if not value or len(value) < _MIN_REDACT_VALUE_LEN:
+            continue
+        for variant in {value, quote(value, safe=""), quote_plus(value)}:
+            text = text.replace(variant, _REDACTED)
+    return text
+
 
 _NUMERIC_ID = re.compile(r"^\d+$")
 _UUID_ID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")

--- a/posthog/temporal/data_imports/sources/common/rest_source/auth.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/auth.py
@@ -14,6 +14,17 @@ class AuthConfigBase(AuthBase):
     def __bool__(self) -> bool:
         return True
 
+    def secret_values(self) -> tuple[str, ...]:
+        """Credential strings this auth carries, for log redaction.
+
+        The tracked HTTP transport masks these wherever they appear in logged
+        URLs, headers, and sampled bodies — so a credential injected under a
+        param/header name the denylist scrubber can't know in advance (e.g. an
+        API key in a query param) is still redacted. Each subclass declares its
+        own secret so the list can't drift from the field that holds it.
+        """
+        return ()
+
 
 class BearerTokenAuth(AuthConfigBase):
     def __init__(self, token: Optional[str] = None) -> None:
@@ -22,6 +33,9 @@ class BearerTokenAuth(AuthConfigBase):
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
         request.headers["Authorization"] = f"Bearer {self.token}"
         return request
+
+    def secret_values(self) -> tuple[str, ...]:
+        return (self.token,) if self.token else ()
 
 
 class APIKeyAuth(AuthConfigBase):
@@ -44,6 +58,9 @@ class APIKeyAuth(AuthConfigBase):
             request.prepare_cookies({self.name: self.api_key or ""})
         return request
 
+    def secret_values(self) -> tuple[str, ...]:
+        return (self.api_key,) if self.api_key else ()
+
 
 class HttpBasicAuth(AuthConfigBase):
     def __init__(
@@ -58,3 +75,16 @@ class HttpBasicAuth(AuthConfigBase):
         encoded = b64encode(f"{self.username}:{self.password}".encode()).decode()
         request.headers["Authorization"] = f"Basic {encoded}"
         return request
+
+    def secret_values(self) -> tuple[str, ...]:
+        return (self.password,) if self.password else ()
+
+
+def auth_secret_values(auth: Optional[AuthBase]) -> tuple[str, ...]:
+    """Secret credential strings carried by an auth object, for log redaction.
+
+    Delegates to :meth:`AuthConfigBase.secret_values` so the knowledge of which
+    field is secret lives on each auth class. Returns ``()`` for ``None`` or any
+    auth that isn't an :class:`AuthConfigBase`.
+    """
+    return auth.secret_values() if isinstance(auth, AuthConfigBase) else ()

--- a/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -10,6 +10,7 @@ from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_
 
 from posthog.temporal.data_imports.sources.common.http import make_tracked_session
 
+from .auth import auth_secret_values
 from .exceptions import IgnoreResponseException
 from .jsonpath_utils import TJsonPath, find_values
 from .paginators import BasePaginator
@@ -53,7 +54,9 @@ class RESTClient:
         # `RESTClient` participates in HTTP logging, metrics, and sample
         # capture. Callers can pass a pre-built `Session` for tests or
         # specialized auth (it should still be a tracked one in prod).
-        self.session = session or make_tracked_session()
+        # The auth's credential values are registered for value-based redaction
+        # so a key injected into a query param/custom header can't leak into logs.
+        self.session = session or make_tracked_session(redact_values=auth_secret_values(auth))
         if self.headers:
             self.session.headers.update(self.headers)
 

--- a/posthog/temporal/data_imports/sources/common/rest_source/tests/test_config_setup.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/tests/test_config_setup.py
@@ -2,7 +2,12 @@ from typing import Any, cast
 
 import pytest
 
-from posthog.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth, BearerTokenAuth, HttpBasicAuth
+from posthog.temporal.data_imports.sources.common.rest_source.auth import (
+    APIKeyAuth,
+    BearerTokenAuth,
+    HttpBasicAuth,
+    auth_secret_values,
+)
 from posthog.temporal.data_imports.sources.common.rest_source.config_setup import (
     Incremental,
     IncrementalParam,
@@ -155,3 +160,19 @@ class TestMergeResourceEndpoints:
         endpoint = cast(Endpoint, merged["endpoint"])
         assert endpoint["params"] == {"limit": 100, "since": "x"}
         assert endpoint["json"] == {"a": 1, "b": 2}
+
+
+class TestAuthSecretValues:
+    @pytest.mark.parametrize(
+        "auth,expected",
+        [
+            (None, ()),
+            (BearerTokenAuth(token="ya29.secret"), ("ya29.secret",)),
+            (APIKeyAuth(api_key="sk_live_x", name="key", location="query"), ("sk_live_x",)),
+            (HttpBasicAuth(username="alice", password="hunter2"), ("hunter2",)),
+            (BearerTokenAuth(), ()),
+            (APIKeyAuth(name="key", location="query"), ()),
+        ],
+    )
+    def test_extracts_secret_strings(self, auth: Any, expected: tuple[str, ...]) -> None:
+        assert auth_secret_values(auth) == expected

--- a/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from requests import Response
 
+from posthog.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
 from posthog.temporal.data_imports.sources.common.rest_source.exceptions import IgnoreResponseException
 from posthog.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator, SinglePagePaginator
 from posthog.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient, RESTClientRetryableError
@@ -109,6 +110,21 @@ class TestRESTClient:
         )
 
         assert len(pages) == 0
+
+    # The auth's secret must be registered with the tracked session so it's masked from
+    # logs even when injected into a query param / custom header; no auth → nothing to redact.
+    @pytest.mark.parametrize(
+        "auth,expected_redact_values",
+        [
+            (APIKeyAuth(api_key="sk_live_x", name="key", location="query"), ("sk_live_x",)),
+            (None, ()),
+        ],
+    )
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session")
+    def test_builds_session_with_credentials_for_redaction(self, MockSession, auth, expected_redact_values) -> None:
+        MockSession.return_value.headers = {}
+        RESTClient(base_url="https://api.example.com", auth=auth)
+        assert MockSession.call_args.kwargs["redact_values"] == expected_redact_values
 
     def test_join_url(self) -> None:
         client = RESTClient(base_url="https://api.example.com")

--- a/posthog/temporal/data_imports/sources/common/test/test_http_observer.py
+++ b/posthog/temporal/data_imports/sources/common/test/test_http_observer.py
@@ -132,6 +132,20 @@ def test_log_redacts_auth_query_params(captured_logs):
     assert "REDACTED" in entry["url"]
 
 
+def test_log_redacts_credential_in_non_denylisted_query_param(captured_logs):
+    # An API key injected into a param the denylist can't anticipate must still
+    # be masked via value-based redaction.
+    request = _make_request(url="https://api.example.com/?subscription-key=sk_live_leaky&page=2")
+    response = _make_response(status_code=200)
+
+    record_request(request, response, started_at_monotonic=time.monotonic(), redact_values=("sk_live_leaky",))
+
+    entry = _entries(captured_logs)[-1]
+    assert "sk_live_leaky" not in entry["url"]
+    assert "REDACTED" in entry["url"]
+    assert "page=2" in entry["url"]
+
+
 def test_log_includes_job_context_fields(captured_logs, job_ctx):
     request = _make_request()
     response = _make_response(status_code=200)

--- a/posthog/temporal/data_imports/sources/common/test/test_http_transport.py
+++ b/posthog/temporal/data_imports/sources/common/test/test_http_transport.py
@@ -83,6 +83,24 @@ def test_make_tracked_adapter_with_none_retry_uses_default():
     assert adapter.max_retries.total == DEFAULT_RETRY.total
 
 
+def test_send_forwards_redact_values_to_record(mock_record, fake_http_send):
+    session = make_tracked_session(redact_values=("sk_live_secret",))
+
+    with fake_http_send(_fake_response(status_code=200, body=b"ok")):
+        session.get("https://api.example.com/v1/ok")
+
+    assert mock_record.call_args.kwargs["redact_values"] == ("sk_live_secret",)
+
+
+def test_send_defaults_redact_values_to_empty(mock_record, fake_http_send):
+    session = make_tracked_session()
+
+    with fake_http_send(_fake_response(status_code=200, body=b"ok")):
+        session.get("https://api.example.com/v1/ok")
+
+    assert mock_record.call_args.kwargs["redact_values"] == ()
+
+
 def test_send_records_request_for_2xx(mock_record, fake_http_send):
     session = make_tracked_session()
 

--- a/posthog/temporal/data_imports/sources/common/test/test_http_url_utils.py
+++ b/posthog/temporal/data_imports/sources/common/test/test_http_url_utils.py
@@ -1,6 +1,11 @@
 import pytest
 
-from posthog.temporal.data_imports.sources.common.http.url_utils import host_of, scrub_url, url_template
+from posthog.temporal.data_imports.sources.common.http.url_utils import (
+    host_of,
+    redact_literal_values,
+    scrub_url,
+    url_template,
+)
 
 
 @pytest.mark.parametrize(
@@ -108,3 +113,37 @@ def test_url_template_replaces_id_segments(url: str, expected: str) -> None:
 )
 def test_host_of(url: str, expected: str) -> None:
     assert host_of(url) == expected
+
+
+@pytest.mark.parametrize(
+    "text,values,expected",
+    [
+        # Raw value anywhere in the text — including a query param whose name the
+        # denylist can't anticipate.
+        (
+            "https://x.test/?subscription-key=sk_live_abcdef123456",
+            ["sk_live_abcdef123456"],
+            "https://x.test/?subscription-key=REDACTED",
+        ),
+        # Percent-encoded form is matched too (query values are URL-encoded).
+        (
+            "https://x.test/?k=a%20b%2Bc",
+            ["a b+c"],
+            "https://x.test/?k=REDACTED",
+        ),
+        # Value in a header-style string / sample payload.
+        (
+            '{"headers": {"Subscription-Key": "sk_live_abcdef123456"}}',
+            ["sk_live_abcdef123456"],
+            '{"headers": {"Subscription-Key": "REDACTED"}}',
+        ),
+        # Multiple secrets.
+        ("a=tok_one b=tok_two", ["tok_one", "tok_two"], "a=REDACTED b=REDACTED"),
+        # Empty / too-short values are skipped so unrelated text isn't mangled.
+        ("page=2&id=ab", ["", "ab"], "page=2&id=ab"),
+        # No secrets supplied — text is returned untouched.
+        ("https://x.test/?api_key=secret", [], "https://x.test/?api_key=secret"),
+    ],
+)
+def test_redact_literal_values(text: str, values: list[str], expected: str) -> None:
+    assert redact_literal_values(text, values) == expected

--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -20,6 +20,7 @@ from posthog.temporal.data_imports.sources.common.http import make_tracked_sessi
 from posthog.temporal.data_imports.sources.common.mixins import _is_host_safe
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resource
+from posthog.temporal.data_imports.sources.common.rest_source.auth import auth_secret_values
 from posthog.temporal.data_imports.sources.common.rest_source.config_setup import create_auth
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import CustomSourceConfig
@@ -305,7 +306,10 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
         except (ValueError, TypeError) as exc:
             return False, f"Invalid auth configuration: {exc}"
 
-        session = make_tracked_session(headers=headers)
+        # Register the credential values so they're redacted from the probe's
+        # request logs/samples even when injected under a manifest-chosen
+        # query-param or header name the denylist scrubber can't anticipate.
+        session = make_tracked_session(headers=headers, redact_values=auth_secret_values(probe_auth))
 
         for resource in manifest["resources"]:
             endpoint = resource.get("endpoint", {})

--- a/posthog/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_custom_source.py
@@ -444,6 +444,22 @@ class TestCustomSourceValidateCredentials(SimpleTestCase):
             assert getattr(probe_auth, attr) == expected, f"{attr} mismatch"
 
     @patch("posthog.temporal.data_imports.sources.custom.source.make_tracked_session")
+    def test_probe_registers_credential_for_redaction(self, mock_session):
+        # The secret must be handed to the tracked session as a redact value so
+        # it's masked from logs/samples even when injected into a query param
+        # whose name the denylist scrubber can't anticipate.
+        mock_session.return_value.request.return_value = MagicMock(status_code=200, text="{}")
+        manifest = _minimal_manifest()
+        manifest["client"]["auth"] = {"type": "api_key", "name": "subscription-key", "location": "query"}
+
+        source = CustomSource()
+        config = CustomSourceConfig(manifest_json=json.dumps(manifest), auth_api_key="sk_live_leaky")
+        ok, err = source.validate_credentials(config, team_id=999)
+        assert ok, err
+
+        assert mock_session.call_args.kwargs["redact_values"] == ("sk_live_leaky",)
+
+    @patch("posthog.temporal.data_imports.sources.custom.source.make_tracked_session")
     def test_returns_false_on_network_error(self, mock_session):
         # A connection-level failure (DNS, TLS, timeout) must surface as a
         # credential validation error pointing at the offending resource.


### PR DESCRIPTION
## Problem

The Custom REST source lets the manifest configure API-key auth injected into a query parameter (or a custom header/cookie) under an arbitrary, user-chosen name. The tracked HTTP transport only redacts credentials from logs and captured request samples by matching against a **fixed denylist of parameter/header names** (`url_utils._REDACT_PARAM_NAMES`, `sampling._AUTH_HEADER_NAMES`). A manifest naming its key something off the denylist — e.g. `subscription-key` — would write the upstream API key in plaintext into `data_imports.http.request` log lines and into sampled requests in object storage.

Flagged in review of #59612.

## Changes

Adds **value-based redaction** on top of the existing name-based scrubbers, mirroring how Airbyte masks `airbyte_secret` config values: we know the exact credential string, so we mask it wherever it appears regardless of injection location (query, header, cookie, body) or parameter name.

- `url_utils.redact_literal_values()` — replaces a known secret string and its URL-encoded forms with `REDACTED`. Skips empty/very short values so unrelated log text isn't mangled.
- `auth.auth_secret_values()` — extracts the credential strings (`token` / `api_key` / `password`) carried by an auth object.
- Threaded the values through `make_tracked_session` → `TrackedHTTPAdapter` → `record_request`, where they're applied to the logged URL and forwarded into the captured sample.
- Wired in automatically at both choke points:
  - **Sync path:** `RESTClient` derives the values from its `auth` object — so this protects *every* REST-based source, not just the custom one.
  - **Probe path:** the custom source's create-time `validate_credentials` probe registers the same values.

This is purely additive — `redact_values` defaults to empty, so behaviour is unchanged for callers that don't pass credentials.

## How did you test this code?

I'm an agent; I did not perform manual testing. Added and ran automated tests (all passing):

- `redact_literal_values` — raw value, percent-encoded form, header/payload string, multiple secrets, short/empty skip, no-op when empty.
- `auth_secret_values` — extraction across bearer / api_key / http_basic, and empty when no credential set.
- Transport — adapter forwards `redact_values` to `record_request` (and defaults to empty).
- `RESTClient` — builds its tracked session with credentials derived from `auth`.
- Custom source probe — registers the credential for redaction when auth is injected into a query param.
- Observer end-to-end — a key in a non-denylisted query param (`subscription-key`) is masked in the logged URL while unrelated params survive.

## 🤖 Agent context

Authored by Claude Code (claude-opus-4-8) while working through review feedback on #59612. Tools: Read/Edit/Bash/Grep, plus two parallel Explore subagents to study how Airbyte handles credential masking and descending-order incremental resume.

Key decision: the reviewer offered "constrain the param name to the denylist" vs "thread the configured name into the scrubber." The Airbyte exploration showed the robust industry approach is **value-based** masking (mask the known secret value everywhere) rather than name-based, so we chose that — it covers any injection location and any name without restricting what users can name their auth param. Deriving the values from the `auth` object inside `RESTClient` (rather than threading them per-source) means the protection is automatic for all sources.

Stacked on #59612.
