### PR TITLE
fix(devbox): don't pin region on coder update

### DIFF
--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -31,7 +31,6 @@ from .coder import (
     GIT_NAME_PARAMETER,
     GIT_SIGNING_KEY_SECRET,
     REGIONS,
-    WORKSPACE_REGION_PARAMETER,
     _diagnose_unreachable_coder,
     _fail,
     coder_authenticated,
@@ -267,22 +266,13 @@ def _workspace_status_color(status: str) -> str:
     return WORKSPACE_STATUS_COLORS.get(status, "white")
 
 
-def _pinned_region_param(workspace: dict[str, Any]) -> dict[str, str]:
-    """Pin `workspace_region` to the workspace's current value for `coder update`.
+def _sync_workspace_parameters(name: str) -> None:
+    """Push local config (git identity, dotfiles) to workspace parameters before start.
 
-    Coder re-prompts for any parameter whose template-declared option set has
-    changed since the workspace was created (see coder.com docs on rich
-    parameters). The recent addition of `eu-central-1` did exactly that, so
-    every update path now forwards the current value to suppress the picker.
-    Boxes predating region metadata default to us-east-1 — the only region
-    that existed before the metadata item was added.
+    `workspace_region` is intentionally not forwarded: it is immutable, so Coder
+    carries it forward on its own and rejects any explicit value on `coder
+    update` (see the comment on `WORKSPACE_REGION_PARAMETER`).
     """
-    region = get_workspace_region(workspace) or DEFAULT_REGION
-    return {WORKSPACE_REGION_PARAMETER: region}
-
-
-def _sync_workspace_parameters(name: str, workspace: dict[str, Any]) -> None:
-    """Push local config (git identity, dotfiles) to workspace parameters before start."""
     config = load_config()
     params: dict[str, str] = {}
 
@@ -296,10 +286,8 @@ def _sync_workspace_parameters(name: str, workspace: dict[str, Any]) -> None:
     if dotfiles_uri:
         params[DOTFILES_URI_PARAMETER] = dotfiles_uri
 
-    if not params:
-        return
-    params.update(_pinned_region_param(workspace))
-    update_workspace_parameters(name, params)
+    if params:
+        update_workspace_parameters(name, params)
 
 
 def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: bool) -> None:
@@ -315,7 +303,7 @@ def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: 
         click.echo("Wait for the current operation to complete.")
         return
 
-    _sync_workspace_parameters(name, workspace)
+    _sync_workspace_parameters(name)
 
     if status == "stopped":
         click.echo(f"Starting devbox '{name}'...")
@@ -1332,7 +1320,7 @@ def devbox_update(workspace: str | None, verbose: bool) -> None:
         click.echo(f"Devbox '{name}' is already up to date.")
         return
     config = load_config()
-    params: dict[str, str] = _pinned_region_param(ws)
+    params: dict[str, str] = {}
     if dotfiles_uri := config.get("dotfiles_uri"):
         params[DOTFILES_URI_PARAMETER] = dotfiles_uri
     click.echo(f"Updating '{name}' to the latest template...")

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -45,14 +45,16 @@ DOTFILES_URI_PARAMETER = "dotfiles_uri"
 DOTFILES_BRANCH_PARAMETER = "dotfiles_branch"
 JETBRAINS_IDES_PARAMETER = "jetbrains_ides"
 
-# Region selector. The template defines `workspace_region` with a us-east-1
-# default; eu-central-1 became a valid option when the EU infrastructure went
-# live. The value is immutable after creation, but it must still be forwarded
-# on `coder update` and the parameter sync -- when a template author changes a
-# parameter's allowed values, Coder re-prompts existing workspaces for that
-# parameter regardless of `--use-parameter-defaults`, and the prompt is not
-# bypassable by any flag. Pinning the current value short-circuits the picker.
-# Valid values match the template contract exactly.
+# Create-time region selector. The template defines `workspace_region` with a
+# us-east-1 default; eu-central-1 became a valid option when the EU
+# infrastructure went live. The value is immutable after creation, so it is
+# forwarded on `coder create` only -- never on `coder update` or the pre-start
+# parameter sync. Coder carries an immutable parameter's value forward on its
+# own during an update and *rejects* any explicit `--parameter
+# workspace_region=` with "parameter is immutable and cannot be updated". The
+# option-change re-prompt that no flag can bypass only applies to *mutable*
+# parameters, so forwarding the region here breaks every resume instead of
+# suppressing a picker. Valid values match the template contract exactly.
 WORKSPACE_REGION_PARAMETER = "workspace_region"
 REGIONS = ("us-east-1", "eu-central-1")
 DEFAULT_REGION = REGIONS[0]

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -1678,10 +1678,7 @@ class TestDevboxCommands:
         assert result.exit_code == 0
         assert "Updating" in result.output
         assert captured["name"] == "devbox-test-user"
-        assert captured["parameters"] == {
-            "dotfiles_uri": "https://github.com/user/dotfiles",
-            "workspace_region": coder.DEFAULT_REGION,
-        }
+        assert captured["parameters"] == {"dotfiles_uri": "https://github.com/user/dotfiles"}
 
     def test_devbox_update_skips_when_up_to_date(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(devbox_cli, "ensure_runtime_ready", lambda: None)
@@ -2171,7 +2168,6 @@ class TestStartExistingWorkspace:
                 "git_name": "PostHog Engineer",
                 "git_email": "test-user@example.com",
                 "dotfiles_uri": "https://github.com/user/dotfiles",
-                "workspace_region": coder.DEFAULT_REGION,
             },
         }
 
@@ -2196,14 +2192,13 @@ class TestStartExistingWorkspace:
 
         assert calls == ["start"]
 
-    def test_sync_pins_workspace_region_from_metadata_to_suppress_picker(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When a `coder update` actually fires, pin the current region.
+    def test_sync_never_forwards_immutable_workspace_region(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The pre-start sync must omit `workspace_region`.
 
-        Coder re-prompts for any parameter whose template-declared option set
-        changed since workspace creation. Forwarding the workspace's current
-        region as `--parameter workspace_region=<value>` short-circuits that
-        picker -- the prompt is otherwise unanswerable from environments that
-        can't deliver stdin (e.g. an IDE's read-only output channel).
+        It is immutable; Coder carries it forward on its own and rejects any
+        explicit value on `coder update` with "parameter is immutable and
+        cannot be updated", which would break every resume of a region-aware
+        box. Even for an eu-central-1 workspace, the region must not appear.
         """
         captured: dict[str, object] = {}
         monkeypatch.setattr(devbox_cli, "get_workspace_status", lambda ws: "stopped")
@@ -2228,10 +2223,8 @@ class TestStartExistingWorkspace:
         }
         devbox_cli._start_existing_workspace("devbox-test-user", workspace, verbose=False)
 
