### PR TITLE
feat(traces): switch traces billing metrics to traces_mb_ingested

### DIFF
--- a/nodejs/src/common/services/quota-limiting.service.ts
+++ b/nodejs/src/common/services/quota-limiting.service.ts
@@ -12,6 +12,7 @@ export type QuotaResource =
     | 'workflow_destinations_dispatched'
     | 'logs_mb_ingested'
     | 'metrics_mb_ingested'
+    | 'traces_mb_ingested'
 
 export const QUOTA_LIMITER_CACHE_KEY = '@posthog/quota-limits/'
 

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -15,6 +15,7 @@ import { APP_METRICS_OUTPUT, AppMetricsOutput } from '../ingestion/common/output
 import { IngestionOutputs } from '../ingestion/outputs/ingestion-outputs'
 import { SingleIngestionOutput } from '../ingestion/outputs/single-ingestion-output'
 import { parseJSON } from '../utils/json-parse'
+import { getDefaultTracesIngestionConsumerConfig } from './config'
 import { LogRecord, encodeLogRecords } from './log-record-avro'
 import {
     DEFAULT_LOGS_RETENTION_DAYS,
@@ -33,6 +34,7 @@ import { LOGS_DLQ_OUTPUT, LOGS_OUTPUT, LogsDlqOutput, LogsOutput } from './outpu
 import { compileRuleSet } from './sampling/compile-rules'
 import type { SamplingRulesCache } from './sampling/sampling-rules-cache'
 import { BASE_REDIS_KEY } from './services/logs-rate-limiter.service'
+import { TracesIngestionConsumer } from './traces-ingestion-consumer'
 
 const DEFAULT_TEST_TIMEOUT = 5000
 jest.setTimeout(DEFAULT_TEST_TIMEOUT)
@@ -1560,6 +1562,73 @@ describe('LogsIngestionConsumer', () => {
 
             console.log(`[thread-relief] longestDelay = ${longestDelay}ms`)
             expect(longestDelay).toBeLessThan(120)
+        })
+    })
+
+    describe('TracesIngestionConsumer billing identity', () => {
+        const createTracesIngestionConsumer = (): TracesIngestionConsumer => {
+            const tracesConsumer = new TracesIngestionConsumer(
+                // Blank the traces Redis host so it reuses the hub's pool (like the logs-consumer tests),
+                // avoiding a second eager pool that would keep handles open after the suite.
+                { ...hub, ...getDefaultTracesIngestionConsumerConfig(), TRACES_REDIS_HOST: '' },
+                {
+                    ...hub,
+                    outputs: new IngestionOutputs<AppMetricsOutput | LogsOutput | LogsDlqOutput>({
+                        [APP_METRICS_OUTPUT]: new SingleIngestionOutput(
+                            APP_METRICS_OUTPUT,
+                            KAFKA_APP_METRICS_2,
+                            mockProducer,
+                            'test'
+                        ),
+                        [LOGS_OUTPUT]: new SingleIngestionOutput(
+                            LOGS_OUTPUT,
+                            KAFKA_LOGS_CLICKHOUSE,
+                            mockProducer,
+                            'test'
+                        ),
+                        [LOGS_DLQ_OUTPUT]: new SingleIngestionOutput(
+                            LOGS_DLQ_OUTPUT,
+                            KAFKA_LOGS_INGESTION_DLQ,
+                            mockProducer,
+                            'test'
+                        ),
+                    }),
+                }
+            )
+            tracesConsumer['kafkaConsumer'] = {
+                connect: jest.fn(),
+                disconnect: jest.fn(),
+                isHealthy: jest.fn().mockReturnValue({ status: 'healthy' }),
+            } as any
+            return tracesConsumer
+        }
+
+        it('meters usage as traces, not logs', async () => {
+            const tracesConsumer = createTracesIngestionConsumer()
+            tracesConsumer['queueUsageMetric'](team.id, 'bytes_ingested', 500)
+            await tracesConsumer['appMetricsAggregator'].flush()
+
+            const messages = getProducedKafkaMessages().filter((m) => m.topic === KAFKA_APP_METRICS_2)
+            expect(messages).toHaveLength(1)
+            const value = Buffer.isBuffer(messages[0].value)
+                ? parseJSON(messages[0].value.toString())
+                : parseJSON(messages[0].value as string)
+            expect(value?.app_source).toBe('traces')
+        })
+
+        it('quota-limits against traces_mb_ingested, not logs_mb_ingested', async () => {
+            jest.mocked(hub.quotaLimiting.isTeamTokenQuotaLimited).mockResolvedValue(false)
+            const tracesConsumer = createTracesIngestionConsumer()
+
+            const messages = await createKafkaMessages([createLogMessage()], {
+                token: team.api_token,
+                bytes_uncompressed: '1024',
+                record_count: '5',
+            })
+            const parsed = await tracesConsumer['_parseKafkaBatch'](messages)
+            await tracesConsumer['filterQuotaLimitedMessages'](parsed)
+
+            expect(hub.quotaLimiting.isTeamTokenQuotaLimited).toHaveBeenCalledWith(team.api_token, 'traces_mb_ingested')
         })
     })
 })

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -5,7 +5,7 @@ import { Counter } from 'prom-client'
 
 import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
 import { AppMetricsAggregator } from '~/common/services/app-metrics-aggregator'
