### PR TITLE
fix(api): validate test_account_filters on ProjectSerializer too

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -432,6 +432,10 @@ class ProjectBackwardCompatSerializer(
     def validate_modifiers(value: dict | None) -> dict | None:
         return TeamSerializer.validate_modifiers(value)
 
+    @staticmethod
+    def validate_test_account_filters(value: object) -> list[dict[str, object]]:
+        return TeamSerializer.validate_test_account_filters(value)
+
     def validate_proactive_tasks_enabled(self, value: bool | None) -> bool | None:
         return TeamSerializer.validate_proactive_tasks_enabled(cast(TeamSerializer, self), value)
 


### PR DESCRIPTION
## Problem

[#58129](https://github.com/PostHog/posthog/pull/58129) and [#58320](https://github.com/PostHog/posthog/pull/58320) added a pydantic-based `validate_test_account_filters` to reject non-array writes to `Team.test_account_filters`, and [#58375](https://github.com/PostHog/posthog/pull/58375) backfilled the corrupted rows. But that validator was only wired into `TeamSerializer`.

`ProjectBackwardCompatSerializer` — which backs the `/api/projects/` endpoint used by the MCP `project-settings-update` tool — was still missing the same guard, so the field could continue to be corrupted through that path. A customer ticket landed in escalation when an MCP client wrote a JSON-encoded string through the project endpoint.

## Changes

Wire the existing `validate_test_account_filters` into `ProjectBackwardCompatSerializer` via a `@staticmethod` that delegates to `TeamSerializer.validate_test_account_filters`. This matches the pattern already used for `validate_modifiers`, `validate_session_replay_config`, `validate_session_recording_linked_flag`, etc.

No new validation logic — the shared pydantic adapter from `posthog/api/team.py` is reused, so behavior on `/api/projects/` is now identical to `/api/environments/`.

## How did you test this code?

I'm an agent. No new automated test was added — the underlying validator is already covered by `test_validate_test_account_filters_rejects_invalid_filters` on the team endpoint, and the change is a single delegating staticmethod with no new logic. Verified Python syntax parses.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Single 3-line staticmethod following the existing "delegate to TeamSerializer" convention. Considered moving the parameterized team-endpoint test into \`team_api_test_factory()\` so both endpoints would inherit it, but decided that touched more code than the user's "keep changes concise" framing called for — happy to add that on request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*