### PR TITLE
fix: normalize model names, fix claude 4.8

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -9,7 +9,13 @@ import structlog
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from llm_gateway.api.handler import ANTHROPIC_CONFIG, BEDROCK_CONFIG, _sanitize_request_data, handle_llm_request
+from llm_gateway.api.handler import (
+    ANTHROPIC_CONFIG,
+    BEDROCK_CONFIG,
+    _sanitize_request_data,
+    handle_llm_request,
+    normalize_litellm_model_name,
+)
 from llm_gateway.bedrock import count_tokens_with_bedrock, ensure_bedrock_configured, map_to_bedrock_model
 from llm_gateway.circuit_breaker import AnthropicCircuitBreaker
 from llm_gateway.config import get_settings
@@ -203,9 +209,11 @@ async def _handle_anthropic_messages(
     if await _maybe_bypass_anthropic(breaker, body.model, product, use_bedrock_fallback=use_bedrock_fallback):
         return await _send_bedrock_messages(data, user, request, body.stream or False, product)
 
+    litellm_data = {**data, "model": normalize_litellm_model_name(body.model, ANTHROPIC_CONFIG.name)}
+
     try:
         result = await handle_llm_request(
-            request_data=data,
+            request_data=litellm_data,
             user=user,
             model=body.model,
             is_streaming=body.stream or False,

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -46,6 +46,22 @@ OPENAI_CONFIG = ProviderConfig(name="openai", endpoint_name="chat_completions")
 OPENAI_RESPONSES_CONFIG = ProviderConfig(name="openai", endpoint_name="responses")
 OPENAI_TRANSCRIPTION_CONFIG = ProviderConfig(name="openai", endpoint_name="audio_transcriptions")
 
+_KNOWN_LITELLM_PROVIDER_PREFIXES = (
+    "anthropic/",
+    "bedrock/",
+    "fireworks_ai/",
+    "openai/",
+    "openrouter/",
+)
+
+
+def normalize_litellm_model_name(model: str, provider: str) -> str:
+    """Add an explicit LiteLLM provider prefix when a provider endpoint receives a bare model ID."""
+    if model.startswith(_KNOWN_LITELLM_PROVIDER_PREFIXES):
+        return model
+    return f"{provider}/{model}"
+
+
 # Google providers require litellm[google], which we don't install. Reject these
 # at the edge so litellm doesn't crash deep in vertex_llm_base with an ImportError.
 # Match both explicit provider prefixes (gemini/foo, vertex_ai/foo) and bare names

--- a/services/llm-gateway/src/llm_gateway/api/openai.py
+++ b/services/llm-gateway/src/llm_gateway/api/openai.py
@@ -9,19 +9,13 @@ from llm_gateway.api.handler import (
     OPENAI_RESPONSES_CONFIG,
     OPENAI_TRANSCRIPTION_CONFIG,
     handle_llm_request,
+    normalize_litellm_model_name,
 )
 from llm_gateway.dependencies import RateLimitedUser
 from llm_gateway.models.openai import ChatCompletionRequest, ResponsesRequest, TranscriptionRequest
 from llm_gateway.products.config import validate_product
 
 openai_router = APIRouter()
-
-
-def _normalize_model_name(model: str) -> str:
-    """Ensure model name has openai/ prefix for litellm routing."""
-    if model.startswith("openai/"):
-        return model
-    return f"openai/{model}"
 
 
 async def _handle_chat_completions(
@@ -55,7 +49,7 @@ async def _handle_responses(
     data = body.model_dump(exclude_none=True)
 
     original_model = body.model
-    normalized_model = _normalize_model_name(original_model)
+    normalized_model = normalize_litellm_model_name(original_model, OPENAI_RESPONSES_CONFIG.name)
     data["model"] = normalized_model
 
     return await handle_llm_request(
@@ -148,7 +142,7 @@ async def _handle_transcription(
             },
         )
 
-    normalized_model = _normalize_model_name(model)
+    normalized_model = normalize_litellm_model_name(model, OPENAI_TRANSCRIPTION_CONFIG.name)
     content = await file.read()
     file_tuple = (file.filename, content, file.content_type or "audio/mpeg")
 

--- a/services/llm-gateway/tests/test_anthropic.py
+++ b/services/llm-gateway/tests/test_anthropic.py
@@ -234,6 +234,29 @@ class TestAnthropicMessagesEndpoint:
         assert data["role"] == "assistant"
         assert data["usage"]["input_tokens"] == 10
 
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_bare_claude_model_is_prefixed_for_litellm_routing(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        provider_mock_response: dict,
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump = MagicMock(return_value=provider_mock_response)
+        mock_anthropic.return_value = mock_response
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-opus-4-8",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+            headers={"Authorization": "Bearer phx_test_key"},
+        )
+
+        assert response.status_code == 200
+        assert mock_anthropic.call_args.kwargs["model"] == "anthropic/claude-opus-4-8"
+
     @pytest.mark.parametrize(
         "error_status,error_message,error_type",
         [
@@ -475,7 +498,7 @@ class TestAnthropicMessagesEndpoint:
 
         assert response.status_code == 200
         call_kwargs = mock_anthropic.call_args.kwargs
-        assert call_kwargs["model"] == "claude-sonnet-4-6"
+        assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
         assert "provider" not in call_kwargs
         assert "use_bedrock_fallback" not in call_kwargs
 
@@ -1028,7 +1051,7 @@ class TestAnthropicCircuitBreakerIntegration:
 
         assert response.status_code == 200
         forwarded_model = mock_anthropic.call_args.kwargs["model"]
-        assert forwarded_model == "claude-sonnet-4-6"
+        assert forwarded_model == "anthropic/claude-sonnet-4-6"
         breaker.record_outcome.assert_awaited_with(success=True)
         breaker.evaluate.assert_not_called()
 
@@ -1057,7 +1080,7 @@ class TestAnthropicCircuitBreakerIntegration:
 
         assert response.status_code == 200
         forwarded_model = mock_anthropic.call_args.kwargs["model"]
-        assert forwarded_model == "claude-sonnet-4-6"
+        assert forwarded_model == "anthropic/claude-sonnet-4-6"
         breaker.record_outcome.assert_awaited_with(success=True)
 
     @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
@@ -1138,9 +1161,9 @@ class TestAnthropicCircuitBreakerIntegration:
         mock_anthropic: MagicMock,
         authenticated_client: TestClient,
         install_breaker,
-        request_body: dict,
         mock_response_dict: dict,
     ) -> None:
+        request_body = {"model": "claude-opus-4-8", "messages": [{"role": "user", "content": "Hi"}]}
         breaker = install_breaker(bypass=False)
         error = Exception("rate limited")
         error.status_code = 429  # type: ignore[attr-defined]
@@ -1167,6 +1190,8 @@ class TestAnthropicCircuitBreakerIntegration:
         assert response.status_code == 200
         breaker.record_outcome.assert_awaited_with(success=False)
         assert mock_anthropic.call_count == 2
+        assert mock_anthropic.call_args_list[0].kwargs["model"] == "anthropic/claude-opus-4-8"
+        assert mock_anthropic.call_args_list[1].kwargs["model"] == "bedrock/us.anthropic.claude-opus-4-8"
 
     def test_streaming_success_records_after_stream_completes(
         self,


### PR DESCRIPTION
## Problem

LiteLLM uses provider-prefixed model names (e.g. `anthropic/claude-opus-4-8`) for routing. When bare model IDs were passed to the Anthropic endpoint, LiteLLM had to infer the provider, which could lead to ambiguous or incorrect routing. The OpenAI endpoint already had a local helper to handle this, but it was narrow in scope and not reusable.

## Changes

Introduces a shared `normalize_litellm_model_name(model, provider)` utility in `handler.py` that prepends an explicit provider prefix to any model name that doesn't already carry a known LiteLLM provider prefix. The Anthropic endpoint now uses this to ensure model names are prefixed before being forwarded to LiteLLM. The existing OpenAI-specific `_normalize_model_name` helper is removed and replaced with calls to the shared utility.

## How did you test this code?

A new test (`test_bare_claude_model_is_prefixed_for_litellm_routing`) verifies that a bare model ID sent to the Anthropic `/v1/messages` endpoint is forwarded to LiteLLM as `anthropic/<model>`. Existing tests were updated to assert the prefixed model name, and the 429-fallback test now additionally asserts that the Bedrock retry uses the correct `bedrock/` prefixed model name.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update