### PR TITLE
feat(property-vals): emit-once seen cache in merger

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7364,6 +7364,7 @@ dependencies = [
  "lifecycle",
  "metrics",
  "proptest",
+ "quick_cache",
  "rdkafka",
  "serde",
  "serde_json",

--- a/rust/property-vals-rs/Cargo.toml
+++ b/rust/property-vals-rs/Cargo.toml
@@ -14,6 +14,7 @@ common-liveness = { path = "../common/liveness" }
 envconfig = { workspace = true }
 lifecycle = { path = "../common/lifecycle" }
 metrics = { workspace = true }
+quick_cache = { workspace = true }
 rdkafka = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -38,6 +38,9 @@ pub struct Config {
     #[envconfig(default = "0")]
     pub max_values_per_key: usize,
 
+    #[envconfig(default = "0")]
+    pub merger_seen_cache_capacity: usize,
+
     #[envconfig(default = "60")]
     pub kafka_produce_timeout_secs: u64,
 

--- a/rust/property-vals-rs/src/lib.rs
+++ b/rust/property-vals-rs/src/lib.rs
@@ -3,5 +3,6 @@ pub mod config;
 pub mod fan_out;
 pub mod metrics_consts;
 pub mod producer;
+pub mod seen_cache;
 pub mod types;
 pub mod worker;

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -9,7 +9,7 @@ use property_vals_rs::{
     fan_out::{extract_tuple, fan_out, fan_out_group},
     producer::AggregatedProducer,
     types::{Event, GroupIdentify, PropertyValueMessage},
-    worker::worker_loop,
+    worker::{worker_loop, ReductionConfig},
 };
 use serve_metrics::setup_metrics_routes;
 use tokio::net::TcpListener;
@@ -151,7 +151,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         events_handle.clone(),
         move |e: &Event| fan_out(e, &excluded_events),
         "events",
-        0,
+        ReductionConfig::default(),
     ));
     tokio::spawn(worker_loop::<GroupIdentify, _, _>(
         shared_config.clone(),
@@ -160,7 +160,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         groups_handle.clone(),
         move |g: &GroupIdentify| fan_out_group(g, &excluded_groups),
         "groups",
-        0,
+        ReductionConfig::default(),
     ));
     tokio::spawn(worker_loop::<PropertyValueMessage, _, _>(
         shared_config.clone(),
@@ -169,7 +169,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         merger_handle.clone(),
         |m: &PropertyValueMessage| extract_tuple(m),
         "merger",
-        shared_config.max_values_per_key,
+        ReductionConfig {
+            max_values_per_key: shared_config.max_values_per_key,
+            seen_cache_capacity: shared_config.merger_seen_cache_capacity,
+        },
     ));
     drop(events_handle);
     drop(groups_handle);

--- a/rust/property-vals-rs/src/metrics_consts.rs
+++ b/rust/property-vals-rs/src/metrics_consts.rs
@@ -11,3 +11,6 @@ pub const PRODUCER_FLUSH_FAILED: &str = "property_vals_rs_producer_flush_failed_
 pub const OFFSET_STORE_FAILED: &str = "property_vals_rs_offset_store_failed_total";
 pub const KAFKA_RECV_ERRORS: &str = "property_vals_rs_kafka_recv_errors_total";
 pub const TOP_K_DROPPED: &str = "property_vals_rs_top_k_dropped_total";
+pub const SEEN_CACHE_HITS: &str = "property_vals_rs_seen_cache_hits_total";
+pub const SEEN_CACHE_MISSES: &str = "property_vals_rs_seen_cache_misses_total";
+pub const SEEN_CACHE_EVICTED: &str = "property_vals_rs_seen_cache_evicted_total";

--- a/rust/property-vals-rs/src/seen_cache.rs
+++ b/rust/property-vals-rs/src/seen_cache.rs
@@ -37,18 +37,17 @@ impl SeenCache {
         Self { cache, worker }
     }
 
