### PR TITLE
feat(experiments): add pagination to the shared metrics view

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -1,7 +1,7 @@
 from django.db.models.functions import Lower
 
 from drf_spectacular.utils import extend_schema
-from rest_framework import serializers, viewsets
+from rest_framework import filters, serializers, viewsets
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
@@ -137,8 +137,10 @@ class ExperimentSavedMetricSerializer(
 @extend_schema(extensions={"x-swagger-tag": "experiment_saved_metrics", "x-product": "experiments"})
 class ExperimentSavedMetricViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.ModelViewSet):
     scope_object = "experiment_saved_metric"
-    queryset = ExperimentSavedMetric.objects.prefetch_related("created_by").order_by(Lower("name")).all()
+    queryset = ExperimentSavedMetric.objects.prefetch_related("created_by").order_by(Lower("name")).distinct()
     serializer_class = ExperimentSavedMetricSerializer
+    filter_backends = [filters.SearchFilter]
+    search_fields = ["name", "description", "tagged_items__tag__name"]
 
     def perform_destroy(self, instance: ExperimentSavedMetric) -> None:
         service = ExperimentSavedMetricService(team=self.team, user=self.request.user)

--- a/ee/clickhouse/views/test/test_experiment_saved_metrics.py
+++ b/ee/clickhouse/views/test/test_experiment_saved_metrics.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 from products.experiments.backend.experiment_saved_metric_service import ExperimentSavedMetricService
@@ -922,3 +923,61 @@ class TestExperimentSavedMetricsCRUD(APILicensedTest):
         # Verify the old name is preserved
         self.assertEqual(response.json()["query"]["source"]["name"], "Action to Delete")
         self.assertEqual(response.json()["query"]["source"]["id"], action_id)
