### PR TITLE
feat(experiments): add pagination to the shared metrics modal.

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -24,8 +24,15 @@ export function SharedMetricModal({
     experiment: Experiment
     onSave: (metrics: SharedMetric[], context: MetricContext) => void
 }): JSX.Element | null {
-    const { isModalOpen, context, compatibleSharedMetrics, searchTerm, canLoadMore, sharedMetricsResponseLoading } =
-        useValues(sharedMetricModalLogic)
+    const {
+        isModalOpen,
+        context,
+        compatibleSharedMetrics,
+        searchTerm,
+        canLoadMore,
+        sharedMetricsResponseLoading,
+        hasAnyCompatibleSharedMetrics,
+    } = useValues(sharedMetricModalLogic)
     const { closeSharedMetricModal, setSearchTerm, loadNextSharedMetrics } = useActions(sharedMetricModalLogic)
     const { savingTagsMetricId } = useValues(sharedMetricsLogic)
     const { updateSharedMetricTags } = useActions(sharedMetricsLogic)
@@ -93,7 +100,7 @@ export function SharedMetricModal({
             }
         >
             <div className="deprecated-space-y-2">
-                {compatibleSharedMetrics.length > 0 ? (
+                {hasAnyCompatibleSharedMetrics ? (
                     <>
                         {experiment.saved_metrics.length > 0 && (
                             <LemonBanner type="info">
@@ -150,6 +157,8 @@ export function SharedMetricModal({
                         </div>
                         <LemonTable
                             dataSource={compatibleSharedMetrics}
+                            loading={sharedMetricsResponseLoading}
+                            emptyState={<div>No shared metrics match your search.</div>}
                             columns={[
                                 {
                                     title: '',

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -100,7 +100,7 @@ export function SharedMetricModal({
             }
         >
             <div className="deprecated-space-y-2">
-                {hasAnyCompatibleSharedMetrics ? (
+                {hasAnyCompatibleSharedMetrics || sharedMetricsResponseLoading ? (
                     <>
                         {experiment.saved_metrics.length > 0 && (
                             <LemonBanner type="info">

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { LemonBanner, LemonButton, LemonInput, LemonLabel, LemonModal, Link } from '@posthog/lemon-ui'
 
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { pluralize } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
 import { tagsModel } from '~/models/tagsModel'
@@ -13,7 +14,6 @@ import { Experiment } from '~/types'
 import { InlineTagEditor } from '../SharedMetrics/InlineTagEditor'
 import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
 import { sharedMetricsLogic } from '../SharedMetrics/sharedMetricsLogic'
-import { matchesSharedMetricSearch } from '../utils'
 import { MetricContext } from './experimentMetricModalLogic'
 import { sharedMetricModalLogic } from './sharedMetricModalLogic'
 
@@ -24,9 +24,11 @@ export function SharedMetricModal({
     experiment: Experiment
     onSave: (metrics: SharedMetric[], context: MetricContext) => void
 }): JSX.Element | null {
-    const { isModalOpen, context, compatibleSharedMetrics, searchTerm } = useValues(sharedMetricModalLogic)
-    const { closeSharedMetricModal, setSearchTerm, updateSharedMetricTags } = useActions(sharedMetricModalLogic)
+    const { isModalOpen, context, compatibleSharedMetrics, searchTerm, canLoadMore, sharedMetricsResponseLoading } =
+        useValues(sharedMetricModalLogic)
+    const { closeSharedMetricModal, setSearchTerm, loadNextSharedMetrics } = useActions(sharedMetricModalLogic)
     const { savingTagsMetricId } = useValues(sharedMetricsLogic)
+    const { updateSharedMetricTags } = useActions(sharedMetricsLogic)
     const { tags: allTags } = useValues(tagsModel)
 
     const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])
@@ -46,18 +48,16 @@ export function SharedMetricModal({
         closeSharedMetricModal()
     }
 
-    const availableSharedMetrics = compatibleSharedMetrics.filter(
-        (metric: SharedMetric) =>
-            !experiment.saved_metrics.some((savedMetric) => savedMetric.saved_metric === metric.id)
-    )
+    const alreadyAddedIds = new Set(experiment.saved_metrics.map((savedMetric) => savedMetric.saved_metric))
 
-    const searchLower = searchTerm.toLowerCase()
-    const filteredMetrics = searchTerm
-        ? availableSharedMetrics.filter((metric) => matchesSharedMetricSearch(metric, searchLower))
-        : availableSharedMetrics
+    // Already-added metrics stay visible but are not selectable.
+    const selectableMetrics = compatibleSharedMetrics.filter((metric: SharedMetric) => !alreadyAddedIds.has(metric.id))
 
+    /**
+     * we need to get the tags from the metrics that can be added to the experiment
+     */
     const availableTags = Array.from(
-        new Set(filteredMetrics.flatMap((metric: SharedMetric) => metric.tags ?? []).filter(Boolean))
+        new Set(selectableMetrics.flatMap((metric: SharedMetric) => metric.tags ?? []).filter(Boolean))
     ).sort()
 
     return (
@@ -93,13 +93,13 @@ export function SharedMetricModal({
             }
         >
             <div className="deprecated-space-y-2">
-                {availableSharedMetrics.length > 0 ? (
+                {compatibleSharedMetrics.length > 0 ? (
                     <>
                         {experiment.saved_metrics.length > 0 && (
                             <LemonBanner type="info">
-                                {`Hiding ${experiment.saved_metrics.length} shared ${
-                                    experiment.saved_metrics.length > 1 ? 'metrics' : 'metric'
-                                } already in use with this experiment.`}
+                                {`${pluralize(experiment.saved_metrics.length, 'shared metric')} ${
+                                    experiment.saved_metrics.length > 1 ? 'are' : 'is'
+                                } already in the experiment.`}
                             </LemonBanner>
                         )}
                         <LemonInput
@@ -115,7 +115,7 @@ export function SharedMetricModal({
                                 size="xsmall"
                                 type="secondary"
                                 onClick={() => {
-                                    setSelectedMetricIds(filteredMetrics.map((metric: SharedMetric) => metric.id))
+                                    setSelectedMetricIds(selectableMetrics.map((metric: SharedMetric) => metric.id))
                                 }}
                             >
                                 All
@@ -138,7 +138,7 @@ export function SharedMetricModal({
                                     type="secondary"
                                     onClick={() => {
                                         setSelectedMetricIds(
-                                            filteredMetrics
+                                            selectableMetrics
                                                 .filter((metric: SharedMetric) => metric.tags?.includes(tag))
                                                 .map((metric: SharedMetric) => metric.id)
                                         )
@@ -149,7 +149,7 @@ export function SharedMetricModal({
                             ))}
                         </div>
                         <LemonTable
-                            dataSource={filteredMetrics}
+                            dataSource={compatibleSharedMetrics}
                             columns={[
                                 {
                                     title: '',
@@ -157,6 +157,7 @@ export function SharedMetricModal({
                                     render: (_, metric: SharedMetric) => (
                                         <input
                                             type="checkbox"
+                                            disabled={alreadyAddedIds.has(metric.id)}
                                             checked={selectedMetricIds.includes(metric.id)}
                                             onChange={(e) => {
                                                 if (e.target.checked) {
@@ -172,8 +173,15 @@ export function SharedMetricModal({
                                 },
                                 {
                                     title: 'Name',
-                                    dataIndex: 'name',
                                     key: 'name',
+                                    render: (_, metric: SharedMetric) => (
+                                        <span>
+                                            {metric.name}
+                                            {alreadyAddedIds.has(metric.id) && (
+                                                <span className="text-secondary ml-2">(already added)</span>
+                                            )}
+                                        </span>
+                                    ),
                                 },
                                 {
                                     title: 'Description',
@@ -205,7 +213,16 @@ export function SharedMetricModal({
                                 },
                             ]}
                             footer={
-                                <div className="flex items-center justify-center m-2">
+                                <div className="flex flex-col items-center gap-2 m-2">
+                                    {canLoadMore && (
+                                        <LemonButton
+                                            type="secondary"
+                                            onClick={loadNextSharedMetrics}
+                                            loading={sharedMetricsResponseLoading}
+                                        >
+                                            Load more metrics
+                                        </LemonButton>
+                                    )}
                                     <Link to={`${urls.experiments()}?tab=shared-metrics`} target="_blank">
                                         See all shared metrics
                                     </Link>
@@ -216,9 +233,8 @@ export function SharedMetricModal({
                 ) : (
                     <LemonBanner className="w-full" type="info">
                         <div className="mb-2">
-                            {compatibleSharedMetrics.length > 0
-                                ? 'All of your shared metrics are already in this experiment.'
-                                : "You don't have any shared metrics that match the experiment type. Shared metrics let you create reusable metrics that you can quickly add to any experiment."}
+                            You don't have any shared metrics that match the experiment type. Shared metrics let you
+                            create reusable metrics that you can quickly add to any experiment.
                         </div>
                         <Link to={urls.experimentsSharedMetric('new')} target="_blank">
                             New shared metric

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
@@ -1,0 +1,97 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+
+import { useMocks } from '~/mocks/jest'
+import { NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import { METRIC_CONTEXTS } from './experimentMetricModalLogic'
+import { MODAL_PAGE_SIZE, sharedMetricModalLogic } from './sharedMetricModalLogic'
+
+const metric = (id: number, kind: NodeKind = NodeKind.ExperimentMetric): any => ({
+    id,
+    name: `metric ${id}`,
+    query: { kind },
+})
+
+describe('sharedMetricModalLogic', () => {
+    let logic: ReturnType<typeof sharedMetricModalLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/experiment_saved_metrics': (req) => {
+                    const offset = parseInt(req.url.searchParams.get('offset') ?? '0')
+                    const search = req.url.searchParams.get('search') ?? ''
+                    if (offset === 0) {
+                        return [
+                            200,
+                            {
+                                count: 3,
+                                next: `http://localhost/api/projects/997/experiment_saved_metrics?limit=${MODAL_PAGE_SIZE}&offset=${MODAL_PAGE_SIZE}&search=${search}`,
+                                previous: null,
+                                results: [metric(1), metric(2, NodeKind.ExperimentTrendsQuery)],
+                            },
+                        ]
+                    }
+                    return [200, { count: 3, next: null, previous: null, results: [metric(3)] }]
+                },
+            },
+        })
+        initKeaTests()
+        logic = sharedMetricModalLogic()
+        logic.mount()
+    })
+
+    afterEach(() => logic.unmount())
+
+    it('openSharedMetricModal resets search and loads page 1 with limit 20 offset 0', async () => {
+        jest.spyOn(api, 'get')
+        await expectLogic(logic, () => {
+            logic.actions.setSearchTerm('stale')
+            logic.actions.openSharedMetricModal(METRIC_CONTEXTS.primary)
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({ searchTerm: '' })
+        expect(api.get).toHaveBeenLastCalledWith(expect.stringContaining(`limit=${MODAL_PAGE_SIZE}`))
+        expect(api.get).toHaveBeenLastCalledWith(expect.stringContaining('offset=0'))
+    })
+
+    it('compatibleSharedMetrics filters out non-ExperimentMetric kinds', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({
+            compatibleSharedMetrics: [expect.objectContaining({ id: 1 })],
+            canLoadMore: true,
+        })
+    })
+
+    it('loadNextSharedMetrics appends the next page', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+        await expectLogic(logic, () => {
+            logic.actions.loadNextSharedMetrics()
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({
+            compatibleSharedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],
+            canLoadMore: false,
+        })
+    })
+
+    it('setSearchTerm triggers a debounced reload with search and replaces results', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+
+        jest.spyOn(api, 'get')
+        await expectLogic(logic, () => {
+            logic.actions.setSearchTerm('revenue')
+        }).toFinishAllListeners()
+        expect(api.get).toHaveBeenLastCalledWith(expect.stringContaining('search=revenue'))
+        await expectLogic(logic).toMatchValues({
+            compatibleSharedMetrics: [expect.objectContaining({ id: 1 })],
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
@@ -24,6 +24,9 @@ describe('sharedMetricModalLogic', () => {
                 '/api/projects/:team_id/experiment_saved_metrics': (req) => {
                     const offset = parseInt(req.url.searchParams.get('offset') ?? '0')
                     const search = req.url.searchParams.get('search') ?? ''
+                    if (search === 'nomatch') {
+                        return [200, { count: 0, next: null, previous: null, results: [] }]
+                    }
                     if (offset === 0) {
                         return [
                             200,
@@ -93,5 +96,38 @@ describe('sharedMetricModalLogic', () => {
         await expectLogic(logic).toMatchValues({
             compatibleSharedMetrics: [expect.objectContaining({ id: 1 })],
         })
+    })
+
+    it('tracks hasAnyCompatibleSharedMetrics from the unfiltered baseline, not the current search', async () => {
+        // initial unfiltered load establishes that compatible metrics exist
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({ hasAnyCompatibleSharedMetrics: true })
+
+        // a search that returns zero must NOT flip the baseline to false
+        await expectLogic(logic, () => {
+            logic.actions.setSearchTerm('nomatch')
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({
+            compatibleSharedMetrics: [],
+            hasAnyCompatibleSharedMetrics: true,
+        })
+    })
+
+    it('hasAnyCompatibleSharedMetrics is false when the unfiltered load has no compatible metrics', async () => {
+        // mount with a fresh mock where the baseline genuinely has none
+        useMocks({
+            get: {
+                '/api/projects/:team_id/experiment_saved_metrics': () => [
+                    200,
+                    { count: 0, next: null, previous: null, results: [] },
+                ],
+            },
+        })
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({ hasAnyCompatibleSharedMetrics: false })
     })
 })

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
@@ -75,7 +75,7 @@ describe('sharedMetricModalLogic', () => {
             logic.actions.loadSharedMetrics()
         }).toFinishAllListeners()
         await expectLogic(logic, () => {
-            logic.actions.loadNextSharedMetrics()
+            logic.actions.loadNextSharedMetrics(null)
         }).toFinishAllListeners()
         await expectLogic(logic).toMatchValues({
             compatibleSharedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -1,25 +1,25 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
 
+import api, { CountedPaginatedResponse } from 'lib/api'
+import { toParams } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 
 import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
-import { sharedMetricsLogic } from '../SharedMetrics/sharedMetricsLogic'
 import { METRIC_CONTEXTS, type MetricContext } from './experimentMetricModalLogic'
 import type { sharedMetricModalLogicType } from './sharedMetricModalLogicType'
+
+export const MODAL_PAGE_SIZE = 20
 
 export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
     path(['scenes', 'experiments', 'Metrics', 'sharedMetricModalLogic']),
 
     connect(() => ({
-        actions: [
-            sharedMetricsLogic,
-            ['loadSharedMetrics', 'updateSharedMetricTags'],
-            eventUsageLogic,
-            ['reportExperimentSharedMetricAssigned'],
-        ],
-        values: [sharedMetricsLogic, ['sharedMetrics', 'sharedMetricsLoading']],
+        actions: [eventUsageLogic, ['reportExperimentSharedMetricAssigned']],
+        values: [teamLogic, ['currentProjectId']],
     })),
 
     actions({
@@ -31,12 +31,6 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         setSharedMetric: (sharedMetric: SharedMetric) => ({ sharedMetric }),
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
     }),
-
-    listeners(({ actions }) => ({
-        openSharedMetricModal: () => {
-            actions.loadSharedMetrics()
-        },
-    })),
 
     reducers({
         isModalOpen: [
@@ -71,18 +65,59 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
             '',
             {
                 setSearchTerm: (_, { searchTerm }) => searchTerm,
+                openSharedMetricModal: () => '',
                 closeSharedMetricModal: () => '',
             },
         ],
     }),
 
-    selectors({
-        isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
-        compatibleSharedMetrics: [
-            (s) => [s.sharedMetrics],
-            (sharedMetrics: SharedMetric[]): SharedMetric[] => {
-                return sharedMetrics.filter((metric) => metric.query.kind === NodeKind.ExperimentMetric)
+    loaders(({ values }) => ({
+        sharedMetricsResponse: [
+            null as CountedPaginatedResponse<SharedMetric> | null,
+            {
+                loadSharedMetrics: async () => {
+                    const params = toParams({
+                        limit: MODAL_PAGE_SIZE,
+                        offset: 0,
+                        search: values.searchTerm || undefined,
+                    })
+                    return (await api.get(
+                        `api/projects/${values.currentProjectId}/experiment_saved_metrics?${params}`
+                    )) as CountedPaginatedResponse<SharedMetric>
+                },
+                loadNextSharedMetrics: async () => {
+                    const next = values.sharedMetricsResponse?.next
+                    if (!next) {
+                        return values.sharedMetricsResponse
+                    }
+                    const response: CountedPaginatedResponse<SharedMetric> = await api.get(next)
+                    return {
+                        ...response,
+                        results: [...(values.sharedMetricsResponse?.results ?? []), ...response.results],
+                    }
+                },
             },
         ],
+    })),
+
+    selectors({
+        loadedSharedMetrics: [(s) => [s.sharedMetricsResponse], (response): SharedMetric[] => response?.results ?? []],
+        compatibleSharedMetrics: [
+            (s) => [s.loadedSharedMetrics],
+            (loadedSharedMetrics: SharedMetric[]): SharedMetric[] =>
+                loadedSharedMetrics.filter((metric) => metric.query.kind === NodeKind.ExperimentMetric),
+        ],
+        canLoadMore: [(s) => [s.sharedMetricsResponse], (response): boolean => !!response?.next],
+        isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
     }),
+
+    listeners(({ actions }) => ({
+        openSharedMetricModal: () => {
+            actions.loadSharedMetrics()
+        },
+        setSearchTerm: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadSharedMetrics()
+        },
+    })),
 ])

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -95,15 +95,18 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                         `api/projects/${values.currentProjectId}/experiment_saved_metrics?${params}`
                     )) as CountedPaginatedResponse<SharedMetric>
                 },
-                loadNextSharedMetrics: async () => {
+                loadNextSharedMetrics: async (_, breakpoint) => {
                     const next = values.sharedMetricsResponse?.next
                     if (!next) {
                         return values.sharedMetricsResponse
                     }
+                    const baseResults = values.sharedMetricsResponse?.results ?? []
                     const response: CountedPaginatedResponse<SharedMetric> = await api.get(next)
+                    // Abort if a concurrent loadSharedMetrics (e.g. a new search) superseded this page request.
+                    breakpoint()
                     return {
                         ...response,
-                        results: [...(values.sharedMetricsResponse?.results ?? []), ...response.results],
+                        results: [...baseResults, ...response.results],
                     }
                 },
             },

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -30,6 +30,7 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         closeSharedMetricModal: true,
         setSharedMetric: (sharedMetric: SharedMetric) => ({ sharedMetric }),
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
+        setHasAnyCompatibleSharedMetrics: (hasAny: boolean) => ({ hasAny }),
     }),
 
     reducers({
@@ -67,6 +68,15 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                 setSearchTerm: (_, { searchTerm }) => searchTerm,
                 openSharedMetricModal: () => '',
                 closeSharedMetricModal: () => '',
+            },
+        ],
+        // Whether the experiment has any compatible shared metrics at all, captured from the
+        // unfiltered (empty-search) load — so a search returning zero does not flip it to false.
+        hasAnyCompatibleSharedMetrics: [
+            false,
+            {
+                setHasAnyCompatibleSharedMetrics: (_, { hasAny }) => hasAny,
+                openSharedMetricModal: () => false,
             },
         ],
     }),
@@ -111,13 +121,19 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
     }),
 
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         openSharedMetricModal: () => {
             actions.loadSharedMetrics()
         },
         setSearchTerm: async (_, breakpoint) => {
             await breakpoint(300)
             actions.loadSharedMetrics()
+        },
+        loadSharedMetricsSuccess: () => {
+            // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
+            if (!values.searchTerm) {
+                actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
+            }
         },
     })),
 ])

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -951,14 +951,3 @@ export function getOrderedMetricsWithResults(
             metricIndex: originalIndexMap.get(metric.uuid) ?? index, // Original position for retry
         }))
 }
-
-export function matchesSharedMetricSearch(
-    metric: { name: string; description?: string; tags?: string[] },
-    searchLower: string
-): boolean {
-    return (
-        metric.name.toLowerCase().includes(searchLower) ||
-        (metric.description?.toLowerCase().includes(searchLower) ?? false) ||
-        (metric.tags?.some((tag) => tag.toLowerCase().includes(searchLower)) ?? false)
-    )
-}


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

The "add shared metric" modal loaded all saved metrics for the project up front and filtered them client-side, following the same pattern as the shared metrics scene. For teams with a large metric library, this is a heavy, unpaginated payload every time the modal opens, and search only matches what is already in memory.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR moves the shared metric modal to server-side search, using a "load more" pagination pattern, and stops relying on `sharedMetricsLogic` for its data.

### Paginated modal logic

`sharedMetricModalLogic` now owns its own data via a `loaders` block instead of borrowing `sharedMetrics` from `sharedMetricsLogic`. `loadSharedMetrics` fetches the first page (`limit=20`, `offset=0`, optional `search`), and `loadNextSharedMetrics` follows the response's `next` URL and appends results, driving a "Load more metrics" button via the `canLoadMore` selector. Opening the modal resets the search term, and typing is debounced for 300ms before reloading.

The tricky bit is the empty state. We still want to distinguish "you have no compatible shared metrics at all" from "your current search returned nothing". A new `hasAnyCompatibleSharedMetrics` reducer captures that answer from the unfiltered (empty-search) load only, so a search returning zero results does not flip the empty state to "you have no metrics". This is covered explicitly in the logic tests.

- `frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts`

### Modal wiring

The modal renders `compatibleSharedMetrics` directly (as paginated server results) rather than a client-filtered list. Already-added metrics now stay visible in the table but are rendered with an "(already added)" label and a disabled checkbox, rather than being hidden entirely. The footer gained the "Load more metrics" button above the existing "See all shared metrics" link, and the table shows a loading state and an "No shared metrics match your search." empty state. Copy was tidied up to use `pluralize`.

- `frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx`

### Side effects

With both the scene (#60755) and the modal now filtering server-side, the client-side `matchesSharedMetricSearch` helper has no remaining callers and is deleted.

- `frontend/src/scenes/experiments/utils.ts`

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest --testPathPattern="sharedMetricModalLogic"
```

![cat-type-small](https://github.com/user-attachments/assets/22ec31f9-956c-487e-9982-56529b036de9)

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
Model: Opus 4.8
Manually refactored: **yes**
Skills used:
- /test-driven-development (superpowers)
- /writing-kea-logics (local)

Relevant decisions:
- Moved the modal to own its data in `sharedMetricModalLogic` via a `loaders` block rather than continuing to borrow `sharedMetrics` from
`sharedMetricsLogic`, so the modal can paginate and search server-side independently of the scene.