### PR TITLE
fix(admin): register moved hogflow and cdp admins via package init

### DIFF
--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -1,3 +1,4 @@
+import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
@@ -175,11 +176,15 @@ class TestProductAdminRegistration:
     # `admin/` package. `autodiscover_modules("admin")` only imports the package's
     # `__init__`, so it must import those submodules for the `@admin.register`
     # decorators to fire — otherwise the models silently vanish from Django admin.
-    def test_moved_product_models_are_registered(self):
+    @pytest.mark.parametrize(
+        "model",
+        [HogFlow, HogFlowTemplate, HogFlowBatchJob, HogFunction, Plugin, PluginConfig],
+        ids=lambda m: m.__name__,
+    )
+    def test_moved_product_models_are_registered(self, model):
         # Tests skip the lazy admin registry, so trigger registration explicitly.
         register_all_admin()
-        for model in (HogFlow, HogFlowTemplate, HogFlowBatchJob, HogFunction, Plugin, PluginConfig):
-            assert admin.site.is_registered(model), f"{model.__name__} is not registered in Django admin"
+        assert admin.site.is_registered(model), f"{model.__name__} is not registered in Django admin"
 
 
 class TestOrganizationMemberInlineConfig(BaseTest):

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -16,6 +16,8 @@ from products.cdp.backend.admin.plugin_attachment_inline import PluginAttachment
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 from products.cdp.backend.models.plugin import Plugin, PluginConfig
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
+from products.workflows.backend.models.hog_flow.hog_flow_template import HogFlowTemplate
+from products.workflows.backend.models.hog_flow_batch_job import HogFlowBatchJob
 
 
 class TestOAuthSidebarRegrouping(BaseTest):
@@ -176,7 +178,7 @@ class TestProductAdminRegistration:
     def test_moved_product_models_are_registered(self):
         # Tests skip the lazy admin registry, so trigger registration explicitly.
         register_all_admin()
-        for model in (HogFlow, HogFunction, Plugin, PluginConfig):
+        for model in (HogFlow, HogFlowTemplate, HogFlowBatchJob, HogFunction, Plugin, PluginConfig):
             assert admin.site.is_registered(model), f"{model.__name__} is not registered in Django admin"
 
 

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.test import RequestFactory
 
-from posthog.admin import _OAUTH_ADMIN_MODEL_NAMES, install_admin_app_list_overrides
+from posthog.admin import _OAUTH_ADMIN_MODEL_NAMES, install_admin_app_list_overrides, register_all_admin
 from posthog.admin.admins.event_ingestion_restriction_config import EventIngestionRestrictionConfigAdmin
 from posthog.admin.admins.user_admin import UserAdmin
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberForUserInline, OrganizationMemberInline
@@ -13,6 +13,9 @@ from posthog.models import User
 from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig
 
 from products.cdp.backend.admin.plugin_attachment_inline import PluginAttachmentInline
+from products.cdp.backend.models.hog_functions.hog_function import HogFunction
+from products.cdp.backend.models.plugin import Plugin, PluginConfig
+from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
 
 
 class TestOAuthSidebarRegrouping(BaseTest):
@@ -162,6 +165,19 @@ class TestEventIngestionRestrictionConfigAdminConfig:
         admin_instance = EventIngestionRestrictionConfigAdmin(EventIngestionRestrictionConfig, AdminSite())
         assert "display_team_id" in admin_instance.list_display
         assert "display_team_id" in admin_instance.readonly_fields
+
+
+class TestProductAdminRegistration:
+    # Regression guard: these models live in product apps (`products/cdp`,
+    # `products/workflows`) whose admin classes are split across submodules of an
+    # `admin/` package. `autodiscover_modules("admin")` only imports the package's
+    # `__init__`, so it must import those submodules for the `@admin.register`
+    # decorators to fire — otherwise the models silently vanish from Django admin.
+    def test_moved_product_models_are_registered(self):
+        # Tests skip the lazy admin registry, so trigger registration explicitly.
+        register_all_admin()
+        for model in (HogFlow, HogFunction, Plugin, PluginConfig):
+            assert admin.site.is_registered(model), f"{model.__name__} is not registered in Django admin"
 
 
 class TestOrganizationMemberInlineConfig(BaseTest):

