### PR TITLE
fix(ci): unblock test-timing auto-commit and de-tax durations

### DIFF
--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -296,18 +296,20 @@ class MigrationTaxCorrector:
     def _lookup_call_time(test_id: str, junit_call: dict[str, float]) -> float | None:
         """Find a durations key's call time in the JUnit map.
 
-        Exact match first; otherwise anchored-suffix on the `::class::test`
-        tail, accepted only when unique — JUnit ids and pytest node ids can
-        differ only in file-path prefix. Only ever called for the handful of
-        high / placeholder durations, so the linear scan is cheap.
+        Exact match first; otherwise a suffix anchored on the file basename
+        (`file.py::[Class::]test`) at a path boundary, accepted only when
+        unique — JUnit ids and pytest node ids can differ only in directory
+        prefix. Anchoring on the basename keeps a bare function name from
+        colliding across files. Only ever called for the handful of high /
+        placeholder durations, so the linear scan is cheap.
         """
         if test_id in junit_call:
             return junit_call[test_id]
         parts = test_id.split("::")
         if len(parts) < 2:
             return None
-        suffix = "::" + "::".join(parts[-2:]) if len(parts) >= 3 else "::" + parts[-1]
-        matches = [v for k, v in junit_call.items() if k.endswith(suffix)]
+        tail = "::".join([parts[0].rsplit("/", 1)[-1], *parts[1:]])
+        matches = [v for k, v in junit_call.items() if k == tail or k.endswith("/" + tail)]
         return matches[0] if len(matches) == 1 else None
 
     def _correct_statistically(self) -> MigrationTaxResult:

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -10,13 +10,15 @@
 """
 Prepare test durations for pytest-split sharding.
 
-Merges timing artifacts from CI shards and corrects migration-inflated
-first-test durations using JUnit results to identify carriers.
+Merges timing artifacts from CI shards and removes migration-tax
+contamination using JUnit call times as a setup-free contamination signal.
 
-Each shard's first test absorbs Django migration overhead (~6.5 min),
-making that test look artificially slow. This script detects those
-carriers, subtracts the migration tax, and outputs clean durations
-for balanced pytest-split distribution.
+Under --reuse-db the per-shard Django DB build (~7 min on master) is
+absorbed into whichever test first touches the DB, inflating its recorded
+duration and skewing pytest-split. This script merges the per-shard
+artifacts, floors any test recorded far above its JUnit call time (or
+sitting at a flat-default placeholder) back to that call time, and outputs
+clean durations for balanced distribution.
 """
 
 import re
@@ -39,6 +41,16 @@ MIN_DURATION = 0.01
 # Tests with recorded duration above this threshold in a single shard
 # are candidates for migration carriers (real tests rarely exceed this)
 CARRIER_THRESHOLD_SECONDS = 200.0
+# A test recorded this far above its JUnit call time absorbed per-shard DB
+# setup. Under --reuse-db the migration walk lands on whichever test first
+# touches the DB (not reliably the first test in the file), so detect it by
+# the call-time gap rather than by position. Migration/DB setup is hundreds
+# of seconds; legit per-test setup is tens at most, so this separates them.
+MIGRATION_TAX_THRESHOLD_SECONDS = 120.0
+# pytest-split writes these flat values for tests it has no timing for. They
+# are placeholders, not measurements — when JUnit has a real call time for
+# the test, prefer that. See reference: .test_durations ships 60.0 / 18.0.
+DEFAULT_PLACEHOLDER_SECONDS = (60.0, 18.0)
 
 
 @dataclass
