### PR TITLE
fix(cdp): do not mark handled 4xx fetch responses as destination failures

### DIFF
--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -1170,6 +1170,55 @@ describe('Hog Executor', () => {
             expect(result.invocation.queueScheduledAt).toBeUndefined()
         })
 
+        it('does not set result.error for a non-retriable 4xx response', async () => {
+            mockRequest.mockImplementation((req: any, res: any) => {
+                res.writeHead(404, { 'Content-Type': 'text/plain' })
+                res.end('not found')
+            })
+
+            const invocation = await createFetchInvocation({
+                url: `${baseUrl}/test`,
+                method: 'GET',
+            })
+
+            const vmStateStackLength = invocation.state.vmState!.stack.length
+
+            const result = await executor.executeFetch(invocation)
+
+            // A 4xx is the hog function's to handle - it must not count as a destination failure
+            expect(result.error).toBeUndefined()
+            expect(result.invocation.queueScheduledAt).toBeUndefined()
+            expect(result.invocation.state.attempts).toBe(0)
+
+            // The response is still delivered to the VM stack so the hog code can react to it
+            expect(result.invocation.state.vmState!.stack.length).toBe(vmStateStackLength + 1)
+            expect(result.invocation.state.vmState!.stack.slice(-1)[0]).toEqual({
+                status: 404,
+                body: 'not found',
+            })
+        })
+
+        it('reports succeeded when a hog function handles a 404 and returns normally', async () => {
+            mockRequest.mockImplementation((req: any, res: any) => {
+                res.writeHead(404, { 'Content-Type': 'text/plain' })
+                res.end('not found')
+            })
+
+            const invocation = await createFetchInvocation({
+                url: `${baseUrl}/test`,
+                method: 'GET',
+            })
+
+            const result = await executor.executeWithAsyncFunctions(invocation)
+
+            expect(result.finished).toBe(true)
+            expect(result.error).toBeUndefined()
+
+            // Mirror hog-function-monitoring.service: the metric is derived from result.error
+            const metricName = result.error ? 'failed' : 'succeeded'
+            expect(metricName).toBe('succeeded')
+        })
+
         it('respects maxFetchRetries option to disable retries', async () => {
             mockRequest.mockImplementation((req: any, res: any) => {
                 res.writeHead(500, { 'Content-Type': 'text/plain' })

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -713,7 +713,10 @@ export class HogExecutorService {
                 result.invocation.queueScheduledAt = DateTime.utc().plus({ milliseconds: backoffMs })
 
                 return result
-            } else {
+            } else if (fetchError || (fetchResponse?.status ?? 500) >= 500) {
+                // Only a network/security/timeout error or a server-side (5xx) response is a real
+                // destination failure. A non-retriable 4xx is delivered to the VM stack below so the
+                // hog function can handle it (e.g. a 404 on an existence check) and still report success.
                 result.error = new Error(message)
             }
         }


### PR DESCRIPTION
## Problem

A hog function (CDP destination) that calls `fetch`, receives a non-retriable `4xx` response, gracefully handles it, and returns normally was being recorded as a **destination failure** in app metrics.

The cause: in `HogExecutorService.executeFetch`, the branch that handles non-`2xx`/`3xx` responses stamped `result.error` for *any* status `>= 400` once retries were exhausted (or never possible). That `error` is preserved across VM resumption via the `previousResult` spread in `createInvocationResult`, and `execute()`'s success path never clears it. Downstream, `hog-function-monitoring.service.ts` derives the metric purely from `result.error` (`result.error ? 'failed' : 'succeeded'`), so a cleanly-handled `4xx` counted toward the failure rate.

A common case is a function that calls an external API and treats a specific `4xx` as a normal, successful branch in the hog code — for example a `404` on an existence check, or a `400` that means "already in the desired state". At low traffic, a handful of these handled `4xx`s trivially crosses the default 1% failure-rate threshold and triggers the daily data pipeline failures alert email — paging users for behaviour that is working as intended.

## Changes

In `executeFetch`, only stamp `result.error` for genuine destination failures:

- a `fetchError` (network / security / timeout), or
- a server-side `5xx` response.

A non-retriable `4xx` (without a `fetchError`) is still delivered to the VM stack exactly as before — the response object with its `status` and `body` — so the hog function can read `response.status` and handle it, and a function that returns normally now reports as `succeeded`. A function that wants a `4xx` to count as a failure can still `throw`, which sets `result.error` via the executor's catch path.

The retry path is untouched: retriable statuses (`408/429/500/502/503/504`) and network errors still retry per `isFetchResponseRetriable`. The only behaviour change is what happens *after* retries are exhausted (or were never possible) — a `4xx` no longer marks the invocation as errored, while a `5xx` still does.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. I ran the automated suite for the affected file and validated the change against production data.

Automated tests (added to the `executeFetch` describe block):

1. A `404` response does **not** set `result.error`, and the response is pushed to the VM stack with `status: 404`.
2. A full `executeWithAsyncFunctions` flow where the hog function receives a `404` and returns normally finishes with no error, so the derived metric is `succeeded`.
3. The existing `500` retry-exhaustion test still sets `result.error` (real `5xx` destination failure) — kept green.

Ran `pnpm --filter @posthog/plugin-server test hog-executor` (all `executeFetch` tests green) and `tsc --noEmit -p .` (no new type errors).

Production-data validation (both PostHog Cloud regions, 7-day window):

- The overwhelming majority of destination invocations currently recorded as `failed` are handled `4xx`. In one region that's well over 90% of all destination failures; in the other it's roughly a third, with genuine network/timeout failures making up most of the rest. In **both** regions the reclassification is surgical — only handled `4xx` flip to `succeeded`, while `5xx`, network and timeout failures stay recorded as failures.
- More than half of the destinations currently breaching the failure-rate alert threshold do so *purely* because of handled `4xx`, and would stop generating false alerts after this change; the remainder have genuine failures and continue to alert.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

Suggested changelog note: a destination's success/failure is determined by the function itself — returning normally counts as `succeeded`; throwing, or a `5xx`/network/timeout, counts as `failed` — so a handled `4xx` no longer auto-counts as a failure.

## Docs update

Worth a short note in the destinations docs on how success vs failure is determined (return normally vs `throw`).

## 🤖 Agent context

Authored by Claude Code (agent), driven by a maintainer.

**Root cause:** `result.error` was set for all `>= 400` statuses on the non-retriable/exhausted path, then preserved across VM resume by `createInvocationResult`'s `previousResult` spread, and never cleared on the success path of `execute()`. The monitoring service maps `result.error` truthiness directly to the `failed`/`succeeded` metric.

**Decision:** keep the change minimal — gate the existing `result.error = new Error(message)` line behind `fetchError || (fetchResponse?.status ?? 500) >= 500` rather than refactoring the retry block. This preserves the retry semantics (`isFetchResponseRetriable` unchanged) and only alters the terminal error-stamping. A missing response (no status) defaults to `500`, so it is still treated as a failure. Considered and rejected: clearing `result.error` later in `execute()` on the success path — more invasive, and treats the symptom rather than the source.

**Blast-radius / safety analysis (verified against the code):**

- *Execution & retries unchanged.* The fetch response is pushed onto the VM stack regardless of `result.error`, in both old and new code, so functions already ran their handling path to completion. Retry behaviour is identical.
- *Auto-disable (HogWatcher) unaffected.* It charges cost from `result.finished` + per-timing `duration_ms` and never reads `result.error`, so token/cost accounting is bit-for-bit identical — no destination is disabled or re-enabled by this change.
- *Billing unaffected.* Destination billing is driven by a separate `billable_invocation` metric emitted at trigger time, independent of the fetch outcome; and the `succeeded`+`failed` usage rollup is invariant under moving an invocation from one bucket to the other.
- *Job state.* A finished, handled-`4xx` invocation moves from `job.fail()` to `job.ack()`; both are terminal — neither re-executes the invocation, so there are no duplicate side effects.
- *Genuine failures preserved.* `5xx`, network, timeout and security errors still set `result.error`; a `4xx` that the function does not handle (and instead throws) is still caught and recorded as `failed`.

**Customer-visible effects (intended):** handled `4xx` now show as `succeeded` in app metrics and on the Invocations view (previously `failed`), and the failure-rate digest emails fewer false positives. The underlying `HTTP fetch failed … status code 4xx` log line is still emitted, so visibility in logs is retained.

**Rollout:** this touches a customer-visible signal across all destinations at once. Suggested safeguards (not all included in this PR): an env-config kill-switch mirroring the existing `HOG_INVOCATION_RESULTS_ENABLED` per-region pattern for instant rollback; the changelog/docs note above; and 24–48h monitoring of the succeeded/failed ratio, the watcher disabled-count, and `billable_invocation` (all expected flat except the intended metric shift).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrNavNSqqmCrZX36w4LZGv)_