### PR TITLE
fix(insights): show formula input when toggling formula mode on

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
@@ -21,8 +21,10 @@ export function TrendsFormula({ insightProps }: EditorFilterProps): JSX.Element 
     const [localValues, setLocalValues] = useState<TrendsFormulaNode[]>(values)
 
     useEffect(() => {
-        // Don't clear the formulas so that the values are still there after toggling the formula switch
-        if (formulaNodes) {
+        // Don't clear the formulas so that the values are still there after toggling the formula switch.
+        // formulaNodes is [] (truthy) when no formula is set, so check length to fall through to the
+        // hasFormula branch that seeds one empty input when formula mode is toggled on.
+        if (formulaNodes && formulaNodes.length > 0) {
             setValues(formulaNodes)
             // Merge incoming formulas with existing local fields, maintaining order
             setLocalValues((prev) => {

--- a/playwright/page-models/insights/trendsInsight.ts
+++ b/playwright/page-models/insights/trendsInsight.ts
@@ -21,7 +21,6 @@ export class TrendsInsight extends ChartInsightBase {
 
     private readonly detailsLoader: Locator
     private readonly addSeriesButton: Locator
-    private readonly addFormulaButton: Locator
 
     constructor(page: Page) {
         super(page, page.getByTestId('insights-graph'))
@@ -35,7 +34,6 @@ export class TrendsInsight extends ChartInsightBase {
         this.breakdownButton = page.getByTestId('add-breakdown-button')
         this.formulaSwitch = page.locator('#trends-formula-switch')
         this.formulaInput = page.getByPlaceholder('Example: (A + B) / 100')
-        this.addFormulaButton = page.getByRole('button', { name: 'Add formula' })
         this.dateRangeButton = page.getByTestId('date-filter')
         this.chartTypeButton = page.getByTestId('chart-filter')
         this.comparisonButton = page.getByTestId('compare-filter')
@@ -99,10 +97,10 @@ export class TrendsInsight extends ChartInsightBase {
 
     async setFormula(formula: string): Promise<void> {
         await this.formulaSwitch.click()
-        await this.addFormulaButton.click()
         await this.formulaInput.first().waitFor({ state: 'visible' })
         await this.formulaInput.first().fill(formula)
         await this.formulaInput.first().press('Enter')
+        await this.waitForChart()
     }
 
     mathSelector(seriesIndex: number): Locator {


### PR DESCRIPTION
## Problem

The trends formula Playwright helper (`setFormula`) was flaky, but while stabilizing it we found a real UX bug underneath.

When you toggle **Formula mode** on a fresh trends insight (no formula set yet), formula mode is enabled but **no formula input appears** — you only see a bare "Add formula" button and have to click it to get an input. This contradicts the component's own documented intent ("Always ensure at least one empty value when formula mode is enabled").

Root cause: the `formulaNodes` selector returns `[]` (an empty array, which is **truthy**) when no formula is set. The `useEffect` in `TrendsFormula.tsx` guarded on `if (formulaNodes)`, so the empty array always took the "merge existing formulas" branch and skipped the `else if (hasFormula)` branch that seeds the first empty input.

The Playwright helper only passed before because it clicked "Add formula" after toggling the switch — masking the bug. Removing that click (the original flake fix) exposed it, so the formula input never became visible and the test timed out.

## Changes

- **Fix the UX bug** in `TrendsFormula.tsx`: guard on `formulaNodes.length > 0` so an empty `formulaNodes` falls through to the branch that seeds one empty input. Toggling formula mode now shows an input immediately, as intended.

Before
<img width="684" height="112" alt="Screenshot 2026-05-29 at 12 43 52" src="https://github.com/user-attachments/assets/ce6e1524-ab5e-4189-a925-0aa1c321bda1" />

After
<img width="686" height="165" alt="Screenshot 2026-05-29 at 12 44 10" src="https://github.com/user-attachments/assets/adb6071d-1652-4bc7-9584-269b1e6ceace" />

- **Simplify the `setFormula` Playwright helper**: drop the extra `addFormulaButton.click()` (no longer needed now that the switch shows an input on its own) and remove the now-unused `addFormulaButton` field/initializer.
- Wait for the chart to re-render after submitting the formula so the details table reflects the formula result before assertions run.

The disable-formula path and the load-existing-formula path are unchanged.

## How did you test this code?

I am an agent. I made the edits and let lint-staged run during commit (oxlint/oxfmt). I did not run the Playwright suite locally.

- The previously-failing **Playwright E2E** job (`Combine two series with a formula and verify computed total`) now passes in CI, along with all other checks.
- The human author verified the fix manually in the local UI: toggling Formula mode on a fresh trends insight now shows one empty formula input immediately (previously it showed only an "Add formula" button), saved formulas still load on reload, and disabling formula mode restores the original series.

## 🤖 Agent context

Agent-assisted via PostHog Code. The original change only touched the Playwright page model to fix a flaky test. CI then failed because removing the `addFormulaButton.click()` exposed that toggling the formula switch never rendered an input. Investigation traced this to the truthy-empty-array guard in `TrendsFormula.tsx`'s effect; the fix was to check the array length so the documented "seed one empty input" branch runs. The component fix was chosen over reverting the helper because it addresses the underlying UX bug rather than masking it. The human author confirmed the behavior in the local UI.
