### PR TITLE
feat(mcp): add read-only tasks MCP tools

### DIFF
--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -735,23 +735,3 @@ export const logsViewsDestroy = async (projectId: string, shortId: string, optio
         method: 'DELETE',
     })
 }
-
-export const getTasksRunsLogsRetrieveUrl = (projectId: string, taskId: string, id: string) => {
-    return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/logs/`
-}
-
-/**
- * Fetch the logs for a task run as JSONL. If the run resumes from another (state.resume_from_run_id), each ancestor's log is concatenated first (oldest ancestor → ... → this run) so resume consumers see a single continuous history and can find the most recent git_checkpoint event regardless of which run emitted it.
- * @summary Get task run logs
- */
-export const tasksRunsLogsRetrieve = async (
-    projectId: string,
-    taskId: string,
-    id: string,
-    options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getTasksRunsLogsRetrieveUrl(projectId, taskId, id), {
-        ...options,
-        method: 'GET',
-    })
-}

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -735,3 +735,23 @@ export const logsViewsDestroy = async (projectId: string, shortId: string, optio
         method: 'DELETE',
     })
 }
+
+export const getTasksRunsLogsRetrieveUrl = (projectId: string, taskId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/logs/`
+}
+
+/**
+ * Fetch the logs for a task run as JSONL. If the run resumes from another (state.resume_from_run_id), each ancestor's log is concatenated first (oldest ancestor → ... → this run) so resume consumers see a single continuous history and can find the most recent git_checkpoint event regardless of which run emitted it.
+ * @summary Get task run logs
+ */
+export const tasksRunsLogsRetrieve = async (
+    projectId: string,
+    taskId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getTasksRunsLogsRetrieveUrl(projectId, taskId, id), {
+        ...options,
+        method: 'GET',
+    })
+}

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -27,6 +27,7 @@ from rest_framework import status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
 
@@ -220,6 +221,28 @@ def _is_internal_debug_team(team_id: int | None) -> bool:
     return team_id == 2 and settings.CLOUD_DEPLOYMENT == "US"
 
 
+class _SchemaAwareLimitOffsetPagination(LimitOffsetPagination):
+    """LimitOffsetPagination subclass that surfaces `default_limit`/`max_limit` in the OpenAPI schema."""
+
+    def get_schema_operation_parameters(self, view):
+        parameters = super().get_schema_operation_parameters(view)
+        for parameter in parameters:
+            if parameter.get("name") == self.limit_query_param:
+                parameter["schema"]["default"] = self.default_limit
+                if self.max_limit is not None:
+                    parameter["schema"]["maximum"] = self.max_limit
+                parameter["schema"]["minimum"] = 1
+            elif parameter.get("name") == self.offset_query_param:
+                parameter["schema"]["default"] = 0
+                parameter["schema"]["minimum"] = 0
+        return parameters
+
+
+class TasksPagination(_SchemaAwareLimitOffsetPagination):
+    default_limit = 50
+    max_limit = 100
+
+
 def task_visibility_q(user_id: int | None) -> Q:
     """Filter for tasks visible to the given user.
 
@@ -331,6 +354,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, APIScopePermission, TasksAccessPermission]
     scope_object = "task"
     queryset = Task.objects.all()
+    pagination_class = TasksPagination
 
     @validated_request(
         query_serializer=TaskListQuerySerializer,
@@ -1164,7 +1188,7 @@ class TaskAutomationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return Response(TaskAutomationSerializer(automation, context=self.get_serializer_context()).data)
 
 
-@extend_schema(tags=["task-runs"])
+@extend_schema(tags=["task-runs", "tasks"])
 class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     """
     API for managing task runs. Each run represents an execution of a task.
@@ -1183,6 +1207,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     ).all()
     http_method_names = ["get", "post", "patch", "head", "options"]
     filter_rewrite_rules = {"team_id": "team_id"}
+    pagination_class = TasksPagination
 
     @validated_request(
         responses={

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -82,7 +82,13 @@ def build_task_run_artifact_size_error(
 
 
 class TaskSerializer(serializers.ModelSerializer):
-    repository = serializers.CharField(max_length=255, required=False, allow_blank=True, allow_null=True)
+    repository = serializers.CharField(
+        max_length=255,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).",
+    )
     # UserIntegration is scoped to request.user in validate_github_user_integration.
     github_user_integration = serializers.PrimaryKeyRelatedField(  # nosemgrep: unscoped-primary-key-related-field
         queryset=UserIntegration.objects.filter(kind="github"),
@@ -93,9 +99,22 @@ class TaskSerializer(serializers.ModelSerializer):
     latest_run = serializers.SerializerMethodField()
     created_by = UserBasicSerializer(read_only=True)
 
-    title = serializers.CharField(max_length=255, required=False, allow_blank=True)
-    description = serializers.CharField(required=False, allow_blank=True)
-    origin_product = serializers.ChoiceField(choices=Task.OriginProduct.choices, required=False)
+    title = serializers.CharField(
+        max_length=255,
+        required=False,
+        allow_blank=True,
+        help_text="Short human-readable title. Auto-generated from `description` when omitted.",
+    )
+    description = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Free-form description of the work to be done. Used as the prompt passed to the agent.",
+    )
+    origin_product = serializers.ChoiceField(
+        choices=Task.OriginProduct.choices,
+        required=False,
+        help_text="PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).",
+    )
     # Write-only: which SignalReportTask row to create when linking a task to a report from the
     # public task API (e.g. PostHog Code inbox). Only implementation is supported; research/repo
     # selection links are created by server-side flows.

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -312,7 +312,8 @@ export interface TaskApi {
   * `slack` - Slack
   * `support_queue` - Support Queue
   * `session_summaries` - Session Summaries
-  * `signal_report` - Signal Report */
+  * `signal_report` - Signal Report
+  * `signals_scout` - Signals Scout */
     origin_product?: OriginProductEnumApi
     /**
      * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -393,7 +394,8 @@ export interface PatchedTaskApi {
   * `slack` - Slack
   * `support_queue` - Support Queue
   * `session_summaries` - Session Summaries
-  * `signal_report` - Signal Report */
+  * `signal_report` - Signal Report
+  * `signals_scout` - Signals Scout */
     origin_product?: OriginProductEnumApi
     /**
      * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -295,12 +295,27 @@ export interface TaskApi {
     /** @nullable */
     readonly task_number: number | null
     readonly slug: string
-    /** @maxLength 255 */
+    /**
+     * Short human-readable title. Auto-generated from `description` when omitted.
+     * @maxLength 255
+     */
     title?: string
     title_manually_set?: boolean
+    /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
     description?: string
+    /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
+
+  * `error_tracking` - Error Tracking
+  * `eval_clusters` - Eval Clusters
+  * `user_created` - User Created
+  * `automation` - Automation
+  * `slack` - Slack
+  * `support_queue` - Support Queue
+  * `session_summaries` - Session Summaries
+  * `signal_report` - Signal Report */
     origin_product?: OriginProductEnumApi
     /**
+     * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
      * @maxLength 255
      * @nullable
      */
@@ -361,12 +376,27 @@ export interface PatchedTaskApi {
     /** @nullable */
     readonly task_number?: number | null
     readonly slug?: string
-    /** @maxLength 255 */
+    /**
+     * Short human-readable title. Auto-generated from `description` when omitted.
+     * @maxLength 255
+     */
     title?: string
     title_manually_set?: boolean
+    /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
     description?: string
+    /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
+
+  * `error_tracking` - Error Tracking
+  * `eval_clusters` - Eval Clusters
+  * `user_created` - User Created
+  * `automation` - Automation
+  * `slack` - Slack
+  * `support_queue` - Support Queue
+  * `session_summaries` - Session Summaries
+  * `signal_report` - Signal Report */
     origin_product?: OriginProductEnumApi
     /**
+     * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
      * @maxLength 255
      * @nullable
      */
@@ -1730,10 +1760,13 @@ export type TasksListParams = {
     internal?: boolean
     /**
      * Number of results to return per page.
+     * @minimum 1
+     * @maximum 100
      */
     limit?: number
     /**
      * The initial index from which to return the results.
+     * @minimum 0
      */
     offset?: number
     /**
@@ -1796,10 +1829,13 @@ export const TasksListStatus = {
 export type TasksRunsListParams = {
     /**
      * Number of results to return per page.
+     * @minimum 1
+     * @maximum 100
      */
     limit?: number
     /**
      * The initial index from which to return the results.
+     * @minimum 0
      */
     offset?: number
 }

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -852,26 +852,6 @@ export const tasksRunsConnectionTokenRetrieve = async (
     })
 }
 
-export const getTasksRunsLogsRetrieveUrl = (projectId: string, taskId: string, id: string) => {
-    return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/logs/`
-}
-
-/**
- * Fetch the logs for a task run as JSONL. If the run resumes from another (state.resume_from_run_id), each ancestor's log is concatenated first (oldest ancestor → ... → this run) so resume consumers see a single continuous history and can find the most recent git_checkpoint event regardless of which run emitted it.
- * @summary Get task run logs
- */
-export const tasksRunsLogsRetrieve = async (
-    projectId: string,
-    taskId: string,
-    id: string,
-    options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getTasksRunsLogsRetrieveUrl(projectId, taskId, id), {
-        ...options,
-        method: 'GET',
-    })
-}
-
 export const getTasksRunsRelayMessageCreateUrl = (projectId: string, taskId: string, id: string) => {
     return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/relay_message/`
 }

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -852,6 +852,26 @@ export const tasksRunsConnectionTokenRetrieve = async (
     })
 }
 