-    pub fn seen_or_insert(&self, key: &TupleKey) -> bool {
+    pub fn seen(&self, key: &TupleKey) -> bool {
         if self.cache.get(key).is_some() {
             metrics::counter!(SEEN_CACHE_HITS, "worker" => self.worker).increment(1);
             true
         } else {
             metrics::counter!(SEEN_CACHE_MISSES, "worker" => self.worker).increment(1);
-            self.cache.insert(key.clone(), ());
             false
         }
     }
 
-    pub fn forget(&self, key: &TupleKey) {
-        self.cache.remove(key);
+    pub fn insert(&self, key: &TupleKey) {
+        self.cache.insert(key.clone(), ());
     }
 }

--- a/rust/property-vals-rs/src/seen_cache.rs
+++ b/rust/property-vals-rs/src/seen_cache.rs
@@ -20,11 +20,6 @@ impl Lifecycle<TupleKey, ()> for EvictingLifecycle {
 
 type Inner = sync::Cache<TupleKey, (), UnitWeighter, DefaultHashBuilder, EvictingLifecycle>;
 
-/// Bounded "already emitted" set for emit-once at the merger. Holds the most
-/// recently seen tuples up to `capacity`: a tuple still resident is suppressed
-/// (it is already in ClickHouse within the cache horizon), and one that has
-/// aged out is re-emitted, with the AggregatingMergeTree absorbing the
-/// duplicate. Memory is bounded by `capacity`, not by total tuple cardinality.
 pub struct SeenCache {
     cache: Inner,
     worker: &'static str,
@@ -42,9 +37,6 @@ impl SeenCache {
         Self { cache, worker }
     }
 
-    /// On a hit, returns true (the caller suppresses the tuple) and refreshes
-    /// the entry's recency so hot tuples stay resident. On a miss, inserts the
-    /// tuple and returns false (the caller emits it).
     pub fn seen_or_insert(&self, key: &TupleKey) -> bool {
         if self.cache.get(key).is_some() {
             metrics::counter!(SEEN_CACHE_HITS, "worker" => self.worker).increment(1);
@@ -56,8 +48,6 @@ impl SeenCache {
         }
     }
 
-    /// Undo an insert when the produce that would have persisted the tuple
-    /// failed, so the next flush re-emits it instead of suppressing it.
     pub fn forget(&self, key: &TupleKey) {
         self.cache.remove(key);
     }

--- a/rust/property-vals-rs/src/seen_cache.rs
+++ b/rust/property-vals-rs/src/seen_cache.rs
@@ -1,0 +1,64 @@
+use quick_cache::{sync, DefaultHashBuilder, Lifecycle, UnitWeighter};
+
+use crate::metrics_consts::{SEEN_CACHE_EVICTED, SEEN_CACHE_HITS, SEEN_CACHE_MISSES};
+use crate::types::TupleKey;
+
+#[derive(Clone)]
+struct EvictingLifecycle {
+    worker: &'static str,
+}
+
+impl Lifecycle<TupleKey, ()> for EvictingLifecycle {
+    type RequestState = ();
+
+    fn begin_request(&self) -> Self::RequestState {}
+
+    fn on_evict(&self, _state: &mut Self::RequestState, _key: TupleKey, _val: ()) {
+        metrics::counter!(SEEN_CACHE_EVICTED, "worker" => self.worker).increment(1);
+    }
+}
+
+type Inner = sync::Cache<TupleKey, (), UnitWeighter, DefaultHashBuilder, EvictingLifecycle>;
+
+/// Bounded "already emitted" set for emit-once at the merger. Holds the most
+/// recently seen tuples up to `capacity`: a tuple still resident is suppressed
+/// (it is already in ClickHouse within the cache horizon), and one that has
+/// aged out is re-emitted, with the AggregatingMergeTree absorbing the
+/// duplicate. Memory is bounded by `capacity`, not by total tuple cardinality.
+pub struct SeenCache {
+    cache: Inner,
+    worker: &'static str,
+}
+
+impl SeenCache {
+    pub fn new(capacity: usize, worker: &'static str) -> Self {
+        let cache = sync::Cache::with(
+            capacity,
+            capacity as u64,
+            UnitWeighter,
+            DefaultHashBuilder::default(),
+            EvictingLifecycle { worker },
+        );
+        Self { cache, worker }
+    }
+
+    /// On a hit, returns true (the caller suppresses the tuple) and refreshes
+    /// the entry's recency so hot tuples stay resident. On a miss, inserts the
+    /// tuple and returns false (the caller emits it).
+    pub fn seen_or_insert(&self, key: &TupleKey) -> bool {
+        if self.cache.get(key).is_some() {
+            metrics::counter!(SEEN_CACHE_HITS, "worker" => self.worker).increment(1);
+            true
+        } else {
+            metrics::counter!(SEEN_CACHE_MISSES, "worker" => self.worker).increment(1);
+            self.cache.insert(key.clone(), ());
+            false
+        }
+    }
+
+    /// Undo an insert when the produce that would have persisted the tuple
+    /// failed, so the next flush re-emits it instead of suppressing it.
+    pub fn forget(&self, key: &TupleKey) {
+        self.cache.remove(key);
+    }
+}

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -134,7 +134,7 @@ pub(crate) async fn flush<P: Producer>(
     let to_emit: Vec<(TupleKey, u64)> = match seen_cache {
         Some(cache) => snapshot
             .into_iter()
-            .filter(|(tuple, _)| !cache.seen_or_insert(tuple))
+            .filter(|(tuple, _)| !cache.seen(tuple))
             .collect(),
         None => snapshot,
     };
@@ -150,15 +150,15 @@ pub(crate) async fn flush<P: Producer>(
         if let Err(e) = producer.produce(to_emit.clone()).await {
             metrics::counter!(PRODUCER_FLUSH_FAILED, "worker" => worker).increment(1);
             error!(error = %e, "produce failed; restoring counts, retrying next flush");
-            if let Some(cache) = seen_cache {
-                for (tuple, _) in &to_emit {
-                    cache.forget(tuple);
-                }
-            }
             for (tuple, count) in to_emit {
                 aggregator.add(tuple, count);
             }
             return;
+        }
+        if let Some(cache) = seen_cache {
+            for (tuple, _) in &to_emit {
+                cache.insert(tuple);
+            }
         }
     }
 

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -12,8 +12,6 @@ use crate::producer::Producer;
 use crate::seen_cache::SeenCache;
 use crate::types::{IngestableEvent, PropertyType, TupleKey};
 
-/// Per-worker reduction settings. Events and groups run with these disabled
-/// (`Default`); only the merger applies the top-K cap and the seen cache.
 #[derive(Clone, Copy, Default)]
 pub struct ReductionConfig {
     pub max_values_per_key: usize,
@@ -43,9 +41,6 @@ pub async fn worker_loop<E, P, F>(
     let _guard = handle.process_scope();
 
     let mut aggregator = Aggregator::new();
-    // Emit-once dedup, merger only (capacity 0 = disabled). Bounded by capacity,
-    // not cardinality; a forgotten or evicted tuple is re-emitted and the
-    // AggregatingMergeTree absorbs the duplicate.
     let seen_cache = (reduction.seen_cache_capacity > 0)
         .then(|| SeenCache::new(reduction.seen_cache_capacity, worker));
     // One Offset handle per partition: the latest message we've consumed.
@@ -136,9 +131,6 @@ pub(crate) async fn flush<P: Producer>(
         snapshot = cap_top_k(snapshot, max_values_per_key, worker);
     }
 
-    // Emit-once: drop tuples already in the seen cache, keep and remember the
-    // rest. The kept set is exactly what we insert, so a produce failure can
-    // forget those entries and re-emit them on the next flush.
     let to_emit: Vec<(TupleKey, u64)> = match seen_cache {
         Some(cache) => snapshot
             .into_iter()

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -9,7 +9,16 @@ use crate::aggregator::Aggregator;
 use crate::config::Config;
 use crate::metrics_consts::*;
 use crate::producer::Producer;
+use crate::seen_cache::SeenCache;
 use crate::types::{IngestableEvent, PropertyType, TupleKey};
+
+/// Per-worker reduction settings. Events and groups run with these disabled
+/// (`Default`); only the merger applies the top-K cap and the seen cache.
+#[derive(Clone, Copy, Default)]
+pub struct ReductionConfig {
+    pub max_values_per_key: usize,
+    pub seen_cache_capacity: usize,
+}
 
 /// One worker loop. Each pod runs one worker per input topic.
 ///
@@ -25,7 +34,7 @@ pub async fn worker_loop<E, P, F>(
     handle: lifecycle::Handle,
     fan_out_fn: F,
     worker: &'static str,
-    max_values_per_key: usize,
+    reduction: ReductionConfig,
 ) where
     E: IngestableEvent,
     P: Producer,
@@ -34,6 +43,11 @@ pub async fn worker_loop<E, P, F>(
     let _guard = handle.process_scope();
 
     let mut aggregator = Aggregator::new();
+    // Emit-once dedup, merger only (capacity 0 = disabled). Bounded by capacity,
+    // not cardinality; a forgotten or evicted tuple is re-emitted and the
+    // AggregatingMergeTree absorbs the duplicate.
+    let seen_cache = (reduction.seen_cache_capacity > 0)
+        .then(|| SeenCache::new(reduction.seen_cache_capacity, worker));
     // One Offset handle per partition: the latest message we've consumed.
     // On successful flush we call .store() on each, which advances the
     // consumer's stored offset; auto-commit ships it to the broker.
@@ -47,7 +61,7 @@ pub async fn worker_loop<E, P, F>(
         tokio::select! {
             _ = handle.shutdown_recv() => {
                 info!("worker received shutdown; draining final flush");
-                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_SHUTDOWN, worker, max_values_per_key).await;
+                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_SHUTDOWN, worker, reduction.max_values_per_key, seen_cache.as_ref()).await;
                 if let Err(e) = consumer.commit() {
                     warn!(error = %e, "kafka sync commit at shutdown failed; falling back to broker auto-commit");
                 }
@@ -55,7 +69,7 @@ pub async fn worker_loop<E, P, F>(
             }
             _ = flush_timer.tick() => {
                 handle.report_healthy();
-                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_TIMER, worker, max_values_per_key).await;
+                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_TIMER, worker, reduction.max_values_per_key, seen_cache.as_ref()).await;
             }
             recv = consumer.json_recv::<E>() => {
                 handle.report_healthy();
@@ -82,7 +96,8 @@ pub async fn worker_loop<E, P, F>(
                                 &producer,
                                 FLUSH_REASON_BACKPRESSURE,
                                 worker,
-                                max_values_per_key,
+                                reduction.max_values_per_key,
+                                seen_cache.as_ref(),
                             ).await;
                         }
                     }
@@ -110,6 +125,7 @@ pub(crate) async fn flush<P: Producer>(
     reason: &'static str,
     worker: &'static str,
     max_values_per_key: usize,
+    seen_cache: Option<&SeenCache>,
 ) {
     if aggregator.is_empty() && pending_offsets.is_empty() {
         return;
@@ -120,20 +136,38 @@ pub(crate) async fn flush<P: Producer>(
         snapshot = cap_top_k(snapshot, max_values_per_key, worker);
     }
 
-    metrics::counter!(FLUSH_TOTAL, "reason" => reason, "worker" => worker).increment(1);
-    metrics::histogram!(FLUSH_TUPLES, "worker" => worker).record(snapshot.len() as f64);
+    // Emit-once: drop tuples already in the seen cache, keep and remember the
+    // rest. The kept set is exactly what we insert, so a produce failure can
+    // forget those entries and re-emit them on the next flush.
+    let to_emit: Vec<(TupleKey, u64)> = match seen_cache {
+        Some(cache) => snapshot
+            .into_iter()
+            .filter(|(tuple, _)| !cache.seen_or_insert(tuple))
+            .collect(),
+        None => snapshot,
+    };
 
-    for (_, count) in &snapshot {
+    metrics::counter!(FLUSH_TOTAL, "reason" => reason, "worker" => worker).increment(1);
+    metrics::histogram!(FLUSH_TUPLES, "worker" => worker).record(to_emit.len() as f64);
+
+    for (_, count) in &to_emit {
         metrics::histogram!(FLUSH_TUPLE_COUNT, "worker" => worker).record(*count as f64);
     }
 
-    if let Err(e) = producer.produce(snapshot.clone()).await {
-        metrics::counter!(PRODUCER_FLUSH_FAILED, "worker" => worker).increment(1);
-        error!(error = %e, "produce failed; restoring counts, retrying next flush");
-        for (tuple, count) in snapshot {
-            aggregator.add(tuple, count);
+    if !to_emit.is_empty() {
+        if let Err(e) = producer.produce(to_emit.clone()).await {
+            metrics::counter!(PRODUCER_FLUSH_FAILED, "worker" => worker).increment(1);
+            error!(error = %e, "produce failed; restoring counts, retrying next flush");
+            if let Some(cache) = seen_cache {
+                for (tuple, _) in &to_emit {
+                    cache.forget(tuple);
+                }
+            }
+            for (tuple, count) in to_emit {
+                aggregator.add(tuple, count);
+            }
+            return;
         }
-        return;
     }
 
     // Produce succeeded; advance the stored offset for each partition we
@@ -329,6 +363,7 @@ mod tests {
             FLUSH_REASON_TIMER,
             "test",
             0,
+            None,
         )
         .await;
 
@@ -351,6 +386,7 @@ mod tests {
             FLUSH_REASON_TIMER,
             "test",
             0,
+            None,
         )
         .await;
 
@@ -376,6 +412,7 @@ mod tests {
             FLUSH_REASON_TIMER,
             "test",
             0,
+            None,
         )
         .await;
         assert!(!agg.is_empty());
@@ -387,6 +424,7 @@ mod tests {
             FLUSH_REASON_TIMER,
             "test",
             0,
+            None,
         )
         .await;
         assert!(agg.is_empty());
@@ -405,6 +443,7 @@ mod tests {
             FLUSH_REASON_TIMER,
             "test",
             0,
+            None,
         )
         .await;
         assert_eq!(producer.call_count(), 0);
@@ -424,6 +463,7 @@ mod tests {
             FLUSH_REASON_TIMER,
             "test",
             0,
+            None,
         )
         .await;
 
@@ -436,6 +476,7 @@ mod tests {
             FLUSH_REASON_TIMER,
             "test",
             0,
+            None,
         )
         .await;
 
@@ -460,12 +501,139 @@ mod tests {
                 FLUSH_REASON_TIMER,
                 "test",
                 0,
+                None,
             )
             .await;
         }
 
         assert_eq!(agg.len(), 1);
         assert_eq!(producer.call_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn seen_cache_suppresses_already_emitted_tuples() {
+        let cache = SeenCache::new(1000, "test");
+        let mut pending: HashMap<i32, Offset> = HashMap::new();
+        let producer = MockProducer::new();
+
+        let mut agg = Aggregator::new();
+        agg.add(tuple(2, "k", "v"), 1);
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+            0,
+            Some(&cache),
+        )
+        .await;
+        assert_eq!(producer.last_items().len(), 1, "first sight is emitted");
+
+        agg.add(tuple(2, "k", "v"), 1);
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+            0,
+            Some(&cache),
+        )
+        .await;
+        assert_eq!(
+            producer.call_count(),
+            1,
+            "an already-cached tuple is suppressed, so there is no second produce"
+        );
+        assert!(
+            agg.is_empty(),
+            "suppressed tuples still drain the aggregator"
+        );
+    }
+
+    #[tokio::test]
+    async fn seen_cache_reemits_after_produce_failure() {
+        let cache = SeenCache::new(1000, "test");
+        let mut pending: HashMap<i32, Offset> = HashMap::new();
+        let producer = MockProducer::new().fail_on(1);
+
+        let mut agg = Aggregator::new();
+        agg.add(tuple(2, "k", "v"), 1);
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+            0,
+            Some(&cache),
+        )
+        .await;
+        assert_eq!(agg.len(), 1, "failed produce restores the tuple for retry");
+
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+            0,
+            Some(&cache),
+        )
+        .await;
+        assert_eq!(producer.call_count(), 2);
+        assert_eq!(
+            producer.last_items().len(),
+            1,
+            "a tuple forgotten on produce failure is re-emitted, not lost to the cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn seen_cache_emits_new_values_and_suppresses_repeats() {
+        let cache = SeenCache::new(1000, "test");
+        let mut pending: HashMap<i32, Offset> = HashMap::new();
+        let producer = MockProducer::new();
+
+        let mut agg = Aggregator::new();
+        agg.add(tuple(2, "k", "a"), 1);
+        agg.add(tuple(2, "k", "b"), 1);
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+            0,
+            Some(&cache),
+        )
+        .await;
+        assert_eq!(
+            producer.last_items().len(),
+            2,
+            "distinct new tuples all emit"
+        );
+
+        agg.add(tuple(2, "k", "a"), 1); // already seen
+        agg.add(tuple(2, "k", "c"), 1); // new
+        flush(
+            &mut agg,
+            &mut pending,
+            &producer,
+            FLUSH_REASON_TIMER,
+            "test",
+            0,
+            Some(&cache),
+        )
+        .await;
+        let batch = producer.last_items();
+        assert_eq!(
+            batch.len(),
+            1,
+            "only the new value emits; the repeat is suppressed"
+        );
+        assert_eq!(batch[0].0.property_value, "c");
     }
 
     fn arb_property_type() -> impl Strategy<Value = PropertyType> {
@@ -536,6 +704,7 @@ mod tests {
                             FLUSH_REASON_TIMER,
                             "test",
                             0,
+                            None,
                         ));
                     }
                 }


### PR DESCRIPTION
## Problem

property-vals-rs re-produces a tuple once per flush window for as long as that tuple keeps appearing. Re-emission of recurring tuples across flushes contributes to increase write volume to clickhouse. 


## Changes

Adds a bounded "already emitted" cache to the merger. At flush, a tuple still resident in the cache is suppressed; a new one is emitted and then inserted into the cache only after the produce succeeds.

- New `SeenCache` wraps a `quick_cache` LRU keyed on the full `(team, type, key, value)` tuple, with a custom eviction lifecycle. Same structure property-defs-rs uses for its dedup cache.
- Controlled by `MERGER_SEEN_CACHE_CAPACITY` (default `0` = disabled). Capacity bounds memory directly; it is independent of total cardinality.

Trade-offs:

- This degrades `property_count` to a presence-ish undercount, because a suppressed occurrence does not increment the count. I will likely remove this col as a follow up. 
- On a merger redeploy the cache starts cold and produced volume returns to the full rate until it re-warms. 

## How did you test this code?

I'm an agent. Added and ran automated unit tests for the cache path:

- an already-cached tuple is suppressed (no second produce, aggregator still drained)
- a tuple forgotten on produce failure is re-emitted on retry, not lost to the cache
- distinct new values all emit while a repeat is suppressed

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The cache lives in the merger because the intermediate topic is hashed by the full tuple, so each tuple has a single owning merger pod and the per-pod caches do not overlap, which makes the dedup correct without coordination. Chose an exact LRU (`quick_cache`) over a bloom filter on purpose: the bloom is cheaper per element but its false positives drop genuinely-new values, whereas the LRU's only failure mode is re-emitting an evicted tuple, which is lossless. Sizing is against the active working set, which was measured to be small per pod, rather than the all-time cardinality. Ships disabled (capacity 0); enabling and capacity tuning are operational, guided by the hit/miss/eviction metrics.