+
+    def _create_saved_metric(self, name: str, description: str = "", tags: list[str] | None = None) -> int:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+            data={
+                "name": name,
+                "description": description,
+                "tags": tags or [],
+                "query": {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "source": {"kind": "EventsNode", "event": "$pageview"},
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        return response.json()["id"]
+
+    @parameterized.expand(
+        [
+            ("by_name", "alpha", {"Alpha conversion"}),
+            ("by_description", "revenue tracker", {"Beta signups"}),
+            ("by_tag", "growth", {"Beta signups"}),
+            ("no_match", "zzz-nothing", set()),
+        ]
+    )
+    def test_search_filters_saved_metrics(self, _name: str, search: str, expected_names: set[str]) -> None:
+        self._create_saved_metric("Alpha conversion", description="checkout funnel")
+        self._create_saved_metric("Beta signups", description="revenue tracker thing", tags=["growth"])
+
+        response = self.client.get(f"/api/projects/{self.team.id}/experiment_saved_metrics/?search={search}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned = {row["name"] for row in response.json()["results"]}
+        self.assertEqual(returned, expected_names)
+
+    def test_search_returns_each_metric_once_with_multiple_matching_tags(self) -> None:
+        self._create_saved_metric("Tagged metric", description="", tags=["growth", "growth-team"])
+
+        response = self.client.get(f"/api/projects/{self.team.id}/experiment_saved_metrics/?search=growth")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["count"], 1)
+        self.assertEqual(len(body["results"]), 1)
+
+    def test_list_paginates_with_limit_and_offset(self) -> None:
+        for i in range(5):
+            self._create_saved_metric(f"Metric {i:02d}")
+
+        page1 = self.client.get(f"/api/projects/{self.team.id}/experiment_saved_metrics/?limit=2&offset=0").json()
+        page2 = self.client.get(f"/api/projects/{self.team.id}/experiment_saved_metrics/?limit=2&offset=2").json()
+
+        self.assertEqual(page1["count"], 5)
+        self.assertEqual(len(page1["results"]), 2)
+        self.assertEqual(len(page2["results"]), 2)
+        ids_page1 = {row["id"] for row in page1["results"]}
+        ids_page2 = {row["id"] for row in page2["results"]}
+        self.assertEqual(ids_page1 & ids_page2, set())

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
@@ -17,6 +17,7 @@ import {
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { pluralize } from 'lib/utils'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -24,10 +25,10 @@ import { urls } from 'scenes/urls'
 import { tagsModel } from '~/models/tagsModel'
 import { NodeKind } from '~/queries/schema/schema-general'
 
-import { isLegacySharedMetric, matchesSharedMetricSearch } from '../utils'
+import { isLegacySharedMetric } from '../utils'
 import { InlineTagEditor } from './InlineTagEditor'
 import { SharedMetric } from './sharedMetricLogic'
-import { sharedMetricsLogic } from './sharedMetricsLogic'
+import { PAGE_SIZE, sharedMetricsLogic } from './sharedMetricsLogic'
 
 export const scene: SceneExport = {
     component: SharedMetrics,
@@ -35,14 +36,13 @@ export const scene: SceneExport = {
 }
 
 export function SharedMetrics(): JSX.Element {
-    const { sharedMetrics, sharedMetricsLoading, searchTerm, savingTagsMetricId } = useValues(sharedMetricsLogic)
+    const { sharedMetrics, sharedMetricsLoading, searchTerm, savingTagsMetricId, pagination, count, page } =
+        useValues(sharedMetricsLogic)
     const { setSearchTerm, updateSharedMetricTags, deleteSharedMetric } = useActions(sharedMetricsLogic)
     const { tags: allTags } = useValues(tagsModel)
 
-    const searchLower = searchTerm.toLowerCase()
-    const filteredMetrics = searchTerm
-        ? (sharedMetrics || []).filter((metric) => matchesSharedMetricSearch(metric, searchLower))
-        : sharedMetrics || []
+    const startCount = count === 0 ? 0 : (page - 1) * PAGE_SIZE + 1
+    const endCount = page * PAGE_SIZE < count ? page * PAGE_SIZE : count
 
     const columns: LemonTableColumns<SharedMetric> = [
         {
@@ -70,7 +70,6 @@ export function SharedMetrics(): JSX.Element {
                     />
                 )
             },
-            sorter: (a, b) => a.name.localeCompare(b.name),
         },
         {
             key: 'description',
@@ -178,20 +177,31 @@ export function SharedMetrics(): JSX.Element {
                 having to set them up each time.
             </LemonBanner>
             <div className="flex justify-between items-center gap-2">
-                <LemonInput
-                    type="search"
-                    placeholder="Search shared metrics..."
-                    value={searchTerm}
-                    onChange={setSearchTerm}
-                />
+                <div className="flex items-center gap-2">
+                    <LemonInput
+                        type="search"
+                        placeholder="Search shared metrics..."
+                        value={searchTerm}
+                        onChange={setSearchTerm}
+                    />
+                    {count ? (
+                        <span className="text-secondary whitespace-nowrap">
+                            {`${startCount}${endCount - startCount > 1 ? '-' + endCount : ''} of ${pluralize(
+                                count,
+                                'metric'
+                            )}`}
+                        </span>
+                    ) : null}
+                </div>
                 <LemonButton size="small" type="primary" to={urls.experimentsSharedMetric('new')}>
                     New shared metric
                 </LemonButton>
             </div>
             <LemonTable
                 columns={columns}
-                dataSource={filteredMetrics}
+                dataSource={sharedMetrics}
                 loading={sharedMetricsLoading}
+                pagination={pagination}
                 emptyState={<div>You haven't created any shared metrics yet.</div>}
             />
         </div>

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
@@ -186,7 +186,7 @@ export function SharedMetrics(): JSX.Element {
                     />
                     {count ? (
                         <span className="text-secondary whitespace-nowrap">
-                            {`${startCount}${endCount - startCount > 1 ? '-' + endCount : ''} of ${pluralize(
+                            {`${startCount}${endCount > startCount ? '-' + endCount : ''} of ${pluralize(
                                 count,
                                 'metric'
                             )}`}

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconCopy, IconPencil, IconTrash } from '@posthog/icons'
+import { IconChevronLeft, IconChevronRight, IconCopy, IconPencil, IconTrash } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -36,9 +36,9 @@ export const scene: SceneExport = {
 }
 
 export function SharedMetrics(): JSX.Element {
-    const { sharedMetrics, sharedMetricsLoading, searchTerm, savingTagsMetricId, pagination, count, page } =
+    const { sharedMetrics, sharedMetricsLoading, searchTerm, savingTagsMetricId, count, page } =
         useValues(sharedMetricsLogic)
-    const { setSearchTerm, updateSharedMetricTags, deleteSharedMetric } = useActions(sharedMetricsLogic)
+    const { setSearchTerm, setPage, updateSharedMetricTags, deleteSharedMetric } = useActions(sharedMetricsLogic)
     const { tags: allTags } = useValues(tagsModel)
 
     const startCount = count === 0 ? 0 : (page - 1) * PAGE_SIZE + 1
@@ -201,9 +201,27 @@ export function SharedMetrics(): JSX.Element {
                 columns={columns}
                 dataSource={sharedMetrics}
                 loading={sharedMetricsLoading}
-                pagination={pagination}
                 emptyState={<div>You haven't created any shared metrics yet.</div>}
             />
+            {count > PAGE_SIZE ? (
+                <div className="flex items-center justify-end gap-1">
+                    <span className="text-secondary whitespace-nowrap">
+                        {`${startCount}${endCount > startCount ? '-' + endCount : ''} of ${pluralize(count, 'metric')}`}
+                    </span>
+                    <LemonButton
+                        icon={<IconChevronLeft />}
+                        size="small"
+                        disabledReason={page <= 1 ? 'No previous page' : undefined}
+                        onClick={() => setPage(page - 1)}
+                    />
+                    <LemonButton
+                        icon={<IconChevronRight />}
+                        size="small"
+                        disabledReason={endCount >= count ? 'No next page' : undefined}
+                        onClick={() => setPage(page + 1)}
+                    />
+                </div>
+            ) : null}
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.test.ts
@@ -1,0 +1,83 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { PAGE_SIZE, sharedMetricsLogic } from './sharedMetricsLogic'
+
+describe('sharedMetricsLogic', () => {
+    let logic: ReturnType<typeof sharedMetricsLogic.build>
+
+    const makeMetrics = (count: number, search: string, offset: number): any => ({
+        count,
+        results: [
+            { id: 1, name: `${search || 'metric'} a` },
+            { id: 2, name: `${search || 'metric'} b` },
+        ].slice(offset > 0 ? 1 : 0),
+    })
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/experiment_saved_metrics': (req) => [
+                    200,
+                    makeMetrics(
+                        2,
+                        req.url.searchParams.get('search') ?? '',
+                        parseInt(req.url.searchParams.get('offset') ?? '0')
+                    ),
+                ],
+            },
+        })
+        initKeaTests()
+        logic = sharedMetricsLogic()
+        logic.mount()
+    })
+
+    afterEach(() => logic.unmount())
+
+    it('loads the first page with limit and offset 0', async () => {
+        jest.spyOn(api, 'get')
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+        expect(api.get).toHaveBeenCalledWith(expect.stringContaining(`limit=${PAGE_SIZE}`))
+        expect(api.get).toHaveBeenCalledWith(expect.stringContaining('offset=0'))
+        await expectLogic(logic).toMatchValues({ count: 2 })
+    })
+
+    it('setPage reloads with the correct offset', async () => {
+        jest.spyOn(api, 'get')
+        await expectLogic(logic, () => {
+            logic.actions.setPage(2)
+        }).toFinishAllListeners()
+        expect(api.get).toHaveBeenLastCalledWith(expect.stringContaining(`offset=${PAGE_SIZE}`))
+        await expectLogic(logic).toMatchValues({ page: 2 })
+    })
+
+    it('setSearchTerm resets page to 1 and reloads with search', async () => {
+        logic.actions.setPage(3)
+        await expectLogic(logic).toMatchValues({ page: 3 })
+
+        jest.spyOn(api, 'get')
+        await expectLogic(logic, () => {
+            logic.actions.setSearchTerm('revenue')
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({ page: 1, searchTerm: 'revenue' })
+        expect(api.get).toHaveBeenLastCalledWith(expect.stringContaining('search=revenue'))
+    })
+
+    it('pagination selector reflects current page and total count', async () => {
+        await expectLogic(logic).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({
+            pagination: expect.objectContaining({
+                controlled: true,
+                pageSize: PAGE_SIZE,
+                currentPage: 1,
+                entryCount: 2,
+            }),
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
@@ -79,5 +80,24 @@ describe('sharedMetricsLogic', () => {
                 entryCount: 2,
             }),
         })
+    })
+
+    it('setPage and setSearchTerm push state to the URL', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setPage(2)
+        }).toFinishAllListeners()
+        expect(router.values.searchParams.page).toEqual(2)
+
+        await expectLogic(logic, () => {
+            logic.actions.setSearchTerm('revenue')
+        }).toFinishAllListeners()
+        expect(router.values.searchParams.search).toEqual('revenue')
+        expect(router.values.searchParams.page).toBeUndefined()
+    })
+
+    it('seeds page and search from the URL', async () => {
+        router.actions.push('/experiments/shared-metrics', { page: '3', search: 'beta' })
+        await expectLogic(logic).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({ page: 3, searchTerm: 'beta' })
     })
 })

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.test.ts
@@ -1,4 +1,3 @@
-import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
@@ -70,34 +69,8 @@ describe('sharedMetricsLogic', () => {
         expect(api.get).toHaveBeenLastCalledWith(expect.stringContaining('search=revenue'))
     })
 
-    it('pagination selector reflects current page and total count', async () => {
+    it('exposes current page and total count', async () => {
         await expectLogic(logic).toFinishAllListeners()
-        await expectLogic(logic).toMatchValues({
-            pagination: expect.objectContaining({
-                controlled: true,
-                pageSize: PAGE_SIZE,
-                currentPage: 1,
-                entryCount: 2,
-            }),
-        })
-    })
-
-    it('setPage and setSearchTerm push state to the URL', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.setPage(2)
-        }).toFinishAllListeners()
-        expect(router.values.searchParams.page).toEqual(2)
-
-        await expectLogic(logic, () => {
-            logic.actions.setSearchTerm('revenue')
-        }).toFinishAllListeners()
-        expect(router.values.searchParams.search).toEqual('revenue')
-        expect(router.values.searchParams.page).toBeUndefined()
-    })
-
-    it('seeds page and search from the URL', async () => {
-        router.actions.push('/experiments/shared-metrics', { page: '3', search: 'beta' })
-        await expectLogic(logic).toFinishAllListeners()
-        await expectLogic(logic).toMatchValues({ page: 3, searchTerm: 'beta' })
+        await expectLogic(logic).toMatchValues({ page: 1, count: 2 })
     })
 })

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -1,13 +1,19 @@
-import { actions, connect, events, kea, listeners, path, reducers } from 'kea'
+import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
-import api from 'lib/api'
+import api, { CountedPaginatedResponse } from 'lib/api'
+import { PaginationManual } from 'lib/lemon-ui/PaginationControl'
+import { toParams } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
 import type { SharedMetric } from './sharedMetricLogic'
 import type { sharedMetricsLogicType } from './sharedMetricsLogicType'
+
+export const PAGE_SIZE = 100
+
+export type SharedMetricsResult = CountedPaginatedResponse<SharedMetric>
 
 export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
     path(['scenes', 'experiments', 'sharedMetricsLogic']),
@@ -16,6 +22,7 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
     actions({
         updateSharedMetricTags: (metricId: SharedMetric['id'], tags: string[]) => ({ metricId, tags }),
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
+        setPage: (page: number) => ({ page }),
         deleteSharedMetric: (metricId: SharedMetric['id']) => ({ metricId }),
     }),
 
@@ -34,21 +41,55 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
                 setSearchTerm: (_, { searchTerm }) => searchTerm,
             },
         ],
+        page: [
+            1,
+            {
+                setPage: (_, { page }) => page,
+                setSearchTerm: () => 1,
+            },
+        ],
     }),
 
     loaders(({ values }) => ({
         sharedMetrics: [
-            [] as SharedMetric[],
+            { count: 0, results: [] } as SharedMetricsResult,
             {
                 loadSharedMetrics: async () => {
-                    const response = await api.get(`api/projects/${values.currentProjectId}/experiment_saved_metrics`)
-                    return response.results as SharedMetric[]
+                    const params = toParams({
+                        limit: PAGE_SIZE,
+                        offset: (values.page - 1) * PAGE_SIZE,
+                        search: values.searchTerm || undefined,
+                    })
+                    const response = await api.get(
+                        `api/projects/${values.currentProjectId}/experiment_saved_metrics?${params}`
+                    )
+                    return response as SharedMetricsResult
                 },
             },
         ],
     })),
 
+    selectors({
+        count: [(s) => [s.sharedMetrics], (sharedMetrics): number => sharedMetrics.count],
+        pagination: [
+            (s) => [s.page, s.count],
+            (page, count): PaginationManual => ({
+                controlled: true,
+                pageSize: PAGE_SIZE,
+                currentPage: page,
+                entryCount: count,
+            }),
+        ],
+    }),
+
     listeners(({ actions, values }) => ({
+        setPage: async () => {
+            actions.loadSharedMetrics()
+        },
+        setSearchTerm: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadSharedMetrics()
+        },
         updateSharedMetricTags: async ({ metricId, tags }) => {
             try {
                 await api.update(`api/projects/${values.currentProjectId}/experiment_saved_metrics/${metricId}`, {

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -1,5 +1,6 @@
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { actionToUrl, urlToAction } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -13,8 +14,6 @@ import type { sharedMetricsLogicType } from './sharedMetricsLogicType'
 
 export const PAGE_SIZE = 100
 
-export type SharedMetricsResult = CountedPaginatedResponse<SharedMetric>
-
 export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
     path(['scenes', 'experiments', 'sharedMetricsLogic']),
     connect(() => ({ values: [teamLogic, ['currentProjectId']] })),
@@ -23,6 +22,7 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
         updateSharedMetricTags: (metricId: SharedMetric['id'], tags: string[]) => ({ metricId, tags }),
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setPage: (page: number) => ({ page }),
+        setCount: (count: number) => ({ count }),
         deleteSharedMetric: (metricId: SharedMetric['id']) => ({ metricId }),
     }),
 
@@ -48,11 +48,17 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
                 setSearchTerm: () => 1,
             },
         ],
+        count: [
+            0,
+            {
+                setCount: (_, { count }) => count,
+            },
+        ],
     }),
 
-    loaders(({ values }) => ({
+    loaders(({ values, actions }) => ({
         sharedMetrics: [
-            { count: 0, results: [] } as SharedMetricsResult,
+            [] as SharedMetric[],
             {
                 loadSharedMetrics: async () => {
                     const params = toParams({
@@ -60,17 +66,17 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
                         offset: (values.page - 1) * PAGE_SIZE,
                         search: values.searchTerm || undefined,
                     })
-                    const response = await api.get(
+                    const response: CountedPaginatedResponse<SharedMetric> = await api.get(
                         `api/projects/${values.currentProjectId}/experiment_saved_metrics?${params}`
                     )
-                    return response as SharedMetricsResult
+                    actions.setCount(response.count)
+                    return response.results
                 },
             },
         ],
     })),
 
-    selectors({
-        count: [(s) => [s.sharedMetrics], (sharedMetrics): number => sharedMetrics.count],
+    selectors(({ actions }) => ({
         pagination: [
             (s) => [s.page, s.count],
             (page, count): PaginationManual => ({
@@ -78,9 +84,11 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
                 pageSize: PAGE_SIZE,
                 currentPage: page,
                 entryCount: count,
+                onForward: () => actions.setPage(page + 1),
+                onBackward: () => actions.setPage(page - 1),
             }),
         ],
-    }),
+    })),
 
     listeners(({ actions, values }) => ({
         setPage: async () => {
@@ -108,6 +116,39 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
                 actions.loadSharedMetrics()
             } catch {
                 lemonToast.error('Failed to delete shared metric')
+            }
+        },
+    })),
+
+    actionToUrl(({ values }) => {
+        const buildUrl = (): [string, Record<string, string>] => {
+            const params: Record<string, string> = {}
+            if (values.page > 1) {
+                params.page = String(values.page)
+            }
+            if (values.searchTerm) {
+                params.search = values.searchTerm
+            }
+            return ['/experiments/shared-metrics', params]
+        }
+        return {
+            setPage: () => buildUrl(),
+            setSearchTerm: () => buildUrl(),
+        }
+    }),
+
+    urlToAction(({ actions, values }) => ({
+        '/experiments/shared-metrics': (_, searchParams) => {
+            const urlPage = parseInt(searchParams.page ?? '1') || 1
+            const urlSearch = searchParams.search ?? ''
+            const searchChanged = urlSearch !== values.searchTerm
+            if (searchChanged) {
+                // setSearchTerm resets page to 1, so apply it first then restore the URL's page below.
+                actions.setSearchTerm(urlSearch)
+            }
+            // After a search change the page is 1; set the URL page whenever it differs from the resulting page.
+            if (urlPage !== (searchChanged ? 1 : values.page)) {
+                actions.setPage(urlPage)
             }
         },
     })),

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -1,11 +1,9 @@
-import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, connect, events, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
-import { actionToUrl, urlToAction } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
-import { PaginationManual } from 'lib/lemon-ui/PaginationControl'
 import { toParams } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -76,20 +74,6 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
         ],
     })),
 
-    selectors(({ actions }) => ({
-        pagination: [
-            (s) => [s.page, s.count],
-            (page, count): PaginationManual => ({
-                controlled: true,
-                pageSize: PAGE_SIZE,
-                currentPage: page,
-                entryCount: count,
-                onForward: () => actions.setPage(page + 1),
-                onBackward: () => actions.setPage(page - 1),
-            }),
-        ],
-    })),
-
     listeners(({ actions, values }) => ({
         setPage: async () => {
             actions.loadSharedMetrics()
@@ -116,39 +100,6 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
                 actions.loadSharedMetrics()
             } catch {
                 lemonToast.error('Failed to delete shared metric')
-            }
-        },
-    })),
-
-    actionToUrl(({ values }) => {
-        const buildUrl = (): [string, Record<string, string>] => {
-            const params: Record<string, string> = {}
-            if (values.page > 1) {
-                params.page = String(values.page)
-            }
-            if (values.searchTerm) {
-                params.search = values.searchTerm
-            }
-            return ['/experiments/shared-metrics', params]
-        }
-        return {
-            setPage: () => buildUrl(),
-            setSearchTerm: () => buildUrl(),
-        }
-    }),
-
-    urlToAction(({ actions, values }) => ({
-        '/experiments/shared-metrics': (_, searchParams) => {
-            const urlPage = parseInt(searchParams.page ?? '1') || 1
-            const urlSearch = searchParams.search ?? ''
-            const searchChanged = urlSearch !== values.searchTerm
-            if (searchChanged) {
-                // setSearchTerm resets page to 1, so apply it first then restore the URL's page below.
-                actions.setSearchTerm(urlSearch)
-            }
-            // After a search change the page is 1; set the URL page whenever it differs from the resulting page.
-            if (urlPage !== (searchChanged ? 1 : values.page)) {
-                actions.setPage(urlPage)
             }
         },
     })),

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -729,6 +729,10 @@ export type ExperimentSavedMetricsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+    /**
+     * A search term.
+     */
+    search?: string
 }
 
 export type ExperimentsListParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -46333,6 +46333,10 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    /**
+     * A search term.
+     */
+    search?: string;
     };
 
     export type ExperimentsListParams = {

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -19,6 +19,7 @@ export const ExperimentSavedMetricsListParams = /* @__PURE__ */ zod.object({
 export const ExperimentSavedMetricsListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    search: zod.string().optional().describe('A search term.'),
 })
 
 export const ExperimentSavedMetricsCreateParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -477,6 +477,7 @@ const experimentSavedMetricsList = (): ToolBase<
             query: {
                 limit: params.limit,
                 offset: params.offset,
+                search: params.search,
             },
         })
         const filtered = {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-saved-metrics-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-saved-metrics-list.json
@@ -8,6 +8,10 @@
         "offset": {
             "description": "The initial index from which to return the results.",
             "type": "number"
+        },
+        "search": {
+            "description": "A search term.",
+            "type": "string"
         }
     },
     "type": "object"


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

The shared metrics view loaded every saved metric for the project in a single request and filtered them client-side. For teams with a large library of shared metrics, this means a heavy, unpaginated payload on every visit and a search that only matches whatever is already in memory. The list also lacked pagination, so there was no way to navigate a large library.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR moves the shared metrics view to server-side search and pagination, so the frontend fetches one page at a time and lets the backend do the filtering.

### Server-side search

Added a `SearchFilter` to `ExperimentSavedMetricViewSet` matching on `name`, `description`, and tag name (`tagged_items__tag__name`). Because joining across tags can produce duplicate rows when a metric has multiple matching tags, the queryset now uses `.distinct()` instead of `.all()`. The `search` query param flows through to the generated frontend and MCP types.

- `ee/clickhouse/views/experiment_saved_metrics.py`
- `products/experiments/frontend/generated/api.schemas.ts` (generated)
- `services/mcp/src/generated/experiments/api.ts` (generated)
- `services/mcp/src/tools/generated/experiments.ts` (generated)

### Paginated logic

`sharedMetricsLogic` now drives a `PaginationManual` against the server. It tracks `page` and `count`, requests `limit`/`offset` from the endpoint, and debounces the search input by 300ms before reloading. Changing the search term resets the page to 1.

- `frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx`

| pagination |
| - |
| <img width="947" height="131" alt="image" src="https://github.com/user-attachments/assets/9bf77601-c222-4a0b-88f0-b2baa25d8de8" /> |

### View wiring

The table now consumes `sharedMetrics` directly (no more in-memory `filteredMetrics`) and renders the manual `pagination` object. Added a `"{start}-{end} of N metrics"` count next to the search box. The client-side name `sorter` was removed because ordering is now handled by the backend (`order_by(Lower("name"))`).

- `frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx`

| result count |
| - |
| <img width="372" height="60" alt="image" src="https://github.com/user-attachments/assets/7cae8700-3e0b-478e-b677-f31a838a70e5" /> |

### Side effects

The shared metric modal (`SharedMetricModal.tsx`) still uses the client-side `matchesSharedMetricSearch` helper, so that util is intentionally kept — only the `SharedMetrics` scene moved to server-side filtering.


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test ee/clickhouse/views/test/test_experiment_saved_metrics.py -v
```

```bash
pnpm --filter=@posthog/frontend jest --testPathPattern="sharedMetricsLogic"
```

![cat-type-small](https://github.com/user-attachments/assets/5f835cbf-a0c6-4195-92d1-b1e9919bbb65)

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
Model: Opus 4.8
Manually refactored: **yes**
Skills used:
- /writing-kea-logics (local)
- /improving-drf-endpoints (local)
- /adopting-generated-api-types (local)
- /test-driven-development (superpowers)

Relevant decisions:
- The queryset switched to `.distinct()` because the tag join multiplies rows for metrics with several matching tags — covered by
`test_search_returns_each_metric_once_with_multiple_matching_tags`.