-import { QuotaLimiting } from '~/common/services/quota-limiting.service'
+import { QuotaLimiting, QuotaResource } from '~/common/services/quota-limiting.service'
 import { instrumentFn, instrumented } from '~/common/tracing/tracing-utils'
 import { AppMetricsOutput } from '~/ingestion/common/outputs'
 import { IngestionOutputs } from '~/ingestion/outputs/ingestion-outputs'
@@ -126,6 +126,9 @@ export const logsBytesDroppedByRuleCounter = new Counter({
 
 export class LogsIngestionConsumer {
     protected name = 'LogsIngestionConsumer'
+    // Billing identity for quota enforcement and usage metering; overridden by subclasses (e.g. traces).
+    protected quotaResource: QuotaResource = 'logs_mb_ingested'
+    protected appSource = 'logs'
     protected kafkaConsumer: KafkaConsumerInterface
     private appMetricsAggregator: AppMetricsAggregator
     private redis: RedisV2
@@ -389,7 +392,7 @@ export class LogsIngestionConsumer {
             (
                 await Promise.all(
                     uniqueTokens.map(async (token) =>
-                        (await this.deps.quotaLimiting.isTeamTokenQuotaLimited(token, 'logs_mb_ingested'))
+                        (await this.deps.quotaLimiting.isTeamTokenQuotaLimited(token, this.quotaResource))
                             ? token
                             : null
                     )
@@ -564,7 +567,7 @@ export class LogsIngestionConsumer {
         }
         this.appMetricsAggregator.queue({
             team_id: teamId,
-            app_source: 'logs',
+            app_source: this.appSource,
             app_source_id: '',
             instance_id: '',
             metric_kind: 'usage',
@@ -584,7 +587,7 @@ export class LogsIngestionConsumer {
             }
             this.appMetricsAggregator.queue({
                 team_id: teamId,
-                app_source: 'logs',
+                app_source: this.appSource,
                 app_source_id: '',
                 instance_id: ruleId,
                 metric_kind: 'usage',
@@ -605,7 +608,7 @@ export class LogsIngestionConsumer {
             }
             this.appMetricsAggregator.queue({
                 team_id: teamId,
-                app_source: 'logs',
+                app_source: this.appSource,
                 app_source_id: '',
                 instance_id: ruleId,
                 metric_kind: 'usage',

--- a/nodejs/src/logs-ingestion/traces-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/traces-ingestion-consumer.ts
@@ -3,6 +3,9 @@ import { LogsIngestionConsumer, LogsIngestionConsumerDeps } from './logs-ingesti
 
 export class TracesIngestionConsumer extends LogsIngestionConsumer {
     protected override name = 'TracesIngestionConsumer'
+    // Meter and quota-limit traces against their own billing identity, not logs'.
+    protected override quotaResource = 'traces_mb_ingested' as const
+    protected override appSource = 'traces'
 
     constructor(config: LogsIngestionConsumerConfig & TracesIngestionConsumerConfig, deps: LogsIngestionConsumerDeps) {
         // Topics are wired into `deps.outputs` by the server, so the only consumer-level


### PR DESCRIPTION
## Problem

Traces ingestion was sharing the same billing identity as logs ingestion — quota enforcement checked `logs_mb_ingested` and usage metrics were emitted with `app_source: 'logs'`. This meant traces consumption could not be independently quota-limited or metered.

## Changes

- Added `traces_mb_ingested` as a valid `QuotaResource` type.
- Introduced `quotaResource` and `appSource` protected fields on `LogsIngestionConsumer`, defaulting to `'logs_mb_ingested'` and `'logs'` respectively, replacing the previously hardcoded string literals throughout quota enforcement and usage metering.
- `TracesIngestionConsumer` overrides both fields to `'traces_mb_ingested'` and `'traces'`, giving traces its own distinct billing identity.

## How did you test this code?

Two new tests were added to the `LogsIngestionConsumer` test suite under a `TracesIngestionConsumer billing identity` describe block:

- **`meters usage as traces, not logs`** — verifies that `queueUsageMetric` emits an app metrics message with `app_source: 'traces'`.
- **`quota-limits against traces_mb_ingested, not logs_mb_ingested`** — verifies that `filterQuotaLimitedMessages` calls `isTeamTokenQuotaLimited` with `'traces_mb_ingested'` rather than `'logs_mb_ingested'`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update