### PR TITLE
fix(dashboards): show add tile button in edit mode

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
@@ -113,7 +113,7 @@ describe('DashboardHeader', () => {
             scenario: 'Edit mode',
             dashboardMode: DashboardMode.Edit,
             canEdit: true,
-            visible: ['dashboard-edit-mode-discard', 'dashboard-edit-mode-save'],
+            visible: ['dashboard-edit-mode-discard', 'dashboard-edit-mode-save', 'dashboard-add-tile'],
             notVisible: ['dashboard-share-button', 'add-text-tile-to-dashboard', 'dashboard-add-graph-header'],
         },
         {

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -19,6 +19,69 @@ import { AccessControlLevel, AccessControlResourceType, DashboardMode } from '~/
 import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
 import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
 
+export function DashboardAddTileButton(): JSX.Element | null {
+    const { dashboard } = useValues(dashboardLogic)
+    const { loadDashboard } = useActions(dashboardLogic)
+    const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
+    const { push } = useActions(router)
+
+    if (!dashboard) {
+        return null
+    }
+
+    return (
+        <MaxTool
+            className="shrink-0"
+            identifier="upsert_dashboard"
+            context={{
+                current_dashboard: {
+                    id: dashboard.id,
+                    name: dashboard.name,
+                    description: dashboard.description,
+                    tags: dashboard.tags,
+                },
+            }}
+            contextDescription={{
+                text: dashboard.name,
+                icon: iconForType('dashboard'),
+            }}
+            active={false}
+            callback={() => loadDashboard({ action: DashboardLoadAction.Update })}
+            position="top-right"
+        >
+            <AccessControlAction
+                resourceType={AccessControlResourceType.Dashboard}
+                minAccessLevel={AccessControlLevel.Editor}
+                userAccessLevel={dashboard.user_access_level}
+            >
+                <LemonMenu
+                    items={[
+                        {
+                            label: 'Insight',
+                            onClick: showAddInsightToDashboardModal,
+                            'data-attr': 'dashboard-add-insight',
+                        },
+                        {
+                            label: 'Text card',
+                            onClick: () => push(urls.dashboardTextTile(dashboard.id, 'new')),
+                            'data-attr': 'dashboard-add-text-tile',
+                        },
+                        {
+                            label: 'Button',
+                            onClick: () => push(urls.dashboardButtonTile(dashboard.id, 'new')),
+                            'data-attr': 'dashboard-add-button-tile',
+                        },
+                    ]}
+                >
+                    <LemonButton type="primary" data-attr="dashboard-add-tile" size="small" icon={<IconPlusSmall />}>
+                        Add
+                    </LemonButton>
+                </LemonMenu>
+            </AccessControlAction>
+        </MaxTool>
+    )
+}
+
 export function EditModeActions(): JSX.Element {
     const { dashboardLoading, canEditDashboard } = useValues(dashboardLogic)
     const { setDashboardMode, cancelEditMode } = useActions(dashboardLogic)
@@ -68,6 +131,7 @@ export function EditModeActions(): JSX.Element {
                     Save
                 </LemonButton>
             </AppShortcut>
+            <DashboardAddTileButton />
         </>
     )
 }
@@ -91,8 +155,7 @@ export function FullscreenModeActions(): JSX.Element {
 
 export function ViewModeActions(): JSX.Element {
     const { dashboard, canEditDashboard, tiles } = useValues(dashboardLogic)
-    const { setDashboardMode, loadDashboard } = useActions(dashboardLogic)
-    const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
+    const { setDashboardMode } = useActions(dashboardLogic)
     const { push } = useActions(router)
     if (!dashboard) {
         return <></>
@@ -133,59 +196,7 @@ export function ViewModeActions(): JSX.Element {
                     </LemonButton>
                 </AppShortcut>
             )}
-            <MaxTool
-                identifier="upsert_dashboard"
-                context={{
-                    current_dashboard: {
-                        id: dashboard.id,
-                        name: dashboard.name,
-                        description: dashboard.description,
-                        tags: dashboard.tags,
-                    },
-                }}
-                contextDescription={{
-                    text: dashboard.name,
-                    icon: iconForType('dashboard'),
-                }}
-                active={false}
-                callback={() => loadDashboard({ action: DashboardLoadAction.Update })}
-                position="top-right"
-            >
-                <AccessControlAction
-                    resourceType={AccessControlResourceType.Dashboard}
-                    minAccessLevel={AccessControlLevel.Editor}
-                    userAccessLevel={dashboard.user_access_level}
-                >
-                    <LemonMenu
-                        items={[
-                            {
-                                label: 'Insight',
-                                onClick: showAddInsightToDashboardModal,
-                                'data-attr': 'dashboard-add-insight',
-                            },
-                            {
-                                label: 'Text card',
-                                onClick: () => push(urls.dashboardTextTile(dashboard.id, 'new')),
-                                'data-attr': 'dashboard-add-text-tile',
-                            },
-                            {
-                                label: 'Button',
-                                onClick: () => push(urls.dashboardButtonTile(dashboard.id, 'new')),
-                                'data-attr': 'dashboard-add-button-tile',
-                            },
-                        ]}
-                    >
-                        <LemonButton
-                            type="primary"
-                            data-attr="dashboard-add-tile"
-                            size="small"
-                            icon={<IconPlusSmall />}
-                        >
-                            Add
-                        </LemonButton>
-                    </LemonMenu>
-                </AccessControlAction>
-            </MaxTool>
+            <DashboardAddTileButton />
         </>
     )
 }


### PR DESCRIPTION
## Problem

When editing a dashboard layout, the header **Add** menu (insight, text card, button) disappeared because edit mode swapped in a different action bar with only Cancel and Save. Users had to exit edit mode to add tiles.

tl;dr:
Basically always show the Add button whether or not they are in edit mode

## Changes

- Extracted `DashboardAddTileButton` and render it in both view and edit header actions
- Kept **Add** as the rightmost action in both modes so its position stays stable
- Added `shrink-0` on the Add wrapper so it is not collapsed in the header flex row
- Updated `DashboardHeader` tests to expect `dashboard-add-tile` in edit mode

## How did you test this code?

Agent-authored PR — manual UI verification was not performed by the agent.

Automated tests run:

- `pnpm jest frontend/src/scenes/dashboard/DashboardHeader.test.tsx`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — UI behavior fix only.

## 🤖 Agent context

Cursor agent (Composer) implemented this from a request to keep the dashboard header **Add** button visible in layout edit mode.

The Add menu lived only in `ViewModeActions`; `EditModeActions` replaced the whole action group with Cancel/Save. The fix shares one `DashboardAddTileButton` component used as the last child in both action groups so **Add** stays rightmost when switching modes.

An earlier attempt hoisted **Add** into `DashboardHeader` without an import, which caused a runtime `ReferenceError`; that approach was reverted in favor of keeping **Add** inside `DashboardHeaderActions` only.

Made with [Cursor](https://cursor.com)