### PR TITLE
feat(data-warehouse): link sync warnings to source management page

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -14595,6 +14595,10 @@
                     "description": "Name of the ExternalDataSchema responsible for syncing the table",
                     "type": "string"
                 },
+                "source_id": {
+                    "description": "ID of the ExternalDataSource, used to link to its management page. Null for self-managed tables.",
+                    "type": ["string", "null"]
+                },
                 "source_type": {
                     "description": "Source type, e.g. \"Stripe\", \"Hubspot\"",
                     "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -479,6 +479,8 @@ export interface DataWarehouseSyncWarning {
     schema_name: string
     /** Source type, e.g. "Stripe", "Hubspot" */
     source_type: string
+    /** ID of the ExternalDataSource, used to link to its management page. Null for self-managed tables. */
+    source_id?: string | null
     /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */
     status: string
     /** Human-readable warning shown to the user */

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -28,11 +28,13 @@ import { Resizer } from 'lib/components/Resizer/Resizer'
 import { type ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { TZLabel } from 'lib/components/TZLabel'
 import { IconTableChart } from 'lib/lemon-ui/icons'
+import { Link } from 'lib/lemon-ui/Link'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { transformDataTableToDataTableRows } from 'lib/utils/dataTableTransformations'
 import { InsightErrorState, StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { HogQLBoldNumber } from 'scenes/insights/views/BoldNumber/BoldNumber'
+import { urls } from 'scenes/urls'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -957,7 +959,17 @@ const SyncWarningsBanner = ({ warnings }: { warnings?: HogQLQueryResponse['warni
             </div>
             <ul className="list-disc pl-5 space-y-1">
                 {warnings.map((warning, index) => (
-                    <li key={`${warning.table_name}-${warning.schema_name}-${index}`}>{warning.message}</li>
+                    <li key={`${warning.table_name}-${warning.schema_name}-${index}`}>
+                        {warning.message}
+                        {warning.source_id && (
+                            <>
+                                {' '}
+                                <Link to={urls.dataWarehouseSource(`managed-${warning.source_id}`)} target="_blank">
+                                    Manage source
+                                </Link>
+                            </>
+                        )}
+                    </li>
                 ))}
             </ul>
         </LemonBanner>

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1426,6 +1426,12 @@ class DataWarehouseSyncWarning(BaseModel):
         ...,
         description="Name of the ExternalDataSchema responsible for syncing the table",
     )
+    source_id: str | None = Field(
+        default=None,
+        description=(
+            "ID of the ExternalDataSource, used to link to its management page. Null for self-managed tables."
+        ),
+    )
     source_type: str = Field(..., description='Source type, e.g. "Stripe", "Hubspot"')
     status: str = Field(
         ...,

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -1095,6 +1095,8 @@ export interface DataWarehouseSyncWarningApi {
     message: string
     /** Name of the ExternalDataSchema responsible for syncing the table */
     schema_name: string
+    /** ID of the ExternalDataSource, used to link to its management page. Null for self-managed tables. */
+    source_id?: string | null
     /** Source type, e.g. "Stripe", "Hubspot" */
     source_type: string
     /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */

--- a/products/data_warehouse/backend/sync_status.py
+++ b/products/data_warehouse/backend/sync_status.py
@@ -57,12 +57,14 @@ def _build_warning_for_schema(
 ) -> DataWarehouseSyncWarning | None:
     schema_status = schema.status
     source_type = schema.source.source_type if schema.source_id else "unknown"
+    source_id = str(schema.source_id) if schema.source_id else None
 
     def build(*, status: str, message: str) -> DataWarehouseSyncWarning:
         return DataWarehouseSyncWarning(
             table_name=table_name,
             schema_name=schema.name,
             source_type=source_type,
+            source_id=source_id,
             status=status,
             message=message,
         )

--- a/products/data_warehouse/backend/test/test_sync_status.py
+++ b/products/data_warehouse/backend/test/test_sync_status.py
@@ -129,6 +129,7 @@ class TestWarehouseSyncWarnings(BaseTest):
         warnings = get_warehouse_sync_warnings(self.table, now=self.now)
         assert len(warnings) == 1
         assert warnings[0].status == str(ExternalDataSchema.Status.RUNNING)
+        assert warnings[0].source_id == str(self.source.id)
         assert "more than twice" in warnings[0].message
 
     def test_no_warning_when_running_at_exact_threshold(self) -> None:
@@ -158,6 +159,7 @@ class TestWarehouseSyncWarnings(BaseTest):
         warnings = get_warehouse_sync_warnings(self.table, now=self.now)
         assert len(warnings) == 1
         assert "paused" in warnings[0].message.lower()
+        assert warnings[0].source_id == str(self.source.id)
         # status must be consistent with the "paused" message, not the raw schema status (Completed).
         assert warnings[0].status == ExternalDataSchema.Status.PAUSED
 

--- a/products/data_warehouse/backend/test/test_sync_status.py
+++ b/products/data_warehouse/backend/test/test_sync_status.py
@@ -103,6 +103,7 @@ class TestWarehouseSyncWarnings(BaseTest):
         assert warning.table_name == "stripe_charge"
         assert warning.schema_name == "Charge"
         assert warning.source_type == ExternalDataSourceType.STRIPE
+        assert warning.source_id == str(self.source.id)
         assert warning.status == str(status)
         assert "stripe_charge" in warning.message
 

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -788,6 +788,8 @@ export interface DataWarehouseSyncWarningApi {
     message: string
     /** Name of the ExternalDataSchema responsible for syncing the table */
     schema_name: string
+    /** ID of the ExternalDataSource, used to link to its management page. Null for self-managed tables. */
+    source_id?: string | null
     /** Source type, e.g. "Stripe", "Hubspot" */
     source_type: string
     /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -456,6 +456,8 @@ export namespace Schemas {
       message: string;
       /** Name of the ExternalDataSchema responsible for syncing the table */
       schema_name: string;
+      /** ID of the ExternalDataSource, used to link to its management page. Null for self-managed tables. */
+      source_id?: string | null;
       /** Source type, e.g. "Stripe", "Hubspot" */
       source_type: string;
       /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */


### PR DESCRIPTION
## Problem

When a SQL editor query reads from a data warehouse table whose source is failing, paused, hit a billing limit, or is stale, we surface a warning banner. But the banner was a dead end — users had no quick way to get to the source to diagnose or fix the underlying sync issue.

## Changes

- Added an optional `source_id` to `DataWarehouseSyncWarning` (the schema query type), populated from the responsible `ExternalDataSchema`'s source. It's `null` for self-managed tables.
- The sync-warnings banner in the SQL editor output pane now renders a "Manage source" link next to each warning when a `source_id` is present, linking to the source's management page (opens in a new tab).

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran locally:

- Regenerated query schema (`schema.json` / `schema.py`) via `pnpm schema:build`.
- Frontend TypeScript check — no errors in the changed files.
- ruff lint/format on the backend files and frontend format — clean.
- Updated `test_sync_status.py` to assert `source_id`. I could not complete a full backend test run locally because the ClickHouse test-database setup timed out in my environment — the backend change is a single-field passthrough, so please confirm `products/data_warehouse/backend/test/test_sync_status.py` is green in CI.

## 🤖 Agent context

Authored by Claude Code at the request of the human author.

- The warning type previously carried `table_name`, `schema_name`, `source_type`, `status`, and `message` but no identifier to build a source link from. Added `source_id` rather than a fully-formed URL so URL construction stays in the frontend (`urls.dataWarehouseSource`), consistent with how the connection selector links to sources (`managed-${id}` prefix).
- Left the existing "Check the data warehouse source for details." copy in the failure message untouched, since that message also flows into LLM/MCP contexts; the link makes it actionable without changing the text.
