### PR TITLE
fix(llma): use toString zero-UUID guard in generation sampling

### DIFF
--- a/posthog/temporal/ai_observability/trace_summarization/sampling.py
+++ b/posthog/temporal/ai_observability/trace_summarization/sampling.py
@@ -144,9 +144,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     AND timestamp < toDateTime({end_ts}, 'UTC')
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
-                -- argMaxIf returns the zero UUID (not NULL) when no rows match.
-                -- Compare via toString because toUUIDOrZero / toUUID('...zero...')
-                -- are not in the HogQL function allowlist.
+                -- argMaxIf returns the zero UUID (not NULL) with no matches; toUUIDOrZero isn't in the HogQL allowlist.
                 HAVING toString(last_generation_id) != '00000000-0000-0000-0000-000000000000'
                     AND event_count <= {max_events}
                     AND total_properties_size <= {max_properties_size}

--- a/posthog/temporal/ai_observability/trace_summarization/sampling.py
+++ b/posthog/temporal/ai_observability/trace_summarization/sampling.py
@@ -144,8 +144,10 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     AND timestamp < toDateTime({end_ts}, 'UTC')
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
-                -- argMaxIf returns the zero UUID (not NULL) when no rows match
-                HAVING last_generation_id != toUUIDOrZero('')
+                -- argMaxIf returns the zero UUID (not NULL) when no rows match.
+                -- Compare via toString because toUUIDOrZero / toUUID('...zero...')
+                -- are not in the HogQL function allowlist.
+                HAVING toString(last_generation_id) != '00000000-0000-0000-0000-000000000000'
                     AND event_count <= {max_events}
                     AND total_properties_size <= {max_properties_size}
                 ORDER BY trace_first_timestamp DESC

--- a/posthog/temporal/ai_observability/trace_summarization/sampling.py
+++ b/posthog/temporal/ai_observability/trace_summarization/sampling.py
@@ -145,7 +145,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
                 -- argMaxIf returns the zero UUID (not NULL) with no matches; toUUIDOrZero isn't in the HogQL allowlist.
-                HAVING toString(last_generation_id) != '00000000-0000-0000-0000-000000000000'
+                HAVING last_generation_id != toUUID('00000000-0000-0000-0000-000000000000')
                     AND event_count <= {max_events}
                     AND total_properties_size <= {max_properties_size}
                 ORDER BY trace_first_timestamp DESC

--- a/posthog/temporal/ai_observability/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/ai_observability/trace_summarization/tests/test_workflow.py
@@ -5,6 +5,11 @@ from contextlib import asynccontextmanager
 import pytest
 from unittest.mock import patch
 
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.placeholders import replace_placeholders
+from posthog.hogql.printer.utils import prepare_and_print_ast
+
+from posthog.sync import database_sync_to_async
 from posthog.temporal.ai_observability.trace_summarization.models import BatchSummarizationInputs, SampledItem
 from posthog.temporal.ai_observability.trace_summarization.sampling import sample_items_in_window_activity
 from posthog.temporal.ai_observability.trace_summarization.workflow import BatchTraceSummarizationWorkflow
@@ -217,10 +222,38 @@ class TestSampleItemsInWindowActivity:
 
             # argMaxIf with no matching rows returns the zero UUID (not NULL), so
             # HAVING must explicitly compare against it — IS NOT NULL doesn't catch it.
-            zero_uuid_guard = CallCollector("toUUIDOrZero")
+            # The comparison goes through toString because toUUIDOrZero / toUUID
+            # of the zero-UUID literal are not in the HogQL function allowlist.
             assert query.having is not None
-            zero_uuid_guard.visit(query.having)
-            assert zero_uuid_guard.found, "HAVING must guard against zero-UUID phantom generations"
+            to_string_guard = CallCollector("toString")
+            to_string_guard.visit(query.having)
+            assert to_string_guard.found, "HAVING must guard against zero-UUID phantom generations"
+
+            class ConstantFinder(TraversingVisitor):
+                def __init__(self, value: str) -> None:
+                    self.value = value
+                    self.found = False
+
+                def visit_constant(self, node: ast.Constant) -> None:
+                    if node.value == self.value:
+                        self.found = True
+
+            zero_uuid_literal = ConstantFinder("00000000-0000-0000-0000-000000000000")
+            zero_uuid_literal.visit(query.having)
+            assert zero_uuid_literal.found, "HAVING must compare against the literal zero UUID"
+
+            # Validate the query against the real HogQL printer — every function call
+            # must be in the allowlist. Without this, a regression like toUUIDOrZero
+            # (rejected at runtime as `QueryError: Unsupported function call`) ships.
+            # Wrapped in database_sync_to_async because the printer loads the team
+            # via the Django ORM, which is blocked from this async test context.
+            placeholders = mock_execute.call_args.kwargs["placeholders"]
+            materialized = replace_placeholders(query, placeholders)
+            await database_sync_to_async(prepare_and_print_ast, thread_sensitive=False)(
+                materialized,
+                HogQLContext(team_id=mock_team.id, enable_select_queries=True),
+                "clickhouse",
+            )
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio

