### PR TITLE
fix(visual_review): allow tolerate via personal API keys

### DIFF
--- a/products/visual_review/backend/presentation/views.py
+++ b/products/visual_review/backend/presentation/views.py
@@ -356,7 +356,15 @@ class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """
 
     scope_object = "visual_review"
-    scope_object_write_actions = ["create", "complete", "approve", "auto_approve", "add_snapshots", "recompute"]
+    scope_object_write_actions = [
+        "create",
+        "complete",
+        "approve",
+        "auto_approve",
+        "add_snapshots",
+        "recompute",
+        "mark_tolerated",
+    ]
     scope_object_read_actions = ["list", "retrieve", "snapshots", "counts", "snapshot_history", "tolerated_hashes"]
     serializer_class = RunSerializer
 

--- a/products/visual_review/backend/tests/test_presentation.py
+++ b/products/visual_review/backend/tests/test_presentation.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 from products.visual_review.backend import logic
@@ -195,7 +196,6 @@ class TestRunViewSet(VisualReviewTeamScopedTestMixin, APIBaseTest):
         self.assertFalse(response.json()["run"]["approved"])
 
     def _changed_snapshot_for_tolerate(self) -> tuple[str, str]:
-        """Set up a run with a single CHANGED snapshot and return (run_id, snapshot_id)."""
         logic.get_or_create_artifact(
             repo_id=self.vr_project.id,
             content_hash="new_hash",
@@ -219,45 +219,30 @@ class TestRunViewSet(VisualReviewTeamScopedTestMixin, APIBaseTest):
         snapshot.save(update_fields=["result"])
         return str(create_result.run_id), str(snapshot.id)
 
-    def test_mark_tolerated_via_session_auth(self):
+    @parameterized.expand(
+        [
+            ("session_auth", None, status.HTTP_200_OK),
+            ("personal_api_key_write_scope", "visual_review:write", status.HTTP_200_OK),
+            ("personal_api_key_read_scope", "visual_review:read", status.HTTP_403_FORBIDDEN),
+        ]
+    )
+    def test_mark_tolerated_permission_boundary(self, _name: str, scope: str | None, expected_status: int):
         run_id, snapshot_id = self._changed_snapshot_for_tolerate()
+
+        extra_headers = {}
+        if scope is not None:
+            key = self.create_personal_api_key_with_scopes([scope])
+            self.client.logout()
+            extra_headers["HTTP_AUTHORIZATION"] = f"Bearer {key}"
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/visual_review/runs/{run_id}/tolerate/",
             {"snapshot_id": snapshot_id},
             format="json",
+            **extra_headers,
         )
 
-        assert response.status_code == status.HTTP_200_OK, response.json()
-
-    def test_mark_tolerated_via_personal_api_key_with_write_scope(self):
-        """Regression: tolerate must be reachable from personal API keys (MCP path)."""
-        run_id, snapshot_id = self._changed_snapshot_for_tolerate()
-        key = self.create_personal_api_key_with_scopes(["visual_review:write"])
-
-        self.client.logout()
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/visual_review/runs/{run_id}/tolerate/",
-            {"snapshot_id": snapshot_id},
-            format="json",
-            HTTP_AUTHORIZATION=f"Bearer {key}",
-        )
-
-        assert response.status_code == status.HTTP_200_OK, response.json()
-
-    def test_mark_tolerated_via_personal_api_key_with_read_scope_is_forbidden(self):
-        run_id, snapshot_id = self._changed_snapshot_for_tolerate()
-        key = self.create_personal_api_key_with_scopes(["visual_review:read"])
-
-        self.client.logout()
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/visual_review/runs/{run_id}/tolerate/",
-            {"snapshot_id": snapshot_id},
-            format="json",
-            HTTP_AUTHORIZATION=f"Bearer {key}",
-        )
-
-        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+        assert response.status_code == expected_status, response.json()
 
     def _seed_history_row(
         self,

--- a/products/visual_review/backend/tests/test_presentation.py
+++ b/products/visual_review/backend/tests/test_presentation.py
@@ -229,17 +229,15 @@ class TestRunViewSet(VisualReviewTeamScopedTestMixin, APIBaseTest):
     def test_mark_tolerated_permission_boundary(self, _name: str, scope: str | None, expected_status: int):
         run_id, snapshot_id = self._changed_snapshot_for_tolerate()
 
-        extra_headers = {}
         if scope is not None:
             key = self.create_personal_api_key_with_scopes([scope])
             self.client.logout()
-            extra_headers["HTTP_AUTHORIZATION"] = f"Bearer {key}"
+            self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {key}")
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/visual_review/runs/{run_id}/tolerate/",
             {"snapshot_id": snapshot_id},
             format="json",
-            **extra_headers,
         )
 
         assert response.status_code == expected_status, response.json()

--- a/products/visual_review/backend/tests/test_presentation.py
+++ b/products/visual_review/backend/tests/test_presentation.py
@@ -194,6 +194,71 @@ class TestRunViewSet(VisualReviewTeamScopedTestMixin, APIBaseTest):
         # Per-snapshot approval is DB only — run not finalized
         self.assertFalse(response.json()["run"]["approved"])
 
+    def _changed_snapshot_for_tolerate(self) -> tuple[str, str]:
+        """Set up a run with a single CHANGED snapshot and return (run_id, snapshot_id)."""
+        logic.get_or_create_artifact(
+            repo_id=self.vr_project.id,
+            content_hash="new_hash",
+            storage_path="visual_review/new_hash",
+        )
+        create_result = api.create_run(
+            CreateRunInput(
+                repo_id=self.vr_project.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                snapshots=[SnapshotManifestItem(identifier="Button", content_hash="new_hash")],
+                baseline_hashes={"Button": "old_hash"},
+            ),
+            team_id=self.team.id,
+        )
+        snapshot = RunSnapshot.objects.get(run_id=create_result.run_id, identifier="Button")
+        # The diff pipeline normally classifies the snapshot — short-circuit it here
+        # so the test stays a permission-boundary test rather than an integration test.
+        snapshot.result = SnapshotResult.CHANGED
+        snapshot.save(update_fields=["result"])
+        return str(create_result.run_id), str(snapshot.id)
+
+    def test_mark_tolerated_via_session_auth(self):
+        run_id, snapshot_id = self._changed_snapshot_for_tolerate()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/visual_review/runs/{run_id}/tolerate/",
+            {"snapshot_id": snapshot_id},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+    def test_mark_tolerated_via_personal_api_key_with_write_scope(self):
+        """Regression: tolerate must be reachable from personal API keys (MCP path)."""
+        run_id, snapshot_id = self._changed_snapshot_for_tolerate()
+        key = self.create_personal_api_key_with_scopes(["visual_review:write"])
+
+        self.client.logout()
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/visual_review/runs/{run_id}/tolerate/",
+            {"snapshot_id": snapshot_id},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {key}",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+    def test_mark_tolerated_via_personal_api_key_with_read_scope_is_forbidden(self):
+        run_id, snapshot_id = self._changed_snapshot_for_tolerate()
+        key = self.create_personal_api_key_with_scopes(["visual_review:read"])
+
+        self.client.logout()
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/visual_review/runs/{run_id}/tolerate/",
+            {"snapshot_id": snapshot_id},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {key}",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+
     def _seed_history_row(
         self,
         sha: str,


### PR DESCRIPTION
## Problem

The `mark_tolerated` action on `RunViewSet` (`POST /api/projects/:id/visual_review/runs/:run_id/tolerate/`) was missing from the viewset's `scope_object_write_actions`. As a result, any request authenticated with a personal API key (or OAuth token) was rejected at the API-scope permission layer with `This action does not support personal API key access`.

In practice this meant the visual-review MCP integration could **approve** and **quarantine** snapshots but could not **tolerate** them — the only one of the three write actions that hadn't been added to the scope list. It surfaced when trying to mark a couple of benign unrelated snapshot diffs as tolerated via the MCP.

## Changes

- Add `mark_tolerated` to `RunViewSet.scope_object_write_actions`, so the action derives the `visual_review:write` required scope and is reachable from personal API keys / OAuth tokens with that scope.
- Add three parameterised regression tests:
  - session auth can tolerate (200),
  - personal API key with `visual_review:write` can tolerate (200) — the regression,
  - personal API key with only `visual_review:read` is still forbidden (403).

No behaviour change to the tolerate logic itself; this is purely the permission-scope wiring.

## How did you test this code?

I'm an agent. I ran the new tests locally via `hogli test`:

- `products/visual_review/backend/tests/test_presentation.py::TestRunViewSet -k tolerate` — 3 passed.

The write-scope test fails before the one-line `scope_object_write_actions` change (403) and passes after (200), confirming it pins the regression.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — internal API-scope fix.

## 🤖 Agent context

Authored by PostHog Code. Found while triaging a separate user-interviews PR's visual-review run: the MCP `tolerate` tool returned HTTP 403 `This action does not support personal API key access`, while `approve` worked. Traced it to `posthog/permissions.py:APIScopePermission` requiring the action to appear in the viewset's read/write action lists to derive a required scope; `mark_tolerated` was absent from `RunViewSet.scope_object_write_actions` whereas the analogous `quarantine`/`unquarantine` on `RepoViewSet` and `approve`/`auto_approve` on `RunViewSet` were present. One-line list addition plus regression coverage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
