### PR TITLE
fix(ci): force-reinstall cargo-shear to fix repo-wide Rust lint failures

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -400,7 +400,11 @@ jobs:
               uses: cargo-bins/cargo-binstall@5cbf019d8cb9b9d5b086218c41458ea35d817691 # main
 
             - name: Install cargo-shear
-              run: cargo binstall --no-confirm cargo-shear@1.1.12
+              # --force is required: Swatinem/rust-cache restores ~/.cargo/.crates2.json
+              # (which records cargo-shear as installed) but not the binary itself, so
+              # without --force binstall short-circuits ("already installed") and the
+              # next step fails with `error: no such command: shear`.
+              run: cargo binstall --no-confirm --force cargo-shear@1.1.12
 
             - name: Run cargo shear
               run: cargo shear


### PR DESCRIPTION
## Summary

Rust CI is currently **red on `master` and every open PR**. The `Lint Rust services` job fails at the `Run cargo shear` step with:

```
error: no such command: `shear`
```

Because `Rust Tests Pass` is a fail-fast collate check, the failed lint job also cancels the `Build Rust services` job and all `Test Rust (...)` shards, so PRs show a wall of red that has nothing to do with their actual changes.

## Root cause

`Swatinem/rust-cache` (saved only on `master`) restores `~/.cargo/.crates2.json`, which records `cargo-shear@1.1.12` as already installed — but the `~/.cargo/bin/cargo-shear` **binary itself is not in the restored cache**. So:

```yaml
- name: Install cargo-shear
  run: cargo binstall --no-confirm cargo-shear@1.1.12   # sees stale metadata -> "already installed (Done in <1ms)", skips
- name: Run cargo shear
  run: cargo shear                                       # binary absent -> "no such command: shear"
```

The install step reports success (`INFO cargo-shear v1.1.12 is already installed`), masking that the binary is missing.

## Fix

Add `--force` so `binstall` always reinstalls the prebuilt binary regardless of cached metadata:

```yaml
run: cargo binstall --no-confirm --force cargo-shear@1.1.12
```

This is a prebuilt-binary download (a few seconds), so the cost is negligible.

## Why `--force` (and the longer-term option)

`--force` is the minimal, robust fix for the symptom. The deeper issue is the `rust-cache` / `binstall` interaction caching install metadata without the corresponding binary. A more systemic fix would be to stop caching cargo-installed binaries via rust-cache's `cache-bin: false` (or install CLI tools before the cache step). `cargo-shear` is currently the only `binstall`-ed tool in this workflow, so `--force` fully resolves the present breakage; `cache-bin: false` can be a follow-up if more tools are added.

## Test plan

- [ ] This PR's own `Lint Rust services` job runs the modified workflow and the `Run cargo shear` step passes.
- [ ] `Rust Tests Pass` goes green (no longer cancelled by the lint fail-fast).