### PR TITLE
feat(funnels): rework horizontal funnel chart on hog-charts BarChart

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -368,6 +368,36 @@ describe('BarChart', () => {
             await waitFor(() => expect(getHogChartTooltip()?.textContent ?? '').toBe(''))
         })
 
+        it('stacked horizontal with barTrack flags clicks in the empty remainder region as inTrack', () => {
+            const onPointClick = jest.fn()
+            const { chart } = renderHogChart(
+                <BarChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ barLayout: 'stacked', axisOrientation: 'horizontal', bars: { track: true } }}
+                    onPointClick={onPointClick}
+                />
+            )
+            // Tue row stacks to 35 while the axis runs to 55 (Wed) — its right side is empty track.
+            const yMidRow = dimensions.plotTop + dimensions.plotHeight / 2
+            // Click on the filled bar → a real segment, not the track.
+            fireEvent.mouseMove(chart.element, {
+                clientX: dimensions.plotLeft + dimensions.plotWidth * 0.2,
+                clientY: yMidRow,
+            })
+            fireEvent.click(chart.element)
+            expect(onPointClick.mock.calls[0][0].inTrack).toBeFalsy()
+            onPointClick.mockClear()
+            // Click past the value extent, in the remainder → flagged as a track click.
+            fireEvent.mouseMove(chart.element, {
+                clientX: dimensions.plotLeft + dimensions.plotWidth * 0.95,
+                clientY: yMidRow,
+            })
+            fireEvent.click(chart.element)
+            expect(onPointClick.mock.calls[0][0].inTrack).toBe(true)
+        })
+
         describe('sparse-stacked horizontal (overlap layout)', () => {
             // Mirrors `buildTrendsBarAggregatedSeries`: each series has one non-zero value at
             // its own dataIndex, every label is the same band. Smallest bar paints on top, so

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -75,13 +75,8 @@ function computeBandTrackRects(
     const valueMin = Math.min(axisA, axisB)
     const valueSize = Math.abs(axisB - axisA)
     const bandwidth = scales.band.bandwidth()
-    const seen = new Set<string>()
     const rects: BarRect[] = []
-    for (const label of labels) {
-        if (seen.has(label)) {
-            continue
-        }
-        seen.add(label)
+    for (const label of new Set(labels)) {
         const bandStart = scales.band(label)
         if (bandStart == null) {
             continue

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -5,12 +5,15 @@ import { type BarChartPrivate, computeBarTrackRect, computeSeriesBars } from '..
 import {
     BAR_TRACK_HOVER_ALPHA,
     type BarRect,
+    type BarRoundedCorners,
     type BarShadow,
     drawBarHighlight,
     drawBars,
     drawBarTracks,
     drawGrid,
+    drawSolidBarTracks,
     type DrawContext,
+    clipToRoundedRects,
 } from '../../core/canvas-renderer'
 import { Chart } from '../../core/Chart'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
@@ -47,15 +50,64 @@ import { BarTooltip } from './BarTooltip'
 import {
     type BarLayout,
     barContainsPointOnBandAxis,
+    computeStackEdges,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
     iterBarsAtCursor,
     isStackedLayout,
+    type StackEdges,
 } from './utils/bars-under-cursor'
 
 function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
     const start = scales.band(label)
     return start == null ? undefined : start + scales.band.bandwidth() / 2
+}
+
+const ALL_CORNERS: BarRoundedCorners = { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true }
+
+/** One track rect per unique band, spanning the full value axis behind the stack. */
+function computeBandTrackRects(
+    scales: BarChartPrivate['__barChart'],
+    labels: string[],
+    isHorizontal: boolean
+): BarRect[] {
+    const [axisA = 0, axisB = 0] = scales.value.range()
+    const valueMin = Math.min(axisA, axisB)
+    const valueSize = Math.abs(axisB - axisA)
+    const bandwidth = scales.band.bandwidth()
+    const seen = new Set<string>()
+    const rects: BarRect[] = []
+    for (const label of labels) {
+        if (seen.has(label)) {
+            continue
+        }
+        seen.add(label)
+        const bandStart = scales.band(label)
+        if (bandStart == null) {
+            continue
+        }
+        rects.push(
+            isHorizontal
+                ? { x: valueMin, y: bandStart, width: valueSize, height: bandwidth, corners: ALL_CORNERS, dataIndex: 0 }
+                : { x: bandStart, y: valueMin, width: bandwidth, height: valueSize, corners: ALL_CORNERS, dataIndex: 0 }
+        )
+    }
+    return rects
+}
+
+/** Whether a cursor sits within a band's slot on the band axis (anywhere in that row's track). */
+function cursorInBandTrack(
+    scales: BarChartPrivate['__barChart'],
+    label: string,
+    cursor: { x: number; y: number },
+    isHorizontal: boolean
+): boolean {
+    const bandStart = scales.band(label)
+    if (bandStart == null) {
+        return false
+    }
+    const bandCoord = isHorizontal ? cursor.y : cursor.x
+    return bandCoord >= bandStart && bandCoord < bandStart + scales.band.bandwidth()
 }
 
 /** Center of a specific series's bar within a band. Used by overlays (e.g. annotations)
@@ -129,14 +181,19 @@ function BarChartInner<Meta = unknown>({
         xTickFormatter,
     } = config ?? {}
     const {
-        cornerRadius: barCornerRadius = 0,
-        track: barTrack = false,
+        cornerRadius = 0,
+        rounding = 'cap',
+        track,
         shadow: barShadow,
         divergingStack = false,
         maxBandRange,
         bandPadding,
         minBandSize,
     } = config?.bars ?? {}
+    const roundStackBaseline = rounding === 'pill'
+    const barCornerRadius = rounding === 'none' ? 0 : cornerRadius
+    const barTrack = !!track
+    const barTrackColor = typeof track === 'object' ? track.color : undefined
     const isHorizontal = axisOrientation === 'horizontal'
 
     const resolvedMinBandSize = minBandSize ?? (isHorizontal ? HORIZONTAL_MIN_BAND_SIZE_DEFAULT : 0)
@@ -178,6 +235,11 @@ function BarChartInner<Meta = unknown>({
         }
         return m
     }, [barLayout, series])
+
+    const stackEdges = useMemo<StackEdges | undefined>(
+        () => (roundStackBaseline && barLayout !== 'grouped' ? computeStackEdges(series, labels.length) : undefined),
+        [roundStackBaseline, barLayout, series, labels.length]
+    )
 
     const chartConfig = useMemo<BarChartConfig>(() => {
         const base = { ...config, isPercent: barLayout === 'percent' }
@@ -316,6 +378,8 @@ function BarChartInner<Meta = unknown>({
                 .filter((s) => !s.visibility?.excluded)
                 .map((s) => {
                     const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
+                    const topAtIndex = stackEdges?.topKeyAtIndex.get(axisId)
+                    const bottomAtIndex = stackEdges?.bottomKeyAtIndex.get(axisId)
                     const bars = computeSeriesBars({
                         series: s,
                         labels: drawLabels,
@@ -324,20 +388,27 @@ function BarChartInner<Meta = unknown>({
                         isHorizontal,
                         stackedBand: stackedData?.get(s.key),
                         isTopOfStack: topStackedKeyByAxis.get(axisId) === s.key,
+                        capRoundedAtIndex: stackEdges ? (i) => topAtIndex?.[i] === s.key : undefined,
+                        baseRoundedAtIndex:
+                            stackEdges && roundStackBaseline ? (i) => bottomAtIndex?.[i] === s.key : undefined,
                     }).filter((b): b is BarRect => b !== null)
                     return { series: s, bars }
                 })
 
-            // Tracks are a separate pass so a later series' full-height track can't paint
-            // over an earlier series' bar. Track is "share of a whole" semantics — only
-            // meaningful for grouped layouts; in stacked/percent every layer would paint
-            // a full-height track over the same band with the wrong corners.
             if (barTrack && barLayout === 'grouped') {
                 const [axisStart = 0, axisEnd = 0] = d3Scales.value.range()
                 for (const { series: s, bars } of seriesBars) {
                     const tracks = bars.map((b) => computeBarTrackRect(b, axisStart, axisEnd, isHorizontal))
                     drawBarTracks(baseDrawCtx, s, tracks, barCornerRadius)
                 }
+            } else if (barTrack) {
+                const tracks = computeBandTrackRects(d3Scales, drawLabels, isHorizontal)
+                drawSolidBarTracks(
+                    ctx,
+                    tracks,
+                    barTrackColor ?? theme.gridColor ?? 'rgba(0, 0, 0, 0.08)',
+                    barCornerRadius
+                )
             }
 
             const resolvedShadow = resolveBarShadow(barShadow)
@@ -352,8 +423,17 @@ function BarChartInner<Meta = unknown>({
                 ctx.shadowOffsetX = resolvedShadow.offsetX ?? 0
                 ctx.shadowOffsetY = resolvedShadow.offsetY ?? 0
             }
+            // Pill mode: clip the stack to the rounded band so a too-thin edge segment still rounds.
+            const pillClip = roundStackBaseline && isStackedLayout(barLayout)
+            if (pillClip) {
+                ctx.save()
+                clipToRoundedRects(ctx, computeBandTrackRects(d3Scales, drawLabels, isHorizontal), barCornerRadius)
+            }
             for (const { series: s, bars } of seriesBars) {
                 drawBars(baseDrawCtx, s, bars, barCornerRadius)
+            }
+            if (pillClip) {
+                ctx.restore()
             }
             if (resolvedShadow) {
                 ctx.restore()
@@ -365,8 +445,12 @@ function BarChartInner<Meta = unknown>({
             barLayout,
             isHorizontal,
             topStackedKeyByAxis,
+            stackEdges,
+            roundStackBaseline,
             barCornerRadius,
             barTrack,
+            barTrackColor,
+            theme.gridColor,
             xTickFormatter,
             barShadow,
         ]
@@ -412,6 +496,8 @@ function BarChartInner<Meta = unknown>({
                     isHorizontal,
                     stackedData,
                     topStackedKeyByAxis,
+                    stackEdges,
+                    roundStackBaseline,
                 })
                 if (visible) {
                     const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
@@ -434,6 +520,8 @@ function BarChartInner<Meta = unknown>({
                     isHorizontal,
                     stackedData,
                     topStackedKeyByAxis,
+                    stackEdges,
+                    roundStackBaseline,
                 })) {
                     if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
                         continue
@@ -459,6 +547,9 @@ function BarChartInner<Meta = unknown>({
             }
             ctx.save()
             ctx.globalAlpha = alpha
+            if (roundStackBaseline && stackedHighlight) {
+                clipToRoundedRects(ctx, computeBandTrackRects(d3Scales, drawLabels, isHorizontal), barCornerRadius)
+            }
             for (const { series: s, bar, isTrackHighlight } of items) {
                 if (isTrackHighlight) {
                     const parsed = d3.color(s.color)
@@ -485,7 +576,16 @@ function BarChartInner<Meta = unknown>({
             ctx.restore()
             return true
         },
-        [stackedData, barLayout, isHorizontal, topStackedKeyByAxis, barCornerRadius, barTrack]
+        [
+            stackedData,
+            barLayout,
+            isHorizontal,
+            topStackedKeyByAxis,
+            stackEdges,
+            roundStackBaseline,
+            barCornerRadius,
+            barTrack,
+        ]
     )
 
     // Show each series's own segment value (resolveValue) but anchor the tooltip/value labels
@@ -514,10 +614,11 @@ function BarChartInner<Meta = unknown>({
                     topStackedKeyByAxis,
                     series: seriesRef.current,
                     labels: labelsRef.current,
+                    barTrack,
                 }) ?? clickData
             )
         },
-        [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef]
+        [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef, barTrack]
     )
 
     const chart = (
@@ -576,6 +677,7 @@ export function resolveClickedBarSeries<Meta>({
     topStackedKeyByAxis,
     series,
     labels,
+    barTrack,
 }: {
     clickData: PointClickData<Meta>
     d3Scales: BarScaleSet
@@ -585,6 +687,7 @@ export function resolveClickedBarSeries<Meta>({
     topStackedKeyByAxis: Map<string, string>
     series: Series<Meta>[]
     labels: readonly string[]
+    barTrack: boolean
 }): PointClickData<Meta> | null {
     const { cursor, label, dataIndex, crossSeriesData } = clickData
     if (!cursor) {
@@ -629,6 +732,10 @@ export function resolveClickedBarSeries<Meta>({
         topStackedKeyByAxis,
     })
     if (!visible) {
+        // No filled segment under the cursor — a click in a tracked band's empty remainder.
+        if (barTrack && cursorInBandTrack(d3Scales, label, cursor, isHorizontal)) {
+            return { ...clickData, inTrack: true }
+        }
         return null
     }
     const hit = crossSeriesData.find((d) => d.series.key === visible.series.key)

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.test.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.test.ts
@@ -5,6 +5,7 @@ import { dimensions } from '../../../testing/jsdom'
 import {
     barContainsPoint,
     barContainsPointOnBandAxis,
+    computeStackEdges,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
 } from './bars-under-cursor'
@@ -96,6 +97,41 @@ describe('barContainsPoint', () => {
                 })
             ).toBe(false)
         })
+    })
+})
+
+describe('computeStackEdges', () => {
+    const series = (key: string, data: number[]): Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'> => ({
+        key,
+        data,
+    })
+
+    it('picks the bottommost and topmost non-zero segment per band', () => {
+        const { topKeyAtIndex, bottomKeyAtIndex } = computeStackEdges(
+            [series('value', [100, 55]), series('filler', [0, 45])],
+            2
+        )
+        expect(bottomKeyAtIndex.get('left')).toEqual(['value', 'value'])
+        expect(topKeyAtIndex.get('left')).toEqual(['value', 'filler'])
+    })
+
+    it('skips excluded series and treats zero/non-finite as absent', () => {
+        const excluded: Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'> = {
+            key: 'hidden',
+            data: [10],
+            visibility: { excluded: true },
+        }
+        const { topKeyAtIndex, bottomKeyAtIndex } = computeStackEdges([excluded, series('a', [0]), series('b', [7])], 1)
+        expect(bottomKeyAtIndex.get('left')).toEqual(['b'])
+        expect(topKeyAtIndex.get('left')).toEqual(['b'])
+    })
+
+    it('keys edges by yAxisId', () => {
+        const left: Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'> = { key: 'l', data: [3], yAxisId: 'left' }
+        const right: Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'> = { key: 'r', data: [4], yAxisId: 'right' }
+        const { topKeyAtIndex } = computeStackEdges([left, right], 1)
+        expect(topKeyAtIndex.get('left')).toEqual(['l'])
+        expect(topKeyAtIndex.get('right')).toEqual(['r'])
     })
 })
 

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.test.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.test.ts
@@ -1,6 +1,6 @@
 import type { BarRect } from '../../../core/canvas-renderer'
 import { computeStackData, createBarScales } from '../../../core/scales'
-import type { Series } from '../../../core/types'
+import { DEFAULT_Y_AXIS_ID, type Series } from '../../../core/types'
 import { dimensions } from '../../../testing/jsdom'
 import {
     barContainsPoint,
@@ -111,8 +111,8 @@ describe('computeStackEdges', () => {
             [series('value', [100, 55]), series('filler', [0, 45])],
             2
         )
-        expect(bottomKeyAtIndex.get('left')).toEqual(['value', 'value'])
-        expect(topKeyAtIndex.get('left')).toEqual(['value', 'filler'])
+        expect(bottomKeyAtIndex.get(DEFAULT_Y_AXIS_ID)).toEqual(['value', 'value'])
+        expect(topKeyAtIndex.get(DEFAULT_Y_AXIS_ID)).toEqual(['value', 'filler'])
     })
 
     it('skips excluded series and treats zero/non-finite as absent', () => {
@@ -122,8 +122,8 @@ describe('computeStackEdges', () => {
             visibility: { excluded: true },
         }
         const { topKeyAtIndex, bottomKeyAtIndex } = computeStackEdges([excluded, series('a', [0]), series('b', [7])], 1)
-        expect(bottomKeyAtIndex.get('left')).toEqual(['b'])
-        expect(topKeyAtIndex.get('left')).toEqual(['b'])
+        expect(bottomKeyAtIndex.get(DEFAULT_Y_AXIS_ID)).toEqual(['b'])
+        expect(topKeyAtIndex.get(DEFAULT_Y_AXIS_ID)).toEqual(['b'])
     })
 
     it('keys edges by yAxisId', () => {

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
@@ -10,6 +10,46 @@ export function isStackedLayout(layout: BarLayout): boolean {
     return layout !== 'grouped'
 }
 
+export interface StackEdges {
+    topKeyAtIndex: Map<string, (string | null)[]>
+    bottomKeyAtIndex: Map<string, (string | null)[]>
+}
+
+export function computeStackEdges(
+    series: readonly Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>[],
+    indexCount: number
+): StackEdges {
+    const topKeyAtIndex = new Map<string, (string | null)[]>()
+    const bottomKeyAtIndex = new Map<string, (string | null)[]>()
+    const arrFor = (m: Map<string, (string | null)[]>, axisId: string): (string | null)[] => {
+        let arr = m.get(axisId)
+        if (!arr) {
+            arr = new Array(indexCount).fill(null)
+            m.set(axisId, arr)
+        }
+        return arr
+    }
+    for (const s of series) {
+        if (s.visibility?.excluded) {
+            continue
+        }
+        const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
+        const topArr = arrFor(topKeyAtIndex, axisId)
+        const bottomArr = arrFor(bottomKeyAtIndex, axisId)
+        for (let i = 0; i < indexCount; i++) {
+            const v = s.data[i]
+            if (typeof v !== 'number' || !isFinite(v) || v === 0) {
+                continue
+            }
+            topArr[i] = s.key
+            if (bottomArr[i] == null) {
+                bottomArr[i] = s.key
+            }
+        }
+    }
+    return { topKeyAtIndex, bottomKeyAtIndex }
+}
+
 /** Grouped-layout hit-test that ignores the value axis so a cursor above (or below) a bar still
  *  selects the bar whose band-slot it lines up with. Matches chart.js's `mode: 'point', axis: 'x'`
  *  behaviour — without this, hovering above a short bar in a grouped pair would fail every
@@ -55,6 +95,8 @@ export interface BarsAtCursorArgs {
     isHorizontal: boolean
     stackedData?: Map<string, StackedBand>
     topStackedKeyByAxis: Map<string, string>
+    stackEdges?: StackEdges
+    roundStackBaseline?: boolean
 }
 
 export interface BarAtCursor<S> {
@@ -68,7 +110,8 @@ export interface BarAtCursor<S> {
 export function* iterBarsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>>(
     args: Omit<BarsAtCursorArgs, 'series'> & { series: readonly S[] }
 ): Generator<BarAtCursor<S>> {
-    const { series, label, dataIndex, scales, layout, isHorizontal, stackedData, topStackedKeyByAxis } = args
+    const { series, label, dataIndex, scales, layout, isHorizontal, stackedData, topStackedKeyByAxis, stackEdges } =
+        args
     for (const s of series) {
         if (s.visibility?.excluded) {
             continue
@@ -76,6 +119,13 @@ export function* iterBarsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 
         const stackedBand = stackedData?.get(s.key)
         const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
         const isTopOfStack = topStackedKeyByAxis.get(axisId) === s.key
+        let capRounded: boolean | undefined
+        let baseRounded: boolean | undefined
+        if (stackEdges && isStackedLayout(layout)) {
+            capRounded = stackEdges.topKeyAtIndex.get(axisId)?.[dataIndex] === s.key
+            baseRounded =
+                args.roundStackBaseline === true && stackEdges.bottomKeyAtIndex.get(axisId)?.[dataIndex] === s.key
+        }
         const bar = computeBarAtIndex({
             series: s as unknown as Series,
             label,
@@ -85,6 +135,8 @@ export function* iterBarsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 
             isHorizontal,
             stackedBand,
             isTopOfStack,
+            capRounded,
+            baseRounded,
         })
         if (bar) {
             yield { series: s, bar }

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -103,6 +103,10 @@ export interface PointClickData<Meta = unknown> {
     /** Cursor position in pixels relative to the chart wrapper at click time, or `null`
      *  when unavailable. Same origin as `TooltipContext.hoverPosition`. */
     cursor: { x: number; y: number } | null
+    /** True when the click landed in the empty `track` region past the filled bar rather than on a
+     *  segment — funnel charts route this to the drop-off remainder. Only set when a track is drawn;
+     *  `series`/`dataIndex` still reference the clicked band. */
+    inTrack?: boolean
 }
 
 /** Context object passed to the `renderTooltip` render prop and tooltip event callbacks. */
@@ -209,14 +213,16 @@ export interface TooltipConfig {
 /** Bar appearance + band-layout details. Grouped under {@link BarChartConfig.bars} to keep the
  *  config flat at the top level. `barLayout` stays top-level as the primary discriminator. */
 export interface BarsConfig {
-    /** Corner radius in px for the rounded end(s) of a bar. Stacked bars only round the topmost
-     *  segment. Defaults to 0 (square). */
+    /** Corner radius in px for the rounded end(s) of a bar. Defaults to 0 (square). */
     cornerRadius?: number
-    /** Draw a faint hatched track behind each bar, spanning the full plot height — for
-     *  funnel-style charts where every bar is a share of a whole. Only honored when
-     *  `barLayout: 'grouped'`; ignored for stacked/percent (the "share of a whole"
-     *  semantics don't apply when bars share a band). Defaults to `false`. */
-    track?: boolean
+    /** How `cornerRadius` applies to a stack. `cap` (default) rounds only the topmost segment's far
+     *  end; `pill` rounds the whole stack both ends, resolved per band (funnel-style — a 100% single
+     *  segment still rounds both); `none` forces square corners regardless of `cornerRadius`. */
+    rounding?: 'cap' | 'pill' | 'none'
+    /** Track behind each bar spanning the full value axis, for "share of a whole" charts. `true`
+     *  uses a default colour, `{ color }` overrides it. Grouped draws a per-series tinted+hatched
+     *  track per sub-band slot; stacked/percent draws one neutral track per band. Defaults to none. */
+    track?: boolean | { color?: string }
     /** Drop shadow under each bar so it reads as layered over a `track`. */
     shadow?: boolean | { color: string; blur: number; offsetX?: number; offsetY?: number }
     /** Stacked layout only — use d3.stackOffsetDiverging so negative values stack below the zero

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -18,9 +18,9 @@ import { StepDecorations } from './StepDecorations'
 
 const ROW_HEIGHT_PX = 76
 const BAR_PADDING = 0.6
-const GLYPH_COLUMN_WIDTH_PX = 24
+const GLYPH_COLUMN_WIDTH_PX = 40
 
-function getFillerColor(): string {
+function getTrackColor(): string {
     if (typeof document === 'undefined') {
         return 'rgba(0, 0, 0, 0.08)'
     }
@@ -40,7 +40,7 @@ export function FunnelBarHorizontalChart({
 }: ChartParams): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
-    const fillerColor = useMemo(() => getFillerColor(), [isDarkModeOn])
+    const trackColor = useMemo(() => getTrackColor(), [isDarkModeOn])
 
     const { insightProps } = useValues(insightLogic)
     const {
@@ -70,37 +70,37 @@ export function FunnelBarHorizontalChart({
                 breakdownFilter,
                 getColor: getFunnelsColor,
                 getLabel: (variant) => String(variant.breakdown_value ?? variant.name ?? ''),
-                fillerColor,
             }),
-        [steps, stepReference, breakdownFilter, getFunnelsColor, fillerColor]
+        [steps, stepReference, breakdownFilter, getFunnelsColor]
     )
 
     const chartConfig = useMemo<BarChartConfig>(
         () => ({
             barLayout: 'stacked',
-            bars: { cornerRadius: 4, bandPadding: BAR_PADDING },
+            bars: { cornerRadius: 6, rounding: 'pill', track: { color: trackColor }, bandPadding: BAR_PADDING },
             axisOrientation: 'horizontal',
             hideXAxis: true,
             hideYAxis: true,
             showGrid: false,
             animateHover: true,
             margins: { top: 0, right: 0, bottom: 0, left: GLYPH_COLUMN_WIDTH_PX },
-            tooltip: { placement: 'top' },
+            tooltip: { placement: 'cursor' },
         }),
-        []
+        [trackColor]
     )
 
     const onPointClick = (clickData: PointClickData<FunnelBarHorizontalSegmentMeta>): void => {
-        const meta = clickData.series.meta
         const step = steps[clickData.dataIndex]
-        if (!step || !meta) {
+        if (!step) {
             return
         }
-        if (meta.isDropOff) {
+        // A click in the empty track region is the drop-off remainder.
+        if (clickData.inTrack) {
             openPersonsModalForStep({ step, converted: false })
             return
         }
-        if (meta.breakdownIndex != null && step.nested_breakdown?.[meta.breakdownIndex]) {
+        const meta = clickData.series.meta
+        if (meta?.breakdownIndex != null && step.nested_breakdown?.[meta.breakdownIndex]) {
             openPersonsModalForSeries({
                 step,
                 series: step.nested_breakdown[meta.breakdownIndex],

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useMemo, type ErrorInfo } from 'react'
+import { useCallback, useMemo, useState, type ErrorInfo } from 'react'
 
 import { buildTheme } from 'lib/charts/utils/theme'
 import { BarChart, type BarChartConfig, type PointClickData, type TooltipContext } from 'lib/hog-charts'
@@ -16,8 +16,11 @@ import { FunnelBarHorizontalTooltip } from './FunnelBarHorizontalTooltip'
 import { buildFunnelBarHorizontalData, type FunnelBarHorizontalSegmentMeta } from './funnelBarHorizontalTransforms'
 import { StepDecorations } from './StepDecorations'
 
-const ROW_HEIGHT_PX = 76
-const BAR_PADDING = 0.6
+// Each row is `gap + bar + gap`. The bar keeps a constant thickness; the gaps grow to fit the
+// step's header/footer text (which wraps to more lines as the chart narrows), so rows never overlap.
+const MIN_GAP_PX = 28
+const GAP_BREATHING_PX = 10
+const BAR_THICKNESS_PX = 30
 const GLYPH_COLUMN_WIDTH_PX = 40
 
 function getTrackColor(): string {
@@ -63,6 +66,15 @@ export function FunnelBarHorizontalChart({
     const hasOptionalSteps = steps.some((_, stepIndex) => isStepOptional(stepIndex + 1))
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural
 
+    const [measuredGapPx, setMeasuredGapPx] = useState<number | null>(null)
+    const gapPx = Math.max(MIN_GAP_PX, (measuredGapPx ?? 0) + GAP_BREATHING_PX)
+    const rowHeightPx = 2 * gapPx + BAR_THICKNESS_PX
+    const bandPadding = (2 * gapPx) / rowHeightPx
+    const gapFraction = gapPx / rowHeightPx
+    const handleMeasureGap = useCallback((px: number): void => {
+        setMeasuredGapPx((prev) => (prev != null && Math.abs(prev - px) < 0.5 ? prev : px))
+    }, [])
+
     const { series, labels } = useMemo(
         () =>
             buildFunnelBarHorizontalData(steps, {
@@ -77,7 +89,7 @@ export function FunnelBarHorizontalChart({
     const chartConfig = useMemo<BarChartConfig>(
         () => ({
             barLayout: 'stacked',
-            bars: { cornerRadius: 6, rounding: 'pill', track: { color: trackColor }, bandPadding: BAR_PADDING },
+            bars: { cornerRadius: 6, rounding: 'pill', track: { color: trackColor }, bandPadding },
             axisOrientation: 'horizontal',
             hideXAxis: true,
             hideYAxis: true,
@@ -86,7 +98,7 @@ export function FunnelBarHorizontalChart({
             margins: { top: 0, right: 0, bottom: 0, left: GLYPH_COLUMN_WIDTH_PX },
             tooltip: { placement: 'cursor' },
         }),
-        [trackColor]
+        [trackColor, bandPadding]
     )
 
     const onPointClick = (clickData: PointClickData<FunnelBarHorizontalSegmentMeta>): void => {
@@ -126,9 +138,9 @@ export function FunnelBarHorizontalChart({
     }
 
     return (
-        <div data-attr="funnel-bar-horizontal" className="w-full p-4">
+        <div data-attr="funnel-bar-horizontal" className="w-full px-1 py-4">
             {/* eslint-disable-next-line react/forbid-dom-props */}
-            <div className="relative flex w-full" style={{ height: steps.length * ROW_HEIGHT_PX }}>
+            <div className="relative flex w-full" style={{ height: steps.length * rowHeightPx }}>
                 <BarChart<FunnelBarHorizontalSegmentMeta>
                     series={series}
                     labels={labels}
@@ -146,7 +158,8 @@ export function FunnelBarHorizontalChart({
                         hasOptionalSteps={hasOptionalSteps}
                         showPersonsModal={showPersonsModal}
                         openPersonsModalForStep={openPersonsModalForStep}
-                        gapFraction={BAR_PADDING / 2}
+                        gapFraction={gapFraction}
+                        onMeasureGap={handleMeasureGap}
                     />
                 </BarChart>
             </div>

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/StepDecorations.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/StepDecorations.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/forbid-dom-props */
 import clsx from 'clsx'
+import { useLayoutEffect, useRef } from 'react'
 
 import { IconInfinity } from '@posthog/icons'
 
@@ -39,6 +40,8 @@ interface StepDecorationsProps {
     openPersonsModalForStep: (args: { step: FunnelStepWithConversionMetrics; converted: boolean }) => void
     /** Fraction of each band reserved for gap. Header and metadata rows each occupy half this gap. */
     gapFraction: number
+    /** Reports the tallest header/footer content (px) so the parent can grow rows to fit wrapped text. */
+    onMeasureGap?: (gapPx: number) => void
 }
 
 export function StepDecorations({
@@ -50,10 +53,37 @@ export function StepDecorations({
     showPersonsModal,
     openPersonsModalForStep,
     gapFraction,
+    onMeasureGap,
 }: StepDecorationsProps): JSX.Element {
     const layout = useChartLayout<FunnelBarHorizontalSegmentMeta>()
     const { plotTop, plotLeft, plotHeight, plotWidth } = layout.dimensions
     const rowHeight = steps.length > 0 ? plotHeight / steps.length : 0
+
+    // The measured divs flow at natural height inside their fixed-height slots, so their offsetHeight
+    // is the unconstrained content height — the max drives the parent's row height. Wrapping depends
+    // only on plotWidth, so this converges in a single pass and never loops.
+    const slotRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+    const setSlotRef =
+        (key: string) =>
+        (el: HTMLDivElement | null): void => {
+            if (el) {
+                slotRefs.current.set(key, el)
+            } else {
+                slotRefs.current.delete(key)
+            }
+        }
+    useLayoutEffect(() => {
+        if (!onMeasureGap || plotWidth <= 0) {
+            return
+        }
+        let tallest = 0
+        for (const el of slotRefs.current.values()) {
+            tallest = Math.max(tallest, el.offsetHeight)
+        }
+        if (tallest > 0) {
+            onMeasureGap(tallest)
+        }
+    }, [onMeasureGap, plotWidth, steps])
 
     return (
         <>
@@ -119,31 +149,36 @@ export function StepDecorations({
                                 width: plotWidth,
                                 height: gapHeight,
                             }}
-                            className={clsx('flex flex-wrap items-center justify-between leading-5', dimRow)}
+                            className={clsx('flex items-center', dimRow)}
                         >
-                            <div className="flex items-center max-w-full grow">
-                                <div className="overflow-hidden font-bold break-words whitespace-normal">
-                                    {isUnordered ? (
-                                        <span>Completed {step.order + 1} steps</span>
-                                    ) : (
-                                        <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} allowWrap />
-                                    )}
+                            <div
+                                ref={setSlotRef(`${stepIndex}-header`)}
+                                className="flex w-full flex-wrap items-center justify-between leading-5"
+                            >
+                                <div className="flex items-center max-w-full grow">
+                                    <div className="overflow-hidden font-bold break-words whitespace-normal">
+                                        {isUnordered ? (
+                                            <span>Completed {step.order + 1} steps</span>
+                                        ) : (
+                                            <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} allowWrap />
+                                        )}
+                                    </div>
+                                    {isOptional ? <div className="ml-1 text-xs">(optional)</div> : null}
+                                    {!isUnordered &&
+                                        stepIndex > 0 &&
+                                        step.action_id === steps[stepIndex - 1].action_id && <DuplicateStepIndicator />}
+                                    <FunnelStepMore stepIndex={stepIndex} />
                                 </div>
-                                {isOptional ? <div className="ml-1 text-xs">(optional)</div> : null}
-                                {!isUnordered && stepIndex > 0 && step.action_id === steps[stepIndex - 1].action_id && (
-                                    <DuplicateStepIndicator />
-                                )}
-                                <FunnelStepMore stepIndex={stepIndex} />
+                                {step.average_conversion_time && step.average_conversion_time >= Number.EPSILON ? (
+                                    <div
+                                        className="text-secondary text-xs"
+                                        title="Average time of conversion from previous step"
+                                    >
+                                        Avg time:{' '}
+                                        <b>{humanFriendlyDuration(step.average_conversion_time, { maxUnits: 2 })}</b>
+                                    </div>
+                                ) : null}
                             </div>
-                            {step.average_conversion_time && step.average_conversion_time >= Number.EPSILON ? (
-                                <div
-                                    className="text-secondary text-xs"
-                                    title="Average time of conversion from previous step"
-                                >
-                                    Avg time:{' '}
-                                    <b>{humanFriendlyDuration(step.average_conversion_time, { maxUnits: 2 })}</b>
-                                </div>
-                            ) : null}
                         </header>
 
                         <div
@@ -154,54 +189,63 @@ export function StepDecorations({
                                 width: plotWidth,
                                 height: gapHeight,
                             }}
-                            className={clsx('flex flex-wrap items-center gap-2 leading-5', dimRow)}
+                            className={clsx('flex items-center', dimRow)}
                         >
-                            <Tooltip
-                                title={getTooltipTitleForConverted(funnelsFilter, aggregationTargetLabel, stepIndex)}
-                                placement="bottom"
+                            <div
+                                ref={setSlotRef(`${stepIndex}-footer`)}
+                                className="flex w-full flex-wrap items-center gap-2 leading-5"
                             >
-                                <ValueInspectorButton
-                                    onClick={
-                                        showPersonsModal
-                                            ? () => openPersonsModalForStep({ step, converted: true })
-                                            : undefined
-                                    }
-                                >
-                                    <IconTrendingFlat
-                                        style={{ color: 'var(--success)' }}
-                                        className="mr-1 text-xl align-bottom"
-                                    />
-                                    <b>{formatConvertedCount(step, aggregationTargetLabel)}</b>
-                                </ValueInspectorButton>{' '}
-                                {!isFirstStep && (
-                                    <span className="text-secondary grow">
-                                        {`(${formatConvertedPercentage(step)}) completed step`}
-                                    </span>
-                                )}
-                            </Tooltip>
-                            {!isFirstStep && (
                                 <Tooltip
-                                    title={getTooltipTitleForDroppedOff(funnelsFilter, aggregationTargetLabel)}
+                                    title={getTooltipTitleForConverted(
+                                        funnelsFilter,
+                                        aggregationTargetLabel,
+                                        stepIndex
+                                    )}
                                     placement="bottom"
                                 >
                                     <ValueInspectorButton
                                         onClick={
                                             showPersonsModal
-                                                ? () => openPersonsModalForStep({ step, converted: false })
+                                                ? () => openPersonsModalForStep({ step, converted: true })
                                                 : undefined
                                         }
                                     >
-                                        <IconTrendingFlatDown
-                                            style={{ color: 'var(--danger)' }}
+                                        <IconTrendingFlat
+                                            style={{ color: 'var(--success)' }}
                                             className="mr-1 text-xl align-bottom"
                                         />
-                                        <b>{formatDroppedOffCount(step, aggregationTargetLabel)}</b>
+                                        <b>{formatConvertedCount(step, aggregationTargetLabel)}</b>
                                     </ValueInspectorButton>{' '}
-                                    <span className="text-secondary">
-                                        {`(${formatDroppedOffPercentage(step)}) dropped off`}
-                                    </span>
+                                    {!isFirstStep && (
+                                        <span className="text-secondary grow">
+                                            {`(${formatConvertedPercentage(step)}) completed step`}
+                                        </span>
+                                    )}
                                 </Tooltip>
-                            )}
+                                {!isFirstStep && (
+                                    <Tooltip
+                                        title={getTooltipTitleForDroppedOff(funnelsFilter, aggregationTargetLabel)}
+                                        placement="bottom"
+                                    >
+                                        <ValueInspectorButton
+                                            onClick={
+                                                showPersonsModal
+                                                    ? () => openPersonsModalForStep({ step, converted: false })
+                                                    : undefined
+                                            }
+                                        >
+                                            <IconTrendingFlatDown
+                                                style={{ color: 'var(--danger)' }}
+                                                className="mr-1 text-xl align-bottom"
+                                            />
+                                            <b>{formatDroppedOffCount(step, aggregationTargetLabel)}</b>
+                                        </ValueInspectorButton>{' '}
+                                        <span className="text-secondary">
+                                            {`(${formatDroppedOffPercentage(step)}) dropped off`}
+                                        </span>
+                                    </Tooltip>
+                                )}
+                            </div>
                         </div>
                     </div>
                 )

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
@@ -1,10 +1,6 @@
 import { EntityTypes, FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
 
-import {
-    buildFunnelBarHorizontalData,
-    FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
-    FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX,
-} from './funnelBarHorizontalTransforms'
+import { buildFunnelBarHorizontalData, FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX } from './funnelBarHorizontalTransforms'
 
 type StepOverrides = Partial<FunnelStepWithConversionMetrics> & {
     fromBasisStep: number
@@ -42,7 +38,6 @@ const options = {
     stepReference: FunnelStepReference.total,
     getColor: () => '#1d4aff',
     getLabel: (variant: FunnelStepWithConversionMetrics) => String(variant.breakdown_value ?? variant.name),
-    fillerColor: '#eef0f3',
 }
 
 describe('buildFunnelBarHorizontalData', () => {
@@ -67,32 +62,24 @@ describe('buildFunnelBarHorizontalData', () => {
             makeStep({ count: 20, fromBasisStep: 0.2, name: 'Purchased' }),
         ]
 
-        it('emits one segment series + one filler series, each with one value per step', () => {
+        it('emits a single value series with one percentage per step (remainder is the chart track)', () => {
             const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, options)
 
-            expect(series).toHaveLength(2)
+            expect(series).toHaveLength(1)
             expect(series[0].data).toEqual([100, 50, 20])
-            expect(series[1].data).toEqual([0, 50, 80])
         })
 
-        it('tags each series with its drop-off / breakdown role for click + tooltip routing', () => {
+        it('tags the segment with a null breakdownIndex for click + tooltip routing', () => {
             const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, options)
 
-            expect(series[0].meta).toEqual({ isDropOff: false, breakdownIndex: null })
-            expect(series[1].meta).toEqual({ isDropOff: true, breakdownIndex: null })
+            expect(series[0].meta).toEqual({ breakdownIndex: null })
         })
 
-        it('hides the filler from the tooltip so it doesn’t double up with FunnelTooltip’s drop-off section', () => {
-            const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, options)
-            expect(series[1].visibility?.tooltip).toBe(false)
-        })
-
-        it('colors the segment from the representative step and the filler from options.fillerColor', () => {
+        it('colors the segment from the representative step', () => {
             const getColor = jest.fn(() => '#abcabc')
             const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, { ...options, getColor })
 
             expect(series[0].color).toBe('#abcabc')
-            expect(series[1].color).toBe(options.fillerColor)
             expect(getColor).toHaveBeenCalledWith(noBreakdownSteps[0])
         })
     })
@@ -117,24 +104,23 @@ describe('buildFunnelBarHorizontalData', () => {
             }),
         ]
 
-        it('emits one series per variant plus the trailing filler', () => {
+        it('emits one series per variant', () => {
             const { series } = buildFunnelBarHorizontalData(breakdownSteps, options)
 
-            expect(series).toHaveLength(3)
-            expect(series.map((s) => s.label)).toEqual(['mobile', 'desktop', 'Drop-off'])
+            expect(series).toHaveLength(2)
+            expect(series.map((s) => s.label)).toEqual(['mobile', 'desktop'])
         })
 
         it('builds per-step fractions per variant against the configured basis step', () => {
             const { series } = buildFunnelBarHorizontalData(breakdownSteps, options)
             expect(series[0].data).toEqual([60, 30])
             expect(series[1].data).toEqual([40, 10])
-            expect(series[2].data).toEqual([0, 60])
         })
 
         it('tags each segment with its source breakdownIndex', () => {
             const { series } = buildFunnelBarHorizontalData(breakdownSteps, options)
-            expect(series[0].meta).toEqual({ isDropOff: false, breakdownIndex: 0 })
-            expect(series[1].meta).toEqual({ isDropOff: false, breakdownIndex: 1 })
+            expect(series[0].meta).toEqual({ breakdownIndex: 0 })
+            expect(series[1].meta).toEqual({ breakdownIndex: 1 })
         })
 
         it('zeros a missing variant at a later step rather than rolling its count into another bar', () => {
@@ -155,10 +141,9 @@ describe('buildFunnelBarHorizontalData', () => {
             ]
 
             const { series } = buildFunnelBarHorizontalData(skewed, options)
-            expect(series).toHaveLength(3)
+            expect(series).toHaveLength(2)
             expect(series[0].data).toEqual([60, 50]) // mobile
             expect(series[1].data).toEqual([40, 0]) // desktop — missing in step 1
-            expect(series[2].data).toEqual([0, 50]) // filler
         })
     })
 
@@ -177,14 +162,13 @@ describe('buildFunnelBarHorizontalData', () => {
         ]
         const breakdownFilter = { breakdown: '$browser' }
 
-        it('collapses to one segment + filler, sourced from the single visible variant', () => {
+        it('collapses to one segment sourced from the single visible variant', () => {
             const { series } = buildFunnelBarHorizontalData(collapsedSteps, { ...options, breakdownFilter })
 
-            expect(series).toHaveLength(2)
+            expect(series).toHaveLength(1)
             expect(series[0].label).toBe('mobile')
             expect(series[0].data).toEqual([100, 50])
             expect(series[0].meta?.breakdownIndex).toBe(0)
-            expect(series[1].data).toEqual([0, 50])
         })
 
         it('falls back to the parent step’s rate when no breakdownFilter is set', () => {
@@ -236,7 +220,7 @@ describe('buildFunnelBarHorizontalData', () => {
     })
 
     describe('zero-basis-count step', () => {
-        it('emits a zero segment + full filler when basisStep.count is 0', () => {
+        it('emits zero-width segments when basisStep.count is 0 (the track fills the row)', () => {
             const steps = [
                 makeStep({
                     count: 0,
@@ -261,7 +245,6 @@ describe('buildFunnelBarHorizontalData', () => {
             expect(series.map((s) => s.data)).toEqual([
                 [0, 0],
                 [0, 0],
-                [100, 100],
             ])
         })
     })
@@ -290,7 +273,6 @@ describe('buildFunnelBarHorizontalData', () => {
             expect(series.map((s) => s.key)).toEqual([
                 `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}0`,
                 `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}1`,
-                FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
             ])
         })
     })

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
@@ -5,12 +5,10 @@ import type { BreakdownFilter } from '~/queries/schema/schema-general'
 import { FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
 
 export const FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX = 'funnel-bar-horizontal-segment-'
-export const FUNNEL_BAR_HORIZONTAL_FILLER_KEY = 'funnel-bar-horizontal-filler'
 
 const RATE_TO_PERCENT = 100
 
 export interface FunnelBarHorizontalSegmentMeta {
-    isDropOff: boolean
     breakdownIndex: number | null
 }
 
@@ -24,7 +22,6 @@ interface BuildOptions {
     breakdownFilter?: BreakdownFilter | null
     getColor: (series: FunnelStepWithConversionMetrics) => string
     getLabel: (series: FunnelStepWithConversionMetrics) => string
-    fillerColor: string
 }
 
 function isBreakdownLayout(steps: FunnelStepWithConversionMetrics[]): boolean {
@@ -79,11 +76,10 @@ function buildBreakdownSeries(
             label: options.getLabel(representative),
             data: fractions.map((f) => f * RATE_TO_PERCENT),
             color: options.getColor(representative),
-            meta: { isDropOff: false, breakdownIndex },
+            meta: { breakdownIndex },
         })
     }
 
-    series.push(buildFiller(steps, series, options.fillerColor))
     return series
 }
 
@@ -101,27 +97,8 @@ function buildSingleSeries(
         label: options.getLabel(representative),
         data: fractions.map((f) => f * RATE_TO_PERCENT),
         color: options.getColor(representative),
-        meta: { isDropOff: false, breakdownIndex: isSingleBreakdownCollapse ? 0 : null },
+        meta: { breakdownIndex: isSingleBreakdownCollapse ? 0 : null },
     }
 
-    return [segment, buildFiller(steps, [segment], options.fillerColor)]
-}
-
-function buildFiller(
-    steps: FunnelStepWithConversionMetrics[],
-    segments: Series<FunnelBarHorizontalSegmentMeta>[],
-    color: string
-): Series<FunnelBarHorizontalSegmentMeta> {
-    const fillerData = steps.map((_, stepIndex) => {
-        const covered = segments.reduce((sum, s) => sum + (s.data[stepIndex] ?? 0), 0)
-        return Math.max(0, RATE_TO_PERCENT - covered)
-    })
-    return {
-        key: FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
-        label: 'Drop-off',
-        data: fillerData,
-        color,
-        visibility: { tooltip: false },
-        meta: { isDropOff: true, breakdownIndex: null },
-    }
+    return [segment]
 }


### PR DESCRIPTION
## Problem

The hog-charts "top to bottom" (horizontal) funnel looked a bit messy.

## Changes

Just tidies this version of the funnels chart

<img width="931" height="521" alt="Screenshot 2026-06-01 at 09 23 32" src="https://github.com/user-attachments/assets/7c304f08-d3aa-47b3-b60e-6a427462bfaa" />

## How did you test this code?

locally + Added tests for the new logic: `cornersFor` baseline rounding, `computeStackEdges`, the per-band funnel rounding, the `findVisibleStackedSegment` overlap clipping, and `inTrack` click routing. Chart rendering (curves, track, cursor tooltip, breakdown corners) was checked visually in Storybook.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Key decisions:
- For the growing bar config surface, grouped the options under a `bars` object (chosen by the author over keeping flat keys or a single "share of whole" preset).
- Replaced the funnel's filler-series with the native track instead of keeping a fake segment — this removed the rounding workaround and a hover-highlight bug class, both of which traced back to the phantom segment.

Split from the original combined PR so the canvas/library changes review separately from the overlay polish (#60764). Agent-assisted; requires human review.