-        assert captured["params"] == {
-            "dotfiles_uri": "https://github.com/user/dotfiles",
-            "workspace_region": "eu-central-1",
-        }
+        assert captured["params"] == {"dotfiles_uri": "https://github.com/user/dotfiles"}
+        assert coder.WORKSPACE_REGION_PARAMETER not in captured["params"]
 
     def test_skips_sync_for_running_workspace(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls: list[str] = []


### PR DESCRIPTION
## Problem

`hogli devbox:start` and `devbox:update` fail to resume any region-aware devbox: the pre-start sync forwards the immutable `workspace_region` to `coder update`, and Coder rejects it (`parameter "workspace_region" is immutable and cannot be updated`) regardless of value. The retry shim only drops `is not present`, so it hard-fails — leaving raw `coder start` as the only workaround.

The pin assumed Coder re-prompts on option-set changes (the `eu-central-1` addition). That only applies to *mutable* params; immutable values are carried forward automatically with no prompt (`cli/parameterresolver.go`).

## Changes

- Stop forwarding `workspace_region` on `coder update` (removed `_pinned_region_param`; dropped from sync and `devbox:update`). Still forwarded on `coder create`, where it belongs.
- Comment documents why the region must never go on update, to prevent reintroduction.
- Reverted the pin tests; added a regression guard.

## How did you test this code?

Agent-authored, no manual devbox run. Verified semantics against `coder/coder` `cli/parameterresolver.go`. `ruff`/format/`ty check` clean; `test_devbox.py` 241 passed.

Validated live on a real devbox (Coder v2.33.5): pinning the current value still errors `parameter "workspace_region" is immutable and cannot be updated`, while omitting it carries the region forward with no prompt and the build proceeds.

## 🤖 Agent context

Claude Code (Opus 4.8) via `/wt`. Confirmed the bug by reading Coder's upstream parameter resolver; chose to revert the pin over hardening the retry shim (no remaining caller forwards an immutable param on update). Requires human review.
