### PR TITLE
chore: add CI backwards-compat config rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Examples:
 
 - `.nvmrc` controls the Node.js version for all CI workflows (via `actions/setup-node`) — changing it affects every CI job that runs Node
 - Every job in `.github/workflows/` must declare `timeout-minutes` — prevents stuck runners from burning credits indefinitely
+- **CI workflow changes must stay backwards compatible with open PRs that haven't rebased.** A workflow edit hits every in-flight PR immediately (it runs against the PR merged with master), but companion changes — a new dependency, file, or config — only reach a branch once it rebases. If the workflow starts requiring something an unrebased branch lacks, every such PR fails before its tests run. Make the new behavior degrade gracefully when the prerequisite is absent, or gate it so unrebased branches are unaffected. This has broken CI repeatedly.
 
 ## Security
 


### PR DESCRIPTION
## Problem

CI workflow changes take effect on every open PR the moment they merge, but companion changes (new deps, files, config) only reach a branch once it rebases. Workflow edits that quietly require something an unrebased branch lacks have broken in-flight PRs more than once.

## Changes

Add one AGENTS.md guideline under CI: keep workflow changes backwards compatible with branches that haven't rebased — degrade gracefully when a prerequisite is absent, or gate it.

## How did you test this code?

Docs-only change, no tests. Authored by an agent (Claude Code).

## 🤖 Agent context

Authored with Claude Code. Single guideline line added to the CI section of AGENTS.md after a recurring class of CI breakage; wording kept general and OSS-safe.
