### PR TITLE
fix(hog-charts): lift the value label of the segment under the cursor

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -445,18 +445,23 @@ describe('BarChart', () => {
                         <ValueLabels />
                     </BarChart>
                 )
-                const liftOf = (text: string): string =>
-                    Array.from(chart.element.querySelectorAll<HTMLElement>('[data-attr="hog-chart-value-label"]')).find(
-                        (d) => d.textContent === text
-                    )?.style.transform ?? ''
+                const liftOf = (text: string): string => {
+                    const el = Array.from(
+                        chart.element.querySelectorAll<HTMLElement>('[data-attr="hog-chart-value-label"]')
+                    ).find((d) => d.textContent === text)
+                    if (!el) {
+                        throw new Error(`no value label "${text}"`)
+                    }
+                    return el.style.transform
+                }
 
-                // Cursor in the small slice (0..20): only 'small's label (20) lifts.
+                // small slice (0..20)
                 fireEvent.mouseMove(chart.element, { clientX: xForValue(10), clientY: yMidBand })
                 await waitFor(() => expect(liftOf('20')).toContain('translate(6px, 0px)'))
                 expect(liftOf('50')).not.toContain('6px')
                 expect(liftOf('100')).not.toContain('6px')
 
-                // Move into the mid slice (20..50): the lift follows to 'mid's label (50).
+                // mid slice (20..50) — lift follows the cursor
                 fireEvent.mouseMove(chart.element, { clientX: xForValue(30), clientY: yMidBand })
                 await waitFor(() => expect(liftOf('50')).toContain('translate(6px, 0px)'))
                 expect(liftOf('20')).not.toContain('6px')

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -340,6 +340,48 @@ describe('BarChart', () => {
             expect(tooltipEl?.textContent ?? '').toBe('')
         })
 
+        describe('sparse-stacked horizontal (overlap layout)', () => {
+            // Mirrors `buildTrendsBarAggregatedSeries`: each series has one non-zero value at
+            // its own dataIndex, every label is the same band. Smallest bar paints on top, so
+            // its colour wins at x=0..20, then mid at 20..50, then big at 50..100.
+            const SPARSE_LABELS = ['band', 'band', 'band']
+            const SPARSE_SERIES: Series[] = [
+                // DESC, matching how `trendsDataLogic` sorts ActionsBarValue results.
+                { key: 'big', label: 'Big', data: [100, 0, 0] },
+                { key: 'mid', label: 'Mid', data: [0, 50, 0] },
+                { key: 'small', label: 'Small', data: [0, 0, 20] },
+            ]
+            const HORIZONTAL_STACKED: BarChartConfig = { barLayout: 'stacked', axisOrientation: 'horizontal' }
+            // Value scale `[0, 100]` (already nice).
+            const xForValue = (value: number): number => dimensions.plotLeft + (value / 100) * dimensions.plotWidth
+            const yMidBand = dimensions.plotTop + dimensions.plotHeight / 2
+
+            it.each<[string, number, string, number]>([
+                ['small slice (0 < x < 20)', 10, 'small', 20],
+                ['mid slice (20 < x < 50)', 30, 'mid', 50],
+                ['big slice (50 < x < 100)', 75, 'big', 100],
+            ])(
+                'tooltip narrows to the visible segment with its own value for cursor in the %s',
+                async (_name, valueAtCursor, key, expectedValue) => {
+                    const { chart } = renderHogChart(
+                        <BarChart
+                            series={SPARSE_SERIES}
+                            labels={SPARSE_LABELS}
+                            theme={THEME}
+                            config={HORIZONTAL_STACKED}
+                        />
+                    )
+                    fireEvent.mouseMove(chart.element, {
+                        clientX: xForValue(valueAtCursor),
+                        clientY: yMidBand,
+                    })
+                    const tooltip = await chart.waitForTooltip()
+                    expect(tooltip.seriesData[0].series.key).toBe(key)
+                    expect(tooltip.seriesData[0].value).toBe(expectedValue)
+                }
+            )
+        })
+
         it('grouped layout still narrows when the cursor is above every bar (value-axis miss)', async () => {
             const { chart } = renderHogChart(
                 <BarChart series={SERIES} labels={LABELS} theme={THEME} config={{ barLayout: 'grouped' }} />

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, waitFor } from '@testing-library/react'
 
 import type { BarChartConfig, ChartTheme, PointClickData, Series } from '../../core/types'
 import { ReferenceLine } from '../../overlays/ReferenceLine'
+import { ValueLabels } from '../../overlays/ValueLabels'
 import { getHogChartTooltip, renderHogChart } from '../../testing'
 import { dimensions } from '../../testing/jsdom'
 import { BarChart } from './BarChart'
@@ -437,6 +438,29 @@ describe('BarChart', () => {
                     expect(click.seriesIndex).toBe(expectedSeriesIndex)
                 }
             )
+
+            it('hover-lifts the value label of the segment under the cursor, following the cursor', async () => {
+                const { chart } = renderHogChart(
+                    <BarChart series={SPARSE_SERIES} labels={SPARSE_LABELS} theme={THEME} config={HORIZONTAL_STACKED}>
+                        <ValueLabels />
+                    </BarChart>
+                )
+                const liftOf = (text: string): string =>
+                    Array.from(chart.element.querySelectorAll<HTMLElement>('[data-attr="hog-chart-value-label"]')).find(
+                        (d) => d.textContent === text
+                    )?.style.transform ?? ''
+
+                // Cursor in the small slice (0..20): only 'small's label (20) lifts.
+                fireEvent.mouseMove(chart.element, { clientX: xForValue(10), clientY: yMidBand })
+                await waitFor(() => expect(liftOf('20')).toContain('translate(6px, 0px)'))
+                expect(liftOf('50')).not.toContain('6px')
+                expect(liftOf('100')).not.toContain('6px')
+
+                // Move into the mid slice (20..50): the lift follows to 'mid's label (50).
+                fireEvent.mouseMove(chart.element, { clientX: xForValue(30), clientY: yMidBand })
+                await waitFor(() => expect(liftOf('50')).toContain('translate(6px, 0px)'))
+                expect(liftOf('20')).not.toContain('6px')
+            })
         })
 
         it('grouped layout still narrows when the cursor is above every bar (value-axis miss)', async () => {

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, waitFor } from '@testing-library/react'
 
 import type { BarChartConfig, ChartTheme, PointClickData, Series } from '../../core/types'
 import { ReferenceLine } from '../../overlays/ReferenceLine'
-import { renderHogChart } from '../../testing'
+import { getHogChartTooltip, renderHogChart } from '../../testing'
 import { dimensions } from '../../testing/jsdom'
 import { BarChart } from './BarChart'
 
@@ -338,6 +338,34 @@ describe('BarChart', () => {
             await new Promise((resolve) => setTimeout(resolve, 0))
             const tooltipEl = document.querySelector('[data-hog-charts-tooltip]') as HTMLElement | null
             expect(tooltipEl?.textContent ?? '').toBe('')
+        })
+
+        it('stacked horizontal suppresses tooltip past the bar value extent', async () => {
+            const { chart } = renderHogChart(
+                <BarChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ barLayout: 'stacked', axisOrientation: 'horizontal' }}
+                />
+            )
+            // plotHeight/2 lands in the middle row (Tue), which stacks to 35 while the value axis
+            // runs to the global max (Wed = 55) — so the left of the plot is filled bar and the
+            // right is empty track.
+            const yMidRow = dimensions.plotTop + dimensions.plotHeight / 2
+            // Over the bar: tooltip shows.
+            fireEvent.mouseMove(chart.element, {
+                clientX: dimensions.plotLeft + dimensions.plotWidth * 0.2,
+                clientY: yMidRow,
+            })
+            const tooltip = await chart.waitForTooltip()
+            expect(tooltip.element.textContent).toContain('Tue')
+            // Past the bar's value extent: tooltip must clear.
+            fireEvent.mouseMove(chart.element, {
+                clientX: dimensions.plotLeft + dimensions.plotWidth * 0.95,
+                clientY: yMidRow,
+            })
+            await waitFor(() => expect(getHogChartTooltip()?.textContent ?? '').toBe(''))
         })
 
         describe('sparse-stacked horizontal (overlap layout)', () => {

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -380,6 +380,35 @@ describe('BarChart', () => {
                     expect(tooltip.seriesData[0].value).toBe(expectedValue)
                 }
             )
+
+            it.each<[string, number, string, number, number]>([
+                ['small slice', 10, 'small', 20, 2],
+                ['mid slice', 30, 'mid', 50, 1],
+                ['big slice', 75, 'big', 100, 0],
+            ])(
+                'onPointClick routes to the visible segment for cursor in the %s',
+                async (_name, valueAtCursor, key, expectedValue, expectedSeriesIndex) => {
+                    const onPointClick = jest.fn()
+                    const { chart } = renderHogChart(
+                        <BarChart
+                            series={SPARSE_SERIES}
+                            labels={SPARSE_LABELS}
+                            theme={THEME}
+                            config={HORIZONTAL_STACKED}
+                            onPointClick={onPointClick}
+                        />
+                    )
+                    fireEvent.mouseMove(chart.element, {
+                        clientX: xForValue(valueAtCursor),
+                        clientY: yMidBand,
+                    })
+                    fireEvent.click(chart.element)
+                    const click: PointClickData = onPointClick.mock.calls[0][0]
+                    expect(click.series.key).toBe(key)
+                    expect(click.value).toBe(expectedValue)
+                    expect(click.seriesIndex).toBe(expectedSeriesIndex)
+                }
+            )
         })
 
         it('grouped layout still narrows when the cursor is above every bar (value-axis miss)', async () => {

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -45,9 +45,9 @@ import { BarTooltip } from './BarTooltip'
 import {
     type BarLayout,
     type BarsAtCursorArgs,
-    barContainsPoint,
     barContainsPointOnBandAxis,
     cursorOutsideBarFillExtent,
+    findVisibleStackedSegment,
     iterBarsAtCursor,
     isStackedLayout,
     resolveBarsAtCursor,
@@ -132,12 +132,9 @@ function BarChartInner<Meta = unknown>({
     } = config ?? {}
     const isHorizontal = axisOrientation === 'horizontal'
 
-    // Horizontal charts crush their row labels into an unreadable strip once the band count
-    // grows past what the parent's height can fit. Force a minimum px-per-row so each row
-    // has space for its tick label plus a little breathing room; the wrapper grows and the
-    // outer scene scrolls instead of squashing.
-    // Reserve ~64px for top + bottom margins (axis labels, plot padding) — matches the
-    // DEFAULT_MARGINS + axis-title floor in useChartMargins.
+    // Force a minimum px-per-row so horizontal rows don't crush below their tick labels;
+    // the wrapper grows and the outer scene scrolls. Margin matches DEFAULT_MARGINS + axis
+    // title floor in useChartMargins.
     const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
     const HORIZONTAL_CHART_MARGIN_PX = 64
     const resolvedMinBandSize = minBandSize ?? (isHorizontal ? HORIZONTAL_MIN_BAND_SIZE_DEFAULT : 0)
@@ -399,38 +396,89 @@ function BarChartInner<Meta = unknown>({
             type DrawItem = { series: ResolvedSeries; bar: BarRect; isTrackHighlight: boolean }
             const items: DrawItem[] = []
             let composition = ''
-            // Stacked/percent layouts: every segment in a band shares the same band-axis
-            // extent, so a band-axis-only hit-test picks every overlapping series at once and
-            // the last-drawn bar (the largest) ends up painting the highlight color over the
-            // whole row. Use full-rect containment so only the segment under the cursor is
-            // highlighted. Grouped keeps the band-axis check so cursor-above-bar still picks
-            // the correct sub-band.
+            // Stacked: clip the highlight to the visible slice so hover only changes shade,
+            // never z-order. Grouped keeps band-axis containment for cursor-above-bar.
             const stackedHighlight = isStackedLayout(barLayout)
-            for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
-                series: coloredSeries,
-                label: hoveredLabel,
-                dataIndex: hoverIndex,
-                scales: d3Scales,
-                layout: barLayout,
-                isHorizontal,
-                stackedData,
-                topStackedKeyByAxis,
-            })) {
-                if (hoverPosition) {
-                    const contained = stackedHighlight
-                        ? barContainsPoint(bar, hoverPosition)
-                        : barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)
-                    if (!contained) {
+            if (stackedHighlight && hoverPosition) {
+                const visible = findVisibleStackedSegment({
+                    series: coloredSeries,
+                    labels: drawLabels,
+                    hoveredLabel,
+                    cursor: hoverPosition,
+                    scales: d3Scales,
+                    layout: barLayout,
+                    isHorizontal,
+                    stackedData,
+                    topStackedKeyByAxis,
+                })
+                if (visible) {
+                    const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
+                    // Largest extent strictly smaller than `visible` — its far edge is the
+                    // inner boundary of `visible`'s slice.
+                    let nextSmallerExtent = 0
+                    for (let i = 0; i < drawLabels.length; i++) {
+                        if (drawLabels[i] !== hoveredLabel || i === visible.dataIndex) {
+                            continue
+                        }
+                        for (const { bar } of iterBarsAtCursor<ResolvedSeries>({
+                            series: coloredSeries,
+                            label: drawLabels[i],
+                            dataIndex: i,
+                            scales: d3Scales,
+                            layout: barLayout,
+                            isHorizontal,
+                            stackedData,
+                            topStackedKeyByAxis,
+                        })) {
+                            const ext = isHorizontal ? bar.width : bar.height
+                            if (ext > 0 && ext < visibleExtent && ext > nextSmallerExtent) {
+                                nextSmallerExtent = ext
+                            }
+                        }
+                    }
+                    const baselinePx = isHorizontal ? visible.bar.x : visible.bar.y + visible.bar.height
+                    const clipped: BarRect = isHorizontal
+                        ? {
+                              x: baselinePx + nextSmallerExtent,
+                              y: visible.bar.y,
+                              width: Math.max(0, visibleExtent - nextSmallerExtent),
+                              height: visible.bar.height,
+                              corners: visible.bar.corners,
+                              dataIndex: visible.bar.dataIndex,
+                          }
+                        : {
+                              x: visible.bar.x,
+                              y: baselinePx - visibleExtent,
+                              width: visible.bar.width,
+                              height: Math.max(0, visibleExtent - nextSmallerExtent),
+                              corners: visible.bar.corners,
+                              dataIndex: visible.bar.dataIndex,
+                          }
+                    items.push({ series: visible.series, bar: clipped, isTrackHighlight: false })
+                    composition += 'b'
+                }
+            } else {
+                for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
+                    series: coloredSeries,
+                    label: hoveredLabel,
+                    dataIndex: hoverIndex,
+                    scales: d3Scales,
+                    layout: barLayout,
+                    isHorizontal,
+                    stackedData,
+                    topStackedKeyByAxis,
+                })) {
+                    if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
                         continue
                     }
+                    const isTrackHighlight =
+                        barTrack === true &&
+                        barLayout === 'grouped' &&
+                        hoverPosition != null &&
+                        cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal)
+                    items.push({ series: s, bar, isTrackHighlight })
+                    composition += isTrackHighlight ? 't' : 'b'
                 }
-                const isTrackHighlight =
-                    barTrack === true &&
-                    barLayout === 'grouped' &&
-                    hoverPosition != null &&
-                    cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal)
-                items.push({ series: s, bar, isTrackHighlight })
-                composition += isTrackHighlight ? 't' : 'b'
             }
             if (items.length === 0) {
                 lastHoverKeyRef.current = null

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -414,23 +414,10 @@ function BarChartInner<Meta = unknown>({
                     const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
                     const { nextSmallerExtent } = visible
                     const baselinePx = isHorizontal ? visible.bar.x : visible.bar.y + visible.bar.height
+                    const clippedExtent = Math.max(0, visibleExtent - nextSmallerExtent)
                     const clipped: BarRect = isHorizontal
-                        ? {
-                              x: baselinePx + nextSmallerExtent,
-                              y: visible.bar.y,
-                              width: Math.max(0, visibleExtent - nextSmallerExtent),
-                              height: visible.bar.height,
-                              corners: visible.bar.corners,
-                              dataIndex: visible.bar.dataIndex,
-                          }
-                        : {
-                              x: visible.bar.x,
-                              y: baselinePx - visibleExtent,
-                              width: visible.bar.width,
-                              height: Math.max(0, visibleExtent - nextSmallerExtent),
-                              corners: visible.bar.corners,
-                              dataIndex: visible.bar.dataIndex,
-                          }
+                        ? { ...visible.bar, x: baselinePx + nextSmallerExtent, width: clippedExtent }
+                        : { ...visible.bar, y: baselinePx - visibleExtent, height: clippedExtent }
                     items.push({ series: visible.series, bar: clipped, isTrackHighlight: false })
                     composition += 'b'
                 }

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -45,6 +45,7 @@ import { BarTooltip } from './BarTooltip'
 import {
     type BarLayout,
     type BarsAtCursorArgs,
+    barContainsPoint,
     barContainsPointOnBandAxis,
     cursorOutsideBarFillExtent,
     iterBarsAtCursor,
@@ -398,6 +399,13 @@ function BarChartInner<Meta = unknown>({
             type DrawItem = { series: ResolvedSeries; bar: BarRect; isTrackHighlight: boolean }
             const items: DrawItem[] = []
             let composition = ''
+            // Stacked/percent layouts: every segment in a band shares the same band-axis
+            // extent, so a band-axis-only hit-test picks every overlapping series at once and
+            // the last-drawn bar (the largest) ends up painting the highlight color over the
+            // whole row. Use full-rect containment so only the segment under the cursor is
+            // highlighted. Grouped keeps the band-axis check so cursor-above-bar still picks
+            // the correct sub-band.
+            const stackedHighlight = isStackedLayout(barLayout)
             for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
                 series: coloredSeries,
                 label: hoveredLabel,
@@ -408,8 +416,13 @@ function BarChartInner<Meta = unknown>({
                 stackedData,
                 topStackedKeyByAxis,
             })) {
-                if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
-                    continue
+                if (hoverPosition) {
+                    const contained = stackedHighlight
+                        ? barContainsPoint(bar, hoverPosition)
+                        : barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)
+                    if (!contained) {
+                        continue
+                    }
                 }
                 const isTrackHighlight =
                     barTrack === true &&

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -517,6 +517,43 @@ function BarChartInner<Meta = unknown>({
         [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef]
     )
 
+    // Publish the visible segment under the cursor so overlays (value labels) can target it.
+    // Sparse-stacked bands hold several dataIndexes at one band slot, so `hoverIndex` alone
+    // can't say which segment the cursor is on.
+    const resolveHoverSegment = useCallback(
+        (
+            hoverIndex: number,
+            hoverPosition: { x: number; y: number } | null,
+            scales: ChartScales
+        ): { seriesKey: string; dataIndex: number } | null => {
+            if (
+                !isStackedLayout(barLayout) ||
+                !hoverPosition ||
+                hoverIndex < 0 ||
+                hoverIndex >= labelsRef.current.length
+            ) {
+                return null
+            }
+            const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
+            if (!d3Scales) {
+                return null
+            }
+            const visible = findVisibleStackedSegment({
+                series: seriesRef.current,
+                labels: labelsRef.current,
+                hoveredLabel: labelsRef.current[hoverIndex],
+                cursor: hoverPosition,
+                scales: d3Scales,
+                layout: barLayout,
+                isHorizontal,
+                stackedData,
+                topStackedKeyByAxis,
+            })
+            return visible ? { seriesKey: visible.series.key, dataIndex: visible.dataIndex } : null
+        },
+        [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef]
+    )
+
     const chart = (
         <Chart
             series={series}
@@ -539,6 +576,7 @@ function BarChartInner<Meta = unknown>({
             )}
             onPointClick={onPointClick}
             wrapClickData={onPointClick ? wrapClickData : undefined}
+            resolveHoverSegment={resolveHoverSegment}
             className={className}
             dataAttr={dataAttr}
             resolveValue={resolveValue}

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -530,6 +530,7 @@ function BarChartInner<Meta = unknown>({
                 <BarTooltip<Meta>
                     ctx={ctx}
                     userTooltip={tooltip}
+                    allSeries={series}
                     stackedData={stackedData}
                     topStackedKeyByAxis={topStackedKeyByAxis}
                     layout={barLayout}

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -127,8 +127,29 @@ function BarChartInner<Meta = unknown>({
         maxBandRange,
         bandPadding,
         barShadow,
+        minBandSize,
     } = config ?? {}
     const isHorizontal = axisOrientation === 'horizontal'
+
+    // Horizontal charts crush their row labels into an unreadable strip once the band count
+    // grows past what the parent's height can fit. Force a minimum px-per-row so each row
+    // has space for its tick label plus a little breathing room; the wrapper grows and the
+    // outer scene scrolls instead of squashing.
+    // Reserve ~64px for top + bottom margins (axis labels, plot padding) — matches the
+    // DEFAULT_MARGINS + axis-title floor in useChartMargins.
+    const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
+    const HORIZONTAL_CHART_MARGIN_PX = 64
+    const resolvedMinBandSize = minBandSize ?? (isHorizontal ? HORIZONTAL_MIN_BAND_SIZE_DEFAULT : 0)
+    const wrapperMinHeight = useMemo(() => {
+        if (!isHorizontal || resolvedMinBandSize <= 0) {
+            return undefined
+        }
+        const uniqueBands = new Set(labels).size
+        if (uniqueBands === 0) {
+            return undefined
+        }
+        return uniqueBands * resolvedMinBandSize + HORIZONTAL_CHART_MARGIN_PX
+    }, [isHorizontal, resolvedMinBandSize, labels])
 
     const stackedData = useMemo((): Map<string, StackedBand> | undefined => {
         if (barLayout === 'percent') {
@@ -469,7 +490,7 @@ function BarChartInner<Meta = unknown>({
         [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef]
     )
 
-    return (
+    const chart = (
         <Chart
             series={series}
             labels={labels}
@@ -498,6 +519,11 @@ function BarChartInner<Meta = unknown>({
             {children}
         </Chart>
     )
+
+    if (wrapperMinHeight === undefined) {
+        return chart
+    }
+    return <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: wrapperMinHeight }}>{chart}</div>
 }
 
 /** Pure helper extracted so the click-rewrite is unit-testable and the component-level

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../core/canvas-renderer'
 import { Chart } from '../../core/Chart'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
+import { DEFAULT_MARGINS, X_AXIS_TITLE_MARGIN } from '../../core/hooks/useChartMargins'
 import { useLatest } from '../../core/hooks/useLatest'
 import {
     buildSegmentResolveValue,
@@ -44,13 +45,11 @@ import { computeVisibleXLabels } from '../../overlays/AxisLabels'
 import { BarTooltip } from './BarTooltip'
 import {
     type BarLayout,
-    type BarsAtCursorArgs,
     barContainsPointOnBandAxis,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
     iterBarsAtCursor,
     isStackedLayout,
-    resolveBarsAtCursor,
 } from './utils/bars-under-cursor'
 
 function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
@@ -86,6 +85,11 @@ export interface BarChartProps<Meta = unknown> {
 
 // Negative offsetY casts the shadow upward onto the visible track above the bar.
 const DEFAULT_BAR_SHADOW: BarShadow = { color: 'rgba(0,0,0,0.30)', blur: 12, offsetY: -4 }
+
+// Horizontal floor: each row gets at least this much px so tick labels don't crush; wrapper scrolls.
+const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
+// Reserve room for chart-edge margins + worst-case x-axis title margin (matches useChartMargins).
+const HORIZONTAL_CHART_MARGIN_PX = DEFAULT_MARGINS.top + DEFAULT_MARGINS.bottom + X_AXIS_TITLE_MARGIN
 
 function resolveBarShadow(barShadow: BarChartConfig['barShadow']): BarShadow | undefined {
     if (barShadow === true) {
@@ -132,11 +136,6 @@ function BarChartInner<Meta = unknown>({
     } = config ?? {}
     const isHorizontal = axisOrientation === 'horizontal'
 
-    // Force a minimum px-per-row so horizontal rows don't crush below their tick labels;
-    // the wrapper grows and the outer scene scrolls. Margin matches DEFAULT_MARGINS + axis
-    // title floor in useChartMargins.
-    const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
-    const HORIZONTAL_CHART_MARGIN_PX = 64
     const resolvedMinBandSize = minBandSize ?? (isHorizontal ? HORIZONTAL_MIN_BAND_SIZE_DEFAULT : 0)
     const wrapperMinHeight = useMemo(() => {
         if (!isHorizontal || resolvedMinBandSize <= 0) {
@@ -413,29 +412,7 @@ function BarChartInner<Meta = unknown>({
                 })
                 if (visible) {
                     const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
-                    // Largest extent strictly smaller than `visible` — its far edge is the
-                    // inner boundary of `visible`'s slice.
-                    let nextSmallerExtent = 0
-                    for (let i = 0; i < drawLabels.length; i++) {
-                        if (drawLabels[i] !== hoveredLabel || i === visible.dataIndex) {
-                            continue
-                        }
-                        for (const { bar } of iterBarsAtCursor<ResolvedSeries>({
-                            series: coloredSeries,
-                            label: drawLabels[i],
-                            dataIndex: i,
-                            scales: d3Scales,
-                            layout: barLayout,
-                            isHorizontal,
-                            stackedData,
-                            topStackedKeyByAxis,
-                        })) {
-                            const ext = isHorizontal ? bar.width : bar.height
-                            if (ext > 0 && ext < visibleExtent && ext > nextSmallerExtent) {
-                                nextSmallerExtent = ext
-                            }
-                        }
-                    }
+                    const { nextSmallerExtent } = visible
                     const baselinePx = isHorizontal ? visible.bar.x : visible.bar.y + visible.bar.height
                     const clipped: BarRect = isHorizontal
                         ? {
@@ -527,6 +504,7 @@ function BarChartInner<Meta = unknown>({
     const resolvePositionValue = useMemo(() => buildStackedPositionValue(stackedData), [stackedData])
 
     const seriesRef = useLatest(series)
+    const labelsRef = useLatest(labels)
 
     // Stacked/percent segments share a band slot — rewrite the click payload to the
     // segment under the cursor so drop-off fillers and per-breakdown segments route correctly.
@@ -545,10 +523,11 @@ function BarChartInner<Meta = unknown>({
                     stackedData,
                     topStackedKeyByAxis,
                     series: seriesRef.current,
+                    labels: labelsRef.current,
                 }) ?? clickData
             )
         },
-        [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef]
+        [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef]
     )
 
     const chart = (
@@ -581,10 +560,12 @@ function BarChartInner<Meta = unknown>({
         </Chart>
     )
 
-    if (wrapperMinHeight === undefined) {
-        return chart
-    }
-    return <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: wrapperMinHeight }}>{chart}</div>
+    // Always wrap — switching shape (axisOrientation, empty labels) would otherwise remount Chart.
+    return (
+        <div className="flex flex-col flex-1" style={{ minHeight: wrapperMinHeight }}>
+            {chart}
+        </div>
+    )
 }
 
 /** Pure helper extracted so the click-rewrite is unit-testable and the component-level
@@ -599,6 +580,7 @@ export function resolveClickedStackedSegment<Meta>({
     stackedData,
     topStackedKeyByAxis,
     series,
+    labels,
 }: {
     clickData: PointClickData<Meta>
     d3Scales: BarScaleSet
@@ -607,37 +589,44 @@ export function resolveClickedStackedSegment<Meta>({
     stackedData: Map<string, StackedBand> | undefined
     topStackedKeyByAxis: Map<string, string>
     series: Series<Meta>[]
+    labels: readonly string[]
 }): PointClickData<Meta> | null {
     if (!isStackedLayout(barLayout)) {
         return null
     }
-    const { cursor, label, dataIndex, crossSeriesData } = clickData
+    const { cursor, label, crossSeriesData } = clickData
     if (!cursor) {
         return null
     }
-    const cursorArgs: BarsAtCursorArgs & { cursor: { x: number; y: number } } = {
+    // Walk every dataIndex that maps to the clicked band — for sparse-stacked overlap the
+    // visible segment lives at a different dataIndex than `clickData.dataIndex` (the band).
+    const visible = findVisibleStackedSegment({
         series: crossSeriesData.map((d) => d.series),
-        label,
-        dataIndex,
+        labels,
+        hoveredLabel: label,
         cursor,
         scales: d3Scales,
         layout: barLayout,
         isHorizontal,
         stackedData,
         topStackedKeyByAxis,
-    }
-    const { strictHit } = resolveBarsAtCursor(cursorArgs)
-    if (!strictHit) {
+    })
+    if (!visible) {
         return null
     }
-    const hit = crossSeriesData.find((d) => d.series.key === strictHit)
+    const hit = crossSeriesData.find((d) => d.series.key === visible.series.key)
     if (!hit) {
         return null
     }
+    // Re-read value at the visible segment's own dataIndex — `hit.value` was resolved at the
+    // band's dataIndex, which is a sparse-zero cell for the visible series.
+    const raw = hit.series.data[visible.dataIndex]
+    const resolvedValue = typeof raw === 'number' && Number.isFinite(raw) ? raw : hit.value
     return {
         ...clickData,
+        dataIndex: visible.dataIndex,
         series: hit.series,
-        value: hit.value,
+        value: resolvedValue,
         seriesIndex: series.findIndex((s) => s.key === hit.series.key),
     }
 }

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -13,6 +13,7 @@ import {
     type DrawContext,
 } from '../../core/canvas-renderer'
 import { Chart } from '../../core/Chart'
+import type { HoverSegment } from '../../core/chart-context'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
 import { DEFAULT_MARGINS, X_AXIS_TITLE_MARGIN } from '../../core/hooks/useChartMargins'
 import { useLatest } from '../../core/hooks/useLatest'
@@ -525,7 +526,7 @@ function BarChartInner<Meta = unknown>({
             hoverIndex: number,
             hoverPosition: { x: number; y: number } | null,
             scales: ChartScales
-        ): { seriesKey: string; dataIndex: number } | null => {
+        ): HoverSegment | null => {
             if (
                 !isStackedLayout(barLayout) ||
                 !hoverPosition ||

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarTooltip.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarTooltip.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import type { BarChartPrivate } from '../../core/bar-layout'
 import { useChartLayout } from '../../core/chart-context'
 import type { BarScaleSet, StackedBand } from '../../core/scales'
-import type { TooltipContext } from '../../core/types'
+import type { Series, TooltipContext } from '../../core/types'
 import { DefaultTooltip } from '../../overlays/DefaultTooltip'
 import {
     type BarLayout,
@@ -15,6 +15,9 @@ import {
 export interface BarTooltipProps<Meta> {
     ctx: TooltipContext<Meta>
     userTooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
+    /** Every drawn series, including those hidden from the tooltip — the visible-segment
+     *  hit-test must see the full stack, not just the tooltip-visible subset. */
+    allSeries: Series<Meta>[]
     stackedData: Map<string, StackedBand> | undefined
     topStackedKeyByAxis: Map<string, string>
     layout: BarLayout
@@ -24,6 +27,7 @@ export interface BarTooltipProps<Meta> {
 export function BarTooltip<Meta>({
     ctx,
     userTooltip,
+    allSeries,
     stackedData,
     topStackedKeyByAxis,
     layout,
@@ -39,7 +43,8 @@ export function BarTooltip<Meta>({
             isHorizontal,
             stackedData,
             topStackedKeyByAxis,
-            labels
+            labels,
+            allSeries
         )
         if (!narrowed) {
             return null
@@ -58,7 +63,8 @@ function narrowSeriesByCursor<Meta>(
     isHorizontal: boolean,
     stackedData: Map<string, StackedBand> | undefined,
     topStackedKeyByAxis: Map<string, string>,
-    labels: string[]
+    labels: string[],
+    allSeries: Series<Meta>[]
 ): TooltipContext<Meta> | null {
     const cursor = ctx.hoverPosition
     if (!cursor) {
@@ -83,7 +89,7 @@ function narrowSeriesByCursor<Meta>(
     let visibleDataIndex: number | null = null
     if (isStackedLayout(layout)) {
         const visible = findVisibleStackedSegment({
-            series: seriesList,
+            series: allSeries,
             labels,
             hoveredLabel: ctx.label,
             cursor,
@@ -93,10 +99,13 @@ function narrowSeriesByCursor<Meta>(
             stackedData,
             topStackedKeyByAxis,
         })
-        if (visible) {
-            visibleKey = visible.series.key
-            visibleDataIndex = visible.dataIndex
+        // No filled segment under the cursor — it's in the empty track past the bar's value
+        // extent (e.g. right of the longest horizontal bar). Suppress rather than show a tooltip.
+        if (!visible) {
+            return null
         }
+        visibleKey = visible.series.key
+        visibleDataIndex = visible.dataIndex
     }
     let filtered = ctx.seriesData.filter((entry) => hits.has(entry.series.key))
     if (isStackedLayout(layout) && filtered.length > 1 && visibleKey) {

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarTooltip.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarTooltip.tsx
@@ -5,7 +5,12 @@ import { useChartLayout } from '../../core/chart-context'
 import type { BarScaleSet, StackedBand } from '../../core/scales'
 import type { TooltipContext } from '../../core/types'
 import { DefaultTooltip } from '../../overlays/DefaultTooltip'
-import { type BarLayout, isStackedLayout, resolveBarsAtCursor } from './utils/bars-under-cursor'
+import {
+    type BarLayout,
+    findVisibleStackedSegment,
+    isStackedLayout,
+    resolveBarsAtCursor,
+} from './utils/bars-under-cursor'
 
 export interface BarTooltipProps<Meta> {
     ctx: TooltipContext<Meta>
@@ -24,10 +29,18 @@ export function BarTooltip<Meta>({
     layout,
     isHorizontal,
 }: BarTooltipProps<Meta>): React.ReactElement | null {
-    const { scales } = useChartLayout()
+    const { scales, labels } = useChartLayout()
     const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
     if (d3Scales && ctx.hoverPosition && ctx.dataIndex >= 0) {
-        const narrowed = narrowSeriesByCursor(ctx, d3Scales, layout, isHorizontal, stackedData, topStackedKeyByAxis)
+        const narrowed = narrowSeriesByCursor(
+            ctx,
+            d3Scales,
+            layout,
+            isHorizontal,
+            stackedData,
+            topStackedKeyByAxis,
+            labels
+        )
         if (!narrowed) {
             return null
         }
@@ -36,21 +49,23 @@ export function BarTooltip<Meta>({
     return <>{userTooltip ? userTooltip(ctx) : DefaultTooltip(ctx)}</>
 }
 
-/** Stacked/percent: cursor-resolved segment is moved to seriesData[0]. */
+/** Moves the cursor-resolved segment to seriesData[0] and (for sparse-stacked overlap)
+ *  re-reads its value at its own dataIndex so it isn't a zero from a band-collapsed cell. */
 function narrowSeriesByCursor<Meta>(
     ctx: TooltipContext<Meta>,
     scales: BarScaleSet,
     layout: BarLayout,
     isHorizontal: boolean,
     stackedData: Map<string, StackedBand> | undefined,
-    topStackedKeyByAxis: Map<string, string>
+    topStackedKeyByAxis: Map<string, string>,
+    labels: string[]
 ): TooltipContext<Meta> | null {
     const cursor = ctx.hoverPosition
     if (!cursor) {
         return ctx
     }
     const seriesList = ctx.seriesData.map((entry) => entry.series)
-    const { hits, strictHit } = resolveBarsAtCursor({
+    const { hits } = resolveBarsAtCursor({
         series: seriesList,
         label: ctx.label,
         dataIndex: ctx.dataIndex,
@@ -64,12 +79,43 @@ function narrowSeriesByCursor<Meta>(
     if (hits.size === 0) {
         return null
     }
+    let visibleKey: string | null = null
+    let visibleDataIndex: number | null = null
+    if (isStackedLayout(layout)) {
+        const visible = findVisibleStackedSegment({
+            series: seriesList,
+            labels,
+            hoveredLabel: ctx.label,
+            cursor,
+            scales,
+            layout,
+            isHorizontal,
+            stackedData,
+            topStackedKeyByAxis,
+        })
+        if (visible) {
+            visibleKey = visible.series.key
+            visibleDataIndex = visible.dataIndex
+        }
+    }
     let filtered = ctx.seriesData.filter((entry) => hits.has(entry.series.key))
-    if (isStackedLayout(layout) && filtered.length > 1 && strictHit) {
-        const idx = filtered.findIndex((entry) => entry.series.key === strictHit)
+    if (isStackedLayout(layout) && filtered.length > 1 && visibleKey) {
+        const idx = filtered.findIndex((entry) => entry.series.key === visibleKey)
         if (idx > 0) {
             filtered = [filtered[idx], ...filtered.filter((_, i) => i !== idx)]
         }
+    }
+    // `entry.value` was resolved at ctx.dataIndex, which for sparse-stacked overlap is a
+    // zero cell for the visible series. Re-read from its own dataIndex.
+    if (visibleKey != null && visibleDataIndex != null && visibleDataIndex !== ctx.dataIndex) {
+        filtered = filtered.map((entry) => {
+            if (entry.series.key !== visibleKey) {
+                return entry
+            }
+            const raw = entry.series.data[visibleDataIndex!]
+            const value = typeof raw === 'number' && Number.isFinite(raw) ? raw : entry.value
+            return { ...entry, value }
+        })
     }
     return { ...ctx, seriesData: filtered }
 }

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarTooltip.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarTooltip.tsx
@@ -105,17 +105,20 @@ function narrowSeriesByCursor<Meta>(
             filtered = [filtered[idx], ...filtered.filter((_, i) => i !== idx)]
         }
     }
-    // `entry.value` was resolved at ctx.dataIndex, which for sparse-stacked overlap is a
-    // zero cell for the visible series. Re-read from its own dataIndex.
+    // For sparse-stacked overlap ctx.dataIndex is a zero cell for the visible series. Rewrite
+    // the entry's value (and ctx.dataIndex) to the segment's own index so row clicks route
+    // correctly downstream.
     if (visibleKey != null && visibleDataIndex != null && visibleDataIndex !== ctx.dataIndex) {
+        const di = visibleDataIndex
         filtered = filtered.map((entry) => {
             if (entry.series.key !== visibleKey) {
                 return entry
             }
-            const raw = entry.series.data[visibleDataIndex!]
+            const raw = entry.series.data[di]
             const value = typeof raw === 'number' && Number.isFinite(raw) ? raw : entry.value
             return { ...entry, value }
         })
+        return { ...ctx, seriesData: filtered, dataIndex: di }
     }
     return { ...ctx, seriesData: filtered }
 }

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
@@ -118,3 +118,31 @@ export function resolveBarsAtCursor(
     }
     return { hits, strictHit }
 }
+
+/** Visible stacked segment under the cursor — last-drawn bar whose rect contains it.
+ *  Walks every dataIndex sharing the hovered band to cover sparse-stacked overlap. */
+export function findVisibleStackedSegment<S extends Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>>(
+    args: Omit<BarsAtCursorArgs, 'series' | 'label' | 'dataIndex'> & {
+        series: readonly S[]
+        labels: readonly string[]
+        hoveredLabel: string
+        cursor: { x: number; y: number }
+    }
+): { series: S; bar: BarRect; dataIndex: number } | null {
+    const { labels, hoveredLabel, cursor, isHorizontal } = args
+    let visible: { series: S; bar: BarRect; dataIndex: number } | null = null
+    for (let dataIndex = 0; dataIndex < labels.length; dataIndex++) {
+        if (labels[dataIndex] !== hoveredLabel) {
+            continue
+        }
+        for (const { series: s, bar } of iterBarsAtCursor({ ...args, label: labels[dataIndex], dataIndex })) {
+            const extent = isHorizontal ? bar.width : bar.height
+            if (extent <= 0 || !barContainsPoint(bar, cursor)) {
+                continue
+            }
+            // Overwrite so the last-drawn (smallest, painted on top) candidate wins.
+            visible = { series: s, bar, dataIndex }
+        }
+    }
+    return visible
+}

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
@@ -120,7 +120,8 @@ export function resolveBarsAtCursor(
 }
 
 /** Visible stacked segment under the cursor — last-drawn bar whose rect contains it.
- *  Walks every dataIndex sharing the hovered band to cover sparse-stacked overlap. */
+ *  Also returns the next-smaller extent (the far edge of the bar that overdraws this
+ *  segment's near side); callers clip the highlight rect there so hover preserves z-order. */
 export function findVisibleStackedSegment<S extends Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>>(
     args: Omit<BarsAtCursorArgs, 'series' | 'label' | 'dataIndex'> & {
         series: readonly S[]
@@ -128,21 +129,35 @@ export function findVisibleStackedSegment<S extends Pick<Series, 'key' | 'visibi
         hoveredLabel: string
         cursor: { x: number; y: number }
     }
-): { series: S; bar: BarRect; dataIndex: number } | null {
+): { series: S; bar: BarRect; dataIndex: number; nextSmallerExtent: number } | null {
     const { labels, hoveredLabel, cursor, isHorizontal } = args
-    let visible: { series: S; bar: BarRect; dataIndex: number } | null = null
+    let visible: { series: S; bar: BarRect; dataIndex: number; extent: number } | null = null
+    const allExtents: number[] = []
     for (let dataIndex = 0; dataIndex < labels.length; dataIndex++) {
         if (labels[dataIndex] !== hoveredLabel) {
             continue
         }
         for (const { series: s, bar } of iterBarsAtCursor({ ...args, label: labels[dataIndex], dataIndex })) {
             const extent = isHorizontal ? bar.width : bar.height
-            if (extent <= 0 || !barContainsPoint(bar, cursor)) {
+            if (extent <= 0) {
+                continue
+            }
+            allExtents.push(extent)
+            if (!barContainsPoint(bar, cursor)) {
                 continue
             }
             // Overwrite so the last-drawn (smallest, painted on top) candidate wins.
-            visible = { series: s, bar, dataIndex }
+            visible = { series: s, bar, dataIndex, extent }
         }
     }
-    return visible
+    if (!visible) {
+        return null
+    }
+    let nextSmallerExtent = 0
+    for (const ext of allExtents) {
+        if (ext < visible.extent && ext > nextSmallerExtent) {
+            nextSmallerExtent = ext
+        }
+    }
+    return { series: visible.series, bar: visible.bar, dataIndex: visible.dataIndex, nextSmallerExtent }
 }

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from '../overlays/Tooltip'
 import { normalizeAxisLabel } from '../utils/axis-labels'
 import { composeDrawHoverWithCrosshair } from './canvas-renderer'
 import { ChartHoverContext, ChartLayoutContext } from './chart-context'
-import type { ChartHoverContextValue, ChartLayoutContextValue } from './chart-context'
+import type { ChartHoverContextValue, ChartLayoutContextValue, HoverSegment } from './chart-context'
 import { useChartCanvas } from './hooks/useChartCanvas'
 import { useChartDraw } from './hooks/useChartDraw'
 import { useChartInteraction } from './hooks/useChartInteraction'
@@ -68,6 +68,19 @@ function resolveHoverAnimationMs(animateHover: boolean | number | undefined): nu
     return 0
 }
 
+// Primitive signature of the resolved hover segment, used as a memo key so the hover context
+// identity only changes when the segment changes. `'none'` = no resolver, `'empty'` = resolver
+// ran but the cursor is over no segment.
+function hoverSegmentSignature(segment: HoverSegment | null | undefined): string {
+    if (segment === undefined) {
+        return 'none'
+    }
+    if (segment === null) {
+        return 'empty'
+    }
+    return `${segment.seriesKey} ${segment.dataIndex}`
+}
+
 function OverlayLayer({ children }: { children: React.ReactNode }): React.ReactElement {
     return <div style={OVERLAY_STYLE}>{children}</div>
 }
@@ -120,7 +133,7 @@ export interface ChartProps<Meta = unknown> {
         hoverIndex: number,
         hoverPosition: { x: number; y: number } | null,
         scales: ChartScales
-    ) => { seriesKey: string; dataIndex: number } | null
+    ) => HoverSegment | null
 }
 
 export function Chart<Meta = unknown>({
@@ -295,12 +308,7 @@ export function Chart<Meta = unknown>({
         resolveHoverSegment && scales ? (resolveHoverSegment(hoverIndex, hoverPosition, scales) ?? null) : undefined
     // Key the memo on a primitive so the context identity only changes when the resolved segment
     // changes — not on every mousemove within the same segment.
-    const hoverSegmentKey =
-        hoverSegment === undefined
-            ? 'none'
-            : hoverSegment === null
-              ? 'empty'
-              : `${hoverSegment.seriesKey} ${hoverSegment.dataIndex}`
+    const hoverSegmentKey = hoverSegmentSignature(hoverSegment)
     const hoverValue = useMemo<ChartHoverContextValue>(
         () => ({ hoverIndex, hoverSegment }),
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -113,6 +113,14 @@ export interface ChartProps<Meta = unknown> {
      *  cursor) before it reaches `onPointClick`, using the committed `scales` from this render.
      *  Chart-type adapters provide this; consumers do not. */
     wrapClickData?: (data: PointClickData<Meta>, scales: ChartScales) => PointClickData<Meta>
+    /** Chart-type seam: resolve which segment the cursor is over (the visible slice in a stacked
+     *  band), published on the hover context as `hoverSegment` so overlays (value labels) can
+     *  target it instead of guessing from `hoverIndex`. Return `null` when over no segment. */
+    resolveHoverSegment?: (
+        hoverIndex: number,
+        hoverPosition: { x: number; y: number } | null,
+        scales: ChartScales
+    ) => { seriesKey: string; dataIndex: number } | null
 }
 
 export function Chart<Meta = unknown>({
@@ -133,6 +141,7 @@ export function Chart<Meta = unknown>({
     labelToCoord,
     valueRangeSeries,
     wrapClickData,
+    resolveHoverSegment,
 }: ChartProps<Meta>): React.ReactElement {
     const {
         xTickFormatter,
@@ -282,7 +291,21 @@ export function Chart<Meta = unknown>({
         }
     }, [scales, dimensions, labels, coloredSeries, theme, stablePositionValue, canvasBounds, axisValue])
 
-    const hoverValue = useMemo<ChartHoverContextValue>(() => ({ hoverIndex }), [hoverIndex])
+    const hoverSegment =
+        resolveHoverSegment && scales ? (resolveHoverSegment(hoverIndex, hoverPosition, scales) ?? null) : undefined
+    // Key the memo on a primitive so the context identity only changes when the resolved segment
+    // changes — not on every mousemove within the same segment.
+    const hoverSegmentKey =
+        hoverSegment === undefined
+            ? 'none'
+            : hoverSegment === null
+              ? 'empty'
+              : `${hoverSegment.seriesKey} ${hoverSegment.dataIndex}`
+    const hoverValue = useMemo<ChartHoverContextValue>(
+        () => ({ hoverIndex, hoverSegment }),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [hoverIndex, hoverSegmentKey]
+    )
 
     return (
         <ChartLayoutContext.Provider value={layoutValue}>

--- a/frontend/src/lib/hog-charts/core/chart-context.ts
+++ b/frontend/src/lib/hog-charts/core/chart-context.ts
@@ -41,16 +41,22 @@ export interface ChartLayoutContextValue<Meta = unknown> {
     axis: ChartAxisContextValue
 }
 
+/** The segment the cursor resolved to within a band (stacked bars: the visible slice). */
+export interface HoverSegment {
+    seriesKey: string
+    dataIndex: number
+}
+
 /** Hover state isolated from layout so mousemoves don't invalidate every overlay.
  *  Only {@link Crosshair} (and consumers of {@link useChartHover}) re-render. */
 export interface ChartHoverContextValue {
     /** Index of the currently hovered data point, or -1 when not hovering. */
     hoverIndex: number
     /** The segment the cursor actually resolved to, for chart types that disambiguate within
-     *  a band (stacked bars: the visible slice under the cursor). `undefined` when the chart
-     *  doesn't resolve segments (overlays fall back to `hoverIndex`); `null` when it does but
-     *  the cursor is over no segment (e.g. the empty track past a bar) — overlays target nothing. */
-    hoverSegment?: { seriesKey: string; dataIndex: number } | null
+     *  a band. `undefined` when the chart doesn't resolve segments (overlays fall back to
+     *  `hoverIndex`); `null` when it does but the cursor is over no segment (e.g. the empty
+     *  track past a bar) — overlays target nothing. */
+    hoverSegment?: HoverSegment | null
 }
 
 /** Merged layout + hover shape returned by {@link useChart}. */

--- a/frontend/src/lib/hog-charts/core/chart-context.ts
+++ b/frontend/src/lib/hog-charts/core/chart-context.ts
@@ -46,6 +46,11 @@ export interface ChartLayoutContextValue<Meta = unknown> {
 export interface ChartHoverContextValue {
     /** Index of the currently hovered data point, or -1 when not hovering. */
     hoverIndex: number
+    /** The segment the cursor actually resolved to, for chart types that disambiguate within
+     *  a band (stacked bars: the visible slice under the cursor). `undefined` when the chart
+     *  doesn't resolve segments (overlays fall back to `hoverIndex`); `null` when it does but
+     *  the cursor is over no segment (e.g. the empty track past a bar) — overlays target nothing. */
+    hoverSegment?: { seriesKey: string; dataIndex: number } | null
 }
 
 /** Merged layout + hover shape returned by {@link useChart}. */

--- a/frontend/src/lib/hog-charts/core/hooks/useChartMargins.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartMargins.ts
@@ -14,7 +14,7 @@ const MIN_LEFT_MARGIN = 20
 const MIN_RIGHT_MARGIN_DUAL_AXIS = 48
 const Y_LABEL_RIGHT_PADDING = 12
 const X_LABEL_EDGE_PADDING = 4
-const X_AXIS_TITLE_MARGIN = 22
+export const X_AXIS_TITLE_MARGIN = 22
 const Y_AXIS_TITLE_MARGIN = 24
 
 interface UseChartMarginsOptions {

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -226,6 +226,11 @@ export interface BarChartConfig extends ChartConfig {
     bandPadding?: number
     /** Drop shadow under each bar so it reads as layered over a `barTrack`. */
     barShadow?: boolean | { color: string; blur: number; offsetX?: number; offsetY?: number }
+    /** Horizontal bar charts only — minimum px per row. When many rows would otherwise crush
+     *  into an unreadable strip, the chart expands its container height so each row has at
+     *  least this much vertical space (label height + breathing room). Defaults to `24`.
+     *  Pass `0` to opt out. */
+    minBandSize?: number
 }
 
 export interface LineChartConfig extends ChartConfig {

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
@@ -321,9 +321,26 @@ describe('ValueLabels', () => {
             { key: 's1', label: 'S1', color: '#0f0', data: [0, 20] },
         ]
         const ctx = makeContext(series, { labels: ['Mon', 'Mon'], hoverSegment: null, hoverIndex: 1 })
-        for (const d of labelDivs(renderInChart(ctx, <ValueLabels />).container)) {
-            expect(d.style.transform).not.toContain('-6px')
-        }
+        const transforms = labelDivs(renderInChart(ctx, <ValueLabels />).container).map((d) => d.style.transform)
+        transforms.forEach((t) => expect(t).not.toContain('-6px'))
+    })
+
+    it('stack-total mode: lifts the total whose band the hovered segment sits in, not the others', () => {
+        // Totals: Mon = 10 + 5 = 15, Tue = 20 + 15 = 35. Hovering a segment in the Mon band
+        // lifts Mon's total label; Tue's must stay put.
+        const series: ResolvedSeries[] = [
+            { key: 'a', label: 'A', color: '#f00', data: [10, 20] },
+            { key: 'b', label: 'B', color: '#0f0', data: [5, 15] },
+        ]
+        const ctx = makeContext(series, { labels: ['Mon', 'Tue'], hoverSegment: { seriesKey: 'a', dataIndex: 0 } })
+        const byText = Object.fromEntries(
+            labelDivs(renderInChart(ctx, <ValueLabels mode="stack-total" />).container).map((d) => [
+                d.textContent,
+                d.style.transform,
+            ])
+        )
+        expect(byText['15']).toContain('-6px')
+        expect(byText['35']).not.toContain('-6px')
     })
 
     it('in percent layout, formatter receives each segment fraction (0..1), not raw data', () => {

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
@@ -312,6 +312,20 @@ describe('ValueLabels', () => {
         })
     })
 
+    it('lifts nothing when the chart resolves the cursor to no segment (hoverSegment null)', () => {
+        // Stacked bars publish `hoverSegment: null` when the cursor is past the bar's value
+        // extent — the segment-driven path must lift nothing rather than fall back to hoverIndex.
+        // (The happy path — lift follows the cursor's segment — is covered end-to-end in BarChart.test.)
+        const series: ResolvedSeries[] = [
+            { key: 's0', label: 'S0', color: '#f00', data: [10, 0] },
+            { key: 's1', label: 'S1', color: '#0f0', data: [0, 20] },
+        ]
+        const ctx = makeContext(series, { labels: ['Mon', 'Mon'], hoverSegment: null, hoverIndex: 1 })
+        for (const d of labelDivs(renderInChart(ctx, <ValueLabels />).container)) {
+            expect(d.style.transform).not.toContain('-6px')
+        }
+    })
+
     it('in percent layout, formatter receives each segment fraction (0..1), not raw data', () => {
         // Both series have non-zero values in both bands so we exercise the `raw / total`
         // division, not the trivial single-segment-per-band 100% path.

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -388,7 +388,7 @@ export function ValueLabels({
     mode = 'per-segment',
 }: ValueLabelsProps): React.ReactElement | null {
     const { series, scales, labels, theme, resolvePositionValue, axis, dimensions } = useChartLayout()
-    const { hoverIndex } = useChartHover()
+    const { hoverIndex, hoverSegment } = useChartHover()
     const isHorizontal = axis.orientation === 'horizontal'
     const isPercent = axis.isPercent
 
@@ -443,10 +443,27 @@ export function ValueLabels({
 
     const borderColor = theme.backgroundColor ?? 'white'
 
+    const candidateIsHovered = (c: Candidate): boolean => {
+        // Charts that resolve the exact segment under the cursor (stacked bars) drive the lift
+        // off `hoverSegment` — `hoverIndex` is ambiguous when segments share a band. `null` means
+        // the cursor is over no segment (e.g. past the bar), so nothing lifts.
+        if (hoverSegment !== undefined) {
+            if (!hoverSegment) {
+                return false
+            }
+            if (c.seriesIndex === -1) {
+                // Stack-total label: lift when the hovered segment sits in its band.
+                return labels[c.dataIndex] === labels[hoverSegment.dataIndex]
+            }
+            return series[c.seriesIndex]?.key === hoverSegment.seriesKey && c.dataIndex === hoverSegment.dataIndex
+        }
+        return c.dataIndex === hoverIndex && liftableIndices.has(c.dataIndex)
+    }
+
     return (
         <>
             {visible.map((c) => {
-                const isHovered = c.dataIndex === hoverIndex && liftableIndices.has(c.dataIndex)
+                const isHovered = candidateIsHovered(c)
                 return (
                     <div
                         key={c.key}

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -448,7 +448,7 @@ export function ValueLabels({
         // off `hoverSegment` — `hoverIndex` is ambiguous when segments share a band. `null` means
         // the cursor is over no segment (e.g. past the bar), so nothing lifts.
         if (hoverSegment !== undefined) {
-            if (!hoverSegment) {
+            if (hoverSegment === null) {
                 return false
             }
             if (c.seriesIndex === -1) {

--- a/frontend/src/lib/hog-charts/testing/overlay.tsx
+++ b/frontend/src/lib/hog-charts/testing/overlay.tsx
@@ -2,7 +2,7 @@ import { render, type RenderResult } from '@testing-library/react'
 import type { ReactNode } from 'react'
 
 import { ChartHoverContext, ChartLayoutContext } from '../core/chart-context'
-import type { BaseChartContext, ChartLayoutContextValue } from '../core/chart-context'
+import type { BaseChartContext, ChartLayoutContextValue, HoverSegment } from '../core/chart-context'
 import type { ChartScales, ChartTheme, ResolvedSeries, ResolveValueFn } from '../core/types'
 import { dimensions as DEFAULT_DIMENSIONS } from './jsdom'
 
@@ -19,7 +19,7 @@ export interface OverlayContextOverrides {
     axisOrientation?: 'vertical' | 'horizontal'
     isPercent?: boolean
     hoverIndex?: number
-    hoverSegment?: { seriesKey: string; dataIndex: number } | null
+    hoverSegment?: HoverSegment | null
     xTickFormatter?: (value: string, index: number) => string | null
 }
 

--- a/frontend/src/lib/hog-charts/testing/overlay.tsx
+++ b/frontend/src/lib/hog-charts/testing/overlay.tsx
@@ -19,6 +19,7 @@ export interface OverlayContextOverrides {
     axisOrientation?: 'vertical' | 'horizontal'
     isPercent?: boolean
     hoverIndex?: number
+    hoverSegment?: { seriesKey: string; dataIndex: number } | null
     xTickFormatter?: (value: string, index: number) => string | null
 }
 
@@ -39,6 +40,7 @@ export function makeOverlayContext(scales: ChartScales, overrides: OverlayContex
             isPercent: overrides.isPercent ?? false,
         },
         hoverIndex: overrides.hoverIndex ?? -1,
+        hoverSegment: overrides.hoverSegment,
     }
 }
 
@@ -46,11 +48,11 @@ export function makeOverlayContext(scales: ChartScales, overrides: OverlayContex
  *  in isolation without booting a real chart. Pass hand-rolled scales so you can
  *  assert exact pixel positions without depending on d3's tick algorithm. */
 export function renderOverlayInChart(node: ReactNode, ctx: BaseChartContext): RenderResult {
-    const { hoverIndex, ...layout } = ctx
+    const { hoverIndex, hoverSegment, ...layout } = ctx
     const layoutValue: ChartLayoutContextValue = layout
     return render(
         <ChartLayoutContext.Provider value={layoutValue}>
-            <ChartHoverContext.Provider value={{ hoverIndex }}>{node}</ChartHoverContext.Provider>
+            <ChartHoverContext.Provider value={{ hoverIndex, hoverSegment }}>{node}</ChartHoverContext.Provider>
         </ChartLayoutContext.Provider>
     )
 }

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { setupJsdom, setupSyncRaf } from 'lib/hog-charts/testing'
+import { dimensions, setupJsdom, setupSyncRaf } from 'lib/hog-charts/testing'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { buildTrendsQuery, chart, getHogChart, personsModal, renderInsight } from '~/test/insight-testing'
@@ -352,6 +352,33 @@ describe('TrendsBarChart (ActionsBarValue)', () => {
         )
         const [seriesArg] = onDataPointClick.mock.calls[0]
         expect(seriesArg.day).toBeUndefined()
+    })
+
+    it('tooltip on a breakdown shows that breakdown row with its own value', async () => {
+        // Regression: aggregated tooltip used to read the visible series's value at
+        // ctx.dataIndex, a sparse-zero cell, so the row showed `0` (or the wrong row).
+        renderInsight({
+            query: aggregatedBar({
+                series: [{ kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' }],
+                breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+            }),
+            featureFlags: HOG_CHARTS_FLAG,
+        })
+        await screen.findByRole('img', { name: /chart with 5 data series/i }, { timeout: 5000 })
+
+        // Spike has aggregated_value 11 — largest, so it's the topmost row in DESC layout.
+        const canvas = screen.getByRole('img', { name: /chart with/i })
+        const wrapper = canvas.parentElement!
+        fireEvent.mouseMove(wrapper, {
+            clientX: dimensions.plotLeft + 10,
+            clientY: dimensions.plotTop + 10,
+        })
+
+        const tooltip = chart.getTooltip()
+        expect(tooltip).not.toBeNull()
+        const rowText = tooltip!.textContent ?? ''
+        expect(rowText).toContain('Spike')
+        expect(rowText).toContain('11')
     })
 
     it('renders InsightEmptyState when every aggregated_value is zero', async () => {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -185,10 +185,8 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
     )
 
     const aggregatedConfig: BarChartConfig = useMemo(() => {
-        // Aggregated band keys are synthetic `${displayLabel}__${seriesId}` so multiple
-        // series with duplicate display labels don't collapse onto one band. Render the
-        // human label via the categorical-axis formatter, and skip repeats so band-shared
-        // breakdown rows don't draw the same text six times on top of itself.
+        // Band keys are synthetic per-series; render the human label via the categorical-axis
+        // formatter and skip repeats so band-shared breakdown rows don't double-paint.
         let xTickFormatter: BarChartConfig['xTickFormatter']
         if (displayLabels && labels) {
             const firstIndexOf = new Map<string, number>()
@@ -268,14 +266,11 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
 
     const renderTooltip = useCallback(
         (ctx: TooltipContext<TrendsSeriesMeta>) => {
-            // Sparse-stacked: drop sibling series with data=0 at this band so the tooltip shows one row.
+            // BarTooltip already put the cursor-visible segment at seriesData[0] — keep just that.
             const tooltipCtx: TooltipContext<TrendsSeriesMeta> = isAggregated
                 ? {
                       ...ctx,
-                      seriesData: ctx.seriesData.filter((entry) => {
-                          const raw = entry.series.data[ctx.dataIndex]
-                          return typeof raw === 'number' && raw !== 0
-                      }),
+                      seriesData: ctx.seriesData.slice(0, 1),
                   }
                 : ctx
             const onRowClick = canHandleClick

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -113,7 +113,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
               )
             : !!indexedResults[0].data && indexedResults.some((r: IndexedTrendResult) => r.count !== 0))
 
-    const { series, labels } = useMemo(() => {
+    const { series, labels, displayLabels } = useMemo(() => {
         if (isAggregated) {
             return buildTrendsBarAggregatedSeries<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
                 getColor: getTrendsColor,
@@ -126,7 +126,11 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
             getHidden: getTrendsHidden,
             buildMeta: buildTrendsSeriesMeta,
         })
-        return { series: timeSeries, labels: currentPeriodResult?.labels ?? EMPTY_LABELS }
+        return {
+            series: timeSeries,
+            labels: currentPeriodResult?.labels ?? EMPTY_LABELS,
+            displayLabels: undefined,
+        }
     }, [isAggregated, indexedResults, getTrendsColor, getTrendsHidden, currentPeriodResult?.labels])
 
     const valueLabelFormatter = useCallback(
@@ -180,19 +184,41 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
         [trendsFilter, isPercentStackView, baseCurrency]
     )
 
-    const aggregatedConfig: BarChartConfig = useMemo(
-        () => ({
+    const aggregatedConfig: BarChartConfig = useMemo(() => {
+        // Aggregated band keys are synthetic `${displayLabel}__${seriesId}` so multiple
+        // series with duplicate display labels don't collapse onto one band. Render the
+        // human label via the categorical-axis formatter, and skip repeats so band-shared
+        // breakdown rows don't draw the same text six times on top of itself.
+        let xTickFormatter: BarChartConfig['xTickFormatter']
+        if (displayLabels && labels) {
+            const firstIndexOf = new Map<string, number>()
+            labels.forEach((l, i) => {
+                if (!firstIndexOf.has(l)) {
+                    firstIndexOf.set(l, i)
+                }
+            })
+            xTickFormatter = (label: string, i: number) =>
+                firstIndexOf.get(label) === i ? (displayLabels[i] ?? null) : null
+        }
+        return {
             showGrid: true,
             tooltip: AGGREGATED_TOOLTIP_CONFIG,
             yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
             axisOrientation: 'horizontal',
             barLayout: 'stacked',
             yTickFormatter: aggregatedYTickFormatter,
+            xTickFormatter,
             xAxisLabel: trendsFilter?.xAxisLabel,
             yAxisLabel: trendsFilter?.yAxisLabel,
-        }),
-        [yAxisScaleType, aggregatedYTickFormatter, trendsFilter?.xAxisLabel, trendsFilter?.yAxisLabel]
-    )
+        }
+    }, [
+        yAxisScaleType,
+        aggregatedYTickFormatter,
+        trendsFilter?.xAxisLabel,
+        trendsFilter?.yAxisLabel,
+        displayLabels,
+        labels,
+    ])
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
 

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
@@ -72,14 +72,80 @@ describe('buildTrendsBarAggregatedSeries', () => {
         ...overrides,
     })
 
-    it('returns labels aligned with results, in the same order', () => {
+    it('returns display labels aligned with results, in the same order; band labels stay unique', () => {
         const results = [
             mkResult({ id: 'a', label: 'A', aggregated_value: 1 }),
             mkResult({ id: 'b', label: 'B', aggregated_value: 2 }),
             mkResult({ id: 'c', label: 'C', aggregated_value: 3 }),
         ]
-        const { labels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED })
-        expect(labels).toEqual(['A', 'B', 'C'])
+        const { labels, displayLabels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED })
+        expect(displayLabels).toEqual(['A', 'B', 'C'])
+        expect(new Set(labels).size).toBe(labels.length)
+    })
+
+    it('splits same-label results into separate bands when they come from different series (no breakdown)', () => {
+        // Four trends series of the same event surface label="$pageview" each but have
+        // distinct action.order — they should not collapse onto one band.
+        const results = [
+            mkResult({ id: 'r0', label: '$pageview', action: { order: 0 }, aggregated_value: 10 }),
+            mkResult({ id: 'r1', label: '$pageview', action: { order: 1 }, aggregated_value: 20 }),
+            mkResult({ id: 'r2', label: '$pageview', action: { order: 2 }, aggregated_value: 30 }),
+            mkResult({ id: 'r3', label: '$pageview', action: { order: 3 }, aggregated_value: 40 }),
+        ]
+        const { labels, displayLabels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED })
+        expect(displayLabels).toEqual(['$pageview', '$pageview', '$pageview', '$pageview'])
+        expect(new Set(labels).size).toBe(4)
+    })
+
+    it('groups same-label breakdown rows of one series onto one band (overlap layout preserved)', () => {
+        // Formula+breakdown shape: each formula gets a top-level `order`, breakdown rows of
+        // the same formula share it. They should share a band so the existing overlap-on-top
+        // visual still works.
+        const results = [
+            mkResult({ id: 'r0', label: 'Binary Size', order: 0, breakdown_value: ['1.18.1'], aggregated_value: 355 }),
+            mkResult({ id: 'r1', label: 'Binary Size', order: 0, breakdown_value: ['1.18.0'], aggregated_value: 330 }),
+            mkResult({ id: 'r2', label: 'Binary Size', order: 0, breakdown_value: ['1.17.0'], aggregated_value: 320 }),
+            mkResult({
+                id: 'r3',
+                label: 'Embedded Assets',
+                order: 1,
+                breakdown_value: ['1.18.1'],
+                aggregated_value: 14,
+            }),
+            mkResult({
+                id: 'r4',
+                label: 'Embedded Assets',
+                order: 1,
+                breakdown_value: ['1.18.0'],
+                aggregated_value: 0,
+            }),
+            mkResult({
+                id: 'r5',
+                label: 'Runtime & Code',
+                order: 2,
+                breakdown_value: ['1.18.1'],
+                aggregated_value: 355,
+            }),
+            mkResult({
+                id: 'r6',
+                label: 'Runtime & Code',
+                order: 2,
+                breakdown_value: ['1.18.0'],
+                aggregated_value: 327,
+            }),
+        ]
+        const { labels, displayLabels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED })
+        expect(displayLabels).toEqual([
+            'Binary Size',
+            'Binary Size',
+            'Binary Size',
+            'Embedded Assets',
+            'Embedded Assets',
+            'Runtime & Code',
+            'Runtime & Code',
+        ])
+        // 7 results, but only 3 distinct band slots — one per formula.
+        expect(new Set(labels).size).toBe(3)
     })
 
     it('places each aggregated_value at the index matching its own band — zero everywhere else', () => {
@@ -113,7 +179,7 @@ describe('buildTrendsBarAggregatedSeries', () => {
 
     it.each([
         {
-            name: 'suffixes labels with compare_label so compare-against-previous rows get distinct bands',
+            name: 'suffixes display labels with compare_label so compare-against-previous rows render distinctly',
             results: [
                 { id: 'a', label: 'Microsoft Edge', compare_label: 'current', aggregated_value: 100 },
                 { id: 'b', label: 'Microsoft Edge', compare_label: 'previous', aggregated_value: 80 },
@@ -122,7 +188,7 @@ describe('buildTrendsBarAggregatedSeries', () => {
             expected: ['Microsoft Edge - current', 'Microsoft Edge - previous', 'Safari - current'],
         },
         {
-            name: 'leaves labels unchanged when compare_label is absent',
+            name: 'leaves display labels unchanged when compare_label is absent',
             results: [
                 { id: 'a', label: 'Chrome', aggregated_value: 1 },
                 { id: 'b', label: 'Safari', aggregated_value: 2 },
@@ -130,9 +196,11 @@ describe('buildTrendsBarAggregatedSeries', () => {
             expected: ['Chrome', 'Safari'],
         },
     ])('$name', ({ results, expected }) => {
-        const { labels } = buildTrendsBarAggregatedSeries(results.map(mkResult), { getColor: () => RED })
-        expect(labels).toEqual(expected)
-        // No duplicates — every band gets a unique d3 domain key.
+        const { labels, displayLabels } = buildTrendsBarAggregatedSeries(results.map(mkResult), {
+            getColor: () => RED,
+        })
+        expect(displayLabels).toEqual(expected)
+        // Distinct display labels → distinct band keys after the series-id suffix.
         expect(new Set(labels).size).toBe(labels.length)
     })
 
@@ -142,11 +210,11 @@ describe('buildTrendsBarAggregatedSeries', () => {
             mkResult({ id: 'b', label: 'B', aggregated_value: 2 }),
             mkResult({ id: 'c', label: 'C', aggregated_value: 3 }),
         ]
-        const { series, labels } = buildTrendsBarAggregatedSeries(results, {
+        const { series, displayLabels } = buildTrendsBarAggregatedSeries(results, {
             getColor: () => RED,
             getHidden: (_r, i) => i === 1,
         })
-        expect(labels).toEqual(['A', 'C'])
+        expect(displayLabels).toEqual(['A', 'C'])
         expect(series).toHaveLength(2)
         expect(series[0].data).toEqual([1, 0])
         expect(series[1].data).toEqual([0, 3])

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
@@ -98,6 +98,9 @@ export function buildTrendsBarTimeSeriesConfig(opts: BuildTrendsBarTimeSeriesCon
     }
 }
 
+/** Separator between display label and series id in synthetic band keys. */
+const BAND_KEY_SEP = '\u001f'
+
 // Sparse-stacked: hog-charts BarChart allows one color per series, so we emit N series with
 // data=0 except at their own band — d3.stack reduces this to one visible segment per band.
 // Trade-off: only the last series gets rounded-corner caps.
@@ -116,7 +119,7 @@ export function buildTrendsBarAggregatedSeries<R extends TrendsBarResultLike, M 
     // different series get distinct bands (breakdowns of one series still share a band).
     const labels = visible.map((r, i) => {
         const seriesId = r.action?.order ?? r.order ?? 0
-        return `${displayLabels[i]}__${seriesId}`
+        return `${displayLabels[i]}${BAND_KEY_SEP}${seriesId}`
     })
     const n = visible.length
     const series = visible.map((r, index) => {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
@@ -19,6 +19,9 @@ export interface TrendsBarResultLike {
     compare?: boolean
     compare_label?: string | null
     action?: { order?: number } | null
+    // Formula-mode results have a top-level `order` instead of `action.order` — it identifies
+    // which formula the row belongs to so breakdown rows of the same formula can share a band.
+    order?: number | null
     breakdown_value?: unknown
     filter?: unknown
 }
@@ -102,14 +105,21 @@ export function buildTrendsBarTimeSeriesConfig(opts: BuildTrendsBarTimeSeriesCon
 export function buildTrendsBarAggregatedSeries<R extends TrendsBarResultLike, M = unknown>(
     results: R[],
     opts: BuildTrendsBarSeriesOpts<R, M>
-): { series: Series<M>[]; labels: string[] } {
+): { series: Series<M>[]; labels: string[]; displayLabels: string[] } {
     // Hidden results are dropped entirely — keeping them as `excluded` series would leave
     // a phantom band on the category axis with no bar.
     const visible = opts.getHidden ? results.filter((r, i) => !opts.getHidden!(r, i)) : results
-    // d3.scaleBand collapses duplicate domain entries — suffix compare rows so each gets its own band.
-    const labels = visible.map((r) => {
+    const displayLabels = visible.map((r) => {
         const base = r.label ?? ''
         return r.compare_label ? `${base} - ${r.compare_label}` : base
+    })
+    // d3.scaleBand dedupes its domain. Band key suffix = the series identity (`action.order`
+    // for normal series, top-level `order` for formula rows). Breakdowns of one series share
+    // an identity → same band → bars overlap by descending size in the same row. Different
+    // series with the same display label get different identities → distinct bands.
+    const labels = visible.map((r, i) => {
+        const seriesId = r.action?.order ?? r.order ?? 0
+        return `${displayLabels[i]}__${seriesId}`
     })
     const n = visible.length
     const series = visible.map((r, index) => {
@@ -120,5 +130,5 @@ export function buildTrendsBarAggregatedSeries<R extends TrendsBarResultLike, M 
         }
         return buildMainTrendsBarSeries(r, index, opts, data)
     })
-    return { series, labels }
+    return { series, labels, displayLabels }
 }

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
@@ -19,8 +19,7 @@ export interface TrendsBarResultLike {
     compare?: boolean
     compare_label?: string | null
     action?: { order?: number } | null
-    // Formula-mode results have a top-level `order` instead of `action.order` — it identifies
-    // which formula the row belongs to so breakdown rows of the same formula can share a band.
+    // Formula rows carry a top-level `order` instead of `action.order`.
     order?: number | null
     breakdown_value?: unknown
     filter?: unknown
@@ -113,10 +112,8 @@ export function buildTrendsBarAggregatedSeries<R extends TrendsBarResultLike, M 
         const base = r.label ?? ''
         return r.compare_label ? `${base} - ${r.compare_label}` : base
     })
-    // d3.scaleBand dedupes its domain. Band key suffix = the series identity (`action.order`
-    // for normal series, top-level `order` for formula rows). Breakdowns of one series share
-    // an identity → same band → bars overlap by descending size in the same row. Different
-    // series with the same display label get different identities → distinct bands.
+    // Suffix the band key with the series identity so duplicate display labels from
+    // different series get distinct bands (breakdowns of one series still share a band).
     const labels = visible.map((r, i) => {
         const seriesId = r.action?.order ?? r.order ?? 0
         return `${displayLabels[i]}__${seriesId}`


### PR DESCRIPTION
## Problem

On the aggregated/stacked horizontal bar chart, the value-label hover-lift behaved inconsistently — hovering a bar would sometimes shift its value label and sometimes not.

Root cause: the lift is keyed on `hoverIndex`, which is resolved purely from the band (categorical) axis and is a single number. But the aggregated chart is *sparse-stacked* — several series share one band slot, each with its real value at its own `dataIndex`. So `hoverIndex` (a bisector over duplicate band positions) matches only one of the segments in a shared band; only that label lifted, regardless of which segment the cursor was actually over.

## Changes

Resolve the *visible segment under the cursor* (the same `findVisibleStackedSegment` the hover highlight and tooltip already use) and lift exactly that label.

- Added a `resolveHoverSegment` chart-type seam on `Chart`; `BarChart` supplies it (stacked layouts only) and `Chart` publishes the result as `hoverSegment` on the hover context.
- `ValueLabels` lifts the candidate matching `hoverSegment` (series key + dataIndex). When the cursor is over no segment (`hoverSegment === null`, e.g. past the bar) nothing lifts; non-resolving charts (line, grouped) fall back to the existing `hoverIndex` behavior.
- `hoverSegment` identity is keyed on a primitive so the hover context only changes when the resolved segment changes — overlays don't re-render on every mousemove within a segment.

Stacked on #60488 — depends on `findVisibleStackedSegment` introduced there.

## How did you test this code?

I'm an agent. Automated tests I ran (all green):

- `frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx` — added an end-to-end test: hover the small slice → its label lifts and the others don't, then move into the mid slice → the lift follows. Exercises the full path (`resolveHoverSegment` → `Chart` → `ValueLabels`) and fails on the pre-fix code.
- `frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx` — unit guard for the `hoverSegment === null` (past-the-bar) suppression branch.
- Full `frontend/src/lib/hog-charts/` suite and `products/product_analytics/.../TrendsBarChart/` suite.

Needs a visual re-check on a live aggregated horizontal bar chart with value labels.

## 🤖 Agent context

Authored by Claude (Claude Code). Split out of #60488 to keep that PR under 500 LOC; this is the most self-contained of the bundled hover fixes and stacks cleanly on the `findVisibleStackedSegment` helper from the base PR. Considered two lighter alternatives (lift all labels in a band together; band-label match instead of dataIndex) but chose per-segment resolution because it matches the hover highlight and tooltip exactly.