+export const getTasksRunsLogsRetrieveUrl = (projectId: string, taskId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/logs/`
+}
+
+/**
+ * Fetch the logs for a task run as JSONL. If the run resumes from another (state.resume_from_run_id), each ancestor's log is concatenated first (oldest ancestor → ... → this run) so resume consumers see a single continuous history and can find the most recent git_checkpoint event regardless of which run emitted it.
+ * @summary Get task run logs
+ */
+export const tasksRunsLogsRetrieve = async (
+    projectId: string,
+    taskId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getTasksRunsLogsRetrieveUrl(projectId, taskId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
 export const getTasksRunsRelayMessageCreateUrl = (projectId: string, taskId: string, id: string) => {
     return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/relay_message/`
 }

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -185,10 +185,17 @@ export const tasksCreateBodyTitleMax = 255
 export const tasksCreateBodyRepositoryMax = 255
 
 export const TasksCreateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(tasksCreateBodyTitleMax).optional(),
+    title: zod
+        .string()
+        .max(tasksCreateBodyTitleMax)
+        .optional()
+        .describe('Short human-readable title. Auto-generated from `description` when omitted.'),
     title_manually_set: zod.boolean().optional(),
-    description: zod.string().optional(),
-    origin_product: zod
+    description: zod
+        .string()
+        .optional()
+        .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
+    origin_product:  zod
         .enum([
             'error_tracking',
             'eval_clusters',
@@ -200,11 +207,18 @@ export const TasksCreateBody = /* @__PURE__ */ zod.object({
             'signal_report',
             'signals_scout',
         ])
-        .optional()
         .describe(
             '\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout'
+        )
+        .optional()
+        .describe(
+            'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
         ),
-    repository: zod.string().max(tasksCreateBodyRepositoryMax).nullish(),
+    repository: zod
+        .string()
+        .max(tasksCreateBodyRepositoryMax)
+        .nullish()
+        .describe('Target GitHub repository in `organization\/repo` format (e.g. `posthog\/posthog-js`).'),
     github_integration: zod.number().nullish().describe('GitHub integration for this task'),
     github_user_integration: zod
         .uuid()
@@ -240,10 +254,17 @@ export const tasksUpdateBodyTitleMax = 255
 export const tasksUpdateBodyRepositoryMax = 255
 
 export const TasksUpdateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(tasksUpdateBodyTitleMax).optional(),
+    title: zod
+        .string()
+        .max(tasksUpdateBodyTitleMax)
+        .optional()
+        .describe('Short human-readable title. Auto-generated from `description` when omitted.'),
     title_manually_set: zod.boolean().optional(),
-    description: zod.string().optional(),
-    origin_product: zod
+    description: zod
+        .string()
+        .optional()
+        .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
+    origin_product:  zod
         .enum([
             'error_tracking',
             'eval_clusters',
@@ -255,11 +276,18 @@ export const TasksUpdateBody = /* @__PURE__ */ zod.object({
             'signal_report',
             'signals_scout',
         ])
-        .optional()
         .describe(
             '\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout'
+        )
+        .optional()
+        .describe(
+            'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
         ),
-    repository: zod.string().max(tasksUpdateBodyRepositoryMax).nullish(),
+    repository: zod
+        .string()
+        .max(tasksUpdateBodyRepositoryMax)
+        .nullish()
+        .describe('Target GitHub repository in `organization\/repo` format (e.g. `posthog\/posthog-js`).'),
     github_integration: zod.number().nullish().describe('GitHub integration for this task'),
     github_user_integration: zod
         .uuid()
@@ -295,10 +323,17 @@ export const tasksPartialUpdateBodyTitleMax = 255
 export const tasksPartialUpdateBodyRepositoryMax = 255
 
 export const TasksPartialUpdateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(tasksPartialUpdateBodyTitleMax).optional(),
+    title: zod
+        .string()
+        .max(tasksPartialUpdateBodyTitleMax)
+        .optional()
+        .describe('Short human-readable title. Auto-generated from `description` when omitted.'),
     title_manually_set: zod.boolean().optional(),
-    description: zod.string().optional(),
-    origin_product: zod
+    description: zod
+        .string()
+        .optional()
+        .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
+    origin_product:  zod
         .enum([
             'error_tracking',
             'eval_clusters',
@@ -310,11 +345,18 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod.object({
             'signal_report',
             'signals_scout',
         ])
-        .optional()
         .describe(
             '\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout'
+        )
+        .optional()
+        .describe(
+            'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
         ),
-    repository: zod.string().max(tasksPartialUpdateBodyRepositoryMax).nullish(),
+    repository: zod
+        .string()
+        .max(tasksPartialUpdateBodyRepositoryMax)
+        .nullish()
+        .describe('Target GitHub repository in `organization\/repo` format (e.g. `posthog\/posthog-js`).'),
     github_integration: zod.number().nullish().describe('GitHub integration for this task'),
     github_user_integration: zod
         .uuid()

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -195,7 +195,7 @@ export const TasksCreateBody = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
-    origin_product:  zod
+    origin_product: zod
         .enum([
             'error_tracking',
             'eval_clusters',
@@ -212,7 +212,7 @@ export const TasksCreateBody = /* @__PURE__ */ zod.object({
         )
         .optional()
         .describe(
-            'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
+            'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout'
         ),
     repository: zod
         .string()
@@ -264,7 +264,7 @@ export const TasksUpdateBody = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
-    origin_product:  zod
+    origin_product: zod
         .enum([
             'error_tracking',
             'eval_clusters',
@@ -281,7 +281,7 @@ export const TasksUpdateBody = /* @__PURE__ */ zod.object({
         )
         .optional()
         .describe(
-            'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
+            'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout'
         ),
     repository: zod
         .string()
@@ -333,7 +333,7 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
-    origin_product:  zod
+    origin_product: zod
         .enum([
             'error_tracking',
             'eval_clusters',
@@ -350,7 +350,7 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod.object({
         )
         .optional()
         .describe(
-            'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
+            'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout'
         ),
     repository: zod
         .string()

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -36,6 +36,7 @@ tools:
     tasks-list:
         operation: tasks_list
         enabled: true
+        feature_flag: tasks
         scopes:
             - task:read
         annotations:
@@ -79,6 +80,7 @@ tools:
     tasks-retrieve:
         operation: tasks_retrieve
         enabled: true
+        feature_flag: tasks
         scopes:
             - task:read
         annotations:
@@ -123,6 +125,7 @@ tools:
     tasks-runs-list:
         operation: tasks_runs_list
         enabled: true
+        feature_flag: tasks
         scopes:
             - task:read
         annotations:
@@ -162,6 +165,7 @@ tools:
     tasks-runs-retrieve:
         operation: tasks_runs_retrieve
         enabled: true
+        feature_flag: tasks
         scopes:
             - task:read
         annotations:
@@ -176,6 +180,7 @@ tools:
     tasks-runs-session-logs-retrieve:
         operation: tasks_runs_session_logs_retrieve
         enabled: true
+        feature_flag: tasks
         scopes:
             - task:read
         annotations:

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -18,14 +18,38 @@ tools:
     sandbox-create:
         operation: sandbox_create
         enabled: false
+    sandbox-destroy:
+        operation: sandbox_destroy
+        enabled: false
     sandbox-list:
         operation: sandbox_list
+        enabled: false
+    sandbox-partial-update:
+        operation: sandbox_partial_update
+        enabled: false
+    sandbox-retrieve:
+        operation: sandbox_retrieve
         enabled: false
     task-automations-create:
         operation: task_automations_create
         enabled: false
+    task-automations-destroy:
+        operation: task_automations_destroy
+        enabled: false
     task-automations-list:
         operation: task_automations_list
+        enabled: false
+    task-automations-partial-update:
+        operation: task_automations_partial_update
+        enabled: false
+    task-automations-retrieve:
+        operation: task_automations_retrieve
+        enabled: false
+    task-automations-run-create:
+        operation: task_automations_run_create
+        enabled: false
+    task-automations-update:
+        operation: task_automations_update
         enabled: false
     tasks-create:
         operation: tasks_create
@@ -203,6 +227,9 @@ tools:
         enabled: false
     tasks-runs-stream-retrieve:
         operation: tasks_runs_stream_retrieve
+        enabled: false
+    tasks-slack-thread-context-retrieve:
+        operation: tasks_slack_thread_context_retrieve
         enabled: false
     tasks-staged-artifacts-finalize-upload-create:
         operation: tasks_staged_artifacts_finalize_upload_create

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -114,7 +114,8 @@ tools:
         title: Get task
         description: >
             Get a specific task by ID, including its description, repository, origin product, current stage, and latest
-            run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.
+            run summary. Sandbox connection credentials and the presigned log URL are omitted from the embedded
+            `latest_run`. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.
         feature_flag: tasks
         response:
             exclude:
@@ -203,8 +204,8 @@ tools:
         title: Get task run
         description: >
             Get full details for a specific task run including status, stage, environment, branch, artifacts summary,
-            state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the
-            sandbox environment used).
+            state, error message, and timestamps. Sandbox connection credentials (`state.sandbox_connect_token`,
+            `state.sandbox_url`) and the presigned `log_url` are omitted from the response.
         feature_flag: tasks
         response:
             exclude:

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -119,6 +119,8 @@ tools:
         response:
             exclude:
                 - latest_run.log_url
+                - latest_run.state.sandbox_connect_token
+                - latest_run.state.sandbox_url
     tasks-run-create:
         operation: tasks_run_create
         enabled: false
@@ -207,6 +209,8 @@ tools:
         response:
             exclude:
                 - log_url
+                - state.sandbox_connect_token
+                - state.sandbox_url
     tasks-runs-session-logs-retrieve:
         operation: tasks_runs_session_logs_retrieve
         enabled: true

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -1,0 +1,213 @@
+# MCP tool definition — tool entries are scaffolded from the OpenAPI schema.
+# The tool list and operation IDs are kept in sync automatically:
+#   pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+#
+# To enable a tool, set enabled: true and add required scopes + annotations.
+# All other fields (title, description, enrich_url, etc.) are yours to configure.
+category: Tasks
+feature: tasks
+url_prefix: /tasks
+ui_apps: {}
+tools:
+    code-invites-check-access-retrieve:
+        operation: code_invites_check_access_retrieve
+        enabled: false
+    code-invites-redeem-create:
+        operation: code_invites_redeem_create
+        enabled: false
+    sandbox-create:
+        operation: sandbox_create
+        enabled: false
+    sandbox-list:
+        operation: sandbox_list
+        enabled: false
+    task-automations-create:
+        operation: task_automations_create
+        enabled: false
+    task-automations-list:
+        operation: task_automations_list
+        enabled: false
+    tasks-create:
+        operation: tasks_create
+        enabled: false
+    tasks-destroy:
+        operation: tasks_destroy
+        enabled: false
+    tasks-list:
+        operation: tasks_list
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        enrich_url: '{id}'
+        list: true
+        title: List tasks
+        description: >
+            List agent tasks in the current project. Supports filtering by `origin_product`, `stage`, `organization`,
+            `repository`, `created_by`, and `internal`. Returns lightweight task metadata only — call tasks-retrieve for
+            the full task including its latest run, or tasks-runs-list for run history. Requires the calling token's
+            organization to have Tasks access enabled.
+        response:
+            include:
+                - id
+                - task_number
+                - title
+                - description
+                - origin_product
+                - repository
+                - internal
+                - created_at
+                - updated_at
+    tasks-partial-update:
+        operation: tasks_partial_update
+        enabled: false
+    tasks-presence-create:
+        operation: tasks_presence_create
+        enabled: false
+    tasks-presence-destroy:
+        operation: tasks_presence_destroy
+        enabled: false
+    tasks-repositories-retrieve:
+        operation: tasks_repositories_retrieve
+        enabled: false
+    tasks-repository-readiness-retrieve:
+        operation: tasks_repository_readiness_retrieve
+        enabled: false
+    tasks-retrieve:
+        operation: tasks_retrieve
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        enrich_url: '{id}'
+        title: Get task
+        description: >
+            Get a specific task by ID, including its description, repository, origin product, current stage, and latest
+            run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.
+    tasks-run-create:
+        operation: tasks_run_create
+        enabled: false
+    tasks-runs-append-log-create:
+        operation: tasks_runs_append_log_create
+        enabled: false
+    tasks-runs-artifacts-create:
+        operation: tasks_runs_artifacts_create
+        enabled: false
+    tasks-runs-artifacts-download-create:
+        operation: tasks_runs_artifacts_download_create
+        enabled: false
+    tasks-runs-artifacts-finalize-upload-create:
+        operation: tasks_runs_artifacts_finalize_upload_create
+        enabled: false
+    tasks-runs-artifacts-prepare-upload-create:
+        operation: tasks_runs_artifacts_prepare_upload_create
+        enabled: false
+    tasks-runs-artifacts-presign-create:
+        operation: tasks_runs_artifacts_presign_create
+        enabled: false
+    tasks-runs-command-create:
+        operation: tasks_runs_command_create
+        enabled: false
+    tasks-runs-connection-token-retrieve:
+        operation: tasks_runs_connection_token_retrieve
+        enabled: false
+    tasks-runs-create:
+        operation: tasks_runs_create
+        enabled: false
+    tasks-runs-list:
+        operation: tasks_runs_list
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List task runs
+        description: >
+            List all runs for a specific task. Returns lightweight run metadata only — call tasks-runs-retrieve for full
+            run detail including state, output, and artifacts.
+        response:
+            include:
+                - id
+                - task
+                - stage
+                - branch
+                - status
+                - environment
+                - error_message
+                - state.sandbox_environment_id
+                - created_at
+                - updated_at
+                - completed_at
+    tasks-runs-logs-retrieve:
+        operation: tasks_runs_logs_retrieve
+        enabled: false
+    tasks-runs-partial-update:
+        operation: tasks_runs_partial_update
+        enabled: false
+    tasks-runs-relay-message-create:
+        operation: tasks_runs_relay_message_create
+        enabled: false
+    tasks-runs-resume-in-cloud-create:
+        operation: tasks_runs_resume_in_cloud_create
+        enabled: false
+    tasks-runs-retrieve:
+        operation: tasks_runs_retrieve
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get task run
+        description: >
+            Get full details for a specific task run including status, stage, environment, branch, artifacts summary,
+            state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the
+            sandbox environment used).
+    tasks-runs-session-logs-retrieve:
+        operation: tasks_runs_session_logs_retrieve
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get task run session logs
+        description: >
+            Fetch session log events emitted by the agent for a specific run. Supports filtering by `event_types`,
+            `exclude_types`, pagination with `limit`/`offset`, and `after` cursor. Use this instead of the streaming
+            endpoint when invoking from an MCP client.
+        param_overrides:
+            limit:
+                default: 100
+    tasks-runs-set-output-partial-update:
+        operation: tasks_runs_set_output_partial_update
+        enabled: false
+    tasks-runs-start-create:
+        operation: tasks_runs_start_create
+        enabled: false
+    tasks-runs-stream-retrieve:
+        operation: tasks_runs_stream_retrieve
+        enabled: false
+    tasks-staged-artifacts-finalize-upload-create:
+        operation: tasks_staged_artifacts_finalize_upload_create
+        enabled: false
+    tasks-staged-artifacts-prepare-upload-create:
+        operation: tasks_staged_artifacts_prepare_upload_create
+        enabled: false
+    tasks-summaries-create:
+        operation: tasks_summaries_create
+        enabled: false
+    tasks-update:
+        operation: tasks_update
+        enabled: false

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -36,7 +36,6 @@ tools:
     tasks-list:
         operation: tasks_list
         enabled: true
-        feature_flag: tasks
         scopes:
             - task:read
         annotations:
@@ -51,6 +50,7 @@ tools:
             `repository`, `created_by`, and `internal`. Returns lightweight task metadata only — call tasks-retrieve for
             the full task including its latest run, or tasks-runs-list for run history. Requires the calling token's
             organization to have Tasks access enabled.
+        feature_flag: tasks
         response:
             include:
                 - id
@@ -80,7 +80,6 @@ tools:
     tasks-retrieve:
         operation: tasks_retrieve
         enabled: true
-        feature_flag: tasks
         scopes:
             - task:read
         annotations:
@@ -92,6 +91,7 @@ tools:
         description: >
             Get a specific task by ID, including its description, repository, origin product, current stage, and latest
             run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.
+        feature_flag: tasks
     tasks-run-create:
         operation: tasks_run_create
         enabled: false
@@ -125,7 +125,6 @@ tools:
     tasks-runs-list:
         operation: tasks_runs_list
         enabled: true
-        feature_flag: tasks
         scopes:
             - task:read
         annotations:
@@ -137,6 +136,7 @@ tools:
         description: >
             List all runs for a specific task. Returns lightweight run metadata only — call tasks-runs-retrieve for full
             run detail including state, output, and artifacts.
+        feature_flag: tasks
         response:
             include:
                 - id
@@ -165,7 +165,6 @@ tools:
     tasks-runs-retrieve:
         operation: tasks_runs_retrieve
         enabled: true
-        feature_flag: tasks
         scopes:
             - task:read
         annotations:
@@ -177,10 +176,10 @@ tools:
             Get full details for a specific task run including status, stage, environment, branch, artifacts summary,
             state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the
             sandbox environment used).
+        feature_flag: tasks
     tasks-runs-session-logs-retrieve:
         operation: tasks_runs_session_logs_retrieve
         enabled: true
-        feature_flag: tasks
         scopes:
             - task:read
         annotations:
@@ -195,6 +194,7 @@ tools:
         param_overrides:
             limit:
                 default: 100
+        feature_flag: tasks
     tasks-runs-set-output-partial-update:
         operation: tasks_runs_set_output_partial_update
         enabled: false

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -116,6 +116,9 @@ tools:
             Get a specific task by ID, including its description, repository, origin product, current stage, and latest
             run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.
         feature_flag: tasks
+        response:
+            exclude:
+                - latest_run.log_url
     tasks-run-create:
         operation: tasks_run_create
         enabled: false
@@ -201,6 +204,9 @@ tools:
             state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the
             sandbox environment used).
         feature_flag: tasks
+        response:
+            exclude:
+                - log_url
     tasks-runs-session-logs-retrieve:
         operation: tasks_runs_session_logs_retrieve
         enabled: true

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -228,8 +228,8 @@ tools:
             endpoint when invoking from an MCP client.
         param_overrides:
             limit:
-                default: 100
                 description: Maximum number of entries to return (default 100, max 5000)
+                default: 100
         feature_flag: tasks
     tasks-runs-set-output-partial-update:
         operation: tasks_runs_set_output_partial_update

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -229,6 +229,7 @@ tools:
         param_overrides:
             limit:
                 default: 100
+                description: Maximum number of entries to return (default 100, max 5000)
         feature_flag: tasks
     tasks-runs-set-output-partial-update:
         operation: tasks_runs_set_output_partial_update

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4796,7 +4796,6 @@
         "summary": "List tasks",
         "title": "List tasks",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -4812,7 +4811,6 @@
         "summary": "Get task",
         "title": "Get task",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -4828,7 +4826,6 @@
         "summary": "List task runs",
         "title": "List task runs",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -4844,7 +4841,6 @@
         "summary": "Get task run",
         "title": "Get task run",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -4860,7 +4856,6 @@
         "summary": "Get task run session logs",
         "title": "Get task run session logs",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4789,6 +4789,81 @@
             "readOnlyHint": true
         }
     },
+    "tasks-list": {
+        "description": "List agent tasks in the current project. Supports filtering by `origin_product`, `stage`, `organization`, `repository`, `created_by`, and `internal`. Returns lightweight task metadata only — call tasks-retrieve for the full task including its latest run, or tasks-runs-list for run history. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List tasks",
+        "title": "List tasks",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-retrieve": {
+        "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task",
+        "title": "Get task",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-runs-list": {
+        "description": "List all runs for a specific task. Returns lightweight run metadata only — call tasks-runs-retrieve for full run detail including state, output, and artifacts.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List task runs",
+        "title": "List task runs",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-runs-retrieve": {
+        "description": "Get full details for a specific task run including status, stage, environment, branch, artifacts summary, state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the sandbox environment used).",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task run",
+        "title": "Get task run",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-runs-session-logs-retrieve": {
+        "description": "Fetch session log events emitted by the agent for a specific run. Supports filtering by `event_types`, `exclude_types`, pagination with `limit`/`offset`, and `after` cursor. Use this instead of the streaming endpoint when invoking from an MCP client.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task run session logs",
+        "title": "Get task run session logs",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "update-feature-flag": {
         "description": "Update a feature flag by ID in the current project.",
         "category": "Feature flags",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4806,7 +4806,7 @@
         "feature_flag": "tasks"
     },
     "tasks-retrieve": {
-        "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",
+        "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Sandbox connection credentials and the presigned log URL are omitted from the embedded `latest_run`. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "Get task",
@@ -4838,7 +4838,7 @@
         "feature_flag": "tasks"
     },
     "tasks-runs-retrieve": {
-        "description": "Get full details for a specific task run including status, stage, environment, branch, artifacts summary, state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the sandbox environment used).",
+        "description": "Get full details for a specific task run including status, stage, environment, branch, artifacts summary, state, error message, and timestamps. Sandbox connection credentials (`state.sandbox_connect_token`, `state.sandbox_url`) and the presigned `log_url` are omitted from the response.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "Get task run",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4802,7 +4802,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-retrieve": {
         "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",
@@ -4817,7 +4818,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-runs-list": {
         "description": "List all runs for a specific task. Returns lightweight run metadata only — call tasks-runs-retrieve for full run detail including state, output, and artifacts.",
@@ -4832,7 +4834,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-runs-retrieve": {
         "description": "Get full details for a specific task run including status, stage, environment, branch, artifacts summary, state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the sandbox environment used).",
@@ -4847,7 +4850,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-runs-session-logs-retrieve": {
         "description": "Fetch session log events emitted by the agent for a specific run. Supports filtering by `event_types`, `exclude_types`, pagination with `limit`/`offset`, and `after` cursor. Use this instead of the streaming endpoint when invoking from an MCP client.",
@@ -4862,7 +4866,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "update-feature-flag": {
         "description": "Update a feature flag by ID in the current project.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5151,7 +5151,6 @@
         "summary": "List tasks",
         "title": "List tasks",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -5167,7 +5166,6 @@
         "summary": "Get task",
         "title": "Get task",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -5183,7 +5181,6 @@
         "summary": "List task runs",
         "title": "List task runs",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -5199,7 +5196,6 @@
         "summary": "Get task run",
         "title": "Get task run",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -5215,7 +5211,6 @@
         "summary": "Get task run session logs",
         "title": "Get task run session logs",
         "required_scopes": ["task:read"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5161,7 +5161,7 @@
         "feature_flag": "tasks"
     },
     "tasks-retrieve": {
-        "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",
+        "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Sandbox connection credentials and the presigned log URL are omitted from the embedded `latest_run`. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "Get task",
@@ -5193,7 +5193,7 @@
         "feature_flag": "tasks"
     },
     "tasks-runs-retrieve": {
-        "description": "Get full details for a specific task run including status, stage, environment, branch, artifacts summary, state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the sandbox environment used).",
+        "description": "Get full details for a specific task run including status, stage, environment, branch, artifacts summary, state, error message, and timestamps. Sandbox connection credentials (`state.sandbox_connect_token`, `state.sandbox_url`) and the presigned `log_url` are omitted from the response.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "Get task run",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5157,7 +5157,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-retrieve": {
         "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",
@@ -5172,7 +5173,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-runs-list": {
         "description": "List all runs for a specific task. Returns lightweight run metadata only — call tasks-runs-retrieve for full run detail including state, output, and artifacts.",
@@ -5187,7 +5189,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-runs-retrieve": {
         "description": "Get full details for a specific task run including status, stage, environment, branch, artifacts summary, state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the sandbox environment used).",
@@ -5202,7 +5205,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-runs-session-logs-retrieve": {
         "description": "Fetch session log events emitted by the agent for a specific run. Supports filtering by `event_types`, `exclude_types`, pagination with `limit`/`offset`, and `after` cursor. Use this instead of the streaming endpoint when invoking from an MCP client.",
@@ -5217,7 +5221,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "update-feature-flag": {
         "description": "Update a feature flag by ID in the current project.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5144,6 +5144,81 @@
             "readOnlyHint": false
         }
     },
+    "tasks-list": {
+        "description": "List agent tasks in the current project. Supports filtering by `origin_product`, `stage`, `organization`, `repository`, `created_by`, and `internal`. Returns lightweight task metadata only — call tasks-retrieve for the full task including its latest run, or tasks-runs-list for run history. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List tasks",
+        "title": "List tasks",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-retrieve": {
+        "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task",
+        "title": "Get task",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-runs-list": {
+        "description": "List all runs for a specific task. Returns lightweight run metadata only — call tasks-runs-retrieve for full run detail including state, output, and artifacts.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List task runs",
+        "title": "List task runs",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-runs-retrieve": {
+        "description": "Get full details for a specific task run including status, stage, environment, branch, artifacts summary, state, error message, and timestamps. The `state` object contains `sandbox_environment_id` (the UUID of the sandbox environment used).",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task run",
+        "title": "Get task run",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-runs-session-logs-retrieve": {
+        "description": "Fetch session log events emitted by the agent for a specific run. Supports filtering by `event_types`, `exclude_types`, pagination with `limit`/`offset`, and `after` cursor. Use this instead of the streaming endpoint when invoking from an MCP client.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task run session logs",
+        "title": "Get task run session logs",
+        "required_scopes": ["task:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "update-feature-flag": {
         "description": "Update a feature flag by ID in the current project.",
         "category": "Feature flags",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -25852,12 +25852,27 @@ export namespace Schemas {
       /** @nullable */
       readonly task_number: number | null;
       readonly slug: string;
-      /** @maxLength 255 */
+      /**
+         * Short human-readable title. Auto-generated from `description` when omitted.
+         * @maxLength 255
+         */
       title?: string;
       title_manually_set?: boolean;
+      /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
+      /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
+
+      * `error_tracking` - Error Tracking
+      * `eval_clusters` - Eval Clusters
+      * `user_created` - User Created
+      * `automation` - Automation
+      * `slack` - Slack
+      * `support_queue` - Support Queue
+      * `session_summaries` - Session Summaries
+      * `signal_report` - Signal Report */
       origin_product?: OriginProductEnum;
       /**
+         * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
          * @maxLength 255
          * @nullable
          */
@@ -31910,12 +31925,27 @@ export namespace Schemas {
       /** @nullable */
       readonly task_number?: number | null;
       readonly slug?: string;
-      /** @maxLength 255 */
+      /**
+         * Short human-readable title. Auto-generated from `description` when omitted.
+         * @maxLength 255
+         */
       title?: string;
       title_manually_set?: boolean;
+      /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
+      /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
+
+      * `error_tracking` - Error Tracking
+      * `eval_clusters` - Eval Clusters
+      * `user_created` - User Created
+      * `automation` - Automation
+      * `slack` - Slack
+      * `support_queue` - Support Queue
+      * `session_summaries` - Session Summaries
+      * `signal_report` - Signal Report */
       origin_product?: OriginProductEnum;
       /**
+         * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
          * @maxLength 255
          * @nullable
          */
@@ -49497,10 +49527,13 @@ export namespace Schemas {
     internal?: boolean;
     /**
      * Number of results to return per page.
+     * @minimum 1
+     * @maximum 100
      */
     limit?: number;
     /**
      * The initial index from which to return the results.
+     * @minimum 0
      */
     offset?: number;
     /**
@@ -49565,10 +49598,13 @@ export namespace Schemas {
     export type TasksRunsListParams = {
     /**
      * Number of results to return per page.
+     * @minimum 1
+     * @maximum 100
      */
     limit?: number;
     /**
      * The initial index from which to return the results.
+     * @minimum 0
      */
     offset?: number;
     };

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -25869,7 +25869,8 @@ export namespace Schemas {
       * `slack` - Slack
       * `support_queue` - Support Queue
       * `session_summaries` - Session Summaries
-      * `signal_report` - Signal Report */
+      * `signal_report` - Signal Report
+      * `signals_scout` - Signals Scout */
       origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -31942,7 +31943,8 @@ export namespace Schemas {
       * `slack` - Slack
       * `support_queue` - Support Queue
       * `session_summaries` - Session Summaries
-      * `signal_report` - Signal Report */
+      * `signal_report` - Signal Report
+      * `signals_scout` - Signals Scout */
       origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -1,0 +1,165 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * MCP service uses these Zod schemas for generated tool handlers.
+ * To regenerate: hogli build:openapi
+ *
+ * PostHog API - MCP 5 enabled ops
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+/**
+ * Get a list of tasks for the current project, with optional filtering by origin product, stage, organization, repository, and created_by.
+ * @summary List tasks
+ */
+export const TasksListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const tasksListQueryLimitDefault = 50
+export const tasksListQueryLimitMax = 100
+
+export const tasksListQueryOffsetDefault = 0
+export const tasksListQueryOffsetMin = 0
+
+export const TasksListQueryParams = /* @__PURE__ */ zod.object({
+    archived: zod
+        .enum(['true', 'false', 'all'])
+        .optional()
+        .describe(
+            "Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.\n\n* `true` - true\n* `false` - false\n* `all` - all"
+        ),
+    created_by: zod.number().optional().describe('Filter by creator user ID'),
+    internal: zod
+        .boolean()
+        .optional()
+        .describe(
+            'When true, list internal tasks instead of user-facing ones. Honored in debug environments or for staff users; ignored for non-staff users in production. Defaults to excluding internal tasks.'
+        ),
+    limit: zod
+        .number()
+        .min(1)
+        .max(tasksListQueryLimitMax)
+        .default(tasksListQueryLimitDefault)
+        .describe('Number of results to return per page.'),
+    offset: zod
+        .number()
+        .min(tasksListQueryOffsetMin)
+        .default(tasksListQueryOffsetDefault)
+        .describe('The initial index from which to return the results.'),
+    organization: zod.string().min(1).optional().describe('Filter by repository organization'),
+    origin_product: zod.string().min(1).optional().describe('Filter by origin product'),
+    repository: zod.string().min(1).optional().describe('Filter by repository name (can include org/repo format)'),
+    search: zod
+        .string()
+        .optional()
+        .describe(
+            'Case-insensitive substring search over task title and description. A numeric value also matches the task number. An empty value disables the filter.'
+        ),
+    stage: zod.string().min(1).optional().describe('Filter by task run stage'),
+    status: zod
+        .enum(['not_started', 'queued', 'in_progress', 'completed', 'failed', 'cancelled'])
+        .optional()
+        .describe(
+            'Filter tasks by the status of their most recent run.\n\n* `not_started` - not_started\n* `queued` - queued\n* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed\n* `cancelled` - cancelled'
+        ),
+})
+
+/**
+ * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
+ */
+export const TasksRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this task.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Get a list of runs for a specific task.
+ * @summary List task runs
+ */
+export const TasksRunsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    task_id: zod.string(),
+})
+
+export const tasksRunsListQueryLimitDefault = 50
+export const tasksRunsListQueryLimitMax = 100
+
+export const tasksRunsListQueryOffsetDefault = 0
+export const tasksRunsListQueryOffsetMin = 0
+
+export const TasksRunsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod
+        .number()
+        .min(1)
+        .max(tasksRunsListQueryLimitMax)
+        .default(tasksRunsListQueryLimitDefault)
+        .describe('Number of results to return per page.'),
+    offset: zod
+        .number()
+        .min(tasksRunsListQueryOffsetMin)
+        .default(tasksRunsListQueryOffsetDefault)
+        .describe('The initial index from which to return the results.'),
+})
+
+/**
+ * API for managing task runs. Each run represents an execution of a task.
+ */
+export const TasksRunsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this task run.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    task_id: zod.string(),
+})
+
+/**
+ * Fetch session log entries for a task run with optional filtering by timestamp, event type, and limit.
+ * @summary Get filtered task run session logs
+ */
+export const TasksRunsSessionLogsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this task run.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    task_id: zod.string(),
+})
+
+export const tasksRunsSessionLogsRetrieveQueryLimitDefault = 1000
+export const tasksRunsSessionLogsRetrieveQueryLimitMax = 5000
+
+export const tasksRunsSessionLogsRetrieveQueryOffsetDefault = 0
+export const tasksRunsSessionLogsRetrieveQueryOffsetMin = 0
+
+export const TasksRunsSessionLogsRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    after: zod.iso.datetime({ offset: true }).optional().describe('Only return events after this ISO8601 timestamp'),
+    event_types: zod.string().min(1).optional().describe('Comma-separated list of event types to include'),
+    exclude_types: zod.string().min(1).optional().describe('Comma-separated list of event types to exclude'),
+    limit: zod
+        .number()
+        .min(1)
+        .max(tasksRunsSessionLogsRetrieveQueryLimitMax)
+        .default(tasksRunsSessionLogsRetrieveQueryLimitDefault)
+        .describe('Maximum number of entries to return (default 1000, max 5000)'),
+    offset: zod
+        .number()
+        .min(tasksRunsSessionLogsRetrieveQueryOffsetMin)
+        .default(tasksRunsSessionLogsRetrieveQueryOffsetDefault)
+        .describe('Zero-based offset into the filtered log entries'),
+})

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -33,6 +33,7 @@ import { GENERATED_TOOLS as replay_vision } from './replay_vision'
 import { GENERATED_TOOLS as sdk_doctor } from './sdk_doctor'
 import { GENERATED_TOOLS as signals } from './signals'
 import { GENERATED_TOOLS as surveys } from './surveys'
+import { GENERATED_TOOLS as tasks } from './tasks'
 import { GENERATED_TOOLS as tracing } from './tracing'
 import { GENERATED_TOOLS as user_interviews } from './user_interviews'
 import { GENERATED_TOOLS as visual_review } from './visual_review'
@@ -72,6 +73,7 @@ export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = 
     ...sdk_doctor,
     ...signals,
     ...surveys,
+    ...tasks,
     ...tracing,
     ...user_interviews,
     ...visual_review,

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -78,7 +78,11 @@ const tasksRetrieve = (): ToolBase<typeof TasksRetrieveSchema, WithPostHogUrl<Sc
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.id))}/`,
         })
-        const filtered = omitResponseFields(result, ['latest_run.log_url']) as typeof result
+        const filtered = omitResponseFields(result, [
+            'latest_run.log_url',
+            'latest_run.state.sandbox_connect_token',
+            'latest_run.state.sandbox_url',
+        ]) as typeof result
         return await withPostHogUrl(context, filtered, `/tasks/${filtered.id}`)
     },
 })
@@ -131,7 +135,11 @@ const tasksRunsRetrieve = (): ToolBase<typeof TasksRunsRetrieveSchema, Schemas.T
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.task_id))}/runs/${encodeURIComponent(String(params.id))}/`,
         })
-        const filtered = omitResponseFields(result, ['log_url']) as typeof result
+        const filtered = omitResponseFields(result, [
+            'log_url',
+            'state.sandbox_connect_token',
+            'state.sandbox_url',
+        ]) as typeof result
         return filtered
     },
 })

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -11,7 +11,7 @@ import {
     TasksRunsSessionLogsRetrieveParams,
     TasksRunsSessionLogsRetrieveQueryParams,
 } from '@/generated/tasks/api'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const TasksListSchema = TasksListQueryParams
@@ -78,7 +78,8 @@ const tasksRetrieve = (): ToolBase<typeof TasksRetrieveSchema, WithPostHogUrl<Sc
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.id))}/`,
         })
-        return await withPostHogUrl(context, result, `/tasks/${result.id}`)
+        const filtered = omitResponseFields(result, ['latest_run.log_url']) as typeof result
+        return await withPostHogUrl(context, filtered, `/tasks/${filtered.id}`)
     },
 })
 
@@ -130,7 +131,8 @@ const tasksRunsRetrieve = (): ToolBase<typeof TasksRunsRetrieveSchema, Schemas.T
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.task_id))}/runs/${encodeURIComponent(String(params.id))}/`,
         })
