### PR TITLE
feat(llma): per-team gateway attribution and signals usage reporting

### DIFF
--- a/ee/billing/dags/customer_archetype.py
+++ b/ee/billing/dags/customer_archetype.py
@@ -582,7 +582,7 @@ def classify_and_push_accounts_batch(
     # Classify LLM batches with global concurrency control. The semaphore is shared
     # across all accounts batches running in parallel so the total in-flight LLM
     # requests stays bounded regardless of executor parallelism.
-    client = get_llm_client("customer_archetype_classification")
+    client = get_llm_client(product="customer_archetype_classification", team_id=ARCHETYPE_TEAM_ID)
     semaphore = _get_llm_semaphore(config.llm_max_concurrent_requests)
     new_classifications: list[AccountClassification] = []
     failed_batches: list[dict[str, Any]] = []

--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -21,46 +21,90 @@ Product = Literal[
     "slack-posthog-code",
     "product_analytics",
     "subscriptions",
+    "signals",
 ]  # If you add a product here, make sure it's also in services/llm-gateway/src/llm_gateway/products/config.py
 
 
-def get_llm_client(product: Product = "django") -> OpenAI:
+def _team_id_header(team_id: int) -> dict[str, str]:
+    return {"x-posthog-property-team_id": str(team_id)}
+
+
+def get_llm_client(*, product: Product, team_id: int) -> OpenAI:
     """
-    Get an OpenAI-compatible client for the LLM gateway.
+    Get an OpenAI-compatible client for the internal LLM gateway.
 
-    The gateway supports all OpenAI, Anthropic, Gemini, OpenRouter, and Fireworks AI chat models through a unified interface.
+    The gateway exposes an OpenAI Chat Completions API but routes to any backend —
+    Anthropic, OpenAI, OpenRouter, Fireworks AI — so callers can pass Claude, GPT,
+    or other model IDs through the same interface.
 
-    If you want the user to be tracked by LLM A and rate limited correctly, you should supply the distinct_id as a `user` argument when making the LLM call. For example:
+    ## Why `team_id` is required
 
-    client = get_llm_client()
-    response = client.chat.completions.create(
-        model="claude-opus-4-5",  # or any supported OpenAI, Anthropic, Gemini, OpenRouter, or Fireworks AI model
-        messages=[...],
-        user=request.user.distinct_id,  # user for analytics and rate limiting
-    )
+    The gateway authenticates with a single shared personal API key (`LLM_GATEWAY_API_KEY`),
+    so every captured `$ai_generation` event lands in the key owner's team unless the
+    request injects an explicit team override via `x-posthog-property-team_id`. The
+    usage reporter aggregates per-team LLM spend by reading
+    `JSONExtractInt(properties, 'team_id')` (see `posthog/tasks/usage_report.py`),
+    so omitting this header silently breaks per-customer-team cost rollups.
+
+    This helper attaches `x-posthog-property-team_id` as a default header on every
+    request made through the returned client, mirroring how MaxAI threads the same
+    value through LangChain metadata (`ee/hogai/llm.py` — `MaxChatMixin._with_posthog_properties`).
+
+    ## Per-call extras
+
+    `ai_product` and `$ai_billable` are owned by the gateway product config (the route
+    sets `ai_product` from `product`, and `$ai_billable` from that product's `billable`
+    flag). Do NOT override them via headers — a typo would silently mis-bill or
+    misattribute the generation.
+
+    For genuinely per-call tags (source-specific metadata, etc.), pass
+    `extra_headers={"x-posthog-property-<key>": "<value>"}` on the individual
+    `chat.completions.create(...)` call. Pass the user's distinct_id as `user=` for
+    rate limiting and per-user analytics breakdown.
+
+    Example:
+        client = get_llm_client(product="signals", team_id=team.id)
+        response = client.chat.completions.create(
+            model="claude-haiku-4-5",
+            messages=[...],
+            user=f"team-{team.id}",
+            extra_headers={
+                "x-posthog-property-source_product": "zendesk",
+            },
+        )
 
     Args:
-        product: The product to use when making requests to the LLM gateway, should be one of the defined products in the gateway. You can use this to filter traces by the `ai_product` propertly, and also to define custom rate limits / model restrictions in the gateway. If not passed, it will default to the "django" product.
+        product: Product tag for the gateway route — used for filtering traces by `ai_product`
+            and for per-product rate-limit / model-restriction policies on the gateway.
+            Must be one of the values in the `Product` literal above and registered in
+            `services/llm-gateway/src/llm_gateway/products/config.py`.
+        team_id: The PostHog team to attribute the captured `$ai_generation` event to.
+            Sent on every request as the `x-posthog-property-team_id` header.
     """
     if not settings.LLM_GATEWAY_URL or not settings.LLM_GATEWAY_API_KEY:
         raise ValueError("LLM_GATEWAY_URL and LLM_GATEWAY_API_KEY must be configured")
 
     base_url = f"{settings.LLM_GATEWAY_URL.rstrip('/')}/{product}/v1"
-    # Bypass HTTP_PROXY/HTTPS_PROXY — the LLM gateway is an internal service
-    return OpenAI(base_url=base_url, api_key=settings.LLM_GATEWAY_API_KEY, http_client=httpx.Client(trust_env=False))
+    return OpenAI(
+        base_url=base_url,
+        api_key=settings.LLM_GATEWAY_API_KEY,
+        default_headers=_team_id_header(team_id),
+        http_client=httpx.Client(trust_env=False),
+    )
 
 
-def get_async_llm_client(product: Product = "django") -> AsyncOpenAI:
+def get_async_llm_client(*, product: Product, team_id: int) -> AsyncOpenAI:
     """
-    Get an async OpenAI-compatible client for the LLM gateway.
-
-    Same as get_llm_client but returns an AsyncOpenAI client for use in async contexts.
+    Async variant of `get_llm_client`. See `get_llm_client` for the full rationale on
+    why `team_id` is required and how to attach extra per-call event properties.
     """
     if not settings.LLM_GATEWAY_URL or not settings.LLM_GATEWAY_API_KEY:
         raise ValueError("LLM_GATEWAY_URL and LLM_GATEWAY_API_KEY must be configured")
 
     base_url = f"{settings.LLM_GATEWAY_URL.rstrip('/')}/{product}/v1"
-    # Bypass HTTP_PROXY/HTTPS_PROXY — the LLM gateway is an internal service
     return AsyncOpenAI(
-        base_url=base_url, api_key=settings.LLM_GATEWAY_API_KEY, http_client=httpx.AsyncClient(trust_env=False)
+        base_url=base_url,
+        api_key=settings.LLM_GATEWAY_API_KEY,
+        default_headers=_team_id_header(team_id),
+        http_client=httpx.AsyncClient(trust_env=False),
     )

--- a/posthog/llm/test_gateway_client.py
+++ b/posthog/llm/test_gateway_client.py
@@ -3,7 +3,7 @@ from typing import get_args
 import pytest
 from unittest.mock import patch
 
-from posthog.llm.gateway_client import Product, get_llm_client
+from posthog.llm.gateway_client import Product, get_async_llm_client, get_llm_client
 
 
 class TestGetLlmClient:
@@ -17,7 +17,7 @@ class TestGetLlmClient:
         mock_settings.LLM_GATEWAY_API_KEY = "test-key"
 
         with pytest.raises(ValueError, match="LLM_GATEWAY_URL and LLM_GATEWAY_API_KEY must be configured"):
-            get_llm_client()
+            get_llm_client(product="django", team_id=1)
 
     @patch("posthog.llm.gateway_client.settings")
     def test_raises_when_gateway_api_key_missing(self, mock_settings):
@@ -25,14 +25,14 @@ class TestGetLlmClient:
         mock_settings.LLM_GATEWAY_API_KEY = ""
 
         with pytest.raises(ValueError, match="LLM_GATEWAY_URL and LLM_GATEWAY_API_KEY must be configured"):
-            get_llm_client()
+            get_llm_client(product="django", team_id=1)
 
     @patch("posthog.llm.gateway_client.settings")
     def test_returns_client_with_correct_base_url(self, mock_settings):
         mock_settings.LLM_GATEWAY_URL = "http://gateway:8080"
         mock_settings.LLM_GATEWAY_API_KEY = "test-key"
 
-        client = get_llm_client()
+        client = get_llm_client(product="django", team_id=1)
 
         assert str(client.base_url) == "http://gateway:8080/django/v1/"
         assert client.api_key == "test-key"
@@ -44,6 +44,7 @@ class TestGetLlmClient:
             ("llm_gateway", "/llm_gateway/v1/"),
             ("posthog_code", "/posthog_code/v1/"),
             ("wizard", "/wizard/v1/"),
+            ("signals", "/signals/v1/"),
         ],
     )
     @patch("posthog.llm.gateway_client.settings")
@@ -51,7 +52,7 @@ class TestGetLlmClient:
         mock_settings.LLM_GATEWAY_URL = "http://gateway:8080"
         mock_settings.LLM_GATEWAY_API_KEY = "test-key"
 
-        client = get_llm_client(product=product)
+        client = get_llm_client(product=product, team_id=1)
 
         assert expected_path in str(client.base_url)
 
@@ -60,6 +61,32 @@ class TestGetLlmClient:
         mock_settings.LLM_GATEWAY_URL = "http://gateway:8080/"
         mock_settings.LLM_GATEWAY_API_KEY = "test-key"
 
-        client = get_llm_client()
+        client = get_llm_client(product="django", team_id=1)
 
         assert str(client.base_url) == "http://gateway:8080/django/v1/"
