### PR TITLE
fix(signals): always allow local domains

### DIFF
--- a/products/tasks/backend/services/agentsh.py
+++ b/products/tasks/backend/services/agentsh.py
@@ -36,12 +36,10 @@ def _get_infrastructure_domains() -> list[str]:
         if hostname and hostname not in domains:
             domains.append(hostname)
 
-    if getattr(settings, "DEBUG", False):
-        for hostname in ["localhost", "host.docker.internal"]:
-            if hostname not in domains:
-                domains.append(hostname)
-
     return domains
+
+
+LOCAL_DEV_DOMAINS = ["localhost", "host.docker.internal"]
 
 
 def generate_env_wrapper() -> str:
@@ -164,18 +162,32 @@ def generate_policy_yaml(allowed_domains: list[str] | None = None) -> str:
                 "cidrs": ["169.254.169.254/32", "fd00:ec2::254/128"],
                 "decision": "deny",
             },
-            {
-                "name": "allow-domains",
-                "domains": merged_domains,
-                "ports": allowed_ports,
-                "decision": "allow",
-            },
-            {
-                "name": "default-deny-network",
-                "domains": ["*"],
-                "decision": "deny",
-            },
         ]
+
+        if getattr(settings, "DEBUG", False):
+            network_rules.append(
+                {
+                    "name": "allow-local-dev-hosts",
+                    "domains": LOCAL_DEV_DOMAINS,
+                    "decision": "allow",
+                }
+            )
+
+        network_rules.extend(
+            [
+                {
+                    "name": "allow-domains",
+                    "domains": merged_domains,
+                    "ports": allowed_ports,
+                    "decision": "allow",
+                },
+                {
+                    "name": "default-deny-network",
+                    "domains": ["*"],
+                    "decision": "deny",
+                },
+            ]
+        )
     else:
         network_rules = [
             {

--- a/products/tasks/backend/tests/test_agentsh.py
+++ b/products/tasks/backend/tests/test_agentsh.py
@@ -134,6 +134,28 @@ class TestGeneratePolicyYaml(TestCase):
         self.assertIn(8000, allow_rule["ports"])
         self.assertIn(8010, allow_rule["ports"])
 
+    @override_settings(DEBUG=True)
+    def test_debug_mode_allows_local_dev_hosts_on_any_port(self):
+        policy = yaml.safe_load(generate_policy_yaml(["example.com"]))
+        dev_rule = next(rule for rule in policy["network_rules"] if rule["name"] == "allow-local-dev-hosts")
+        self.assertEqual(dev_rule["decision"], "allow")
+        self.assertIn("host.docker.internal", dev_rule["domains"])
+        self.assertIn("localhost", dev_rule["domains"])
+        self.assertNotIn("ports", dev_rule)
+
+    @override_settings(DEBUG=True)
+    def test_debug_mode_local_dev_rule_precedes_default_deny(self):
+        policy = yaml.safe_load(generate_policy_yaml(["example.com"]))
+        rules = policy["network_rules"]
+        dev_idx = next(i for i, rule in enumerate(rules) if rule["name"] == "allow-local-dev-hosts")
+        deny_idx = next(i for i, rule in enumerate(rules) if rule["name"] == "default-deny-network")
+        self.assertLess(dev_idx, deny_idx)
+
+    def test_non_debug_mode_omits_local_dev_hosts_rule(self):
+        policy = yaml.safe_load(generate_policy_yaml(["example.com"]))
+        rule_names = [r["name"] for r in policy["network_rules"]]
+        self.assertNotIn("allow-local-dev-hosts", rule_names)
+
     def test_allow_all_policy_when_no_domains(self):
         policy = yaml.safe_load(generate_policy_yaml(None))
         rules = policy["network_rules"]


### PR DESCRIPTION
Signals pipeline breaks locally with docker sandboxes due to local domains not being allowlisted for all ports, we don't mind which ports they use locally and we want to allow it to access the MCP server at 8787