### PR TITLE
feat(quill): add composable Table primitive

### DIFF
--- a/packages/quill/apps/storybook/.storybook/storybook.css
+++ b/packages/quill/apps/storybook/.storybook/storybook.css
@@ -48,6 +48,15 @@
 @import '../../../packages/primitives/src/styles/layers.css';
 
 /*
+ * Primitive BEM styles, from the built package. Components stories (e.g.
+ * DataTable) import primitives via `@posthog/quill-primitives`, whose JS does
+ * NOT inject CSS — so without this they render with classnames but no styles.
+ * The primitives' OWN stories import from source and still hot-reload their BEM;
+ * this only backstops cross-package consumers. Rebuild primitives to refresh.
+ */
+@import '../../../packages/primitives/dist/quill-primitives.css';
+
+/*
  * Scan sources, not dist. Vite HMR forwards any .tsx change in these
  * trees to Tailwind's scanner and we get new utilities emitted on the
  * next tick.

--- a/packages/quill/packages/blocks/package.json
+++ b/packages/quill/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-blocks",
-    "version": "0.3.0-beta.11",
+    "version": "0.3.0-beta.12",
     "private": true,
     "description": "Internal workspace package (private, not published). The highest layer of the quill design system — product-level patterns made of components + primitives (e.g. a PageHeader with title + breadcrumb + action slot, an EmptyState with icon + copy + CTA, a CommandPalette, a user-menu dropdown). Opinionated and shape-stable across products so they feel consistent. Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/blocks/package.json
+++ b/packages/quill/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-blocks",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "private": true,
     "description": "Internal workspace package (private, not published). The highest layer of the quill design system — product-level patterns made of components + primitives (e.g. a PageHeader with title + breadcrumb + action slot, an EmptyState with icon + copy + CTA, a CommandPalette, a user-menu dropdown). Opinionated and shape-stable across products so they feel consistent. Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/package.json
+++ b/packages/quill/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-components",
-    "version": "0.3.0-beta.11",
+    "version": "0.3.0-beta.12",
     "private": true,
     "description": "Internal workspace package (private, not published). The middle layer of the quill design system — higher-level compositions of primitives that wire several of them together with sensible defaults (e.g. a FormField that composes Label + Input + validation state, or a ConfirmDialog that composes Dialog + Button + destructive variant). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/package.json
+++ b/packages/quill/packages/components/package.json
@@ -36,8 +36,11 @@
         "lucide-react": "^0.577.0"
     },
     "devDependencies": {
+        "@storybook/react": "catalog:",
         "@tailwindcss/vite": "^4.1.17",
         "@tanstack/react-table": "^8.21.3",
+        "@types/react": "catalog:",
+        "@types/react-dom": "catalog:",
         "@vitejs/plugin-react": "^5.1.1",
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4"

--- a/packages/quill/packages/components/package.json
+++ b/packages/quill/packages/components/package.json
@@ -37,6 +37,7 @@
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.1.17",
+        "@tanstack/react-table": "^8.21.3",
         "@vitejs/plugin-react": "^5.1.1",
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4"

--- a/packages/quill/packages/components/package.json
+++ b/packages/quill/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-components",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "private": true,
     "description": "Internal workspace package (private, not published). The middle layer of the quill design system — higher-level compositions of primitives that wire several of them together with sensible defaults (e.g. a FormField that composes Label + Input + validation state, or a ConfirmDialog that composes Dialog + Button + destructive variant). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/src/data-table.stories.tsx
+++ b/packages/quill/packages/components/src/data-table.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { type ColumnDef } from '@tanstack/react-table'
+import * as React from 'react'
+
+import { Badge } from '@posthog/quill-primitives'
+
+import { DataTable } from './data-table'
+
+interface Person {
+    id: string
+    name: string
+    email: string
+    role: string
+    signups: number
+    status: 'Active' | 'Invited'
+}
+
+const people: Person[] = Array.from({ length: 8 }, (_, i) => ({
+    id: `USR-${i + 1}`,
+    name: ['Ava', 'Ben', 'Cara', 'Dan', 'Eve', 'Finn', 'Gia', 'Hugo'][i],
+    email: `${['ava', 'ben', 'cara', 'dan', 'eve', 'finn', 'gia', 'hugo'][i]}@example.com`,
+    role: i % 3 === 0 ? 'Admin' : 'Member',
+    signups: [42, 17, 88, 5, 63, 29, 71, 13][i],
+    status: i % 4 === 0 ? 'Invited' : 'Active',
+}))
+
+const columns: ColumnDef<Person>[] = [
+    {
+        accessorKey: 'name',
+        header: 'Name',
+        cell: (info) => <span className="font-medium">{info.getValue<string>()}</span>,
+    },
+    { accessorKey: 'email', header: 'Email' },
+    { accessorKey: 'role', header: 'Role' },
+    {
+        accessorKey: 'signups',
+        header: 'Signups',
+        cell: (info) => <span className="tabular-nums">{info.getValue<number>()}</span>,
+    },
+    {
+        accessorKey: 'status',
+        header: 'Status',
+        enableSorting: false,
+        cell: (info) => <Badge>{info.getValue<string>()}</Badge>,
+    },
+]
+
+const meta = {
+    title: 'Components/DataTable',
+    tags: ['autodocs'],
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Click a sortable header (Name, Email, Role, Signups) to toggle asc → desc → off.
+export const Default: Story = {
+    render: () => (
+        <>
+            <p className="mb-4 text-sm text-muted-foreground">
+                Built with <a className="text-primary underline" href="https://tanstack.com/table/latest/docs/framework/react/guides/getting-started" target="_blank">TanStack Table</a> and quill primitives.
+            </p>
+            <DataTable columns={columns} data={people} className="max-w-2xl rounded-md border border-[var(--border)]" />
+        </>
+    ),
+}
+
+const manyPeople: Person[] = Array.from({ length: 50 }, (_, i) => ({
+    id: `USR-${i + 1}`,
+    name: `Person ${i + 1}`,
+    email: `person${i + 1}@example.com`,
+    role: i % 3 === 0 ? 'Admin' : 'Member',
+    signups: (i * 37) % 100,
+    status: i % 4 === 0 ? 'Invited' : 'Active',
+}))
+
+export const StickyHeader: Story = {
+    render: () => (
+        <DataTable
+            columns={columns}
+            data={manyPeople}
+            stickyHeader
+            className="h-72 max-w-2xl rounded-md border border-[var(--border)]"
+        />
+    ),
+}
+
+export const Empty: Story = {
+    render: () => (
+        <DataTable columns={columns} data={[]} className="max-w-2xl rounded-md border border-[var(--border)]" />
+    ),
+}

--- a/packages/quill/packages/components/src/data-table.stories.tsx
+++ b/packages/quill/packages/components/src/data-table.stories.tsx
@@ -2,7 +2,18 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { type ColumnDef } from '@tanstack/react-table'
 import * as React from 'react'
 
-import { Badge } from '@posthog/quill-primitives'
+import { FolderPlus } from 'lucide-react'
+
+import {
+    Badge,
+    Button,
+    Empty as QuillEmpty,
+    EmptyContent,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from '@posthog/quill-primitives'
 
 import { DataTable } from './data-table'
 
@@ -95,8 +106,35 @@ export const StickyHeader: Story = {
     ),
 }
 
+// Default empty state — minimal and generic.
 export const Empty: Story = {
     render: () => (
         <DataTable columns={columns} data={[]} className="max-w-2xl rounded-md border border-[var(--border)]" />
+    ),
+}
+
+// Override the empty slot with app-specific copy and actions.
+export const EmptyCustom: Story = {
+    render: () => (
+        <DataTable
+            columns={columns}
+            data={[]}
+            className="max-w-2xl rounded-md border border-[var(--border)]"
+            empty={
+                <QuillEmpty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <FolderPlus />
+                        </EmptyMedia>
+                        <EmptyTitle>No projects yet</EmptyTitle>
+                        <EmptyDescription>Get started by creating or importing a project.</EmptyDescription>
+                    </EmptyHeader>
+                    <EmptyContent className="flex-row justify-center gap-2">
+                        <Button variant="primary">Create project</Button>
+                        <Button variant="outline">Import</Button>
+                    </EmptyContent>
+                </QuillEmpty>
+            }
+        />
     ),
 }

--- a/packages/quill/packages/components/src/data-table.stories.tsx
+++ b/packages/quill/packages/components/src/data-table.stories.tsx
@@ -35,6 +35,13 @@ const people: Person[] = Array.from({ length: 8 }, (_, i) => ({
     status: i % 4 === 0 ? 'Invited' : 'Active',
 }))
 
+// Active users read as success, pending invites as warning — same semantic
+// mapping the Table primitive's Status column uses.
+function StatusBadge({ status }: { status: string }): React.ReactElement {
+    const variant = status === 'Active' ? 'success' : status === 'Invited' ? 'warning' : 'destructive'
+    return <Badge variant={variant}>{status}</Badge>
+}
+
 const columns: ColumnDef<Person>[] = [
     {
         accessorKey: 'name',
@@ -52,7 +59,7 @@ const columns: ColumnDef<Person>[] = [
         accessorKey: 'status',
         header: 'Status',
         enableSorting: false,
-        cell: (info) => <Badge>{info.getValue<string>()}</Badge>,
+        cell: (info) => <StatusBadge status={info.getValue<string>()} />,
     },
 ]
 

--- a/packages/quill/packages/components/src/data-table.stories.tsx
+++ b/packages/quill/packages/components/src/data-table.stories.tsx
@@ -58,7 +58,17 @@ export const Default: Story = {
     render: () => (
         <>
             <p className="mb-4 text-sm text-muted-foreground">
-                Built with <a className="text-primary underline" href="https://tanstack.com/table/latest/docs/framework/react/guides/getting-started" target="_blank">TanStack Table</a> and quill primitives.
+                Built with{' '}
+                {/* eslint-disable-next-line react/forbid-elements -- plain link in a storybook demo */}
+                <a
+                    className="text-primary underline"
+                    href="https://tanstack.com/table/latest/docs/framework/react/guides/getting-started"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    TanStack Table
+                </a>{' '}
+                and quill primitives.
             </p>
             <DataTable columns={columns} data={people} className="max-w-2xl rounded-md border border-[var(--border)]" />
         </>

--- a/packages/quill/packages/components/src/data-table.tsx
+++ b/packages/quill/packages/components/src/data-table.tsx
@@ -6,10 +6,10 @@ import {
     getSortedRowModel,
     useReactTable,
 } from '@tanstack/react-table'
-import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react'
+import { ArrowDown, ArrowUp, ChevronsUpDown, Inbox } from 'lucide-react'
 import * as React from 'react'
 
