### PR TITLE
fix(traces): give traces ingestion its own rate-limiter key and wire TRACES_LIMITER_* config

### DIFF
--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -1045,6 +1045,9 @@ describe('LogsIngestionConsumer', () => {
             hub.LOGS_LIMITER_REFILL_RATE_KB_PER_SECOND = 0.001
             hub.LOGS_LIMITER_TTL_SECONDS = 3600
 
+            await consumer.stop()
+            consumer = await createLogsIngestionConsumer(hub)
+
             const messages = [
                 ...(await createKafkaMessages([createLogMessage()], {
                     token: team.api_token,

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -1610,11 +1610,11 @@ describe('LogsIngestionConsumer', () => {
     })
 
     describe('TracesIngestionConsumer billing identity', () => {
-        const createTracesIngestionConsumer = (): TracesIngestionConsumer => {
+        const createTracesIngestionConsumer = (configOverrides: Record<string, any> = {}): TracesIngestionConsumer => {
             const tracesConsumer = new TracesIngestionConsumer(
                 // Blank the traces Redis host so it reuses the hub's pool (like the logs-consumer tests),
                 // avoiding a second eager pool that would keep handles open after the suite.
-                { ...hub, ...getDefaultTracesIngestionConsumerConfig(), TRACES_REDIS_HOST: '' },
+                { ...hub, ...getDefaultTracesIngestionConsumerConfig(), TRACES_REDIS_HOST: '', ...configOverrides },
                 {
                     ...hub,
                     outputs: new IngestionOutputs<AppMetricsOutput | LogsOutput | LogsDlqOutput>({
@@ -1673,6 +1673,25 @@ describe('LogsIngestionConsumer', () => {
             await tracesConsumer['filterQuotaLimitedMessages'](parsed)
 
             expect(hub.quotaLimiting.isTeamTokenQuotaLimited).toHaveBeenCalledWith(team.api_token, 'traces_mb_ingested')
+        })
+
+        it('rate-limits against its own Redis key namespace, not the logs one', () => {
+            const tracesConsumer = createTracesIngestionConsumer()
+            const prefix = tracesConsumer['rateLimiter']['rateLimiter'].getKeyPrefix()
+
+            expect(prefix).toBe('@posthog-test/traces-rate-limiter/tokens')
+            expect(prefix).not.toContain('logs-rate-limiter')
+        })
+
+        it('applies TRACES_LIMITER_* tuning rather than the logs limiter config', () => {
+            const tracesConsumer = createTracesIngestionConsumer({
+                TRACES_LIMITER_BUCKET_SIZE_KB: 42,
+                TRACES_LIMITER_REFILL_RATE_KB_PER_SECOND: 7,
+            })
+            const limiterConfig = tracesConsumer['rateLimiter']['config']
+
+            expect(limiterConfig.LOGS_LIMITER_BUCKET_SIZE_KB).toBe(42)
+            expect(limiterConfig.LOGS_LIMITER_REFILL_RATE_KB_PER_SECOND).toBe(7)
         })
     })
 })

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -152,35 +152,41 @@ export class LogsIngestionConsumer {
     constructor(
         config: LogsIngestionConsumerConfig,
         private deps: LogsIngestionConsumerDeps,
-        overrides: Partial<LogsIngestionConsumerConfig> = {}
+        overrides: Partial<LogsIngestionConsumerConfig> = {},
+        // Redis key namespace for the token-bucket rate limiter. Subclasses (e.g. traces) pass
+        // their own so their per-team buckets don't share state with logs. Defaults to logs.
+        rateLimiterName: string = 'logs-rate-limiter'
     ) {
+        // Merge overrides once so every downstream consumer reads the same effective config —
+        // a per-use-site `overrides.X ?? config.X` pattern is easy to forget (the rate limiter did).
+        const mergedConfig = { ...config, ...overrides }
+
         // The group and topic are configurable allowing for multiple ingestion consumers to be run in parallel
-        this.groupId = overrides.LOGS_INGESTION_CONSUMER_GROUP_ID ?? config.LOGS_INGESTION_CONSUMER_GROUP_ID
-        this.topic = overrides.LOGS_INGESTION_CONSUMER_CONSUME_TOPIC ?? config.LOGS_INGESTION_CONSUMER_CONSUME_TOPIC
+        this.groupId = mergedConfig.LOGS_INGESTION_CONSUMER_GROUP_ID
+        this.topic = mergedConfig.LOGS_INGESTION_CONSUMER_CONSUME_TOPIC
 
         this.appMetricsAggregator = new AppMetricsAggregator(deps.outputs)
 
         this.kafkaConsumer = createKafkaConsumer({ groupId: this.groupId, topic: this.topic })
         // Logs ingestion uses its own Redis instance with TLS support
         this.redis = createRedisV2PoolFromConfig({
-            connection:
-                (overrides.LOGS_REDIS_HOST ?? config.LOGS_REDIS_HOST)
-                    ? {
-                          url: overrides.LOGS_REDIS_HOST ?? config.LOGS_REDIS_HOST,
-                          options: {
-                              port: overrides.LOGS_REDIS_PORT ?? config.LOGS_REDIS_PORT,
-                              tls: (overrides.LOGS_REDIS_TLS ?? config.LOGS_REDIS_TLS) ? {} : undefined,
-                          },
-                          name: 'logs-redis',
-                      }
-                    : { url: config.REDIS_URL, name: 'logs-redis-fallback' },
-            poolMinSize: config.REDIS_POOL_MIN_SIZE,
-            poolMaxSize: config.REDIS_POOL_MAX_SIZE,
+            connection: mergedConfig.LOGS_REDIS_HOST
+                ? {
+                      url: mergedConfig.LOGS_REDIS_HOST,
+                      options: {
+                          port: mergedConfig.LOGS_REDIS_PORT,
+                          tls: mergedConfig.LOGS_REDIS_TLS ? {} : undefined,
+                      },
+                      name: 'logs-redis',
+                  }
+                : { url: mergedConfig.REDIS_URL, name: 'logs-redis-fallback' },
+            poolMinSize: mergedConfig.REDIS_POOL_MIN_SIZE,
+            poolMaxSize: mergedConfig.REDIS_POOL_MAX_SIZE,
         })
-        this.rateLimiter = new LogsRateLimiterService(config, this.redis)
-        this.samplingService = new LogsSamplingService(this.redis, config.LOGS_LIMITER_TTL_SECONDS)
-        this.samplingEnabledTeamsRaw = overrides.LOGS_SAMPLING_ENABLED_TEAMS ?? config.LOGS_SAMPLING_ENABLED_TEAMS
-        this.samplingKillswitch = overrides.LOGS_SAMPLING_KILLSWITCH ?? config.LOGS_SAMPLING_KILLSWITCH
+        this.rateLimiter = new LogsRateLimiterService(mergedConfig, this.redis, rateLimiterName)
+        this.samplingService = new LogsSamplingService(this.redis, mergedConfig.LOGS_LIMITER_TTL_SECONDS)
+        this.samplingEnabledTeamsRaw = mergedConfig.LOGS_SAMPLING_ENABLED_TEAMS
+        this.samplingKillswitch = mergedConfig.LOGS_SAMPLING_KILLSWITCH
     }
 
     private isSamplingEvalEnabledForTeam(teamId: number): boolean {

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -818,4 +818,33 @@ describe('LogsRateLimiterService', () => {
             expect(result.tokensBefore).toBe(DEFAULT_BUCKET_SIZE_KB)
         })
     })
+
+    // Construction does no Redis I/O, so these need neither a hub nor a live connection.
+    describe('key namespacing', () => {
+        const minimalConfig = {
+            LOGS_LIMITER_TEAM_BUCKET_SIZE_KB: '',
+            LOGS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND: '',
+            LOGS_LIMITER_DISABLED_FOR_TEAMS: '',
+            LOGS_LIMITER_ENABLED_TEAMS: '*',
+            LOGS_LIMITER_BUCKET_SIZE_KB: 100,
+            LOGS_LIMITER_REFILL_RATE_KB_PER_SECOND: 10,
+            LOGS_LIMITER_TTL_SECONDS: 3600,
+        } as any
+
+        it.each([
+            {
+                limiterName: undefined,
+                expectedPrefix: '@posthog-test/logs-rate-limiter/tokens',
+                description: 'defaults to the logs key prefix',
+            },
+            {
+                limiterName: 'traces-rate-limiter',
+                expectedPrefix: '@posthog-test/traces-rate-limiter/tokens',
+                description: 'uses a distinct prefix when a limiter name is given (e.g. traces)',
+            },
+        ])('$description', ({ limiterName, expectedPrefix }) => {
+            const rateLimiter = new LogsRateLimiterService(minimalConfig, {} as RedisV2, limiterName)
+            expect(rateLimiter['rateLimiter'].getKeyPrefix()).toBe(expectedPrefix)
+        })
+    })
 })

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
@@ -29,11 +29,15 @@ export type LogsRateLimiterConfig = Pick<
     | 'LOGS_LIMITER_TTL_SECONDS'
 >
 
-const LIMITER_NAME = 'logs-rate-limiter'
+const DEFAULT_LIMITER_NAME = 'logs-rate-limiter'
+
+/** Redis key prefix for a given limiter name. Each ingestion type (logs, traces) gets its own
+ * namespace so their token buckets don't share — and deplete — the same per-team state. */
+export const buildBaseRedisKey = (limiterName: string = DEFAULT_LIMITER_NAME): string =>
+    process.env.NODE_ENV == 'test' ? `@posthog-test/${limiterName}` : `@posthog/${limiterName}`
 
 /** Re-exported for the consumer test which needs to clean up keys between runs. */
-export const BASE_REDIS_KEY =
-    process.env.NODE_ENV == 'test' ? `@posthog-test/${LIMITER_NAME}` : `@posthog/${LIMITER_NAME}`
+export const BASE_REDIS_KEY = buildBaseRedisKey()
 
 export type LogsRateLimit = {
     tokensBefore: number
@@ -60,7 +64,8 @@ export class LogsRateLimiterService {
 
     constructor(
         private config: LogsRateLimiterConfig,
-        redis: RedisV2
+        redis: RedisV2,
+        limiterName: string = DEFAULT_LIMITER_NAME
     ) {
         this.teamBucketSizes = this.parseTeamConfig(config.LOGS_LIMITER_TEAM_BUCKET_SIZE_KB)
         this.teamRefillRates = this.parseTeamConfig(config.LOGS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND)
@@ -70,7 +75,7 @@ export class LogsRateLimiterService {
             // Bucket params are passed per-request so live `this.config` mutations
             // (used in tests) take effect. failOpen=false preserves the legacy
             // throw-on-Redis-outage behaviour.
-            { name: LIMITER_NAME, failOpen: false },
+            { name: limiterName, failOpen: false },
             redis
         )
     }

--- a/nodejs/src/logs-ingestion/traces-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/traces-ingestion-consumer.ts
@@ -10,20 +10,26 @@ export class TracesIngestionConsumer extends LogsIngestionConsumer {
     constructor(config: LogsIngestionConsumerConfig & TracesIngestionConsumerConfig, deps: LogsIngestionConsumerDeps) {
         // Topics are wired into `deps.outputs` by the server, so the only consumer-level
         // overrides left are the consume topic / group / Redis / rate-limiter settings.
-        super(config, deps, {
-            LOGS_INGESTION_CONSUMER_GROUP_ID: config.TRACES_INGESTION_CONSUMER_GROUP_ID,
-            LOGS_INGESTION_CONSUMER_CONSUME_TOPIC: config.TRACES_INGESTION_CONSUMER_CONSUME_TOPIC,
-            LOGS_REDIS_HOST: config.TRACES_REDIS_HOST,
-            LOGS_REDIS_PORT: config.TRACES_REDIS_PORT,
-            LOGS_REDIS_PASSWORD: config.TRACES_REDIS_PASSWORD,
-            LOGS_REDIS_TLS: config.TRACES_REDIS_TLS,
-            LOGS_LIMITER_ENABLED_TEAMS: config.TRACES_LIMITER_ENABLED_TEAMS,
-            LOGS_LIMITER_DISABLED_FOR_TEAMS: config.TRACES_LIMITER_DISABLED_FOR_TEAMS,
-            LOGS_LIMITER_BUCKET_SIZE_KB: config.TRACES_LIMITER_BUCKET_SIZE_KB,
-            LOGS_LIMITER_REFILL_RATE_KB_PER_SECOND: config.TRACES_LIMITER_REFILL_RATE_KB_PER_SECOND,
-            LOGS_LIMITER_TTL_SECONDS: config.TRACES_LIMITER_TTL_SECONDS,
-            LOGS_LIMITER_TEAM_BUCKET_SIZE_KB: config.TRACES_LIMITER_TEAM_BUCKET_SIZE_KB,
-            LOGS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND: config.TRACES_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND,
-        })
+        super(
+            config,
+            deps,
+            {
+                LOGS_INGESTION_CONSUMER_GROUP_ID: config.TRACES_INGESTION_CONSUMER_GROUP_ID,
+                LOGS_INGESTION_CONSUMER_CONSUME_TOPIC: config.TRACES_INGESTION_CONSUMER_CONSUME_TOPIC,
+                LOGS_REDIS_HOST: config.TRACES_REDIS_HOST,
+                LOGS_REDIS_PORT: config.TRACES_REDIS_PORT,
+                LOGS_REDIS_PASSWORD: config.TRACES_REDIS_PASSWORD,
+                LOGS_REDIS_TLS: config.TRACES_REDIS_TLS,
+                LOGS_LIMITER_ENABLED_TEAMS: config.TRACES_LIMITER_ENABLED_TEAMS,
+                LOGS_LIMITER_DISABLED_FOR_TEAMS: config.TRACES_LIMITER_DISABLED_FOR_TEAMS,
+                LOGS_LIMITER_BUCKET_SIZE_KB: config.TRACES_LIMITER_BUCKET_SIZE_KB,
+                LOGS_LIMITER_REFILL_RATE_KB_PER_SECOND: config.TRACES_LIMITER_REFILL_RATE_KB_PER_SECOND,
+                LOGS_LIMITER_TTL_SECONDS: config.TRACES_LIMITER_TTL_SECONDS,
+                LOGS_LIMITER_TEAM_BUCKET_SIZE_KB: config.TRACES_LIMITER_TEAM_BUCKET_SIZE_KB,
+                LOGS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND: config.TRACES_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND,
+            },
+            // Own Redis key namespace so traces token buckets don't share per-team state with logs.
+            'traces-rate-limiter'
+        )
     }
 }


### PR DESCRIPTION
## Problem

The `TracesIngestionConsumer` extends `LogsIngestionConsumer` and reuses its token-bucket rate limiter infrastructure. Before this change, both consumers wrote their per-team rate-limit state to the same Redis key namespace (`@posthog/logs-rate-limiter`). This meant traces traffic could deplete a team's logs rate-limit bucket (and vice versa), causing incorrect throttling across two unrelated ingestion pipelines.

Additionally, the `LogsIngestionConsumer` constructor was applying overrides inconsistently — some fields used `overrides.X ?? config.X` and others read directly from `config`, making it easy to silently miss an override (which is exactly how the rate limiter ended up ignoring the traces-specific config values).

## Changes

- `LogsRateLimiterService` now accepts an optional `limiterName` parameter. The Redis key prefix is derived from this name via a new `buildBaseRedisKey` helper, so logs and traces get isolated namespaces (`logs-rate-limiter` vs `traces-rate-limiter`).
- `LogsIngestionConsumer` merges `config` and `overrides` into a single `mergedConfig` object at construction time, eliminating the scattered `overrides.X ?? config.X` pattern and ensuring all downstream services (including the rate limiter) see the correct effective config.
- `TracesIngestionConsumer` passes `'traces-rate-limiter'` as the limiter name to `super(...)`, giving it its own isolated per-team token buckets.

## How did you test this code?

New automated tests cover:

- `LogsRateLimiterService` key namespacing: verifies the default prefix is `logs-rate-limiter` and that passing `'traces-rate-limiter'` produces a distinct, non-overlapping prefix.
- `TracesIngestionConsumer` rate limiter isolation: verifies the consumer's rate limiter uses the `traces-rate-limiter` key namespace and that `TRACES_LIMITER_*` config values are correctly forwarded through the merged config to the rate limiter.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update