### PR TITLE
feat(slack-app): use slack integration kind for coding-agent mentions

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_interactivity.py
+++ b/posthog/temporal/ai/posthog_code_slack_interactivity.py
@@ -95,9 +95,7 @@ def process_posthog_code_task_termination_payload(payload: dict[str, Any]) -> No
         return
 
     try:
-        integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
-        )
+        integration = Integration.objects.get(id=integration_id, kind="slack", integration_id=slack_team_id)
     except Integration.DoesNotExist:
         logger.warning("posthog_code_terminate_integration_not_found", integration_id=integration_id)
         return

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -612,7 +612,7 @@ def resolve_posthog_code_slack_user_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -641,7 +641,7 @@ def handle_posthog_code_rules_command_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     dispatch_rules_command(
@@ -667,7 +667,7 @@ def collect_posthog_code_thread_messages_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -692,7 +692,7 @@ def cascade_posthog_code_repository_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     all_repos = _get_full_repo_names(integration)
@@ -729,7 +729,7 @@ def select_posthog_code_repository_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     all_repos = _get_full_repo_names(integration)
@@ -761,7 +761,7 @@ async def discover_posthog_code_repository_via_agent_activity(
 
     integration = await Integration.objects.select_related("team", "team__organization").aget(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
 
@@ -882,7 +882,7 @@ def enforce_posthog_code_billing_quota_activity(
 
     integration = Integration.objects.select_related("team").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -902,7 +902,7 @@ def post_posthog_code_no_repos_activity(
 ) -> None:
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -931,7 +931,7 @@ def post_posthog_code_repo_picker_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -986,7 +986,7 @@ def block_posthog_code_task_if_no_personal_github_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1040,7 +1040,7 @@ def create_posthog_code_task_for_repo_activity(
 ) -> None:
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1186,7 +1186,7 @@ def create_posthog_code_routing_rule_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1256,7 +1256,7 @@ def forward_posthog_code_followup_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1696,7 +1696,7 @@ def post_posthog_code_picker_timeout_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1724,7 +1724,7 @@ def post_posthog_code_internal_error_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)

--- a/posthog/temporal/ai/posthog_code_slack_mention_command.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention_command.py
@@ -174,7 +174,7 @@ def resolve_posthog_code_slack_command_user_activity(
     candidates = list(
         Integration.objects.filter(
             id__in=inputs.integration_ids,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id=inputs.slack_team_id,
         ).select_related("team", "team__organization")
     )

--- a/posthog/temporal/tests/ai/test_block_missing_user_github.py
+++ b/posthog/temporal/tests/ai/test_block_missing_user_github.py
@@ -26,9 +26,7 @@ class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
     @patch("posthog.models.integration.SlackIntegration")
     def test_returns_true_and_posts_block_when_user_has_no_personal_github(self, mock_slack_cls):

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -58,6 +58,11 @@ logger = structlog.get_logger(__name__)
 
 HANDLED_EVENT_TYPES = ["app_mention", "link_shared"]
 
+# Slack integration kind used by the PostHog Code coding-agent flow. Historically this used
+# a dedicated `slack-posthog-code` install, but the notifications Slack app (`slack`) carries
+# every scope the coding agent needs, so both surfaces share one kind.
+SLACK_INTEGRATION_KIND = "slack"
+
 POSTHOG_CODE_SLACK_AVAILABILITY_FLAG = "posthog-code-slack-availability"
 
 # Scopes the coding-agent flow exercises end-to-end. Slack stores the granted scope set
@@ -609,7 +614,7 @@ def does_other_region_claim_workspace(*, slack_team_id: str, kinds: list[str], i
     target_url = f"{scheme}://{target_domain}/slack/workspace/claims/"
 
     body = json.dumps({"slack_team_id": slack_team_id, "kinds": kinds}).encode("utf-8")
-    signing_secret = SlackIntegration.posthog_code_slack_config()["SLACK_POSTHOG_CODE_SIGNING_SECRET"]
+    signing_secret = SlackIntegration.slack_config()["SLACK_APP_SIGNING_SECRET"]
     signature, ts = sign_slack_request(body, signing_secret)
 
     try:
@@ -665,8 +670,8 @@ def slack_workspace_claims_view(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=405)
 
     try:
-        posthog_code_config = SlackIntegration.posthog_code_slack_config()
-        validate_slack_request(request, posthog_code_config["SLACK_POSTHOG_CODE_SIGNING_SECRET"])
+        slack_config = SlackIntegration.slack_config()
+        validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
         logger.warning("slack_app_workspace_claims_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
@@ -1037,7 +1042,7 @@ def _replace_repo_picker_message_with_selection(
     try:
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
         slack = SlackIntegration(integration)
         text = f"Repository selected: `{selected_repo}`"
@@ -1071,7 +1076,7 @@ def _replace_repo_picker_message_with_no_repo(
     try:
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
         slack = SlackIntegration(integration)
         text = "Continuing without a repository."
@@ -1525,7 +1530,7 @@ def route_posthog_code_event_to_relevant_region(
 
         result = load_integrations(
             slack_team_id=slack_team_id,
-            kinds=["slack-posthog-code"],
+            kinds=[SLACK_INTEGRATION_KIND],
             slack_user_id=str(event.get("user") or ""),
             user=None,
             channel=event.get("channel") if isinstance(event.get("channel"), str) else None,
@@ -1536,7 +1541,7 @@ def route_posthog_code_event_to_relevant_region(
         if not result.candidates:
             return _route_to_other_region_or_drop(request, slack_team_id, proxied=proxied, other_domain=other_domain)
 
-        if _us_should_handle_instead(slack_team_id, ["slack-posthog-code"], can_defer_to_other_region, incoming_host):
+        if _us_should_handle_instead(slack_team_id, [SLACK_INTEGRATION_KIND], can_defer_to_other_region, incoming_host):
             return _proxy_event_and_return_route(request, other_domain)
 
         # Gate the entire @PostHog surface on the rollout flag at the candidate
@@ -1697,8 +1702,8 @@ def posthog_code_event_handler(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=405)
 
     try:
-        posthog_code_config = SlackIntegration.posthog_code_slack_config()
-        validate_slack_request(request, posthog_code_config["SLACK_POSTHOG_CODE_SIGNING_SECRET"])
+        slack_config = SlackIntegration.slack_config()
+        validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
         logger.warning("posthog_code_event_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
@@ -1840,7 +1845,7 @@ def _handle_repo_picker_options(payload: dict) -> JsonResponse:
         team_id = payload.get("team", {}).get("id")
         if team_id:
             fallback_integration = (
-                Integration.objects.filter(kind="slack-posthog-code", integration_id=team_id).order_by("id").first()
+                Integration.objects.filter(kind=SLACK_INTEGRATION_KIND, integration_id=team_id).order_by("id").first()
             )
             if fallback_integration:
                 hinted_integration_id = fallback_integration.id
@@ -1875,7 +1880,7 @@ def _handle_repo_picker_options(payload: dict) -> JsonResponse:
             raise Integration.DoesNotExist
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
     except Integration.DoesNotExist:
         logger.info("posthog_code_repo_picker_options_no_integration", context_token=context_token)
@@ -1954,7 +1959,7 @@ def _handle_repo_picker_submit(payload: dict) -> HttpResponse:
         try:
             # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
             integration = Integration.objects.get(
-                id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+                id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
             )
             SlackIntegration(integration).client.chat_postMessage(
                 channel=channel,
@@ -2093,8 +2098,8 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=405)
 
     try:
-        posthog_code_config = SlackIntegration.posthog_code_slack_config()
-        validate_slack_request(request, posthog_code_config["SLACK_POSTHOG_CODE_SIGNING_SECRET"])
+        slack_config = SlackIntegration.slack_config()
+        validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
         logger.warning("posthog_code_interactivity_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
@@ -2126,19 +2131,19 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
     if slack_team_id and ctx_integration_id:
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=ctx_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind="slack-posthog-code",
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
     elif slack_team_id and hinted_integration_id and hinted_user_id and requesting_user == hinted_user_id:
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=hinted_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind="slack-posthog-code",
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
     elif slack_team_id and terminate_integration_id and (not terminate_user_id or requesting_user == terminate_user_id):
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=terminate_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind="slack-posthog-code",
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
 

--- a/products/slack_app/backend/models.py
+++ b/products/slack_app/backend/models.py
@@ -64,9 +64,9 @@ class SlackUserProfileCache(UUIDModel):
 
 
 class SlackSettings(UUIDModel):
-    """Per-(Slack workspace, Slack user) settings for inbound `slack-posthog-code`
-    events. Currently stores the routing default — which PostHog integration a
-    mention from this Slack user should route to.
+    """Per-(Slack workspace, Slack user) settings for inbound Slack events.
+    Currently stores the routing default — which PostHog integration a mention
+    from this Slack user should route to.
 
     Two row shapes share this table:
     - ``slack_user_id`` set → that Slack user's personal settings for this workspace.

--- a/products/slack_app/backend/services/commands.py
+++ b/products/slack_app/backend/services/commands.py
@@ -168,7 +168,7 @@ def _handle_project_show(
     else:
         result = load_integrations(
             slack_team_id=slack_workspace_id,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=slack_user_id,
             user=user,
         )
@@ -239,7 +239,7 @@ def _handle_project_set(
     else:
         target = (
             Integration.objects.filter(
-                kind="slack-posthog-code",
+                kind="slack",
                 integration_id=slack_workspace_id,
                 team_id=target_team_id,
             )
@@ -298,7 +298,7 @@ def resolve_command_target(
         resolve_from_candidates,
     )
 
-    initial = load_integrations(slack_team_id=slack_team_id, kinds=["slack-posthog-code"])
+    initial = load_integrations(slack_team_id=slack_team_id, kinds=["slack"])
     candidates = initial.candidates
     if not candidates:
         return [], ResolutionResult(integration=None, source="needs_picker", candidates=[])

--- a/products/slack_app/backend/tests/test_collect_thread_messages.py
+++ b/products/slack_app/backend/tests/test_collect_thread_messages.py
@@ -169,7 +169,7 @@ class TestCollectThreadMessages:
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -51,9 +51,7 @@ class TestSlackThreadTaskMapping(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         self.task = self.Task.objects.create(
             team=self.team,
             title="Test task",
@@ -149,9 +147,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com", distinct_id="user-1")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
     @patch("posthog.temporal.ai.posthog_code_slack_mention.execute_task_processing_workflow")
     @patch("posthog.temporal.ai.posthog_code_slack_mention.SlackIntegration")
@@ -541,9 +537,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         self.task = self.Task.objects.create(
             team=self.team,
             title="Test task",
@@ -880,9 +874,7 @@ class TestEnforcePostHogCodeBillingQuotaActivity(TestCase):
     def setUp(self):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
     @patch("posthog.models.integration.SlackIntegration")
     @patch("ee.billing.quota_limiting.is_team_limited", return_value=True)

--- a/products/slack_app/backend/tests/test_guess_repository.py
+++ b/products/slack_app/backend/tests/test_guess_repository.py
@@ -37,7 +37,7 @@ class TestGetFullRepoNames:
 
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )
@@ -160,7 +160,7 @@ class TestGetFullRepoNamesCache:
         self.team = Team.objects.create(organization=self.organization, name="Cache Team")
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_CACHE",
             sensitive_config={"access_token": "xoxb-cache"},
         )
@@ -203,7 +203,7 @@ class TestGetFullRepoNamesCache:
         team_b = Team.objects.create(organization=org_b, name="Other Team")
         slack_b = Integration.objects.create(
             team=team_b,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_OTHER",
             sensitive_config={"access_token": "xoxb-other"},
         )
@@ -320,7 +320,7 @@ class TestPostRepoPickerPrewarm:
         self.team = Team.objects.create(organization=self.organization, name="Prewarm Team")
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_PREWARM",
             sensitive_config={"access_token": "xoxb-prewarm"},
         )
@@ -474,7 +474,7 @@ class TestHandleRulesCommandActivity:
 
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )

--- a/products/slack_app/backend/tests/test_integration_resolver.py
+++ b/products/slack_app/backend/tests/test_integration_resolver.py
@@ -31,7 +31,7 @@ class TestResolveIntegration:
         # Different workspace; should never match the WORKSPACE-scoped lookups.
         self.integration_other_workspace = Integration.objects.create(
             team=self.team_a,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_OTHER",
             sensitive_config={"access_token": "xoxb-other"},
         )
@@ -39,14 +39,14 @@ class TestResolveIntegration:
     def _mk_integration(self, team: Team) -> Integration:
         return Integration.objects.create(
             team=team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id=WORKSPACE,
             sensitive_config={"access_token": "xoxb"},
         )
 
     def _workspace_integrations(self) -> list[Integration]:
         return list(
-            Integration.objects.filter(kind="slack-posthog-code", integration_id=WORKSPACE).select_related(
+            Integration.objects.filter(kind="slack", integration_id=WORKSPACE).select_related(
                 "team", "team__organization"
             )
         )
@@ -75,7 +75,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
             channel="C1",
@@ -107,7 +107,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
             channel="C1",
@@ -128,7 +128,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
         )
@@ -146,7 +146,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
         )
@@ -156,21 +156,21 @@ class TestResolveIntegration:
         assert {i.id for i in result.candidates} == {self.integration_a.id, self.integration_b.id}
 
     def test_user_default_ignored_when_target_kind_changed(self):
-        # Stored default points at integration_a, but its kind was switched
-        # away from "slack-posthog-code" (e.g. it became a plain notifications
-        # "slack" install). The default must silently fall through rather than
-        # routing the user to the wrong-kind integration.
+        # Stored default points at integration_a, but its kind no longer matches the
+        # Slack lookup (e.g. the row was repurposed for a different provider). The
+        # default must silently fall through rather than routing the user to the
+        # wrong-kind integration.
         SlackSettings.objects.create(
             default_integration=self.integration_a,
             slack_workspace_id=WORKSPACE,
             slack_user_id=SLACK_USER,
         )
-        self.integration_a.kind = "slack"
+        self.integration_a.kind = "github"
         self.integration_a.save(update_fields=["kind"])
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
         )
@@ -195,7 +195,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
         )
@@ -212,7 +212,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
         )
@@ -230,7 +230,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
         )
@@ -245,7 +245,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
         )
@@ -256,7 +256,7 @@ class TestResolveIntegration:
     def test_picker_with_multiple_candidates(self):
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
         )
@@ -271,7 +271,7 @@ class TestResolveIntegration:
         # integration becomes a candidate.
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=None,
         )
@@ -293,7 +293,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=None,
         )
@@ -319,7 +319,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=None,
             channel="C1",
@@ -341,7 +341,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=None,
         )
@@ -356,7 +356,7 @@ class TestResolveIntegration:
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
-            kinds=["slack-posthog-code"],
+            kinds=["slack"],
             slack_user_id=SLACK_USER,
             user=self.user,
         )

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -34,22 +34,22 @@ class TestPostHogCodeEventHandler(TestCase):
             **extra_headers,
         )
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_url_verification(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         response = self._post_event({"type": "url_verification", "challenge": "test-challenge-123"})
         assert response.status_code == 200
         assert response.json() == {"challenge": "test-challenge-123"}
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_invalid_signature(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": "different-secret"}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": "different-secret"}
         response = self._post_event({"type": "url_verification", "challenge": "test"})
         assert response.status_code == 403
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_retry_returns_200(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         body = json.dumps({"type": "event_callback", "event": {"type": "app_mention"}}).encode()
         signature, ts = sign_slack_request(body, self.signing_secret)
         response = self.client.post(
@@ -73,7 +73,7 @@ class TestPostHogCodeEventHandler(TestCase):
         ]
     )
     @patch("products.slack_app.backend.api.route_posthog_code_event_to_relevant_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_event_callback_dispatch(
         self,
         _name,
@@ -84,7 +84,7 @@ class TestPostHogCodeEventHandler(TestCase):
         mock_config,
         mock_route,
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_route.return_value = route_result
         payload = {
             "type": "event_callback",
@@ -109,7 +109,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
         self.posthog_code_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             config={"scope": ",".join(sorted(POSTHOG_CODE_REQUIRED_SLACK_SCOPES))},
             sensitive_config={"access_token": "xoxb-posthog-code-test"},
@@ -314,7 +314,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         other_team = Team.objects.create(organization=self.organization, name="Other")
         other_integration = Integration.objects.create(
             team=other_team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             config=self.posthog_code_integration.config,
             sensitive_config={"access_token": "xoxb-other"},
@@ -405,7 +405,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         other_team = Team.objects.create(organization=self.organization, name="Other")
         disabled_integration = Integration.objects.create(
             team=other_team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             config=self.posthog_code_integration.config,
             sensitive_config={"access_token": "xoxb-other"},
@@ -474,67 +474,6 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         assert passed_integration.integration_id == "T12345"
 
     @patch("products.slack_app.backend.api._proxy_event_and_return_route")
-    @patch("products.slack_app.backend.api.asyncio.run")
-    @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
-    def test_app_mention_on_us_with_only_notifications_proxies_to_eu(
-        self, mock_sync_connect, mock_asyncio_run, mock_proxy
-    ):
-        # US (primary) holds only a notifications install. The coding-agent install may live in EU,
-        # so the event must be proxied without consulting the lookup endpoint (US doesn't ask).
-        self.posthog_code_integration.delete()
-        Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id="T12345",
-            sensitive_config={"access_token": "xoxb-notifications"},
-        )
-        mock_proxy.return_value = "proxied"
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
-
-        from products.slack_app.backend.api import ROUTE_PROXIED, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
-
-        assert result == ROUTE_PROXIED
-        mock_proxy.assert_called_once()
-        # Target is the EU domain — never the incoming host.
-        assert mock_proxy.call_args.args[1] == "eu.posthog.com"
-        mock_sync_connect.assert_not_called()
-        mock_asyncio_run.assert_not_called()
-
-    @patch("products.slack_app.backend.api._proxy_event_and_return_route")
-    @patch("products.slack_app.backend.api.asyncio.run")
-    @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
-    def test_loop_header_with_only_notifications_returns_no_integration(
-        self, mock_sync_connect, mock_asyncio_run, mock_proxy
-    ):
-        # The second hop must not bounce the event back. Without local coding-agent install AND
-        # the loop header set, we drop with ROUTE_NO_INTEGRATION rather than proxy again.
-        self.posthog_code_integration.delete()
-        Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id="T12345",
-            sensitive_config={"access_token": "xoxb-notifications"},
-        )
-        request = self.factory.post(
-            "/slack/event-callback/",
-            HTTP_HOST="us.posthog.com",
-            headers={"x-posthog-region-proxied": "1"},
-        )
-
-        from products.slack_app.backend.api import ROUTE_NO_INTEGRATION, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
-
-        assert result == ROUTE_NO_INTEGRATION
-        mock_proxy.assert_not_called()
-        mock_sync_connect.assert_not_called()
-        mock_asyncio_run.assert_not_called()
-
-    @patch("products.slack_app.backend.api._proxy_event_and_return_route")
     @override_settings(DEBUG=False)
     def test_us_no_local_proxies_to_eu(self, mock_proxy):
         mock_proxy.return_value = "proxied"
@@ -601,7 +540,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
         assert result == ROUTE_PROXIED
         mock_lookup.assert_called_once()
-        assert mock_lookup.call_args.kwargs["kinds"] == ["slack-posthog-code"]
+        assert mock_lookup.call_args.kwargs["kinds"] == ["slack"]
         mock_proxy.assert_called_once()
         assert mock_proxy.call_args.args[1] == "us.posthog.com"
         mock_sync_connect.assert_not_called()

--- a/products/slack_app/backend/tests/test_posthog_code_interactivity.py
+++ b/products/slack_app/backend/tests/test_posthog_code_interactivity.py
@@ -41,9 +41,9 @@ class TestPostHogCodeInteractivityHandler(TestCase):
         response = self.client.get("/slack/interactivity-callback/")
         assert response.status_code == 405
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_invalid_signature_returns_403(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": "different-secret"}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": "different-secret"}
         response = self._post_interactivity({"type": "block_suggestion"})
         assert response.status_code == 403
 
@@ -60,7 +60,7 @@ class TestRepoPickerOptions(TestCase):
         OrganizationMembership.objects.create(user=self.user, organization=self.organization)
         self.posthog_code_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-posthog-code-test"},
         )
@@ -96,9 +96,9 @@ class TestRepoPickerOptions(TestCase):
         )
 
     @patch("products.slack_app.backend.api._get_full_repo_names")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_returns_filtered_repos(self, mock_config, mock_get_repos):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_get_repos.return_value = ["posthog/posthog", "posthog/posthog-js", "posthog/hogvm"]
 
         payload = {
@@ -115,9 +115,9 @@ class TestRepoPickerOptions(TestCase):
         assert options[0]["value"] == "posthog/posthog-js"
 
     @patch("products.slack_app.backend.api._get_full_repo_names")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_empty_query_returns_all(self, mock_config, mock_get_repos):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_get_repos.return_value = ["posthog/posthog", "posthog/posthog-js"]
 
         payload = {
@@ -131,9 +131,9 @@ class TestRepoPickerOptions(TestCase):
         assert response.status_code == 200
         assert len(response.json()["options"]) == 2
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_wrong_user_returns_empty(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
 
         payload = {
             "type": "block_suggestion",
@@ -146,9 +146,9 @@ class TestRepoPickerOptions(TestCase):
         assert response.status_code == 200
         assert response.json()["options"] == []
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_expired_token_returns_empty(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         cache.delete(f"posthog_code_repo_picker_ctx:{self.context_token}")
 
         payload = {
@@ -165,11 +165,11 @@ class TestRepoPickerOptions(TestCase):
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_submit_signals_temporal_workflow(
         self, mock_config, mock_sync_connect, mock_asyncio_run, mock_webclient_class
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_webclient_class.return_value = MagicMock()
         self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
         cache.set(f"posthog_code_repo_picker_ctx:{self.context_token}", self.context_payload, timeout=900)
@@ -199,11 +199,11 @@ class TestRepoPickerOptions(TestCase):
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_no_repo_button_signals_temporal_workflow(
         self, mock_config, mock_sync_connect, mock_asyncio_run, mock_webclient_class
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_webclient_class.return_value = MagicMock()
         self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
         cache.set(f"posthog_code_repo_picker_ctx:{self.context_token}", self.context_payload, timeout=900)
@@ -233,9 +233,9 @@ class TestRepoPickerOptions(TestCase):
         assert "without a repository" in update_call["text"].lower()
 
     @patch("posthog.models.integration.WebClient")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_submit_without_workflow_id_posts_expired(self, mock_config, mock_webclient_class):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client
         self.context_payload.pop("workflow_id", None)
@@ -263,7 +263,7 @@ class TestRepoPickerOptions(TestCase):
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_submit_signal_failure_posts_expired(
         self,
         mock_config,
@@ -271,7 +271,7 @@ class TestRepoPickerOptions(TestCase):
         mock_asyncio_run,
         mock_webclient_class,
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client
         self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
@@ -300,9 +300,9 @@ class TestRepoPickerOptions(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_terminate_action_starts_temporal_workflow(self, mock_config, mock_sync_connect, mock_asyncio_run):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
 
         payload = {
             "type": "block_actions",
@@ -546,7 +546,7 @@ class TestInteractivityRegionRouting(TestCase):
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
         self.posthog_code_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-posthog-code-test"},
         )
@@ -626,17 +626,17 @@ class TestInteractivityRegionRouting(TestCase):
 
     @patch("products.slack_app.backend.api._proxy_event_to_region")
     @patch("products.slack_app.backend.api._get_full_repo_names", return_value=["posthog/posthog"])
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_local_match_handles_without_proxy(self, mock_config, _mock_repos, mock_proxy):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         response = self._post(self._local_picker_payload(), host="us.posthog.com")
         assert response.status_code == 200
         mock_proxy.assert_not_called()
 
     @patch("products.slack_app.backend.api._proxy_event_to_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_us_no_local_proxies_to_eu(self, mock_config, mock_proxy):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_proxy.return_value = self._proxy_response(200, b'{"forwarded": true}')
 
         response = self._post(self._foreign_picker_payload(), host="us.posthog.com")
@@ -647,9 +647,9 @@ class TestInteractivityRegionRouting(TestCase):
         assert mock_proxy.call_args.args[1] == "eu.posthog.com"
 
     @patch("products.slack_app.backend.api._proxy_event_to_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_eu_no_local_proxies_to_us(self, mock_config, mock_proxy):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_proxy.return_value = self._proxy_response(200, b'{"forwarded": true}')
 
         response = self._post(self._foreign_picker_payload(), host="eu.posthog.com")
@@ -659,12 +659,12 @@ class TestInteractivityRegionRouting(TestCase):
         assert mock_proxy.call_args.args[1] == "us.posthog.com"
 
     @patch("products.slack_app.backend.api._proxy_event_to_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_loop_header_skips_proxy_block_suggestion_returns_empty_options(self, mock_config, mock_proxy):
         # The loop header is what guarantees at-most-one hop. If we receive a payload that we
         # don't own AND the header is set, the other region already deferred — there is no
         # second region to try, so we must return Slack-safe defaults instead of proxying.
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
 
         response = self._post(
             self._foreign_picker_payload(),
@@ -677,9 +677,9 @@ class TestInteractivityRegionRouting(TestCase):
         mock_proxy.assert_not_called()
 
     @patch("products.slack_app.backend.api._proxy_event_to_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_loop_header_skips_proxy_block_actions_returns_200(self, mock_config, mock_proxy):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
 
         response = self._post(
             self._foreign_action_payload(),
@@ -691,9 +691,9 @@ class TestInteractivityRegionRouting(TestCase):
         mock_proxy.assert_not_called()
 
     @patch("products.slack_app.backend.api._proxy_event_to_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_proxy_failure_returns_502_for_actions(self, mock_config, mock_proxy):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_proxy.return_value = None
 
         response = self._post(self._foreign_action_payload(), host="us.posthog.com")
@@ -702,11 +702,11 @@ class TestInteractivityRegionRouting(TestCase):
         mock_proxy.assert_called_once()
 
     @patch("products.slack_app.backend.api._proxy_event_to_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_proxy_failure_returns_empty_options_for_suggestion(self, mock_config, mock_proxy):
         # block_suggestion has a tight render budget on Slack's side; a 502 would surface as a
         # spinner-then-error in the dropdown. Empty options keeps the UI responsive instead.
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_proxy.return_value = None
 
         response = self._post(self._foreign_picker_payload(), host="us.posthog.com")
@@ -716,9 +716,9 @@ class TestInteractivityRegionRouting(TestCase):
         mock_proxy.assert_called_once()
 
     @patch("products.slack_app.backend.api._proxy_event_to_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_proxy_relays_content_type_verbatim(self, mock_config, mock_proxy):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_proxy.return_value = self._proxy_response(201, b"<xml/>", content_type="application/xml")
 
         response = self._post(self._foreign_picker_payload(), host="us.posthog.com")
@@ -730,12 +730,12 @@ class TestInteractivityRegionRouting(TestCase):
     @patch("products.slack_app.backend.api._proxy_event_to_region")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_terminate_hints_local_handles(self, mock_config, mock_sync_connect, _mock_asyncio_run, mock_proxy):
         # Terminate buttons embed integration_id in the action value (not context_token). When
         # the value points at a row in this DB, we must handle locally without consulting the
         # other region — even when the loop header is absent.
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
 
         payload = {
             "type": "block_actions",

--- a/products/slack_app/backend/tests/test_resolve_slack_user.py
+++ b/products/slack_app/backend/tests/test_resolve_slack_user.py
@@ -23,7 +23,7 @@ class TestResolveSlackUser:
 
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )
@@ -143,7 +143,7 @@ class TestLookupSlackUserIdByEmail:
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )

--- a/products/slack_app/backend/tests/test_slack_settings.py
+++ b/products/slack_app/backend/tests/test_slack_settings.py
@@ -17,13 +17,13 @@ class TestSlackSettings:
         self.team_b = Team.objects.create(organization=self.organization, name="Team B")
         self.integration_a = Integration.objects.create(
             team=self.team_a,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_WS",
             sensitive_config={"access_token": "xoxb-a"},
         )
         self.integration_b = Integration.objects.create(
             team=self.team_b,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_WS",
             sensitive_config={"access_token": "xoxb-b"},
         )

--- a/products/slack_app/backend/tests/test_terminate.py
+++ b/products/slack_app/backend/tests/test_terminate.py
@@ -27,9 +27,7 @@ class TestProcessPostHogCodeTaskTermination(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         self.task = self.Task.objects.create(
             team=self.team,
             title="Test task",

--- a/products/slack_app/backend/tests/test_workspace_claims.py
+++ b/products/slack_app/backend/tests/test_workspace_claims.py
@@ -18,9 +18,9 @@ from products.slack_app.backend.tests.helpers import sign_slack_request
 class TestSlackWorkspaceClaimsView(TestCase):
     """The receiver-side endpoint that the other region calls to ask "do you claim this workspace?".
 
-    Authenticated with the same HMAC scheme Slack uses, against the PostHog Code Slack signing
-    secret that both regions already share. The signed body covers `slack_team_id + kinds`, so a
-    captured signature cannot be replayed against a different workspace.
+    Authenticated with the same HMAC scheme Slack uses, against the Slack app signing secret that
+    both regions already share. The signed body covers `slack_team_id + kinds`, so a captured
+    signature cannot be replayed against a different workspace.
     """
 
     def setUp(self):
@@ -44,70 +44,70 @@ class TestSlackWorkspaceClaimsView(TestCase):
         response = self.client.get("/slack/workspace/claims/")
         assert response.status_code == 405
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_existing_integration_returns_claimed(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_PRESENT",
             sensitive_config={"access_token": "xoxb"},
         )
-        response = self._post({"slack_team_id": "T_PRESENT", "kinds": ["slack-posthog-code"]})
+        response = self._post({"slack_team_id": "T_PRESENT", "kinds": ["slack"]})
         assert response.status_code == 200
         assert response.json() == {"claimed": True}
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_any_of_kinds_match_returns_claimed(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         Integration.objects.create(
             team=self.team,
             kind="slack",
             integration_id="T_NOTIF",
             sensitive_config={"access_token": "xoxb"},
         )
-        response = self._post({"slack_team_id": "T_NOTIF", "kinds": ["slack", "slack-posthog-code"]})
+        response = self._post({"slack_team_id": "T_NOTIF", "kinds": ["slack"]})
         assert response.status_code == 200
         assert response.json() == {"claimed": True}
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_missing_integration_returns_not_claimed(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
-        response = self._post({"slack_team_id": "T_UNKNOWN", "kinds": ["slack-posthog-code"]})
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
+        response = self._post({"slack_team_id": "T_UNKNOWN", "kinds": ["slack"]})
         assert response.status_code == 200
         assert response.json() == {"claimed": False}
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_invalid_signature_returns_403(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": "different-secret"}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": "different-secret"}
         response = self._post({"slack_team_id": "T_PRESENT", "kinds": ["slack"]})
         assert response.status_code == 403
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_missing_team_id_returns_400(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         response = self._post({"kinds": ["slack"]})
         assert response.status_code == 400
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_no_valid_kinds_returns_400(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         response = self._post({"slack_team_id": "T_PRESENT", "kinds": ["github", "not-real"]})
         assert response.status_code == 400
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_other_kinds_for_same_id_do_not_count(self, mock_config):
         # Same integration_id can be reused across PostHog integration kinds (e.g. a GitHub install
         # whose external id happens to collide with a Slack workspace). The endpoint must scope
         # to the requested Slack kinds only.
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         Integration.objects.create(
             team=self.team,
             kind="github",
             integration_id="T_PRESENT",
             sensitive_config={"access_token": "ghp"},
         )
-        response = self._post({"slack_team_id": "T_PRESENT", "kinds": ["slack", "slack-posthog-code"]})
+        response = self._post({"slack_team_id": "T_PRESENT", "kinds": ["slack"]})
         assert response.status_code == 200
         assert response.json() == {"claimed": False}
 
@@ -126,14 +126,14 @@ class TestDoesOtherRegionClaimWorkspace(TestCase):
         from products.slack_app.backend.api import does_other_region_claim_workspace
 
         with (
-            patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config") as mock_config,
+            patch("products.slack_app.backend.api.SlackIntegration.slack_config") as mock_config,
             patch("products.slack_app.backend.api.requests.post") as mock_post,
         ):
-            mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+            mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
             mock_post.return_value = mock_post_return
             kwargs = {
                 "slack_team_id": "T123",
-                "kinds": ["slack-posthog-code"],
+                "kinds": ["slack"],
                 "incoming_host": "eu.posthog.com",
                 **call_overrides,
             }
@@ -186,10 +186,10 @@ class TestDoesOtherRegionClaimWorkspace(TestCase):
         from products.slack_app.backend.api import does_other_region_claim_workspace
 
         with (
-            patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config") as mock_config,
+            patch("products.slack_app.backend.api.SlackIntegration.slack_config") as mock_config,
             patch("products.slack_app.backend.api.requests.post") as mock_post,
         ):
-            mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+            mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
             mock_post.side_effect = requests.ConnectionError("boom")
             result = does_other_region_claim_workspace(
                 slack_team_id="T123", kinds=["slack"], incoming_host="us.posthog.com"

--- a/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
@@ -47,7 +47,7 @@ class TestForwardPendingUserMessage(TestCase):
         )
         cls.slack_integration = Integration.objects.create(
             team=cls.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T123",
             config={},
         )

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -50,7 +50,7 @@ class TestRelaySlackMessage(TestCase):
         )
         cls.integration = Integration.objects.create(
             team=cls.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T123",
             config={},
         )

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3294,9 +3294,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
         SlackThreadTaskMapping.objects.create(
             team=self.team,
@@ -3345,9 +3343,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
         SlackThreadTaskMapping.objects.create(
             team=self.team,
@@ -3475,9 +3471,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
         mock_execute_relay.return_value = "relay-1"
 
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         SlackThreadTaskMapping.objects.create(
             team=self.team,
             integration=integration,
@@ -3559,9 +3553,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         SlackThreadTaskMapping.objects.create(
             team=self.team,
             integration=integration,


### PR DESCRIPTION
## Problem

The PostHog Code coding-agent Slack flow (`@PostHog` mentions, `/rules` command, repo picker, terminate-task interactivity) ran against its own dedicated Slack app (`Integration.kind="slack-posthog-code"`), separate from the regular notifications Slack app (`kind="slack"`). That forced orgs to install two PostHog Slack apps to use `@PostHog` mentions, even though the notifications Slack app already requests every OAuth scope the coding agent needs.

This re-applies #59354 — which made the same swap on master and then was reverted in #59584 while the region-routing work was in flight — on top of `vojtab/slack-region-routing`.

## Changes

- **Integration lookups** (`products/slack_app/backend/api.py`, `products/slack_app/backend/services/commands.py`, `posthog/temporal/ai/posthog_code_slack_*.py`): all `kind="slack-posthog-code"` lookups now use `kind="slack"`. Extracted `SLACK_INTEGRATION_KIND` module constant in `slack_app/backend/api.py`.
- **Webhook validation**: `/slack/event-callback`, `/slack/interactivity-callback`, and the cross-region `/slack/workspace/claims/` probe now validate with `SLACK_APP_SIGNING_SECRET` (notifications app) instead of `SLACK_POSTHOG_CODE_SIGNING_SECRET`. Both secrets are provisioned in both Cloud regions, so the cross-region probe keeps working.
- **Routing**: `route_posthog_code_event_to_relevant_region` and `does_other_region_claim_workspace` now pass `kinds=["slack"]`. The list-of-kinds parameter shape is preserved for now; collapsing it to a single kind belongs in a follow-up.
- **Tests**: updated fixtures to `kind="slack"`, swapped webhook signing-secret mocks to `slack_config()` / `SLACK_APP_SIGNING_SECRET`, dropped two `test_posthog_code_event_handler.py` scenarios that only existed to assert dual-kind dispatch (no longer meaningful with one kind).

### Out of scope (deliberate)

To keep this diff focused, the following remain in place and can be cleaned up in a follow-up:

- `IntegrationKind.SLACK_POSTHOG_CODE` enum value and the `oauth_config_for_kind`/`redirect_uri`/`authorize_url`/`SLACK_INTEGRATION_KINDS` branches that reference it.
- `SlackIntegration.posthog_code_slack_config()` classmethod.
- Frontend Authorize button (`PostHogCodeSlackIntegration.tsx`), `integrationsLogic` filters, settings page entry, `posthog_code_slack_service` preflight block.
- LLM gateway product aliases and MCP / OpenAPI generated types.

### Risks to watch

- Orgs with **only** the `slack-posthog-code` install (no `kind="slack"` row) lose the mention flow. Per the original PR's audit this was just internal orgs `381971` and `2`; a fresh audit before rollout is recommended.
- `kind="slack"` rows authorized before `ba8b5b5` (2026-05-04) may not have the required scopes — `app_mentions:read`, `channels:history`, `reactions:write`, `users:read.email`, etc. Detect via `config->>'scope'` and prompt reauth (follow-up PR).

## How did you test this code?

Agent-authored re-application of #59354. Automated tests:

- `hogli test products/slack_app/backend/tests/` — 318 passed
- `hogli test posthog/temporal/tests/ai/test_block_missing_user_github.py products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py products/tasks/backend/temporal/slack_relay/tests/test_activities.py` — 27 passed
- `hogli test products/tasks/backend/tests/test_api.py` — 373 passed
- `ruff check` clean on edited files
- Tested locally with just the slack creds + tested also the proxing stuff manually

No manual end-to-end testing performed in this session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change.

## 🤖 Agent context

Authored by Claude Code at the user's request. The user pointed at #59354 (originally merged, then reverted in #59584) and asked to re-apply the same `slack-posthog-code → slack` runtime swap on top of `vojtab/slack-region-routing`. The plan was deliberately scoped to lookups + webhook secret only — no enum / migration / frontend changes — so the diff stays reviewable and the riskier cleanup can land separately.

Two dual-kind regression tests in `test_posthog_code_event_handler.py` (`test_app_mention_on_us_with_only_notifications_proxies_to_eu`, `test_loop_header_with_only_notifications_returns_no_integration`) were deleted because their premise — "workspace holds notifications-only, no coding-agent install" — no longer corresponds to any state in the new model. All other touched tests were updated rather than removed.