### PR TITLE
chore(storybook): minify prod build with esbuild

### DIFF
--- a/common/storybook/.storybook/main.ts
+++ b/common/storybook/.storybook/main.ts
@@ -61,6 +61,8 @@ const config: StorybookConfig = {
     build: {
         test: {
             disableSourcemaps: !!process.env.CI,
+            // esbuild minifier: the default swc one rejects `extractComments` and breaks prod builds
+            esbuildMinify: true,
         },
     },
 


### PR DESCRIPTION
## Problem

`posthog-storybook`'s Cloudflare Pages deploy fails on every master commit. The production `storybook build` minifies with `swcMinify`, and the pinned `@swc/core` rejects the `extractComments` option it's handed (`unknown field 'extractComments'`). CI is unaffected because it builds with `--test`, which uses `esbuildMinify`.

## Changes

Set `build.test.esbuildMinify: true` in `common/storybook/.storybook/main.ts`. The webpack5 builder then minifies all production builds with esbuild — the minifier CI already validates — instead of the broken swc path.

## How did you test this code?

Agent (Claude Code). Ran the exact Cloudflare command locally (`pnpm turbo --filter=@posthog/storybook build`, no `--test`): before → 1776 `extractComments` errors, build fails; after → 7/7 tasks, clean `dist`. No manual UI testing.

## 🤖 Agent context

Authored with Claude Code. Ruled out OOM and a stale `NODE_VERSION` pin before tracing the cause to the swc-vs-esbuild minifier split between Cloudflare's plain build and CI's `--test` build. Picked the builder's own `esbuildMinify` flag over importing terser-webpack-plugin or disabling minification (the latter risks Cloudflare's 25 MiB/file limit).