@@ -72,14 +84,21 @@ _JUNIT_ARTIFACT_KEY = {"Core": "core", "CorePOE": "core-poe", "Temporal": "tempo
 
 @dataclass
 class JUnitShard:
-    """JUnit results from a single CI shard."""
+    """JUnit call-time data from a single CI shard.
+
+    XMLs are produced with `-o junit_duration_report=call`, so each
+    testcase's `time` is call time only — no fixture setup/teardown. The gap
+    between a test's recorded total and its call time is a reliable signal of
+    setup contamination (the migration walk shows up as a huge phantom gap),
+    used to detect and undo it in the merged .test_durations.
+    """
 
     name: str
-    first_test_id: str
+    call_times: dict[str, float]
 
     @classmethod
     def load_all(cls, junit_dir: Path, segment: str | None = None) -> list["JUnitShard"]:
-        """Load JUnit XMLs and extract the first test (carrier) from each shard.
+        """Load JUnit XMLs and extract per-test call times from each shard.
 
         JUnit artifact dirs are named like "junit-results-backend-core-1".
         Segment match is anchored at the artifact prefix so "Core" doesn't
@@ -103,27 +122,31 @@ class JUnitShard:
             if not xml_files:
                 continue
 
-            first_test_id = cls._find_first_test(xml_files[0])
-            if first_test_id:
-                shards.append(cls(name=shard_dir.name, first_test_id=first_test_id))
+            shards.append(cls(name=shard_dir.name, call_times=cls._parse_call_times(xml_files[0])))
 
         return shards
 
     @staticmethod
-    def _find_first_test(xml_path: Path) -> str | None:
-        """Extract the first parseable testcase id from a JUnit XML file."""
+    def _parse_call_times(xml_path: Path) -> dict[str, float]:
+        """Extract {pytest_id: call_time} for every parseable testcase."""
         try:
             tree = ET.parse(xml_path)
         except ParseError as e:
             logger.warning("  Could not parse JUnit XML %s: %s", xml_path, e)
-            return None
+            return {}
+        call_times: dict[str, float] = {}
         for tc in tree.getroot().iter("testcase"):
-            classname = tc.get("classname", "")
-            name = tc.get("name", "")
-            pytest_id = _junit_to_pytest_id(classname, name)
-            if pytest_id:
-                return pytest_id
-        return None
+            pytest_id = _junit_to_pytest_id(tc.get("classname", ""), tc.get("name", ""))
+            time = tc.get("time")
+            if not pytest_id or time is None:
+                continue
+            try:
+                value = float(time)
+            except ValueError:
+                continue
+            # Keep the largest if a test id appears more than once (parametrize).
+            call_times[pytest_id] = max(call_times.get(pytest_id, 0.0), value)
+        return call_times
 
 
 @dataclass
@@ -191,20 +214,25 @@ class TimingMerger:
 
 
 class MigrationTaxCorrector:
-    """Detects and corrects migration-inflated first-test durations.
+    """Removes migration-tax contamination from merged durations.
 
-    The first test in each CI shard absorbs Django migration overhead
-    (creating template DB, running migrations, etc.). This inflates that
-    test's recorded duration by ~6.5 min, which skews pytest-split's
-    shard balancing.
+    Under --reuse-db the per-shard Django DB build (~7 min on master) lands
+    on whichever test first touches the DB, inflating that test's recorded
+    setup+call duration and skewing pytest-split's shard balancing. The
+    outlier-merge then prefers that inflated value over the test's real one.
 
-    Two detection modes:
-    - JUnit-based (preferred): uses JUnit XML to identify the first test
-      per shard — precise, no false positives.
-    - Statistical fallback: when JUnit is unavailable, identifies tests
-      whose duration is a clear outlier (>CARRIER_THRESHOLD_SECONDS above
-      the next-highest test in the merged data). Expects exactly one
-      carrier per shard, using the shard count as a guide.
+    Two modes:
+    - JUnit-based (preferred): JUnit call time is the call phase only, so a
+      test recorded far above it absorbed setup tax. Floor such tests (and
+      pytest-split flat-default placeholders) to the call time. This under-
+      counts a carrier's own real setup, but that's small and unrecoverable
+      post-merge, so it's a safe conservative floor. Location-independent —
+      catches the tax wherever it lands, not just on the first test. Risk: a
+      test with genuinely heavy (>threshold) setup would be wrongly floored;
+      none observed, and every floor is logged.
+    - Statistical fallback: when JUnit is unavailable (Products), identify
+      the N highest-duration outliers (one carrier per shard) and subtract
+      the average tax. Coarser, but no per-test call time exists there.
     """
 
     def __init__(
@@ -219,65 +247,80 @@ class MigrationTaxCorrector:
 
     def correct(self) -> MigrationTaxResult:
         if self.junit_shards:
-            carriers = self._find_carriers_from_junit()
-        elif self.expected_shard_count > 0:
-            carriers = self._find_carriers_statistically()
-        else:
-            logger.info("  No JUnit data or shard count — skipping carrier correction")
-            return MigrationTaxResult(
-                corrected_durations=dict(self.durations),
-                migration_tax_seconds=0,
-                carriers_found=0,
-            )
+            return self._correct_from_junit()
+        if self.expected_shard_count > 0:
+            return self._correct_statistically()
+        logger.info("  No JUnit data or shard count — skipping carrier correction")
+        return MigrationTaxResult(dict(self.durations), migration_tax_seconds=0, carriers_found=0)
 
+    def _correct_from_junit(self) -> MigrationTaxResult:
+        """Floor contaminated / placeholder durations to their JUnit call time."""
+        junit_call: dict[str, float] = {}
+        for shard in self.junit_shards:
+            for test_id, call in shard.call_times.items():
+                junit_call[test_id] = max(junit_call.get(test_id, 0.0), call)
+
+        corrected = dict(self.durations)
+        removed: list[float] = []
+        for test_id, recorded in self.durations.items():
+            is_placeholder = any(abs(recorded - d) < 1e-3 for d in DEFAULT_PLACEHOLDER_SECONDS)
+            could_be_contaminated = recorded > MIGRATION_TAX_THRESHOLD_SECONDS
+            # Cheap short-circuit: only the high or placeholder values can be
+            # bad, so skip the suffix lookup for the ~58k healthy small ones.
+            if not (is_placeholder or could_be_contaminated):
+                continue
+
+            call = self._lookup_call_time(test_id, junit_call)
+            if call is None or call >= recorded:
+                continue
+
+            contaminated = could_be_contaminated and recorded - call > MIGRATION_TAX_THRESHOLD_SECONDS
+            if not (contaminated or is_placeholder):
+                continue
+
+            corrected[test_id] = max(MIN_DURATION, call)
+            removed.append(recorded - call)
+            reason = "migration tax" if contaminated else "flat-default"
+            logger.info("  De-taxed %s: %.0fs -> %.1fs (%s, junit call)", test_id[:60], recorded, call, reason)
+
+        avg_removed = sum(removed) / len(removed) if removed else 0.0
+        if removed:
+            logger.info(
+                "  De-taxed %d tests via JUnit, avg removed %.0fs (%.1fm)", len(removed), avg_removed, avg_removed / 60
+            )
+        else:
+            logger.info("  No JUnit-detected contamination")
+        return MigrationTaxResult(corrected, migration_tax_seconds=avg_removed, carriers_found=len(removed))
+
+    @staticmethod
+    def _lookup_call_time(test_id: str, junit_call: dict[str, float]) -> float | None:
+        """Find a durations key's call time in the JUnit map.
+
+        Exact match first; otherwise anchored-suffix on the `::class::test`
+        tail, accepted only when unique — JUnit ids and pytest node ids can
+        differ only in file-path prefix. Only ever called for the handful of
+        high / placeholder durations, so the linear scan is cheap.
+        """
+        if test_id in junit_call:
+            return junit_call[test_id]
+        parts = test_id.split("::")
+        if len(parts) < 2:
+            return None
+        suffix = "::" + "::".join(parts[-2:]) if len(parts) >= 3 else "::" + parts[-1]
+        matches = [v for k, v in junit_call.items() if k.endswith(suffix)]
+        return matches[0] if len(matches) == 1 else None
+
+    def _correct_statistically(self) -> MigrationTaxResult:
+        carriers = self._find_carriers_statistically()
         if not carriers:
             logger.info("  No migration carriers found")
-            return MigrationTaxResult(
-                corrected_durations=dict(self.durations),
-                migration_tax_seconds=0,
-                carriers_found=0,
-            )
-
+            return MigrationTaxResult(dict(self.durations), migration_tax_seconds=0, carriers_found=0)
         migration_tax = self._estimate_tax(carriers)
-        corrected = self._apply_correction(carriers, migration_tax)
-
         return MigrationTaxResult(
-            corrected_durations=corrected,
+            corrected_durations=self._apply_correction(carriers, migration_tax),
             migration_tax_seconds=migration_tax,
             carriers_found=len(carriers),
         )
-
-    def _find_carriers_from_junit(self) -> dict[str, float]:
-        """Identify carriers from JUnit first-test-per-shard data.
-
-        JUnit XMLs are produced with `-o junit_duration_report=call`, so the
-        `time` attribute reflects only call time, not Django setup/migration.
-        Use JUnit only to identify the first test per shard, then check the
-        merged .test_durations value for that test to decide if it's actually
-        a carrier (carriers absorb setup time into their recorded duration).
-        """
-        carriers = {}
-        for junit_shard in self.junit_shards:
-            test_id = junit_shard.first_test_id
-
-            matched_key = self._match_duration_key(test_id)
-            if not matched_key:
-                logger.warning("  Could not match first test %s to durations", test_id[:60])
-                continue
-
-            recorded_duration = self.durations.get(matched_key, 0.0)
-            if recorded_duration < CARRIER_THRESHOLD_SECONDS:
-                continue
-
-            carriers[matched_key] = recorded_duration
-            logger.debug(
-                "  Carrier (JUnit): %s recorded=%.0fs from %s",
-                matched_key[:60],
-                recorded_duration,
-                junit_shard.name,
-            )
-
-        return carriers
 
     def _find_carriers_statistically(self) -> dict[str, float]:
         """Identify carriers by finding the N highest-duration outliers.
@@ -311,32 +354,6 @@ class MigrationTaxCorrector:
             )
 
         return carriers
