### PR TITLE
chore(hog-charts): move LineChart into its own folder

### DIFF
--- a/frontend/src/lib/hog-charts/charts/LineChart/LineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart/LineChart.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import type { LineChartConfig, Series } from '../core/types'
-import { DEFAULT_Y_AXIS_ID } from '../core/types'
-import { ReferenceLine } from '../overlays/ReferenceLine'
-import { ValueLabels } from '../overlays/ValueLabels'
-import { playHoverAtFraction, Stage, useReactiveTheme } from '../story-helpers'
-import { ciRanges, trendLine } from '../utils/statistics'
+import type { LineChartConfig, Series } from '../../core/types'
+import { DEFAULT_Y_AXIS_ID } from '../../core/types'
+import { ReferenceLine } from '../../overlays/ReferenceLine'
+import { ValueLabels } from '../../overlays/ValueLabels'
+import { playHoverAtFraction, Stage, useReactiveTheme } from '../../story-helpers'
+import { ciRanges, trendLine } from '../../utils/statistics'
 import { LineChart } from './LineChart'
 
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']

--- a/frontend/src/lib/hog-charts/charts/LineChart/LineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart/LineChart.test.tsx
@@ -1,6 +1,6 @@
-import type { ChartTheme, Series } from '../core/types'
-import { ReferenceLine } from '../overlays/ReferenceLine'
-import { renderHogChart } from '../testing'
+import type { ChartTheme, Series } from '../../core/types'
+import { ReferenceLine } from '../../overlays/ReferenceLine'
+import { renderHogChart } from '../../testing'
 import { LineChart } from './LineChart'
 
 const THEME: ChartTheme = {

--- a/frontend/src/lib/hog-charts/charts/LineChart/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart/LineChart.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useMemo } from 'react'
 
-import { drawArea, drawGrid, drawHighlightPoint, drawLine, drawPoints } from '../core/canvas-renderer'
-import type { DrawContext } from '../core/canvas-renderer'
-import { Chart } from '../core/Chart'
-import { ChartErrorBoundary } from '../core/ChartErrorBoundary'
+import { drawArea, drawGrid, drawHighlightPoint, drawLine, drawPoints } from '../../core/canvas-renderer'
+import type { DrawContext } from '../../core/canvas-renderer'
+import { Chart } from '../../core/Chart'
+import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
 import {
     buildSegmentResolveValue,
     buildStackedPositionValue,
@@ -12,9 +12,9 @@ import {
     createScales as createLineScales,
     resolveYScaleForSeries,
     yTickCountForHeight,
-} from '../core/scales'
-import type { ScaleSet, StackedBand } from '../core/scales'
-import { DEFAULT_Y_AXIS_ID } from '../core/types'
+} from '../../core/scales'
+import type { ScaleSet, StackedBand } from '../../core/scales'
+import { DEFAULT_Y_AXIS_ID } from '../../core/types'
 import type {
     ChartDimensions,
     ChartDrawArgs,
@@ -27,7 +27,7 @@ import type {
     Series,
     TooltipContext,
     YAxisScale,
-} from '../core/types'
+} from '../../core/types'
 
 // Brand for the private ChartScales._private slot used by LineChart. The base Chart
 // and other chart types treat this as opaque; LineChart's drawStatic narrows back to it.

--- a/frontend/src/lib/hog-charts/charts/Sparkline/Sparkline.tsx
+++ b/frontend/src/lib/hog-charts/charts/Sparkline/Sparkline.tsx
@@ -4,7 +4,7 @@ import { useChartHover } from '../../core/chart-context'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
 import { useLatest } from '../../core/hooks/useLatest'
 import type { ChartTheme, LineChartConfig, Series } from '../../core/types'
-import { LineChart } from '../LineChart'
+import { LineChart } from '../LineChart/LineChart'
 
 export interface SparklineProps {
     data: number[]

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -17,7 +17,7 @@ import {
     type XAxisConfig,
     type YAxisConfig,
 } from '../../utils/use-axis-formatters'
-import { LineChart } from '../LineChart'
+import { LineChart } from '../LineChart/LineChart'
 import {
     resolveValueLabelsConfig,
     useSeriesWithValueLabelAllowlist,

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -1,8 +1,8 @@
 // Components
 export { BarChart } from './charts/BarChart/BarChart'
 export type { BarChartProps } from './charts/BarChart/BarChart'
-export { LineChart } from './charts/LineChart'
-export type { LineChartProps } from './charts/LineChart'
+export { LineChart } from './charts/LineChart/LineChart'
+export type { LineChartProps } from './charts/LineChart/LineChart'
 export { TimeSeriesLineChart } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
 export type {
     ConfidenceIntervalConfig,

--- a/frontend/src/lib/hog-charts/overlays/ReferenceLine.stories.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ReferenceLine.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { LineChart } from '../charts/LineChart'
+import { LineChart } from '../charts/LineChart/LineChart'
 import type { LineChartConfig, Series } from '../core/types'
 import { Stage, useReactiveTheme } from '../story-helpers'
 import { ReferenceLine } from './ReferenceLine'

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.stories.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { LineChart } from '../charts/LineChart'
+import { LineChart } from '../charts/LineChart/LineChart'
 import type { LineChartConfig, Series } from '../core/types'
 import { Stage, useReactiveTheme } from '../story-helpers'
 import { ValueLabels } from './ValueLabels'


### PR DESCRIPTION
## Problem

`docs/CONTRIBUTING.md` says chart-type React goes at *"`charts/<name>/<Name>.tsx`"*. Every chart type follows that — `BarChart/BarChart.tsx`, `BoxPlot/BoxPlot.tsx`, `PieChart/PieChart.tsx`, `Sparkline/Sparkline.tsx`, `TimeSeriesBarChart/TimeSeriesBarChart.tsx`, `TimeSeriesLineChart/TimeSeriesLineChart.tsx` — except LineChart, which sat flat at `charts/LineChart.tsx`, `charts/LineChart.test.tsx`, `charts/LineChart.stories.tsx`.

The flat layout also blocked adding LineChart-adjacent helpers (sub-components, utils, fixtures) without arbitrarily picking where they go.

## Changes

- `git mv` the three files into `charts/LineChart/` so blame is preserved.
- Bump the relative imports inside them from `../core/…`, `../overlays/…`, `../testing`, `../story-helpers`, `../utils/…` to `../../…`.
- Update the four import sites that point at the old path: the library barrel (`index.ts`, two lines) and two overlay stories (`ValueLabels.stories.tsx`, `ReferenceLine.stories.tsx`).

No behavioral changes — purely structural.

## How did you test this code?

I'm an agent. I could not run jest, tsc, or build locally in this remote task environment. Verified by inspection:

- `git status` reports all three moves as renames (similarity preserved), so blame survives.
- Every relative import inside the moved files now has the `../../` prefix that the new depth requires.
- Grepped the whole repo for `charts/LineChart['\"]` after the move and got zero hits, confirming no consumer still points at the old path.

Worth running CI to confirm.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — this aligns the implementation with the existing convention in `frontend/src/lib/hog-charts/docs/CONTRIBUTING.md`.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Surfaced by a convention scan of every chart type in the library — LineChart was the only one not following the documented folder layout. Three of four external import sites are story files (rarely touched), so the churn is small and contained.