### PR TITLE
chore(hog-charts): decouple BoxPlotDatum from the app's query schema

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BoxPlot/computeBoxLayout.ts
+++ b/frontend/src/lib/hog-charts/charts/BoxPlot/computeBoxLayout.ts
@@ -1,14 +1,18 @@
-import type { BoxPlotDatum as SchemaBoxPlotDatum } from '~/queries/schema/schema-general'
-
 import type { BoxRect } from '../../core/canvas-renderer'
 import type { BarScaleSet } from '../../core/scales'
 
 export type { BoxRect }
 
-/** Six-number summary plus an opaque `day` identifier. Structurally compatible with the
- *  canonical `BoxPlotDatum` in `queries/schema-general.ts` (we only care about the six
- *  numbers; `day` is the consumer-side key for click handlers / persons-modal labels). */
-export type BoxPlotDatum = Pick<SchemaBoxPlotDatum, 'min' | 'p25' | 'median' | 'mean' | 'p75' | 'max'> & {
+/** Six-number summary plus an opaque `day` identifier. Defined independently of any app schema
+ *  so the library stays self-contained — app types (e.g. trends' `BoxPlotDatum`) structurally
+ *  satisfy this when they carry the same six numbers. */
+export interface BoxPlotDatum {
+    min: number
+    p25: number
+    median: number
+    mean: number
+    p75: number
+    max: number
     /** Optional identifier for this x position (e.g. ISO date). The chart treats it as opaque. */
     day?: string
 }


### PR DESCRIPTION
## Problem

`charts/BoxPlot/computeBoxLayout.ts` was reaching into `~/queries/schema/schema-general` to derive its `BoxPlotDatum` type via `Pick`:

\`\`\`ts
import type { BoxPlotDatum as SchemaBoxPlotDatum } from '~/queries/schema/schema-general'

export type BoxPlotDatum = Pick<SchemaBoxPlotDatum, 'min' | 'p25' | 'median' | 'mean' | 'p75' | 'max'> & {
    day?: string
}
\`\`\`

`docs/CONTRIBUTING.md` for the library is explicit: *"No kea, no PostHog imports. Theme, colors, and data are passed in as props. The library has no app dependencies — it's used by trends but shouldn't know about them."*

Even though this is a type-only import, it couples the library to changes in the app's query schema — if a future schema rename or field removal lands, the lib's compile breaks for reasons that have nothing to do with charting.

## Changes

Define `BoxPlotDatum` as a self-contained interface in the library. Same fields, same shape — consumers that pass schema-typed data (trends' `BoxPlotDatum` is a superset that adds `label`, `series_index`, etc.) still structurally satisfy this.

## How did you test this code?

I'm an agent. I could not run jest or tsc locally in this remote task environment. Verified by inspection that the new interface has the same six required number fields and the same optional `day` string field that the previous `Pick<…> & { day?: string }` produced, so structural compatibility with the schema type's supersets is preserved.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — this PR aligns the implementation with the existing convention in `frontend/src/lib/hog-charts/docs/CONTRIBUTING.md`.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Surfaced by a scan of all chart types in the library for convention violations — this was the only app-import found across `frontend/src/lib/hog-charts/charts/`. Decoupling is mechanical: the lib only used six numeric fields and the optional `day` key, so a direct interface preserves the existing call-site contract without changes to BoxPlot consumers.