-
-    def _match_duration_key(self, junit_test_id: str) -> str | None:
-        """Find the matching key in durations for a JUnit test ID.
-
-        Prefers exact match. Falls back to suffix match on the `::class::test`
-        tail — anchored, so a JUnit id of `test_create` cannot pick up
-        `test_create_user`. JUnit IDs and pytest node IDs sometimes differ
-        only in file-path prefix (e.g. relative vs absolute), so suffix is
-        the right comparison.
-        """
-        if junit_test_id in self.durations:
-            return junit_test_id
-
-        parts = junit_test_id.split("::")
-        if len(parts) < 2:
-            return None
-
-        suffix = "::" + "::".join(parts[-2:]) if len(parts) >= 3 else "::" + parts[-1]
-        matches = [k for k in self.durations if k.endswith(suffix)]
-        if len(matches) == 1:
-            return matches[0]
-        if len(matches) > 1:
-            logger.warning(
-                "  Ambiguous suffix match for %s — %d candidates, skipping", junit_test_id[:60], len(matches)
-            )
-        return None
 
     @staticmethod
     def _estimate_tax(carriers: dict[str, float]) -> float:

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -148,6 +148,27 @@ class TestJUnitCallTimeCorrection:
         result = MigrationTaxCorrector(durations, junit_shards=shards).correct()
         assert result.corrected_durations["posthog/x.py::T::test_setup_heavy"] == 42.0
 
