### PR TITLE
fix(signals): default inbox deep link to posthog-code scheme

### DIFF
--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -47,8 +47,8 @@ logger = logging.getLogger(__name__)
 _SUMMARY_EXCERPT_MAX_LEN = 600
 _SLACK_HEADER_MAX_LEN = 150
 
-# Deep link opened by the PostHog Code desktop app. Override via env for prod (`posthog-code`).
-POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME = getattr(settings, "POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME", "posthog-code-dev")
+# Deep link opened by the PostHog Code desktop app. Override via env for dev (`posthog-code-dev`).
+POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME = getattr(settings, "POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME", "posthog-code")
 
 # Priority ranking — lower index is higher priority. Index used for threshold comparison.
 _PRIORITY_ORDER: tuple[str, ...] = (

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -89,7 +89,7 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
     assert "Inbox" in context_text
     button = blocks[3]["elements"][0]
     assert button["text"]["text"] == "Open in PostHog Code"
-    assert button["url"] == "posthog-code-dev://inbox/report-uuid"
+    assert button["url"] == "posthog-code://inbox/report-uuid"
     assert text == "Inbox for Marcus Twix (P1): Checkout errors spiked"
 
 
@@ -285,7 +285,7 @@ def test_dispatch_sends_to_configured_reviewer(org_and_team):
     assert "Inbox for Reviewer Bot (P1)" in call_kwargs["text"]
     blocks = call_kwargs["blocks"]
     assert blocks[0]["text"]["text"] == "Inbox for <@U_REVIEWER> · P1"
-    assert blocks[3]["elements"][0]["url"] == f"posthog-code-dev://inbox/{report.id}"
+    assert blocks[3]["elements"][0]["url"] == f"posthog-code://inbox/{report.id}"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

The Slack inbox notification "Open in PostHog Code" button was generating `posthog-code-dev://` links by default, which only open the dev build of the PostHog Code desktop app. End users with the production app installed couldn't follow the deep link.

## Changes

- Flip the default scheme in `POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME` from `posthog-code-dev` to `posthog-code` so deep links target the production desktop app out of the box.
- Update the override comment and the affected tests to match the new default. Dev environments can still set `POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME=posthog-code-dev` via env/settings.

## How did you test this code?

I'm an agent. I updated the two existing tests in `products/signals/backend/test/test_slack_inbox_notifications.py` to assert the new default scheme. I did not run the test suite or manually verify the Slack rendering.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference this deep link scheme.

## 🤖 Agent context

PostHog Code session. Searched for `posthog-code-dev` references — found one default in `slack_inbox_notifications.py` plus two test assertions. The constant is already designed to be env-overridable, so the fix is just flipping the default; dev users who want the dev-app deep link can still set `POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME` explicitly.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*