### PR TITLE
chore(billing): rebrand platform add-ons to packages in BillingHero

### DIFF
--- a/frontend/src/scenes/billing/BillingHero.tsx
+++ b/frontend/src/scenes/billing/BillingHero.tsx
@@ -63,10 +63,10 @@ const BADGE_CONFIG: Record<BillingPlan | StartupProgramLabel, CopyVariation> = {
                 If you're growing like crazy, you might want to check out our{' '}
                 {scrollToProduct ? (
                     <>
-                        <Link onClick={() => scrollToProduct('platform_and_support')}>Platform add-ons</Link>
+                        <Link onClick={() => scrollToProduct('platform_and_support')}>Platform packages</Link>
                     </>
                 ) : (
-                    'Platform add-ons'
+                    'Platform packages'
                 )}
                 .
             </p>
@@ -122,9 +122,9 @@ const BADGE_CONFIG: Record<BillingPlan | StartupProgramLabel, CopyVariation> = {
             <p>
                 If you're growing like crazy, you might want to check out our{' '}
                 {scrollToProduct ? (
-                    <Link onClick={() => scrollToProduct('platform_and_support')}>Platform add-ons</Link>
+                    <Link onClick={() => scrollToProduct('platform_and_support')}>Platform packages</Link>
                 ) : (
-                    'Platform add-ons'
+                    'Platform packages'
                 )}
                 .
             </p>
@@ -140,9 +140,9 @@ const BADGE_CONFIG: Record<BillingPlan | StartupProgramLabel, CopyVariation> = {
                 <p>
                     If you're growing like crazy, you might want to check out our{' '}
                     {scrollToProduct ? (
-                        <Link onClick={() => scrollToProduct('platform_and_support')}>Platform add-ons</Link>
+                        <Link onClick={() => scrollToProduct('platform_and_support')}>Platform packages</Link>
                     ) : (
-                        'Platform add-ons'
+                        'Platform packages'
                     )}
                     .
                 </p>


### PR DESCRIPTION
## Problem

The "Good call!" callout on the billing/overview page (and the matching Startup and YC callouts) still references "Platform add-ons". The product surface has rebranded add-ons to **packages**, so this copy is out of date for users on the monthly Pay-as-you-go plan.

## Changes

Updated `frontend/src/scenes/billing/BillingHero.tsx` so the three callouts that mention add-ons now read "Platform packages":

- `BillingPlan.Paid` — "If you're growing like crazy, you might want to check out our Platform packages."
- `StartupProgramLabel.Startup` — same copy.
- `StartupProgramLabel.YC` — same copy in the second paragraph.

The link target (`scrollToProduct('platform_and_support')`) is unchanged — only the visible label.

The `BillingPlan.Teams`/`Boost`/`Scale` subtitles still say "with Teams/Boost/Scale add-on" — those refer to specific named add-on products rather than the generic Platform add-ons grouping, so I left them alone. Happy to update those too if the rebrand applies there as well.

## How did you test this code?

I'm an agent and did not run the app manually. The change is a literal copy swap in three sibling configuration entries; no logic or types changed. No automated tests target this exact string.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — this is in-product copy.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) via PostHog Code in response to a Slack ticket asking to update the "Platform add-ons" wording in the Pay-as-you-go callout on `/organization/billing` to reflect the add-ons → packages rebrand.

I extended the change beyond the Pay-as-you-go callout to the Startup and YC variants because all three render the same sentence ("…check out our Platform add-ons.") via separate copy entries in `BADGE_CONFIG`, and leaving two of them stale would partially defeat the rebrand. I did not touch the Teams/Boost/Scale subtitles, which name specific add-on products rather than the generic grouping — flagged in Changes for reviewer confirmation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*