+    def test_keeps_high_recorded_test_with_small_gap(self):
+        # Above the 120s threshold (so it passes the short-circuit) but the
+        # gap to call time is small — a genuinely slow test, not a carrier.
+        # Exercises the inner false-positive guard the short-circuit hides.
+        durations = {"posthog/x.py::T::test_slow": 150.0}
+        shards = [self._shard("core-1", {"posthog/x.py::T::test_slow": 140.0})]
+        result = MigrationTaxCorrector(durations, junit_shards=shards).correct()
+        assert result.corrected_durations["posthog/x.py::T::test_slow"] == 150.0
+        assert result.carriers_found == 0
+
+    def test_function_style_name_not_floored_when_ambiguous(self):
+        # A bare function name shared across files must not match by suffix —
+        # ambiguous lookups return None, so the value is left untouched.
+        durations = {"products/a/test_x.py::test_run": 408.0}
+        shards = [
+            self._shard("core-1", {"products/b/test_y.py::test_run": 1.0}),
+            self._shard("core-2", {"products/c/test_z.py::test_run": 1.0}),
+        ]
+        result = MigrationTaxCorrector(durations, junit_shards=shards).correct()
+        assert result.corrected_durations["products/a/test_x.py::test_run"] == 408.0
+
     def test_suffix_match_when_path_prefix_differs(self):
         # durations key has a path prefix the JUnit id lacks — suffix match.
         durations = {"posthog/api/test/x.py::T::test_a": 408.0}

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from optimize_test_durations import JUnitShard, _pick_outlier, outlier_merge_durations
+from optimize_test_durations import JUnitShard, MigrationTaxCorrector, _pick_outlier, outlier_merge_durations
 
 # Minimal valid JUnit XML — one testcase with a CamelCase classname so
 # _junit_to_pytest_id resolves cleanly.
