### PR TITLE
fix(data-warehouse): only require prefix when a no-prefix source exists

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1028,14 +1028,14 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             if not is_valid:
                 raise ValidationError(error_message)
 
-            if self.prefix_required(source_type):
-                if not prefix:
+            if not prefix:
+                if self.prefix_required(source_type):
                     return Response(
                         status=status.HTTP_400_BAD_REQUEST,
                         data={"message": "Source type already exists. Prefix is required"},
                     )
-                if self.prefix_exists(source_type, prefix):
-                    return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Prefix already exists"})
+            elif self.prefix_exists(source_type, prefix):
+                return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Prefix already exists"})
 
         if access_method == ExternalDataSource.AccessMethod.WAREHOUSE and is_any_external_data_schema_paused(
             self.team_id
@@ -1514,12 +1514,17 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             )
 
     def prefix_required(self, source_type: str) -> bool:
-        source_type_exists = (
+        # A prefix is only needed when a no-prefix source of the same type already
+        # exists. Two no-prefix sources would write to the same table names; sources
+        # with distinct prefixes (including one no-prefix + N prefixed) have separate
+        # table namespaces and cannot collide.
+        no_prefix_source_exists = (
             ExternalDataSource.objects.exclude(deleted=True)
             .filter(team_id=self.team.pk, source_type=source_type)
+            .filter(Q(prefix__isnull=True) | Q(prefix=""))
             .exists()
         )
-        return source_type_exists
+        return no_prefix_source_exists
 
     def prefix_exists(self, source_type: str, prefix: str) -> bool:
         prefix_exists = (
@@ -1960,14 +1965,14 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
 
             return Response(status=status.HTTP_200_OK)
 
-        if self.prefix_required(source_type):
-            if not prefix:
+        if not prefix:
+            if self.prefix_required(source_type):
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,
                     data={"message": "Source type already exists. Prefix is required"},
                 )
-            elif self.prefix_exists(source_type, prefix):
-                return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Prefix already exists"})
+        elif self.prefix_exists(source_type, prefix):
+            return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Prefix already exists"})
 
         return Response(status=status.HTTP_200_OK)
 

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -580,6 +580,149 @@ class TestExternalDataSource(APIBaseTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"message": "Prefix already exists"})
 