--- a/products/cdp/backend/admin/__init__.py
+++ b/products/cdp/backend/admin/__init__.py
@@ -1,0 +1,3 @@
+# Importing these submodules fires their `@admin.register` decorators when
+# `autodiscover_modules("admin")` imports this package.
+from products.cdp.backend.admin import hog_function_admin, plugin_admin, plugin_config_admin  # noqa: F401

--- a/products/workflows/backend/admin/__init__.py
+++ b/products/workflows/backend/admin/__init__.py
@@ -1,0 +1,3 @@
+# Importing these submodules fires their `@admin.register` decorators when
+# `autodiscover_modules("admin")` imports this package.
+from products.workflows.backend.admin import hog_flow_admin  # noqa: F401

--- a/products/workflows/backend/admin/__init__.py
+++ b/products/workflows/backend/admin/__init__.py
@@ -1,3 +1,7 @@
 # Importing these submodules fires their `@admin.register` decorators when
 # `autodiscover_modules("admin")` imports this package.
-from products.workflows.backend.admin import hog_flow_admin  # noqa: F401
+from products.workflows.backend.admin import (  # noqa: F401
+    hog_flow_admin,
+    hog_flow_batch_job_admin,
+    hog_flow_template_admin,
+)

--- a/products/workflows/backend/admin/hog_flow_batch_job_admin.py
+++ b/products/workflows/backend/admin/hog_flow_batch_job_admin.py
@@ -1,0 +1,55 @@
+from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html
+
+from products.workflows.backend.models.hog_flow_batch_job import HogFlowBatchJob
+
+
+@admin.register(HogFlowBatchJob)
+class HogFlowBatchJobAdmin(admin.ModelAdmin):
+    list_display = ("id", "status", "hog_flow_link", "team_link", "created_at")
+    list_filter = (
+        ("status", admin.ChoicesFieldListFilter),
+        ("updated_at", admin.DateFieldListFilter),
+    )
+    list_select_related = ("team", "hog_flow")
+    search_fields = ("hog_flow__name", "team__name", "team__organization__name")
+    ordering = ("-created_at",)
+    readonly_fields = (
+        "id",
+        "team",
+        "team_link",
+        "hog_flow",
+        "hog_flow_link",
+        "created_by",
+        "created_at",
+        "updated_at",
+        "variables",
+        "filters",
+    )
+    fields = (
+        "status",
+        "team_link",
+        "hog_flow_link",
+        "created_by",
+        "created_at",
+        "updated_at",
+        "variables",
+        "filters",
+    )
+
+    @admin.display(description="Team")
+    def team_link(self, batch_job: HogFlowBatchJob):
+        return format_html(
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[batch_job.team.pk]),
+            batch_job.team.name,
+        )
+
+    @admin.display(description="Hog flow")
+    def hog_flow_link(self, batch_job: HogFlowBatchJob):
+        return format_html(
+            '<a href="{}">{}</a>',
+            reverse("admin:workflows_hogflow_change", args=[batch_job.hog_flow.pk]),
+            batch_job.hog_flow.name or batch_job.hog_flow.pk,
+        )

--- a/products/workflows/backend/admin/hog_flow_template_admin.py
+++ b/products/workflows/backend/admin/hog_flow_template_admin.py
@@ -1,0 +1,58 @@
+from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html
+
+from products.workflows.backend.models.hog_flow.hog_flow_template import HogFlowTemplate
+
+
+@admin.register(HogFlowTemplate)
+class HogFlowTemplateAdmin(admin.ModelAdmin):
+    list_display = ("id", "name", "scope", "team_link", "created_at")
+    list_filter = (
+        ("scope", admin.ChoicesFieldListFilter),
+        ("updated_at", admin.DateFieldListFilter),
+    )
+    list_select_related = ("team",)
+    search_fields = ("name", "team__name", "team__organization__name")
+    ordering = ("-created_at",)
+    readonly_fields = (
+        "id",
+        "team",
+        "team_link",
+        "created_by",
+        "created_at",
+        "updated_at",
+        "trigger",
+        "trigger_masking",
+        "conversion",
+        "edges",
+        "actions",
+        "variables",
+    )
+    fields = (
+        "name",
+        "description",
+        "image_url",
+        "tags",
+        "scope",
+        "exit_condition",
+        "abort_action",
+        "team_link",
+        "created_by",
+        "created_at",
+        "updated_at",
+        "trigger",
+        "trigger_masking",
+        "conversion",
+        "edges",
+        "actions",
+        "variables",
+    )
+
+    @admin.display(description="Team")
+    def team_link(self, template: HogFlowTemplate):
+        return format_html(
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[template.team.pk]),
+            template.team.name,
+        )