-import { Button, cn, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@posthog/quill-primitives'
+import { Button, cn, Empty, EmptyHeader, EmptyMedia, EmptyTitle, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@posthog/quill-primitives'
 
 export interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[]
@@ -18,12 +18,29 @@ export interface DataTableProps<TData, TValue> {
     className?: string
     /** Sticky header mode, forwarded to the Table primitive. `'page'` sticks to document scroll. */
     stickyHeader?: boolean | 'page'
-    /** Shown in place of rows when `data` is empty. */
-    emptyMessage?: React.ReactNode
+    /**
+     * Rendered in place of rows when `data` is empty. Defaults to a minimal
+     * "No results" Empty; pass a richer node (custom copy, actions) to override.
+     */
+    empty?: React.ReactNode
 }
 
 // `getIsSorted()` → ARIA sort token for the header cell.
 const ARIA_SORT = { asc: 'ascending', desc: 'descending' } as const
+
+// Minimal, generic empty state. Deliberately unopinionated — no app-specific
+// copy or action buttons; pass a richer `empty` for those. Module-level so it's
+// not re-created each render and stays out of the function signature.
+const DEFAULT_EMPTY = (
+    <Empty>
+        <EmptyHeader>
+            <EmptyMedia variant="icon">
+                <Inbox />
+            </EmptyMedia>
+            <EmptyTitle>No results</EmptyTitle>
+        </EmptyHeader>
+    </Empty>
+)
 
 /**
  * Headless TanStack Table wired onto the quill Table primitive — client-side
@@ -36,7 +53,7 @@ function DataTable<TData, TValue>({
     data,
     className,
     stickyHeader,
-    emptyMessage = 'No results.',
+    empty = DEFAULT_EMPTY,
 }: DataTableProps<TData, TValue>): React.ReactElement {
     const [sorting, setSorting] = React.useState<SortingState>([])
     const table = useReactTable({
@@ -112,9 +129,9 @@ function DataTable<TData, TValue>({
                     <TableRow>
                         <TableCell
                             colSpan={columns.length}
-                            className="py-6 text-center text-[var(--muted-foreground)]"
+                            className="p-2 hover:bg-transparent"
                         >
-                            {emptyMessage}
+                            {empty}
                         </TableCell>
                     </TableRow>
                 )}

--- a/packages/quill/packages/components/src/data-table.tsx
+++ b/packages/quill/packages/components/src/data-table.tsx
@@ -1,0 +1,126 @@
+import {
+    type ColumnDef,
+    type SortingState,
+    flexRender,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table'
+import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react'
+import * as React from 'react'
+
+import { Button, cn, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@posthog/quill-primitives'
+
+export interface DataTableProps<TData, TValue> {
+    columns: ColumnDef<TData, TValue>[]
+    data: TData[]
+    /** Sizing/scroll classes for the table container (forwarded to the Table primitive). */
+    className?: string
+    /** Sticky header mode, forwarded to the Table primitive. `'page'` sticks to document scroll. */
+    stickyHeader?: boolean | 'page'
+    /** Shown in place of rows when `data` is empty. */
+    emptyMessage?: React.ReactNode
+}
+
+// `getIsSorted()` → ARIA sort token for the header cell.
+const ARIA_SORT = { asc: 'ascending', desc: 'descending' } as const
+
+/**
+ * Headless TanStack Table wired onto the quill Table primitive — client-side
+ * sorting out of the box (sortable columns render a sort button + indicator and
+ * set `aria-sort`), selection reflected via the row's `data-state`, and an empty
+ * state. Pass `enableSorting: false` on a column to opt it out.
+ */
+function DataTable<TData, TValue>({
+    columns,
+    data,
+    className,
+    stickyHeader,
+    emptyMessage = 'No results.',
+}: DataTableProps<TData, TValue>): React.ReactElement {
+    const [sorting, setSorting] = React.useState<SortingState>([])
+    const table = useReactTable({
+        data,
+        columns,
+        state: { sorting },
+        onSortingChange: setSorting,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+    })
+    const rows = table.getRowModel().rows
+
+    return (
+        <Table className={className} stickyHeader={stickyHeader}>
+            <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id}>
+                        {headerGroup.headers.map((header) => {
+                            const sorted = header.column.getIsSorted()
+                            const label = header.isPlaceholder
+                                ? null
+                                : flexRender(header.column.columnDef.header, header.getContext())
+                            return (
+                                <TableHead
+                                    key={header.id}
+                                    colSpan={header.colSpan}
+                                    aria-sort={sorted ? ARIA_SORT[sorted] : undefined}
+                                >
+                                    {header.column.getCanSort() && !header.isPlaceholder ? (
+                                        <Button
+                                            size="sm"
+                                            // The Button's built-in selected styling (fill-selected, with
+                                            // hover preserved via its own :not(:hover) rule) marks the
+                                            // active sort. Real semantics live in aria-sort on the <th>.
+                                            aria-selected={sorted ? true : undefined}
+                                            className={cn(
+                                                "gap-1.5",
+                                                sorted && 'text-foreground',
+                                                !sorted && 'hover:bg-fill-hover/50',
+                                            )}
+                                            onClick={header.column.getToggleSortingHandler()}
+                                        >
+                                            {label}
+                                            {sorted === 'asc' ? (
+                                                <ArrowUp className="size-3" />
+                                            ) : sorted === 'desc' ? (
+                                                <ArrowDown className="size-3" />
+                                            ) : (
+                                                <ChevronsUpDown className="size-3 opacity-50" />
+                                            )}
+                                        </Button>
+                                    ) : (
+                                        label
+                                    )}
+                                </TableHead>
+                            )
+                        })}
+                    </TableRow>
+                ))}
+            </TableHeader>
+            <TableBody>
+                {rows.length ? (
+                    rows.map((row) => (
+                        <TableRow key={row.id} data-state={row.getIsSelected() ? 'selected' : undefined}>
+                            {row.getVisibleCells().map((cell) => (
+                                <TableCell key={cell.id}>
+                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    ))
+                ) : (
+                    <TableRow>
+                        <TableCell
+                            colSpan={columns.length}
+                            className="py-6 text-center text-[var(--muted-foreground)]"
+                        >
+                            {emptyMessage}
+                        </TableCell>
+                    </TableRow>
+                )}
+            </TableBody>
+        </Table>
+    )
+}
+
+export { DataTable }

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -52,6 +52,22 @@ const MONTH_NAMES = [
     'December',
 ]
 
+// Tailwind `lg` breakpoint — matches the `lg:` classes that switch this picker
+// between a single calendar and the side-by-side dual-calendar layout.
+const LG_QUERY = '(min-width: 64rem)'
+
+function useMediaQuery(query: string): boolean {
+    const [matches, setMatches] = React.useState(false)
+    React.useEffect(() => {
+        const mql = window.matchMedia(query)
+        const update = (): void => setMatches(mql.matches)
+        update()
+        mql.addEventListener('change', update)
+        return () => mql.removeEventListener('change', update)
+    }, [query])
+    return matches
+}
+
 export interface DateTimeValue {
     start: Date
     end: Date
@@ -234,7 +250,7 @@ function Calendar({
             <div className="flex justify-center items-center py-1 gap-1">
                 <Button
                     variant="default"
-                    size="icon-xs"
+                    size="icon-sm"
                     onClick={handlePrev}
                     disabled={disablePrev}
                     aria-label="Previous month"
@@ -264,7 +280,7 @@ function Calendar({
                 </Select>
                 <Button
                     variant="default"
-                    size="icon-xs"
+                    size="icon-sm"
                     onClick={handleNext}
                     disabled={disableNext}
                     aria-label="Next month"
@@ -472,6 +488,10 @@ export function DateTimePicker({
 }: DateTimePickerProps): React.ReactElement {
     const maxDate = maxDateProp ?? new Date()
     const hasExplicitMaxDate = maxDateProp !== undefined
+    // The second calendar only renders at `lg`; below it (and in compact) there's
+    // a single calendar, so the "can't pick the sibling's month" constraint shouldn't apply.
+    const isLargeScreen = useMediaQuery(LG_QUERY)
+    const twoCalendars = !compact && isLargeScreen
     const [start, setStart] = React.useState<Date>(value.start)
     const [end, setEnd] = React.useState<Date>(value.end)
     const [range, setRange] = React.useState<DateTimeRange>(value.range)
@@ -507,6 +527,21 @@ export function DateTimePicker({
         setRange(CUSTOM_RANGE)
     }
 
+    // Move the visible calendar(s) so an edited date stays in view. With two
+    // calendars, start drives the left and end the right; with one, the single
+    // (right) calendar follows whichever edge changed.
+    const revealStart = (date: Date): void => {
+        const month = new Date(getYear(date), getMonth(date), 1)
+        if (twoCalendars) {
+            setLeftViewing(month)
+        } else {
+            setRightViewing(month)
+        }
+    }
+    const revealEnd = (date: Date): void => {
+        setRightViewing(new Date(getYear(date), getMonth(date), 1))
+    }
+
     const handleStartChange = (next: Date): void => {
         if (start.getTime() === next.getTime()) {
             return
@@ -516,8 +551,10 @@ export function DateTimePicker({
         if (next.getTime() > end.getTime()) {
             setStart(end)
             setEnd(next)
+            revealEnd(next)
         } else {
             setStart(next)
+            revealStart(next)
         }
     }
 
@@ -530,8 +567,10 @@ export function DateTimePicker({
         if (next.getTime() < start.getTime()) {
             setEnd(start)
             setStart(next)
+            revealStart(next)
         } else {
             setEnd(next)
+            revealEnd(next)
         }
     }
 
@@ -542,6 +581,7 @@ export function DateTimePicker({
         }
         setEnd(now)
         setLastSet('end')
+        revealEnd(now)
     }
 
     const handleQuickRange = (next: DateTimeRange): void => {
@@ -653,7 +693,7 @@ export function DateTimePicker({
                                 maxDate={maxDate}
                                 onSelect={handleSelect}
                                 onViewChange={setRightViewing}
-                                siblingViewing={compact ? undefined : leftViewing}
+                                siblingViewing={twoCalendars ? leftViewing : undefined}
                                 weekStartsOn={weekStartsOn}
                             />
                         </div>

--- a/packages/quill/packages/components/src/index.ts
+++ b/packages/quill/packages/components/src/index.ts
@@ -8,6 +8,7 @@
 // top of Table primitives. Opinionated wrappers you'd otherwise hand-roll
 // in every app.
 
+export { DataTable, type DataTableProps } from './data-table'
 export { DateTimePicker, type DateTimePickerProps, type DateTimeValue, type DateFormatOrder } from './date-time-picker'
 export { quickRanges, CUSTOM_RANGE, type DateTimeRange, type DateTimeRangeName } from './date-time-ranges'
 export { useCalendar, Day, Month, type UseCalendarOptions, type UseCalendarReturn } from './use-calendar'

--- a/packages/quill/packages/primitives/package.json
+++ b/packages/quill/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-primitives",
-    "version": "0.3.0-beta.11",
+    "version": "0.3.0-beta.12",
     "private": true,
     "description": "Internal workspace package (private, not published). The lowest layer of the quill design system — unstyled Base UI primitives wrapped with quill's Tailwind classes (Button, Card, Dialog, Input, Popover, Combobox, etc.). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/primitives/package.json
+++ b/packages/quill/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-primitives",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "private": true,
     "description": "Internal workspace package (private, not published). The lowest layer of the quill design system — unstyled Base UI primitives wrapped with quill's Tailwind classes (Button, Card, Dialog, Input, Popover, Combobox, etc.). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/primitives/src/badge.css
+++ b/packages/quill/packages/primitives/src/badge.css
@@ -41,7 +41,7 @@
     /* Variants */
     .quill-badge--variant-default {
         color: var(--foreground);
-        background-color: var(--muted);
+        background-color: var(--fill-hover);
     }
 
     .quill-badge--variant-info {

--- a/packages/quill/packages/primitives/src/index.ts
+++ b/packages/quill/packages/primitives/src/index.ts
@@ -218,6 +218,16 @@ export {
 } from './toast'
 export { Spinner } from './spinner'
 export { Switch } from './switch'
+export {
+    Table,
+    TableHeader,
+    TableBody,
+    TableFooter,
+    TableHead,
+    TableRow,
+    TableCell,
+    TableCaption,
+} from './table'
 export { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs'
 export { Textarea } from './textarea'
 export { Toggle, toggleVariants } from './toggle'

--- a/packages/quill/packages/primitives/src/table.css
+++ b/packages/quill/packages/primitives/src/table.css
@@ -1,0 +1,204 @@
+/* stylelint-disable selector-class-pattern -- descendant/attr selectors fall outside strict BEM */
+@layer components {
+    /* =========================================================================
+       Root — non-scrolling wrapper. Sizing (`className`: height, width, border,
+       radius) lands here; it clips the viewport and hosts the fixed edge-shadow
+       overlays (a pseudo inside the scroller would scroll away).
+       ========================================================================= */
+    .quill-table__root {
+        /* Edge-shadow colour. Black-on-near-black is invisible, so dark mode
+           needs a much stronger alpha. */
+        --tbl-edge-shadow: rgb(0 0 0 / 12%);
+
+        /* Generic viewport-edge shadows, toggled per edge below. */
+        --tbl-shadow-top: 0 0 0 0 transparent;
+        --tbl-shadow-right: 0 0 0 0 transparent;
+        --tbl-shadow-bottom: 0 0 0 0 transparent;
+        --tbl-shadow-left: 0 0 0 0 transparent;
+
+        position: relative;
+        width: 100%;
+
+        /* `clip` (not `hidden`) clips the rounded corners *without* establishing
+           a scroll container, so a `stickyHeader="page"` header can still escape
+           to the document scroll while corners stay clipped. */
+        overflow: clip;
+    }
+
+    .dark .quill-table__root {
+        --tbl-edge-shadow: rgb(0 0 0 / 55%);
+    }
+
+    /* Viewport — owns the scroll; fills the root. */
+    .quill-table__viewport {
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+    }
+
+    /* Page-sticky mode: the header sticks to document scroll, so the viewport must
+       not establish a scroll container. (Root stays `overflow: clip` — it clips
+       without becoming a scroll container, so it doesn't capture the sticky.) */
+    .quill-table__root[data-page-sticky] .quill-table__viewport {
+        overflow: visible;
+    }
+
+    /* Two pseudos stack inset shadows at the four edges; ::before = start edges
+       (top/left), ::after = end edges (right/bottom). Inset so they hug the
+       viewport edge; on the root (non-scrolling) they stay put while scrolling. */
+    .quill-table__root::before,
+    .quill-table__root::after {
+        position: absolute;
+        inset: 0;
+        z-index: 4;
+        pointer-events: none;
+        content: '';
+        border-radius: inherit;
+        transition: box-shadow 0.2s ease;
+    }
+
+    .quill-table__root::before {
+        box-shadow: var(--tbl-shadow-top), var(--tbl-shadow-left);
+    }
+
+    .quill-table__root::after {
+        box-shadow: var(--tbl-shadow-right), var(--tbl-shadow-bottom);
+    }
+
+    /* Right/bottom are always generic. Left/top defer to the frozen column/header
+       shadow when one exists (it sits beside the frozen edge, not over it). */
+    .quill-table__root[data-scroll-right]:not(:has(.quill-table__cell[data-sticky='right'])) {
+        --tbl-shadow-right: inset -16px 0 16px -16px var(--tbl-edge-shadow);
+    }
+
+    .quill-table__root[data-scroll-bottom] {
+        --tbl-shadow-bottom: inset 0 -16px 16px -16px var(--tbl-edge-shadow);
+    }
+
+    .quill-table__root[data-scroll-left]:not(:has(.quill-table__cell[data-sticky='left'])) {
+        --tbl-shadow-left: inset 16px 0 16px -16px var(--tbl-edge-shadow);
+    }
+
+    .quill-table__root[data-scroll-top]:not(:has(.quill-table[data-sticky-header])) {
+        --tbl-shadow-top: inset 0 16px 16px -16px var(--tbl-edge-shadow);
+    }
+
+    .quill-table {
+        /* max-content lets the table outgrow the viewport → horizontal scroll;
+           min-width 100% keeps it filling when content is narrow. */
+        width: max-content;
+        min-width: 100%;
+        font-size: var(--text-xs, 0.75rem);
+        line-height: var(--text-xs--line-height, 1rem);
+        color: var(--foreground);
+        text-align: left;
+        caption-side: bottom;
+        border-spacing: 0;
+        border-collapse: separate;
+    }
+
+    /* =========================================================================
+       Head / body / footer rows
+       ========================================================================= */
+    .quill-table__head {
+        height: 2.25rem;
+        padding-inline: 0.75rem;
+        font-weight: 500;
+        color: var(--muted-foreground);
+        white-space: nowrap;
+        background-color: var(--background);
+        border-bottom: 1px solid var(--border);
+    }
+
+    .quill-table__cell {
+        padding-block: 0.5rem;
+        padding-inline: 0.75rem;
+        background-color: var(--background);
+        border-bottom: 1px solid var(--border);
+    }
+
+    .quill-table__body .quill-table__row:last-child .quill-table__cell {
+        border-bottom: none;
+    }
+
+    .quill-table__row:hover .quill-table__cell {
+        background-color: color-mix(in oklab, var(--muted) 40%, var(--background));
+    }
+
+    .quill-table__row[data-state='selected'] .quill-table__cell {
+        background-color: color-mix(in oklab, var(--primary) 12%, var(--background));
+    }
+
+    .quill-table__footer .quill-table__cell {
+        font-weight: 500;
+        background-color: color-mix(in oklab, var(--muted) 30%, var(--background));
+        border-top: 1px solid var(--border);
+        border-bottom: none;
+    }
+
+    .quill-table__caption {
+        padding-top: 0.5rem;
+        color: var(--muted-foreground);
+    }
+
+    /* Interactive header: the whole label is a button. A negative inline margin
+       pulls the button's padding back so its label aligns with plain headers and
+       its hover background bleeds into the cell padding without shifting layout.
+       Non-interactive headers omit the button, so their width is unaffected. */
+    .quill-table__head > [data-slot='button'] {
+        margin-inline: -0.5rem;
+    }
+
+    /* =========================================================================
+       Sticky header + columns. Frozen edges are delineated by borders only; the
+       generic viewport-edge shadows above still signal off-screen overflow.
+       ========================================================================= */
+
+    /* --- Sticky header --- */
+    .quill-table[data-sticky-header] .quill-table__head {
+        position: sticky;
+        top: var(--quill-table-sticky-top, 0);
+        z-index: 2;
+    }
+
+    /* --- Sticky columns — sticky="left" | "right" on TableHead / TableCell.
+       Default offset 0; for a second sticky column set `left`/`right` via
+       inline style or className to clear the previous one's width. --- */
+    .quill-table__head[data-sticky],
+    .quill-table__cell[data-sticky] {
+        position: sticky;
+        z-index: 1;
+    }
+
+    .quill-table__head[data-sticky='left'],
+    .quill-table__cell[data-sticky='left'] {
+        left: 0;
+        border-right: 1px solid var(--border);
+    }
+
+    .quill-table__head[data-sticky='right'],
+    .quill-table__cell[data-sticky='right'] {
+        right: 0;
+        border-left: 1px solid var(--border);
+    }
+
+    /* Divider on the inner side of a non-edge frozen column lives on the NEIGHBOUR
+       cell, not the frozen cell itself: when the column is stuck against the table
+       edge, the neighbour (and its border) scrolls under it instead of doubling up
+       with the container border. When the column is first/last there is no
+       neighbour, so nothing is drawn — the container edge is the boundary. */
+    .quill-table__cell:has(+ .quill-table__cell[data-sticky='left']),
+    .quill-table__head:has(+ .quill-table__head[data-sticky='left']) {
+        border-right: 1px solid var(--border);
+    }
+
+    .quill-table__cell[data-sticky='right'] + .quill-table__cell,
+    .quill-table__head[data-sticky='right'] + .quill-table__head {
+        border-left: 1px solid var(--border);
+    }
+
+    /* Sticky header cell that is also a sticky column must outrank both. */
+    .quill-table[data-sticky-header] .quill-table__head[data-sticky] {
+        z-index: 3;
+    }
+}

--- a/packages/quill/packages/primitives/src/table.css
+++ b/packages/quill/packages/primitives/src/table.css
@@ -100,11 +100,18 @@
     /* =========================================================================
        Head / body / footer rows
        ========================================================================= */
+
+    /* Uppercase "label" header treatment: the quill Label look (500 weight, muted)
+       plus small-caps tracking. Applied at the cell so every header — text,
+       right-aligned, or an interactive button — gets it consistently. */
     .quill-table__head {
         height: 2.25rem;
         padding-inline: 0.75rem;
+        font-size: var(--text-xxs, 0.625rem);
         font-weight: 500;
         color: var(--muted-foreground);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
         white-space: nowrap;
         background-color: var(--background);
         border-bottom: 1px solid var(--border);

--- a/packages/quill/packages/primitives/src/table.css
+++ b/packages/quill/packages/primitives/src/table.css
@@ -67,7 +67,9 @@
 
     /* Right/bottom are always generic. Left/top defer to the frozen column/header
        shadow when one exists (it sits beside the frozen edge, not over it). */
-    .quill-table__root[data-scroll-right]:not(:has(.quill-table__cell[data-sticky='right'])) {
+    .quill-table__root[data-scroll-right]:not(
+            :has(.quill-table__cell[data-sticky='right'], .quill-table__head[data-sticky='right'])
+        ) {
         --tbl-shadow-right: inset -16px 0 16px -16px var(--tbl-edge-shadow);
     }
 
@@ -75,7 +77,9 @@
         --tbl-shadow-bottom: inset 0 -16px 16px -16px var(--tbl-edge-shadow);
     }
 
-    .quill-table__root[data-scroll-left]:not(:has(.quill-table__cell[data-sticky='left'])) {
+    .quill-table__root[data-scroll-left]:not(
+            :has(.quill-table__cell[data-sticky='left'], .quill-table__head[data-sticky='left'])
+        ) {
         --tbl-shadow-left: inset 16px 0 16px -16px var(--tbl-edge-shadow);
     }
 

--- a/packages/quill/packages/primitives/src/table.css
+++ b/packages/quill/packages/primitives/src/table.css
@@ -109,7 +109,7 @@
        plus small-caps tracking. Applied at the cell so every header — text,
        right-aligned, or an interactive button — gets it consistently. */
     .quill-table__head {
-        height: 2.25rem;
+        height: 2.05rem;
         padding-inline: 0.75rem;
         font-size: var(--text-xxs, 0.625rem);
         font-weight: 500;
@@ -152,12 +152,19 @@
         color: var(--muted-foreground);
     }
 
-    /* Interactive header: the whole label is a button. A negative inline margin
-       pulls the button's padding back so its label aligns with plain headers and
-       its hover background bleeds into the cell padding without shifting layout.
-       Non-interactive headers omit the button, so their width is unaffected. */
+    /* Interactive header: the whole label is a button. It inherits the head's
+       label typography (uppercase, tracked, muted, xxs) so it matches plain
+       headers instead of rendering at the button's own font; utilities in JSX
+       still override (e.g. the selected-sort colour). The negative inline margin
+       aligns the label with plain headers and lets the hover background bleed
+       into the cell padding without shifting layout. */
     .quill-table__head > [data-slot='button'] {
         margin-inline: -0.5rem;
+        font-size: inherit;
+        font-weight: inherit;
+        color: inherit;
+        text-transform: inherit;
+        letter-spacing: inherit;
     }
 
     /* =========================================================================

--- a/packages/quill/packages/primitives/src/table.stories.tsx
+++ b/packages/quill/packages/primitives/src/table.stories.tsx
@@ -1,8 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { ChevronsUpDown } from 'lucide-react'
+import { ChevronsUpDown, MoreHorizontal } from 'lucide-react'
+import * as React from 'react'
 
 import { Badge } from './badge'
 import { Button } from './button'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from './dropdown-menu'
 import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from './table'
 
 const meta = {
@@ -334,6 +342,95 @@ export const InteractiveHeaders: Story = {
                         <TableCell className="font-medium">{row.name}</TableCell>
                         <TableCell>{row.email}</TableCell>
                         <TableCell>{row.role}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ),
+} satisfies Story
+
+// Shared dummy actions menu — a ghost ellipsis Button that opens a quill
+// DropdownMenu. Used by both the cell- and row-action stories.
+function ActionsMenu({ label }: { label: string }): React.ReactElement {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger
+                render={
+                    <Button
+                        size="icon-xs"
+                        aria-label={label}
+                        // Dimmed until the row is hovered; stays full while focused or open.
+                        className="opacity-30 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[popup-open]:opacity-100"
+                    />
+                }
+            >
+                <MoreHorizontal />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+                <DropdownMenuItem>Edit</DropdownMenuItem>
+                <DropdownMenuItem>Duplicate</DropdownMenuItem>
+                <DropdownMenuItem>Copy link</DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}
+
+// Cell actions: an action button pushed to the end of a content cell with
+// `ml-auto`, opening the dummy dropdown menu.
+export const CellActions: Story = {
+    render: () => (
+        <Table className="max-w-2xl rounded-md border border-[var(--border)]">
+            <TableHeader>
+                <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Role</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {manyRows.slice(0, 6).map((row) => (
+                    <TableRow key={row.id} className="group/row">
+                        <TableCell className="font-medium">
+                            <span className="flex items-center gap-2">
+                                {row.name}
+                                <span className="ml-auto">
+                                    <ActionsMenu label={`Actions for ${row.name}`} />
+                                </span>
+                            </span>
+                        </TableCell>
+                        <TableCell>{row.role}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ),
+} satisfies Story
+
+// Row actions: a trailing actions column with the same dummy menu at the end of
+// each row.
+export const RowActions: Story = {
+    render: () => (
+        <Table className="max-w-2xl rounded-md border border-[var(--border)]">
+            <TableHeader>
+                <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Role</TableHead>
+                    <TableHead className="w-0">
+                        <span className="sr-only">Actions</span>
+                    </TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {manyRows.slice(0, 6).map((row) => (
+                    <TableRow key={row.id} className="group/row">
+                        <TableCell className="font-medium">{row.name}</TableCell>
+                        <TableCell>{row.email}</TableCell>
+                        <TableCell>{row.role}</TableCell>
+                        <TableCell className="w-0 text-right">
+                            <ActionsMenu label={`Actions for ${row.name}`} />
+                        </TableCell>
                     </TableRow>
                 ))}
             </TableBody>

--- a/packages/quill/packages/primitives/src/table.stories.tsx
+++ b/packages/quill/packages/primitives/src/table.stories.tsx
@@ -22,6 +22,19 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+// Maps a status string to a semantic Badge variant, shared across the Status
+// columns below. Positive states (Paid/Active) read success, in-flight states
+// (Pending/Invited) read warning, everything else (Unpaid/Refunded) destructive.
+function StatusBadge({ status }: { status: string }): React.ReactElement {
+    const variant =
+        status === 'Paid' || status === 'Active'
+            ? 'success'
+            : status === 'Pending' || status === 'Invited'
+                ? 'warning'
+                : 'destructive'
+    return <Badge variant={variant}>{status}</Badge>
+}
+
 const invoices = [
     { invoice: 'INV001', status: 'Paid', method: 'Credit Card', amount: '$250.00' },
     { invoice: 'INV002', status: 'Pending', method: 'PayPal', amount: '$150.00' },
@@ -47,7 +60,7 @@ export const Default: Story = {
                     <TableRow key={row.invoice}>
                         <TableCell className="font-medium">{row.invoice}</TableCell>
                         <TableCell>
-                            <Badge>{row.status}</Badge>
+                            <StatusBadge status={row.status} />
                         </TableCell>
                         <TableCell>{row.method}</TableCell>
                         <TableCell className="text-right">{row.amount}</TableCell>
@@ -78,7 +91,9 @@ export const Selectable: Story = {
                 {invoices.map((row, i) => (
                     <TableRow key={row.invoice} data-state={i === 1 ? 'selected' : undefined}>
                         <TableCell className="font-medium">{row.invoice}</TableCell>
-                        <TableCell>{row.status}</TableCell>
+                        <TableCell>
+                            <StatusBadge status={row.status} />
+                        </TableCell>
                         <TableCell className="text-right">{row.amount}</TableCell>
                     </TableRow>
                 ))}
@@ -262,7 +277,9 @@ export const PageStickyHeader: Story = {
                         <TableRow key={row.id}>
                             <TableCell className="font-medium">{row.id}</TableCell>
                             <TableCell>{row.customer}</TableCell>
-                            <TableCell>{row.status}</TableCell>
+                            <TableCell>
+                                <StatusBadge status={row.status} />
+                            </TableCell>
                             <TableCell className="text-right">{row.total}</TableCell>
                         </TableRow>
                     ))}
@@ -297,7 +314,7 @@ export const StickyNonFirstColumn: Story = {
                         <TableCell className="font-medium whitespace-nowrap">{row.id}</TableCell>
                         <TableCell className="whitespace-nowrap">{row.customer}</TableCell>
                         <TableCell sticky="left" className="whitespace-nowrap">
-                            {row.status}
+                            <StatusBadge status={row.status} />
                         </TableCell>
                         {wideColumns.map((q, c) => (
                             <TableCell key={q} className="text-right">

--- a/packages/quill/packages/primitives/src/table.stories.tsx
+++ b/packages/quill/packages/primitives/src/table.stories.tsx
@@ -323,11 +323,7 @@ export const InteractiveHeaders: Story = {
                     <TableHead className="w-10">#</TableHead>
                     {(['Name', 'Email', 'Role'] as const).map((label) => (
                         <TableHead key={label}>
-                            <Button
-                                size="sm"
-                                className="gap-1.5 font-medium text-[var(--muted-foreground)]"
-                                aria-label={`Sort by ${label}`}
-                            >
+                            <Button size="sm" className="gap-1.5" aria-label={`Sort by ${label}`}>
                                 {label}
                                 <ChevronsUpDown className="size-2.5" />
                             </Button>

--- a/packages/quill/packages/primitives/src/table.stories.tsx
+++ b/packages/quill/packages/primitives/src/table.stories.tsx
@@ -1,0 +1,342 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { ChevronsUpDown } from 'lucide-react'
+
+import { Badge } from './badge'
+import { Button } from './button'
+import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from './table'
+
+const meta = {
+    title: 'Primitives/Table',
+    component: Table,
+    tags: ['autodocs'],
+} satisfies Meta<typeof Table>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const invoices = [
+    { invoice: 'INV001', status: 'Paid', method: 'Credit Card', amount: '$250.00' },
+    { invoice: 'INV002', status: 'Pending', method: 'PayPal', amount: '$150.00' },
+    { invoice: 'INV003', status: 'Unpaid', method: 'Bank Transfer', amount: '$350.00' },
+    { invoice: 'INV004', status: 'Paid', method: 'Credit Card', amount: '$450.00' },
+    { invoice: 'INV005', status: 'Paid', method: 'PayPal', amount: '$550.00' },
+]
+
+export const Default: Story = {
+    render: () => (
+        <Table className="max-w-2xl">
+            <TableCaption>A list of your recent invoices.</TableCaption>
+            <TableHeader>
+                <TableRow>
+                    <TableHead>Invoice</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Method</TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {invoices.map((row) => (
+                    <TableRow key={row.invoice}>
+                        <TableCell className="font-medium">{row.invoice}</TableCell>
+                        <TableCell>
+                            <Badge>{row.status}</Badge>
+                        </TableCell>
+                        <TableCell>{row.method}</TableCell>
+                        <TableCell className="text-right">{row.amount}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+            <TableFooter>
+                <TableRow>
+                    <TableCell colSpan={3}>Total</TableCell>
+                    <TableCell className="text-right">$1,750.00</TableCell>
+                </TableRow>
+            </TableFooter>
+        </Table>
+    ),
+} satisfies Story
+
+export const Selectable: Story = {
+    render: () => (
+        <Table className="max-w-2xl">
+            <TableHeader>
+                <TableRow>
+                    <TableHead>Invoice</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {invoices.map((row, i) => (
+                    <TableRow key={row.invoice} data-state={i === 1 ? 'selected' : undefined}>
+                        <TableCell className="font-medium">{row.invoice}</TableCell>
+                        <TableCell>{row.status}</TableCell>
+                        <TableCell className="text-right">{row.amount}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ),
+} satisfies Story
+
+const manyRows = Array.from({ length: 40 }, (_, i) => ({
+    id: `USR-${String(i + 1).padStart(3, '0')}`,
+    name: `Person ${i + 1}`,
+    email: `person${i + 1}@example.com`,
+    role: i % 3 === 0 ? 'Admin' : 'Member',
+    status: i % 4 === 0 ? 'Invited' : 'Active',
+}))
+
+export const StickyHeader: Story = {
+    render: () => (
+        <Table stickyHeader className="h-72 max-w-2xl rounded-md border border-[var(--border)]">
+            <TableHeader>
+                <TableRow>
+                    <TableHead>ID</TableHead>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Role</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {manyRows.map((row) => (
+                    <TableRow key={row.id}>
+                        <TableCell className="font-medium">{row.id}</TableCell>
+                        <TableCell>{row.name}</TableCell>
+                        <TableCell>{row.email}</TableCell>
+                        <TableCell>{row.role}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ),
+} satisfies Story
+
+const wideColumns = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+]
+
+export const StickyColumn: Story = {
+    render: () => (
+        <Table className="max-w-xl rounded-md border border-[var(--border)]">
+            <TableHeader>
+                <TableRow>
+                    <TableHead sticky="left">Region</TableHead>
+                    {wideColumns.map((q) => (
+                        <TableHead key={q} className="text-right whitespace-nowrap">
+                            {q}
+                        </TableHead>
+                    ))}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {['North America', 'Europe', 'Asia Pacific', 'Latin America'].map((region, r) => (
+                    <TableRow key={region}>
+                        <TableCell sticky="left" className="font-medium whitespace-nowrap">
+                            {region}
+                        </TableCell>
+                        {wideColumns.map((q, c) => (
+                            <TableCell key={q} className="text-right">
+                                ${(r + 1) * (c + 1) * 1000}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ),
+} satisfies Story
+
+export const StickyHeaderAndFirstColumn: Story = {
+    render: () => (
+        <Table stickyHeader className="h-72 max-w-xl rounded-md border border-[var(--border)]">
+            <TableHeader>
+                <TableRow>
+                    <TableHead sticky="left">User</TableHead>
+                    {wideColumns.map((q) => (
+                        <TableHead key={q} className="text-right whitespace-nowrap">
+                            {q}
+                        </TableHead>
+                    ))}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {manyRows.map((row) => (
+                    <TableRow key={row.id}>
+                        <TableCell sticky="left" className="font-medium whitespace-nowrap">
+                            {row.name}
+                        </TableCell>
+                        {wideColumns.map((q, c) => (
+                            <TableCell key={q} className="text-right">
+                                {(c + 1) * 7}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ),
+} satisfies Story
+
+export const StickyHeaderAndSecondColumn: Story = {
+    render: () => (
+        <Table stickyHeader className="h-72 max-w-xl rounded-md border border-[var(--border)]">
+            <TableHeader>
+                <TableRow>
+                    <TableHead className="whitespace-nowrap">ID</TableHead>
+                    <TableHead sticky="left" className="whitespace-nowrap">
+                        User
+                    </TableHead>
+                    {wideColumns.map((q) => (
+                        <TableHead key={q} className="text-right whitespace-nowrap">
+                            {q}
+                        </TableHead>
+                    ))}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {manyRows.map((row) => (
+                    <TableRow key={row.id}>
+                        <TableCell className="whitespace-nowrap">{row.id}</TableCell>
+                        <TableCell sticky="left" className="font-medium whitespace-nowrap">
+                            {row.name}
+                        </TableCell>
+                        {wideColumns.map((q, c) => (
+                            <TableCell key={q} className="text-right">
+                                {(c + 1) * 7}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ),
+} satisfies Story
+
+// Tall table with no internal scroll — the page scrolls, and the header sticks
+// to the document. `stickyHeader="page"` drops the wrappers' scroll container so
+// stickiness escapes to the window.
+const pageRows = Array.from({ length: 60 }, (_, i) => ({
+    id: `ORD-${String(i + 1).padStart(4, '0')}`,
+    customer: `Customer ${i + 1}`,
+    total: `$${((i + 1) * 37).toLocaleString()}`,
+    status: ['Paid', 'Pending', 'Refunded'][i % 3],
+}))
+
+export const PageStickyHeader: Story = {
+    render: () => (
+        <div className="max-w-2xl">
+            <p className="mb-4 text-sm text-[var(--muted-foreground)]">
+                Scroll the page — the header sticks to the window once it reaches the top.
+            </p>
+            <Table stickyHeader="page" className="rounded-md border border-[var(--border)]">
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Order</TableHead>
+                        <TableHead>Customer</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">Total</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {pageRows.map((row) => (
+                        <TableRow key={row.id}>
+                            <TableCell className="font-medium">{row.id}</TableCell>
+                            <TableCell>{row.customer}</TableCell>
+                            <TableCell>{row.status}</TableCell>
+                            <TableCell className="text-right">{row.total}</TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </div>
+    ),
+} satisfies Story
+
+// Any column can be frozen, not just the first. Here the 3rd column (Status)
+// is sticky="left"; scrolling right slides the Order/Customer columns under it.
+export const StickyNonFirstColumn: Story = {
+    render: () => (
+        <Table className="max-w-xl rounded-md border border-[var(--border)]">
+            <TableHeader>
+                <TableRow>
+                    <TableHead className="whitespace-nowrap">Order</TableHead>
+                    <TableHead className="whitespace-nowrap">Customer</TableHead>
+                    <TableHead sticky="left" className="whitespace-nowrap">
+                        Status
+                    </TableHead>
+                    {wideColumns.map((q) => (
+                        <TableHead key={q} className="text-right whitespace-nowrap">
+                            {q}
+                        </TableHead>
+                    ))}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {pageRows.slice(0, 8).map((row, r) => (
+                    <TableRow key={row.id}>
+                        <TableCell className="font-medium whitespace-nowrap">{row.id}</TableCell>
+                        <TableCell className="whitespace-nowrap">{row.customer}</TableCell>
+                        <TableCell sticky="left" className="whitespace-nowrap">
+                            {row.status}
+                        </TableCell>
+                        {wideColumns.map((q, c) => (
+                            <TableCell key={q} className="text-right">
+                                ${(r + 1) * (c + 1) * 100}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ),
+} satisfies Story
+
+// Interactive headers: the whole label is a quill ghost Button (label + sort
+// icon) with normal button hover — the seam for sorting, column menus, etc. The
+// button aligns with plain headers and doesn't shift layout; the non-interactive
+// "#" header stays plain text.
+export const InteractiveHeaders: Story = {
+    render: () => (
+        <Table className="max-w-2xl rounded-md border border-[var(--border)]">
+            <TableHeader>
+                <TableRow>
+                    <TableHead className="w-10">#</TableHead>
+                    {(['Name', 'Email', 'Role'] as const).map((label) => (
+                        <TableHead key={label}>
+                            <Button
+                                size="sm"
+                                className="gap-1.5 font-medium text-[var(--muted-foreground)]"
+                                aria-label={`Sort by ${label}`}
+                            >
+                                {label}
+                                <ChevronsUpDown className="size-2.5" />
+                            </Button>
+                        </TableHead>
+                    ))}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {manyRows.slice(0, 6).map((row, i) => (
+                    <TableRow key={row.id}>
+                        <TableCell className="text-[var(--muted-foreground)]">{i + 1}</TableCell>
+                        <TableCell className="font-medium">{row.name}</TableCell>
+                        <TableCell>{row.email}</TableCell>
+                        <TableCell>{row.role}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/table.stories.tsx
+++ b/packages/quill/packages/primitives/src/table.stories.tsx
@@ -311,7 +311,7 @@ export const StickyNonFirstColumn: Story = {
     ),
 } satisfies Story
 
-// Interactive headers: the whole label is a quill ghost Button (label + sort
+// Interactive headers: the whole label is a quill Button (label + sort
 // icon) with normal button hover — the seam for sorting, column menus, etc. The
 // button aligns with plain headers and doesn't shift layout; the non-interactive
 // "#" header stays plain text.
@@ -349,7 +349,7 @@ export const InteractiveHeaders: Story = {
     ),
 } satisfies Story
 
-// Shared dummy actions menu — a ghost ellipsis Button that opens a quill
+// Shared dummy actions menu — an ellipsis Button that opens a quill
 // DropdownMenu. Used by both the cell- and row-action stories.
 function ActionsMenu({ label }: { label: string }): React.ReactElement {
     return (

--- a/packages/quill/packages/primitives/src/table.tsx
+++ b/packages/quill/packages/primitives/src/table.tsx
@@ -5,6 +5,18 @@ import { cn } from './lib/utils'
 
 type Sticky = 'left' | 'right'
 
+// Sets each ref (object or callback) to the same node — lets the viewport carry
+// both the internal scroll-tracking ref and a caller-supplied `viewportRef`.
+function setRefs<T>(node: T, ...refs: Array<React.Ref<T> | undefined>): void {
+    for (const ref of refs) {
+        if (typeof ref === 'function') {
+            ref(node)
+        } else if (ref) {
+            ;(ref as React.MutableRefObject<T | null>).current = node
+        }
+    }
+}
+
 // Reflects which edges of `viewport` still have hidden content as
 // `data-scroll-{top,right,bottom,left}` on `root` (the non-scrolling wrapper, so
 // edge-shadow overlays on it stay fixed while content scrolls). CSS keys the
@@ -44,12 +56,7 @@ function useScrollEdges(
     }, [rootRef, viewportRef])
 }
 
-function Table({
-    className,
-    tableClassName,
-    stickyHeader = false,
-    ...props
-}: React.ComponentProps<'table'> & {
+type TableProps = React.ComponentProps<'table'> & {
     /**
      * `true` — header sticks within the table's own scroll viewport (needs a
      * bounded height). `'page'` — header sticks to document scroll instead; the
@@ -57,12 +64,25 @@ function Table({
      * Offset it past fixed page chrome with `--quill-table-sticky-top`.
      */
     stickyHeader?: boolean | 'page'
-    /** Classes for the inner <table>. Size/scroll go on the container via `className`. */
+    /** Classes for the inner `<table>`. Size/scroll go on the container via `className`. */
     tableClassName?: string
-}): React.ReactElement {
+    /** Ref to the scrolling viewport — for scroll-to-row, virtualization, IntersectionObservers, etc. */
+    viewportRef?: React.Ref<HTMLDivElement>
+}
+
+// The forwarded ref points at the `<table>` element (consistent with `...props`,
+// which also land there). The scroll container is reached via `viewportRef`.
+const Table = React.forwardRef<HTMLTableElement, TableProps>(function Table(
+    { className, tableClassName, stickyHeader = false, viewportRef, ...props },
+    ref
+) {
     const rootRef = React.useRef<HTMLDivElement | null>(null)
-    const viewportRef = React.useRef<HTMLDivElement | null>(null)
-    useScrollEdges(rootRef, viewportRef)
+    const innerViewportRef = React.useRef<HTMLDivElement | null>(null)
+    useScrollEdges(rootRef, innerViewportRef)
+    const setViewport = React.useCallback(
+        (node: HTMLDivElement | null): void => setRefs(node, innerViewportRef, viewportRef),
+        [viewportRef]
+    )
     // `className` sizes the non-scrolling root (which clips + hosts the fixed edge
     // shadows); the inner viewport owns the scroll. Sticky header/columns position
     // against the viewport.
@@ -74,8 +94,9 @@ function Table({
             data-page-sticky={stickyHeader === 'page' ? '' : undefined}
             className={cn('quill-table__root', className)}
         >
-            <div ref={viewportRef} data-slot="table-viewport" className="quill-table__viewport">
+            <div ref={setViewport} data-slot="table-viewport" className="quill-table__viewport">
                 <table
+                    ref={ref}
                     data-slot="table"
                     data-sticky-header={stickyHeader ? '' : undefined}
                     className={cn('quill-table', tableClassName)}
@@ -84,56 +105,80 @@ function Table({
             </div>
         </div>
     )
-}
+})
 
-function TableHeader({ className, ...props }: React.ComponentProps<'thead'>): React.ReactElement {
-    return <thead data-slot="table-header" className={cn('quill-table__header', className)} {...props} />
-}
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.ComponentProps<'thead'>>(function TableHeader(
+    { className, ...props },
+    ref
+) {
+    return <thead ref={ref} data-slot="table-header" className={cn('quill-table__header', className)} {...props} />
+})
 
-function TableBody({ className, ...props }: React.ComponentProps<'tbody'>): React.ReactElement {
-    return <tbody data-slot="table-body" className={cn('quill-table__body', className)} {...props} />
-}
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.ComponentProps<'tbody'>>(function TableBody(
+    { className, ...props },
+    ref
+) {
+    return <tbody ref={ref} data-slot="table-body" className={cn('quill-table__body', className)} {...props} />
+})
 
-function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>): React.ReactElement {
-    return <tfoot data-slot="table-footer" className={cn('quill-table__footer', className)} {...props} />
-}
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.ComponentProps<'tfoot'>>(function TableFooter(
+    { className, ...props },
+    ref
+) {
+    return <tfoot ref={ref} data-slot="table-footer" className={cn('quill-table__footer', className)} {...props} />
+})
 
-function TableRow({ className, ...props }: React.ComponentProps<'tr'>): React.ReactElement {
-    return <tr data-slot="table-row" className={cn('quill-table__row', className)} {...props} />
-}
+const TableRow = React.forwardRef<HTMLTableRowElement, React.ComponentProps<'tr'>>(function TableRow(
+    { className, ...props },
+    ref
+) {
+    return <tr ref={ref} data-slot="table-row" className={cn('quill-table__row', className)} {...props} />
+})
 
-function TableHead({
-    className,
-    sticky,
-    ...props
-}: React.ComponentProps<'th'> & { sticky?: Sticky }): React.ReactElement {
-    return (
-        <th
-            data-slot="table-head"
-            data-sticky={sticky}
-            className={cn('quill-table__head', className)}
-            {...props}
-        />
-    )
-}
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ComponentProps<'th'> & { sticky?: Sticky }>(
+    // `scope="col"` by default (the common case); override to "row" for row headers.
+    function TableHead({ className, sticky, scope = 'col', ...props }, ref) {
+        return (
+            <th
+                ref={ref}
+                data-slot="table-head"
+                data-sticky={sticky}
+                scope={scope}
+                className={cn('quill-table__head', className)}
+                {...props}
+            />
+        )
+    }
+)
 
-function TableCell({
-    className,
-    sticky,
-    ...props
-}: React.ComponentProps<'td'> & { sticky?: Sticky }): React.ReactElement {
-    return (
-        <td
-            data-slot="table-cell"
-            data-sticky={sticky}
-            className={cn('quill-table__cell', className)}
-            {...props}
-        />
-    )
-}
+const TableCell = React.forwardRef<HTMLTableCellElement, React.ComponentProps<'td'> & { sticky?: Sticky }>(
+    function TableCell({ className, sticky, ...props }, ref) {
+        return (
+            <td
+                ref={ref}
+                data-slot="table-cell"
+                data-sticky={sticky}
+                className={cn('quill-table__cell', className)}
+                {...props}
+            />
+        )
+    }
+)
 
-function TableCaption({ className, ...props }: React.ComponentProps<'caption'>): React.ReactElement {
-    return <caption data-slot="table-caption" className={cn('quill-table__caption', className)} {...props} />
-}
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.ComponentProps<'caption'>>(function TableCaption(
+    { className, ...props },
+    ref
+) {
+    return <caption ref={ref} data-slot="table-caption" className={cn('quill-table__caption', className)} {...props} />
+})
+
+Table.displayName = 'Table'
+TableHeader.displayName = 'TableHeader'
+TableBody.displayName = 'TableBody'
+TableFooter.displayName = 'TableFooter'
+TableRow.displayName = 'TableRow'
+TableHead.displayName = 'TableHead'
+TableCell.displayName = 'TableCell'
+TableCaption.displayName = 'TableCaption'
 
 export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption }

--- a/packages/quill/packages/primitives/src/table.tsx
+++ b/packages/quill/packages/primitives/src/table.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react'
+
+import './table.css'
+import { cn } from './lib/utils'
+
+type Sticky = 'left' | 'right'
+
+// Reflects which edges of `viewport` still have hidden content as
+// `data-scroll-{top,right,bottom,left}` on `root` (the non-scrolling wrapper, so
+// edge-shadow overlays on it stay fixed while content scrolls). CSS keys the
+// frozen-header/column and generic viewport-edge shadows off these — robust
+// everywhere, unlike the `scroll-state()` container query (recent Chromium only).
+function useScrollEdges(
+    rootRef: React.RefObject<HTMLDivElement | null>,
+    viewportRef: React.RefObject<HTMLDivElement | null>
+): void {
+    React.useEffect(() => {
+        const root = rootRef.current
+        const viewport = viewportRef.current
+        if (!root || !viewport) {
+            return
+        }
+        const updateEdges = (): void => {
+            const { scrollTop, scrollLeft, scrollWidth, clientWidth, scrollHeight, clientHeight } = viewport
+            // scrollLeft is negative when scrolled from the start in RTL; abs() normalizes it.
+            const left = Math.abs(scrollLeft)
+            root.toggleAttribute('data-scroll-top', scrollTop > 0)
+            root.toggleAttribute('data-scroll-bottom', Math.ceil(scrollTop + clientHeight) < scrollHeight)
+            root.toggleAttribute('data-scroll-left', left > 0)
+            root.toggleAttribute('data-scroll-right', Math.ceil(left + clientWidth) < scrollWidth)
+        }
+        updateEdges()
+        viewport.addEventListener('scroll', updateEdges, { passive: true })
+        // Catch viewport and content size changes (rows added, columns resized).
+        const observer = new ResizeObserver(updateEdges)
+        observer.observe(viewport)
+        for (const child of Array.from(viewport.children)) {
+            observer.observe(child)
+        }
+        return () => {
+            viewport.removeEventListener('scroll', updateEdges)
+            observer.disconnect()
+        }
+    }, [rootRef, viewportRef])
+}
+
+function Table({
+    className,
+    tableClassName,
+    stickyHeader = false,
+    ...props
+}: React.ComponentProps<'table'> & {
+    /**
+     * `true` — header sticks within the table's own scroll viewport (needs a
+     * bounded height). `'page'` — header sticks to document scroll instead; the
+     * wrappers drop their scroll container so stickiness escapes to the page.
+     * Offset it past fixed page chrome with `--quill-table-sticky-top`.
+     */
+    stickyHeader?: boolean | 'page'
+    /** Classes for the inner <table>. Size/scroll go on the container via `className`. */
+    tableClassName?: string
+}): React.ReactElement {
+    const rootRef = React.useRef<HTMLDivElement | null>(null)
+    const viewportRef = React.useRef<HTMLDivElement | null>(null)
+    useScrollEdges(rootRef, viewportRef)
+    // `className` sizes the non-scrolling root (which clips + hosts the fixed edge
+    // shadows); the inner viewport owns the scroll. Sticky header/columns position
+    // against the viewport.
+    return (
+        <div
+            ref={rootRef}
+            data-quill
+            data-slot="table-container"
+            data-page-sticky={stickyHeader === 'page' ? '' : undefined}
+            className={cn('quill-table__root', className)}
+        >
+            <div ref={viewportRef} data-slot="table-viewport" className="quill-table__viewport">
+                <table
+                    data-slot="table"
+                    data-sticky-header={stickyHeader ? '' : undefined}
+                    className={cn('quill-table', tableClassName)}
+                    {...props}
+                />
+            </div>
+        </div>
+    )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>): React.ReactElement {
+    return <thead data-slot="table-header" className={cn('quill-table__header', className)} {...props} />
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>): React.ReactElement {
+    return <tbody data-slot="table-body" className={cn('quill-table__body', className)} {...props} />
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>): React.ReactElement {
+    return <tfoot data-slot="table-footer" className={cn('quill-table__footer', className)} {...props} />
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>): React.ReactElement {
+    return <tr data-slot="table-row" className={cn('quill-table__row', className)} {...props} />
+}
+
+function TableHead({
+    className,
+    sticky,
+    ...props
+}: React.ComponentProps<'th'> & { sticky?: Sticky }): React.ReactElement {
+    return (
+        <th
+            data-slot="table-head"
+            data-sticky={sticky}
+            className={cn('quill-table__head', className)}
+            {...props}
+        />
+    )
+}
+
+function TableCell({
+    className,
+    sticky,
+    ...props
+}: React.ComponentProps<'td'> & { sticky?: Sticky }): React.ReactElement {
+    return (
+        <td
+            data-slot="table-cell"
+            data-sticky={sticky}
+            className={cn('quill-table__cell', className)}
+            {...props}
+        />
+    )
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>): React.ReactElement {
+    return <caption data-slot="table-caption" className={cn('quill-table__caption', className)} {...props} />
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption }

--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.3.0-beta.11",
+    "version": "0.3.0-beta.12",
     "description": "PostHog's unified design system — primitives, components, and blocks designed to be compiled by the consumer's Tailwind v4.",
     "license": "MIT",
     "repository": {

--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "description": "PostHog's unified design system — primitives, components, and blocks designed to be compiled by the consumer's Tailwind v4.",
     "license": "MIT",
     "repository": {

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.3.0-beta.11",
+    "version": "0.3.0-beta.12",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/packages/quill/packages/tokens/src/colors.ts
+++ b/packages/quill/packages/tokens/src/colors.ts
@@ -117,8 +117,10 @@ export function buildSemanticColors(): Record<string, ColorTuple> {
         // ── Status (independent of theme hue) ─────────
         destructive: [oklch(0.92, 0.03, 32.22), oklch(0.24, 0.03, 2.79), 'bg-destructive'],
         'destructive-foreground': [
-            oklch(0.59, 0.2, 23.61),
-            oklch(0.6316, 0.1927, 24.53),
+            // Darkened from L=0.59 → 0.51 to clear WCAG AA (5.0:1) on the light
+            // destructive surface; the prior value sat at ~3.6:1.
+            oklch(0.51, 0.2, 23.61),
+            oklch(0.6605, 0.1821, 23.51),
             'text-destructive-foreground',
         ],
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: ^0.35.0
       version: 0.35.0
     posthog-js:
-      specifier: ^1.376.3
-      version: 1.376.3
+      specifier: ^1.378.1
+      version: 1.378.1
     ts-pattern:
       specifier: '4.3'
       version: 4.3.0
@@ -326,7 +326,7 @@ importers:
         version: 3.1.0
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
     devDependencies:
       '@swc/core':
         specifier: ^1.11.29
@@ -354,7 +354,7 @@ importers:
         version: 1.5.15
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
     devDependencies:
       '@swc/core':
         specifier: ^1.11.29
@@ -496,7 +496,7 @@ importers:
         version: 7.6.21(encoding@0.1.13)
       storybook-addon-pseudo-states:
         specifier: 2.1.2
-        version: 2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.20)(@storybook/manager-api@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.6.24)(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.20)(@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       style-loader:
         specifier: ^2.0.0
         version: 2.0.0(webpack@5.88.2)
@@ -749,7 +749,7 @@ importers:
         version: link:../packages/quill/packages/quill
       '@posthog/react':
         specifier: 'catalog:'
-        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.376.3)(react@18.3.1)
+        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.378.1)(react@18.3.1)
       '@posthog/replay-shared':
         specifier: workspace:*
         version: link:../common/replay-shared
@@ -1076,7 +1076,7 @@ importers:
         version: 2.11.0
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       query-selector-shadow-dom:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1839,7 +1839,7 @@ importers:
         version: 7.6.21(encoding@0.1.13)
       storybook-addon-pseudo-states:
         specifier: 2.1.2
-        version: 2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.24)(@storybook/manager-api@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.6.24)(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.1.2(@storybook/components@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/core-events@7.6.24)(@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-dark-mode:
         specifier: 3.0.3
         version: 3.0.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2149,7 +2149,7 @@ importers:
         version: 0.1.7
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2186,7 +2186,7 @@ importers:
         version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2230,7 +2230,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2329,7 +2329,7 @@ importers:
         version: 3.3.0
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2391,7 +2391,7 @@ importers:
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2404,6 +2404,9 @@ importers:
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
+      '@types/react-dom':
+        specifier: 18.3.7
+        version: 18.3.7(@types/react@18.3.27)
       clsx:
         specifier: '*'
         version: 1.2.1
@@ -2419,9 +2422,31 @@ importers:
       kea-router:
         specifier: 'catalog:'
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
+      posthog-js:
+        specifier: 'catalog:'
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@storybook/react':
+        specifier: ^8.6.14
+        version: 8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@7.6.21(encoding@0.1.13))(typescript@6.0.3)
+      '@testing-library/jest-dom':
+        specifier: ^5.17.0
+        version: 5.17.0
+      '@testing-library/react':
+        specifier: ^14.3.1
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@9.3.4)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
 
   products/data_modeling:
     dependencies:
@@ -2483,7 +2508,7 @@ importers:
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2507,7 +2532,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2662,7 +2687,7 @@ importers:
         version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2741,7 +2766,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2843,7 +2868,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2996,7 +3021,7 @@ importers:
         version: 5.4.1
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3118,7 +3143,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3211,7 +3236,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3224,8 +3249,6 @@ importers:
         version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   products/product_tours: {}
-
-  products/query_performance_ai: {}
 
   products/replay:
     dependencies:
@@ -3473,22 +3496,31 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
+      react-window:
+        specifier: '*'
+        version: 2.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   products/user_interviews:
     dependencies:
       '@posthog/icons':
         specifier: '*'
         version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/react':
+        specifier: '*'
+        version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
       clsx:
         specifier: '*'
         version: 1.2.1
+      jest:
+        specifier: '*'
+        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -3500,10 +3532,13 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   products/visual_review:
     dependencies:
@@ -3512,7 +3547,7 @@ importers:
         version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/react':
         specifier: '*'
-        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.376.3)(react@18.3.1)
+        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.378.1)(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3612,7 +3647,7 @@ importers:
         version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.376.3
+        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -9202,8 +9237,8 @@ packages:
   '@posthog/core@1.28.3':
     resolution: {integrity: sha512-SOy0aphKawZzp8jxfeOpTcXPwi6ii0I2V6tX8YXnM+WbxKKR/R+BXLK0jS6LV8kZtW3H5YxmPAfuIbUP1UnGTw==}
 
-  '@posthog/core@1.29.12':
-    resolution: {integrity: sha512-r/2RUa4zbN0XdBp6d+Yk8Jw1rPWXHxyXIgSm/wJf9yDLIouZbH0Pdkgbc1RIuhwL6BIHCFrOqK5jy8TFKTI6iw==}
+  '@posthog/core@1.30.2':
+    resolution: {integrity: sha512-d7RTpfi+/q5+SZ+4f1WhanfEtNBz9onMmUxn3BO0GDT8N5ZT4DEP3LqFisqeP+xkJTaFPWCOVA/nGyKmUX9y9g==}
 
   '@posthog/core@1.7.1':
     resolution: {integrity: sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==}
@@ -9261,8 +9296,8 @@ packages:
   '@posthog/types@1.372.9':
     resolution: {integrity: sha512-B7k9S+H9WUKHXxe1HOkQWbpWtMcrBvsodm5stZaLQ3pYxf9TowtwssdzTtX4hHjzSYqgrS1IpNnJX4vs1KgBzA==}
 
-  '@posthog/types@1.376.3':
-    resolution: {integrity: sha512-w21lBoz3/ZGw7BZT7t2lJq1mpJwMvWpZijW7vEwBFNAQlq0KfKf2mj5KKUYZMXM1GdIQ0jHnn931uXPB1Ae60w==}
+  '@posthog/types@1.378.1':
+    resolution: {integrity: sha512-bKOXVWySe5oKFjV6X9VW9jngIm14d4BvnT7l/Eb7e6DrT5uD+XclvbRdhC5f1/l5KwoIU+qswBobHRPlix2D1w==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -10978,6 +11013,11 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
+  '@storybook/components@8.6.18':
+    resolution: {integrity: sha512-55yViiZzPS/cPBuOeW4QGxGqrusjXVyxuknmbYCIwDtFyyvI/CgbjXRHdxNBaIjz+IlftxvBmmSaOqFG5+/dkA==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
   '@storybook/core-client@7.6.24':
     resolution: {integrity: sha512-1UHiA+h//U0iIm7GAhGG5hN8GaD4rhoqm4ZjUQaCPUemBtEOPMWJk1sQLyGrhlLYDEAp69Sbi4BP/J0LD0nrjQ==}
 
@@ -11047,6 +11087,11 @@ packages:
   '@storybook/manager-api@7.6.4':
     resolution: {integrity: sha512-RFb/iaBJfXygSgXkINPRq8dXu7AxBicTGX7MxqKXbz5FU7ANwV7abH6ONBYURkSDOH9//TQhRlVkF5u8zWg3bw==}
 
+  '@storybook/manager-api@8.6.18':
+    resolution: {integrity: sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
   '@storybook/manager@7.6.21':
     resolution: {integrity: sha512-kwtG7HfxYQIZeGwDg7xFkORhNf0PH+4jRLf/9M6amR537Hctay+Vlv2MGHO6LFzw6IwT4qCtO8xNgzcV9TxZtg==}
 
@@ -11091,6 +11136,11 @@ packages:
   '@storybook/preview-api@7.6.4':
     resolution: {integrity: sha512-KhisNdQX5NdfAln+spLU4B82d804GJQp/CnI5M1mm/taTnjvMgs/wTH9AmR89OPoq+tFZVW0vhy2zgPS3ar71A==}
 
+  '@storybook/preview-api@8.6.18':
+    resolution: {integrity: sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
   '@storybook/preview@7.6.24':
     resolution: {integrity: sha512-8qa9OFD1XKrX0Ts7vZFSd0ugIHoQt4rBGZNG7gE17laFxMTMiNAaTEqBF44f6vslx0z8VjIPtQ8qKeurU0IQdg==}
 
@@ -11114,6 +11164,13 @@ packages:
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
+
+  '@storybook/react-dom-shim@8.6.18':
+    resolution: {integrity: sha512-N4xULcAWZQTUv4jy1/d346Tyb4gufuC3UaLCuU/iVSZ1brYF4OW3ANr+096btbMxY8pR/65lmtoqr5CTGwnBvA==}
+    peerDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1
+      storybook: ^8.6.18
 
   '@storybook/react-vite@7.6.24':
     resolution: {integrity: sha512-0cvvXe9lrxzC50GPDWbJ4tXr3A07CURTv0ryJ9mSeT0YCNMdpX1B20ibxgy6gYgcAa/4fFPCAX6HuOn1Ec6E+g==}
@@ -11159,6 +11216,21 @@ packages:
       typescript:
         optional: true
 
+  '@storybook/react@8.6.18':
+    resolution: {integrity: sha512-BuLpzMkKtF+UCQCbi+lYVX9cdcAMG86Lu2dDn7UFkPi5HRNFq/zHPSvlz1XDgL0OYMtcqB1aoVzFzcyzUBhhjw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@storybook/test': 8.6.18
+      react: 18.3.1
+      react-dom: 18.3.1
+      storybook: ^8.6.18
+      typescript: 6.0.3
+    peerDependenciesMeta:
+      '@storybook/test':
+        optional: true
+      typescript:
+        optional: true
+
   '@storybook/router@7.6.20':
     resolution: {integrity: sha512-mCzsWe6GrH47Xb1++foL98Zdek7uM5GhaSlrI7blWVohGa0qIUYbfJngqR4ZsrXmJeeEvqowobh+jlxg3IJh+w==}
 
@@ -11187,6 +11259,11 @@ packages:
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
+
+  '@storybook/theming@8.6.18':
+    resolution: {integrity: sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
   '@storybook/types@7.6.20':
     resolution: {integrity: sha512-GncdY3x0LpbhmUAAJwXYtJDUQEwfF175gsjH0/fxPkxPoV7Sef9TM41jQLJW/5+6TnZoCZP/+aJZTJtq3ni23Q==}
@@ -20254,8 +20331,8 @@ packages:
   posthog-js-lite@4.2.2:
     resolution: {integrity: sha512-fFCoGtMICWwoW0tsEdyFS7OFFgwe7bTTha/SKEtUdyJ56UyJ8wi6VghxyPkO2GVWpco5Za/edT1z1ovGYPCyLQ==}
 
-  posthog-js@1.376.3:
-    resolution: {integrity: sha512-Wmj4N6E352b8aWt/AjRYIOfagQgOlkb8LCD/r7i1eGj8WPBhrYLEXojQeZ+jndbiPbRo21l24bFJso7fyNafWQ==}
+  posthog-js@1.378.1:
+    resolution: {integrity: sha512-pr9hu7J9eKCWlDxGfn5jbqcaTvaS+quRVxMKo7XRiKHPtFpXoIStOctkRTMumz8LucgD4l5NVbtsaZDi6OrrLQ==}
 
   posthog-node@5.25.0:
     resolution: {integrity: sha512-DFE5lZAoD6hk7RATuT8qVQ7KFgFP5YlFTJciMbU2qq6NX0A8eJxiJcmEsMnB3g30jJJ9suiwGIq4I8ESwf9bZg==}
@@ -23043,8 +23120,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.414.0:
-    resolution: {integrity: sha512-fFQ1O06CPO5T0bnvI3ug+wT7xoQ4XX9ELcjgZV2/ySQKmCAi+IVj6LmMtIrrSMyX5Ad3GQTEPop86d0uuXSLPw==}
+  unlayer-types@1.417.0:
+    resolution: {integrity: sha512-G+yAoOO4d+OwRq/XEoDWwRAF/qniqPMhQNd8Obb3p4GTyPEwKLgzuEzDCab+mXJhmdREh57EoMfqm0aJko3oyw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -31600,9 +31677,9 @@ snapshots:
     dependencies:
       '@posthog/types': 1.372.9
 
-  '@posthog/core@1.29.12':
+  '@posthog/core@1.30.2':
     dependencies:
-      '@posthog/types': 1.376.3
+      '@posthog/types': 1.378.1
 
   '@posthog/core@1.7.1':
     dependencies:
@@ -31648,9 +31725,9 @@ snapshots:
     transitivePeerDependencies:
       - rxjs
 
-  '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.376.3)(react@18.3.1)':
+  '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.378.1)(react@18.3.1)':
     dependencies:
-      posthog-js: 1.376.3
+      posthog-js: 1.378.1
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
@@ -31659,7 +31736,7 @@ snapshots:
 
   '@posthog/types@1.372.9': {}
 
-  '@posthog/types@1.376.3': {}
+  '@posthog/types@1.378.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -33792,6 +33869,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  '@storybook/components@8.6.18(storybook@7.6.21(encoding@0.1.13))':
+    dependencies:
+      storybook: 7.6.21(encoding@0.1.13)
+
   '@storybook/core-client@7.6.24':
     dependencies:
       '@storybook/client-logger': 7.6.24
@@ -34095,6 +34176,10 @@ snapshots:
       - react
       - react-dom
 
+  '@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13))':
+    dependencies:
+      storybook: 7.6.21(encoding@0.1.13)
+
   '@storybook/manager@7.6.21': {}
 
   '@storybook/mdx2-csf@1.1.0': {}
@@ -34196,7 +34281,7 @@ snapshots:
       '@storybook/csf': 0.1.13
       '@storybook/global': 5.0.0
       '@storybook/types': 7.6.24
-      '@types/qs': 6.9.18
+      '@types/qs': 6.15.1
       dequal: 2.0.3
       lodash: 4.18.1
       memoizerific: 1.11.3
@@ -34221,6 +34306,10 @@ snapshots:
       synchronous-promise: 2.0.17
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
+
+  '@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13))':
+    dependencies:
+      storybook: 7.6.21(encoding@0.1.13)
 
   '@storybook/preview@7.6.24': {}
 
@@ -34249,6 +34338,12 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@storybook/react-dom-shim@8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@7.6.21(encoding@0.1.13))':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 7.6.21(encoding@0.1.13)
 
   '@storybook/react-vite@7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(typescript@6.0.3)(vite@5.4.21(@types/node@25.8.0)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))':
     dependencies:
@@ -34366,6 +34461,20 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@storybook/react@8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@7.6.21(encoding@0.1.13))(typescript@6.0.3)':
+    dependencies:
+      '@storybook/components': 8.6.18(storybook@7.6.21(encoding@0.1.13))
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
+      '@storybook/preview-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
+      '@storybook/react-dom-shim': 8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@7.6.21(encoding@0.1.13))
+      '@storybook/theming': 8.6.18(storybook@7.6.21(encoding@0.1.13))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 7.6.21(encoding@0.1.13)
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@storybook/router@7.6.20':
     dependencies:
@@ -34498,6 +34607,10 @@ snapshots:
       memoizerific: 1.11.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@storybook/theming@8.6.18(storybook@7.6.21(encoding@0.1.13))':
+    dependencies:
+      storybook: 7.6.21(encoding@0.1.13)
 
   '@storybook/types@7.6.20':
     dependencies:
@@ -35784,7 +35897,7 @@ snapshots:
   '@types/express-serve-static-core@4.17.43':
     dependencies:
       '@types/node': 22.18.8
-      '@types/qs': 6.9.18
+      '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
 
@@ -46101,15 +46214,15 @@ snapshots:
     dependencies:
       '@posthog/core': 1.7.1
 
-  posthog-js@1.376.3:
+  posthog-js@1.378.1:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
       '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
-      '@posthog/core': 1.29.12
-      '@posthog/types': 1.376.3
+      '@posthog/core': 1.30.2
+      '@posthog/types': 1.378.1
       core-js: 3.40.0
       dompurify: 3.4.0
       fflate: 0.4.8
@@ -46998,7 +47111,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.414.0
+      unlayer-types: 1.417.0
 
   react-grid-layout@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -48171,23 +48284,23 @@ snapshots:
 
   store2@2.14.4: {}
 
-  storybook-addon-pseudo-states@2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.20)(@storybook/manager-api@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.6.24)(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook-addon-pseudo-states@2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.20)(@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@storybook/components': 7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-events': 7.6.20
-      '@storybook/manager-api': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/preview-api': 7.6.24
+      '@storybook/manager-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
+      '@storybook/preview-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
       '@storybook/theming': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  storybook-addon-pseudo-states@2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.24)(@storybook/manager-api@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.6.24)(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook-addon-pseudo-states@2.1.2(@storybook/components@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/core-events@7.6.24)(@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@storybook/components': 7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/components': 8.6.18(storybook@7.6.21(encoding@0.1.13))
       '@storybook/core-events': 7.6.24
-      '@storybook/manager-api': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/preview-api': 7.6.24
+      '@storybook/manager-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
+      '@storybook/preview-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
       '@storybook/theming': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       react: 18.3.1
@@ -49483,7 +49596,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.414.0: {}
+  unlayer-types@1.417.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: ^0.35.0
       version: 0.35.0
     posthog-js:
-      specifier: ^1.378.1
-      version: 1.378.1
+      specifier: ^1.376.3
+      version: 1.376.3
     ts-pattern:
       specifier: '4.3'
       version: 4.3.0
@@ -326,7 +326,7 @@ importers:
         version: 3.1.0
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
     devDependencies:
       '@swc/core':
         specifier: ^1.11.29
@@ -354,7 +354,7 @@ importers:
         version: 1.5.15
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
     devDependencies:
       '@swc/core':
         specifier: ^1.11.29
@@ -496,7 +496,7 @@ importers:
         version: 7.6.21(encoding@0.1.13)
       storybook-addon-pseudo-states:
         specifier: 2.1.2
-        version: 2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.20)(@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.20)(@storybook/manager-api@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.6.24)(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       style-loader:
         specifier: ^2.0.0
         version: 2.0.0(webpack@5.88.2)
@@ -749,7 +749,7 @@ importers:
         version: link:../packages/quill/packages/quill
       '@posthog/react':
         specifier: 'catalog:'
-        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.378.1)(react@18.3.1)
+        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.376.3)(react@18.3.1)
       '@posthog/replay-shared':
         specifier: workspace:*
         version: link:../common/replay-shared
@@ -1076,7 +1076,7 @@ importers:
         version: 2.11.0
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       query-selector-shadow-dom:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1839,7 +1839,7 @@ importers:
         version: 7.6.21(encoding@0.1.13)
       storybook-addon-pseudo-states:
         specifier: 2.1.2
-        version: 2.1.2(@storybook/components@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/core-events@7.6.24)(@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.24)(@storybook/manager-api@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.6.24)(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-dark-mode:
         specifier: 3.0.3
         version: 3.0.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1902,9 +1902,21 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       '@tailwindcss/vite':
         specifier: ^4.1.17
         version: 4.2.2(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: 18.3.27
+        version: 18.3.27
+      '@types/react-dom':
+        specifier: 18.3.7
+        version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^5.1.1
         version: 5.2.0(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
@@ -2137,7 +2149,7 @@ importers:
         version: 0.1.7
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2174,7 +2186,7 @@ importers:
         version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2218,7 +2230,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2317,7 +2329,7 @@ importers:
         version: 3.3.0
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2379,7 +2391,7 @@ importers:
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2392,9 +2404,6 @@ importers:
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
-      '@types/react-dom':
-        specifier: 18.3.7
-        version: 18.3.7(@types/react@18.3.27)
       clsx:
         specifier: '*'
         version: 1.2.1
@@ -2410,31 +2419,9 @@ importers:
       kea-router:
         specifier: 'catalog:'
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
-      posthog-js:
-        specifier: 'catalog:'
-        version: 1.378.1
       react:
         specifier: 18.3.1
         version: 18.3.1
-      react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
-    devDependencies:
-      '@storybook/react':
-        specifier: ^8.6.14
-        version: 8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@7.6.21(encoding@0.1.13))(typescript@6.0.3)
-      '@testing-library/jest-dom':
-        specifier: ^5.17.0
-        version: 5.17.0
-      '@testing-library/react':
-        specifier: ^14.3.1
-        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@testing-library/user-event':
-        specifier: ^14.6.1
-        version: 14.6.1(@testing-library/dom@9.3.4)
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
 
   products/data_modeling:
     dependencies:
@@ -2496,7 +2483,7 @@ importers:
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2520,7 +2507,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2675,7 +2662,7 @@ importers:
         version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2754,7 +2741,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2856,7 +2843,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3009,7 +2996,7 @@ importers:
         version: 5.4.1
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3131,7 +3118,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3224,7 +3211,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3237,6 +3224,8 @@ importers:
         version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   products/product_tours: {}
+
+  products/query_performance_ai: {}
 
   products/replay:
     dependencies:
@@ -3484,31 +3473,22 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
-      react-window:
-        specifier: '*'
-        version: 2.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   products/user_interviews:
     dependencies:
       '@posthog/icons':
         specifier: '*'
         version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react':
-        specifier: '*'
-        version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
       clsx:
         specifier: '*'
         version: 1.2.1
-      jest:
-        specifier: '*'
-        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -3520,13 +3500,10 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
 
   products/visual_review:
     dependencies:
@@ -3535,7 +3512,7 @@ importers:
         version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/react':
         specifier: '*'
-        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.378.1)(react@18.3.1)
+        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.376.3)(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3635,7 +3612,7 @@ importers:
         version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.378.1
+        version: 1.376.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -9225,8 +9202,8 @@ packages:
   '@posthog/core@1.28.3':
     resolution: {integrity: sha512-SOy0aphKawZzp8jxfeOpTcXPwi6ii0I2V6tX8YXnM+WbxKKR/R+BXLK0jS6LV8kZtW3H5YxmPAfuIbUP1UnGTw==}
 
-  '@posthog/core@1.30.2':
-    resolution: {integrity: sha512-d7RTpfi+/q5+SZ+4f1WhanfEtNBz9onMmUxn3BO0GDT8N5ZT4DEP3LqFisqeP+xkJTaFPWCOVA/nGyKmUX9y9g==}
+  '@posthog/core@1.29.12':
+    resolution: {integrity: sha512-r/2RUa4zbN0XdBp6d+Yk8Jw1rPWXHxyXIgSm/wJf9yDLIouZbH0Pdkgbc1RIuhwL6BIHCFrOqK5jy8TFKTI6iw==}
 
   '@posthog/core@1.7.1':
     resolution: {integrity: sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==}
@@ -9284,8 +9261,8 @@ packages:
   '@posthog/types@1.372.9':
     resolution: {integrity: sha512-B7k9S+H9WUKHXxe1HOkQWbpWtMcrBvsodm5stZaLQ3pYxf9TowtwssdzTtX4hHjzSYqgrS1IpNnJX4vs1KgBzA==}
 
-  '@posthog/types@1.378.1':
-    resolution: {integrity: sha512-bKOXVWySe5oKFjV6X9VW9jngIm14d4BvnT7l/Eb7e6DrT5uD+XclvbRdhC5f1/l5KwoIU+qswBobHRPlix2D1w==}
+  '@posthog/types@1.376.3':
+    resolution: {integrity: sha512-w21lBoz3/ZGw7BZT7t2lJq1mpJwMvWpZijW7vEwBFNAQlq0KfKf2mj5KKUYZMXM1GdIQ0jHnn931uXPB1Ae60w==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -11001,11 +10978,6 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@storybook/components@8.6.18':
-    resolution: {integrity: sha512-55yViiZzPS/cPBuOeW4QGxGqrusjXVyxuknmbYCIwDtFyyvI/CgbjXRHdxNBaIjz+IlftxvBmmSaOqFG5+/dkA==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
   '@storybook/core-client@7.6.24':
     resolution: {integrity: sha512-1UHiA+h//U0iIm7GAhGG5hN8GaD4rhoqm4ZjUQaCPUemBtEOPMWJk1sQLyGrhlLYDEAp69Sbi4BP/J0LD0nrjQ==}
 
@@ -11075,11 +11047,6 @@ packages:
   '@storybook/manager-api@7.6.4':
     resolution: {integrity: sha512-RFb/iaBJfXygSgXkINPRq8dXu7AxBicTGX7MxqKXbz5FU7ANwV7abH6ONBYURkSDOH9//TQhRlVkF5u8zWg3bw==}
 
-  '@storybook/manager-api@8.6.18':
-    resolution: {integrity: sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
   '@storybook/manager@7.6.21':
     resolution: {integrity: sha512-kwtG7HfxYQIZeGwDg7xFkORhNf0PH+4jRLf/9M6amR537Hctay+Vlv2MGHO6LFzw6IwT4qCtO8xNgzcV9TxZtg==}
 
@@ -11124,11 +11091,6 @@ packages:
   '@storybook/preview-api@7.6.4':
     resolution: {integrity: sha512-KhisNdQX5NdfAln+spLU4B82d804GJQp/CnI5M1mm/taTnjvMgs/wTH9AmR89OPoq+tFZVW0vhy2zgPS3ar71A==}
 
-  '@storybook/preview-api@8.6.18':
-    resolution: {integrity: sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
   '@storybook/preview@7.6.24':
     resolution: {integrity: sha512-8qa9OFD1XKrX0Ts7vZFSd0ugIHoQt4rBGZNG7gE17laFxMTMiNAaTEqBF44f6vslx0z8VjIPtQ8qKeurU0IQdg==}
 
@@ -11152,13 +11114,6 @@ packages:
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
-
-  '@storybook/react-dom-shim@8.6.18':
-    resolution: {integrity: sha512-N4xULcAWZQTUv4jy1/d346Tyb4gufuC3UaLCuU/iVSZ1brYF4OW3ANr+096btbMxY8pR/65lmtoqr5CTGwnBvA==}
-    peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
-      storybook: ^8.6.18
 
   '@storybook/react-vite@7.6.24':
     resolution: {integrity: sha512-0cvvXe9lrxzC50GPDWbJ4tXr3A07CURTv0ryJ9mSeT0YCNMdpX1B20ibxgy6gYgcAa/4fFPCAX6HuOn1Ec6E+g==}
@@ -11204,21 +11159,6 @@ packages:
       typescript:
         optional: true
 
-  '@storybook/react@8.6.18':
-    resolution: {integrity: sha512-BuLpzMkKtF+UCQCbi+lYVX9cdcAMG86Lu2dDn7UFkPi5HRNFq/zHPSvlz1XDgL0OYMtcqB1aoVzFzcyzUBhhjw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@storybook/test': 8.6.18
-      react: 18.3.1
-      react-dom: 18.3.1
-      storybook: ^8.6.18
-      typescript: 6.0.3
-    peerDependenciesMeta:
-      '@storybook/test':
-        optional: true
-      typescript:
-        optional: true
-
   '@storybook/router@7.6.20':
     resolution: {integrity: sha512-mCzsWe6GrH47Xb1++foL98Zdek7uM5GhaSlrI7blWVohGa0qIUYbfJngqR4ZsrXmJeeEvqowobh+jlxg3IJh+w==}
 
@@ -11247,11 +11187,6 @@ packages:
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
-
-  '@storybook/theming@8.6.18':
-    resolution: {integrity: sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
   '@storybook/types@7.6.20':
     resolution: {integrity: sha512-GncdY3x0LpbhmUAAJwXYtJDUQEwfF175gsjH0/fxPkxPoV7Sef9TM41jQLJW/5+6TnZoCZP/+aJZTJtq3ni23Q==}
@@ -11757,6 +11692,17 @@ packages:
     resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@temporalio/activity@1.15.0':
     resolution: {integrity: sha512-kKEIrHMTsANiEpDVZd+v3OT6kU20UtcvAK7iibJNzQnoZUGC7XnqdKQlBuGYBxgpJzD9ppGgskXRczW+XU5Kng==}
@@ -20308,8 +20254,8 @@ packages:
   posthog-js-lite@4.2.2:
     resolution: {integrity: sha512-fFCoGtMICWwoW0tsEdyFS7OFFgwe7bTTha/SKEtUdyJ56UyJ8wi6VghxyPkO2GVWpco5Za/edT1z1ovGYPCyLQ==}
 
-  posthog-js@1.378.1:
-    resolution: {integrity: sha512-pr9hu7J9eKCWlDxGfn5jbqcaTvaS+quRVxMKo7XRiKHPtFpXoIStOctkRTMumz8LucgD4l5NVbtsaZDi6OrrLQ==}
+  posthog-js@1.376.3:
+    resolution: {integrity: sha512-Wmj4N6E352b8aWt/AjRYIOfagQgOlkb8LCD/r7i1eGj8WPBhrYLEXojQeZ+jndbiPbRo21l24bFJso7fyNafWQ==}
 
   posthog-node@5.25.0:
     resolution: {integrity: sha512-DFE5lZAoD6hk7RATuT8qVQ7KFgFP5YlFTJciMbU2qq6NX0A8eJxiJcmEsMnB3g30jJJ9suiwGIq4I8ESwf9bZg==}
@@ -23097,8 +23043,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.417.0:
-    resolution: {integrity: sha512-G+yAoOO4d+OwRq/XEoDWwRAF/qniqPMhQNd8Obb3p4GTyPEwKLgzuEzDCab+mXJhmdREh57EoMfqm0aJko3oyw==}
+  unlayer-types@1.414.0:
+    resolution: {integrity: sha512-fFQ1O06CPO5T0bnvI3ug+wT7xoQ4XX9ELcjgZV2/ySQKmCAi+IVj6LmMtIrrSMyX5Ad3GQTEPop86d0uuXSLPw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -31654,9 +31600,9 @@ snapshots:
     dependencies:
       '@posthog/types': 1.372.9
 
-  '@posthog/core@1.30.2':
+  '@posthog/core@1.29.12':
     dependencies:
-      '@posthog/types': 1.378.1
+      '@posthog/types': 1.376.3
 
   '@posthog/core@1.7.1':
     dependencies:
@@ -31702,9 +31648,9 @@ snapshots:
     transitivePeerDependencies:
       - rxjs
 
-  '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.378.1)(react@18.3.1)':
+  '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.376.3)(react@18.3.1)':
     dependencies:
-      posthog-js: 1.378.1
+      posthog-js: 1.376.3
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
@@ -31713,7 +31659,7 @@ snapshots:
 
   '@posthog/types@1.372.9': {}
 
-  '@posthog/types@1.378.1': {}
+  '@posthog/types@1.376.3': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -33846,10 +33792,6 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@storybook/components@8.6.18(storybook@7.6.21(encoding@0.1.13))':
-    dependencies:
-      storybook: 7.6.21(encoding@0.1.13)
-
   '@storybook/core-client@7.6.24':
     dependencies:
       '@storybook/client-logger': 7.6.24
@@ -34153,10 +34095,6 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13))':
-    dependencies:
-      storybook: 7.6.21(encoding@0.1.13)
-
   '@storybook/manager@7.6.21': {}
 
   '@storybook/mdx2-csf@1.1.0': {}
@@ -34284,10 +34222,6 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13))':
-    dependencies:
-      storybook: 7.6.21(encoding@0.1.13)
-
   '@storybook/preview@7.6.24': {}
 
   '@storybook/preview@7.6.4': {}
@@ -34315,12 +34249,6 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@storybook/react-dom-shim@8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@7.6.21(encoding@0.1.13))':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 7.6.21(encoding@0.1.13)
 
   '@storybook/react-vite@7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(typescript@6.0.3)(vite@5.4.21(@types/node@25.8.0)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))':
     dependencies:
@@ -34438,20 +34366,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@storybook/react@8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@7.6.21(encoding@0.1.13))(typescript@6.0.3)':
-    dependencies:
-      '@storybook/components': 8.6.18(storybook@7.6.21(encoding@0.1.13))
-      '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
-      '@storybook/preview-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
-      '@storybook/react-dom-shim': 8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@7.6.21(encoding@0.1.13))
-      '@storybook/theming': 8.6.18(storybook@7.6.21(encoding@0.1.13))
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 7.6.21(encoding@0.1.13)
-    optionalDependencies:
-      typescript: 6.0.3
 
   '@storybook/router@7.6.20':
     dependencies:
@@ -34584,10 +34498,6 @@ snapshots:
       memoizerific: 1.11.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@storybook/theming@8.6.18(storybook@7.6.21(encoding@0.1.13))':
-    dependencies:
-      storybook: 7.6.21(encoding@0.1.13)
 
   '@storybook/types@7.6.20':
     dependencies:
@@ -35034,6 +34944,14 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
       vite: 7.3.3(@types/node@22.18.8)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
+
+  '@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@temporalio/activity@1.15.0':
     dependencies:
@@ -46183,15 +46101,15 @@ snapshots:
     dependencies:
       '@posthog/core': 1.7.1
 
-  posthog-js@1.378.1:
+  posthog-js@1.376.3:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
       '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
-      '@posthog/core': 1.30.2
-      '@posthog/types': 1.378.1
+      '@posthog/core': 1.29.12
+      '@posthog/types': 1.376.3
       core-js: 3.40.0
       dompurify: 3.4.0
       fflate: 0.4.8
@@ -47080,7 +46998,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.417.0
+      unlayer-types: 1.414.0
 
   react-grid-layout@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -48253,23 +48171,23 @@ snapshots:
 
   store2@2.14.4: {}
 
-  storybook-addon-pseudo-states@2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.20)(@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook-addon-pseudo-states@2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.20)(@storybook/manager-api@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.6.24)(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@storybook/components': 7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-events': 7.6.20
-      '@storybook/manager-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
-      '@storybook/preview-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
+      '@storybook/manager-api': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/preview-api': 7.6.24
       '@storybook/theming': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  storybook-addon-pseudo-states@2.1.2(@storybook/components@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/core-events@7.6.24)(@storybook/manager-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/preview-api@8.6.18(storybook@7.6.21(encoding@0.1.13)))(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook-addon-pseudo-states@2.1.2(@storybook/components@7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.24)(@storybook/manager-api@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.6.24)(@storybook/theming@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@storybook/components': 8.6.18(storybook@7.6.21(encoding@0.1.13))
+      '@storybook/components': 7.6.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-events': 7.6.24
-      '@storybook/manager-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
-      '@storybook/preview-api': 8.6.18(storybook@7.6.21(encoding@0.1.13))
+      '@storybook/manager-api': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/preview-api': 7.6.24
       '@storybook/theming': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       react: 18.3.1
@@ -49565,7 +49483,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.417.0: {}
+  unlayer-types@1.414.0: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## Problem

Quill had no table primitive, so product surfaces hand-rolled tables with inconsistent sticky/scroll/affordance behaviour. This adds a composable low-level `Table` in `@posthog/quill-primitives`, plus a higher-level `DataTable` in `@posthog/quill-components` that wires TanStack Table onto it.

> Data tabel component

<img width="1406" height="678" alt="2026-05-30 15 43 32" src="https://github.com/user-attachments/assets/ac1c7271-f68d-40eb-a577-393687d11166" />

---


<img width="698" height="192" alt="image" src="https://github.com/user-attachments/assets/1d0c2fa5-0c00-497a-8bfd-d74df5804486" />

---


<img width="699" height="259" alt="image" src="https://github.com/user-attachments/assets/65f933d2-5587-42de-af74-226ef84f5f66" />

---


> Table primitive
<img width="727" height="290" alt="image" src="https://github.com/user-attachments/assets/c6092ecd-7238-4caa-a934-b5654aa2af94" />

---


<img width="717" height="233" alt="image" src="https://github.com/user-attachments/assets/78c382af-a357-49e1-a77c-b04c2010d8c2" />


---

<img width="1406" height="684" alt="2026-05-30 15 46 01" src="https://github.com/user-attachments/assets/4b6aaa03-0e02-4d60-a4a9-0f6fe10a8404" />

---

<img width="1406" height="684" alt="2026-05-30 15 46 01" src="https://github.com/user-attachments/assets/ec110e73-427e-4664-b239-493de92adeba" />

---

## Changes

**`Table` primitive** (`packages/quill/packages/primitives/src/table.{tsx,css}`) — composable parts (`Table`, `TableHeader/Body/Footer`, `TableRow`, `TableHead`, `TableCell`, `TableCaption`) following quill's `data-slot` conventions, with refs forwarded on every part:

- **Sticky headers** — `stickyHeader` (viewport-scoped) and `stickyHeader="page"` (document scroll). Page mode uses `overflow: clip` on the root so corners stay clipped without creating a scroll container that captures the sticky.
- **Sticky columns** — `sticky="left" | "right"` on any cell, first or non-first; inner dividers live on the neighbour cell so a stuck column doesn't double its border against the table edge.
- **Overflow affordance** — generic viewport-edge shadows on a non-scrolling wrapper, driven by `data-scroll-*` set from a small scroll/resize effect.
- **Uppercase "label" headers** and **interactive (button) headers** that inherit the header typography so they match plain headers without layout shift.

**`DataTable` component** (`packages/quill/packages/components/src/data-table.tsx`) — headless TanStack Table on the primitive: client-side sorting (sort buttons + `aria-sort`, active column marked via the Button's `aria-selected` styling), selection via row `data-state`, and a minimal generic default empty state overridable through a single `empty` slot.

Storybook stories for every mode. Also: bump all quill packages to `0.3.0-beta.10`; load the built primitives stylesheet in storybook so cross-package consumers get BEM styles; align the components package's React types to the workspace catalog (React 18).

Also bump the light-mode destructive foreground to clear WCAG AA contrast (5.0:1, was ~3.6:1) on the destructive surface, and share a small status helper across the table stories so the Status columns render consistently.

## How did you test this code?

Locally

## Known limitation: 
in `stickyHeader="page"` mode the viewport doesn't scroll (it's `overflow: visible` so stickiness escapes to the document), so the viewport-edge shadows and internal horizontal scroll don't apply — page mode is for tables that fit the page width and scroll with the document. Wide tables should use the bounded-viewport mode.

