### PR TITLE
chore(slack_app): deprecate posthog-code-slack-billing-gate patch

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -266,18 +266,20 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             # case (see products/slack_app/backend/api.py); this is the defense in
             # depth that also covers replays, manual workflow starts, and the race
             # where the webhook saw "not limited" but Redis flipped before we got
-            # here. Wrapped in `workflow.patched` so in-flight workflows from
-            # before this deploy stay deterministic on replay.
-            if workflow.patched("posthog-code-slack-billing-gate"):
-                blocked = await _execute_posthog_code_activity(
-                    enforce_posthog_code_billing_quota_activity,
-                    inputs,
-                    channel,
-                    thread_ts,
-                    slack_user_id,
-                )
-                if blocked:
-                    return
+            # here. The patch marker is preserved via `deprecate_patch` so any
+            # straggler workflow that recorded the pre-patch path on its first
+            # task can still replay deterministically on the post-deprecation
+            # worker. Drop the `deprecate_patch` call once the next drain completes.
+            workflow.deprecate_patch("posthog-code-slack-billing-gate")
+            blocked = await _execute_posthog_code_activity(
+                enforce_posthog_code_billing_quota_activity,
+                inputs,
+                channel,
+                thread_ts,
+                slack_user_id,
+            )
+            if blocked:
+                return
 
             followup_handled = await _execute_posthog_code_activity(
                 forward_posthog_code_followup_activity,


### PR DESCRIPTION
## Problem

`PostHogCodeSlackMentionWorkflow.run` gates the AI-credits quota check behind `workflow.patched("posthog-code-slack-billing-gate")` so workflows started before the gate was deployed continued to skip it on replay. Pre-patch workflows have drained, so the gate's conditional path no longer serves a purpose — the branch only adds replay-history noise and a future foot-gun (next time someone reads this, the comment claims "in-flight workflows" that no longer exist).

## Changes

Standard two-step Temporal patch lifecycle, step 1: replace `if workflow.patched("posthog-code-slack-billing-gate"):` with a top-level `workflow.deprecate_patch("posthog-code-slack-billing-gate")` and run the quota gate unconditionally. The deprecation marker keeps replay deterministic for any straggler workflow that recorded the pre-patch path on its first task. A follow-up PR will drop the `deprecate_patch` call after the next full drain (per the precedent in `products/tasks/backend/temporal/process_task/workflow.py:107`).

## How did you test this code?

Agent-authored; I am Claude (Opus 4.7). No manual deploy verification.

Ran the related Temporal/Slack-app suites locally:

```
pytest posthog/temporal/tests/ai/test_module_integrity.py \
       posthog/temporal/tests/ai/test_block_missing_user_github.py \
       products/slack_app/backend/tests/test_followup_forwarding.py \
       products/slack_app/backend/tests/test_guess_repository.py
```

111 tests pass. One pre-existing failure (`test_cap_reached_truncates_and_warns`) is a structlog/caplog wiring issue in code I didn't touch — reproduces on master and is unrelated.

No test mocks `workflow.patched("posthog-code-slack-billing-gate")` directly, so they were already exercising the post-patch path; the switch to `deprecate_patch` doesn't change observable behavior under the test worker.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — internal workflow lifecycle hygiene.

## 🤖 Agent context

Authored by Claude (Opus 4.7) inside Claude Code. Followed the two-step Temporal patch lifecycle documented at `products/tasks/backend/temporal/process_task/workflow.py:99-110` (the only prior `deprecate_patch` precedent in the repo) — step 1 here, step 2 (deleting the marker) is a follow-up after the next drain. The comment around the patch was rewritten to describe the post-deprecation invariant rather than the rollout context that no longer applies.
