### PR TITLE
fix(workflows) batch trigger distinct

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.test.ts
@@ -270,7 +270,10 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
 
             // Mock the batch person query service to return some persons
             const mockGetBlastRadiusPersons = jest.fn().mockResolvedValue({
-                users_affected: ['person-1', 'person-2'],
+                users_affected: [
+                    { person_id: 'person-1', distinct_id: 'distinct-1' },
+                    { person_id: 'person-2', distinct_id: 'distinct-2' },
+                ],
                 cursor: null,
                 has_more: false,
             })
@@ -302,11 +305,13 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
                 state: {
                     event: expect.objectContaining({
                         event: '$batch_hog_flow_invocation',
+                        distinct_id: 'distinct-1',
                     }),
                     actionStepCount: 0,
                 },
                 person: expect.objectContaining({
                     id: 'person-1',
+                    name: 'distinct-1',
                 }),
             })
             expect(result[1]).toMatchObject({
@@ -319,11 +324,13 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
                 state: {
                     event: expect.objectContaining({
                         event: '$batch_hog_flow_invocation',
+                        distinct_id: 'distinct-2',
                     }),
                     actionStepCount: 0,
                 },
                 person: expect.objectContaining({
                     id: 'person-2',
+                    name: 'distinct-2',
                 }),
             })
 
@@ -346,12 +353,15 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
             const mockGetBlastRadiusPersons = jest
                 .fn()
                 .mockResolvedValueOnce({
-                    users_affected: ['person-1', 'person-2'],
+                    users_affected: [
+                        { person_id: 'person-1', distinct_id: 'distinct-1' },
+                        { person_id: 'person-2', distinct_id: 'distinct-2' },
+                    ],
                     cursor: 'cursor-1',
                     has_more: true,
                 })
                 .mockResolvedValueOnce({
-                    users_affected: ['person-3'],
+                    users_affected: [{ person_id: 'person-3', distinct_id: 'distinct-3' }],
                     cursor: null,
                     has_more: false,
                 })
@@ -402,17 +412,23 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
             const mockGetBlastRadiusPersons = jest
                 .fn()
                 .mockResolvedValueOnce({
-                    users_affected: ['person-1', 'person-2'],
+                    users_affected: [
+                        { person_id: 'person-1', distinct_id: 'distinct-1' },
+                        { person_id: 'person-2', distinct_id: 'distinct-2' },
+                    ],
                     cursor: 'cursor-1',
                     has_more: true,
                 })
                 .mockResolvedValueOnce({
-                    users_affected: ['person-3', 'person-4'],
+                    users_affected: [
+                        { person_id: 'person-3', distinct_id: 'distinct-3' },
+                        { person_id: 'person-4', distinct_id: 'distinct-4' },
+                    ],
                     cursor: 'cursor-2',
                     has_more: true,
                 })
                 .mockResolvedValueOnce({
-                    users_affected: ['person-5'],
+                    users_affected: [{ person_id: 'person-5', distinct_id: 'distinct-5' }],
                     cursor: null,
                     has_more: false,
                 })
@@ -463,7 +479,7 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
 
             // Mock the batch person query service
             const mockGetBlastRadiusPersons = jest.fn().mockResolvedValue({
-                users_affected: ['person-1'],
+                users_affected: [{ person_id: 'person-1', distinct_id: 'distinct-1' }],
             })
             processor['hogFlowBatchPersonQueryService'].getBlastRadiusPersons = mockGetBlastRadiusPersons
 
@@ -507,7 +523,7 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
 
             // Mock the batch person query service
             const mockGetBlastRadiusPersons = jest.fn().mockResolvedValue({
-                users_affected: ['person-1'],
+                users_affected: [{ person_id: 'person-1', distinct_id: 'distinct-1' }],
             })
             processor['hogFlowBatchPersonQueryService'].getBlastRadiusPersons = mockGetBlastRadiusPersons
 
@@ -627,7 +643,10 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
 
             // Mock the batch person query service
             const mockGetBlastRadiusPersons = jest.fn().mockResolvedValue({
-                users_affected: ['distinct-1', 'distinct-2'],
+                users_affected: [
+                    { person_id: 'distinct-1', distinct_id: 'did-1' },
+                    { person_id: 'distinct-2', distinct_id: 'did-2' },
+                ],
             })
             processor['hogFlowBatchPersonQueryService'].getBlastRadiusPersons = mockGetBlastRadiusPersons
 

