### PR TITLE
fix(data-warehouse): default sync type to full refresh on enable

### DIFF
--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -114,6 +114,47 @@ def _reset_cdc_for_full_resnapshot(instance: ExternalDataSchema) -> None:
         instance.save(update_fields=["status"])
 
 
+def _resolve_default_sync_config_on_enable(instance: ExternalDataSchema) -> tuple[str, dict[str, Any]]:
+    """Pick a sync method for a schema being enabled without one configured.
+
+    Mirrors the sync-method form's preference: use incremental replication when the source
+    reports it's supported and exposes an incremental field (cheaper than re-syncing the whole
+    table each run), otherwise fall back to full refresh, which is always valid. Webhook and CDC
+    are intentionally excluded — they need extra setup (webhook endpoint, replication publication
+    + primary key) that a bare enable toggle can't provide, so those stay behind the explicit
+    configuration flow. Any discovery failure degrades to full refresh so enabling never breaks.
+
+    Returns the chosen sync_type and any sync_type_config keys to merge in.
+    """
+    full_refresh: tuple[str, dict[str, Any]] = (ExternalDataSchema.SyncType.FULL_REFRESH, {})
+
+    source = instance.source
+    if not source.source_type or not source.job_inputs:
+        return full_refresh
+
+    try:
+        source_impl = SourceRegistry.get_source(ExternalDataSourceType(source.source_type))
+        config = source_impl.parse_config(source.job_inputs)
+        schemas = source_impl.get_schemas(config, instance.team_id, names=[instance.name])
+    except Exception as e:
+        capture_exception(e)
+        return full_refresh
+
+    schema = next((s for s in schemas if s.name == instance.name), None)
+    if schema is None or not schema.supports_incremental or not schema.incremental_fields:
+        return full_refresh
+
+    field = schema.incremental_fields[0]
+    config_updates: dict[str, Any] = {
+        "incremental_field": field["field"],
+        "incremental_field_type": field["field_type"],
+    }
+    if schema.detected_primary_keys:
+        config_updates["primary_key_columns"] = schema.detected_primary_keys
+
+    return (ExternalDataSchema.SyncType.INCREMENTAL, config_updates)
+
+
 class ExternalDataSchemaSerializer(serializers.ModelSerializer):
     table = serializers.SerializerMethodField(read_only=True)
     incremental = serializers.SerializerMethodField(read_only=True)
@@ -481,8 +522,16 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
                 validated_data["sync_time_of_day"] = None
                 instance.sync_time_of_day = None
 
+        # Enabling a schema that was never configured derives a sensible sync method (incremental
+        # when the source supports it, else full refresh) rather than rejecting the request. Users
+        # can switch to a different method later via the schema configuration page.
         if source.supports_scheduled_sync and should_sync is True and sync_type is None and instance.sync_type is None:
-            raise ValidationError("Sync type must be set up first before enabling schema")
+            sync_type, default_config_updates = _resolve_default_sync_config_on_enable(instance)
+            validated_data["sync_type"] = sync_type
+            if default_config_updates:
+                payload = instance.sync_type_config or {}
+                payload.update(default_config_updates)
+                validated_data["sync_type_config"] = payload
 
         # Catches a CDC schema being flipped on later when sync_type isn't changing — the
         # sync_type branch above doesn't run, so PK presence isn't enforced there.

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -29,7 +29,7 @@ from posthog.temporal.data_imports.sources.stripe.source import StripeSource
 from products.data_warehouse.backend.api.test.utils import create_external_data_source_ok
 from products.data_warehouse.backend.direct_postgres import DIRECT_POSTGRES_URL_PATTERN
 from products.data_warehouse.backend.external_data_source.webhooks import WebhookHogFunctionCreateResult
-from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.data_warehouse.backend.types import ExternalDataSourceType, IncrementalFieldType
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
@@ -466,6 +466,90 @@ class TestExternalDataSchema(APIBaseTest):
         assert "primary key" in str(response.json()).lower()
         schema.refresh_from_db()
         assert schema.should_sync is False
