### PR TITLE
chore(ci): allow manual dispatch and raise timeout for stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
     stale:
         runs-on: ubuntu-24.04
-        timeout-minutes: 10
+        timeout-minutes: 60
         steps:
             - name: Check if holiday period
               id: holiday

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -2,6 +2,7 @@ name: 'Handle stale PRs'
 on:
     schedule:
         - cron: '30 7 * * 1-5'
+    workflow_dispatch:
 
 permissions:
     contents: read


### PR DESCRIPTION
## Problem

Two small follow-ups after #60402 landed:

1. The stale workflow only runs on a Mon–Fri 07:30 UTC cron — useful to be able to trigger it on-demand from the Actions tab, both to validate that the new `operations-per-run: 5000` budget actually completes a full cycle, and to nudge re-evaluation without waiting for the next scheduled tick.
2. `timeout-minutes: 10` was sized against the old 250-op cap. With the budget at 5000 and a backlog of un-evaluated issues from before #60402, the first few runs may do substantial catch-up work and could time out before completing.

## Changes

```yaml
on:
    schedule:
        - cron: '30 7 * * 1-5'
    workflow_dispatch:        # new: manual Actions-tab trigger

jobs:
    stale:
        timeout-minutes: 10 → 60
```

### Is 5000 enough?

Yes, with plenty of headroom. `operations-per-run` is GitHub **API operations**, not issues/PRs visited — confirmed via both `actions/stale@v10.2.0` source (`StaleOperations._operationsConsumed < operationsPerRun`) and the action's own README:

> "This option aims to limit the number of operations made with the GitHub API to avoid reaching the rate limit. Only the actor and the batch of issues (100 per batch) will consume the operations."

Most per-issue checks cost zero ops — only `getIssues()` (per page of 100) and conditional actions (label add / comment / close / events-fetch on already-stale issues) draw against the budget.

Rough budget for PostHog (~7k open issues + ~200 PRs):

| | ops |
| --- | --- |
| Listing all issues (1 op per page of 100) | ~72 |
| Per "not stale, do nothing" visit (the vast majority) | 0 |
| Stale-labeled issues being checked (events + comments) | 1–3 each |
| Newly marked stale (label + comment) | 2 each |
| Closing (comment + label + state change) | 3 each |

Steady state for PostHog is somewhere around 200–400 ops/run. The first few runs after #60402 may burn extra on backlog clearance (issues that should have been marked stale weeks ago but weren't because of the previous cap) — even being generous, that's well under 2000. 5000 has 5–25× headroom across all scenarios.

The `enable-statistics: true` block in the workflow log will confirm the real number on the first cron tick after this PR lands. If it ever runs hot, the knob is easy to bump again.

### Why 60 minutes for the timeout

With 5000 ops and the app token's 15k req/hr rate limit, max theoretical runtime is ~20 minutes (5000 / 15000 × 60). 60 leaves comfortable headroom for slow API responses and backlog runs without hiding genuinely runaway behavior.

## How did you test this code?

I'm Claude (Opus 4.7) — agent-authored, no live run.

- Inspection only on both changes: `workflow_dispatch:` is a one-line addition to an existing `on:` block; `timeout-minutes` is a single-value bump. Neither affects what the stale action does, only when / for how long.
- Confirmed `actions/stale` op accounting via source reading (`StaleOperations`, `_consumeIssueOperation`) and README.
- Will be exercisable from the Actions tab the moment this lands.

## Publish to changelog?

no

## 🤖 Agent context

Authored via Claude Code (Opus 4.7) as a follow-up to #60402.