### PR TITLE
fix(data-warehouse): set postgres statement_timeout via client cursor

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1860,7 +1860,9 @@ def postgres_source(
                 # wide/partitioned scans the source's default (often 30-60s)
                 # kills the fetch before rows come back.
                 try:
-                    with connection.cursor() as setup_cursor:
+                    # Use psycopg.Cursor directly to bypass cursor_factory (which may be
+                    # ServerCursor and requires a `name` arg, breaking an unnamed cursor()).
+                    with psycopg.Cursor(connection) as setup_cursor:
                         setup_cursor.execute(
                             sql.SQL("SET statement_timeout = {timeout}").format(
                                 timeout=sql.Literal(SYNC_STATEMENT_TIMEOUT_MS)


### PR DESCRIPTION
## Problem

Postgres warehouse syncs were silently failing to apply the 10-minute `statement_timeout` bump on the streaming connection. The connection is opened with `cursor_factory=psycopg.ServerCursor` for non-read-replica syncs, so the unnamed `connection.cursor()` used to run `SET statement_timeout` raised:

```
ServerCursor.__init__() missing 1 required positional argument: 'name'
```

In psycopg3 a `ServerCursor` requires a `name` (it's backed by `DECLARE … CURSOR`), and a `SET` statement can't run on a server cursor anyway. The exception was caught and logged at DEBUG, so it went unnoticed — but it meant wide / partitioned scans were left exposed to the source's short default `statement_timeout` (often 30–60s), killing the fetch before rows came back.

This was a regression: the pre-revert code ran the `SET` through `psycopg.Cursor(connection)` directly to bypass the factory, and that was inadvertently swapped back to `connection.cursor()`.

## Changes

Run the `SET statement_timeout` through `psycopg.Cursor(connection)` directly, bypassing the connection's `ServerCursor` factory. This restores the known-good pattern. The streaming reads are unaffected — they pass an explicit cursor name, so they correctly get server-side cursors.

## How did you test this code?

I'm an agent (Claude Code). I traced the regression via `git blame` to the revert that reintroduced it, and confirmed the psycopg3 cursor-factory behaviour. No new automated test was added — this is a one-line restoration of a prior pattern on a code path that's awkward to unit-test without a live Postgres connection. `ruff check` passes on the changed file.

## 🤖 Agent context

Authored with Claude Code while investigating a failed Postgres sync. The user surfaced a `statement_timeout` warning in the sync logs alongside an unrelated offset-overflow error (the latter is being handled in a separate PR). I diagnosed the `ServerCursor` factory interaction, found via blame that a prior revert had reintroduced the bug, and restored the `psycopg.Cursor(connection)` approach the code used before.