### PR TITLE
fix(alerts): prefetch related rows in alert list queryset

### DIFF
--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -691,7 +691,11 @@ class AlertSimulateResponseSerializer(serializers.Serializer):
 
 class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "alert"
-    queryset = AlertConfiguration.objects.select_related("team", "insight").order_by("-created_at")
+    queryset = (
+        AlertConfiguration.objects.select_related("team", "insight", "threshold", "created_by")
+        .prefetch_related("subscribed_users")
+        .order_by("-created_at")
+    )
     serializer_class = AlertSerializer
 
     def safely_get_queryset(self, queryset) -> QuerySet:


### PR DESCRIPTION
## Problem

Loading a single page of alerts in the UI (`ALERTS_PER_PAGE = 30`) fans out into ~90+ extra DB queries. `AlertSerializer.to_representation` accesses three relations that aren't on the list queryset:

- `subscribed_users.all()` — M2M with no `prefetch_related`, one query per row
- `threshold` — FK not in `select_related`, one query per row that has a threshold
- `created_by` — FK not in `select_related`, one query per row

The base queryset only `select_related`d `team` and `insight`.

## Changes

Expand the list queryset in `AlertViewSet`:

- Add `threshold` and `created_by` to `select_related`
- Prefetch `subscribed_users`

A 30-row page should now resolve in ~4 queries instead of ~90+. No behavior changes — same fields, same shape.

## How did you test this code?

I'm an agent — I have not manually verified this in a running PostHog instance. No new automated tests were added; the change is a queryset-only optimization with no behavioral surface area. A reviewer should sanity-check via `assertNumQueries` in the alerts API tests, or just hit `/api/projects/<id>/alerts/` locally with Django's debug toolbar.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude via PostHog Code (Slack). The friction point was diagnosing the N+1 — investigation started in APM spans for the list endpoint (no matching root spans surfaced for the last day) before reading the viewset and serializer source. Once the serializer was open, the three FK/M2M accesses inside `to_representation` made the cause obvious; the fix is a one-line queryset change.

Did not add tests because the change is purely a queryset hint; suggesting the reviewer add `assertNumQueries` coverage if this kind of regression is worth guarding against.