### PR TITLE
fix(experiments): include fingerprint in saved-metric cache key

### DIFF
--- a/posthog/temporal/experiments/activities.py
+++ b/posthog/temporal/experiments/activities.py
@@ -408,16 +408,18 @@ def _calculate_experiment_saved_metric_sync(
             error_message=f"Saved metric {metric_uuid} not found for experiment {experiment_id}",
         )
 
-    # The frontend wraps every saved metric with breakdownFilter.breakdowns from
-    # the link metadata before posting to /query (see sharedMetricsToExperimentMetrics
-    # in experimentLogic.tsx). The activity must apply the same wrapper or the
-    # response cache key diverges and the warmed entry is never read.
+    # The frontend receives saved metrics with two extra fields injected before
+    # they get posted back to /query: a breakdownFilter wrapper (from the link
+    # metadata, via sharedMetricsToExperimentMetrics in experimentLogic.tsx) and
+    # a fingerprint (added by the experiment API serializer). The activity must
+    # apply both or the response cache key diverges from /query's.
     query = {
         **saved_metric.query,
         "breakdownFilter": {
             **(saved_metric.query.get("breakdownFilter") or {}),
             "breakdowns": saved_metric_metadata.get("breakdowns") or [],
         },
+        "fingerprint": fingerprint,
     }
     metric_type = query.get("metric_type")
     metric_obj: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]

--- a/posthog/temporal/experiments/test_cache_warming.py
+++ b/posthog/temporal/experiments/test_cache_warming.py
@@ -105,10 +105,10 @@ class TestTemporalRecalcWarmsResponseCache(ExperimentQueryRunnerBaseTest):
     @freeze_time("2020-01-10T12:00:00Z")
     def test_temporal_activity_warms_query_cache_for_saved_metric(self):
         """
-        Saved metrics take a different path: the frontend merges
-        ExperimentToSavedMetric.metadata.breakdowns into a breakdownFilter on
-        the metric before posting to /query. The activity must apply the same
-        merge or the cache key diverges. This test covers that path.
+        Saved metrics go through two backend-side transformations before /query
+        sees them: the API serializer adds `fingerprint`, and the frontend wraps
+        with `breakdownFilter` from the link metadata. The activity must apply
+        both or the response cache key diverges from what /query reads.
         """
         feature_flag = self.create_feature_flag()
         experiment = self.create_experiment(
@@ -158,12 +158,21 @@ class TestTemporalRecalcWarmsResponseCache(ExperimentQueryRunnerBaseTest):
                 )
         flush_persons_and_events()
 
-        # Build the metric the way the frontend does for saved metrics:
-        # wrap with breakdownFilter merged from link.metadata.breakdowns
-        # (see sharedMetricsToExperimentMetrics in experimentLogic.tsx).
+        fingerprint = compute_metric_fingerprint(
+            metric_dict,
+            experiment.start_date,
+            get_experiment_stats_method(experiment),
+            experiment.exposure_criteria,
+            only_count_matured_users=experiment.only_count_matured_users,
+        )
+
+        # Build the metric the way /query sees it for saved metrics:
+        # fingerprint added by the API serializer (presentation/serializers.py)
+        # plus breakdownFilter wrapped by sharedMetricsToExperimentMetrics on the frontend.
         frontend_metric_dict = {
             **metric_dict,
             "breakdownFilter": {"breakdowns": []},
+            "fingerprint": fingerprint,
         }
         frontend_query = ExperimentQuery.model_validate(
             {
@@ -175,13 +184,6 @@ class TestTemporalRecalcWarmsResponseCache(ExperimentQueryRunnerBaseTest):
 
         cache.clear()
 
-        fingerprint = compute_metric_fingerprint(
-            metric_dict,
-            experiment.start_date,
-            get_experiment_stats_method(experiment),
-            experiment.exposure_criteria,
-            only_count_matured_users=experiment.only_count_matured_users,
-        )
         with patch("posthog.temporal.experiments.activities.close_old_connections"):
             activity_result = _calculate_experiment_saved_metric_sync.func(  # type: ignore[attr-defined]
                 experiment.id, metric_dict["uuid"], fingerprint


### PR DESCRIPTION
## Problem

The experiment API serializer writes a `fingerprint` into `saved_metric.query` before returning it to the frontend (`presentation/serializers.py:332`). The frontend sends that metric — fingerprint and all — back to `/query`, where the fingerprint ends up in the cache key. The Temporal activity was reading the raw `saved_metric.query` from the DB (no fingerprint), so it warmed a different cache key than the one `/query` reads from. The previous fix only handled `breakdownFilter`; the fingerprint divergence was still hiding the warmed entry.

## Changes

In `_calculate_experiment_saved_metric_sync`, write the fingerprint into the metric dict (same `fingerprint` parameter already passed to the activity, computed via the same `compute_metric_fingerprint` call the serializer uses).

## How did you test this code?

- Updated saved-metric test to mirror the full transformation the frontend applies (breakdownFilter + fingerprint).
- Existing inline-metric test still passes — inline metrics get their fingerprint stored in the DB at create time, so no equivalent gap exists there.
- mypy clean on the changed files.