### PR TITLE
chore(ci): add nudge for org members using non-PostHog git email

### DIFF
--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -60,8 +60,11 @@ jobs:
         steps:
             # GitHub App token is required because GITHUB_TOKEN can't read
             # org-private memberships (a private member looks like a non-member).
-            # On PRs from forks the secrets aren't available, so this step is
-            # allowed to fail — external contributors are never nudged.
+            # `owner`/`repositories` keep the token narrow while still scoping it at
+            # the org, so the org-level `Members: read` permission flows through —
+            # without `owner` the token is repo-scoped and that permission is dropped
+            # (see ci-backend.yml). On PRs from forks the secrets aren't available,
+            # so this step is allowed to fail — external contributors are never nudged.
             - name: Get app token for org membership check
               id: app-token
               continue-on-error: true
@@ -69,6 +72,8 @@ jobs:
               with:
                   client-id: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
+                  owner: ${{ github.repository_owner }}
+                  repositories: ${{ github.event.repository.name }}
 
             - name: Check whether PR author is a PostHog org member
               id: membership
@@ -98,6 +103,8 @@ jobs:
 
             - name: Nudge if commits use a non-PostHog email
               if: steps.membership.outputs.is-member == 'true'
+              # A non-critical nudge must never turn the PR red on a transient API error.
+              continue-on-error: true
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               env:
                   PR_AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -53,7 +53,9 @@ jobs:
         name: Nudge org members using a non-PostHog git email
         runs-on: ubuntu-24.04
         timeout-minutes: 5
-        if: github.event.pull_request.draft == false
+        # Only on the initial `opened` action (not `ready_for_review`), so it
+        # fires exactly once. Drafts are fine — we still want to nudge early.
+        if: github.event.action == 'opened'
 
         steps:
             # GitHub App token is required because GITHUB_TOKEN can't read
@@ -152,7 +154,11 @@ jobs:
                           marker,
                           `Hey @${author}! 👋`,
                           '',
-                          `It looks like some commits here were authored with an email that isn't your \`@posthog.com\` address (${emailList}). As a PostHog team member, please point your local git author email at your \`@posthog.com\` address so your contributions are attributed correctly.`,
+                          `Some commits on this PR were authored with an email that isn't your \`@posthog.com\` address (${emailList}). Since you're on the PostHog team, it's worth pointing your local git author email at your \`@posthog.com\` address. Why it matters:`,
+                          '',
+                          '- **Your commits get linked to your GitHub account** instead of showing up as an unrecognized author — so they appear on your contribution graph and reviewers can see who actually wrote what.',
+                          '- **Consistent, recognizable authorship across the team** in git history, which keeps internal contributions clearly distinguishable from external community ones.',
+                          '- **One identity for tooling to key off of** — anything that maps git history back to people works reliably when everyone uses their work address.',
                           '',
                           'You can fix it for this repo with:',
                           '',

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -114,15 +114,16 @@ jobs:
                           per_page: 100,
                       });
 
