### PR TITLE
fix(workflows): mark batch schedule section as optional

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -544,7 +544,7 @@ function BatchScheduleSection(): JSX.Element {
     return (
         <>
             <LemonDivider />
-            <LemonLabel>Schedule</LemonLabel>
+            <LemonLabel showOptional>Schedule</LemonLabel>
             <RecurringSchedulePicker />
         </>
     )


### PR DESCRIPTION
## Problem

In the batch workflow trigger, the recurring schedule picker is optional — a batch can run immediately or on a schedule. But the "Schedule" section heading didn't indicate this, unlike the rest of the app where optional fields are clearly marked with an `(optional)` suffix. This left it ambiguous whether a schedule was required.

In generic **Schedule** trigger workflows the schedule is genuinely required (a start date must be set), so that path should remain unmarked.

## Changes

- Added the `showOptional` prop to the `LemonLabel` for the batch trigger's schedule section, so the heading now reads **Schedule (optional)** using the same marker convention used elsewhere in the app.
- The generic schedule-trigger workflow is untouched — it renders the picker without a `LemonLabel` and keeps its "a start date is required" validation, so it stays required.

## How did you test this code?

I'm an agent. I made a one-line UI change (adding an existing prop to an existing component) and did not run automated tests or perform manual verification. The change reuses `LemonLabel`'s built-in `showOptional` rendering.

<img width="722" height="357" alt="Screenshot 2026-05-29 at 13 02 34" src="https://github.com/user-attachments/assets/652bd216-2c98-4d9d-bd46-0c7d04679f50" />

## 🤖 Agent context

Authored by an agent (Claude Code). The request was to bring the batch workflow's schedule section heading in line with how optional fields are marked elsewhere, while keeping schedule required for generic schedule-trigger workflows.

- Located the schedule heading in `products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx` (`BatchScheduleSection`).
- Confirmed `LemonLabel` already supports a `showOptional` prop that renders the standard `(optional)` marker, rather than hardcoding the text — reusing the existing convention.
- Verified the generic schedule-trigger code path does not use a `LemonLabel` for the schedule, so no change was needed there to keep it required.

https://claude.ai/code/session_01Mo9Z2FDc6wEmBkG1R6jkjz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo9Z2FDc6wEmBkG1R6jkjz)_