+
+    @patch("posthog.llm.gateway_client.settings")
+    def test_attaches_team_id_default_header(self, mock_settings):
+        mock_settings.LLM_GATEWAY_URL = "http://gateway:8080"
+        mock_settings.LLM_GATEWAY_API_KEY = "test-key"
+
+        client = get_llm_client(product="signals", team_id=42)
+
+        assert client.default_headers.get("x-posthog-property-team_id") == "42"
+
+    @patch("posthog.llm.gateway_client.settings")
+    def test_async_client_attaches_team_id_default_header(self, mock_settings):
+        mock_settings.LLM_GATEWAY_URL = "http://gateway:8080"
+        mock_settings.LLM_GATEWAY_API_KEY = "test-key"
+
+        client = get_async_llm_client(product="signals", team_id=42)
+
+        assert client.default_headers.get("x-posthog-property-team_id") == "42"
+
+    def test_team_id_is_required(self):
+        with pytest.raises(TypeError):
+            get_llm_client(product="django")  # type: ignore[call-arg]
+
+    def test_product_is_required(self):
+        with pytest.raises(TypeError):
+            get_llm_client(team_id=1)  # type: ignore[call-arg]

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -3757,6 +3757,284 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
         self.assertEqual(result[0][0], self.org_1_team_1.id)
         self.assertEqual(result[0][1], 240)
 
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_signals_ai_product_excluded_from_ai_credits(self, mock_region: MagicMock) -> None:
+        """Generations tagged ai_product='signals' must not count toward PostHog AI credits."""
+        from posthog.tasks.usage_report import get_teams_with_ai_credits_used_in_period
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        period_start, period_end = period
+
+        # Billable generation tagged as signals — should be excluded
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_signals",
+            timestamp=period_start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_signals",
+                "$ai_total_cost_usd": 5.0,
+                "$ai_billable": True,
+                "ai_product": "signals",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period_start, period_end)
+
+        self.assertEqual(result, [])
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_ai_credits_counts_events_without_ai_product(self, mock_region: MagicMock) -> None:
+        """Generations missing the ai_product property remain billable under PostHog AI."""
+        from posthog.tasks.usage_report import get_teams_with_ai_credits_used_in_period
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        period_start, period_end = period
+
+        # Matching billable trace — Max AI generations are billed via their paired $ai_trace.
+        _create_event(
+            event="$ai_trace",
+            team=analytics_team,
+            distinct_id="user_legacy",
+            timestamp=period_start + relativedelta(hours=1),
+            properties={
+                "$ai_trace_id": "trace_legacy",
+                "$ai_output_state": {"messages": [{"tool_calls": [{"name": "query_executor"}]}]},
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_legacy",
+            timestamp=period_start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_legacy",
+                "$ai_total_cost_usd": 1.0,
+                "$ai_billable": True,
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period_start, period_end)
+
+        # 1.0 USD * 100 * 1.2 = 120 credits
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], self.org_1_team_1.id)
+        self.assertEqual(result[0][1], 120)
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_signals_credits_only_counts_signals_events(self, mock_region: MagicMock) -> None:
+        """The signals query only counts generations tagged ai_product='signals' for the same team."""
+        from posthog.tasks.usage_report import (
+            get_teams_with_ai_credits_used_in_period,
+            get_teams_with_signals_credits_used_in_period,
+        )
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        period_start, period_end = period
+
+        # Signals event — should appear only in signals credits
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_signals",
+            timestamp=period_start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_signals",
+                "$ai_total_cost_usd": 2.0,
+                "$ai_billable": True,
+                "ai_product": "signals",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        # Max AI event — should appear only in ai credits. Max AI is billed via its paired
+        # $ai_trace (unlike signals, which never emits one), so create a matching billable trace.
+        _create_event(
+            event="$ai_trace",
+            team=analytics_team,
+            distinct_id="user_max",
+            timestamp=period_start + relativedelta(hours=2),
+            properties={
+                "$ai_trace_id": "trace_max",
+                "$ai_output_state": {"messages": [{"tool_calls": [{"name": "query_executor"}]}]},
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_max",
+            timestamp=period_start + relativedelta(hours=2),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_max",
+                "$ai_total_cost_usd": 1.0,
+                "$ai_billable": True,
+                "ai_product": "max_ai",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        flush_persons_and_events()
+
+        signals_result = get_teams_with_signals_credits_used_in_period(period_start, period_end)
+        ai_result = get_teams_with_ai_credits_used_in_period(period_start, period_end)
+
+        # signals: 2.0 USD * 100 * 1.2 = 240
+        self.assertEqual(signals_result, [(self.org_1_team_1.id, 240)])
+        # ai (non-signals only): 1.0 USD * 100 * 1.2 = 120
+        self.assertEqual(ai_result, [(self.org_1_team_1.id, 120)])
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_ai_credits_excludes_traceless_generations(self, mock_region: MagicMock) -> None:
+        """A billable non-signals generation with no matching $ai_trace is NOT billed.
+
+        Max AI generations are billed only via their paired $ai_trace; the empty-trace
+        fallback is scoped to signals. This pins that existing PostHog AI billing is
+        unchanged — it would fail if the fallback leaked back into the exclude_signals path.
+        """
+        from posthog.tasks.usage_report import get_teams_with_ai_credits_used_in_period
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        period_start, period_end = period
+
+        # Billable generation, no ai_product, and NO matching $ai_trace event.
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_orphan",
+            timestamp=period_start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_orphan",
+                "$ai_total_cost_usd": 3.0,
+                "$ai_billable": True,
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period_start, period_end)
+
+        self.assertEqual(result, [])
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_signals_credits_counts_traceless_generation(self, mock_region: MagicMock) -> None:
+        """A billable signals generation with no $ai_trace IS billed via the empty-trace fallback.
+
+        Signals never emits $ai_trace events, so the LEFT JOIN never matches; the fallback is
+        what makes signals billable at all.
+        """
+        from posthog.tasks.usage_report import get_teams_with_signals_credits_used_in_period
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        period_start, period_end = period
+
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_signals",
+            timestamp=period_start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_signals",
+                "$ai_total_cost_usd": 4.0,
+                "$ai_billable": True,
+                "ai_product": "signals",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_signals_credits_used_in_period(period_start, period_end)
+
+        # 4.0 USD * 100 * 1.2 = 480
+        self.assertEqual(result, [(self.org_1_team_1.id, 480)])
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_signals_credits_excludes_non_billable_generation(self, mock_region: MagicMock) -> None:
+        """A signals generation tagged $ai_billable=false is not counted, even for signals."""
+        from posthog.tasks.usage_report import get_teams_with_signals_credits_used_in_period
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        period_start, period_end = period
+
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_signals",
+            timestamp=period_start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_signals",
+                "$ai_total_cost_usd": 4.0,
+                "$ai_billable": False,
+                "ai_product": "signals",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_signals_credits_used_in_period(period_start, period_end)
+
+        self.assertEqual(result, [])
+
+    def test_has_non_zero_usage_counts_signals_credits(self) -> None:
+        """A signals-only org must survive has_non_zero_usage so its report still reaches billing."""
+        import dataclasses
+
+        from posthog.tasks.usage_report import UsageReportCounters, has_non_zero_usage
+
+        zero = {field.name: 0 for field in dataclasses.fields(UsageReportCounters)}
+
+        self.assertFalse(has_non_zero_usage(UsageReportCounters(**zero)))
+        self.assertTrue(has_non_zero_usage(UsageReportCounters(**{**zero, "signals_credits_used_in_period": 5})))
+
 
 class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
     def setUp(self) -> None:

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -194,6 +194,9 @@ class UsageReportCounters:
     # AI Billing Credits (PostHog AI feature usage)
     ai_credits_used_in_period: int
 
+    # Signals Billing Credits (Signals product usage — same cost math as ai_credits, scoped to ai_product='signals')
+    signals_credits_used_in_period: int
+
     # CDP Delivery
     hog_function_calls_in_period: int
     hog_function_fetch_calls_in_period: int
@@ -1084,14 +1087,21 @@ CLOUD_REGION_TO_URL = {
 }
 
 
-@timed_log()
-@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
-def get_teams_with_ai_credits_used_in_period(
+SIGNALS_AI_PRODUCT = "signals"
+
+AiProductFilter = Literal["exclude_signals", "only_signals"]
+
+
+def _get_teams_with_ai_credits_for_product(
     begin: datetime,
     end: datetime,
+    *,
+    ai_product_filter: AiProductFilter,
+    usage_report_tag: str,
 ) -> list[tuple[int, int]]:
     """
-    Calculate AI credits used in the period for billable AI generations.
+    Shared implementation for AI billing credit aggregation, parameterized on
+    the `ai_product` event property.
 
     Billing is performed at the trace level. Traces are billable only if they contain
     tool calls that include at least one non-excluded tool. Free (non-billable) traces:
@@ -1125,11 +1135,24 @@ def get_teams_with_ai_credits_used_in_period(
 
     team_to_query = CLOUD_REGION_TO_TEAM_ID[region]
 
+    # Max AI generations always emit a paired $ai_trace and are billed only when that trace is
+    # flagged billable — this preserves existing PostHog AI billing exactly. Signals generations
+    # never emit a $ai_trace, so the LEFT JOIN never matches; we bill them on the empty-trace
+    # fallback instead (ClickHouse join_use_nulls=0 yields '' — not NULL — for the unmatched
+    # trace_id column, so check empty(), not IS NULL). Scoping the fallback to signals avoids
+    # retroactively changing what counts toward existing PostHog AI credits.
+    if ai_product_filter == "only_signals":
+        ai_product_clause = "AND JSONExtractString(properties, 'ai_product') = %(ai_product)s"
+        billable_clause = "t.is_billable = 1 OR empty(t.trace_id)"
+    else:
+        ai_product_clause = "AND JSONExtractString(properties, 'ai_product') != %(ai_product)s"
+        billable_clause = "t.is_billable = 1"
+
     with tags_context(
-        product=Product.MAX_AI, feature=Feature.USAGE_REPORT, usage_report="ai_credits", kind="usage_report"
+        product=Product.MAX_AI, feature=Feature.USAGE_REPORT, usage_report=usage_report_tag, kind="usage_report"
     ):
         results = sync_execute(
-            """
+            f"""
             WITH trace_analysis AS (
                 WITH %(excluded_tools)s AS excluded_tools
                 SELECT
@@ -1208,6 +1231,7 @@ def get_teams_with_ai_credits_used_in_period(
                         AND timestamp >= %(begin)s
                         AND timestamp < %(end)s
                         AND event = '$ai_generation'
+                        {ai_product_clause}
                 )
                 WHERE
                     ai_billable = 1
@@ -1223,8 +1247,7 @@ def get_teams_with_ai_credits_used_in_period(
             FROM costs c
             LEFT JOIN trace_analysis t ON c.trace_id = t.trace_id
             WHERE
-                -- keep rows that are billable OR have no trace metadata
-                t.is_billable = 1 OR t.trace_id IS NULL
+                {billable_clause}
             GROUP BY
                 c.customer_team_id
             HAVING
@@ -1239,6 +1262,7 @@ def get_teams_with_ai_credits_used_in_period(
                 "end": end,
                 "markup_multiplier": 1 + AI_COST_MARKUP_PERCENT,
                 "excluded_tools": AI_BILLING_EXCLUDED_TOOLS,
+                "ai_product": SIGNALS_AI_PRODUCT,
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
@@ -1246,6 +1270,36 @@ def get_teams_with_ai_credits_used_in_period(
         )
 
     return results
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_teams_with_ai_credits_used_in_period(
+    begin: datetime,
+    end: datetime,
+) -> list[tuple[int, int]]:
+    """PostHog AI (Max) billing credits — excludes events tagged with ai_product='signals'."""
+    return _get_teams_with_ai_credits_for_product(
+        begin,
+        end,
+        ai_product_filter="exclude_signals",
+        usage_report_tag="ai_credits",
+    )
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_teams_with_signals_credits_used_in_period(
+    begin: datetime,
+    end: datetime,
+) -> list[tuple[int, int]]:
+    """Signals billing credits — only events tagged with ai_product='signals'."""
+    return _get_teams_with_ai_credits_for_product(
+        begin,
+        end,
+        ai_product_filter="only_signals",
+        usage_report_tag="signals_credits",
+    )
 
 
 dwh_pricing_free_period_start = datetime(2025, 10, 29, 0, 0, 0, tzinfo=UTC)
@@ -1898,6 +1952,7 @@ def has_non_zero_usage(report: UsageReportCounters) -> bool:
         or report.exceptions_captured_in_period > 0
         or report.ai_event_count_in_period > 0
         or report.ai_credits_used_in_period > 0
+        or report.signals_credits_used_in_period > 0
         or report.workflow_emails_sent_in_period > 0
         or report.workflow_push_sent_in_period > 0
         or report.workflow_sms_sent_in_period > 0
@@ -2153,6 +2208,9 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         ),
         "teams_with_ai_event_count_in_period": get_teams_with_ai_event_count_in_period(period_start, period_end),
         "teams_with_ai_credits_used_in_period": get_teams_with_ai_credits_used_in_period(period_start, period_end),
+        "teams_with_signals_credits_used_in_period": get_teams_with_signals_credits_used_in_period(
+            period_start, period_end
+        ),
         "teams_with_active_hog_destinations_in_period": get_teams_with_active_hog_destinations_in_period(),
         "teams_with_active_hog_transformations_in_period": get_teams_with_active_hog_transformations_in_period(),
         "teams_with_workflow_emails_sent_in_period": get_teams_with_workflow_emails_sent_in_period(
@@ -2317,6 +2375,7 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         rust_events_count_in_period=all_data["teams_with_rust_events_count_in_period"].get(team.id, 0),
         ai_event_count_in_period=all_data["teams_with_ai_event_count_in_period"].get(team.id, 0),
         ai_credits_used_in_period=all_data["teams_with_ai_credits_used_in_period"].get(team.id, 0),
+        signals_credits_used_in_period=all_data["teams_with_signals_credits_used_in_period"].get(team.id, 0),
         active_hog_destinations_in_period=all_data["teams_with_active_hog_destinations_in_period"].get(team.id, 0),
         active_hog_transformations_in_period=all_data["teams_with_active_hog_transformations_in_period"].get(
             team.id, 0

--- a/posthog/temporal/ai/eval_slack_repo_selection.py
+++ b/posthog/temporal/ai/eval_slack_repo_selection.py
@@ -436,7 +436,7 @@ class Command:
             return CaseResult(case=case, actual_stage="skipped", actual_outcome="skipped")
 
         # Stage 2: Haiku gate (heuristic + LLM)
-        needs_repo = classify_task_needs_repo(text, thread_messages)
+        needs_repo = classify_task_needs_repo(text, thread_messages, team_id=ctx.team_id)
         if not needs_repo:
             self.stdout.write(self.style.SUCCESS("  haiku → no_repo (task doesn't need code)"))
             return CaseResult(case=case, actual_stage="haiku", actual_outcome="no_repo")

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -395,6 +395,7 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                         classify_posthog_code_task_needs_repo_activity,
                         event.get("text", ""),
                         thread_messages,
+                        inputs.integration_id,
                     )
                     if not needs_repo:
                         repository = None
@@ -471,6 +472,7 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                             classify_posthog_code_task_needs_repo_activity,
                             event.get("text", ""),
                             thread_messages,
+                            inputs.integration_id,
                         )
                         if not needs_repo:
                             await _execute_posthog_code_activity(
@@ -863,10 +865,19 @@ async def discover_posthog_code_repository_via_agent_activity(
 def classify_posthog_code_task_needs_repo_activity(
     event_text: str,
     thread_messages: list[dict[str, str]],
+    integration_id: int,
 ) -> bool:
     from products.slack_app.backend.api import classify_task_needs_repo
 
-    return classify_task_needs_repo(event_text, thread_messages)
+    try:
+        integration = Integration.objects.only("team_id").get(id=integration_id)
+    except Integration.DoesNotExist:
+        # Integration removed mid-flight: default to picker (matches classify_task_needs_repo's
+        # own error contract) instead of raising and burning retries on a workflow that can no
+        # longer reach Slack anyway.
+        logger.warning("classify_posthog_code_task_needs_repo_integration_missing", integration_id=integration_id)
+        return True
+    return classify_task_needs_repo(event_text, thread_messages, team_id=integration.team_id)
 
 
 @activity.defn

--- a/posthog/temporal/data_imports/signals/pipeline.py
+++ b/posthog/temporal/data_imports/signals/pipeline.py
@@ -4,16 +4,14 @@ import dataclasses
 from datetime import datetime
 from typing import Any
 
-from django.conf import settings
-
 import structlog
 import posthoganalytics
-from google.genai import types
-from posthoganalytics.ai.gemini import AsyncClient, genai
+from openai import AsyncOpenAI
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from posthog.event_usage import groups
+from posthog.llm.gateway_client import get_async_llm_client
 from posthog.models import Organization, Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.data_imports.signals.registry import SignalEmitter, SignalEmitterOutput, SignalSourceTableConfig
@@ -22,8 +20,9 @@ from products.signals.backend.api import emit_signal
 
 logger = structlog.get_logger(__name__)
 
-# Default model to use for LLM calls
-GEMINI_MODEL = "models/gemini-3-flash-preview"
+# Model routed through the internal LLM gateway. Claude Haiku 4.5 is a cheap,
+# fast judgment model that matches the gateway's allowlist for the signals product.
+LLM_MODEL = "claude-haiku-4-5"
 # Concurrent LLM calls limit for actionability/summarization checks
 LLM_CONCURRENCY_LIMIT = 20
 # Concurrent workflow spawns for signal emission
@@ -34,11 +33,30 @@ TEMPORAL_PAYLOAD_MAX_BYTES = 2 * 1024 * 1024
 LLM_MAX_ATTEMPTS = 3
 # Per-call timeout for LLM requests (seconds)
 LLM_CALL_TIMEOUT_SECONDS = 120
-# Thinking budget for LLM calls (summarization & actionability are judgment tasks)
-LLM_THINKING_BUDGET_TOKENS = 1024
 # Backoff between LLM retry attempts (delay = initial * coefficient ^ (attempt - 1))
 LLM_RETRY_INITIAL_DELAY_SECONDS = 5
 LLM_RETRY_BACKOFF_COEFFICIENT = 2.0
+# Cap output tokens for actionability; summarization adds proportionally to its threshold.
+LLM_ACTIONABILITY_MAX_TOKENS = 256
+LLM_SUMMARY_MIN_TOKENS = 256
+
+
+def _signals_extra_headers(output: SignalEmitterOutput, stage: str) -> dict[str, str]:
+    """Per-call event properties that ride along to the gateway as headers.
+
+    The `team_id` header is set as a default on the client at construction time,
+    so it doesn't need to be repeated here. See posthog/llm/gateway_client.py.
+
+    `ai_product` and `$ai_billable` are intentionally NOT set here: the gateway
+    derives both from the `signals` product config (the route path sets
+    `ai_product=signals` and `billable=True`). Passing them as headers would let a
+    typo silently misattribute or mis-bill the generation, so we let the gateway own them.
+    """
+    return {
+        "x-posthog-property-ai_stage": stage,
+        "x-posthog-property-source_product": output.source_product,
+        "x-posthog-property-source_type": output.source_type,
+    }
 
 
 def _capture_pipeline_stage(
@@ -108,33 +126,35 @@ def build_emitter_outputs(
 
 
 async def _summarize_description(
-    client: AsyncClient,
+    client: AsyncOpenAI,
+    team_id: int,
     output: SignalEmitterOutput,
     summarization_prompt: str,
     threshold: int,
 ) -> SignalEmitterOutput:
-    prompt_parts = [types.Part(text=summarization_prompt.format(description=output.description, max_length=threshold))]
+    messages: list[dict[str, str]] = [
+        {"role": "user", "content": summarization_prompt.format(description=output.description, max_length=threshold)}
+    ]
+    extra_headers = _signals_extra_headers(output, stage="summarization")
+    max_tokens = max(threshold // 4, LLM_SUMMARY_MIN_TOKENS)
     for attempt in range(LLM_MAX_ATTEMPTS):
         if attempt > 0:
             await asyncio.sleep(LLM_RETRY_INITIAL_DELAY_SECONDS * (LLM_RETRY_BACKOFF_COEFFICIENT ** (attempt - 1)))
         try:
             response = await asyncio.wait_for(
-                client.models.generate_content(
-                    model=GEMINI_MODEL,
-                    contents=prompt_parts,
-                    config=types.GenerateContentConfig(
-                        max_output_tokens=LLM_THINKING_BUDGET_TOKENS + max(threshold // 4, 256),
-                        thinking_config=types.ThinkingConfig(
-                            thinking_budget=LLM_THINKING_BUDGET_TOKENS,
-                            include_thoughts=False,
-                        ),
-                    ),
+                client.chat.completions.create(
+                    model=LLM_MODEL,
+                    messages=messages,  # type: ignore[arg-type]
+                    max_tokens=max_tokens,
+                    user=f"team-{team_id}",
+                    extra_headers=extra_headers,
                 ),
                 timeout=LLM_CALL_TIMEOUT_SECONDS,
             )
-            if response.candidates and response.candidates[0].finish_reason == types.FinishReason.MAX_TOKENS:
+            choice = response.choices[0]
+            if choice.finish_reason == "length":
                 raise ValueError("LLM summary response was truncated due to token limit")
-            summary = (response.text or "").strip()
+            summary = (choice.message.content or "").strip()
             if not summary:
                 raise ValueError("Empty response from LLM when summarizing description")
             if len(summary) > threshold:
@@ -152,16 +172,18 @@ async def _summarize_description(
                     "attempt": attempt + 1,
                 },
             )
-            prompt_parts.append(
-                types.Part(
-                    text=f"\n\nAttempt {attempt + 1} of {LLM_MAX_ATTEMPTS} to summarize description failed with error: {e!r}\nPlease fix your output."
-                )
+            messages.append(
+                {
+                    "role": "user",
+                    "content": f"Attempt {attempt + 1} of {LLM_MAX_ATTEMPTS} to summarize description failed with error: {e!r}\nPlease fix your output.",
+                }
             )
     # Hard-truncate the description to the threshold if all attempts failed
     return dataclasses.replace(output, description=output.description[:threshold])
 
 
 async def summarize_long_descriptions(
+    team: Team,
     outputs: list[SignalEmitterOutput],
     summarization_prompt: str,
     threshold: int,
@@ -170,7 +192,7 @@ async def summarize_long_descriptions(
     needs_summary = [i for i, output in enumerate(outputs) if len(output.description) > threshold]
     if not needs_summary:
         return outputs
-    client = genai.AsyncClient(api_key=settings.GEMINI_API_KEY)
+    client = get_async_llm_client(product="signals", team_id=team.id)
     semaphore = asyncio.Semaphore(LLM_CONCURRENCY_LIMIT)
     _safe_heartbeat()
     completed_count = 0
@@ -179,7 +201,7 @@ async def summarize_long_descriptions(
         nonlocal completed_count
         async with semaphore:
             try:
-                result = await _summarize_description(client, output, summarization_prompt, threshold)
+                result = await _summarize_description(client, team.id, output, summarization_prompt, threshold)
             except Exception:
                 logger.exception(
                     "Summarization failed, skipping signal",
@@ -214,46 +236,30 @@ async def summarize_long_descriptions(
     return result
 
 
-def _extract_thoughts(response: types.GenerateContentResponse) -> str | None:
-    if not response.candidates:
-        return None
-    content = response.candidates[0].content
-    if content is None or content.parts is None:
-        return None
-    thoughts = []
-    for part in content.parts:
-        if part.text and part.thought:
-            thoughts.append(part.text)
-    return "\n".join(thoughts) if thoughts else None
-
-
 async def _check_actionability(
-    client: AsyncClient,
+    client: AsyncOpenAI,
+    team_id: int,
     output: SignalEmitterOutput,
     actionability_prompt: str,
-) -> tuple[bool, str | None]:
+) -> bool:
     prompt = actionability_prompt.format(description=output.description)
+    extra_headers = _signals_extra_headers(output, stage="actionability")
     for attempt in range(LLM_MAX_ATTEMPTS):
         if attempt > 0:
             await asyncio.sleep(LLM_RETRY_INITIAL_DELAY_SECONDS * (LLM_RETRY_BACKOFF_COEFFICIENT ** (attempt - 1)))
         try:
             response = await asyncio.wait_for(
-                client.models.generate_content(
-                    model=GEMINI_MODEL,
-                    contents=[prompt],
-                    config=types.GenerateContentConfig(
-                        max_output_tokens=LLM_THINKING_BUDGET_TOKENS + 128,
-                        thinking_config=types.ThinkingConfig(
-                            thinking_budget=LLM_THINKING_BUDGET_TOKENS,
-                            include_thoughts=True,
-                        ),
-                    ),
+                client.chat.completions.create(
+                    model=LLM_MODEL,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=LLM_ACTIONABILITY_MAX_TOKENS,
+                    user=f"team-{team_id}",
+                    extra_headers=extra_headers,
                 ),
                 timeout=LLM_CALL_TIMEOUT_SECONDS,
             )
-            thoughts = _extract_thoughts(response)
-            response_text = (response.text or "").strip().upper()
-            return "NOT_ACTION" not in response_text, thoughts
+            response_text = (response.choices[0].message.content or "").strip().upper()
+            return "NOT_ACTION" not in response_text
         except Exception as e:
             posthoganalytics.capture_exception(
                 e,
@@ -267,46 +273,46 @@ async def _check_actionability(
                 },
             )
     # Assume actionable if all retries exhausted
-    return True, None
+    return True
 
 
 async def filter_actionable(
+    team: Team,
     outputs: list[SignalEmitterOutput],
     actionability_prompt: str,
     extra: dict[str, Any],
 ) -> list[SignalEmitterOutput]:
-    client = genai.AsyncClient(api_key=settings.GEMINI_API_KEY)
+    client = get_async_llm_client(product="signals", team_id=team.id)
     semaphore = asyncio.Semaphore(LLM_CONCURRENCY_LIMIT)
     _safe_heartbeat()
     checked_count = 0
 
-    async def _bounded_check(output: SignalEmitterOutput) -> tuple[bool, str | None]:
+    async def _bounded_check(output: SignalEmitterOutput) -> bool:
         nonlocal checked_count
         async with semaphore:
             try:
-                result = await _check_actionability(client, output, actionability_prompt)
+                result = await _check_actionability(client, team.id, output, actionability_prompt)
             except Exception:
                 logger.exception(
                     "Actionability check failed, assuming actionable",
                     signal_source_id=output.source_id,
                     **extra,
                 )
-                return True, None
+                return True
             finally:
                 checked_count += 1
                 if checked_count % LLM_CONCURRENCY_LIMIT == 0:
                     _safe_heartbeat()
             return result
 
-    tasks: dict[int, asyncio.Task[tuple[bool, str | None]]] = {}
+    tasks: dict[int, asyncio.Task[bool]] = {}
     async with asyncio.TaskGroup() as tg:
         for i, output in enumerate(outputs):
             tasks[i] = tg.create_task(_bounded_check(output))
     actionable = []
     filtered_count = 0
     for i, output in enumerate(outputs):
-        is_actionable, thoughts = tasks[i].result()
-        if is_actionable:
+        if tasks[i].result():
             actionable.append(output)
         else:
             filtered_count += 1
@@ -314,7 +320,6 @@ async def filter_actionable(
                 "Filtered non-actionable signal",
                 signal_source_type=output.source_type,
                 signal_source_id=output.source_id,
-                thoughts=thoughts,
                 **extra,
             )
     if filtered_count > 0:
@@ -434,6 +439,7 @@ async def run_signal_pipeline(
         threshold = config.description_summarization_threshold_chars
         pre_summary_by_id = {o.source_id: o for o in outputs}
         outputs = await summarize_long_descriptions(
+            team=team,
             outputs=outputs,
             summarization_prompt=config.summarization_prompt,
             threshold=threshold,
@@ -447,6 +453,7 @@ async def run_signal_pipeline(
     if config.actionability_prompt:
         pre_filter_by_id = {o.source_id: o for o in outputs}
         outputs = await filter_actionable(
+            team=team,
             outputs=outputs,
             actionability_prompt=config.actionability_prompt,
             extra=extra,

--- a/posthog/temporal/data_imports/signals/tests/test_emit_signals.py
+++ b/posthog/temporal/data_imports/signals/tests/test_emit_signals.py
@@ -57,24 +57,13 @@ def _make_config(**overrides: Any) -> SignalSourceTableConfig:
     return SignalSourceTableConfig(**(defaults | overrides))
 
 
-def _make_llm_response(text: str | None, thought: str | None = None) -> MagicMock:
-    """Build a mock Gemini response with optional thought parts."""
+def _make_llm_response(content: str | None, finish_reason: str = "stop") -> MagicMock:
+    """Build a mock OpenAI ChatCompletion response."""
     response = MagicMock()
-    response.text = text
-    parts = []
-    if thought is not None:
-        thought_part = MagicMock()
-        thought_part.text = thought
-        thought_part.thought = True
-        parts.append(thought_part)
-    if text is not None:
-        answer_part = MagicMock()
-        answer_part.text = text
-        answer_part.thought = False
-        parts.append(answer_part)
-    candidate = MagicMock()
-    candidate.content.parts = parts
-    response.candidates = [candidate]
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = finish_reason
+    response.choices = [choice]
     return response
 
 
@@ -272,74 +261,79 @@ class TestCheckActionability:
     )
     async def test_classifies_based_on_llm_response(self, llm_response, expected):
         mock_client = MagicMock()
-        mock_client.models.generate_content = AsyncMock(return_value=_make_llm_response(llm_response))
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_llm_response(llm_response))
 
         output = _make_output(description="test ticket")
-        is_actionable, _thoughts = await _check_actionability(mock_client, output, "Is this actionable? {description}")
+        is_actionable = await _check_actionability(mock_client, 1, output, "Is this actionable? {description}")
 
         assert is_actionable is expected
 
     @pytest.mark.asyncio
-    async def test_returns_thoughts_from_response(self):
-        mock_client = MagicMock()
-        mock_client.models.generate_content = AsyncMock(
-            return_value=_make_llm_response("NOT_ACTIONABLE", thought="Just a billing question, not a bug.")
-        )
-
-        _is_actionable, thoughts = await _check_actionability(
-            mock_client, _make_output(), "Is this actionable? {description}"
-        )
-
-        assert thoughts == "Just a billing question, not a bug."
-
-    @pytest.mark.asyncio
     async def test_assumes_actionable_after_retries_exhausted(self):
         mock_client = MagicMock()
-        mock_client.models.generate_content = AsyncMock(side_effect=Exception("API error"))
+        mock_client.chat.completions.create = AsyncMock(side_effect=Exception("API error"))
 
-        is_actionable, thoughts = await _check_actionability(mock_client, _make_output(), "prompt {description}")
+        with patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics"):
+            is_actionable = await _check_actionability(mock_client, 1, _make_output(), "prompt {description}")
 
         assert is_actionable is True
-        assert thoughts is None
-        assert mock_client.models.generate_content.call_count == LLM_MAX_ATTEMPTS
+        assert mock_client.chat.completions.create.call_count == LLM_MAX_ATTEMPTS
 
     @pytest.mark.asyncio
-    async def test_returns_true_on_none_response_text(self):
+    async def test_returns_true_on_none_response_content(self):
         mock_client = MagicMock()
-        mock_client.models.generate_content = AsyncMock(return_value=_make_llm_response(None))
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_llm_response(None))
 
-        is_actionable, _thoughts = await _check_actionability(mock_client, _make_output(), "prompt {description}")
+        is_actionable = await _check_actionability(mock_client, 1, _make_output(), "prompt {description}")
 
         assert is_actionable is True
+
+    @pytest.mark.asyncio
+    async def test_passes_team_attribution_headers(self):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_llm_response("ACTIONABLE"))
+
+        output = _make_output(source_id="42")
+        await _check_actionability(mock_client, 7, output, "Is this actionable? {description}")
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["user"] == "team-7"
+        headers = call_kwargs["extra_headers"]
+        assert headers["x-posthog-property-ai_stage"] == "actionability"
+        assert headers["x-posthog-property-source_product"] == output.source_product
+        assert headers["x-posthog-property-source_type"] == output.source_type
+        # ai_product and $ai_billable are owned by the gateway product config, not headers
+        assert "x-posthog-property-ai_product" not in headers
+        assert "x-posthog-property-$ai_billable" not in headers
 
 
 class TestFilterActionable:
     @pytest.mark.asyncio
     async def test_filters_non_actionable_outputs(self):
         outputs = [_make_output(source_id="1"), _make_output(source_id="2"), _make_output(source_id="3")]
+        team = MagicMock(id=1)
 
         mock_client = MagicMock()
         responses = [
             _make_llm_response("ACTIONABLE"),
-            _make_llm_response("NOT_ACTIONABLE", thought="This is just a billing question."),
+            _make_llm_response("NOT_ACTIONABLE"),
             _make_llm_response("ACTIONABLE"),
         ]
         call_count = 0
 
-        async def mock_generate(*args, **kwargs):
+        async def mock_create(*args, **kwargs):
             nonlocal call_count
             resp = responses[call_count]
             call_count += 1
             return resp
 
-        mock_client.models.generate_content = mock_generate
+        mock_client.chat.completions.create = mock_create
 
         with (
-            patch(f"{PIPELINE_MODULE_PATH}.genai") as mock_genai,
+            patch(f"{PIPELINE_MODULE_PATH}.get_async_llm_client", return_value=mock_client),
             patch(f"{PIPELINE_MODULE_PATH}.activity"),
         ):
-            mock_genai.AsyncClient.return_value = mock_client
-            result = await filter_actionable(outputs, "prompt {description}", extra={})
+            result = await filter_actionable(team, outputs, "prompt {description}", extra={})
 
         assert [o.source_id for o in result] == ["1", "3"]
 
@@ -350,16 +344,7 @@ class TestSummarizeDescription:
 
     def _mock_client(self, responses: Sequence[str | None]) -> MagicMock:
         client = MagicMock()
-        call_idx = 0
-
-        async def generate(*args, **kwargs):
-            nonlocal call_idx
-            resp = MagicMock()
-            resp.text = responses[call_idx]
-            call_idx += 1
-            return resp
-
-        client.models.generate_content = generate
+        client.chat.completions.create = AsyncMock(side_effect=[_make_llm_response(r) for r in responses])
         return client
 
     @pytest.mark.asyncio
@@ -367,7 +352,7 @@ class TestSummarizeDescription:
         client = self._mock_client(["Short summary."])
         output = _make_output(description="x" * 500)
 
-        result = await _summarize_description(client, output, self.PROMPT, self.THRESHOLD)
+        result = await _summarize_description(client, 1, output, self.PROMPT, self.THRESHOLD)
 
         assert result.description == "Short summary."
 
@@ -376,7 +361,8 @@ class TestSummarizeDescription:
         client = self._mock_client(["a" * 300, "Concise."])
         output = _make_output(description="x" * 500)
 
-        result = await _summarize_description(client, output, self.PROMPT, self.THRESHOLD)
+        with patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics"):
+            result = await _summarize_description(client, 1, output, self.PROMPT, self.THRESHOLD)
 
         assert result.description == "Concise."
 
@@ -387,7 +373,7 @@ class TestSummarizeDescription:
         output = _make_output(description=original)
 
         with patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics"):
-            result = await _summarize_description(client, output, self.PROMPT, self.THRESHOLD)
+            result = await _summarize_description(client, 1, output, self.PROMPT, self.THRESHOLD)
 
         assert result.description == original[: self.THRESHOLD]
 
@@ -403,13 +389,28 @@ class TestSummarizeDescription:
             extra={"html_url": "https://example.com"},
         )
 
-        result = await _summarize_description(client, output, self.PROMPT, self.THRESHOLD)
+        result = await _summarize_description(client, 1, output, self.PROMPT, self.THRESHOLD)
 
         assert result.source_product == "github"
         assert result.source_type == "issue"
         assert result.source_id == "42"
         assert result.weight == 0.8
         assert result.extra == {"html_url": "https://example.com"}
+
+    @pytest.mark.asyncio
+    async def test_passes_team_attribution_headers(self):
+        client = self._mock_client(["Short summary."])
+        output = _make_output(description="x" * 500)
+
+        await _summarize_description(client, 42, output, self.PROMPT, self.THRESHOLD)
+
+        call_kwargs = client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["user"] == "team-42"
+        headers = call_kwargs["extra_headers"]
+        assert headers["x-posthog-property-ai_stage"] == "summarization"
+        # ai_product and $ai_billable are owned by the gateway product config, not headers
+        assert "x-posthog-property-ai_product" not in headers
+        assert "x-posthog-property-$ai_billable" not in headers
 
 
 class TestSummarizeLongDescriptions:
@@ -420,18 +421,16 @@ class TestSummarizeLongDescriptions:
     async def test_only_summarizes_descriptions_above_threshold(self):
         short = _make_output(source_id="1", description="short")
         long = _make_output(source_id="2", description="x" * 200)
+        team = MagicMock(id=1)
 
         mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = "Summarized."
-        mock_client.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_llm_response("Summarized."))
 
         with (
-            patch(f"{PIPELINE_MODULE_PATH}.genai") as mock_genai,
+            patch(f"{PIPELINE_MODULE_PATH}.get_async_llm_client", return_value=mock_client),
             patch(f"{PIPELINE_MODULE_PATH}.activity"),
         ):
-            mock_genai.AsyncClient.return_value = mock_client
-            result = await summarize_long_descriptions([short, long], self.PROMPT, self.THRESHOLD, extra={})
+            result = await summarize_long_descriptions(team, [short, long], self.PROMPT, self.THRESHOLD, extra={})
 
         assert result[0].description == "short"
         assert result[1].description == "Summarized."
@@ -439,8 +438,9 @@ class TestSummarizeLongDescriptions:
     @pytest.mark.asyncio
     async def test_returns_unchanged_when_all_under_threshold(self):
         outputs = [_make_output(source_id="1", description="short"), _make_output(source_id="2", description="also")]
+        team = MagicMock(id=1)
 
-        result = await summarize_long_descriptions(outputs, self.PROMPT, self.THRESHOLD, extra={})
+        result = await summarize_long_descriptions(team, outputs, self.PROMPT, self.THRESHOLD, extra={})
 
         assert result == outputs
 
@@ -573,27 +573,23 @@ class TestPipelineStageTelemetry:
 
         mock_llm_client = MagicMock()
 
-        async def generate_content(*args, **kwargs):
-            contents = kwargs.get("contents") or (args[1] if len(args) > 1 else None)
-            prompt_text = ""
-            if contents:
-                first = contents[0]
-                prompt_text = first.text if hasattr(first, "text") else first
+        async def create(*args, **kwargs):
+            messages = kwargs.get("messages") or []
+            prompt_text = messages[0]["content"] if messages else ""
             if "Summarize" in prompt_text:
                 return _make_llm_response("Summarized ticket body.")
             if "not actionable" in prompt_text:
                 return _make_llm_response("NOT_ACTIONABLE")
             return _make_llm_response("ACTIONABLE")
 
-        mock_llm_client.models.generate_content = generate_content
+        mock_llm_client.chat.completions.create = create
 
         with (
-            patch(f"{PIPELINE_MODULE_PATH}.genai") as mock_genai,
+            patch(f"{PIPELINE_MODULE_PATH}.get_async_llm_client", return_value=mock_llm_client),
             patch(f"{PIPELINE_MODULE_PATH}.activity"),
             patch(f"{PIPELINE_MODULE_PATH}.emit_signal", new_callable=AsyncMock),
             patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture") as capture,
         ):
-            mock_genai.AsyncClient.return_value = mock_llm_client
             await run_signal_pipeline(team=team, config=config, records=records, extra={})
 
         events_by_source_id: dict[str, list[str]] = {}

--- a/posthog/temporal/tests/ai/test_classify_task_needs_repo_activity.py
+++ b/posthog/temporal/tests/ai/test_classify_task_needs_repo_activity.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+from posthog.temporal.ai.posthog_code_slack_mention import classify_posthog_code_task_needs_repo_activity
+
+
+class TestClassifyPostHogCodeTaskNeedsRepoActivity(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="TestOrg")
+        self.team = Team.objects.create(organization=self.org, name="TestTeam")
+        self.integration = Integration.objects.create(
+            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
+        )
+
+    @patch("products.slack_app.backend.api.classify_task_needs_repo")
+    def test_resolves_team_id_from_integration(self, mock_classify):
+        mock_classify.return_value = False
+
+        result = classify_posthog_code_task_needs_repo_activity("fix the checkout test", [], self.integration.id)
+
+        assert result is False
+        mock_classify.assert_called_once_with("fix the checkout test", [], team_id=self.team.id)
+
+    @patch("products.slack_app.backend.api.classify_task_needs_repo")
+    def test_defaults_to_picker_when_integration_missing(self, mock_classify):
+        result = classify_posthog_code_task_needs_repo_activity("fix the checkout test", [], 999999)
+
+        assert result is True
+        mock_classify.assert_not_called()

--- a/posthog/temporal/usage_report/queries.py
+++ b/posthog/temporal/usage_report/queries.py
@@ -76,7 +76,12 @@ from posthog.tasks.usage_report import (
     get_teams_with_recording_count_in_period,
     get_teams_with_rows_exported_in_period,
     get_teams_with_rows_synced_in_period,
+<<<<<<< New base: feat(llma): per-team gateway attribution and signals usage reporting
     get_teams_with_sdk_logs_records_in_period,
+||||||| Common ancestor
+=======
+    get_teams_with_signals_credits_used_in_period,
+>>>>>>> Current commit: feat(llma): per-team gateway attribution and signals usage reporting
     get_teams_with_survey_responses_count_in_period,
     get_teams_with_workflow_billable_invocations_in_period,
     get_teams_with_workflow_emails_sent_in_period,
@@ -423,6 +428,10 @@ QUERIES: list[QuerySpec] = [
     QuerySpec(
         name="teams_with_ai_credits_used_in_period",
         fn=get_teams_with_ai_credits_used_in_period,
+    ),
+    QuerySpec(
+        name="teams_with_signals_credits_used_in_period",
+        fn=get_teams_with_signals_credits_used_in_period,
     ),
     # ---- ClickHouse: workflows / messaging ----------------------------------
     QuerySpec(

--- a/products/ai_observability/backend/summarization/llm/evaluation_summary.py
+++ b/products/ai_observability/backend/summarization/llm/evaluation_summary.py
@@ -3,11 +3,10 @@
 from typing import Any, cast
 
 import structlog
-from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionMessageParam
 from rest_framework import exceptions
 
-from posthog.llm.gateway_client import get_llm_client
+from posthog.llm.gateway_client import get_async_llm_client
 
 from ..constants import SUMMARIZATION_TIMEOUT
 from ..models import OpenAIModel
@@ -86,10 +85,7 @@ async def summarize_evaluation_runs(
 
 {runs_text}"""
 
-    sync_client = get_llm_client("llma_eval_summary")
-    client = AsyncOpenAI(
-        base_url=sync_client.base_url,
-        api_key=sync_client.api_key,
+    client = get_async_llm_client(product="llma_eval_summary", team_id=team_id).with_options(
         timeout=SUMMARIZATION_TIMEOUT,
     )
 

--- a/products/ai_observability/backend/summarization/llm/openai.py
+++ b/products/ai_observability/backend/summarization/llm/openai.py
@@ -27,7 +27,7 @@ def summarize_with_openai(
     system_prompt = load_summarization_template(f"prompts/system_{mode}.djt", {})
     user_prompt = load_summarization_template("prompts/user.djt", {"text_repr": text_repr})
 
-    client = get_llm_client("llma_summarization")
+    client = get_llm_client(product="llma_summarization", team_id=team_id)
 
     messages: list[ChatCompletionMessageParam] = [
         {"role": "system", "content": system_prompt},

--- a/products/ai_observability/backend/translation/llm.py
+++ b/products/ai_observability/backend/translation/llm.py
@@ -9,19 +9,20 @@ from .constants import SUPPORTED_LANGUAGES, TRANSLATION_MODEL
 logger = structlog.get_logger(__name__)
 
 
-def translate_text(text: str, target_language: str, user_distinct_id: str | None = None) -> str:
+def translate_text(text: str, target_language: str, team_id: int, user_distinct_id: str | None = None) -> str:
     """
     Translate text to target language using the LLM gateway.
 
     Args:
         text: The text to translate
         target_language: Target language code (e.g., 'en', 'es', 'fr')
+        team_id: PostHog team for LLM cost attribution
         user_distinct_id: The user's distinct_id for analytics attribution
 
     Returns:
         Translated text
     """
-    client = get_llm_client("llma_translation")
+    client = get_llm_client(product="llma_translation", team_id=team_id)
 
     target_name = SUPPORTED_LANGUAGES.get(target_language, target_language)
 

--- a/products/llm_analytics/backend/api/translate.py
+++ b/products/llm_analytics/backend/api/translate.py
@@ -1,0 +1,132 @@
+"""
+Django REST API endpoint for translating LLM trace message content.
+
+Endpoint:
+- POST /api/environments/:id/llm_analytics/translate/ - Translate text
+"""
+
+import time
+from typing import cast
+
+import structlog
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema
+from rest_framework import exceptions, serializers, status, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.monitoring import monitor
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import report_user_action
+from posthog.models import User
+from posthog.permissions import AccessControlPermission
+from posthog.rate_limit import (
+    LLMAnalyticsTranslationBurstThrottle,
+    LLMAnalyticsTranslationDailyThrottle,
+    LLMAnalyticsTranslationSustainedThrottle,
+)
+
+from products.llm_analytics.backend.api.metrics import llma_track_latency
+from products.llm_analytics.backend.translation.constants import DEFAULT_TARGET_LANGUAGE
+from products.llm_analytics.backend.translation.llm import translate_text
+
+logger = structlog.get_logger(__name__)
+
+
+class TranslateRequestSerializer(serializers.Serializer):
+    text = serializers.CharField(max_length=10000, help_text="The text to translate")
+    target_language = serializers.CharField(
+        max_length=10,
+        default=DEFAULT_TARGET_LANGUAGE,
+        required=False,
+        help_text="Target language code (default: 'en' for English)",
+    )
+
+
+class TranslateResponseSerializer(serializers.Serializer):
+    translation = serializers.CharField(help_text="The translated text")
+    detected_language = serializers.CharField(
+        required=False, allow_null=True, help_text="Detected source language (if available)"
+    )
+    provider = serializers.CharField(help_text="Translation provider used")
+
+
+class LLMAnalyticsTranslateViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """ViewSet for translating LLM trace message content."""
+
+    scope_object = "llm_analytics"
+    permission_classes = [AccessControlPermission]
+
+    def get_throttles(self):
+        return [
+            LLMAnalyticsTranslationBurstThrottle(),
+            LLMAnalyticsTranslationSustainedThrottle(),
+            LLMAnalyticsTranslationDailyThrottle(),
+        ]
+
+    def _validate_feature_access(self, request: Request) -> None:
+        """Validate that the user is authenticated and AI data processing is approved."""
+        if not request.user.is_authenticated:
+            raise exceptions.NotAuthenticated()
+
+        if not self.organization.is_ai_data_processing_approved:
+            raise exceptions.PermissionDenied(
+                "AI data processing must be approved by your organization before using translation"
+            )
+
+    @extend_schema(request=TranslateRequestSerializer, responses={200: OpenApiTypes.OBJECT})
+    @llma_track_latency("llma_translate")
+    @monitor(feature=None, endpoint="llma_translate", method="POST")
+    def create(self, request: Request, *args, **kwargs) -> Response:
+        """Translate text to target language."""
+        self._validate_feature_access(request)
+
+        serializer = TranslateRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        text = serializer.validated_data["text"]
+        target_language = serializer.validated_data.get("target_language", DEFAULT_TARGET_LANGUAGE)
+
+        try:
+            logger.info(
+                "translation_requested",
+                target_language=target_language,
+                text_length=len(text),
+            )
+            start_time = time.time()
+            user = cast(User, request.user)
+            translation = translate_text(text, target_language, team_id=self.team_id, user_distinct_id=user.distinct_id)
+            duration_seconds = time.time() - start_time
+            logger.info(
+                "translation_completed",
+                target_language=target_language,
+                translation_length=len(translation),
+            )
+
+            report_user_action(
+                user,
+                "llma translation generated",
+                {
+                    "target_language": target_language,
+                    "text_length": len(text),
+                    "translation_length": len(translation),
+                    "duration_seconds": duration_seconds,
+                },
+                team=self.team,
+                request=self.request,
+            )
+
+            return Response(
+                {
+                    "translation": translation,
+                    "detected_language": None,
+                    "provider": "openai",
+                },
+                status=status.HTTP_200_OK,
+            )
+        except Exception as e:
+            logger.exception("translation_failed", error=str(e), target_language=target_language)
+            raise exceptions.APIException(
+                detail="Translation failed due to an internal error.",
+                code="translation_error",
+            )

--- a/products/llm_analytics/backend/summarization/llm/__init__.py
+++ b/products/llm_analytics/backend/summarization/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LLM calling utilities for summarization."""
+
+from .call import summarize
+
+__all__ = ["summarize"]

--- a/products/llm_analytics/backend/summarization/llm/call.py
+++ b/products/llm_analytics/backend/summarization/llm/call.py
@@ -1,0 +1,36 @@
+"""
+LLM calling function for summarization via LLM gateway.
+
+Routes all summarization requests through the LLM gateway with OpenAI models.
+"""
+
+from typing import cast
+
+from ..constants import DEFAULT_MODE, DEFAULT_MODEL_OPENAI
+from ..models import OpenAIModel, SummarizationMode
+from .openai import summarize_with_openai
+from .schema import SummarizationResponse
+
+
+def summarize(
+    text_repr: str,
+    team_id: int,
+    mode: SummarizationMode = DEFAULT_MODE,
+    model: OpenAIModel | None = None,
+    user_id: str | None = None,
+) -> SummarizationResponse:
+    """
+    Generate AI-powered summary from text representation via LLM gateway.
+
+    Args:
+        text_repr: Line-numbered text representation to summarize
+        team_id: Team ID for cost tracking and analytics
+        mode: Summary detail level
+        model: OpenAI model to use (defaults to gpt-4.1-mini)
+        user_id: Optional user distinct_id for analytics attribution
+
+    Returns:
+        Structured summarization response with flow diagram, bullets, and notes
+    """
+    openai_model = cast(OpenAIModel, model) if model else DEFAULT_MODEL_OPENAI
+    return summarize_with_openai(text_repr, team_id, mode, openai_model, user_id)

--- a/products/llm_analytics/backend/summarization/llm/evaluation_schema.py
+++ b/products/llm_analytics/backend/summarization/llm/evaluation_schema.py
@@ -1,0 +1,43 @@
+"""
+Pydantic schema for structured LLM evaluation summary outputs.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EvaluationPattern(BaseModel):
+    """A pattern identified across evaluation results."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(description="Short title for the pattern (3-5 words)")
+    description: str = Field(description="Detailed description of the pattern")
+    frequency: str = Field(description="How common this pattern is: 'common', 'occasional', or 'rare'")
+    example_reasoning: str = Field(
+        description="An example reasoning from the evaluated runs that demonstrates this pattern"
+    )
+    example_generation_ids: list[str] = Field(description="List of 1-5 generation IDs that exemplify this pattern")
+
+
+class EvaluationSummaryStatistics(BaseModel):
+    """Statistics about the analyzed evaluation runs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_analyzed: int = Field(description="Total number of evaluation runs analyzed")
+    pass_count: int = Field(description="Number of passing evaluations")
+    fail_count: int = Field(description="Number of failing evaluations")
+    na_count: int = Field(description="Number of N/A (not applicable) evaluations")
+
+
+class EvaluationSummaryResponse(BaseModel):
+    """Structured response from LLM evaluation summarization."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    overall_assessment: str
+    pass_patterns: list[EvaluationPattern]
+    fail_patterns: list[EvaluationPattern]
+    na_patterns: list[EvaluationPattern]
+    recommendations: list[str]
+    statistics: EvaluationSummaryStatistics

--- a/products/llm_analytics/backend/summarization/llm/schema.py
+++ b/products/llm_analytics/backend/summarization/llm/schema.py
@@ -1,0 +1,44 @@
+"""
+Pydantic schema for structured LLM summarization outputs.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SummaryBullet(BaseModel):
+    """A single bullet point in the summary."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    text: str = Field(description="The bullet point text")
+    line_refs: str = Field(
+        description="Single line reference like 'L45' pointing to the most relevant line for this bullet"
+    )
+
+
+class InterestingNote(BaseModel):
+    """A single interesting note."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    text: str = Field(description="The note text")
+    line_refs: str = Field(
+        description="Single line reference like 'L45' pointing to the most relevant line, or empty string if no specific line"
+    )
+
+
+class SummarizationResponse(BaseModel):
+    """Structured response from LLM summarization."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(
+        description="A concise, descriptive title (no longer than 10 words) summarizing the main purpose or outcome of this trace/event"
+    )
+    flow_diagram: str = Field(
+        description="ASCII/text-based flow diagram showing the main steps in an easy, human-readable way. Use arrows (↓, →), branches (├─→, └─→), and symbols (✓, ✗)."
+    )
+    summary_bullets: list[SummaryBullet] = Field(description="3-10 summary bullet points with line references")
+    interesting_notes: list[InterestingNote] = Field(
+        description="Interesting notes (detailed mode). Use empty array for minimal mode."
+    )

--- a/products/llm_analytics/backend/summarization/tests/test_providers.py
+++ b/products/llm_analytics/backend/summarization/tests/test_providers.py
@@ -1,0 +1,159 @@
+import json
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from rest_framework import exceptions
+
+from products.llm_analytics.backend.summarization.llm.openai import summarize_with_openai
+from products.llm_analytics.backend.summarization.llm.schema import SummarizationResponse
+from products.llm_analytics.backend.summarization.models import OpenAIModel, SummarizationMode
+
+
+@pytest.fixture
+def valid_response_json():
+    return json.dumps(
+        {
+            "title": "Test Summary",
+            "flow_diagram": "User -> Assistant",
+            "summary_bullets": [{"text": "Test bullet", "line_refs": "L1"}],
+            "interesting_notes": [],
+        }
+    )
+
+
+class TestSummarizeWithOpenAI:
+    def test_successful_summarization(self, valid_response_json):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = valid_response_json
+
+        with patch("products.llm_analytics.backend.summarization.llm.openai.get_llm_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.return_value = mock_response
+
+            result = summarize_with_openai(
+                text_repr="L1: Test content",
+                team_id=1,
+                mode=SummarizationMode.MINIMAL,
+                model=OpenAIModel.GPT_4_1_MINI,
+            )
+
+            assert isinstance(result, SummarizationResponse)
+            assert result.title == "Test Summary"
+            mock_get_client.assert_called_once_with(product="llma_summarization", team_id=1)
+
+    def test_empty_response_raises_validation_error(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = None
+
+        with patch("products.llm_analytics.backend.summarization.llm.openai.get_llm_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.return_value = mock_response
+
+            with pytest.raises(exceptions.ValidationError, match="empty response"):
+                summarize_with_openai(
+                    text_repr="L1: Test",
+                    team_id=1,
+                    mode=SummarizationMode.MINIMAL,
+                    model=OpenAIModel.GPT_4_1_MINI,
+                )
+
+    def test_api_error_raises_api_exception(self):
+        with patch("products.llm_analytics.backend.summarization.llm.openai.get_llm_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.side_effect = Exception("API Error")
+
+            with pytest.raises(exceptions.APIException, match="Failed to generate summary"):
+                summarize_with_openai(
+                    text_repr="L1: Test",
+                    team_id=1,
+                    mode=SummarizationMode.MINIMAL,
+                    model=OpenAIModel.GPT_4_1_MINI,
+                )
+
+    def test_uses_correct_model(self, valid_response_json):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = valid_response_json
+
+        with patch("products.llm_analytics.backend.summarization.llm.openai.get_llm_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.return_value = mock_response
+
+            summarize_with_openai(
+                text_repr="L1: Test",
+                team_id=1,
+                mode=SummarizationMode.MINIMAL,
+                model=OpenAIModel.GPT_4_1_MINI,
+            )
+
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert call_kwargs["model"] == OpenAIModel.GPT_4_1_MINI
+
+    def test_uses_user_id_when_provided(self, valid_response_json):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = valid_response_json
+
+        with patch("products.llm_analytics.backend.summarization.llm.openai.get_llm_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.return_value = mock_response
+
+            summarize_with_openai(
+                text_repr="L1: Test",
+                team_id=1,
+                mode=SummarizationMode.MINIMAL,
+                model=OpenAIModel.GPT_4_1_MINI,
+                user_id="user-distinct-123",
+            )
+
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert call_kwargs["user"] == "user-distinct-123"
+
+    def test_uses_team_fallback_when_no_user_id(self, valid_response_json):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = valid_response_json
+
+        with patch("products.llm_analytics.backend.summarization.llm.openai.get_llm_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.return_value = mock_response
+
+            summarize_with_openai(
+                text_repr="L1: Test",
+                team_id=42,
+                mode=SummarizationMode.MINIMAL,
+                model=OpenAIModel.GPT_4_1_MINI,
+            )
+
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert call_kwargs["user"] == "team-42"
+
+    def test_uses_json_schema_format(self, valid_response_json):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = valid_response_json
+
+        with patch("products.llm_analytics.backend.summarization.llm.openai.get_llm_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.return_value = mock_response
+
+            summarize_with_openai(
+                text_repr="L1: Test",
+                team_id=1,
+                mode=SummarizationMode.MINIMAL,
+                model=OpenAIModel.GPT_4_1_MINI,
+            )
+
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert call_kwargs["response_format"]["type"] == "json_schema"
+            assert call_kwargs["response_format"]["json_schema"]["strict"] is True

--- a/products/llm_analytics/backend/translation/test/test_llm.py
+++ b/products/llm_analytics/backend/translation/test/test_llm.py
@@ -1,0 +1,154 @@
+"""Tests for translation LLM module."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+
+from products.llm_analytics.backend.translation.constants import SUPPORTED_LANGUAGES, TRANSLATION_MODEL
+from products.llm_analytics.backend.translation.llm import translate_text
+
+MOCK_PATH = "products.llm_analytics.backend.translation.llm.get_llm_client"
+
+
+class TestTranslateText:
+    @patch(MOCK_PATH)
+    def test_returns_translated_text(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="  Hola mundo  "))]
+        mock_get_client.return_value.chat.completions.create.return_value = mock_response
+
+        result = translate_text("Hello world", "es", team_id=1)
+
+        assert result == "Hola mundo"
+
+    @patch(MOCK_PATH)
+    def test_uses_correct_model(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Translated"))]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        translate_text("Test", "es", team_id=1)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == TRANSLATION_MODEL
+
+    @patch(MOCK_PATH)
+    def test_uses_fallback_user_when_no_distinct_id(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Translated"))]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        translate_text("Test", "es", team_id=1)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["user"] == "llma-translation"
+
+    @patch(MOCK_PATH)
+    def test_passes_distinct_id_as_user(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Translated"))]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        translate_text("Test", "es", team_id=1, user_distinct_id="user-123")
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["user"] == "user-123"
+
+    @patch(MOCK_PATH)
+    def test_creates_client_with_correct_product(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Translated"))]
+        mock_get_client.return_value.chat.completions.create.return_value = mock_response
+
+        translate_text("Test", "es", team_id=1)
+
+        mock_get_client.assert_called_once_with(product="llma_translation", team_id=1)
+
+    @parameterized.expand(list(SUPPORTED_LANGUAGES.items()))
+    @patch(MOCK_PATH)
+    def test_includes_language_name_in_prompt(self, lang_code, lang_name, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Translated"))]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        translate_text("Test", lang_code, team_id=1)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        system_message = call_kwargs["messages"][0]["content"]
+        assert lang_name in system_message
+
+    @patch(MOCK_PATH)
+    def test_falls_back_to_language_code_for_unknown_language(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Translated"))]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        translate_text("Test", "unknown_lang", team_id=1)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        system_message = call_kwargs["messages"][0]["content"]
+        assert "unknown_lang" in system_message
+
+    @patch(MOCK_PATH)
+    def test_passes_text_as_user_message(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Translated"))]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        translate_text("Hello world", "es", team_id=1)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        user_message = call_kwargs["messages"][1]
+        assert user_message["role"] == "user"
+        assert user_message["content"] == "Hello world"
+
+    @patch(MOCK_PATH)
+    def test_returns_empty_string_for_none_content(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content=None))]
+        mock_get_client.return_value.chat.completions.create.return_value = mock_response
+
+        result = translate_text("Test", "es", team_id=1)
+
+        assert result == ""
+
+    @patch(MOCK_PATH)
+    def test_strips_whitespace_from_response(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="\n\n  Translated text  \n\n"))]
+        mock_get_client.return_value.chat.completions.create.return_value = mock_response
+
+        result = translate_text("Test", "es", team_id=1)
+
+        assert result == "Translated text"
+
+    @patch(MOCK_PATH)
+    def test_propagates_exceptions(self, mock_get_client):
+        mock_get_client.return_value.chat.completions.create.side_effect = Exception("API Error")
+
+        with pytest.raises(Exception, match="API Error"):
+            translate_text("Test", "es", team_id=1)
+
+    @patch(MOCK_PATH)
+    def test_sets_timeout(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Translated"))]
+        mock_get_client.return_value.chat.completions.create.return_value = mock_response
+
+        translate_text("Test", "es", team_id=1)
+
+        call_kwargs = mock_get_client.return_value.chat.completions.create.call_args.kwargs
+        assert call_kwargs["timeout"] == 30.0

--- a/products/signals/eval/AGENTS.md
+++ b/products/signals/eval/AGENTS.md
@@ -17,7 +17,7 @@ interleaved across groups to simulate real-world arrival patterns.
 
 ### Pipeline stages per signal
 
-1. **Pre-emit** — summarize long descriptions, check actionability (Gemini).
+1. **Pre-emit** — summarize long descriptions, check actionability (Claude Haiku via the internal LLM gateway).
    Signals that fail actionability are dropped.
 2. **Match** — generate search queries (LLM), embed queries (OpenAI),
    cosine search against stored signals, LLM match to existing report or create new,
@@ -46,13 +46,15 @@ pytest products/signals/eval/eval_grouping_e2e.py -xvs --online
 
 Set in `.env` at the repo root (loaded automatically):
 
-| Variable                  | Purpose                                                |
-| ------------------------- | ------------------------------------------------------ |
-| `ANTHROPIC_API_KEY`       | LLM calls (matching, specificity, summarization)       |
-| `OPENAI_API_KEY`          | Embeddings (text-embedding-3-small)                    |
-| `GEMINI_API_KEY`          | Actionability check                                    |
-| `POSTHOG_PROJECT_API_KEY` | Capturing eval results (skip with `--no-capture`)      |
-| `POSTHOG_HOST`            | PostHog instance (defaults to `http://localhost:8010`) |
+| Variable                       | Purpose                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`            | LLM calls (matching, specificity, summarization)                          |
+| `OPENAI_API_KEY`               | Embeddings (text-embedding-3-small)                                       |
+| `LLM_GATEWAY_URL`              | Internal LLM gateway base URL (pre-emit summarization + actionability)    |
+| `LLM_GATEWAY_PERSONAL_API_KEY` | Bearer token for the LLM gateway (PostHog personal API key)               |
+| `SIGNALS_EVAL_TEAM_ID`         | Team id used for LLM cost attribution headers (defaults to `1`)           |
+| `POSTHOG_PROJECT_API_KEY`      | Capturing eval results (skip with `--no-capture`)                         |
+| `POSTHOG_HOST`                 | PostHog instance (defaults to `http://localhost:8010`)                    |
 
 ### CLI options
 

--- a/products/signals/eval/conftest.py
+++ b/products/signals/eval/conftest.py
@@ -1,5 +1,4 @@
 import os
-import logging
 from pathlib import Path
 
 import pytest
@@ -10,15 +9,12 @@ from django.conf import settings
 import posthoganalytics
 from dotenv import load_dotenv
 from posthoganalytics import Posthog
-from posthoganalytics.ai.gemini import genai
 from posthoganalytics.ai.openai import AsyncOpenAI
 
+from posthog.llm.gateway_client import get_async_llm_client
 from posthog.models import Organization, Team
 
 load_dotenv(Path(__file__).resolve().parents[3] / ".env")
-
-logging.getLogger("google_genai").setLevel(logging.ERROR)
-logging.getLogger("google.genai").setLevel(logging.ERROR)
 
 # Initialize posthoganalytics default_client so the LLM wrapper (which requires it) works
 posthoganalytics.default_client = Posthog(  # ty: ignore[invalid-assignment]
@@ -34,10 +30,15 @@ if not settings.ANTHROPIC_API_KEY:
     settings.ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 if not getattr(settings, "OPENAI_API_KEY", ""):
     settings.OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+if not getattr(settings, "LLM_GATEWAY_URL", ""):
+    settings.LLM_GATEWAY_URL = os.environ.get("LLM_GATEWAY_URL", "")
+if not getattr(settings, "LLM_GATEWAY_API_KEY", ""):
+    settings.LLM_GATEWAY_API_KEY = os.environ.get("LLM_GATEWAY_PERSONAL_API_KEY", "") or os.environ.get(
+        "LLM_GATEWAY_API_KEY", ""
+    )
 
-# Gemini client expects GOOGLE_API_KEY; alias from GEMINI_API_KEY if needed
-if not os.environ.get("GOOGLE_API_KEY") and os.environ.get("GEMINI_API_KEY"):
-    os.environ["GOOGLE_API_KEY"] = os.environ["GEMINI_API_KEY"]
+# Team id used by the eval harness when attributing LLM cost via the gateway.
+EVAL_TEAM_ID = int(os.environ.get("SIGNALS_EVAL_TEAM_ID", "1"))
 
 
 def pytest_addoption(parser):
@@ -94,9 +95,13 @@ async def openai_client(posthog_client):
 
 
 @pytest.fixture
-def gemini_client():
-    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY", "")
-    return genai.AsyncClient(api_key=api_key)
+def gateway_client():
+    """Async OpenAI-compatible client pointed at the internal LLM gateway.
+
+    Used by eval_grouping_e2e to drive the production signals pre-emit pipeline
+    (`_check_actionability` etc.) through the gateway rather than calling Gemini directly.
+    """
+    return get_async_llm_client(product="signals", team_id=EVAL_TEAM_ID)
 
 
 @pytest.fixture

--- a/products/signals/eval/eval_grouping_e2e.py
+++ b/products/signals/eval/eval_grouping_e2e.py
@@ -66,15 +66,22 @@ from products.signals.eval.common import (
     MatchFailureMode,
     get_signals_stream,
 )
+from products.signals.eval.conftest import EVAL_TEAM_ID
 from products.signals.eval.fixtures.grouping_data import GROUP_DATA
 from products.signals.eval.mock import EmbeddingStore, ReportStore
 
 
 class EvalGroupingPipeline:
+    def _eval_team(self):
+        """Lightweight Team stand-in for the pipeline helpers — they only read .id."""
+        from unittest.mock import MagicMock
+
+        return MagicMock(id=EVAL_TEAM_ID)
+
     @pytest.fixture(autouse=True)
-    def _setup(self, posthog_client, openai_client, gemini_client, mock_temporal, limit, no_capture, online):
+    def _setup(self, posthog_client, openai_client, gateway_client, mock_temporal, limit, no_capture, online):
         self.posthog_client = posthog_client
-        self.gemini_client = gemini_client
+        self.gateway_client = gateway_client
         self.openai_client = openai_client
         self.store = EmbeddingStore(openai_client)
         self.report_store = ReportStore()
@@ -264,6 +271,7 @@ class EvalGroupingPipeline:
 
         if config.summarization_prompt is not None and config.description_summarization_threshold_chars is not None:
             outputs = await _summarize_long_descriptions(
+                team=self._eval_team(),
                 outputs=outputs,
                 summarization_prompt=config.summarization_prompt,
                 threshold=config.description_summarization_threshold_chars,
@@ -273,10 +281,10 @@ class EvalGroupingPipeline:
         output = outputs[0]
 
         if config.actionability_prompt:
-            is_actionable, thoughts = await _check_actionability(
-                self.gemini_client, output, config.actionability_prompt
+            is_actionable = await _check_actionability(
+                self.gateway_client, EVAL_TEAM_ID, output, config.actionability_prompt
             )
-            await self._capture_pre_emit_actionability(case, thoughts, is_actionable)
+            await self._capture_pre_emit_actionability(case, None, is_actionable)
             if not is_actionable:
                 return None
 

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1183,6 +1183,7 @@ def _resolve_pending_repo_picker_from_followup(event: dict[str, Any], integratio
 def classify_task_needs_repo(
     event_text: str,
     thread_messages: list[dict[str, str]],
+    team_id: int,
 ) -> bool:
     """Classify whether a Slack conversation requires code repository access.
 
@@ -1259,7 +1260,7 @@ def classify_task_needs_repo(
         'Respond with ONLY a JSON object: {{"needs_repo": true}} or {{"needs_repo": false}}'
     )
     try:
-        client = get_llm_client("slack_app_routing")
+        client = get_llm_client(product="slack_app_routing", team_id=team_id)
         response = client.chat.completions.create(
             model="claude-haiku-4-5-20251001",
             messages=[{"role": "user", "content": prompt}],

--- a/products/slack_app/backend/tests/test_guess_repository.py
+++ b/products/slack_app/backend/tests/test_guess_repository.py
@@ -726,5 +726,5 @@ class TestClassifyTaskNeedsRepo:
         ]
     )
     def test_heuristic_classification(self, _name, text, expected):
-        result = classify_task_needs_repo(text, [{"user": "Alessandro", "text": text}])
+        result = classify_task_needs_repo(text, [{"user": "Alessandro", "text": text}], team_id=1)
         assert result is expected

--- a/services/llm-gateway/README.md
+++ b/services/llm-gateway/README.md
@@ -49,7 +49,7 @@ You can use this key directly to make requests to the gateway locally.
 It is also available as `settings.DEV_API_KEY` in Django.
 
 In local dev (`DEBUG=True`), the gateway client defaults to `http://localhost:3308` and this key,
-so `get_llm_client()` works out of the box without setting any environment variables.
+so `get_llm_client(product=..., team_id=...)` works out of the box without setting any environment variables.
 
 You can also provision the key manually:
 
@@ -302,10 +302,19 @@ For calling from PostHog Django:
 ```python
 from posthog.llm.gateway_client import get_llm_client
 
-client = get_llm_client()
+# `team_id` is required: it sets the `x-posthog-property-team_id` header on every
+# request so the captured `$ai_generation` event is attributed to the right
+# customer team (the gateway PAK owns a single internal team; without this
+# property the usage reporter cannot break cost down per customer).
+client = get_llm_client(product="my_product", team_id=team.id)
 response = client.chat.completions.create(
     model="claude-opus-4-5",  # or any supported OpenAI, Anthropic, OpenRouter, or Fireworks AI model
     messages=[...],
     user=request.user.distinct_id,  # user for analytics and rate limiting
 )
 ```
+
+`ai_product` and `$ai_billable` are derived from the product config (`products/config.py`):
+the route sets `ai_product` from the `product` arg, and `$ai_billable` from that product's
+`billable` flag. Set `billable=True` on the product config to bill its generations — don't
+override `$ai_billable` per call via headers (a typo silently mis-bills).

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -63,6 +63,30 @@ def _is_product_billable(product: str) -> bool:
     return bool(config and config.billable)
 
 
+def _apply_owned_event_properties(properties: dict[str, Any], product: str, team_id: int | None) -> None:
+    """Enforce gateway-owned event properties, run after caller `x-posthog-property-*` headers are merged.
+
+    `ai_product` and `$ai_billable` are derived from the product config / route and must NOT be
+    overridable by callers — a typo would silently mis-bill or misattribute the generation, so we
+    re-assert them on top of whatever the headers set. `team_id`, in contrast, is a deliberate caller
+    override (a shared-key caller such as signals sets it to the customer team); we only fall back to
+    the authenticated key owner's team when no override was supplied.
+    """
+    properties["ai_product"] = product
+    properties["$ai_billable"] = _is_product_billable(product)
+    if team_id:
+        properties.setdefault("team_id", team_id)
+    # A header-supplied team_id arrives as a string ("42"); store it as an int so the captured
+    # property matches the rest of the platform (the usage reporter reads it via JSONExtractInt)
+    # rather than relying on ClickHouse string coercion.
+    raw_team_id = properties.get("team_id")
+    if raw_team_id is not None:
+        try:
+            properties["team_id"] = int(raw_team_id)
+        except (TypeError, ValueError):
+            pass
+
+
 # Stable namespace for hashing non-UUID trace identifiers (e.g. Claude Code's
 # JSON-encoded session blobs sent via Anthropic's metadata.user_id) into a
 # deterministic UUID. Generated once and frozen so the same input always maps
@@ -177,8 +201,6 @@ class PostHogCallback(InstrumentedCallback):
             "$ai_stream": is_streaming,
             "$ai_trace_id": trace_id,
             "$ai_span_id": str(uuid4()),
-            "ai_product": product,
-            "$ai_billable": _is_product_billable(product),
             # Stamped explicitly to bypass the SDK's group_type_index lookup.
             # The AI usage report hardcodes `$group_1` (posthog/tasks/usage_report.py)
             # so the gateway must guarantee that slot regardless of how the
@@ -213,8 +235,7 @@ class PostHogCallback(InstrumentedCallback):
             for flag_key, variant in posthog_flags.items():
                 properties[f"$feature/{flag_key}"] = variant
 
-        if team_id:
-            properties["team_id"] = team_id
+        _apply_owned_event_properties(properties, product, team_id)
 
         response_cost = standard_logging_object.get("response_cost")
         if response_cost is not None:
@@ -291,8 +312,6 @@ class PostHogCallback(InstrumentedCallback):
             "$ai_trace_id": trace_id,
             "$ai_is_error": True,
             "$ai_error": standard_logging_object.get("error_str", ""),
-            "ai_product": product,
-            "$ai_billable": _is_product_billable(product),
             "$group_1": self._region_url,
         }
 
@@ -306,8 +325,7 @@ class PostHogCallback(InstrumentedCallback):
             for flag_key, variant in posthog_flags.items():
                 properties[f"$feature/{flag_key}"] = variant
 
-        if team_id:
-            properties["team_id"] = team_id
+        _apply_owned_event_properties(properties, product, team_id)
 
         capture_kwargs: dict[str, Any] = {
             "distinct_id": distinct_id,

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -16,9 +16,9 @@ class ProductConfig:
     allowed_application_ids: frozenset[str] | None = frozenset()
     allowed_models: frozenset[str] | None = None  # None = all allowed
     allow_api_keys: bool = True
-    # Tag emitted $ai_generation events with $ai_billable=true so the PHAI
-    # daily aggregator (posthog/tasks/usage_report.py) rolls them into the
-    # customer team's AI credits bucket.
+    # Tag emitted $ai_generation events with $ai_billable=true so the usage reporter
+    # (posthog/tasks/usage_report.py) rolls them into the customer team's credit bucket
+    # for this product's ai_product (e.g. PostHog AI credits, or signals credits).
     billable: bool = False
 
 
@@ -140,8 +140,10 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allow_api_keys=True,
     ),
     "signals": ProductConfig(
-        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID}),
-        allow_api_keys=False,
+        allowed_application_ids=None,
+        allowed_models=frozenset({"claude-haiku-4-5"}),
+        allow_api_keys=True,
+        billable=True,
     ),
     "subscriptions": ProductConfig(
         allowed_application_ids=None,

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -110,6 +110,69 @@ class TestPostHogCallback:
             mock_client.shutdown.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_on_success_header_team_id_overrides_auth_user_team(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        """A caller-supplied x-posthog-property-team_id wins over the key owner's team.
+
+        This is how a shared-key caller (e.g. signals) attributes a generation to the
+        customer team rather than the key owner's team that the usage reporter reads.
+        """
+        _, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="signals"),
+            # headers arrive as strings — this is the realistic x-posthog-property-team_id path
+            patch("llm_gateway.callbacks.posthog.get_posthog_properties", return_value={"team_id": "999"}),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            call_kwargs = mock_client.capture.call_args.kwargs
+            props = call_kwargs["properties"]
+            # header-supplied customer team wins over auth_user.team_id (456), stored as an int
+            assert props["team_id"] == 999
+            assert isinstance(props["team_id"], int)
+            # the analytics project the event lands in still follows the authenticated team
+            assert call_kwargs["groups"] == {"project": 456}
+
+    @pytest.mark.asyncio
+    async def test_on_success_headers_cannot_override_ai_product_or_billable(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        """ai_product and $ai_billable are gateway-owned: caller headers can't override them.
+
+        Otherwise a typo'd header would silently mis-bill or misattribute the generation.
+        """
+        _, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
+            patch(
+                "llm_gateway.callbacks.posthog.get_posthog_properties",
+                return_value={"ai_product": "spoofed", "$ai_billable": True},
+            ),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            # route-derived product wins over the header value
+            assert props["ai_product"] == "posthog_code"
+            # config-derived billable flag wins (posthog_code is non-billable)
+            assert props["$ai_billable"] is False
+
+    @pytest.mark.asyncio
     async def test_on_success_uses_uuid_when_no_auth_user(
         self,
         callback: PostHogCallback,

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -58,12 +58,10 @@ class TestCheckProductAccess:
             ("llma_translation", "personal_api_key", None, "gpt-4.1-mini", True, None),
             ("llma_translation", "personal_api_key", None, "claude-3-opus", False, "not allowed"),
             ("llma_translation", "oauth_access_token", "any-app-id", "gpt-4.1-mini", False, "not authorized"),
-            # signals requires OAuth with a posthog_code app ID; API keys rejected; no model allowlist
-            ("signals", "personal_api_key", None, None, False, "requires OAuth"),
-            ("signals", "oauth_access_token", "invalid-app-id", None, False, "not authorized"),
-            ("signals", "oauth_access_token", POSTHOG_CODE_US_APP_ID, None, True, None),
-            ("signals", "oauth_access_token", POSTHOG_CODE_EU_APP_ID, None, True, None),
-            ("signals", "oauth_access_token", POSTHOG_CODE_US_APP_ID, "claude-3-opus", True, None),
+            # signals allows API keys (shared gateway key) but only claude-haiku-4-5; OAuth rejected (no app IDs configured)
+            ("signals", "personal_api_key", None, "claude-haiku-4-5", True, None),
+            ("signals", "personal_api_key", None, "claude-3-opus", False, "not allowed"),
+            ("signals", "oauth_access_token", "any-app-id", "claude-haiku-4-5", False, "not authorized"),
             # unknown product
             ("unknown", "personal_api_key", None, None, False, "Unknown product"),
         ],


### PR DESCRIPTION
## Problem

Signals LLM spend was lumped into PostHog AI usage reporting with no way to attribute it per customer team or report it independently. We want to start **reporting** signals usage now (for visibility) without **billing** for it yet, and without changing existing PostHog AI billing.

## Changes

- **LLM gateway client** — `get_llm_client` / `get_async_llm_client` now require `product` + `team_id` and inject `x-posthog-property-team_id`; every caller was updated (llm_analytics, slack_app routing, customer_archetype, signals pipeline + eval).
- **Gateway ownership** — `ai_product` and `$ai_billable` are derived from the product config and re-asserted after caller headers are merged, so a caller can't override them (a typo would otherwise mis-bill). A caller-supplied `team_id` header remains the deliberate per-customer attribution override and is coerced to an int. The `signals` product is marked `billable=true` (API-key access, `claude-haiku-4-5` only).
- **Usage reporting** — `ai_product='signals'` is split into a new `signals_credits` metric. Existing PostHog AI credits are unchanged: the trace-less billing fallback is scoped to signals only (the old `t.trace_id IS NULL` branch was already dead under ClickHouse `join_use_nulls=0`). Wired through both the Celery and Temporal report paths and `has_non_zero_usage`.
- **Signals pipeline** — summarization/actionability now route through the internal gateway.

Signals usage is reported now; billing activation (quota + plans) is deferred to launch.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8) — I did **not** perform manual testing. Automated tests I ran locally, all passing:

- `posthog/tasks/test/test_usage_report.py::TestAIEventsUsageReport` — the signals/non-signals split, trace-less Max-AI excluded, trace-less signals billed, non-billable signals excluded, and the `has_non_zero_usage` regression.
- `services/llm-gateway` full suite (980 passed) including new callback attribution tests (header `team_id` wins and is stored as int; `ai_product`/`$ai_billable` not overridable) and updated `test_product_config`.
- Temporal usage-report `test_parity` / `test_queries_registry` / `test_aggregator` / `test_aggregate_activity`.
- `test_emit_signals` header tests.

Verified that existing PostHog AI billing is a no-op delta (cross-checked against the live ClickHouse engine) and that signals attribution flows end-to-end (gateway → `team_id` property → `JSONExtractInt`).

## Publish to changelog?

do not publish to changelog (not until signals billing launches)

## Docs update

`services/llm-gateway/README.md` and `products/signals/eval/AGENTS.md` updated in this PR.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The work continued an interrupted PostHog Code session that scoped the usage-report split, then went through a multi-agent review (`/qa-team`) and a cleanup pass (`/simplify`).

Decisions made along the way:

- **Scoped the trace-less fallback to signals only**, leaving Max AI billing byte-for-byte unchanged, rather than bundling a live PostHog-AI billing change into a signals PR. The old `IS NULL` disjunct never matched (`join_use_nulls=0` yields `''`, not NULL), so `exclude_signals = t.is_billable = 1` is provably equivalent to prior production behavior; signals (which emit no `$ai_trace`) bill via `empty(t.trace_id)`.
- **Made `ai_product`/`$ai_billable` gateway-owned** (re-asserted after the header merge) so caller header typos can't mis-bill; `team_id` stays a deliberate override and is cast to int to match the rest of the platform.
- **"Report now, bill later"** — signals events are `billable=true` so usage is visible in reports, but signals is intentionally not wired into quota enforcement or plans yet.
- **Registered the signals query on the Temporal usage-report path**, not just the Celery path — without it the shared `_get_team_report` would `KeyError` on the new `signals_credits` key.

Reviewer notes / deliberate follow-ups (not in this PR):

- **Deploy ordering:** ship the gateway `allow_api_keys=true` signals config before (or with) the Django pipeline, otherwise signals LLM calls soft-fail during the rollout window (the pipeline swallows the error and degrades quality).
- The two billing queries duplicate-scan the same partitions — acceptable for a once-daily offline job; collapsible into one `GROUP BY … is_signals` pass later.
- At launch: wire `signals_credits` into quota/plans, and consider validating the header `team_id` against the authenticated key owner's org.

This change is agent-authored and requires human review — please do not self-merge. The scope bundles all `get_llm_client` caller updates because the required-`team_id` signature change is a breaking change that must land atomically.