### PR TITLE
feat(logs): mirror visible log rows as a window on the sparkline

### DIFF
--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -74,6 +74,13 @@ export interface SparklineProps {
     referenceLines?: SparklineReferenceLine[]
     /** Format the per-series tooltip value. Defaults to `humanFriendlyNumber`. */
     renderTooltipValue?: (value: number) => string
+    /**
+     * Inclusive label-index range to highlight as a translucent box behind the bars.
+     * Used to mirror an external selection (e.g. the rows currently visible in a
+     * paired virtualized list) onto the chart. Out-of-range or inverted ranges are
+     * clamped; pass `null`/`undefined` to clear.
+     */
+    highlightedRange?: { startIndex: number; endIndex: number } | null
 }
 
 export function Sparkline({
@@ -96,6 +103,7 @@ export function Sparkline({
     sortTooltipByCount = false,
     referenceLines,
     renderTooltipValue,
+    highlightedRange,
 }: SparklineProps): JSX.Element {
     const tooltipRef = useRef<HTMLDivElement | null>(null)
 
@@ -242,43 +250,61 @@ export function Sparkline({
                                 setTooltip({ ...tooltip } as TooltipModel<'bar'>)
                             },
                         },
-                        ...(referenceLines && referenceLines.length > 0
-                            ? {
-                                  annotation: {
-                                      annotations: Object.fromEntries(
-                                          referenceLines.map((line, i) => {
-                                              const lineColor = getColorVar(line.color || 'danger')
-                                              return [
-                                                  `referenceLine${i}`,
-                                                  {
-                                                      type: 'line',
-                                                      yMin: line.value,
-                                                      yMax: line.value,
-                                                      borderColor: lineColor,
-                                                      borderWidth: 1.5,
-                                                      borderDash: [5, 4],
-                                                      ...(line.label
-                                                          ? {
-                                                                label: {
-                                                                    display: true,
-                                                                    content: line.label,
-                                                                    position: line.labelPosition || 'end',
-                                                                    font: { size: 9 },
-                                                                    color: lineColor,
-                                                                    backgroundColor: 'transparent',
-                                                                    // Sit the label just above the line so it doesn't render on top of it.
-                                                                    // The 20% y-axis headroom set above guarantees it stays inside the chart.
-                                                                    yAdjust: -8,
-                                                                },
-                                                            }
-                                                          : {}),
+                        ...(() => {
+                            const annotations: Record<string, any> = {}
+
+                            if (referenceLines && referenceLines.length > 0) {
+                                referenceLines.forEach((line, i) => {
+                                    const lineColor = getColorVar(line.color || 'danger')
+                                    annotations[`referenceLine${i}`] = {
+                                        type: 'line',
+                                        yMin: line.value,
+                                        yMax: line.value,
+                                        borderColor: lineColor,
+                                        borderWidth: 1.5,
+                                        borderDash: [5, 4],
+                                        ...(line.label
+                                            ? {
+                                                  label: {
+                                                      display: true,
+                                                      content: line.label,
+                                                      position: line.labelPosition || 'end',
+                                                      font: { size: 9 },
+                                                      color: lineColor,
+                                                      backgroundColor: 'transparent',
+                                                      // Sit the label just above the line so it doesn't render on top of it.
+                                                      // The 20% y-axis headroom set above guarantees it stays inside the chart.
+                                                      yAdjust: -8,
                                                   },
-                                              ]
-                                          })
-                                      ),
-                                  },
-                              }
-                            : {}),
+                                              }
+                                            : {}),
+                                    }
+                                })
+                            }
+
+                            if (highlightedRange && labels && labels.length > 0) {
+                                const lastIdx = labels.length - 1
+                                const lo = Math.max(0, Math.min(highlightedRange.startIndex, highlightedRange.endIndex))
+                                const hi = Math.min(
+                                    lastIdx,
+                                    Math.max(highlightedRange.startIndex, highlightedRange.endIndex)
+                                )
+                                if (lo <= hi) {
+                                    annotations.highlightedRange = {
+                                        type: 'box',
+                                        xMin: labels[lo],
+                                        xMax: labels[hi],
+                                        // Drawn under the bars so the data stays legible.
+                                        drawTime: 'beforeDatasetsDraw',
+                                        backgroundColor: 'rgba(0, 0, 0, 0.06)',
+                                        borderColor: 'rgba(0, 0, 0, 0.2)',
+                                        borderWidth: 1,
+                                    }
+                                }
+                            }
+
+                            return Object.keys(annotations).length > 0 ? { annotation: { annotations } } : {}
+                        })(),
                     },
                     maintainAspectRatio: false,
                     interaction: {
@@ -289,7 +315,18 @@ export function Sparkline({
                 },
             }
         },
-        deps: [labels, adjustedData, withXScale, withYScale, renderLabel, data, maximumIndicator, type, referenceLines],
+        deps: [
+            labels,
+            adjustedData,
+            withXScale,
+            withYScale,
+            renderLabel,
+            data,
+            maximumIndicator,
+            type,
+            referenceLines,
+            highlightedRange,
+        ],
     })
 
     const dataPointCount = adjustedData[0]?.values?.length || 0

--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -9,7 +9,7 @@ import { getColorVar } from 'lib/colors'
 import { useChart } from 'lib/hooks/useChart'
 import { useEventListener } from 'lib/hooks/useEventListener'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
-import { humanFriendlyNumber } from 'lib/utils'
+import { hexToRGBA, humanFriendlyNumber } from 'lib/utils'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 
 import { LemonSkeleton } from '../lemon-ui/LemonSkeleton'
@@ -290,14 +290,22 @@ export function Sparkline({
                                     Math.max(highlightedRange.startIndex, highlightedRange.endIndex)
                                 )
                                 if (lo <= hi) {
+                                    // Match the cursor-row highlight hue (`--primary-highlight`):
+                                    // orange in light mode, amber in dark. Read the concrete
+                                    // per-theme token since the semantic var is a nested `var()`
+                                    // that doesn't resolve off-DOM (e.g. on the chart canvas).
+                                    const isDark = document.body.getAttribute('theme') === 'dark'
+                                    const primary = getColorVar(isDark ? 'primary-3000-dark' : 'primary-3000-light')
                                     annotations.highlightedRange = {
                                         type: 'box',
                                         xMin: labels[lo],
-                                        xMax: labels[hi],
+                                        // Extend to the next bucket's start so the last bar is fully enclosed.
+                                        xMax: labels[hi + 1] ?? labels[hi],
                                         // Drawn under the bars so the data stays legible.
                                         drawTime: 'beforeDatasetsDraw',
-                                        backgroundColor: 'rgba(0, 0, 0, 0.06)',
-                                        borderColor: 'rgba(0, 0, 0, 0.2)',
+                                        // 10% fill mirrors the cursor row; a stronger border marks the window edges.
+                                        backgroundColor: hexToRGBA(primary, 0.1),
+                                        borderColor: hexToRGBA(primary, 0.8),
                                         borderWidth: 1,
                                     }
                                 }

--- a/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
@@ -10,9 +10,9 @@ import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { shortTimeZone } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 
-import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
-
 import { DateRange, LogsSparklineBreakdownBy } from '~/queries/schema/schema-general'
+
+import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 
 export interface LogsSparklineData {
     data: {

--- a/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
@@ -1,3 +1,4 @@
+import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { IconChevronDown } from '@posthog/icons'
@@ -8,6 +9,8 @@ import { dayjs } from 'lib/dayjs'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { shortTimeZone } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
+
+import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 
 import { DateRange, LogsSparklineBreakdownBy } from '~/queries/schema/schema-general'
 
@@ -106,6 +109,40 @@ export function LogsSparkline({
         return sparklineData.dates.map((date) => dayjs(date).toISOString())
     }, [sparklineData.dates])
 
+    const { visibleRowDateRange } = useValues(logsViewerLogic)
+
+    // Map the visible-row date range onto bucket indices in `dates`. Buckets are
+    // anchored at their start time; the date_to range edge belongs to the bucket
+    // whose start is the last one <= date_to.
+    const highlightedRange = useMemo(() => {
+        if (!visibleRowDateRange || sparklineData.dates.length === 0) {
+            return null
+        }
+        const fromMs = dayjs(visibleRowDateRange.date_from).valueOf()
+        const toMs = dayjs(visibleRowDateRange.date_to).valueOf()
+        let startIndex = -1
+        let endIndex = -1
+        for (let i = 0; i < sparklineData.dates.length; i++) {
+            const bucketMs = dayjs(sparklineData.dates[i]).valueOf()
+            if (bucketMs <= fromMs) {
+                startIndex = i
+            }
+            if (bucketMs <= toMs) {
+                endIndex = i
+            } else {
+                break
+            }
+        }
+        // Fall back to the first bucket when the range starts before any bucket.
+        if (startIndex === -1) {
+            startIndex = 0
+        }
+        if (endIndex === -1 || endIndex < startIndex) {
+            return null
+        }
+        return { startIndex, endIndex }
+    }, [visibleRowDateRange, sparklineData.dates])
+
     const onSelectionChange = useCallback(
         (selection: { startIndex: number; endIndex: number }): void => {
             const dates = sparklineData.dates
@@ -159,6 +196,7 @@ export function LogsSparkline({
                             tooltipRowCutoff={100}
                             hideZerosInTooltip
                             sortTooltipByCount
+                            highlightedRange={highlightedRange}
                         />
                     ) : !sparklineLoading ? (
                         <div className="h-full text-muted flex items-center justify-center">

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -781,4 +781,61 @@ describe('logsViewerLogic', () => {
             expect(logic.values.prettifiedLogIds.size).toBe(0)
         })
     })
+
+    describe('visible row range tracking', () => {
+        const rawLogsWithTimestamps: LogMessage[] = [
+            { ...createMockRawLog('log-1'), timestamp: '2024-01-01T00:00:00Z' },
+            { ...createMockRawLog('log-2'), timestamp: '2024-01-01T01:00:00Z' },
+            { ...createMockRawLog('log-3'), timestamp: '2024-01-01T02:00:00Z' },
+            { ...createMockRawLog('log-4'), timestamp: '2024-01-01T03:00:00Z' },
+        ]
+
+        beforeEach(() => {
+            ;({ logic } = mountWithLogs(rawLogsWithTimestamps))
+        })
+
+        it('defaults to null', () => {
+            expect(logic.values.visibleRowRange).toBeNull()
+            expect(logic.values.visibleRowDateRange).toBeNull()
+        })
+
+        it('records the visible row index range', () => {
+            logic.actions.setVisibleRowRange(1, 2)
+            expect(logic.values.visibleRowRange).toEqual({ startIndex: 1, stopIndex: 2 })
+        })
+
+        it('derives a date range ordered from earliest to latest', () => {
+            // The viewer renders rows 1..2; logs[1] is at 01:00, logs[2] at 02:00.
+            logic.actions.setVisibleRowRange(1, 2)
+            expect(logic.values.visibleRowDateRange).toEqual({
+                date_from: '2024-01-01T01:00:00.000Z',
+                date_to: '2024-01-01T02:00:00.000Z',
+            })
+        })
+
+        it('orders the date range earliest-first even when logs are sorted descending', () => {
+            // Simulate "latest first" — startIndex points at a later timestamp than stopIndex.
+            logic.actions.setLogs([...rawLogsWithTimestamps].reverse())
+            logic.actions.setVisibleRowRange(0, 1)
+            const range = logic.values.visibleRowDateRange
+            expect(range).not.toBeNull()
+            expect(new Date(range!.date_from).getTime()).toBeLessThan(new Date(range!.date_to).getTime())
+        })
+
+        it('clamps indices that fall outside the loaded logs', () => {
+            logic.actions.setVisibleRowRange(0, 999)
+            expect(logic.values.visibleRowDateRange).toEqual({
+                date_from: '2024-01-01T00:00:00.000Z',
+                date_to: '2024-01-01T03:00:00.000Z',
+            })
+        })
+
+        it('clears when logs are replaced', () => {
+            logic.actions.setVisibleRowRange(0, 2)
+            expect(logic.values.visibleRowRange).not.toBeNull()
+            logic.actions.setLogs([createMockRawLog('new-log')])
+            expect(logic.values.visibleRowRange).toBeNull()
+            expect(logic.values.visibleRowDateRange).toBeNull()
+        })
+    })
 })

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -804,22 +804,32 @@ describe('logsViewerLogic', () => {
             expect(logic.values.visibleRowRange).toEqual({ startIndex: 1, stopIndex: 2 })
         })
 
-        it('derives a date range ordered from earliest to latest', () => {
-            // The viewer renders rows 1..2; logs[1] is at 01:00, logs[2] at 02:00.
-            logic.actions.setVisibleRowRange(1, 2)
-            expect(logic.values.visibleRowDateRange).toEqual({
-                date_from: '2024-01-01T01:00:00.000Z',
-                date_to: '2024-01-01T02:00:00.000Z',
-            })
-        })
-
-        it('orders the date range earliest-first even when logs are sorted descending', () => {
-            // Simulate "latest first" — startIndex points at a later timestamp than stopIndex.
-            logic.actions.setLogs([...rawLogsWithTimestamps].reverse())
-            logic.actions.setVisibleRowRange(0, 1)
-            const range = logic.values.visibleRowDateRange
-            expect(range).not.toBeNull()
-            expect(new Date(range!.date_from).getTime()).toBeLessThan(new Date(range!.date_to).getTime())
+        it.each([
+            {
+                name: 'ascending logs',
+                reverseLogs: false,
+                range: [1, 2] as const,
+                expected: { date_from: '2024-01-01T01:00:00.000Z', date_to: '2024-01-01T02:00:00.000Z' },
+            },
+            {
+                // "Latest first" — startIndex points at a later timestamp than stopIndex.
+                name: 'descending logs',
+                reverseLogs: true,
+                range: [0, 1] as const,
+                expected: { date_from: '2024-01-01T02:00:00.000Z', date_to: '2024-01-01T03:00:00.000Z' },
+            },
+            {
+                name: 'single-row range',
+                reverseLogs: false,
+                range: [2, 2] as const,
+                expected: { date_from: '2024-01-01T02:00:00.000Z', date_to: '2024-01-01T02:00:00.000Z' },
+            },
+        ])('derives a date range ordered earliest-first ($name)', ({ reverseLogs, range, expected }) => {
+            if (reverseLogs) {
+                logic.actions.setLogs([...rawLogsWithTimestamps].reverse())
+            }
+            logic.actions.setVisibleRowRange(range[0], range[1])
+            expect(logic.values.visibleRowDateRange).toEqual(expected)
         })
 
         it('clamps indices that fall outside the loaded logs', () => {

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -376,10 +376,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         // of `orderBy`.
         visibleRowDateRange: [
             (state) => [state.visibleRowRange, state.logs],
-            (
-                visibleRowRange: VisibleRowRange | null,
-                logs: ParsedLogMessage[]
-            ): VisibleLogsTimeRange | null => {
+            (visibleRowRange: VisibleRowRange | null, logs: ParsedLogMessage[]): VisibleLogsTimeRange | null => {
                 if (!visibleRowRange || logs.length === 0) {
                     return null
                 }

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -27,6 +27,11 @@ export interface VisibleLogsTimeRange {
     date_to: string
 }
 
+export interface VisibleRowRange {
+    startIndex: number
+    stopIndex: number
+}
+
 export type LogCursor = number | null
 
 export interface LogsViewerLogicProps {
@@ -134,6 +139,10 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
 
         // Per-row prettify
         togglePrettifyLog: (logId: string) => ({ logId }),
+
+        // Scroll position in the virtualized list (the range of rows currently in
+        // the viewport). Drives the brush overlay on the sparkline.
+        setVisibleRowRange: (startIndex: number, stopIndex: number) => ({ startIndex, stopIndex }),
     }),
 
     reducers(() => ({
@@ -308,6 +317,15 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
                 setLogs: () => new Set<string>(),
             },
         ],
+
+        visibleRowRange: [
+            null as VisibleRowRange | null,
+            {
+                setVisibleRowRange: (_, { startIndex, stopIndex }) => ({ startIndex, stopIndex }),
+                clearLogs: () => null,
+                setLogs: () => null,
+            },
+        ],
     })),
 
     selectors({
@@ -348,6 +366,36 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
                 return {
                     date_from: dayjs(firstTimestamp).toISOString(),
                     date_to: dayjs(lastTimestamp).add(1, 'millisecond').toISOString(),
+                }
+            },
+        ],
+
+        // Date range covered by the currently-visible (scrolled-into-view) rows.
+        // Returns null when no rows are rendered or the indices don't line up with
+        // loaded logs. The values are always ordered date_from <= date_to regardless
+        // of `orderBy`.
+        visibleRowDateRange: [
+            (state) => [state.visibleRowRange, state.logs],
+            (
+                visibleRowRange: VisibleRowRange | null,
+                logs: ParsedLogMessage[]
+            ): VisibleLogsTimeRange | null => {
+                if (!visibleRowRange || logs.length === 0) {
+                    return null
+                }
+                const startIndex = Math.max(0, Math.min(visibleRowRange.startIndex, logs.length - 1))
+                const stopIndex = Math.max(0, Math.min(visibleRowRange.stopIndex, logs.length - 1))
+                const a = logs[startIndex]?.timestamp
+                const b = logs[stopIndex]?.timestamp
+                if (!a || !b) {
+                    return null
+                }
+                const ta = dayjs(a)
+                const tb = dayjs(b)
+                const [earlier, later] = ta.isBefore(tb) ? [ta, tb] : [tb, ta]
+                return {
+                    date_from: earlier.toISOString(),
+                    date_to: later.toISOString(),
                 }
             },
         ],

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -167,6 +167,7 @@ export function VirtualizedLogsList({
         selectLogRange,
         togglePrettifyLog,
         setFocused,
+        setVisibleRowRange,
     } = useActions(logsViewerLogic)
     const { openLogDetails } = useActions(logDetailsModalLogic)
 
@@ -242,9 +243,13 @@ export function VirtualizedLogsList({
         }
     }, [disableCursor, scrollToCursorRequest, cursorIndex, listRef])
 
+    // Tracks the last range we dispatched so we don't fire setVisibleRowRange on
+    // every overscan tick when nothing actually changed.
+    const lastVisibleRangeRef = useRef<{ startIndex: number; stopIndex: number } | null>(null)
+
     const handleRowsRendered = useCallback(
         (
-            _visibleRows: { startIndex: number; stopIndex: number },
+            visibleRows: { startIndex: number; stopIndex: number },
             allRows: { startIndex: number; stopIndex: number }
         ): void => {
             if (
@@ -253,8 +258,22 @@ export function VirtualizedLogsList({
             ) {
                 onLoadMore?.()
             }
+
+            const prev = lastVisibleRangeRef.current
+            if (!prev || prev.startIndex !== visibleRows.startIndex || prev.stopIndex !== visibleRows.stopIndex) {
+                lastVisibleRangeRef.current = { startIndex: visibleRows.startIndex, stopIndex: visibleRows.stopIndex }
+                setVisibleRowRange(visibleRows.startIndex, visibleRows.stopIndex)
+            }
         },
-        [disableInfiniteScroll, shouldLoadMore, dataSource.length, hasMoreLogsToLoad, loading, onLoadMore]
+        [
+            disableInfiniteScroll,
+            shouldLoadMore,
+            dataSource.length,
+            hasMoreLogsToLoad,
+            loading,
+            onLoadMore,
+            setVisibleRowRange,
+        ]
     )
 
     const handleLogRowClick = useCallback(


### PR DESCRIPTION
## Problem

When scrolling the virtualized logs list, there's no visual indication on the sparkline of which slice of time the user is looking at. A customer asked for the bar chart to show "what log I'm actually hovering over." This PR is the first of two steps: it mirrors the **rows currently scrolled into view** as a translucent window on the sparkline. A follow-up will do the inverse — hovering a bucket on the sparkline will highlight the matching rows.

## Changes  
![2026-05-29 15.50.36.gif](https://app.graphite.com/user-attachments/assets/2fce01ea-88a9-4803-a723-09329384f192.gif)



- `logsViewerLogic`
    - new `setVisibleRowRange(startIndex, stopIndex)` action and `visibleRowRange` reducer (resets on `clearLogs` / `setLogs`)
    - new `visibleRowDateRange` selector that derives an ordered `{ date_from, date_to }` from the visible row indices, independent of `orderBy` (so it works for both "latest first" and "oldest first")
- `VirtualizedLogsList`
    - the main list dispatches `setVisibleRowRange` from the existing `onRowsRendered` callback
    - ref-guarded so overscan re-ticks with unchanged indices don't fire actions
    - the pinned list never set `onRowsRendered`, so it remains a no-op there — no leakage between the two list instances
- `Sparkline` (shared component)
    - new optional `highlightedRange?: { startIndex: number; endIndex: number } | null` prop
    - rendered as a translucent `box` annotation drawn _behind_ the bars (`drawTime: 'beforeDatasetsDraw'`) via the already-registered `chartjs-plugin-annotation`
    - merges cleanly with `referenceLines` rather than replacing the annotations block
- `LogsSparkline`
    - reads `visibleRowDateRange` from kea
    - maps the timestamps onto bucket indices in `sparklineData.dates`, clamping ranges that fall outside loaded buckets
    - passes the result through to `Sparkline`

### Why this shape

Two alternatives I considered and rejected:

1. **Index-based positioning on the box annotation** (`xMin: startIndex - 0.5, xMax: endIndex + 0.5`). Clean for category axes, but the logs sparkline uses a `timeseries` x-axis, where annotation `xMin`/`xMax` are interpreted as time values. Using the labels' ISO date strings is the path that respects how the chart is actually configured.
2. **HTML overlay positioned in percent** (purely inside `LogsSparkline`, no `Sparkline` API change). Would have been ~10 fewer lines but the y-axis tick area on the left and right padding mean a percent-based overlay drifts by several pixels relative to the bars. Going through the annotation plugin gets pixel-correct alignment for free.

## How did you test this code?

I'm an agent. Manual UI verification has not been done — please pull and confirm the window tracks the scroll position as expected.

Automated tests added in `logsViewerLogic.test.ts`:

- default state (`visibleRowRange` and `visibleRowDateRange` are `null`)
- `setVisibleRowRange` records the index range
- `visibleRowDateRange` derives an ordered date range from the visible row timestamps
- the derived range is earliest-first even when logs are sorted descending
- out-of-bounds indices are clamped to the loaded log range
- both reducer and selector reset when logs are replaced (`setLogs`)

Frontend typecheck and lint pass cleanly on the four files touched.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — internal UX refinement, no API surface change.

## 🤖 Agent context

Authored end-to-end by an agent (Claude Opus 4.7 via PostHog Code), at Jon McCallum's direction. Original ask came from Paul at cubic.dev. The agent proposed a two-step plan (viewer→sparkline window first, then sparkline→viewer hover) and Jon picked the first step to ship in isolation. Decisions made along the way:

- chose to extend the shared `Sparkline` component with a `highlightedRange` prop rather than fork it or render a logs-specific HTML overlay, because the chart's existing annotation plugin gives pixel-correct alignment for free and keeps the API generic enough that other call sites (alerts, web analytics) could reuse it later
- chose to dispatch from the main list only by leveraging the fact that the pinned list doesn't pass `onRowsRendered` — explicit `disableVisibleRangeTracking` prop felt like ceremony for a behavior that's already implicit
- ref-guarded the dispatch to avoid action spam during overscan re-ticks; kea reducers would coalesce identical state, but the action still fires and burns work in middleware

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)