### PR TITLE
fix(logs-ingestion): add retention days to usage metrics and update tests

### DIFF
--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -1131,6 +1131,7 @@ describe('LogsIngestionConsumer', () => {
                         bytesDropped: 200,
                         recordsDropped: 2,
                         piiReplacements: 0,
+                        retentionDays: 30,
                     },
                 ],
             ])
@@ -1139,7 +1140,7 @@ describe('LogsIngestionConsumer', () => {
 
             const messages = getProducedKafkaMessages().filter((m) => m.topic === KAFKA_APP_METRICS_2)
 
-            expect(messages).toHaveLength(6)
+            expect(messages).toHaveLength(7)
 
             const metricNames = messages.map((m) => parseMetricValue(m.value)?.metric_name)
             expect(metricNames).toContain('bytes_received')
@@ -1148,6 +1149,37 @@ describe('LogsIngestionConsumer', () => {
             expect(metricNames).toContain('records_ingested')
             expect(metricNames).toContain('bytes_dropped')
             expect(metricNames).toContain('records_dropped')
+            expect(metricNames).toContain('bytes_ingested_retention_30d')
+        })
+
+        it('should emit the retention tier matching the team retention_days', async () => {
+            const usageStats = new Map([
+                [
+                    team.id,
+                    {
+                        bytesReceived: 500,
+                        recordsReceived: 5,
+                        bytesAllowed: 500,
+                        recordsAllowed: 5,
+                        bytesDropped: 0,
+                        recordsDropped: 0,
+                        piiReplacements: 0,
+                        retentionDays: 90,
+                    },
+                ],
+            ])
+
+            await consumer['emitUsageMetrics'](usageStats)
+
+            const messages = getProducedKafkaMessages().filter((m) => m.topic === KAFKA_APP_METRICS_2)
+            const retentionMetric = messages
+                .map((m) => parseMetricValue(m.value))
+                .find((m) => m?.metric_name === 'bytes_ingested_retention_90d')
+
+            expect(retentionMetric?.count).toBe(500)
+            const metricNames = messages.map((m) => parseMetricValue(m.value)?.metric_name)
+            expect(metricNames).not.toContain('bytes_ingested_retention_30d')
+            expect(metricNames).not.toContain('bytes_ingested_retention_14d')
         })
 
         it('should skip zero-count metrics', async () => {
@@ -1162,6 +1194,7 @@ describe('LogsIngestionConsumer', () => {
                         bytesDropped: 0,
                         recordsDropped: 0,
                         piiReplacements: 0,
+                        retentionDays: 14,
                     },
                 ],
             ])
@@ -1170,11 +1203,12 @@ describe('LogsIngestionConsumer', () => {
 
             const messages = getProducedKafkaMessages().filter((m) => m.topic === KAFKA_APP_METRICS_2)
 
-            // Should only have 4 metrics (no dropped)
-            expect(messages).toHaveLength(4)
+            // 4 non-zero base metrics (no dropped) + 1 retention tier row
+            expect(messages).toHaveLength(5)
             const metricNames = messages.map((m) => parseMetricValue(m.value)?.metric_name)
             expect(metricNames).not.toContain('bytes_dropped')
             expect(metricNames).not.toContain('records_dropped')
+            expect(metricNames).toContain('bytes_ingested_retention_14d')
         })
 
         it('should handle empty usageStats', async () => {
@@ -1199,6 +1233,7 @@ describe('LogsIngestionConsumer', () => {
                         bytesDropped: 0,
                         recordsDropped: 0,
                         piiReplacements: 0,
+                        retentionDays: 30,
                     },
                 ],
                 [
@@ -1211,6 +1246,7 @@ describe('LogsIngestionConsumer', () => {
                         bytesDropped: 0,
                         recordsDropped: 0,
                         piiReplacements: 0,
+                        retentionDays: 90,
                     },
                 ],
             ])
@@ -1219,13 +1255,13 @@ describe('LogsIngestionConsumer', () => {
 
             const messages = getProducedKafkaMessages().filter((m) => m.topic === KAFKA_APP_METRICS_2)
 
-            // 4 metrics per team (no dropped) = 8 total
-            expect(messages).toHaveLength(8)
+            // 4 base metrics + 1 retention tier per team (no dropped) = 10 total
+            expect(messages).toHaveLength(10)
 
             const team1Messages = messages.filter((m) => parseMetricValue(m.value)?.team_id === team.id)
             const team2Messages = messages.filter((m) => parseMetricValue(m.value)?.team_id === team2.id)
-            expect(team1Messages).toHaveLength(4)
-            expect(team2Messages).toHaveLength(4)
+            expect(team1Messages).toHaveLength(5)
+            expect(team2Messages).toHaveLength(5)
         })
     })
 

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -1152,35 +1152,43 @@ describe('LogsIngestionConsumer', () => {
             expect(metricNames).toContain('bytes_ingested_retention_30d')
         })
 
-        it('should emit the retention tier matching the team retention_days', async () => {
-            const usageStats = new Map([
-                [
-                    team.id,
-                    {
-                        bytesReceived: 500,
-                        recordsReceived: 5,
-                        bytesAllowed: 500,
-                        recordsAllowed: 5,
-                        bytesDropped: 0,
-                        recordsDropped: 0,
-                        piiReplacements: 0,
-                        retentionDays: 90,
-                    },
-                ],
-            ])
+        it.each([
+            { retentionDays: 14, absent: ['bytes_ingested_retention_30d', 'bytes_ingested_retention_90d'] },
+            { retentionDays: 30, absent: ['bytes_ingested_retention_14d', 'bytes_ingested_retention_90d'] },
+            { retentionDays: 90, absent: ['bytes_ingested_retention_14d', 'bytes_ingested_retention_30d'] },
+        ])(
+            'should emit only bytes_ingested_retention_${retentionDays}d for the matching tier',
+            async ({ retentionDays, absent }) => {
+                const usageStats = new Map([
+                    [
+                        team.id,
+                        {
+                            bytesReceived: 500,
+                            recordsReceived: 5,
+                            bytesAllowed: 500,
+                            recordsAllowed: 5,
+                            bytesDropped: 0,
+                            recordsDropped: 0,
+                            piiReplacements: 0,
+                            retentionDays,
+                        },
+                    ],
+                ])
 
-            await consumer['emitUsageMetrics'](usageStats)
+                await consumer['emitUsageMetrics'](usageStats)
 
-            const messages = getProducedKafkaMessages().filter((m) => m.topic === KAFKA_APP_METRICS_2)
-            const retentionMetric = messages
-                .map((m) => parseMetricValue(m.value))
-                .find((m) => m?.metric_name === 'bytes_ingested_retention_90d')
+                const messages = getProducedKafkaMessages().filter((m) => m.topic === KAFKA_APP_METRICS_2)
+                const retentionMetric = messages
+                    .map((m) => parseMetricValue(m.value))
+                    .find((m) => m?.metric_name === `bytes_ingested_retention_${retentionDays}d`)
 
-            expect(retentionMetric?.count).toBe(500)
-            const metricNames = messages.map((m) => parseMetricValue(m.value)?.metric_name)
-            expect(metricNames).not.toContain('bytes_ingested_retention_30d')
-            expect(metricNames).not.toContain('bytes_ingested_retention_14d')
-        })
+                expect(retentionMetric?.count).toBe(500)
+                const metricNames = messages.map((m) => parseMetricValue(m.value)?.metric_name)
+                for (const name of absent) {
+                    expect(metricNames).not.toContain(name)
+                }
+            }
+        )
 
         it('should skip zero-count metrics', async () => {
             const usageStats = new Map([

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -40,6 +40,16 @@ export interface LogsIngestionConsumerDeps {
     outputs: IngestionOutputs<LogsOutput | LogsDlqOutput | AppMetricsOutput>
 }
 
+/** Ingestion default when `logs_settings.retention_days` is unset; must be in `TeamSerializer.VALID_RETENTION_DAYS`. */
+export const DEFAULT_LOGS_RETENTION_DAYS = 14
+
+/** Retention tiers that get their own per-tier usage metric; total = sum across all tiers. */
+const RETENTION_USAGE_TIERS = new Set([14, 30, 90])
+
+function retentionBytesMetricName(retentionDays: number): string | null {
+    return RETENTION_USAGE_TIERS.has(retentionDays) ? `bytes_ingested_retention_${retentionDays}d` : null
+}
+
 export type UsageStats = {
     bytesReceived: number
     recordsReceived: number
@@ -48,6 +58,7 @@ export type UsageStats = {
     bytesDropped: number
     recordsDropped: number
     piiReplacements: number
+    retentionDays: number
 }
 
 const DEFAULT_USAGE_STATS: UsageStats = {
@@ -58,12 +69,10 @@ const DEFAULT_USAGE_STATS: UsageStats = {
     bytesDropped: 0,
     recordsDropped: 0,
     piiReplacements: 0,
+    retentionDays: DEFAULT_LOGS_RETENTION_DAYS,
 }
 
 export type UsageStatsByTeam = Map<number, UsageStats>
-
-/** Ingestion default when `logs_settings.retention_days` is unset; must be in `TeamSerializer.VALID_RETENTION_DAYS`. */
-export const DEFAULT_LOGS_RETENTION_DAYS = 14
 
 /** Cap concurrent per-message processing within a single kafka batch. */
 const MAX_CONCURRENT_MESSAGE_PROCESSES = 50
@@ -448,6 +457,12 @@ export class LogsIngestionConsumer {
                         const jsonParse = logsSettings.json_parse_logs ?? false
                         const retentionDays = logsSettings.retention_days ?? DEFAULT_LOGS_RETENTION_DAYS
 
+                        // Retention is uniform per team; stash for retention-bucketed usage emit
+                        const teamStats = usageStats.get(message.teamId)
+                        if (teamStats) {
+                            teamStats.retentionDays = retentionDays
+                        }
+
                         // ignore empty messages
                         if (message.message.value === null) {
                             return Promise.resolve()
@@ -548,6 +563,11 @@ export class LogsIngestionConsumer {
             this.queueUsageMetric(teamId, 'bytes_dropped', stats.bytesDropped)
             this.queueUsageMetric(teamId, 'records_dropped', stats.recordsDropped)
             this.queueUsageMetric(teamId, 'pii_replacements', stats.piiReplacements)
+
+            const retentionMetric = retentionBytesMetricName(stats.retentionDays)
+            if (retentionMetric) {
+                this.queueUsageMetric(teamId, retentionMetric, stats.bytesAllowed)
+            }
         }
 
         // Best-effort: don't let metric failures block ingestion


### PR DESCRIPTION
## Problem

Billing and usage attribution for log ingestion needs to distinguish between different retention tiers (14d, 30d, 90d) so that per-tier byte ingestion can be tracked separately. Without this, all ingested bytes are reported under a single metric regardless of how long the data is retained, making it impossible to accurately bucket usage by retention tier.

## Changes

Adds a `retentionDays` field to `UsageStats` (defaulting to `DEFAULT_LOGS_RETENTION_DAYS = 14`) and populates it from the team's `logs_settings.retention_days` during message processing.

Introduces a `retentionBytesMetricName` helper that maps a retention day count to a named metric (e.g. `bytes_ingested_retention_30d`) for the supported tiers (14, 30, 90). After emitting the standard per-team usage metrics, a retention-bucketed metric is also emitted using `bytesAllowed` as the count, but only when the retention value matches a known tier.

## How did you test this code?

Existing and new unit tests in `logs-ingestion-consumer.test.ts` cover:

- The correct retention-tier metric name is emitted alongside the standard metrics.
- Only the matching tier metric is emitted (e.g. `bytes_ingested_retention_90d` is present, `bytes_ingested_retention_30d` and `bytes_ingested_retention_14d` are absent).
- Zero-count metric skipping still works correctly, with the retention metric still emitted when bytes are non-zero.
- Multi-team scenarios emit one retention metric per team with the correct tier.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update