### PR TITLE
revert(slack): revert randomized ack emoji on @PostHog mentions

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -17,12 +17,7 @@ from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 
 from products.slack_app.backend.models import SlackThreadTaskMapping
-from products.slack_app.backend.slack_thread import (
-    SlackThreadContext,
-    SlackThreadHandler,
-    ack_emoji_for,
-    stale_ack_emojis_for,
-)
+from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.repo_selection import (
     RepoSelectionRejectedError,
@@ -1050,8 +1045,8 @@ def create_posthog_code_task_for_repo_activity(
     )
     slack = SlackIntegration(integration)
 
-    # Refuse before the ack reaction or the permalink fetch: a denied mention
-    # should not first ack-react and then refuse a second later.
+    # Refuse before the :seedling: reaction or the permalink fetch: a denied
+    # mention should not first ack-react and then refuse a second later.
     if _block_if_team_over_quota(
         integration=integration,
         slack=slack,
@@ -1064,10 +1059,7 @@ def create_posthog_code_task_for_repo_activity(
 
     user_message_ts = event.get("ts")
     if user_message_ts:
-        # Deterministic per ts so activity retries (maximum_attempts=3) land on
-        # the same emoji and `_safe_react`'s `already_reacted` short-circuit
-        # keeps the ack idempotent.
-        _safe_react(slack.client, channel, user_message_ts, ack_emoji_for(user_message_ts))
+        _safe_react(slack.client, channel, user_message_ts, "seedling")
 
     user_text = re.sub(r"<@[A-Z0-9]+>", "", event.get("text", "")).strip()
     title = user_text[:255] if user_text else "Task from Slack"
@@ -1536,7 +1528,7 @@ def _set_followup_done_reaction(slack: Any, channel: str, user_message_ts: str |
     if not user_message_ts:
         return
 
-    for stale_emoji in stale_ack_emojis_for(user_message_ts):
+    for stale_emoji in ("eyes", "seedling"):
         try:
             slack.client.reactions_remove(channel=channel, timestamp=user_message_ts, name=stale_emoji)
         except Exception:

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -1,5 +1,4 @@
 import re
-import hashlib
 from dataclasses import dataclass
 from typing import Any
 
@@ -15,102 +14,6 @@ UPSTREAM_PROVIDER_FAILURE_MESSAGE = (
     "The upstream AI provider failed to process the request. Please retry the task in a few minutes."
 )
 UPSTREAM_PROVIDER_ERROR_STATUS_PATTERN = re.compile(r"\bapi error:\s*(?:429|5\d\d)\b", re.IGNORECASE)
-
-# Legacy fixed ack emoji. Tasks ack'd before the deterministic pool landed used
-# `:seedling:` exclusively; cleanup still tries to remove it so in-flight tasks
-# at deploy time don't end up with a stale reaction. Can be dropped a release
-# cycle after this lands.
-_LEGACY_ACK_EMOJI = "seedling"
-
-# Pool of fun, universally-available Slack emoji names used to acknowledge a mention
-# before the bot starts the longer-running work. Anything in this pool is treated as
-# an in-progress signal by `update_reaction` / `_set_followup_done_reaction` and is
-# cleaned up when the bot reaches a terminal state. Keep these distinct from the
-# stage-specific reactions (:mag: for searching, :hedgehog: for done, :x: for failed)
-# and from "eyes" (the follow-up ack), so the cleanup pool stays unambiguous.
-RANDOM_ACK_EMOJIS: tuple[str, ...] = (
-    # Friendly greetings & thinking
-    "seedling",
-    "wave",
-    "robot_face",
-    "thinking_face",
-    "nerd_face",
-    "sunglasses",
-    # Energy & magic
-    "sparkles",
-    "rocket",
-    "zap",
-    "crystal_ball",
-    "mage",
-    "star2",
-    "dizzy",
-    "rainbow",
-    # Working / tinkering
-    "hammer_and_wrench",
-    "gear",
-    "coffee",
-    "keyboard",
-    "telescope",
-    "brain",
-    "bulb",
-    "compass",
-    # Nature & luck
-    "four_leaf_clover",
-    "cherry_blossom",
-    "sunflower",
-    "herb",
-    # Animal companions
-    "owl",
-    "otter",
-    "penguin",
-    "fox_face",
-    "bee",
-    "butterfly",
-    "unicorn_face",
-    "turtle",
-    "panda_face",
-    "koala",
-    "hamster",
-    # Play & whimsy
-    "art",
-    "balloon",
-    "game_die",
-    # Characters
-    "ninja",
-    "alien",
-    "space_invader",
-)
-
-
-def ack_emoji_for(message_ts: str) -> str:
-    """Pick an emoji from the ack pool deterministically per Slack message ts.
-
-    `create_posthog_code_task_for_repo_activity` retries up to 3 times. With a
-    truly random pick, each retry could choose a different emoji and bypass
-    `_safe_react`'s `already_reacted` short-circuit, piling extra reactions on
-    the user's mention. Keying the choice on the message ts keeps every replay
-    landing on the same emoji. `hashlib` (not `hash()`) is used so the choice
-    is stable across worker processes — PYTHONHASHSEED randomization would
-    otherwise diverge per replay.
-    """
-    digest = hashlib.sha256(message_ts.encode("utf-8")).digest()
-    return RANDOM_ACK_EMOJIS[int.from_bytes(digest[:4], "big") % len(RANDOM_ACK_EMOJIS)]
-
-
-def stale_ack_emojis_for(message_ts: str) -> tuple[str, ...]:
-    """Reactions a cleanup pass should try to remove from `message_ts`.
-
-    `eyes` is the follow-up ack, the deterministic pool pick is the initial
-    ack, and `_LEGACY_ACK_EMOJI` covers tasks ack'd before this pool landed.
-    Keeping the set small (vs. iterating the full pool) avoids burning the
-    `reactions.remove` rate limit on guaranteed-`no_reaction` calls. The
-    legacy emoji is also a pool member, so we dedupe when the deterministic
-    pick coincidentally lands on it.
-    """
-    emojis = ["eyes", ack_emoji_for(message_ts)]
-    if _LEGACY_ACK_EMOJI not in emojis:
-        emojis.append(_LEGACY_ACK_EMOJI)
-    return tuple(emojis)
 
 
 def _format_task_error(error: str) -> str:
@@ -214,7 +117,7 @@ class SlackThreadHandler:
         target_ts = self.context.user_message_ts or self.context.thread_ts
         try:
             client = self._get_client()
-            for stale in stale_ack_emojis_for(target_ts):
+            for stale in ("seedling", "eyes"):
                 try:
                     client.reactions_remove(channel=self.context.channel, timestamp=target_ts, name=stale)
                 except Exception:

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -5,13 +5,10 @@ from django.test import TestCase
 from parameterized import parameterized
 
 from products.slack_app.backend.slack_thread import (
-    RANDOM_ACK_EMOJIS,
     UPSTREAM_PROVIDER_FAILURE_MESSAGE,
     SlackThreadContext,
     SlackThreadHandler,
     _format_task_error,
-    ack_emoji_for,
-    stale_ack_emojis_for,
 )
 
 
@@ -87,7 +84,7 @@ class TestSlackThreadHandler(TestCase):
         mock_client.chat_delete.assert_not_called()
 
     @patch.object(SlackThreadHandler, "_get_client")
-    def test_update_reaction_clears_stale_ack_emojis(self, mock_get_client):
+    def test_update_reaction_removes_seedling_and_eyes(self, mock_get_client):
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
 
@@ -100,37 +97,11 @@ class TestSlackThreadHandler(TestCase):
         handler = SlackThreadHandler(context)
         handler.update_reaction("hedgehog")
 
-        removed_names = [call.kwargs["name"] for call in mock_client.reactions_remove.call_args_list]
-        # Only the candidate ack reactions for this specific ts are removed (not the whole pool),
-        # so cleanup stays cheap regardless of pool size.
-        assert removed_names == list(stale_ack_emojis_for("1234.5678"))
+        remove_calls = mock_client.reactions_remove.call_args_list
+        assert len(remove_calls) == 2
+        assert remove_calls[0].kwargs["name"] == "seedling"
+        assert remove_calls[1].kwargs["name"] == "eyes"
         mock_client.reactions_add.assert_called_once_with(channel="C001", timestamp="1234.5678", name="hedgehog")
-
-    def test_ack_emoji_for_is_deterministic_per_ts(self):
-        # Same ts must always pick the same emoji — activity retries depend on this for
-        # `_safe_react`'s `already_reacted` short-circuit to keep the ack idempotent.
-        assert ack_emoji_for("1700000001.000100") == ack_emoji_for("1700000001.000100")
-        assert ack_emoji_for("1700000001.000100") in RANDOM_ACK_EMOJIS
-        # Different ts values should reach across the pool (sanity check, not a uniformity claim).
-        reached = {ack_emoji_for(f"1700000000.{i:06d}") for i in range(500)}
-        assert len(reached) >= len(RANDOM_ACK_EMOJIS) // 2
-
-    def test_stale_ack_emojis_for_includes_legacy_seedling_and_eyes(self):
-        # `seedling` was the fixed pre-pool ack; tasks ack'd before this code shipped
-        # must still be cleanable. `eyes` is the follow-up ack.
-        stale = stale_ack_emojis_for("1234.5678")
-        assert "eyes" in stale
-        assert "seedling" in stale
-        assert ack_emoji_for("1234.5678") in stale
-
-    def test_stale_ack_emojis_for_dedupes_when_pick_is_seedling(self):
-        # `seedling` is both in the pool and the legacy ack — when the deterministic
-        # pick coincidentally lands on it, the tuple should not contain a duplicate.
-        seedling_ts = "1700000000.000005"
-        assert ack_emoji_for(seedling_ts) == "seedling", "fixture ts no longer maps to seedling"
-        stale = stale_ack_emojis_for(seedling_ts)
-        assert stale == ("eyes", "seedling")
-        assert stale.count("seedling") == 1
 
     @patch.object(SlackThreadHandler, "_get_client")
     def test_post_pr_opened_posts_buttons(self, mock_get_client):


### PR DESCRIPTION
## Problem

Reverts #60469. The randomized ack emoji on @PostHog Slack mentions was poorly received — folks would rather have the predictable `:seedling:` reaction back. This restores the prior behavior.

## Changes

- `products/slack_app/backend/slack_thread.py`: removes `RANDOM_ACK_EMOJIS`, `ack_emoji_for`, `stale_ack_emojis_for`, and the `_LEGACY_ACK_EMOJI` constant. `SlackThreadHandler.update_reaction` goes back to iterating `("seedling", "eyes")` for cleanup.
- `posthog/temporal/ai/posthog_code_slack_mention.py`: `create_posthog_code_task_for_repo_activity` reacts with the fixed `"seedling"` again, and `_set_followup_done_reaction` iterates `("eyes", "seedling")` for cleanup. Comment and imports restored.
- `products/slack_app/backend/tests/test_slack_thread.py`: restores `test_update_reaction_removes_seedling_and_eyes` and drops the deterministic-pool tests.

The diff is the exact inverse of #60469 — `git diff` against that PR's parent commit is empty for these three files.

In-flight tasks ack'd with a random pool emoji at deploy time will not get cleaned up by the next stage transition (only `seedling` and `eyes` are now removed), but the reaction is harmless and decays out of relevance as soon as the thread reaches a terminal state.

## How did you test this code?

I'm an agent. I did not run the existing test suite end-to-end. Verification was limited to:

- `git diff ef4e4425f3e4a9c40f6e5b45ad2405b9c49392fa^ -- <the three files>` produces an empty diff, i.e. the three files are byte-identical to the pre-#60469 state.
- Confirmed `test_followup_forwarding.py` still has its `name="seedling"` assertions (no changes needed there — they were always asserting on the fixed `seedling` ack).
- No other call sites reference the removed `RANDOM_ACK_EMOJIS` / `ack_emoji_for` / `stale_ack_emojis_for` symbols.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude (PostHog Code session) at the user's request to undo #60469. The change is a straight inverse of that PR — no judgment calls to flag beyond "users disliked the random emoji, go back to the fixed `:seedling:`."

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*