### PR TITLE
chore(ci): fix sync push auth shadowed by checkout credentials

### DIFF
--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -28,15 +28,16 @@ jobs:
                   owner: PostHog
                   repositories: posthog-foss
 
-            # blob:none skips historical blobs (avoids a full-history clone); the full
-            # commit graph keeps pushes connected. Lazy blob fetches need origin auth,
-            # so persist-credentials stays default-on.
+            # blob:none avoids a full-history clone; full commit graph keeps pushes connected.
+            # persist-credentials:false so checkout's default-token auth header doesn't shadow
+            # the app token we push with (posthog is public, so lazy blob fetches still work).
             - name: Checkout posthog
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
                   filter: blob:none
                   fetch-tags: true
+                  persist-credentials: false
 
             # Stage on a branch, not master, so master never momentarily exposes raw
             # posthog (ee/, non-MIT LICENSE) before the FOSS cleanup commit lands.

--- a/.github/workflows/private-sync.yml
+++ b/.github/workflows/private-sync.yml
@@ -27,15 +27,16 @@ jobs:
                   owner: PostHog
                   repositories: posthog-private
 
-            # blob:none skips historical blobs (avoids a full-history clone); the full
-            # commit graph keeps pushes connected. Lazy blob fetches need origin auth,
-            # so persist-credentials stays default-on.
+            # blob:none avoids a full-history clone; full commit graph keeps pushes connected.
+            # persist-credentials:false so checkout's default-token auth header doesn't shadow
+            # the app token we push with (posthog is public, so lazy blob fetches still work).
             - name: Checkout posthog
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
                   filter: blob:none
                   fetch-tags: true
+                  persist-credentials: false
 
             # 1:1 mirror: replays posthog's existing signed commits — no new commit, so
             # signing enforcement on posthog-private is unaffected.


### PR DESCRIPTION
## Problem

The sync rework in #60583 broke production **foss-sync** and **private-sync** — both fail at the push step:

- `foss-sync`: `Permission to posthog/posthog-foss.git denied to github-actions[bot]` (403)
- `private-sync`: `Repository not found` (404 — the default token can't see the private repo)

`actions/checkout` persists the default `GITHUB_TOKEN` as an `http.https://github.com/.extraheader`. That `Authorization` header **shadows the app-token credentials embedded in the push remote URL**, so both pushes authenticate as `github-actions[bot]` instead of the `posthog-foss-sync` / `posthog-private-sync` apps. The old `PostHog/git-sync` Docker action never hit this because it ran a fresh clone with no checkout extraheader.

posthog-foss and posthog-private have stopped receiving updates until this lands. master on those repos is **not** corrupted — both runs failed at the first push, so nothing was half-written.

## Changes

Add `persist-credentials: false` to the posthog checkout in both `foss-sync.yml` and `private-sync.yml`. This removes the shadowing auth header, so the app token embedded in the push remote URL is the one used. posthog is public, so the partial-clone (`blob:none`) lazy blob fetches still work unauthenticated.

## How did you test this code?

I'm an agent — no manual end-to-end run (these workflows only trigger on push to posthog master and can't run from a PR/fork).

- Validated both workflow files parse (`python3 -c "import yaml; yaml.safe_load(...)"`).
- The auth mechanism was verified earlier with a manual `blob:none` partial clone of posthog pushed to a throwaway branch on posthog-foss — it **succeeded**, precisely because a manual clone has no `actions/checkout` extraheader. `persist-credentials: false` reproduces that same condition in CI.

End-to-end confirmation will come from the first post-merge run on master.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code at the maintainer's direction. Root-caused from the failing run logs: the 403/404 identities (`github-actions[bot]`) showed the push used the default token, not the app token in the remote URL — the signature of `actions/checkout`'s persisted `http.extraheader` shadowing URL credentials.

Alternatives considered and rejected: a per-remote `http.<url>.extraheader` override (git sends *all* matching extraheaders, producing two `Authorization` headers) and unsetting the generic extraheader before each push (equivalent effect, more fragile). `persist-credentials: false` is the standard, minimal fix; lazy blob fetches stay anonymous because posthog is public.

Note: this commit is **unsigned** — the maintainer's commit-signing key (Secretive, Touch ID) can't be driven from the agent environment. Re-sign via amend from a local terminal if signed commits are required to merge.