+    def _make_external_data_source(
+        self, source_type: str = "Postgres", prefix: t.Optional[str] = None, deleted: bool = False
+    ) -> ExternalDataSource:
+        return ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            source_type=source_type,
+            created_by=self.user,
+            prefix=prefix,
+            deleted=deleted,
+            job_inputs={},
+        )
+
+    @parameterized.expand(
+        [
+            # (description, existing_sources, requested_prefix, expected_status, expected_message)
+            ("empty team allows no prefix", [], "", 200, None),
+            ("empty team allows any prefix", [], "foo_", 200, None),
+            (
+                "only prefixed sources allow new no-prefix source",
+                [("foo_", False), ("bar_", False)],
+                "",
+                200,
+                None,
+            ),
+            (
+                "only prefixed sources allow new distinct prefix",
+                [("foo_", False)],
+                "baz_",
+                200,
+                None,
+            ),
+            (
+                "duplicate prefix is rejected",
+                [("foo_", False)],
+                "foo_",
+                400,
+                "Prefix already exists",
+            ),
+            (
+                "no-prefix source (null) blocks another no-prefix",
+                [(None, False)],
+                "",
+                400,
+                "Source type already exists. Prefix is required",
+            ),
+            (
+                "no-prefix source (empty string) blocks another no-prefix",
+                [("", False)],
+                "",
+                400,
+                "Source type already exists. Prefix is required",
+            ),
+            (
+                "no-prefix source still allows a prefixed source",
+                [(None, False)],
+                "foo_",
+                200,
+                None,
+            ),
+            (
+                # Regression: GitHub issue #60559
+                "soft-deleted no-prefix source does not block recreation",
+                [(None, True), ("foo_", False), ("bar_", False)],
+                "",
+                200,
+                None,
+            ),
+            (
+                "soft-deleted prefix does not block reuse",
+                [("foo_", True)],
+                "foo_",
+                200,
+                None,
+            ),
+        ]
+    )
+    def test_source_prefix_validation(
+        self,
+        _description: str,
+        existing_sources: list[tuple[t.Optional[str], bool]],
+        requested_prefix: str,
+        expected_status: int,
+        expected_message: t.Optional[str],
+    ) -> None:
+        for prefix, deleted in existing_sources:
+            self._make_external_data_source(source_type="Postgres", prefix=prefix, deleted=deleted)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/source_prefix/",
+            data={"source_type": "Postgres", "prefix": requested_prefix},
+        )
+
+        self.assertEqual(response.status_code, expected_status)
+        if expected_message is not None:
+            self.assertEqual(response.json(), {"message": expected_message})
+
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_can_recreate_no_prefix_source_after_deletion(self, _mock_validate):
+        # Regression for GitHub #60559: deleting the only no-prefix source of a
+        # type must allow recreating one with the same (empty) prefix, even when
+        # other prefixed sources of the same type still exist.
+        self._make_external_data_source(source_type="Stripe", prefix="foo_")
+
+        create_response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/",
+            data={
+                "source_type": "Stripe",
+                "created_via": "web",
+                "payload": {
+                    "auth_method": {"selection": "api_key", "stripe_secret_key": "sk_test_123"},
+                    "schemas": [
+                        {"name": STRIPE_CUSTOMER_RESOURCE_NAME, "should_sync": True, "sync_type": "full_refresh"},
+                    ],
+                },
+            },
+        )
+        self.assertEqual(create_response.status_code, 201, create_response.json())
+        source_id = create_response.json()["id"]
+
+        delete_response = self.client.delete(f"/api/environments/{self.team.pk}/external_data_sources/{source_id}")
+        self.assertEqual(delete_response.status_code, 204)
+
+        recreate_response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/",
+            data={
+                "source_type": "Stripe",
+                "created_via": "web",
+                "payload": {
+                    "auth_method": {"selection": "api_key", "stripe_secret_key": "sk_test_123"},
+                    "schemas": [
+                        {"name": STRIPE_CUSTOMER_RESOURCE_NAME, "should_sync": True, "sync_type": "full_refresh"},
+                    ],
+                },
+            },
+        )
+        self.assertEqual(recreate_response.status_code, 201, recreate_response.json())
+
     @patch(
         "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
         return_value=(True, None),


### PR DESCRIPTION
## Problem

Closes #60559

When a team has at least one non-deleted data warehouse source of a given type, the create flow required a prefix on every new source of that type, even if every existing source already had a distinct prefix. The check is broader than the table-name collision constraint it appears to be protecting: a no-prefix source plus any number of prefixed sources of the same type have separate table namespaces (`build_table_name` uses `{prefix or ''}{source_type}_{schema_name}`) and cannot collide.

The user-visible bug from #60559: a customer deleted their only no-prefix Postgres source and could not re-add one with the same (empty) prefix while their other prefixed Postgres sources still existed. Their dashboard queries referenced the un-prefixed table names and broke when they were forced to use a `temp_` prefix as a workaround.

## Changes

- `prefix_required(source_type)` now returns `True` only when a non-deleted *no-prefix* source of the same type already exists (the only collision risk for a new no-prefix source). Handles both `prefix IS NULL` and `prefix = ''` since the field is `CharField(null=True, blank=True)`.
- Restructured the two call sites (`create` and the `source_prefix` validation action) so the prefix-uniqueness check (`prefix_exists`) runs independently of `prefix_required`. Before, `prefix_exists` was nested inside the `prefix_required` branch — fine when `prefix_required` returned `True` for any source-type match, broken under the new narrower semantics.

Behavior matrix after the change:

| Existing sources of this type | Requested prefix | Outcome |
|---|---|---|
| none | any | allowed |
| only prefixed | new prefix | allowed |
| only prefixed | duplicate prefix | rejected (`Prefix already exists`) |
| only prefixed | empty | allowed (new behavior — fix for #60559) |
| one no-prefix exists | empty | rejected (`Source type already exists. Prefix is required`) |
| one no-prefix exists | new prefix | allowed |
| soft-deleted only | any | allowed |

## Open question for reviewer

The previous behavior could be read two ways:

1. **Oversight** — the check is broader than the actual collision constraint, and this PR aligns the two.
2. **Deliberate UX nudge** — "once you have multiple sources of a type, force users to explicitly pick a prefix for each new one for clarity in source lists, dashboard queries, etc."

If (2) was the intent, a smaller fix would be to keep the validation as-is and just improve the error message to name the conflicting sources, then handle one-off cases like #60559 via manual DB intervention. I went with (1) because nothing in the code or original commit (#19009, Dec 2023) documents intent (2), and the customer's existing 5-source configuration shows the system functionally supports the mixed state. Happy to switch to the smaller fix if you'd prefer.

## How did you test this code?

I am an agent (Claude Code, Opus 4.7). I have not performed manual UI testing.

- Added `test_source_prefix_validation` — a parameterized test over the matrix above (10 cases) hitting the `/source_prefix/` validation endpoint with pre-seeded sources.
- Added `test_can_recreate_no_prefix_source_after_deletion` — end-to-end test mirroring the customer scenario: create a no-prefix Stripe source alongside a prefixed one, delete the no-prefix one through the API, then recreate it. Without this fix it returns 400; with the fix it returns 201.
- Ran `hogli test products/data_warehouse/backend/api/test/test_external_data_source.py -k "prefix or recreate"` locally — 19 tests passed, including the existing `test_prefix_external_data_source` and the new tests above.

Manual verification steps for a reviewer:

1. In a team with one or more prefixed Postgres sources but no un-prefixed Postgres source, open the "Add source → Postgres" wizard.
2. Leave the prefix field empty and submit. It should now succeed; before this change it returned `Source type already exists. Prefix is required`.
3. In the same team, try to add a second un-prefixed Postgres source. It should still be rejected with the same message.
4. Try to add a Postgres source with a prefix that another existing Postgres source already uses. It should still be rejected with `Prefix already exists`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) during a customer support investigation triggered by GitHub issue #60559.

- Tracing the validation back to `prefix_required` and the customer's actual warehouse state (5 Postgres sources, 4 of them prefixed) made it clear this was a logic gap, not a soft-delete bug. The earlier hypothesis that `cleanup_cdc_resources_on_deletion` could roll back the soft-delete was ruled out — for non-CDC Postgres sources, that path is a no-op, and even for CDC sources the cleanup calls are wrapped in their own try/except so they can't propagate into the surrounding `transaction.atomic()`.
- The narrowest correct fix is "two no-prefix sources of the same type would collide; nothing else collides at the table-name level". Implemented as a single `Q(prefix__isnull=True) | Q(prefix="")` filter in `prefix_required` plus restructuring the two callers so `prefix_exists` is no longer gated on `prefix_required`.
- Re-verified the fix doesn't introduce table-name collisions (the formula in `helpers.py:64` produces distinct names for no-prefix vs prefixed sources of the same type) and that the update path can't sneak a no-prefix source past the create gate (`update()` forces `validated_data["prefix"] = instance.prefix` on non-direct-Postgres sources).
- Ran the `improving-drf-endpoints` skill — no serializer or `@extend_schema` changes needed since this only modifies the body of an existing helper method and the conditional structure in two viewset actions that already have schema annotations.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
