### PR TITLE
feat(onboarding): add framework icons to wizard supports list

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardCommandBlock.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardCommandBlock.tsx
@@ -1,6 +1,6 @@
 import './WizardCommandBlock.scss'
 
-import { useState } from 'react'
+import { ComponentType, useState } from 'react'
 
 import { CommandBlock } from 'lib/components/CommandBlock/CommandBlock'
 import { cn } from 'lib/utils/css-classes'
@@ -23,22 +23,22 @@ import vueImage from '../logos/vue.svg'
 import { useWizardCommand } from '../sdk-install-instructions/components/SetupWizardBanner'
 
 // Supported wizard frameworks for display
-const WIZARD_FRAMEWORKS: { name: string; icon: string | JSX.Element }[] = [
+const WIZARD_FRAMEWORKS: { name: string; icon: string | ComponentType }[] = [
     { name: 'Next.js', icon: nextjsImage },
     { name: 'React', icon: reactImage },
     { name: 'Angular', icon: angularImage },
     { name: 'Vue', icon: vueImage },
     { name: 'Nuxt', icon: nuxtImage },
-    { name: 'Astro', icon: <AstroLogo /> },
+    { name: 'Astro', icon: AstroLogo },
     { name: 'SvelteKit', icon: svelteImage },
     { name: 'Django', icon: djangoImage },
     { name: 'Flask', icon: flaskImage },
     { name: 'Laravel', icon: laravelImage },
     { name: 'React Native', icon: reactImage },
-    { name: 'iOS', icon: <IOSLogo /> },
+    { name: 'iOS', icon: IOSLogo },
     { name: 'Android', icon: androidImage },
     { name: 'Ruby on Rails', icon: railsImage },
-    { name: 'React Router', icon: <ReactRouterLogo /> },
+    { name: 'React Router', icon: ReactRouterLogo },
     { name: 'Python', icon: pythonImage },
 ]
 
@@ -93,7 +93,7 @@ export function WizardCommandBlock(): JSX.Element {
                                     <img src={fw.icon} alt="" className="w-3 h-3 shrink-0" />
                                 ) : (
                                     <span className="inline-flex w-3 h-3 shrink-0 [&_svg]:!w-3 [&_svg]:!h-3">
-                                        {fw.icon}
+                                        <fw.icon />
                                     </span>
                                 )}
                                 {fw.name}

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardCommandBlock.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardCommandBlock.tsx
@@ -5,26 +5,41 @@ import { useState } from 'react'
 import { CommandBlock } from 'lib/components/CommandBlock/CommandBlock'
 import { cn } from 'lib/utils/css-classes'
 
+import androidImage from '../logos/android.svg'
+import angularImage from '../logos/angular.svg'
+import { AstroLogo } from '../logos/AstroLogo'
+import djangoImage from '../logos/django.svg'
+import flaskImage from '../logos/flask.svg'
+import { IOSLogo } from '../logos/IOSLogo'
+import laravelImage from '../logos/laravel.svg'
+import nextjsImage from '../logos/nextjs.svg'
+import nuxtImage from '../logos/nuxt.svg'
+import pythonImage from '../logos/python.svg'
+import railsImage from '../logos/rails.svg'
+import reactImage from '../logos/react.svg'
+import { ReactRouterLogo } from '../logos/ReactRouterLogo'
+import svelteImage from '../logos/svelte.svg'
+import vueImage from '../logos/vue.svg'
 import { useWizardCommand } from '../sdk-install-instructions/components/SetupWizardBanner'
 
 // Supported wizard frameworks for display
