### PR TITLE
fix(funnels): scope persons modal to the clicked grouped bar

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -455,6 +455,39 @@ describe('BarChart', () => {
             expect(tooltip.seriesData.map((s) => s.series.key)).toEqual(['b'])
         })
 
+        it('grouped onPointClick routes to the sub-band under the cursor, not the first series', async () => {
+            const onPointClick = jest.fn()
+            const { chart } = renderHogChart(
+                <BarChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ barLayout: 'grouped' }}
+                    onPointClick={onPointClick}
+                />
+            )
+            // Band center lands in `b`'s sub-band — the same position the grouped tooltip
+            // narrows to. Before the grouped click-routing fix this reported `a` (series[0]).
+            await chart.clickAtIndex(1)
+            const clickB: PointClickData = onPointClick.mock.calls[0][0]
+            expect(clickB.series.key).toBe('b')
+            expect(clickB.value).toBe(15)
+            expect(clickB.seriesIndex).toBe(1)
+
+            onPointClick.mockClear()
+            // Well left of center sits in `a`'s sub-band.
+            const step = dimensions.plotWidth / (LABELS.length - 1)
+            fireEvent.mouseMove(chart.element, {
+                clientX: dimensions.plotLeft + step * 1 - dimensions.plotWidth * 0.1,
+                clientY: dimensions.plotTop + dimensions.plotHeight / 2,
+            })
+            fireEvent.click(chart.element)
+            const clickA: PointClickData = onPointClick.mock.calls[0][0]
+            expect(clickA.series.key).toBe('a')
+            expect(clickA.value).toBe(20)
+            expect(clickA.seriesIndex).toBe(0)
+        })
+
         it('pins the tooltip on click when tooltip.pinnable is true', async () => {
             const { chart } = renderHogChart(
                 <BarChart series={SERIES} labels={LABELS} theme={THEME} config={{ tooltip: { pinnable: true } }} />

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -455,37 +455,52 @@ describe('BarChart', () => {
             expect(tooltip.seriesData.map((s) => s.series.key)).toEqual(['b'])
         })
 
-        it('grouped onPointClick routes to the sub-band under the cursor, not the first series', async () => {
+        it('grouped onPointClick routes to the sub-band under the cursor', async () => {
+            // Three groups so the middle slot is centred on the band — a click there resolves
+            // to series index 1, which neither a series[0] default nor an off-by-one produces.
+            const threeSeries: Series[] = [
+                { key: 'a', label: 'A', data: [5, 10, 15] },
+                { key: 'b', label: 'B', data: [6, 20, 16] },
+                { key: 'c', label: 'C', data: [7, 30, 17] },
+            ]
             const onPointClick = jest.fn()
             const { chart } = renderHogChart(
                 <BarChart
-                    series={SERIES}
+                    series={threeSeries}
                     labels={LABELS}
                     theme={THEME}
                     config={{ barLayout: 'grouped' }}
                     onPointClick={onPointClick}
                 />
             )
-            // Band center lands in `b`'s sub-band — the same position the grouped tooltip
-            // narrows to. Before the grouped click-routing fix this reported `a` (series[0]).
+            const bandCenterX = dimensions.plotLeft + dimensions.plotWidth / 2
+            const midRowY = dimensions.plotTop + dimensions.plotHeight / 2
+            // Each slot spans ~1/3 of the band; ~8% of plot width sits clearly inside the
+            // outer slots, past the nearest-centre boundary with the middle slot.
+            const slotOffset = dimensions.plotWidth * 0.08
+
+            // Band centre coincides with the middle slot.
             await chart.clickAtIndex(1)
-            const clickB: PointClickData = onPointClick.mock.calls[0][0]
-            expect(clickB.series.key).toBe('b')
-            expect(clickB.value).toBe(15)
-            expect(clickB.seriesIndex).toBe(1)
+            const middle: PointClickData = onPointClick.mock.calls[0][0]
+            expect(middle.series.key).toBe('b')
+            expect(middle.value).toBe(20)
+            expect(middle.seriesIndex).toBe(1)
 
             onPointClick.mockClear()
-            // Well left of center sits in `a`'s sub-band.
-            const step = dimensions.plotWidth / (LABELS.length - 1)
-            fireEvent.mouseMove(chart.element, {
-                clientX: dimensions.plotLeft + step * 1 - dimensions.plotWidth * 0.1,
-                clientY: dimensions.plotTop + dimensions.plotHeight / 2,
-            })
+            fireEvent.mouseMove(chart.element, { clientX: bandCenterX - slotOffset, clientY: midRowY })
             fireEvent.click(chart.element)
-            const clickA: PointClickData = onPointClick.mock.calls[0][0]
-            expect(clickA.series.key).toBe('a')
-            expect(clickA.value).toBe(20)
-            expect(clickA.seriesIndex).toBe(0)
+            const left: PointClickData = onPointClick.mock.calls[0][0]
+            expect(left.series.key).toBe('a')
+            expect(left.value).toBe(10)
+            expect(left.seriesIndex).toBe(0)
+
+            onPointClick.mockClear()
+            fireEvent.mouseMove(chart.element, { clientX: bandCenterX + slotOffset, clientY: midRowY })
+            fireEvent.click(chart.element)
+            const right: PointClickData = onPointClick.mock.calls[0][0]
+            expect(right.series.key).toBe('c')
+            expect(right.value).toBe(30)
+            expect(right.seriesIndex).toBe(2)
         })
 
         it('pins the tooltip on click when tooltip.pinnable is true', async () => {

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -493,8 +493,10 @@ function BarChartInner<Meta = unknown>({
     const seriesRef = useLatest(series)
     const labelsRef = useLatest(labels)
 
-    // Stacked/percent segments share a band slot — rewrite the click payload to the
-    // segment under the cursor so drop-off fillers and per-breakdown segments route correctly.
+    // Bars share a band slot — rewrite the click payload to the bar the cursor actually
+    // landed on. Stacked/percent segments stack along the value axis; grouped bars sit side
+    // by side on the band axis. Without this, both report the first visible series, so
+    // per-breakdown segments and drop-off fillers all route to series[0].
     const wrapClickData = useCallback(
         (clickData: PointClickData<Meta>, scales: ChartScales): PointClickData<Meta> => {
             const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
@@ -502,6 +504,14 @@ function BarChartInner<Meta = unknown>({
                 return clickData
             }
             return (
+                resolveClickedGroupedSegment({
+                    clickData,
+                    d3Scales,
+                    barLayout,
+                    isHorizontal,
+                    topStackedKeyByAxis,
+                    series: seriesRef.current,
+                }) ??
                 resolveClickedStackedSegment({
                     clickData,
                     d3Scales,
@@ -511,7 +521,8 @@ function BarChartInner<Meta = unknown>({
                     topStackedKeyByAxis,
                     series: seriesRef.current,
                     labels: labelsRef.current,
-                }) ?? clickData
+                }) ??
+                clickData
             )
         },
         [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef]
@@ -554,6 +565,64 @@ function BarChartInner<Meta = unknown>({
             {chart}
         </div>
     )
+}
+
+/** Grouped-layout counterpart to {@link resolveClickedStackedSegment}. Grouped bars share a
+ *  band but sit at different group offsets, so `buildPointClickData`'s "first visible series"
+ *  is wrong for every click outside series[0]'s slot. Picks the series whose group slot is
+ *  nearest the cursor on the band axis — the value axis is ignored, so a click above a short
+ *  bar still selects its column (matches chart.js `mode: 'point', axis: 'x'`). Returns `null`
+ *  when the layout isn't grouped, the cursor is absent, or the nearest slot is already the
+ *  reported series, signalling the caller to pass the original `clickData` through unchanged. */
+export function resolveClickedGroupedSegment<Meta>({
+    clickData,
+    d3Scales,
+    barLayout,
+    isHorizontal,
+    topStackedKeyByAxis,
+    series,
+}: {
+    clickData: PointClickData<Meta>
+    d3Scales: BarScaleSet
+    barLayout: BarLayout
+    isHorizontal: boolean
+    topStackedKeyByAxis: Map<string, string>
+    series: Series<Meta>[]
+}): PointClickData<Meta> | null {
+    if (isStackedLayout(barLayout)) {
+        return null
+    }
+    const { cursor, label, dataIndex } = clickData
+    if (!cursor) {
+        return null
+    }
+    const cursorBandCoord = isHorizontal ? cursor.y : cursor.x
+    let nearest: { series: Series<Meta>; distance: number } | null = null
+    for (const { series: s, bar } of iterBarsAtCursor({
+        series,
+        label,
+        dataIndex,
+        scales: d3Scales,
+        layout: barLayout,
+        isHorizontal,
+        topStackedKeyByAxis,
+    })) {
+        const center = isHorizontal ? bar.y + bar.height / 2 : bar.x + bar.width / 2
+        const distance = Math.abs(cursorBandCoord - center)
+        if (!nearest || distance < nearest.distance) {
+            nearest = { series: s, distance }
+        }
+    }
+    if (!nearest || nearest.series.key === clickData.series.key) {
+        return null
+    }
+    const value = clickData.crossSeriesData.find((d) => d.series.key === nearest!.series.key)?.value ?? clickData.value
+    return {
+        ...clickData,
+        series: nearest.series,
+        seriesIndex: series.findIndex((s) => s.key === nearest!.series.key),
+        value,
+    }
 }
 
 /** Pure helper extracted so the click-rewrite is unit-testable and the component-level


### PR DESCRIPTION
## Problem

The new hog-charts funnel conversion bar chart (`FunnelStepsBarChart`, vertical grouped layout) does not filter the persons modal to the bar that was clicked. With a breakdown, clicking any series' bar within a step always opens the modal for the **first** breakdown variant — the legacy chart.js version correctly scoped the modal to the clicked series.

Root cause is in the shared hog-charts `BarChart`: `buildPointClickData` always reports the first visible series, and `wrapClickData` only re-routed the click to the actual segment for **stacked** layouts (`resolveClickedStackedSegment` bails on grouped). Grouped bars sit side by side on the band axis, so the click never resolved to the correct sub-band. (The horizontal funnel chart uses a stacked layout and was already correct.)

Notably the grouped **tooltip** already narrowed to the bar under the cursor — only the click path was inconsistent.

## Changes

- Add `resolveClickedGroupedSegment` to `BarChart`, the grouped-layout counterpart to `resolveClickedStackedSegment`. It picks the series whose group sub-band is nearest the cursor on the band axis, ignoring the value axis (so a click above a short bar still selects its column — matching the tooltip's hit-test and chart.js's `mode: 'point', axis: 'x'`).
- Wire it into `wrapClickData` ahead of the stacked resolver; each returns `null` for the layout it doesn't handle, so exactly one applies.

No change was needed in the funnel component — it already reads `clickData.series.meta.breakdownIndex`; it just never received the correct series before.

## How did you test this code?

I'm an agent. I added and ran automated tests; I did not manually click through the UI.

- Added a `BarChart` unit test asserting a grouped-layout `onPointClick` routes to the sub-band under the cursor (`b`, value 15, seriesIndex 1) and to the adjacent sub-band (`a`, value 20, seriesIndex 0) when the cursor moves left — previously both reported `a`.
- `hogli test frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx` — 47 passed.
- `hogli test frontend/src/lib/hog-charts/core/interaction.test.ts` — 35 passed.
- `pnpm run format:frontend:check` — clean.
- `pnpm --filter=@posthog/frontend lint` — 0 errors.
- Scoped `tsc` over the changed `BarChart.tsx` — no type errors.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Investigated by comparing the legacy `StepBar` (separate fill/backdrop click zones) with the new grouped-layout chart, then traced the click path through `buildPointClickData` → `wrapClickData`. Considered fixing it inside the funnel component, but the component lacks the d3 group scale needed to map cursor → sub-band, so the fix belongs in the shared library where the stacked equivalent already lives. Scope kept to breakdown routing (the reported "doesn't filter" bug); the separate converted-vs-drop-off track behavior was left as-is.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