-                      // Only consider commits attributable to the PR author: either
-                      // GitHub matched the commit to them, or it couldn't match the
-                      // email to any account at all (the usual symptom of a
-                      // misconfigured local git email). Skip commits clearly authored
-                      // by someone else — co-authors, or GitHub's web-flow merge commits.
+                      // Only flag commits GitHub positively attributes to the PR
+                      // author. Everything else keeps its original author and is not
+                      // ours to nudge about: co-authors, external contributors,
+                      // someone else's rebased/pushed commits, web-flow merge commits.
+                      // If a commit's email isn't linked to any GitHub account we
+                      // can't attribute it, so we stay quiet rather than risk nagging
+                      // about someone else's commit.
                       const offendingEmails = new Set();
                       for (const c of commits) {
-                          const matchedLogin = c.author?.login;
-                          if (matchedLogin && matchedLogin !== author) {
+                          if (c.author?.login !== author) {
                               continue;
                           }
                           const email = (c.commit?.author?.email || '').toLowerCase();
@@ -154,11 +155,10 @@ jobs:
                           marker,
                           `Hey @${author}! 👋`,
                           '',
-                          `Some commits on this PR were authored with an email that isn't your \`@posthog.com\` address (${emailList}). Since you're on the PostHog team, it's worth pointing your local git author email at your \`@posthog.com\` address. Why it matters:`,
+                          `It looks like your git author email on this PR isn't your \`@posthog.com\` address (${emailList}). Since you're on the PostHog team, it's worth pointing your local git author email at your \`@posthog.com\` address. Why it matters:`,
                           '',
-                          '- **Your commits get linked to your GitHub account** instead of showing up as an unrecognized author — so they appear on your contribution graph and reviewers can see who actually wrote what.',
-                          '- **Consistent, recognizable authorship across the team** in git history, which keeps internal contributions clearly distinguishable from external community ones.',
-                          '- **One identity for tooling to key off of** — anything that maps git history back to people works reliably when everyone uses their work address.',
+                          '- **Consistent work identity in git history** — internal tooling that attributes commits to team members keys off your `@posthog.com` address.',
+                          '- **Keeps team contributions easy to tell apart from external community ones** when scanning history.',
                           '',
                           'You can fix it for this repo with:',
                           '',

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -48,3 +48,124 @@ jobs:
               run: |
                   SHAME_BODY="Hey @${PR_ACTOR}! 👋\nThis pull request seems to contain no description. Please add useful context, rationale, and/or any other information that will help make sense of this change now and in the distant Mars-based future."
                   gh pr comment "$PR_NUMBER" --body "$SHAME_BODY"
+
+    check-author-email:
+        name: Nudge org members using a non-PostHog git email
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        if: github.event.pull_request.draft == false
+
+        steps:
+            # GitHub App token is required because GITHUB_TOKEN can't read
+            # org-private memberships (a private member looks like a non-member).
+            # On PRs from forks the secrets aren't available, so this step is
+            # allowed to fail — external contributors are never nudged.
+            - name: Get app token for org membership check
+              id: app-token
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
+
+            - name: Check whether PR author is a PostHog org member
+              id: membership
+              if: steps.app-token.outputs.token != ''
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              env:
+                  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+              with:
+                  github-token: ${{ steps.app-token.outputs.token }}
+                  script: |
+                      const author = process.env.PR_AUTHOR;
+                      try {
+                          const { data: membership } = await github.rest.orgs.getMembershipForUser({
+                              org: 'PostHog',
+                              username: author,
+                          });
+                          core.setOutput('is-member', membership.state === 'active' ? 'true' : 'false');
+                      } catch (e) {
+                          if (e.status === 404) {
+                              core.setOutput('is-member', 'false'); // not in the org — nothing to do
+                          } else {
+                              // A flaky membership lookup should never fail the PR.
+                              core.warning(`Could not determine org membership for ${author}: ${e.message}`);
+                              core.setOutput('is-member', 'false');
+                          }
+                      }
+
+            - name: Nudge if commits use a non-PostHog email
+              if: steps.membership.outputs.is-member == 'true'
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              env:
+                  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              with:
+                  script: |
+                      const author = process.env.PR_AUTHOR;
+                      const prNumber = parseInt(process.env.PR_NUMBER, 10);
+
+                      const commits = await github.paginate(github.rest.pulls.listCommits, {
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          pull_number: prNumber,
+                          per_page: 100,
+                      });
+
+                      // Only consider commits attributable to the PR author: either
+                      // GitHub matched the commit to them, or it couldn't match the
+                      // email to any account at all (the usual symptom of a
+                      // misconfigured local git email). Skip commits clearly authored
+                      // by someone else — co-authors, or GitHub's web-flow merge commits.
+                      const offendingEmails = new Set();
+                      for (const c of commits) {
+                          const matchedLogin = c.author?.login;
+                          if (matchedLogin && matchedLogin !== author) {
+                              continue;
+                          }
+                          const email = (c.commit?.author?.email || '').toLowerCase();
+                          if (email && !email.endsWith('@posthog.com')) {
+                              offendingEmails.add(email);
+                          }
+                      }
+
+                      if (offendingEmails.size === 0) {
+                          console.log('All author commits use a @posthog.com email — nothing to nudge.');
+                          return;
+                      }
+
+                      // Post at most once per PR.
+                      const marker = '<!-- author-email-nudge -->';
+                      const existing = await github.paginate(github.rest.issues.listComments, {
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: prNumber,
+                          per_page: 100,
+                      });
+                      if (existing.some((comment) => comment.body?.includes(marker))) {
+                          console.log('Nudge already posted — skipping.');
+                          return;
+                      }
+
+                      const emailList = [...offendingEmails].map((e) => `\`${e}\``).join(', ');
+                      const body = [
+                          marker,
+                          `Hey @${author}! 👋`,
+                          '',
+                          `It looks like some commits here were authored with an email that isn't your \`@posthog.com\` address (${emailList}). As a PostHog team member, please point your local git author email at your \`@posthog.com\` address so your contributions are attributed correctly.`,
+                          '',
+                          'You can fix it for this repo with:',
+                          '',
+                          '```bash',
+                          'git config user.email "you@posthog.com"',
+                          '```',
+                          '',
+                          'Or set it globally with `git config --global user.email "you@posthog.com"`. No need to redo this PR — just a nudge for next time. 🙂',
+                      ].join('\n');
+
+                      await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: prNumber,
+                          body,
+                      });


### PR DESCRIPTION
## Problem

PostHog team members sometimes commit with non-`@posthog.com` email addresses, which makes it harder to:
- Attribute commits to team members in internal tooling that keys off the `@posthog.com` address
- Distinguish team contributions from external community ones when scanning git history

This PR adds an automated nudge in the PR workflow to gently remind org members to use their PostHog email for commits.

## Changes

Added a new `check-author-email` job to `.github/workflows/pr-opened.yml` that:

1. **Verifies org membership** — Uses a GitHub App token to check if the PR author is an active PostHog org member (skips external contributors)
2. **Scans commit emails** — Examines all commits attributed to the PR author and flags any using non-`@posthog.com` addresses
3. **Posts a nudge comment** — If offending emails are found, posts a friendly comment once per PR with:
   - The non-PostHog email(s) detected
   - Explanation of why it matters
   - Git config commands to fix it locally or globally
   - Reassurance that no action is needed on the current PR

The job only runs on the initial `opened` action (not `ready_for_review`), fires exactly once per PR, and gracefully handles fork PRs where secrets aren't available.

## How did you test this code?

This is a CI workflow addition. The logic is straightforward:
- GitHub App token creation and org membership checks use standard GitHub Actions patterns
- Commit email detection uses the GitHub REST API's `pulls.listCommits` endpoint
- Comment deduplication uses a marker comment to prevent duplicate nudges
- Error handling is defensive (flaky membership lookups don't fail the PR, fork PRs are skipped)

The workflow will be tested in practice when merged and triggered by subsequent PRs from org members.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed — this is an internal CI improvement.

https://claude.ai/code/session_01A7XexgSMVdTM9WvUXcA4dj