-const WIZARD_FRAMEWORKS = [
-    'Next.js',
-    'React',
-    'Angular',
-    'Vue',
-    'Nuxt',
-    'Astro',
-    'SvelteKit',
-    'Django',
-    'Flask',
-    'Laravel',
-    'React Native',
-    'iOS',
-    'Android',
-    'Ruby on Rails',
-    'React Router',
-    'Python',
+const WIZARD_FRAMEWORKS: { name: string; icon: string | JSX.Element }[] = [
+    { name: 'Next.js', icon: nextjsImage },
+    { name: 'React', icon: reactImage },
+    { name: 'Angular', icon: angularImage },
+    { name: 'Vue', icon: vueImage },
+    { name: 'Nuxt', icon: nuxtImage },
+    { name: 'Astro', icon: <AstroLogo /> },
+    { name: 'SvelteKit', icon: svelteImage },
+    { name: 'Django', icon: djangoImage },
+    { name: 'Flask', icon: flaskImage },
+    { name: 'Laravel', icon: laravelImage },
+    { name: 'React Native', icon: reactImage },
+    { name: 'iOS', icon: <IOSLogo /> },
+    { name: 'Android', icon: androidImage },
+    { name: 'Ruby on Rails', icon: railsImage },
+    { name: 'React Router', icon: <ReactRouterLogo /> },
+    { name: 'Python', icon: pythonImage },
 ]
 
 const WIZARD_HOG_URL = 'https://res.cloudinary.com/dmukukwp6/image/upload/wizard_3f8bb7a240.png'
@@ -67,14 +82,21 @@ export function WizardCommandBlock(): JSX.Element {
                         Auto-detects your framework, installs the SDK, and sets up event capture.
                     </p>
 
-                    <div className="flex flex-wrap gap-1.5">
+                    <div className="flex flex-wrap gap-1.5 items-center">
                         <span className="text-xs text-muted">Supports:</span>
                         {WIZARD_FRAMEWORKS.map((fw) => (
                             <span
-                                key={fw}
-                                className="text-xs text-muted bg-bg-light border border-border rounded px-1.5 py-0.5"
+                                key={fw.name}
+                                className="inline-flex items-center gap-1 text-xs text-muted bg-bg-light border border-border rounded px-1.5 py-0.5"
                             >
-                                {fw}
+                                {typeof fw.icon === 'string' ? (
+                                    <img src={fw.icon} alt="" className="w-3 h-3 shrink-0" />
+                                ) : (
+                                    <span className="inline-flex w-3 h-3 shrink-0 [&_svg]:!w-3 [&_svg]:!h-3">
+                                        {fw.icon}
+                                    </span>
+                                )}
+                                {fw.name}
                             </span>
                         ))}
                     </div>


### PR DESCRIPTION
## Problem

The wizard install step in onboarding shows a `Supports:` row of framework name pills (Next.js, React, Angular, Vue, Nuxt, Astro, SvelteKit, Django, Flask, Laravel, React Native, iOS, Android, Ruby on Rails, React Router, Python) as plain text. The names alone are harder to scan than name + logo, and we already have icons for every framework in the list.

## Changes

<img width="927" height="657" alt="Screenshot 2026-05-29 at 17 50 03" src="https://github.com/user-attachments/assets/628d2dd0-7e50-42eb-bcbb-ea8bcb6a0294" />

`frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/WizardCommandBlock.tsx`:

- Reshape `WIZARD_FRAMEWORKS` from `string[]` to `{ name; icon }[]` so each entry pairs a label with its existing logo.
- Reuse the SVG/TSX logos already in `frontend/src/scenes/onboarding/sdks/logos/` — same assets that `allSDKs.tsx` uses. No new icon assets.
- Each pill renders as an `inline-flex` with the icon (12 × 12) before the text. `react.svg` is shared between React and React Native, matching `allSDKs.tsx`.
- The three TSX logos (`AstroLogo`, `IOSLogo`, `ReactRouterLogo`) hardcode `h-8 w-8` on their inner `<svg>`. The wrapper overrides them via `[&_svg]:!w-3 [&_svg]:!h-3` so they render at the same size as the SVG-file icons.

## How did you test this code?

Agent-authored — no manual browser verification was performed. Verified:

- oxlint: 0 warnings, 0 errors on the modified file.
- TypeScript: filtered tsc output for `WizardCommandBlock.tsx` produced 0 errors (the broader `typescript:check` aborted with OOM in the sandboxed dev environment — unrelated to this change).

Before merging, a human should pull the branch and confirm at `/project/<id>/onboarding/<product>?step=install`:
- Each `Supports:` pill shows its icon to the left of the name.
- Icons render at ~12px (catches the TSX-logo override regression — they would otherwise render at 32px).
- Light and dark mode both look right (Astro and iOS use `dark:fill-white`).
- Pills wrap cleanly at narrow viewport widths.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — the wizard's supported-framework list is unchanged; this is purely a visual addition.

## 🤖 Agent context

Authored by Claude Opus 4.7 via PostHog Code. Approach: kept the framework list local to this file rather than pulling from `allSDKs.tsx` to avoid coupling onboarding's "what does the wizard CLI support" list to the broader SDK registry — these two lists diverge (e.g. Flask has an icon but no `SDKKey` entry; SvelteKit and Svelte map to the same logo). The render branches on `typeof icon === 'string'` to handle both the SVG-as-URL imports and the TSX-component icons; the `!important` Tailwind override on the wrapper is the cleanest way to shrink the TSX logos without modifying the shared `Astro/IOS/ReactRouter` components, which are reused at h-8 w-8 elsewhere.