-        return result
+        const filtered = omitResponseFields(result, ['log_url']) as typeof result
+        return filtered
     },
 })
 

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -146,7 +146,12 @@ const tasksRunsRetrieve = (): ToolBase<typeof TasksRunsRetrieveSchema, Schemas.T
 
 const TasksRunsSessionLogsRetrieveSchema = TasksRunsSessionLogsRetrieveParams.omit({ project_id: true })
     .extend(TasksRunsSessionLogsRetrieveQueryParams.shape)
-    .extend({ limit: TasksRunsSessionLogsRetrieveQueryParams.shape['limit'].default(100).optional() })
+    .extend({
+        limit: TasksRunsSessionLogsRetrieveQueryParams.shape['limit']
+            .default(100)
+            .optional()
+            .describe('Maximum number of entries to return (default 100, max 5000)'),
+    })
 
 const tasksRunsSessionLogsRetrieve = (): ToolBase<typeof TasksRunsSessionLogsRetrieveSchema, unknown> => ({
     name: 'tasks-runs-session-logs-retrieve',

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -1,0 +1,167 @@
+// AUTO-GENERATED from products/tasks/mcp/tools.yaml + OpenAPI — do not edit
+import { z } from 'zod'
+
+import type { Schemas } from '@/api/generated'
+import {
+    TasksListQueryParams,
+    TasksRetrieveParams,
+    TasksRunsListParams,
+    TasksRunsListQueryParams,
+    TasksRunsRetrieveParams,
+    TasksRunsSessionLogsRetrieveParams,
+    TasksRunsSessionLogsRetrieveQueryParams,
+} from '@/generated/tasks/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const TasksListSchema = TasksListQueryParams
+
+const tasksList = (): ToolBase<typeof TasksListSchema, WithPostHogUrl<Schemas.PaginatedTaskList>> => ({
+    name: 'tasks-list',
+    schema: TasksListSchema,
+    handler: async (context: Context, params: z.infer<typeof TasksListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedTaskList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/`,
+            query: {
+                archived: params.archived,
+                created_by: params.created_by,
+                internal: params.internal,
+                limit: params.limit,
+                offset: params.offset,
+                organization: params.organization,
+                origin_product: params.origin_product,
+                repository: params.repository,
+                search: params.search,
+                stage: params.stage,
+                status: params.status,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'id',
+                    'task_number',
+                    'title',
+                    'description',
+                    'origin_product',
+                    'repository',
+                    'internal',
+                    'created_at',
+                    'updated_at',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(
+            context,
+            {
+                ...filtered,
+                results: await Promise.all(
+                    (filtered.results ?? []).map((item) => withPostHogUrl(context, item, `/tasks/${item.id}`))
+                ),
+            },
+            '/tasks'
+        )
+    },
+})
+
+const TasksRetrieveSchema = TasksRetrieveParams.omit({ project_id: true })
+
+const tasksRetrieve = (): ToolBase<typeof TasksRetrieveSchema, WithPostHogUrl<Schemas.Task>> => ({
+    name: 'tasks-retrieve',
+    schema: TasksRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof TasksRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.Task>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.id))}/`,
+        })
+        return await withPostHogUrl(context, result, `/tasks/${result.id}`)
+    },
+})
+
+const TasksRunsListSchema = TasksRunsListParams.omit({ project_id: true }).extend(TasksRunsListQueryParams.shape)
+
+const tasksRunsList = (): ToolBase<typeof TasksRunsListSchema, WithPostHogUrl<Schemas.PaginatedTaskRunDetailList>> => ({
+    name: 'tasks-runs-list',
+    schema: TasksRunsListSchema,
+    handler: async (context: Context, params: z.infer<typeof TasksRunsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedTaskRunDetailList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.task_id))}/runs/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'id',
+                    'task',
+                    'stage',
+                    'branch',
+                    'status',
+                    'environment',
+                    'error_message',
+                    'state.sandbox_environment_id',
+                    'created_at',
+                    'updated_at',
+                    'completed_at',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/tasks')
+    },
+})
+
+const TasksRunsRetrieveSchema = TasksRunsRetrieveParams.omit({ project_id: true })
+
+const tasksRunsRetrieve = (): ToolBase<typeof TasksRunsRetrieveSchema, Schemas.TaskRunDetail> => ({
+    name: 'tasks-runs-retrieve',
+    schema: TasksRunsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof TasksRunsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.TaskRunDetail>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.task_id))}/runs/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const TasksRunsSessionLogsRetrieveSchema = TasksRunsSessionLogsRetrieveParams.omit({ project_id: true })
+    .extend(TasksRunsSessionLogsRetrieveQueryParams.shape)
+    .extend({ limit: TasksRunsSessionLogsRetrieveQueryParams.shape['limit'].default(100).optional() })
+
+const tasksRunsSessionLogsRetrieve = (): ToolBase<typeof TasksRunsSessionLogsRetrieveSchema, unknown> => ({
+    name: 'tasks-runs-session-logs-retrieve',
+    schema: TasksRunsSessionLogsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof TasksRunsSessionLogsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.task_id))}/runs/${encodeURIComponent(String(params.id))}/session_logs/`,
+            query: {
+                after: params.after,
+                event_types: params.event_types,
+                exclude_types: params.exclude_types,
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return result
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'tasks-list': tasksList,
+    'tasks-retrieve': tasksRetrieve,
+    'tasks-runs-list': tasksRunsList,
+    'tasks-runs-retrieve': tasksRunsRetrieve,
+    'tasks-runs-session-logs-retrieve': tasksRunsSessionLogsRetrieve,
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-list.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "archived": {
+            "description": "Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.\n\n* `true` - true\n* `false` - false\n* `all` - all",
+            "enum": ["true", "false", "all"],
+            "type": "string"
+        },
+        "created_by": {
+            "description": "Filter by creator user ID",
+            "type": "number"
+        },
+        "internal": {
+            "description": "When true, list internal tasks instead of user-facing ones. Honored in debug environments or for staff users; ignored for non-staff users in production. Defaults to excluding internal tasks.",
+            "type": "boolean"
+        },
+        "limit": {
+            "default": 50,
+            "description": "Number of results to return per page.",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+        },
+        "offset": {
+            "default": 0,
+            "description": "The initial index from which to return the results.",
+            "minimum": 0,
+            "type": "number"
+        },
+        "organization": {
+            "description": "Filter by repository organization",
+            "minLength": 1,
+            "type": "string"
+        },
+        "origin_product": {
+            "description": "Filter by origin product",
+            "minLength": 1,
+            "type": "string"
+        },
+        "repository": {
+            "description": "Filter by repository name (can include org/repo format)",
+            "minLength": 1,
+            "type": "string"
+        },
+        "search": {
+            "description": "Case-insensitive substring search over task title and description. A numeric value also matches the task number. An empty value disables the filter.",
+            "type": "string"
+        },
+        "stage": {
+            "description": "Filter by task run stage",
+            "minLength": 1,
+            "type": "string"
+        },
+        "status": {
+            "description": "Filter tasks by the status of their most recent run.\n\n* `not_started` - not_started\n* `queued` - queued\n* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed\n* `cancelled` - cancelled",
+            "enum": ["not_started", "queued", "in_progress", "completed", "failed", "cancelled"],
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-retrieve.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this task.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-runs-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-runs-list.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "default": 50,
+            "description": "Number of results to return per page.",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+        },
+        "offset": {
+            "default": 0,
+            "description": "The initial index from which to return the results.",
+            "minimum": 0,
+            "type": "number"
+        },
+        "task_id": {
+            "type": "string"
+        }
+    },
+    "required": ["task_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-runs-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-runs-retrieve.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this task run.",
+            "type": "string"
+        },
+        "task_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "task_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-runs-session-logs-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/tasks-runs-session-logs-retrieve.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "after": {
+            "description": "Only return events after this ISO8601 timestamp",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+            "type": "string"
+        },
+        "event_types": {
+            "description": "Comma-separated list of event types to include",
+            "minLength": 1,
+            "type": "string"
+        },
+        "exclude_types": {
+            "description": "Comma-separated list of event types to exclude",
+            "minLength": 1,
+            "type": "string"
+        },
+        "id": {
+            "description": "A UUID string identifying this task run.",
+            "type": "string"
+        },
+        "limit": {
+            "default": 100,
+            "description": "Maximum number of entries to return (default 1000, max 5000)",
+            "maximum": 5000,
+            "minimum": 1,
+            "type": "number"
+        },
+        "offset": {
+            "default": 0,
+            "description": "Zero-based offset into the filtered log entries",
+            "minimum": 0,
+            "type": "number"
+        },
+        "task_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "task_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "archived": {
+            "description": "Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.\n\n* `true` - true\n* `false` - false\n* `all` - all",
+            "enum": ["true", "false", "all"],
+            "type": "string"
+        },
+        "created_by": {
+            "description": "Filter by creator user ID",
+            "type": "number"
+        },
+        "internal": {
+            "description": "When true, list internal tasks instead of user-facing ones. Honored in debug environments or for staff users; ignored for non-staff users in production. Defaults to excluding internal tasks.",
+            "type": "boolean"
+        },
+        "limit": {
+            "default": 50,
+            "description": "Number of results to return per page.",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+        },
+        "offset": {
+            "default": 0,
+            "description": "The initial index from which to return the results.",
+            "minimum": 0,
+            "type": "number"
+        },
+        "organization": {
+            "description": "Filter by repository organization",
+            "minLength": 1,
+            "type": "string"
+        },
+        "origin_product": {
+            "description": "Filter by origin product",
+            "minLength": 1,
+            "type": "string"
+        },
+        "repository": {
+            "description": "Filter by repository name (can include org/repo format)",
+            "minLength": 1,
+            "type": "string"
+        },
+        "search": {
+            "description": "Case-insensitive substring search over task title and description. A numeric value also matches the task number. An empty value disables the filter.",
+            "type": "string"
+        },
+        "stage": {
+            "description": "Filter by task run stage",
+            "minLength": 1,
+            "type": "string"
+        },
+        "status": {
+            "description": "Filter tasks by the status of their most recent run.\n\n* `not_started` - not_started\n* `queued` - queued\n* `in_progress` - in_progress\n* `completed` - completed\n* `failed` - failed\n* `cancelled` - cancelled",
+            "enum": ["not_started", "queued", "in_progress", "completed", "failed", "cancelled"],
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-retrieve.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this task.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-list.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "default": 50,
+            "description": "Number of results to return per page.",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+        },
+        "offset": {
+            "default": 0,
+            "description": "The initial index from which to return the results.",
+            "minimum": 0,
+            "type": "number"
+        },
+        "task_id": {
+            "type": "string"
+        }
+    },
+    "required": ["task_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-retrieve.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this task run.",
+            "type": "string"
+        },
+        "task_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "task_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-session-logs-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-session-logs-retrieve.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "after": {
+            "description": "Only return events after this ISO8601 timestamp",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+            "type": "string"
+        },
+        "event_types": {
+            "description": "Comma-separated list of event types to include",
+            "minLength": 1,
+            "type": "string"
+        },
+        "exclude_types": {
+            "description": "Comma-separated list of event types to exclude",
+            "minLength": 1,
+            "type": "string"
+        },
+        "id": {
+            "description": "A UUID string identifying this task run.",
+            "type": "string"
+        },
+        "limit": {
+            "default": 100,
+            "description": "Maximum number of entries to return (default 100, max 5000)",
+            "maximum": 5000,
+            "minimum": 1,
+            "type": "number"
+        },
+        "offset": {
+            "default": 0,
+            "description": "Zero-based offset into the filtered log entries",
+            "minimum": 0,
+            "type": "number"
+        },
+        "task_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "task_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -705,9 +705,10 @@ describe('Tool Filtering - Feature Flags', () => {
                 'customer-analytics-csp',
                 'notebooks-collaboration',
                 'replay-vision',
+                'tasks',
             ])
         )
-        expect(flags).toHaveLength(9)
+        expect(flags).toHaveLength(10)
     })
 
     // Exercise the real predicate (toolPassesFlagGate) over hand-rolled entries

--- a/services/mcp/tests/unit/tool-schema-snapshots.test.ts
+++ b/services/mcp/tests/unit/tool-schema-snapshots.test.ts
@@ -83,9 +83,9 @@ describe('Tool schema snapshots', () => {
     it('snapshots runtime tool schemas', async () => {
         const shouldUpdateSnapshots = isSnapshotUpdateAll()
         const root = path.resolve(__dirname, '__snapshots__', 'tool-schemas')
-        // Enable flag-gated tools we snapshot here: agent-feedback, tracing (APM spans). Other
+        // Enable flag-gated tools we snapshot here: agent-feedback, tracing (APM spans), tasks. Other
         // flag-gated tools (logs-alerts, visual-review, etc.) stay off to keep the surface stable.
-        const featureFlags = { 'mcp-feedback-tool': true, tracing: true }
+        const featureFlags = { 'mcp-feedback-tool': true, tracing: true, tasks: true }
         const tools = [...(await getToolsFromContext(context, { featureFlags }))].sort((a, b) =>
             a.name.localeCompare(b.name)
         )


### PR DESCRIPTION
## Problem

The Tasks product still has no MCP tool definitions on master, so coding agents cannot read tasks or inspect task runs via the MCP server. This PR ships the read-only surface only — write operations (create / update / run) are intentionally out of scope and tracked in #56013.

## Changes

### Enabled MCP tools (`products/tasks/mcp/tools.yaml`)

| Tool | Operation |
|---|---|
| `tasks-list` | `GET /api/projects/:project_id/tasks/` |
| `tasks-retrieve` | `GET /api/projects/:project_id/tasks/:id/` |
| `tasks-runs-list` | `GET /api/projects/:project_id/tasks/:task_id/runs/` |
| `tasks-runs-retrieve` | `GET /api/projects/:project_id/tasks/:task_id/runs/:id/` |
| `tasks-runs-session-logs-retrieve` | `GET /api/projects/:project_id/tasks/:task_id/runs/:id/session_logs/` |

All require the `task:read` scope; all are flagged `readOnly: true, destructive: false, idempotent: true`. The remaining 34 operations are scaffolded into the YAML as `enabled: false` to keep `--sync-all` idempotent.

### Backend (`products/tasks/backend/`)

- New `TasksPagination` (`LimitOffsetPagination` subclass) that surfaces `default_limit` / `max_limit` / `minimum` in the generated OpenAPI schema, wired into `TaskViewSet` and `TaskRunViewSet`.
- `help_text` on `TaskSerializer.title`, `description`, `origin_product`, and `repository` — these flow into the Zod `.describe()` calls in the generated tool so agents see self-describing parameters.
- Added `"tasks"` to `TaskRunViewSet`'s `@extend_schema(tags=...)` so the MCP scaffolder discovers the nested run operations via `x-explicit-tags`.

### Codegen output

`hogli build:openapi` is idempotent on a second run. Generated diff covers the tasks frontend client, the MCP schema JSON, and the new `services/mcp/src/generated/tasks/api.ts` + `services/mcp/src/tools/generated/tasks.ts`. `products/logs/frontend/generated/api.ts` shrinks by one operation because `tasks_runs_logs_retrieve` now lives under the `tasks` tag.

## How did you test this code?

- `hogli build:openapi` end-to-end — passes, idempotent on re-run, zero drift.
- `pnpm --filter=@posthog/mcp test` — 1302 tests pass, 5 new snapshots written for the new tools. The 9 failing test files are a pre-existing `@shared/guidelines.md` resolution issue on master, unrelated to this PR.
- Tested locally with following testing scenario
```markdown
# PostHog Tasks MCP Tools — Testing Scenarios

  ## 1. List tasks (no filters)

  **Tool:** `tasks-list`
  **Input:** `limit=10, offset=0`
  **Expected:** Paginated list with lightweight metadata
  **Verified:** 29 tasks returned; fields include id, task_number, title, origin_product, repository, internal, timestamps; pagination cursor present (`next` populated)

  ## 2. List tasks with filters

  **Tool:** `tasks-list`
  **Input:** `origin_product=slack`
  **Expected:** Result set narrowed to matching tasks
  **Verified:** Filter accepted; 29 slack-origin tasks returned (every task in this local project originated from slack)

  ## 3. Retrieve a task

  **Tool:** `tasks-retrieve`
  **Input:** `id=f247f9d3-…`
  **Expected:** Full task payload including latest run summary
  **Verified:** Returned slug `HED-28`, description, origin_product=slack, github_integration ref, embedded `latest_run` with status=failed, environment=cloud, state, and a presigned `log_url`

  ## 4. List runs for a task

  **Tool:** `tasks-runs-list`
  **Input:** `task_id=f247f9d3-…`
  **Expected:** Lightweight run metadata, ordered most-recent-first
  **Verified:** 1 run returned with id, status, environment, timestamps — matches `latest_run.id` from scenario 3

  ## 5. Retrieve a single run

  **Tool:** `tasks-runs-retrieve`
  **Input:** `task_id=f247f9d3-…, id=0d943a1e-…`
  **Expected:** Full run detail
  **Verified:** Returned status, environment, error_message=`Activity task failed`, state with `slack_thread_url`, `pr_authorship_mode`, presigned `log_url`, and timestamps

  ## 6. Pull session logs

  **Tool:** `tasks-runs-session-logs-retrieve`
  **Input:** `task_id, id, limit=5, offset=0`
  **Expected:** Session log events
  **Verified:** 5 notification events returned (`_posthog/console`, `_posthog/progress`) with `sessionId` matching the run UUID

  ## 7. Session logs pagination

  **Tool:** `tasks-runs-session-logs-retrieve`
  **Input:** Two calls — `limit=5, offset=0` and `limit=5, offset=5`
  **Expected:** Non-overlapping log slices
  **Verified:** offset=0 returned setup events (`Fetching task details`, `Setting up sandbox`); offset=5 returned later events (`Creating environment from local Docker sandbox image`, …) with strictly later
  timestamps — no overlap

  ## 8. Batch run status check (4 parallel)

  **Tool:** `tasks-runs-retrieve` × 4 (parallel)
  **Expected:** Each call returns its own run's data
  **Verified:** All 4 parallel calls returned distinct `id` matching the requested run UUID; no cross-contamination

  ## 9. Batch session log collection (4 parallel)

  **Tool:** `tasks-runs-session-logs-retrieve` × 4 (parallel)
  **Input:** `limit=3, offset=0` per (task, run) pair
  **Expected:** Each call returns its run's logs without cross-contamination
  **Verified:** Each response's `sessionId` in the notification params matches the requested run UUID

  ## 10. Unknown ID handling

  **Tool:** `tasks-retrieve`
  **Input:** `id=00000000-0000-0000-0000-000000000000`
  **Expected:** Clean 404 surfaced to the MCP client
  **Verified:** `404 Not Found` with structured body `{type: invalid_request, code: not_found, detail: "Not found.", attr: null}` — propagated cleanly, no 500
```

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Authored by Claude Code (Opus 4.7).