@@ -107,6 +107,72 @@ class TestJUnitShardSegmentFilter:
         # Unknown segments fall back to lowercase passthrough — should just
         # match nothing in this fixture, not crash.
         assert JUnitShard.load_all(junit_dir, segment="Bogus") == []
+
+
+class TestJUnitCallTimeCorrection:
+    """JUnit call time is ground truth — floor contaminated / placeholder values."""
+
+    @staticmethod
+    def _shard(name: str, call_times: dict[str, float]) -> JUnitShard:
+        return JUnitShard(name=name, call_times=call_times)
+
+    def test_floors_migration_tax_contamination(self):
+        # Tax landed on a non-first test: recorded 408s, real call 4.3s.
+        durations = {"posthog/x.py::T::test_a": 408.0, "posthog/x.py::T::test_b": 2.0}
+        shards = [self._shard("core-1", {"posthog/x.py::T::test_a": 4.3, "posthog/x.py::T::test_b": 2.0})]
+        result = MigrationTaxCorrector(durations, junit_shards=shards).correct()
+        assert result.corrected_durations["posthog/x.py::T::test_a"] == 4.3
+        assert result.corrected_durations["posthog/x.py::T::test_b"] == 2.0
+        assert result.carriers_found == 1
+
+    def test_floors_flat_default_placeholder(self):
+        # 60.0 is a pytest-split placeholder; JUnit knows the real call time.
+        durations = {"posthog/x.py::T::test_a": 60.0}
+        shards = [self._shard("core-1", {"posthog/x.py::T::test_a": 0.5})]
+        result = MigrationTaxCorrector(durations, junit_shards=shards).correct()
+        assert result.corrected_durations["posthog/x.py::T::test_a"] == 0.5
+
+    def test_leaves_genuinely_slow_test_untouched(self):
+        # Real end-to-end test: recorded ~= call, small gap, not flooded.
+        durations = {"posthog/x.py::T::test_slow": 102.0}
+        shards = [self._shard("core-1", {"posthog/x.py::T::test_slow": 101.5})]
+        result = MigrationTaxCorrector(durations, junit_shards=shards).correct()
+        assert result.corrected_durations["posthog/x.py::T::test_slow"] == 102.0
+        assert result.carriers_found == 0
+
+    def test_leaves_gray_zone_setup_untouched(self):
+        # Recorded 42s, call 1s: 41s gap is below the 120s tax threshold and
+        # not a flat default, so it's treated as legit setup and kept.
+        durations = {"posthog/x.py::T::test_setup_heavy": 42.0}
+        shards = [self._shard("core-1", {"posthog/x.py::T::test_setup_heavy": 1.0})]
+        result = MigrationTaxCorrector(durations, junit_shards=shards).correct()
+        assert result.corrected_durations["posthog/x.py::T::test_setup_heavy"] == 42.0
+
+    def test_suffix_match_when_path_prefix_differs(self):
+        # durations key has a path prefix the JUnit id lacks — suffix match.
+        durations = {"posthog/api/test/x.py::T::test_a": 408.0}
+        shards = [self._shard("core-1", {"api/test/x.py::T::test_a": 3.0})]
+        result = MigrationTaxCorrector(durations, junit_shards=shards).correct()
+        assert result.corrected_durations["posthog/api/test/x.py::T::test_a"] == 3.0
+
+    def test_no_junit_match_leaves_value(self):
+        # No JUnit entry for the test — can't verify, so keep the value.
+        durations = {"posthog/x.py::T::test_a": 408.0}
+        shards = [self._shard("core-1", {"posthog/x.py::T::test_other": 1.0})]
+        result = MigrationTaxCorrector(durations, junit_shards=shards).correct()
+        assert result.corrected_durations["posthog/x.py::T::test_a"] == 408.0
+
+
+class TestStatisticalCorrection:
+    """No JUnit (Products): fall back to top-N outlier carriers."""
+
+    def test_subtracts_average_tax_from_outliers(self):
+        durations = {f"t{i}": 1.0 for i in range(10)}
+        durations["t0"] = 410.0  # one carrier
+        result = MigrationTaxCorrector(durations, expected_shard_count=1).correct()
+        # carrier floored toward its real (small) value after tax subtraction
+        assert result.corrected_durations["t0"] < 410.0
+        assert result.carriers_found == 1
 
 
 if __name__ == "__main__":

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -40,9 +40,10 @@ const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
 // --- Django shard auto-sizing (Amdahl's law) ---
 // wall_clock = overhead + (total_from_durations_file / shards)
 //