### PR DESCRIPTION
## Problem

The recent move of the workflows and CDP models into their product apps (#60248) also relocated their Django admin classes into `admin/` **packages** (`products/cdp/backend/admin/` and `products/workflows/backend/admin/`), split across submodules — but the package `__init__.py` files were left empty.

PostHog registers admins lazily through `autodiscover_modules("admin")`, which imports only each app's top-level `admin` module — i.e. the package's `__init__.py`. With an empty `__init__`, the submodules holding the `@admin.register` decorators were never imported, so `HogFlow`, `HogFunction`, `Plugin`, and `PluginConfig` silently disappeared from Django admin. Every other product uses a single `admin.py` file, which autodiscover imports directly, so only these two packaged products were affected.

## Changes
<img width="644" height="200" alt="Screenshot 2026-05-29 at 13 50 55" src="https://github.com/user-attachments/assets/8f2c32ab-8626-48b3-977d-bc00ab92c19e" />

**Fix the regression** — import the decorator-bearing submodules from each package `__init__.py` so their `@admin.register` decorators fire during autodiscover. This restores exactly the four admins that existed before the move (`HogFlow`, `HogFunction`, `Plugin`, `PluginConfig`).

**New admins (net-new, not part of the regression)** — while verifying the workflows admin section, two workflows models had never had a Django admin at all. This PR adds them:

- `HogFlowTemplate` — workflow templates, grouped under Workflows.
- `HogFlowBatchJob` — batch/broadcast job runs, grouped under Workflows.

Both are read-oriented: foreign-key fields (`team`, `created_by`, and `hog_flow` for the batch job) are declared `readonly` so the admin change pages don't render full-table `<select>` widgets, and JSON payload fields are readonly. `team`/`hog_flow` render as links to their respective admin change pages.

**Regression test** — `posthog/admin/test_admin.py::TestProductAdminRegistration` asserts all six models are registered after `register_all_admin()`.

## How did you test this code?

I manually tested with locally checked out branch that all the models load as they should.

I'm an agent — I did not do manual UI testing. Automated verification only:

- Booted Django and checked `admin.site.is_registered(...)`: **before** the fix the four moved models returned `False`; **after**, all `True`. Confirmed the two new models register and their admin change/changelist URLs reverse cleanly.
- The regression test **fails without** the `__init__.py` fix and **passes with** it.
- `ruff check` / `ruff format` clean; pre-commit hooks including `ty check` passed.

## 🤖 Agent context

Authored by Claude Code at the request of the PR author.

Root cause traced to #60248: that move turned two products' `admin` modules into packages whose `__init__.py` was empty, breaking the `autodiscover_modules("admin")` registration path. Chose explicit submodule imports over the central registry's dynamic `pkgutil.iter_modules` approach since there are only a few files and it's clearer/grep-friendly. After confirming nothing was missing relative to the pre-move baseline, the author asked to also add admins for the two previously-unregistered workflows models (`HogFlowTemplate`, `HogFlowBatchJob`) — these are additive. `plugin_attachment_inline` is intentionally not imported explicitly: it has no `@admin.register` decorator and is already pulled in transitively by `plugin_config_admin`.

Note for reviewers: `HogFlowBatchJob` has a `post_save` signal that enqueues a real job invocation on create. The admin allows creates by default (consistent with other admins); flag if you'd prefer add disabled there.

https://claude.ai/code/session_01JaMLKbh61S5uYBQvBgCM77