### PR TITLE
fix(ci): exempt github noreply emails from the author-email nudge

### DIFF
--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -134,6 +134,13 @@ jobs:
                               continue;
                           }
                           const email = (c.commit?.author?.email || '').toLowerCase();
+                          // Skip GitHub noreply addresses (`id+user@users.noreply.github.com`):
+                          // the commit stays attributable to a real account, and it's a
+                          // deliberate "keep my email private" choice on this public repo —
+                          // not a misconfiguration worth nudging about.
+                          if (email.endsWith('@users.noreply.github.com')) {
+                              continue;
+                          }
                           if (email && !email.endsWith('@posthog.com')) {
                               offendingEmails.add(email);
                           }


### PR DESCRIPTION
## Problem

The `check-author-email` nudge (added in #60613) comments on a PR when an org member's commits use a non-`@posthog.com` git author email. As written, it also fires for GitHub privacy addresses like `80100530+darkopia@users.noreply.github.com`, which real PostHog members legitimately use.

These are a different situation from an accidental `someone@gmail.com`:

- The commit is **already attributable to a real GitHub account** (the numeric ID encodes the user), so org membership still maps it to a person — the "who wrote this?" problem is already solved.
- Using the noreply address is a **deliberate "keep my email private" choice** on a public repo. Nudging someone to swap it for `you@posthog.com` is asking them to publish their work email — reversing an intentional choice, not fixing a misconfiguration.

## Changes

Skip author emails ending in `@users.noreply.github.com` before the `@posthog.com` check, so they no longer trigger the nudge. Personal/unattributed emails are still caught.

## How did you test this code?

I'm an agent. No automated test suite covers this workflow's inline script. I validated the file with `actionlint` (passes), confirmed it's `oxfmt`-clean, and checked the YAML parses. The logic change is a single early-`continue` in the email loop, reasoned through the GitHub noreply-attribution behavior described above.

## 🤖 Agent context

Authored by Claude Code (Opus) at the request of @webjunkie as a follow-up to #60613.

Decision trail:
- Considered three options — exempt noreply, keep nudging but reword to acknowledge the privacy tradeoff, or leave as-is.
- The deciding factor: noreply addresses are *already* attributable to a real GitHub identity (unlike a random personal email, which only links if registered to the account), and they represent a deliberate privacy choice on a public repo. The nudge's value is highest for accidental/unattributed emails and arguably negative for noreply.
- Rejected "keep nudging, reword" because it would still nag people who made an intentional choice; it would only be warranted if internal contribution tooling matched on email *domain* rather than GitHub login.
- Chose to exempt, matching the maintainers' stated preference for keeping this low-noise.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7XexgSMVdTM9WvUXcA4dj)_