+
+    def _enable_never_configured_schema(self):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type=ExternalDataSourceType.STRIPE,
+            job_inputs={"auth_method": {"selection": "api_key", "stripe_secret_key": "123"}},
+        )
+        schema = ExternalDataSchema.objects.create(
+            name="BalanceTransaction",
+            team=self.team,
+            source=source,
+            should_sync=False,
+            sync_type=None,
+        )
+
+        with (
+            mock.patch("products.data_warehouse.backend.api.external_data_schema.trigger_external_data_workflow"),
+            mock.patch(
+                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                return_value=False,
+            ),
+            mock.patch("products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow"),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+                data={"should_sync": True},
+            )
+
+        return response, schema
+
+    def test_update_schema_enable_without_sync_type_defaults_to_incremental_when_available(self):
+        # When the source reports incremental support with a field, enabling a never-configured
+        # schema should default to incremental using the first detected field (and detected PKs).
+        fake_schema = SourceSchema(
+            name="BalanceTransaction",
+            supports_incremental=True,
+            supports_append=True,
+            incremental_fields=[
+                {
+                    "label": "created_at",
+                    "type": IncrementalFieldType.DateTime,
+                    "field": "created",
+                    "field_type": IncrementalFieldType.Integer,
+                }
+            ],
+            detected_primary_keys=["id"],
+        )
+        with mock.patch.object(StripeSource, "get_schemas", return_value=[fake_schema]):
+            response, schema = self._enable_never_configured_schema()
+
+        assert response.status_code == status.HTTP_200_OK
+        schema.refresh_from_db()
+        assert schema.should_sync is True
+        assert schema.sync_type == ExternalDataSchema.SyncType.INCREMENTAL
+        assert schema.sync_type_config.get("incremental_field") == "created"
+        assert schema.sync_type_config.get("incremental_field_type") == "integer"
+        assert schema.sync_type_config.get("primary_key_columns") == ["id"]
+
+    def test_update_schema_enable_without_sync_type_defaults_to_full_refresh_when_not_incremental(self):
+        # No incremental support → fall back to full refresh rather than rejecting the enable.
+        fake_schema = SourceSchema(
+            name="BalanceTransaction",
+            supports_incremental=False,
+            supports_append=False,
+            incremental_fields=[],
+        )
+        with mock.patch.object(StripeSource, "get_schemas", return_value=[fake_schema]):
+            response, schema = self._enable_never_configured_schema()
+
+        assert response.status_code == status.HTTP_200_OK
+        schema.refresh_from_db()
+        assert schema.should_sync is True
+        assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
+
+    def test_update_schema_enable_without_sync_type_falls_back_to_full_refresh_on_discovery_error(self):
+        # Discovery failures (bad credentials, source down) must not block enabling — degrade to
+        # full refresh so the toggle still works.
+        with mock.patch.object(StripeSource, "get_schemas", side_effect=Exception("source unreachable")):
+            response, schema = self._enable_never_configured_schema()
+
+        assert response.status_code == status.HTTP_200_OK
+        schema.refresh_from_db()
+        assert schema.should_sync is True
+        assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
 
     @parameterized.expand(
         [ExternalDataSchema.SyncType.APPEND, ExternalDataSchema.SyncType.INCREMENTAL],
@@ -1064,10 +1148,7 @@ class TestUpdateExternalDataSchema:
         assert schedule_desc.schedule.state.paused is False
 
     def test_update_schema_change_should_sync_on_without_sync_type(self, team, user, client: HttpClient, temporal):
-        """Test that we can turn on a schema that doesn't have a sync type set.
-
-        Not sure in which cases this can happen.
-        """
+        """Enabling a schema with no sync type derives a default sync method instead of rejecting."""
         client.force_login(user)
         source_id = create_external_data_source_ok(client, team.pk)
         schema = ExternalDataSchema.objects.filter(source_id=source_id, should_sync=False).first()
@@ -1092,7 +1173,10 @@ class TestUpdateExternalDataSchema:
             content_type="application/json",
         )
 
-        assert response.status_code == 400
+        assert response.status_code == 200
+        schema.refresh_from_db()
+        assert schema.should_sync is True
+        assert schema.sync_type is not None
 
     def test_update_schema_exposes_direct_postgres_table_without_sync_type(
         self, team, user, client: HttpClient, temporal

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -376,9 +376,6 @@ function ManagedSchemaTable({
                         return (
                             <SourceEditorAction source={source}>
                                 <LemonSwitch
-                                    disabledReason={
-                                        schema.sync_type === null ? 'Set up the sync method first' : undefined
-                                    }
                                     checked={schema.should_sync}
                                     onChange={(active) => {
                                         if (!active && schema.sync_type === 'cdc') {


### PR DESCRIPTION
## Problem

Enabling a data warehouse table that was never configured (`sync_type = None`) failed outright. The Enabled toggle in the schemas table was disabled with "Set up the sync method first", and the backend rejected `should_sync=True` with "Sync type must be set up first before enabling schema".

In practice this forced a clunky detour: open the schema's configuration page, accept the pre-selected sync method defaults, hit Save, navigate back, and only then flip the table on. Several users have hit this — most recently with a Convex source where a newly discovered table couldn't be enabled at all.

## Changes

- **Backend** (`external_data_schema.py`): when `should_sync` is being turned on and no sync method is set anywhere, derive a sensible default instead of raising. This mirrors the sync-method form's preference — run source discovery and pick **incremental** replication (using the first detected incremental field and any detected primary keys) when the source reports it's supported, otherwise fall back to **full refresh**. Webhook and CDC are intentionally excluded because they need extra setup (webhook endpoint creation; replication publication + primary key) that a bare enable toggle can't provide, so those stay behind the explicit configuration flow. Any discovery failure degrades to full refresh so enabling never breaks.
- **Frontend** (`SchemasTab.tsx`): remove the `disabledReason` that blocked the Enabled toggle for not-set-up schemas, so the switch can actually be flipped on and let the backend assign the default.
- **Tests**: added coverage for the incremental default, the full-refresh fallback when incremental isn't supported, and the graceful fallback when discovery fails.

## How did you test this code?

I'm an agent. I added automated tests and ran `ruff check` / `ruff format` over the changed Python. I was unable to execute the test suite locally because the dev Postgres container was in a wedged Docker state — the tests need a live DB and Temporal fixtures. Please confirm the tests pass in CI.

## 🤖 Agent context

Authored with Claude Code. Investigation started from a support ticket about a Convex table that couldn't be enabled; traced the symptom to the enable-path validation in the schema serializer (`sync_type is None` rejection) and the matching disabled toggle in the frontend.

Considered two approaches: (A) have the frontend toggle open the sync-method modal pre-filled with the recommended default (one confirmation click), and (B) have the backend auto-assign a default on enable (zero clicks). Chose B for a frictionless experience. For the default value, the backend reuses the same source-discovery path the `incremental_fields` endpoint already uses to compute capabilities, so it can mirror the form's "prefer incremental when possible" behaviour rather than always falling back to full refresh. Webhook/CDC are deliberately left out of the auto-default because they require additional explicit configuration; they remain available via the configuration page.
