### PR TITLE
feat(slack_app): expose slack_app models in django admin

### DIFF
--- a/products/slack_app/backend/admin.py
+++ b/products/slack_app/backend/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import SlackSettings
+from .models import SlackSettings, SlackThreadTaskMapping, SlackUserProfileCache
 
 
 @admin.register(SlackSettings)
@@ -28,3 +28,76 @@ class SlackSettingsAdmin(admin.ModelAdmin):
     autocomplete_fields = ("default_integration",)
     readonly_fields = ("id", "created_at", "updated_at")
     ordering = ("-updated_at",)
+
+
+@admin.register(SlackThreadTaskMapping)
+class SlackThreadTaskMappingAdmin(admin.ModelAdmin):
+    list_select_related = ("team", "integration", "task", "task_run")
+    list_display = (
+        "id",
+        "team",
+        "integration",
+        "slack_workspace_id",
+        "channel",
+        "thread_ts",
+        "task",
+        "task_run",
+        "created_at",
+    )
+    list_filter = (
+        "slack_workspace_id",
+        ("created_at", admin.DateFieldListFilter),
+    )
+    search_fields = (
+        "slack_workspace_id",
+        "channel",
+        "thread_ts",
+        "mentioning_slack_user_id",
+        "task__title",
+        "team__name",
+        "team__organization__name",
+    )
+    readonly_fields = ("id", "created_at", "updated_at")
+    autocomplete_fields = ("team", "integration", "task", "task_run")
+    ordering = ("-created_at",)
+
+    fieldsets = (
+        (None, {"fields": ("id", "team", "integration")}),
+        (
+            "Slack thread",
+            {"fields": ("slack_workspace_id", "channel", "thread_ts", "mentioning_slack_user_id")},
+        ),
+        ("Task", {"fields": ("task", "task_run")}),
+        ("Dates", {"fields": ("created_at", "updated_at")}),
+    )
+
+
+@admin.register(SlackUserProfileCache)
+class SlackUserProfileCacheAdmin(admin.ModelAdmin):
+    list_select_related = ("integration",)
+    list_display = (
+        "id",
+        "integration",
+        "slack_user_id",
+        "email",
+        "display_name",
+        "real_name",
+        "is_admin",
+        "is_owner",
+        "updated_at",
+    )
+    list_filter = (
+        "is_admin",
+        "is_owner",
+        ("updated_at", admin.DateFieldListFilter),
+    )
+    search_fields = ("slack_user_id", "email", "display_name", "real_name")
+    readonly_fields = ("id", "created_at", "updated_at")
+    autocomplete_fields = ("integration",)
+    ordering = ("-updated_at",)
+
+    fieldsets = (
+        (None, {"fields": ("id", "integration", "slack_user_id")}),
+        ("Profile", {"fields": ("email", "display_name", "real_name", "is_admin", "is_owner")}),
+        ("Dates", {"fields": ("created_at", "updated_at")}),
+    )


### PR DESCRIPTION
## Problem

The `slack_app` product is heading into beta and the two backing models — `SlackThreadTaskMapping` and `SlackUserProfileCache` — aren't reachable from `/admin/`. That makes it painful to inspect cached Slack profiles or thread-to-task mappings when something looks off in a workspace.

## Changes

Add `products/slack_app/backend/admin.py` registering both models. Auto-discovered via `autodiscover_modules("admin")` — no central registry edits. All `ForeignKey` fields use `autocomplete_fields` so list/detail pages don't N+1 on `Integration` / `Team` / `Task` / `TaskRun`.

## How did you test this code?

I'm an agent. I ran `ruff check` and `ruff format` on the new file — both pass. No automated admin tests; manual verification is opening `/admin/` and confirming both models appear under **Slack_app**.

## 🤖 Agent context

Cut a fresh branch off `master` (the existing `is_admin`/`is_owner` cache commit already landed). Picked the per-product `products/<name>/backend/admin.py` location rather than the central `posthog/admin/admins/` directory, matching `products/tasks/backend/admin.py` — same Integration-linked context.