-// .test_durations has migration-inflated first-test durations corrected
-// by optimize_test_durations.py (using JUnit to identify carriers and
-// subtract the migration tax). Durations reflect actual test work.
+// .test_durations has migration-tax contamination removed by
+// optimize_test_durations.py: tests recorded far above their JUnit call
+// time (the DB-setup walk lands on whichever test first hits the DB) are
+// floored back to that call time. Durations reflect actual test work.
 //
 // Per-segment overhead constants below cover the fixed per-shard cost
 // outside test work: job setup, pytest collection, per-shard DB setup,

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -46,13 +46,24 @@ const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
 //
 // Per-segment overhead constants below cover the fixed per-shard cost
 // outside test work: job setup, pytest collection, per-shard DB setup,
-// per-segment infra. Measured from JUnit + job wall clocks on a recent
-// run (lower bound — includes some per-test fixture setup that JUnit's
-// junit_duration_report=call doesn't capture):
-//   Core:     median 303s, max 591s   → 4 min covers it comfortably
-//   CorePOE:  median 233s, max 280s   → 4 min has headroom
-//   Temporal: median 375s, max 693s   → 6 min, temporal-server boot adds
-//                                        meaningful fixed cost beyond Core
+// per-segment infra.
+//
+// These are calibrated for the PR path, which is >95% of runs. On PRs the
+// test DB is primed from a cached pre-migrated schema dump (restore step in
+// ci-backend.yml, ~60s) instead of walking Django migrations, so the per-
+// shard overhead stays small. Measured as wall_clock minus the shard's
+// corrected test work on a PR run with the schema cache hitting:
+//   Core:     median ~4.5 min, max ~9 min  → 4 min is tight but holds
+//   CorePOE:  median ~4 min                → 4 min
+//   Temporal: median ~4 min                → 6 min has headroom for temporal-server boot
+//
+// Master pushes SKIP the schema-cache restore and walk migrations fresh
+// (~7 min), so master shards run ~11 min overhead and blow past the 20 min
+// target. That is accepted: master runs are rare, happen uniformly across
+// shards, and are where .test_durations is collected anyway. Calibrating up
+// to protect them would over-shard every PR. Note the consequence: a PR with
+// a schema-cache MISS (stale branch, key drift) falls back to the full walk
+// and its shards will also overrun — uniformly, same as master.
 const DJANGO_OVERHEAD_SECONDS_BY_SEGMENT = {
     Core: 4 * 60,
     CorePOE: 4 * 60,

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -191,7 +191,11 @@ jobs:
                   # to the script — see test_optimize_test_durations.py.
                   uv run .github/scripts/optimize_test_durations.py .test_durations \
                       --merge-files /tmp/core_durations /tmp/temporal_durations /tmp/products_durations /tmp/dagster_durations
-                  rm -rf timing_artifacts /tmp/core_durations /tmp/temporal_durations /tmp/products_durations /tmp/dagster_durations
+                  # Also drop junit_artifacts — ghcommit-action defaults file_pattern
+                  # to "." and chokes on leftover download dirs ("read junit_artifacts/:
+                  # is a directory"). The commit steps below also pin file_pattern as a
+                  # belt-and-braces guard.
+                  rm -rf timing_artifacts junit_artifacts /tmp/core_durations /tmp/temporal_durations /tmp/products_durations /tmp/dagster_durations
 
             - name: Check for changes
               id: check-changes
@@ -213,6 +217,7 @@ jobs:
                   commit_message: 'chore(ci): update backend and dagster test timings'
                   repo: ${{ github.repository }}
                   branch: ${{ github.event.pull_request.head.ref }}
+                  file_pattern: .test_durations
               env:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
@@ -257,6 +262,7 @@ jobs:
                   commit_message: 'chore(ci): update backend and dagster test timings'
                   repo: ${{ github.repository }}
                   branch: chore/update-test-timings
+                  file_pattern: .test_durations
               env:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Problem

Django CI sharding runs on `.test_durations`, which is collected on master and reused to balance PR shards. Two things were degrading it:

- The update-test-timing workflow was failing at the commit step (`ghcommit-action` defaults `file_pattern` to `.` and choked on the leftover `junit_artifacts/` download dir — `read junit_artifacts/: is a directory`), so a fresh `.test_durations` never landed. The committed file was ~5 months stale.
- The migration-tax correction missed carriers. Under `--reuse-db` the ~7 min DB build lands on whichever test first touches the DB — not reliably the first test in the file. The old correction only inspected the first testcase per shard, so off-position carriers leaked through the outlier-merge. One test showed up at 408s vs a real 4.3s, enough to pin a shard.

While here, the `DJANGO_OVERHEAD_SECONDS` comment justified its values with the wrong cause.

## Changes

- **Unblock the auto-commit:** pin `file_pattern: .test_durations` on both commit steps and drop `junit_artifacts/` in cleanup.
- **De-tax via JUnit call time:** `junit_duration_report=call` gives the call phase only, so the gap between a test's recorded total and its call time is a reliable contamination signal. Detect by that gap (position-independent) instead of by first-testcase, and floor offenders — plus pytest-split's flat-default placeholders (60.0/18.0) — to the call time. Products keeps the statistical fallback since those jobs emit no JUnit. Removes ~14 min of phantom work from the merged file.
- **Refresh `.test_durations`** from a recent master run through the de-taxed merge, to restore balanced sharding now rather than waiting on the next timing run.
- **Fix the overhead comment:** the low per-shard overhead on PRs comes from the cached pre-migrated schema restore, not the persons/product DB fixes. Master pushes skip that restore and run hot — accepted, since master is rare and over-sharding to protect it would tax every PR. The `4/4/6` values are unchanged and correct for the PR path.

Known limitation: ~41 flat-default placeholders remain in Products because those jobs emit no JUnit to floor against — left as a follow-up rather than reworking the per-product turbo task here. Master timing collection is intentionally left as-is.

## How did you test this code?

I'm an agent; I did not manually test in CI. Automated/locally:

- `optimize_test_durations.py` unit tests pass (21, including 9 new covering call-time flooring, flat-default handling, the gray-zone-setup no-op, suffix matching, and the statistical fallback).
- Reproduced the full pipeline against real artifacts from a master run: per-segment merge + de-tax + cross-segment merge. Verified the 408s phantom drops to its real 4.3s, only the one genuinely-slow test remains >100s, and ~14 min of phantom work is removed.
- `turbo-discover.js` and the workflow YAML validated (`node --check`, YAML parse).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (agent-assisted), human author @webjunkie.

Investigation path: started by assessing whether the merged auto-sharding PR's `DJANGO_OVERHEAD_SECONDS` retune (9.5 → 4 min) was right. Measuring a master run gave ~11 min overhead, suggesting the value was too low — but that was the wrong baseline. PR runs prime the test DB from a cached schema (~60s) and measure ~4.5 min overhead, so the `4/4/6` values are correct for the path that matters. That detour surfaced the real bugs: the broken commit step and the position-based carrier detection missing off-position carriers.

Decisions: rejected adding JUnit to product jobs (more invasive, and the statistical fallback is good enough) and rejected priming master test jobs to clean timings at the source (out of scope — we optimize in-PR timings, not master collection). Chose a position-independent gap-based correction using call time as a contamination signal; flooring under-counts a carrier's own (small) real setup, accepted as a safe conservative floor with every floor logged.
