### PR TITLE
feat(alerts): paginate alerts tab on the insights page

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6114,8 +6114,15 @@ const api = {
         async update(alertId: AlertType['id'], data: Partial<AlertTypeWrite>): Promise<AlertType> {
             return await new ApiRequest().alert(alertId).update({ data })
         },
-        async list(insightId?: InsightModel['id']): Promise<PaginatedResponse<AlertType>> {
-            return await new ApiRequest().alerts(undefined, insightId).get()
+        async list(
+            insightId?: InsightModel['id'],
+            params: { limit?: number; offset?: number } = {}
+        ): Promise<CountedPaginatedResponse<AlertType>> {
+            const queryParams: Record<string, any> = { ...params }
+            if (insightId !== undefined) {
+                queryParams.insight_id = insightId
+            }
+            return await new ApiRequest().alerts().withQueryString(toParams(queryParams)).get()
         },
         async delete(alertId: AlertType['id']): Promise<void> {
             return await new ApiRequest().alert(alertId).delete()

--- a/frontend/src/lib/components/Alerts/alertFormLogic.test.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.test.ts
@@ -107,7 +107,7 @@ describe('alertFormLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [] })
+        jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [], count: 0 })
         jest.spyOn(api.alerts, 'get').mockResolvedValue(makeSavedAlert())
         createSpy = jest.spyOn(api.alerts, 'create').mockResolvedValue(makeSavedAlert())
         updateSpy = jest.spyOn(api.alerts, 'update').mockResolvedValue(makeSavedAlert())

--- a/frontend/src/lib/components/Alerts/alertsLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertsLogic.ts
@@ -1,5 +1,7 @@
-import { afterMount, kea, path, selectors } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+
+import { PaginationManual } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 
@@ -11,25 +13,65 @@ import { AlertType } from './types'
 
 export interface AlertsLogicProps extends AlertLogicProps {}
 
+export const ALERTS_PER_PAGE = 30
+
 export const alertsLogic = kea<alertsLogicType>([
     path(['lib', 'components', 'Alerts', 'alertsLogic']),
 
-    loaders({
-        alerts: {
-            __default: [] as AlertType[],
-            loadAlerts: async () => {
-                const response = await api.alerts.list()
-                return response.results
-            },
-        },
+    actions({
+        setPage: (page: number) => ({ page }),
     }),
 
-    selectors({
-        alertsSortedByState: [
-            (s) => [s.alerts],
-            (alerts: AlertType[]): AlertType[] => alerts.sort((a, b) => alertComparatorKey(a) - alertComparatorKey(b)),
+    reducers({
+        page: [
+            1,
+            {
+                setPage: (_, { page }) => page,
+            },
         ],
     }),
+
+    loaders(({ values }) => ({
+        alertsResponse: [
+            { results: [], count: 0 } as { results: AlertType[]; count: number },
+            {
+                loadAlerts: async () => {
+                    const response = await api.alerts.list(undefined, {
+                        limit: ALERTS_PER_PAGE,
+                        offset: (values.page - 1) * ALERTS_PER_PAGE,
+                    })
+                    return { results: response.results, count: response.count ?? response.results.length }
+                },
+            },
+        ],
+    })),
+
+    selectors(({ actions }) => ({
+        alerts: [(s) => [s.alertsResponse], (response): AlertType[] => response.results],
+        alertsCount: [(s) => [s.alertsResponse], (response): number => response.count],
+        alertsSortedByState: [
+            (s) => [s.alerts],
+            (alerts: AlertType[]): AlertType[] =>
+                [...alerts].sort((a, b) => alertComparatorKey(a) - alertComparatorKey(b)),
+        ],
+        pagination: [
+            (s) => [s.page, s.alertsCount],
+            (page, count): PaginationManual => ({
+                controlled: true,
+                pageSize: ALERTS_PER_PAGE,
+                currentPage: page,
+                entryCount: count,
+                onBackward: () => actions.setPage(page - 1),
+                onForward: () => actions.setPage(page + 1),
+            }),
+        ],
+    })),
+
+    listeners(({ actions }) => ({
+        setPage: () => {
+            actions.loadAlerts()
+        },
+    })),
 
     afterMount(({ actions }) => actions.loadAlerts()),
 ])

--- a/frontend/src/lib/components/Alerts/insightAlertsLogic.test.ts
+++ b/frontend/src/lib/components/Alerts/insightAlertsLogic.test.ts
@@ -36,7 +36,7 @@ describe('insightAlertsLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        listSpy = jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [] })
+        listSpy = jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [], count: 0 })
     })
 
     afterEach(() => {

--- a/frontend/src/lib/components/Alerts/views/Alerts.tsx
+++ b/frontend/src/lib/components/Alerts/views/Alerts.tsx
@@ -28,7 +28,7 @@ export function Alerts({ alertId }: AlertsProps): JSX.Element {
     const { push } = useActions(router)
     const logic = alertsLogic()
     const { loadAlerts } = useActions(logic)
-    const { alertsSortedByState, alertsLoading } = useValues(logic)
+    const { alertsSortedByState, alertsResponseLoading, pagination } = useValues(logic)
 
     const { alert } = useValues(alertLogic({ alertId }))
 
@@ -125,7 +125,7 @@ export function Alerts({ alertId }: AlertsProps): JSX.Element {
         },
     ]
 
-    const isEmpty = alertsSortedByState.length === 0 && !alertsLoading
+    const isEmpty = alertsSortedByState.length === 0 && !alertsResponseLoading
     // TODO: add info here to sign up for alerts early access
     return (
         <>
@@ -164,13 +164,14 @@ export function Alerts({ alertId }: AlertsProps): JSX.Element {
 
             {isEmpty ? null : (
                 <LemonTable
-                    loading={alertsLoading}
+                    loading={alertsResponseLoading}
                     columns={columns}
                     dataSource={alertsSortedByState}
                     noSortingCancellation
                     rowKey="id"
                     loadingSkeletonRows={5}
                     nouns={['alert', 'alerts']}
+                    pagination={pagination}
                     rowClassName={(alert) => (alert.state === AlertState.NOT_FIRING ? null : 'highlighted')}
                 />
             )}

--- a/frontend/src/lib/components/Alerts/views/Alerts.tsx
+++ b/frontend/src/lib/components/Alerts/views/Alerts.tsx
@@ -28,7 +28,7 @@ export function Alerts({ alertId }: AlertsProps): JSX.Element {
     const { push } = useActions(router)
     const logic = alertsLogic()
     const { loadAlerts } = useActions(logic)
-    const { alertsSortedByState, alertsResponseLoading, pagination } = useValues(logic)
+    const { alertsSortedByState, alertsResponseLoading, pagination, alertsCount } = useValues(logic)
 
     const { alert } = useValues(alertLogic({ alertId }))
 
@@ -125,7 +125,7 @@ export function Alerts({ alertId }: AlertsProps): JSX.Element {
         },
     ]
 
-    const isEmpty = alertsSortedByState.length === 0 && !alertsResponseLoading
+    const isEmpty = alertsCount === 0 && !alertsResponseLoading
     // TODO: add info here to sign up for alerts early access
     return (
         <>


### PR DESCRIPTION
## Problem

The alerts tab at `/project/:id/insights?tab=alerts` rendered a `LemonTable` with no `pagination` prop. `alertsLogic` called `api.alerts.list()` once on mount and read only `response.results`, discarding the `count`, `next`, and `previous` fields the backend already returns.

The DRF `AlertViewSet.list` is already paginated (default `LimitOffsetPagination`, page size 100), so projects with >100 alerts had everything past the first 100 silently truncated and no way to navigate to the rest.

## Changes

Frontend-only — wires the existing backend pagination through to the table.

- `api.alerts.list()` now accepts an optional `{ limit, offset }` and returns `CountedPaginatedResponse<AlertType>`. Existing single-arg callers (`insightAlertsLogic`, terraform export) are unaffected.
- `alertsLogic` adds a `setPage` action + `page` reducer, threads `limit`/`offset` into the loader, exposes a `PaginationManual` selector at `pagination`, and reloads on page change.
- `Alerts.tsx` passes the `pagination` selector into `<LemonTable pagination={...}>` and uses the renamed `alertsResponseLoading` selector in place of `alertsLoading`.

Page size is set to 30 per page (matches the `LemonTable` UX in similar lists in the app).

## How did you test this code?

I'm an agent (PostHog Code). I did not run the frontend locally — `pnpm` / `oxlint` weren't available in this environment, so I have not type-checked or formatted these changes. Reviewer should run `pnpm --filter=@posthog/frontend typescript:check` and `pnpm --filter=@posthog/frontend format` before merging, and manually verify the alerts tab in dev with a project that has >30 alerts (or temporarily lower `ALERTS_PER_PAGE`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — the alerts tab is unchanged from a user's perspective other than now exposing pagination controls when the count exceeds one page.

## 🤖 Agent context

Authored by Claude (Opus 4.7) via PostHog Code at the request of @mattppua. Investigation started by an Explore subagent locating the alerts tab component (`SavedInsights.tsx` → `Alerts.tsx` → `alertsLogic.ts`) and confirming the backend already paginates. Chose to keep the change minimal: no URL-sync for the page param (could be a follow-up), no backend changes, kept the existing in-memory `alertsSortedByState` sort even though it only orders within a page — that matched prior behavior on projects already capped at the first 100. Reviewed `cohortsSceneLogic` as the closest pagination prior art before settling on the `PaginationManual` selector shape.