### PR TITLE
fix(llma): Small ux improvements on sessions page

### DIFF
--- a/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
@@ -267,7 +267,10 @@ function SessionTurnView({
     const traceUrl = combineUrl(urls.aiObservabilityTrace(trace.id), baseTraceParams).url
     const summaryUrl = combineUrl(urls.aiObservabilityTrace(trace.id), { ...baseTraceParams, tab: 'summary' }).url
 
-    const canShowSteps = turn.isLoaded && turn.userVisibleTurn
+    const hasTranscript = turn.isLoaded && !!turn.userVisibleTurn
+    // Auto-show the Steps panel for span-only turns — they have no transcript to fall
+    // back to, so the span tree IS the conversation.
+    const showStepsPanel = (hasTranscript && stepsShown) || (turn.isLoaded && !turn.userVisibleTurn)
 
     return (
         <div className="flex flex-col">
@@ -321,7 +324,7 @@ function SessionTurnView({
                         </div>
                     )}
 
-                    {canShowSteps && stepsShown && (
+                    {showStepsPanel && (
                         <StepsPanel
                             traceId={trace.id}
                             fullTrace={fullTrace}
@@ -334,7 +337,7 @@ function SessionTurnView({
                 <div className="w-40 shrink-0 flex flex-col gap-1 text-xs text-muted">
                     {showSentiment && <SessionTraceSentimentBar traceId={trace.id} createdAt={trace.createdAt} />}
                     <div className="flex flex-col gap-1 items-start">
-                        {canShowSteps && (
+                        {hasTranscript && (
                             <LemonButton size="xsmall" type="tertiary" onClick={() => toggleSteps(trace.id)}>
                                 {stepsShown ? 'Hide steps' : 'Show steps'}
                             </LemonButton>
@@ -380,7 +383,7 @@ function TurnBody({
     turn: SessionTurn
     isLoading: boolean
     onLoad: () => void
-}): JSX.Element {
+}): JSX.Element | null {
     if (isLoading) {
         return (
             <div className="flex items-center gap-2 text-muted text-sm py-2">
@@ -399,7 +402,8 @@ function TurnBody({
         )
     }
     if (!turn.userVisibleTurn) {
-        return <div className="text-muted text-sm py-2">No conversational turn to render in this trace.</div>
+        // No chat to render — the parent renders `StepsPanel` inline below as the substitute.
+        return null
     }
     // `turn.newInputs` / `outputs` come pre-deduped from `extractSessionTurns`.
     return <TranscriptBubbleStream inputs={turn.newInputs} outputs={turn.outputs} />

--- a/products/ai_observability/frontend/ConversationDisplay/TranscriptBubbleStream.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/TranscriptBubbleStream.tsx
@@ -226,19 +226,19 @@ function ScaffoldGroupPill({
     const count = messages.length
     const label = count === 1 ? '1 hidden context block' : `${count} hidden context blocks`
     // Mirror the bubble-alignment convention: user-role on the right, everything else on the left.
-    const alignSelf = role === 'user' ? 'self-end' : 'self-start'
+    const isUser = role === 'user'
+    const alignSelf = isUser ? 'self-end' : 'self-start'
+    const buttonAlignSelf = isUser ? 'self-end' : 'self-start'
     return (
         <div className={`flex flex-col gap-1 text-xs text-muted max-w-[75%] ${alignSelf}`}>
             <button
                 type="button"
-                className="flex items-center gap-1 hover:text-default text-left cursor-pointer"
+                className={`flex items-center gap-1 hover:text-default text-left cursor-pointer ${buttonAlignSelf}`}
                 onClick={() => setExpanded((v) => !v)}
             >
                 <IconChevronRight className={`transition-transform ${expanded ? 'rotate-90' : ''}`} />
                 <span>{expanded ? `Hide ${label}` : `Show ${label}`}</span>
-                {!expanded && distinctTags.length > 0 && (
-                    <span className="font-mono opacity-60">— {distinctTags.join(', ')}</span>
-                )}
+                {distinctTags.length > 0 && <span className="font-mono opacity-60">— {distinctTags.join(', ')}</span>}
             </button>
             {expanded && (
                 <div className="flex flex-col gap-1.5 opacity-70">


### PR DESCRIPTION
## Problem

Just some small UX improvemets

## Changes

- The expand label for system messages was moving between expand/collapsed, now it's steady
- The empty state for sessions without conversation got improved by showing the steps panel which allows digging deeper on that page and feels less like a dead end

|Before|After|
|-|-|
|<img width="739" height="203" alt="empty-state-before" src="https://github.com/user-attachments/assets/b2d6272e-8e58-4c31-b5f5-4edf8fb4c0e7" />|<img width="741" height="307" alt="empty-state-after" src="https://github.com/user-attachments/assets/34f9b684-6fef-4f4a-a35c-ccea5b6afd86" />|


## How did you test this code?

Manually