--- a/posthog/temporal/ai_observability/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/ai_observability/trace_summarization/tests/test_workflow.py
@@ -222,12 +222,11 @@ class TestSampleItemsInWindowActivity:
 
             # argMaxIf with no matching rows returns the zero UUID (not NULL), so
             # HAVING must explicitly compare against it — IS NOT NULL doesn't catch it.
-            # The comparison goes through toString because toUUIDOrZero / toUUID
-            # of the zero-UUID literal are not in the HogQL function allowlist.
+            # toUUIDOrZero is not whitelisted; toUUID('...') is (constant-folded UUID compare).
             assert query.having is not None
-            to_string_guard = CallCollector("toString")
-            to_string_guard.visit(query.having)
-            assert to_string_guard.found, "HAVING must guard against zero-UUID phantom generations"
+            to_uuid_guard = CallCollector("toUUID")
+            to_uuid_guard.visit(query.having)
+            assert to_uuid_guard.found, "HAVING must guard against zero-UUID phantom generations"
 
             class ConstantFinder(TraversingVisitor):
                 def __init__(self, value: str) -> None:


### PR DESCRIPTION
## Problem

`$ai_generation_summary` has been at 0 since 2026-05-20, which in turn took `$ai_generation_clusters` to 0 on 2026-05-27 (clustering uses the last 7 days of summary embeddings). Trace summaries were unaffected because the trace-level path doesn't hit the same expression.

Root cause: the `HAVING` clause in the generation sampling query uses `toUUIDOrZero('')`, which is not in the HogQL function allowlist (`posthog/hogql/functions/clickhouse/conversions.py`). Every `llma-generation-summarization-coordinator-schedule` child workflow has been failing inside `sample_items_in_window_activity` with `QueryError: Unsupported function call 'toUUIDOrZero(...)'`. The existing unit test mocked `execute_hogql_query`, so the HogQL validator never ran against this query.

## Changes

- `posthog/temporal/ai_observability/trace_summarization/sampling.py`: replace `HAVING last_generation_id != toUUIDOrZero('')` with `HAVING last_generation_id != toUUID('00000000-0000-0000-0000-000000000000')`. `toUUID` is HogQL-allowed and constant-folded at plan time, so the comparand is a single `UInt128` value — the per-row work is a 16-byte UUID compare, no string materialization.
- `posthog/temporal/ai_observability/trace_summarization/tests/test_workflow.py`: update `test_generation_filter_is_applied_inside_argmaxif` to assert the new HAVING shape, then run the materialized query through `prepare_and_print_ast`. This catches the same class of regression (function not whitelisted) at unit-test time instead of in production.

## How did you test this code?

I'm an agent (Claude Opus 4.7) collaborating with @andrewm4894.

Automated:
- `hogli test posthog/temporal/ai_observability/trace_summarization/tests/test_workflow.py` — all pass, including the updated guard that now exercises the real HogQL printer.

Local end-to-end against real ClickHouse:
- Confirmed local team 1 had 376 `$ai_generation` events spanning May 18–28 (via `execute-sql`).
- Ran the activity directly through `temporalio.testing.ActivityEnvironment` in `manage.py shell`:
  ```python
  inputs = BatchSummarizationInputs(
      team_id=1, max_items=20, analysis_level='generation',
      window_minutes=60*24*30,
      window_start='2026-04-29T00:00:00',
      window_end='2026-05-29T23:00:00',
  )
  items = await ActivityEnvironment().run(sample_items_in_window_activity, inputs)
  ```
  Returned 20 `SampledItem`s with valid `trace_id` + `generation_id`, no `QueryError`. This is the same code path that's been crashing in prod since 2026-05-20.

Negative-case verification (reproducing the bug):
- Temporarily reverted the HAVING clause back to `toUUIDOrZero('')` and re-ran the same activity.
- Reproduced the exact production error string: `QueryError: Unsupported function call 'toUUIDOrZero(...)'. Perhaps you meant 'toIntOrZero(...)'?`
- Restored the fix; `git diff HEAD` confirms the working tree matches the committed version.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

- Triggered from a Slack thread about the LLMA Generation Cluster Events anomaly alert. An earlier in-thread agent run had already pointed at #59186 and the unwhitelisted `toUUIDOrZero`. Verified independently by greping `posthog/hogql/functions/` (`toUUIDOrZero` absent; `toString` and `toUUID` present in `clickhouse/conversions.py`).
- First pass shipped with `toString(last_generation_id) != '...'`. Reviewed the perf shape on a follow-up: `toUUID('...')` is constant-folded at plan time and reduces the per-row work to a `UInt128` compare instead of materializing a 36-byte string per group. Swapped to the UUID form — same semantics, strictly less work for ClickHouse.
- The `prepare_and_print_ast` step in the test needs `database_sync_to_async` (printer loads the team via Django ORM) and `enable_select_queries=True` (default `HogQLContext` blocks full SELECTs). Both caught by failing test runs while iterating, not guessed up front.
- Verified both directions against local ClickHouse: with the fix the activity returns 20 SampledItems; with the broken HAVING restored it raises the same `QueryError` seen in prod. Working tree confirmed clean against HEAD afterwards. Re-ran end-to-end after the `toString` → `toUUID` swap, same 20-items result.