--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
@@ -58,17 +58,20 @@ export class CdpBatchHogFlowRequestsConsumer extends CdpConsumerBase<PluginsServ
         hogFlow,
         team,
         personId,
+        distinctId,
         defaultVariables,
     }: {
         parentRunId: string
         hogFlow: HogFlow
         team: Team
         personId: string
+        distinctId: string | null
         defaultVariables: Record<string, any>
     }): CyclotronJobInvocation {
         const invocationGlobals = convertBatchHogFlowRequestToHogFunctionInvocationGlobals({
             team: team,
             personId,
+            distinctId,
             siteUrl: this.config.SITE_URL,
         })
 
@@ -156,12 +159,13 @@ export class CdpBatchHogFlowRequestsConsumer extends CdpConsumerBase<PluginsServ
             )
 
             // Create invocations for this batch of persons
-            const batchInvocations = blastRadiusPersons.users_affected.map((personId) =>
+            const batchInvocations = blastRadiusPersons.users_affected.map(({ person_id, distinct_id }) =>
                 this.createHogFlowInvocation({
                     parentRunId: batchHogFlowRequest.parentRunId,
                     hogFlow,
                     team,
-                    personId,
+                    personId: person_id,
+                    distinctId: distinct_id,
                     defaultVariables,
                 })
             )

--- a/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.test.ts
@@ -109,12 +109,12 @@ describe('HogFlowBatchPersonQueryService', () => {
         it("uses the first page's cursor for the next page request", async () => {
             const service = createService()
             const firstPageResponse: BlastRadiusPersonsResponse = {
-                users_affected: ['person_1'],
+                users_affected: [{ person_id: 'person_1', distinct_id: 'did_1' }],
                 cursor: 'next-cursor',
                 has_more: true,
             }
             const secondPageResponse: BlastRadiusPersonsResponse = {
-                users_affected: ['person_2'],
+                users_affected: [{ person_id: 'person_2', distinct_id: null }],
                 cursor: null,
                 has_more: false,
             }

--- a/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.ts
@@ -10,8 +10,13 @@ export interface BlastRadiusResponse {
     total_users: number
 }
 
+export interface BlastRadiusPerson {
+    person_id: string
+    distinct_id: string | null
+}
+
 export interface BlastRadiusPersonsResponse {
-    users_affected: Array<string>
+    users_affected: Array<BlastRadiusPerson>
     cursor: string | null
     has_more: boolean
 }
@@ -73,7 +78,8 @@ export class HogFlowBatchPersonQueryService {
 
     /**
      * Get list of persons affected by filters with cursor-based pagination.
-     * Returns distinct_id and person_id for each matching person, plus pagination info.
+     * Returns {person_id, distinct_id} for each matching person, plus pagination info.
+     * For group-based filters distinct_id is null and person_id carries the group key.
      *
      * @param cursor - Optional cursor from previous response for pagination
      */

--- a/nodejs/src/cdp/templates/_destinations/posthog_capture/posthog-update-person-properties.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_capture/posthog-update-person-properties.template.ts
@@ -33,7 +33,8 @@ postHogCapture({
             secret: false,
             hidden: false,
             default: '{event.distinct_id}',
-            description: 'The distinct ID associated with the Person.',
+            description:
+                'The distinct ID of the person to update. The default `{event.distinct_id}` works for both event-triggered and batch workflows. Do not use `{person.id}` — it would create a new person profile instead of updating the existing one.',
         },
         {
             type: 'dictionary',

--- a/nodejs/src/cdp/utils.ts
+++ b/nodejs/src/cdp/utils.ts
@@ -90,19 +90,23 @@ export function convertToHogFunctionInvocationGlobals(
 export function convertBatchHogFlowRequestToHogFunctionInvocationGlobals({
     team,
     personId,
+    distinctId,
     siteUrl,
 }: {
     team: Team
     personId: string
+    distinctId?: string | null
     siteUrl: string
 }): HogFunctionInvocationGlobals {
     const projectUrl = `${siteUrl}/project/${team.id}`
 
+    // Prefer the distinct_id in the person URL so templates and logs surface a user-facing handle
+    const personUrlHandle = distinctId ?? personId
     const person: HogFunctionInvocationGlobals['person'] = {
         id: personId,
         properties: {},
-        name: '',
-        url: `${projectUrl}/person/${encodeURIComponent(personId)}`,
+        name: distinctId ?? '',
+        url: `${projectUrl}/person/${encodeURIComponent(personUrlHandle)}`,
     }
 
     const context: HogFunctionInvocationGlobals = {
@@ -115,7 +119,8 @@ export function convertBatchHogFlowRequestToHogFunctionInvocationGlobals({
             event: '$batch_hog_flow_invocation',
             properties: {},
             uuid: new UUIDT().toString(),
-            distinct_id: '', // Not applicable for batch processing but left here for compatibility
+            // Populated from persons.pdi for batch invocations; empty when a person has no distinct_ids
+            distinct_id: distinctId ?? '',
             elements_chain: '',
             timestamp: DateTime.now().toISO(),
             url: '',

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -679,10 +679,12 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
 
         try:
             users_affected = get_user_blast_radius_persons(team, filters, group_type_index, cursor)
+            # Cursor is the last person_id/group_key seen; pagination is keyset by that field.
+            next_cursor = users_affected[-1]["person_id"] if users_affected else None
             return Response(
                 {
                     "users_affected": users_affected,
-                    "cursor": users_affected[-1] if users_affected else None,
+                    "cursor": next_cursor,
                     "has_more": len(users_affected) == PERSON_BATCH_SIZE,
                 }
             )

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_person
 from unittest.mock import patch
 
 from parameterized import parameterized
@@ -1446,3 +1446,72 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == expected_status, response.json()
         if expected_error:
             assert response.json()["detail"] == expected_error
+
+
+class TestHogFlowBlastRadiusPersons(ClickhouseTestMixin, APIBaseTest):
+    """Regression coverage for the batch hog flow pipeline: every returned person
+    must carry a distinct_id so templates defaulting to `{event.distinct_id}` resolve
+    when a workflow is triggered by a batch trigger."""
+
+    def test_person_results_include_distinct_id(self):
+        from posthog.models.feature_flag.user_blast_radius import get_user_blast_radius_persons
+
+        for i in range(3):
+            _create_person(
+                team_id=self.team.pk,
+                distinct_ids=[f"person{i}@posthog.com"],
+                properties={"group": f"{i}"},
+            )
+
+        result = get_user_blast_radius_persons(
+            self.team,
+            {
+                "properties": [
+                    {"key": "group", "type": "person", "value": ["0", "1"], "operator": "exact"},
+                ],
+            },
+        )
+
+        self.assertEqual(len(result), 2)
+        for entry in result:
+            self.assertIn("person_id", entry)
+            self.assertIn("distinct_id", entry)
+            self.assertIsNotNone(entry["person_id"])
+            # Each created person has exactly one distinct_id, so the pdi join must surface it
+            self.assertIsNotNone(entry["distinct_id"])
+            self.assertTrue(entry["distinct_id"].endswith("@posthog.com"))
+
+    def test_group_results_use_same_shape_with_null_distinct_id(self):
+        """Groups are surfaced in the same shape so the Node consumer can handle
+        both uniformly. distinct_id is None because groups have no distinct_id."""
+        from posthog.models import GroupTypeMapping
+        from posthog.models.feature_flag.user_blast_radius import get_user_blast_radius_persons
+        from posthog.models.group.util import create_group
+
+        GroupTypeMapping.objects.create(
+            team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
+        )
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="acme",
+            properties={"industry": "finance"},
+        )
+
+        result = get_user_blast_radius_persons(
+            self.team,
+            {
+                "properties": [
+                    {
+                        "key": "industry",
+                        "type": "group",
+                        "value": ["finance"],
+                        "operator": "exact",
+                        "group_type_index": 0,
+                    },
+                ],
+            },
+            group_type_index=0,
+        )
+
+        self.assertEqual(result, [{"person_id": "acme", "distinct_id": None}])

--- a/posthog/models/feature_flag/user_blast_radius.py
+++ b/posthog/models/feature_flag/user_blast_radius.py
@@ -107,11 +107,15 @@ def _get_person_blast_radius(team: Team, filter: Filter) -> tuple[int, int]:
 
 
 def _build_person_query(team: Team, filter: Filter, return_count: bool = True, cursor: Optional[str] = None):
-    """Build HogQL AST query to count or select distinct persons matching filters."""
+    """Build HogQL AST query to count or select distinct persons matching filters.
+
+    When return_count=False, the query also returns any distinct_id for each person
+    via persons.pdi. Pagination orders by persons.id so GROUP BY yields one row per person.
+    """
     from posthog.hogql import ast
     from posthog.hogql.property import property_to_expr
 
-    # Build the main SELECT with either count(DISTINCT persons.id) or DISTINCT persons.id
+    # Build the main SELECT with either count(DISTINCT persons.id) or (persons.id, any(pdi.distinct_id))
     if return_count:
         select_query = ast.SelectQuery(
             select=[ast.Call(name="count", distinct=True, args=[ast.Field(chain=["persons", "id"])])],
@@ -119,9 +123,12 @@ def _build_person_query(team: Team, filter: Filter, return_count: bool = True, c
         )
     else:
         select_query = ast.SelectQuery(
-            select=[ast.Field(chain=["persons", "id"])],
+            select=[
+                ast.Field(chain=["persons", "id"]),
+                ast.Call(name="any", args=[ast.Field(chain=["persons", "pdi", "distinct_id"])]),
+            ],
             select_from=ast.JoinExpr(table=ast.Field(chain=["persons"])),
-            distinct=True,
+            group_by=[ast.Field(chain=["persons", "id"])],
         )
 
     # Build WHERE clause with team_id and property filters
@@ -413,11 +420,17 @@ def _build_group_query(
     return select_query
 
 
-def _get_person_blast_radius_persons(team: Team, filter: Filter, cursor: Optional[str] = None) -> list[str]:
-    """Get distinct person IDs matching person-based feature flag filters."""
+def _get_person_blast_radius_persons(
+    team: Team, filter: Filter, cursor: Optional[str] = None
+) -> list[dict[str, Optional[str]]]:
+    """Get person IDs and a distinct_id for each, matching person-based feature flag filters.
+
+    Returns a list of {"person_id": str, "distinct_id": str | None}. distinct_id may be
+    None if a person has no pdi rows (possible on personless-events teams with INNER JOIN).
+    """
     from posthog.hogql.query import execute_hogql_query
 
-    # Build the SELECT query to get person IDs
+    # Build the SELECT query to get (person_id, distinct_id) pairs
     select_query = _build_person_query(team, filter, return_count=False, cursor=cursor)
 
     tag_queries(product=Product.FEATURE_FLAGS, feature=Feature.QUERY)
@@ -426,15 +439,25 @@ def _get_person_blast_radius_persons(team: Team, filter: Filter, cursor: Optiona
         team=team,
     )
 
-    # Extract person IDs from results
-    person_ids = [str(row[0]) for row in response.results] if response.results else []
-    return person_ids
+    if not response.results:
+        return []
+    return [
+        {
+            "person_id": str(row[0]),
+            "distinct_id": str(row[1]) if row[1] is not None else None,
+        }
+        for row in response.results
+    ]
 
 
 def _get_group_blast_radius_persons(
     team: Team, filter: Filter, group_type_index: GroupTypeIndex, cursor: Optional[str] = None
-) -> list[str]:
-    """Get distinct group keys matching group-based feature flag filters."""
+) -> list[dict[str, Optional[str]]]:
+    """Get distinct group keys matching group-based feature flag filters.
+
+    Returns dicts shaped like the person variant so callers can handle both uniformly:
+    {"person_id": <group_key>, "distinct_id": None}. Groups have no distinct_id concept.
+    """
     from posthog.hogql.query import execute_hogql_query
 
     properties = filter.property_groups.flat
@@ -456,6 +479,6 @@ def _get_group_blast_radius_persons(
         workload=Workload.OFFLINE,
     )
 
-    # Extract group keys from results
-    group_keys = [str(row[0]) for row in response.results] if response.results else []
-    return group_keys
+    if not response.results:
+        return []
+    return [{"person_id": str(row[0]), "distinct_id": None} for row in response.results]


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
<!-- Add the `skip-migration-service-check` label if every migration here is DB-noop (e.g. `SeparateDatabaseAndState` with empty `database_operations`, or pure `RunPython`) and it's safe to ship alongside service code. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
