### PR TITLE
chore(workflows): revert distinct_id description on update person properties

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/posthog_capture/posthog-update-person-properties.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_capture/posthog-update-person-properties.template.ts
@@ -33,8 +33,7 @@ postHogCapture({
             secret: false,
             hidden: false,
             default: '{event.distinct_id}',
-            description:
-                'Which person to update. Use `{event.distinct_id}` for event-triggered workflows, or `{person.id}` for batch workflows.',
+            description: 'The distinct ID associated with the Person.',
         },
         {
             type: 'dictionary',


### PR DESCRIPTION
## Problem

The `Update person properties` workflow action's `distinct_id` input description was changed in #58831 to suggest using `{person.id}` for batch-triggered workflows. That guidance is incorrect — `{person.id}` is the person UUID, which does not match an existing `distinct_id` and ends up creating a new person profile on capture.

Now that batch-trigger workflows populate `{event.distinct_id}` directly, the older, simpler description is accurate again.

## Changes

Revert the `distinct_id` input description on `template-posthog-update-person-properties` back to:

> The distinct ID associated with the Person.

## How did you test this code?

Agent-authored change. No tests were run — this is a single string-literal revert in a template file. The default value (`{event.distinct_id}`) and surrounding schema are unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes.

## 🤖 Agent context

Authored by PostHog Code at a user's request after a support thread surfaced that batch-trigger workflows now provide `{event.distinct_id}` correctly, so the prior advice to use `{person.id}` for batch workflows is no longer accurate (and was actively misleading — it minted new person profiles). The user asked to revert the description to its pre-#58831 wording. The previous wording was retrieved from the GitHub commit history (commit `2e82feb3`) since the local checkout only contained a single commit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*