### PR TITLE
chore(data-warehouse): clearer activity log for schema enable/disable

### DIFF
--- a/products/data_warehouse/frontend/shared/components/activityDescriptions.tsx
+++ b/products/data_warehouse/frontend/shared/components/activityDescriptions.tsx
@@ -120,6 +120,19 @@ export function externalDataSourceActivityDescriber(
 
     if (logItem.activity == 'updated') {
         if (logItem.scope === ActivityScope.EXTERNAL_DATA_SCHEMA) {
+            const changes = logItem.detail?.changes ?? []
+            const enabledChange = changes.find((change) => change.field === 'enabled')
+            if (enabledChange && changes.length === 1) {
+                const verb = enabledChange.after ? 'enabled' : 'disabled'
+                return {
+                    description: (
+                        <>
+                            <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> {verb} schema{' '}
+                            <strong>{displayName}</strong>
+                        </>
+                    ),
+                }
+            }
             return {
                 description: (
                     <>


### PR DESCRIPTION
## Problem

Toggling an external data schema between enabled and disabled (the `should_sync` field) shows up in the source's activity feed as the same generic `"<user> updated schema X"` line you get for any other edit (sync type, frequency, etc.) — so you can't tell at a glance whether someone paused a sync or just tweaked its config.

## Changes

Frontend describer change only. In `externalDataSourceActivityDescriber`, when an `ExternalDataSchema` `updated` log entry has exactly one change and that change is to the `enabled` field, render:

- `<user> enabled schema X` when `enabled` flips false → true
- `<user> disabled schema X` when `enabled` flips true → false

Multi-field updates still fall through to the existing `"updated schema X"` description so we don't lose info about co-edited fields.

**Backwards compatibility:** no backend changes, no migrations. The activity log layer already renames `should_sync` to `enabled` in the stored `Change` records (via `field_name_overrides["ExternalDataSchema"]` in `posthog/models/activity_logging/activity_log.py`), so historic log rows render with the new verbs without any backfill.

## How did you test this code?

I'm an agent. I did not run the dev server or click through the UI. What I did run:

- TypeScript check via `pnpm --filter=@posthog/frontend typescript:check`. No new errors attributable to this file — the only errors that appear on it are pre-existing environment errors (`react/jsx-runtime` / `JSX.IntrinsicElements`) that hit every TSX file in the repo on this runner.
- Inspected the existing test suite at `posthog/test/activity_logging/test_external_data_schema_activity_logging.py` — backend behavior is unchanged, so those tests should continue to pass without modification.

Reviewer manual verification suggestions: toggle a warehouse schema's enabled switch and check the source's activity tab reads `"<you> disabled schema <name> (...)"`; toggle back on and confirm it reads `"<you> enabled schema <name> (...)"`; change sync frequency to confirm it still reads `"<you> updated schema <name> (...)"`. Existing project with prior schema toggle logs should also render with the new verbs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) in PostHog Cloud Tasks. Jovan asked for the schema activity logs to read as "Disabled"/"Enabled" instead of a generic "updated", and to consider whether the change would break existing logs.

Decisions:

- Considered adding new backend `activity` values (`"enabled"` / `"disabled"`) but kept `activity == "updated"` so scope filters, activity-log queries, and the existing `ActivityScope` typing continue to work — the verb is purely a render-time concern.
- Considered always rendering enable/disable verbs even when other fields also changed, but chose to only short-circuit when `enabled` is the sole change so multi-field saves don't visually hide their other edits. In practice the schema UI fires separate requests for the toggle vs. the config form, so this rarely matters.
- Confirmed existing rows already store `field: "enabled"` with boolean before/after, so no migration or dual-read is needed.