### PR TITLE
feat(funnels): polish horizontal funnel step decorations

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
@@ -50,7 +50,7 @@ export const Grouped: Story = {
 export const WithBarTrack: Story = {
     render: () => {
         const theme = useReactiveTheme()
-        const config: BarChartConfig = { barLayout: 'grouped', showGrid: true, barTrack: true, barCornerRadius: 6 }
+        const config: BarChartConfig = { barLayout: 'grouped', showGrid: true, bars: { track: true, cornerRadius: 6 } }
         return (
             <Stage>
                 <BarChart series={THREE_SERIES} labels={DAYS} config={config} theme={theme} />
@@ -242,7 +242,7 @@ export const LargeDataset: Story = {
 export const CustomCornerRadius: Story = {
     render: () => {
         const theme = useReactiveTheme()
-        const config: BarChartConfig = { barLayout: 'grouped', showGrid: true, barCornerRadius: 12 }
+        const config: BarChartConfig = { barLayout: 'grouped', showGrid: true, bars: { cornerRadius: 12 } }
         return (
             <Stage>
                 <BarChart series={TWO_SERIES} labels={DAYS} config={config} theme={theme} />

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -368,6 +368,36 @@ describe('BarChart', () => {
             await waitFor(() => expect(getHogChartTooltip()?.textContent ?? '').toBe(''))
         })
 
+        it('stacked horizontal with barTrack flags clicks in the empty remainder region as inTrack', () => {
+            const onPointClick = jest.fn()
+            const { chart } = renderHogChart(
+                <BarChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ barLayout: 'stacked', axisOrientation: 'horizontal', bars: { track: true } }}
+                    onPointClick={onPointClick}
+                />
+            )
+            // Tue row stacks to 35 while the axis runs to 55 (Wed) — its right side is empty track.
+            const yMidRow = dimensions.plotTop + dimensions.plotHeight / 2
+            // Click on the filled bar → a real segment, not the track.
+            fireEvent.mouseMove(chart.element, {
+                clientX: dimensions.plotLeft + dimensions.plotWidth * 0.2,
+                clientY: yMidRow,
+            })
+            fireEvent.click(chart.element)
+            expect(onPointClick.mock.calls[0][0].inTrack).toBeFalsy()
+            onPointClick.mockClear()
+            // Click past the value extent, in the remainder → flagged as a track click.
+            fireEvent.mouseMove(chart.element, {
+                clientX: dimensions.plotLeft + dimensions.plotWidth * 0.95,
+                clientY: yMidRow,
+            })
+            fireEvent.click(chart.element)
+            expect(onPointClick.mock.calls[0][0].inTrack).toBe(true)
+        })
+
         describe('sparse-stacked horizontal (overlap layout)', () => {
             // Mirrors `buildTrendsBarAggregatedSeries`: each series has one non-zero value at
             // its own dataIndex, every label is the same band. Smallest bar paints on top, so

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -5,12 +5,15 @@ import { type BarChartPrivate, computeBarTrackRect, computeSeriesBars } from '..
 import {
     BAR_TRACK_HOVER_ALPHA,
     type BarRect,
+    type BarRoundedCorners,
     type BarShadow,
     drawBarHighlight,
     drawBars,
     drawBarTracks,
     drawGrid,
+    drawSolidBarTracks,
     type DrawContext,
+    clipToRoundedRects,
 } from '../../core/canvas-renderer'
 import { Chart } from '../../core/Chart'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
@@ -29,6 +32,7 @@ import {
 } from '../../core/scales'
 import type {
     BarChartConfig,
+    BarsConfig,
     ChartDimensions,
     ChartDrawArgs,
     ChartScales,
@@ -46,15 +50,66 @@ import { BarTooltip } from './BarTooltip'
 import {
     type BarLayout,
     barContainsPointOnBandAxis,
+    computeStackEdges,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
     iterBarsAtCursor,
     isStackedLayout,
+    type StackEdges,
 } from './utils/bars-under-cursor'
 
 function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
     const start = scales.band(label)
     return start == null ? undefined : start + scales.band.bandwidth() / 2
+}
+
+const ALL_CORNERS: BarRoundedCorners = { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true }
+
+/** One track rect per unique band, spanning the full value axis behind the stack — the
+ *  funnel-style "remainder of the whole" backdrop. Rounded on all corners so it reads as a pill. */
+function computeBandTrackRects(
+    scales: BarChartPrivate['__barChart'],
+    labels: string[],
+    isHorizontal: boolean
+): BarRect[] {
+    const [axisA = 0, axisB = 0] = scales.value.range()
+    const valueMin = Math.min(axisA, axisB)
+    const valueSize = Math.abs(axisB - axisA)
+    const bandwidth = scales.band.bandwidth()
+    const seen = new Set<string>()
+    const rects: BarRect[] = []
+    for (const label of labels) {
+        if (seen.has(label)) {
+            continue
+        }
+        seen.add(label)
+        const bandStart = scales.band(label)
+        if (bandStart == null) {
+            continue
+        }
+        rects.push(
+            isHorizontal
+                ? { x: valueMin, y: bandStart, width: valueSize, height: bandwidth, corners: ALL_CORNERS, dataIndex: 0 }
+                : { x: bandStart, y: valueMin, width: bandwidth, height: valueSize, corners: ALL_CORNERS, dataIndex: 0 }
+        )
+    }
+    return rects
+}
+
+/** Whether a cursor sits within a band's slot on the band axis — i.e. anywhere in that row's
+ *  full-width track, used to recognise a click in the empty remainder region. */
+function cursorInBandTrack(
+    scales: BarChartPrivate['__barChart'],
+    label: string,
+    cursor: { x: number; y: number },
+    isHorizontal: boolean
+): boolean {
+    const bandStart = scales.band(label)
+    if (bandStart == null) {
+        return false
+    }
+    const bandCoord = isHorizontal ? cursor.y : cursor.x
+    return bandCoord >= bandStart && bandCoord < bandStart + scales.band.bandwidth()
 }
 
 /** Center of a specific series's bar within a band. Used by overlays (e.g. annotations)
@@ -91,7 +146,7 @@ const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
 // Reserve room for chart-edge margins + worst-case x-axis title margin (matches useChartMargins).
 const HORIZONTAL_CHART_MARGIN_PX = DEFAULT_MARGINS.top + DEFAULT_MARGINS.bottom + X_AXIS_TITLE_MARGIN
 
-function resolveBarShadow(barShadow: BarChartConfig['barShadow']): BarShadow | undefined {
+function resolveBarShadow(barShadow: BarsConfig['shadow']): BarShadow | undefined {
     if (barShadow === true) {
         return DEFAULT_BAR_SHADOW
     }
@@ -124,16 +179,23 @@ function BarChartInner<Meta = unknown>({
         yScaleType = 'linear',
         showGrid = false,
         barLayout = 'stacked',
-        barCornerRadius = 0,
-        barTrack = false,
         axisOrientation = 'vertical',
         xTickFormatter,
+    } = config ?? {}
+    const {
+        cornerRadius = 0,
+        rounding = 'cap',
+        track,
+        shadow: barShadow,
         divergingStack = false,
         maxBandRange,
         bandPadding,
-        barShadow,
         minBandSize,
-    } = config ?? {}
+    } = config?.bars ?? {}
+    const roundStackBaseline = rounding === 'pill'
+    const barCornerRadius = rounding === 'none' ? 0 : cornerRadius
+    const barTrack = !!track
+    const barTrackColor = typeof track === 'object' ? track.color : undefined
     const isHorizontal = axisOrientation === 'horizontal'
 
     const resolvedMinBandSize = minBandSize ?? (isHorizontal ? HORIZONTAL_MIN_BAND_SIZE_DEFAULT : 0)
@@ -175,6 +237,14 @@ function BarChartInner<Meta = unknown>({
         }
         return m
     }, [barLayout, series])
+
+    // Per-band non-zero stack edges — only needed when `roundStackBaseline` opts into funnel-style
+    // pill rounding, where the visible top/bottom segment differs per band (e.g. a 100% step has
+    // no filler). Left undefined otherwise so existing per-series cap rounding is unchanged.
+    const stackEdges = useMemo<StackEdges | undefined>(
+        () => (roundStackBaseline && barLayout !== 'grouped' ? computeStackEdges(series, labels.length) : undefined),
+        [roundStackBaseline, barLayout, series, labels.length]
+    )
 
     const chartConfig = useMemo<BarChartConfig>(() => {
         const base = { ...config, isPercent: barLayout === 'percent' }
@@ -313,6 +383,8 @@ function BarChartInner<Meta = unknown>({
                 .filter((s) => !s.visibility?.excluded)
                 .map((s) => {
                     const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
+                    const topAtIndex = stackEdges?.topKeyAtIndex.get(axisId)
+                    const bottomAtIndex = stackEdges?.bottomKeyAtIndex.get(axisId)
                     const bars = computeSeriesBars({
                         series: s,
                         labels: drawLabels,
@@ -321,20 +393,30 @@ function BarChartInner<Meta = unknown>({
                         isHorizontal,
                         stackedBand: stackedData?.get(s.key),
                         isTopOfStack: topStackedKeyByAxis.get(axisId) === s.key,
+                        capRoundedAtIndex: stackEdges ? (i) => topAtIndex?.[i] === s.key : undefined,
+                        baseRoundedAtIndex:
+                            stackEdges && roundStackBaseline ? (i) => bottomAtIndex?.[i] === s.key : undefined,
                     }).filter((b): b is BarRect => b !== null)
                     return { series: s, bars }
                 })
 
-            // Tracks are a separate pass so a later series' full-height track can't paint
-            // over an earlier series' bar. Track is "share of a whole" semantics — only
-            // meaningful for grouped layouts; in stacked/percent every layer would paint
-            // a full-height track over the same band with the wrong corners.
+            // Tracks are a separate pass before the bars so the stack paints on top. Grouped
+            // gets a per-series tinted+hatched track in each sub-band slot; stacked/percent gets
+            // one neutral solid track per band behind the whole stack (a single full-axis pill).
             if (barTrack && barLayout === 'grouped') {
                 const [axisStart = 0, axisEnd = 0] = d3Scales.value.range()
                 for (const { series: s, bars } of seriesBars) {
                     const tracks = bars.map((b) => computeBarTrackRect(b, axisStart, axisEnd, isHorizontal))
                     drawBarTracks(baseDrawCtx, s, tracks, barCornerRadius)
                 }
+            } else if (barTrack) {
+                const tracks = computeBandTrackRects(d3Scales, drawLabels, isHorizontal)
+                drawSolidBarTracks(
+                    ctx,
+                    tracks,
+                    barTrackColor ?? theme.gridColor ?? 'rgba(0, 0, 0, 0.08)',
+                    barCornerRadius
+                )
             }
 
             const resolvedShadow = resolveBarShadow(barShadow)
@@ -349,8 +431,18 @@ function BarChartInner<Meta = unknown>({
                 ctx.shadowOffsetX = resolvedShadow.offsetX ?? 0
                 ctx.shadowOffsetY = resolvedShadow.offsetY ?? 0
             }
+            // Pill mode: mask the whole stack to the rounded band so the outer corners round even
+            // when the edge segment (e.g. the last of many breakdowns) is too thin to round itself.
+            const pillClip = roundStackBaseline && isStackedLayout(barLayout)
+            if (pillClip) {
+                ctx.save()
+                clipToRoundedRects(ctx, computeBandTrackRects(d3Scales, drawLabels, isHorizontal), barCornerRadius)
+            }
             for (const { series: s, bars } of seriesBars) {
                 drawBars(baseDrawCtx, s, bars, barCornerRadius)
+            }
+            if (pillClip) {
+                ctx.restore()
             }
             if (resolvedShadow) {
                 ctx.restore()
@@ -362,8 +454,12 @@ function BarChartInner<Meta = unknown>({
             barLayout,
             isHorizontal,
             topStackedKeyByAxis,
+            stackEdges,
+            roundStackBaseline,
             barCornerRadius,
             barTrack,
+            barTrackColor,
+            theme.gridColor,
             xTickFormatter,
             barShadow,
         ]
@@ -409,6 +505,8 @@ function BarChartInner<Meta = unknown>({
                     isHorizontal,
                     stackedData,
                     topStackedKeyByAxis,
+                    stackEdges,
+                    roundStackBaseline,
                 })
                 if (visible) {
                     const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
@@ -431,6 +529,8 @@ function BarChartInner<Meta = unknown>({
                     isHorizontal,
                     stackedData,
                     topStackedKeyByAxis,
+                    stackEdges,
+                    roundStackBaseline,
                 })) {
                     if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
                         continue
@@ -456,6 +556,10 @@ function BarChartInner<Meta = unknown>({
             }
             ctx.save()
             ctx.globalAlpha = alpha
+            // Match the static layer's pill mask so an edge segment's highlight rounds with it.
+            if (roundStackBaseline && stackedHighlight) {
+                clipToRoundedRects(ctx, computeBandTrackRects(d3Scales, drawLabels, isHorizontal), barCornerRadius)
+            }
             for (const { series: s, bar, isTrackHighlight } of items) {
                 if (isTrackHighlight) {
                     const parsed = d3.color(s.color)
@@ -482,7 +586,16 @@ function BarChartInner<Meta = unknown>({
             ctx.restore()
             return true
         },
-        [stackedData, barLayout, isHorizontal, topStackedKeyByAxis, barCornerRadius, barTrack]
+        [
+            stackedData,
+            barLayout,
+            isHorizontal,
+            topStackedKeyByAxis,
+            stackEdges,
+            roundStackBaseline,
+            barCornerRadius,
+            barTrack,
+        ]
     )
 
     // Show each series's own segment value (resolveValue) but anchor the tooltip/value labels
@@ -511,10 +624,11 @@ function BarChartInner<Meta = unknown>({
                     topStackedKeyByAxis,
                     series: seriesRef.current,
                     labels: labelsRef.current,
+                    barTrack,
                 }) ?? clickData
             )
         },
-        [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef]
+        [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef, barTrack]
     )
 
     const chart = (
@@ -569,6 +683,7 @@ export function resolveClickedStackedSegment<Meta>({
     topStackedKeyByAxis,
     series,
     labels,
+    barTrack,
 }: {
     clickData: PointClickData<Meta>
     d3Scales: BarScaleSet
@@ -578,6 +693,7 @@ export function resolveClickedStackedSegment<Meta>({
     topStackedKeyByAxis: Map<string, string>
     series: Series<Meta>[]
     labels: readonly string[]
+    barTrack: boolean
 }): PointClickData<Meta> | null {
     if (!isStackedLayout(barLayout)) {
         return null
@@ -600,6 +716,11 @@ export function resolveClickedStackedSegment<Meta>({
         topStackedKeyByAxis,
     })
     if (!visible) {
+        // No filled segment under the cursor — for a tracked funnel that's the empty remainder
+        // region of the band, so flag it as a track click (the consumer routes it to drop-off).
+        if (barTrack && cursorInBandTrack(d3Scales, label, cursor, isHorizontal)) {
+            return { ...clickData, inTrack: true }
+        }
         return null
     }
     const hit = crossSeriesData.find((d) => d.series.key === visible.series.key)

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.test.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.test.ts
@@ -1,5 +1,14 @@
 import type { BarRect } from '../../../core/canvas-renderer'
-import { barContainsPoint, barContainsPointOnBandAxis, cursorOutsideBarFillExtent } from './bars-under-cursor'
+import { computeStackData, createBarScales } from '../../../core/scales'
+import type { Series } from '../../../core/types'
+import { dimensions, makeSeries } from '../../../testing'
+import {
+    barContainsPoint,
+    barContainsPointOnBandAxis,
+    computeStackEdges,
+    cursorOutsideBarFillExtent,
+    findVisibleStackedSegment,
+} from './bars-under-cursor'
 
 const verticalBar: BarRect = { x: 100, y: 120, width: 50, height: 200, corners: {}, dataIndex: 0 }
 const horizontalBar: BarRect = { x: 60, y: 100, width: 140, height: 40, corners: {}, dataIndex: 0 }
@@ -88,5 +97,110 @@ describe('barContainsPoint', () => {
                 })
             ).toBe(false)
         })
+    })
+})
+
+describe('computeStackEdges', () => {
+    const series = (key: string, data: number[]): Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'> => ({
+        key,
+        data,
+    })
+
+    it('picks the bottommost and topmost non-zero segment per band', () => {
+        // Funnel-style: value spans both bands, filler is zero at the 100% first step.
+        const { topKeyAtIndex, bottomKeyAtIndex } = computeStackEdges(
+            [series('value', [100, 55]), series('filler', [0, 45])],
+            2
+        )
+        expect(bottomKeyAtIndex.get('left')).toEqual(['value', 'value'])
+        // Step 0: filler is zero, so value is also the visible top. Step 1: filler is the top.
+        expect(topKeyAtIndex.get('left')).toEqual(['value', 'filler'])
+    })
+
+    it('skips excluded series and treats zero/non-finite as absent', () => {
+        const excluded: Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'> = {
+            key: 'hidden',
+            data: [10],
+            visibility: { excluded: true },
+        }
+        const { topKeyAtIndex, bottomKeyAtIndex } = computeStackEdges([excluded, series('a', [0]), series('b', [7])], 1)
+        expect(bottomKeyAtIndex.get('left')).toEqual(['b'])
+        expect(topKeyAtIndex.get('left')).toEqual(['b'])
+    })
+
+    it('keys edges by yAxisId', () => {
+        const left: Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'> = { key: 'l', data: [3], yAxisId: 'left' }
+        const right: Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'> = { key: 'r', data: [4], yAxisId: 'right' }
+        const { topKeyAtIndex } = computeStackEdges([left, right], 1)
+        expect(topKeyAtIndex.get('left')).toEqual(['l'])
+        expect(topKeyAtIndex.get('right')).toEqual(['r'])
+    })
+})
+
+describe('findVisibleStackedSegment — highlight clipping', () => {
+    const topStackedKeyByAxis = (series: { key: string }[]): Map<string, string> => {
+        const m = new Map<string, string>()
+        series.forEach((s) => m.set('left', s.key))
+        return m
+    }
+
+    it('does not clip an adjacent-stack segment (funnel value sitting beside the filler)', () => {
+        // value [0..54], filler [54..100] — they touch but never overlap, so hovering the value
+        // segment must highlight its whole slice (nextSmallerExtent === 0).
+        const labels = ['0']
+        const value = makeSeries({ key: 'value', data: [54] })
+        const filler = makeSeries({ key: 'filler', data: [46] })
+        const series = [value, filler]
+        const scales = createBarScales(series, labels, dimensions, {
+            barLayout: 'stacked',
+            axisOrientation: 'horizontal',
+        })
+        const stackedData = computeStackData(series, labels)
+        const bandStart = scales.band('0')!
+        const cursor = { x: scales.value(27), y: bandStart + scales.band.bandwidth() / 2 }
+        const result = findVisibleStackedSegment({
+            series,
+            labels,
+            hoveredLabel: '0',
+            cursor,
+            scales,
+            layout: 'stacked',
+            isHorizontal: true,
+            stackedData,
+            topStackedKeyByAxis: topStackedKeyByAxis(series),
+        })
+        expect(result?.series.key).toBe('value')
+        expect(result?.nextSmallerExtent).toBe(0)
+    })
+
+    it('clips a nested overlap segment to the part not overdrawn by smaller on-top segments', () => {
+        // Sparse/aggregated layout: every series is non-zero at its own index but shares the band,
+        // so all draw from the baseline (nested). Hovering the big slice must clip past the mid one.
+        const labels = ['b', 'b']
+        const big = makeSeries({ key: 'big', data: [100, 0] })
+        const mid = makeSeries({ key: 'mid', data: [0, 50] })
+        const series = [big, mid]
+        const scales = createBarScales(series, labels, dimensions, {
+            barLayout: 'stacked',
+            axisOrientation: 'horizontal',
+        })
+        const stackedData = computeStackData(series, labels)
+        const bandStart = scales.band('b')!
+        const cursor = { x: scales.value(75), y: bandStart + scales.band.bandwidth() / 2 }
+        const result = findVisibleStackedSegment({
+            series,
+            labels,
+            hoveredLabel: 'b',
+            cursor,
+            scales,
+            layout: 'stacked',
+            isHorizontal: true,
+            stackedData,
+            topStackedKeyByAxis: topStackedKeyByAxis(series),
+        })
+        expect(result?.series.key).toBe('big')
+        // mid's slice [0..50%px] overlaps big's [0..100%px], so its width clips big's highlight.
+        const midWidthPx = Math.abs(scales.value(50) - scales.value(0))
+        expect(result?.nextSmallerExtent).toBeCloseTo(midWidthPx, 5)
     })
 })

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
@@ -10,6 +10,51 @@ export function isStackedLayout(layout: BarLayout): boolean {
     return layout !== 'grouped'
 }
 
+/** Per-axis, per-index key of the topmost / bottommost non-zero stacked segment. Cap and
+ *  baseline rounding for funnel-style stacks must be resolved per band, not per series: a
+ *  100% first step has no filler, so its single segment is simultaneously top and bottom. */
+export interface StackEdges {
+    topKeyAtIndex: Map<string, (string | null)[]>
+    bottomKeyAtIndex: Map<string, (string | null)[]>
+}
+
+export function computeStackEdges(
+    series: readonly Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>[],
+    indexCount: number
+): StackEdges {
+    const topKeyAtIndex = new Map<string, (string | null)[]>()
+    const bottomKeyAtIndex = new Map<string, (string | null)[]>()
+    const arrFor = (m: Map<string, (string | null)[]>, axisId: string): (string | null)[] => {
+        let arr = m.get(axisId)
+        if (!arr) {
+            arr = new Array(indexCount).fill(null)
+            m.set(axisId, arr)
+        }
+        return arr
+    }
+    for (const s of series) {
+        if (s.visibility?.excluded) {
+            continue
+        }
+        const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
+        const topArr = arrFor(topKeyAtIndex, axisId)
+        const bottomArr = arrFor(bottomKeyAtIndex, axisId)
+        for (let i = 0; i < indexCount; i++) {
+            const v = s.data[i]
+            if (typeof v !== 'number' || !isFinite(v) || v === 0) {
+                continue
+            }
+            // Series iterate bottom → top (d3.stack key order), so the last non-zero write
+            // at an index is the top segment; the first is the bottom.
+            topArr[i] = s.key
+            if (bottomArr[i] == null) {
+                bottomArr[i] = s.key
+            }
+        }
+    }
+    return { topKeyAtIndex, bottomKeyAtIndex }
+}
+
 /** Grouped-layout hit-test that ignores the value axis so a cursor above (or below) a bar still
  *  selects the bar whose band-slot it lines up with. Matches chart.js's `mode: 'point', axis: 'x'`
  *  behaviour — without this, hovering above a short bar in a grouped pair would fail every
@@ -55,6 +100,11 @@ export interface BarsAtCursorArgs {
     isHorizontal: boolean
     stackedData?: Map<string, StackedBand>
     topStackedKeyByAxis: Map<string, string>
+    /** When present, cap/baseline rounding is resolved per band from the visible non-zero
+     *  stack (funnel-style) so hover highlights match the rounded static bars. */
+    stackEdges?: StackEdges
+    /** Round the baseline-side corners of the bottom-of-stack segment. Only honored with `stackEdges`. */
+    roundStackBaseline?: boolean
 }
 
 export interface BarAtCursor<S> {
@@ -68,7 +118,8 @@ export interface BarAtCursor<S> {
 export function* iterBarsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>>(
     args: Omit<BarsAtCursorArgs, 'series'> & { series: readonly S[] }
 ): Generator<BarAtCursor<S>> {
-    const { series, label, dataIndex, scales, layout, isHorizontal, stackedData, topStackedKeyByAxis } = args
+    const { series, label, dataIndex, scales, layout, isHorizontal, stackedData, topStackedKeyByAxis, stackEdges } =
+        args
     for (const s of series) {
         if (s.visibility?.excluded) {
             continue
@@ -76,6 +127,13 @@ export function* iterBarsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 
         const stackedBand = stackedData?.get(s.key)
         const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
         const isTopOfStack = topStackedKeyByAxis.get(axisId) === s.key
+        let capRounded: boolean | undefined
+        let baseRounded: boolean | undefined
+        if (stackEdges && isStackedLayout(layout)) {
+            capRounded = stackEdges.topKeyAtIndex.get(axisId)?.[dataIndex] === s.key
+            baseRounded =
+                args.roundStackBaseline === true && stackEdges.bottomKeyAtIndex.get(axisId)?.[dataIndex] === s.key
+        }
         const bar = computeBarAtIndex({
             series: s as unknown as Series,
             label,
@@ -85,6 +143,8 @@ export function* iterBarsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 
             isHorizontal,
             stackedBand,
             isTopOfStack,
+            capRounded,
+            baseRounded,
         })
         if (bar) {
             yield { series: s, bar }
@@ -119,9 +179,18 @@ export function resolveBarsAtCursor(
     return { hits, strictHit }
 }
 
+/** Value-axis interval [near, far] of a bar, regardless of orientation. */
+function valueAxisExtentRange(bar: BarRect, isHorizontal: boolean): [number, number] {
+    return isHorizontal ? [bar.x, bar.x + bar.width] : [bar.y, bar.y + bar.height]
+}
+
 /** Visible stacked segment under the cursor — last-drawn bar whose rect contains it.
  *  Also returns the next-smaller extent (the far edge of the bar that overdraws this
- *  segment's near side); callers clip the highlight rect there so hover preserves z-order. */
+ *  segment's near side); callers clip the highlight rect there so hover preserves z-order.
+ *  Only segments that actually *overlap* the visible one count — in a sparse/aggregated
+ *  overlap layout every segment is drawn from the baseline (nested), so a smaller one paints
+ *  over this segment's near side; in a proper adjacent stack (funnels) the neighbours sit
+ *  beside it and must not clip its highlight. */
 export function findVisibleStackedSegment<S extends Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>>(
     args: Omit<BarsAtCursorArgs, 'series' | 'label' | 'dataIndex'> & {
         series: readonly S[]
@@ -132,7 +201,7 @@ export function findVisibleStackedSegment<S extends Pick<Series, 'key' | 'visibi
 ): { series: S; bar: BarRect; dataIndex: number; nextSmallerExtent: number } | null {
     const { labels, hoveredLabel, cursor, isHorizontal } = args
     let visible: { series: S; bar: BarRect; dataIndex: number; extent: number } | null = null
-    const allExtents: number[] = []
+    const candidates: { extent: number; range: [number, number] }[] = []
     for (let dataIndex = 0; dataIndex < labels.length; dataIndex++) {
         if (labels[dataIndex] !== hoveredLabel) {
             continue
@@ -142,7 +211,7 @@ export function findVisibleStackedSegment<S extends Pick<Series, 'key' | 'visibi
             if (extent <= 0) {
                 continue
             }
-            allExtents.push(extent)
+            candidates.push({ extent, range: valueAxisExtentRange(bar, isHorizontal) })
             if (!barContainsPoint(bar, cursor)) {
                 continue
             }
@@ -153,6 +222,15 @@ export function findVisibleStackedSegment<S extends Pick<Series, 'key' | 'visibi
     if (!visible) {
         return null
     }
-    const nextSmallerExtent = allExtents.reduce((max, ext) => (ext < visible!.extent && ext > max ? ext : max), 0)
+    const [visNear, visFar] = valueAxisExtentRange(visible.bar, isHorizontal)
+    // Largest overdrawing segment: smaller extent (drawn on top) AND a real pixel overlap with
+    // the visible slice. Adjacent stack neighbours only touch at an edge, so they don't count.
+    const nextSmallerExtent = candidates.reduce((max, c) => {
+        if (c.extent >= visible!.extent || c.extent <= max) {
+            return max
+        }
+        const overlaps = c.range[0] < visFar && visNear < c.range[1]
+        return overlaps ? c.extent : max
+    }, 0)
     return { series: visible.series, bar: visible.bar, dataIndex: visible.dataIndex, nextSmallerExtent }
 }

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -111,11 +111,10 @@ export function TimeSeriesBarChart<Meta = unknown>({
         yAxisLabel: yAxis?.label,
         showGrid: yAxis?.showGrid,
         barLayout,
-        barCornerRadius,
         axisOrientation,
         showCrosshair,
         tooltip: tooltipConfig,
-        divergingStack,
+        bars: { cornerRadius: barCornerRadius, divergingStack },
     }
 
     return (

--- a/frontend/src/lib/hog-charts/core/bar-layout.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.test.ts
@@ -37,6 +37,24 @@ describe('hog-charts bar-layout', () => {
         ])('returns no rounding when shouldRoundCap is false', ({ isHorizontal, isPositive }) => {
             expect(cornersFor(isHorizontal, isPositive, false)).toEqual({})
         })
+
+        it.each([
+            { isHorizontal: false, isPositive: true, expected: { bottomLeft: true, bottomRight: true } },
+            { isHorizontal: false, isPositive: false, expected: { topLeft: true, topRight: true } },
+            { isHorizontal: true, isPositive: true, expected: { topLeft: true, bottomLeft: true } },
+            { isHorizontal: true, isPositive: false, expected: { topRight: true, bottomRight: true } },
+        ])('rounds the baseline end (h=$isHorizontal, +=$isPositive)', ({ isHorizontal, isPositive, expected }) => {
+            expect(cornersFor(isHorizontal, isPositive, false, true)).toEqual(expected)
+        })
+
+        it('rounds both ends as a pill when cap and baseline are both set', () => {
+            expect(cornersFor(true, true, true, true)).toEqual({
+                topLeft: true,
+                bottomLeft: true,
+                topRight: true,
+                bottomRight: true,
+            })
+        })
     })
 
     describe('computeSeriesBars — grouped', () => {
@@ -117,6 +135,54 @@ describe('hog-charts bar-layout', () => {
                 isTopOfStack,
             })
             expect(bars[0]?.corners).toEqual(expectedCorners)
+        })
+
+        it('rounds both ends per band when capRoundedAtIndex/baseRoundedAtIndex are funnel-style', () => {
+            // Funnel: step 0 is 100% (no filler), step 1 splits value + filler. The value segment
+            // is the bottom of every band; it is also the visible top at step 0 (filler is zero).
+            const labels = ['0', '1']
+            const value = makeSeries({ key: 'value', data: [100, 55] })
+            const filler = makeSeries({ key: 'filler', data: [0, 45] })
+            const scales = createBarScales([value, filler], labels, dimensions, {
+                barLayout: 'stacked',
+                axisOrientation: 'horizontal',
+            })
+            const stacks = computeStackData([value, filler], labels)
+            // Per-band non-zero edges: value is bottom at both; top at step 0, filler is top at step 1.
+            const topKeyAtIndex = ['value', 'filler']
+            const bottomKeyAtIndex = ['value', 'value']
+            const valueBars = computeSeriesBars({
+                series: value,
+                labels,
+                scales,
+                layout: 'stacked',
+                isHorizontal: true,
+                stackedBand: stacks.get('value'),
+                isTopOfStack: false,
+                capRoundedAtIndex: (i) => topKeyAtIndex[i] === 'value',
+                baseRoundedAtIndex: (i) => bottomKeyAtIndex[i] === 'value',
+            })
+            const fillerBars = computeSeriesBars({
+                series: filler,
+                labels,
+                scales,
+                layout: 'stacked',
+                isHorizontal: true,
+                stackedBand: stacks.get('filler'),
+                isTopOfStack: true,
+                capRoundedAtIndex: (i) => topKeyAtIndex[i] === 'filler',
+                baseRoundedAtIndex: (i) => bottomKeyAtIndex[i] === 'filler',
+            })
+            // Step 0: value is the only segment — rounded pill on both ends.
+            expect(valueBars[0]?.corners).toEqual({
+                topLeft: true,
+                bottomLeft: true,
+                topRight: true,
+                bottomRight: true,
+            })
+            // Step 1: value rounds the baseline (left) only; filler rounds the cap (right) only.
+            expect(valueBars[1]?.corners).toEqual({ topLeft: true, bottomLeft: true })
+            expect(fillerBars[1]?.corners).toEqual({ topRight: true, bottomRight: true })
         })
 
         it('returns nulls when stackedBand is omitted for non-grouped layouts', () => {

--- a/frontend/src/lib/hog-charts/core/bar-layout.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.ts
@@ -11,15 +11,42 @@ export interface BarChartPrivate {
 export type SeriesBarLayout = (BarRect | null)[]
 
 /** Cap is the side away from the value-axis baseline; pass `shouldRoundCap: false` for stacked
- *  layers below the topmost. */
-export function cornersFor(isHorizontal: boolean, isPositive: boolean, shouldRoundCap: boolean): BarRoundedCorners {
-    if (!shouldRoundCap) {
-        return {}
+ *  layers below the topmost. `shouldRoundBaseline` rounds the side *towards* the baseline — used
+ *  for the bottom-of-stack layer so a funnel-style bar reads as one rounded pill on both ends. */
+export function cornersFor(
+    isHorizontal: boolean,
+    isPositive: boolean,
+    shouldRoundCap: boolean,
+    shouldRoundBaseline: boolean = false
+): BarRoundedCorners {
+    const corners: BarRoundedCorners = {}
+    if (shouldRoundCap) {
+        if (isHorizontal) {
+            if (isPositive) {
+                corners.topRight = corners.bottomRight = true
+            } else {
+                corners.topLeft = corners.bottomLeft = true
+            }
+        } else if (isPositive) {
+            corners.topLeft = corners.topRight = true
+        } else {
+            corners.bottomLeft = corners.bottomRight = true
+        }
     }
-    if (isHorizontal) {
-        return isPositive ? { topRight: true, bottomRight: true } : { topLeft: true, bottomLeft: true }
+    if (shouldRoundBaseline) {
+        if (isHorizontal) {
+            if (isPositive) {
+                corners.topLeft = corners.bottomLeft = true
+            } else {
+                corners.topRight = corners.bottomRight = true
+            }
+        } else if (isPositive) {
+            corners.bottomLeft = corners.bottomRight = true
+        } else {
+            corners.topLeft = corners.topRight = true
+        }
     }
-    return isPositive ? { topLeft: true, topRight: true } : { bottomLeft: true, bottomRight: true }
+    return corners
 }
 
 function makeBarRect(
@@ -47,6 +74,13 @@ export interface ComputeSeriesBarsOptions {
     /** Required for `stacked` and `percent` layouts. Must be omitted for `grouped`. */
     stackedBand?: StackedBand
     isTopOfStack: boolean
+    /** Per-index override for cap rounding — funnels round whichever segment is the topmost
+     *  *non-zero* one at each band, which varies by band (e.g. a 100% first step has no
+     *  filler). When omitted, falls back to the per-series `isTopOfStack`. */
+    capRoundedAtIndex?: (dataIndex: number) => boolean
+    /** Per-index override for baseline rounding — rounds the side towards the value-axis
+     *  baseline for the bottom-of-stack segment. When omitted, the baseline is never rounded. */
+    baseRoundedAtIndex?: (dataIndex: number) => boolean
 }
 
 export function computeSeriesBars({
@@ -57,6 +91,8 @@ export function computeSeriesBars({
     isHorizontal,
     stackedBand,
     isTopOfStack,
+    capRoundedAtIndex,
+    baseRoundedAtIndex,
 }: ComputeSeriesBarsOptions): SeriesBarLayout {
     const result: SeriesBarLayout = new Array(labels.length)
     for (let i = 0; i < labels.length; i++) {
@@ -65,10 +101,12 @@ export function computeSeriesBars({
             label: labels[i],
             dataIndex: i,
             scales,
-            layout,
             isHorizontal,
+            layout,
             stackedBand,
             isTopOfStack,
+            capRounded: capRoundedAtIndex?.(i),
+            baseRounded: baseRoundedAtIndex?.(i),
         })
     }
     return result
@@ -84,6 +122,10 @@ export interface ComputeBarAtIndexOptions {
     /** Required for `stacked` and `percent` layouts. Must be omitted for `grouped`. */
     stackedBand?: StackedBand
     isTopOfStack: boolean
+    /** Resolved cap-rounding for this bar. Overrides the `isGrouped || isTopOfStack` default. */
+    capRounded?: boolean
+    /** Resolved baseline-rounding for this bar. Defaults to `false`. */
+    baseRounded?: boolean
 }
 
 /** Single-bar fast path for `drawHover` so the overlay redraw doesn't recompute every bar
@@ -97,6 +139,8 @@ export function computeBarAtIndex({
     isHorizontal,
     stackedBand,
     isTopOfStack,
+    capRounded,
+    baseRounded,
 }: ComputeBarAtIndexOptions): BarRect | null {
     const isGrouped = layout === 'grouped'
     if (!isGrouped && !stackedBand) {
@@ -112,7 +156,8 @@ export function computeBarAtIndex({
         return null
     }
 
-    const shouldRoundCap = isGrouped || isTopOfStack
+    const shouldRoundCap = capRounded ?? (isGrouped || isTopOfStack)
+    const shouldRoundBaseline = isGrouped ? false : (baseRounded ?? false)
     const bandWidth = scales.band.bandwidth()
 
     if (isGrouped) {
@@ -135,7 +180,7 @@ export function computeBarAtIndex({
     // For stacked/percent the bar's "positive direction" depends on which pixel is further from baseline,
     // which differs by orientation: horizontal = larger x-pixel, vertical = smaller y-pixel (axis is inverted).
     const isPositive = isHorizontal ? topPixel >= bottomPixel : topPixel <= bottomPixel
-    const corners = cornersFor(isHorizontal, isPositive, shouldRoundCap)
+    const corners = cornersFor(isHorizontal, isPositive, shouldRoundCap, shouldRoundBaseline)
     return makeBarRect(isHorizontal, bandStart, bandWidth, topPixel, bottomPixel, corners, dataIndex)
 }
 

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -534,6 +534,39 @@ function fillTrackRects(ctx: CanvasRenderingContext2D, tracks: BarRect[], corner
     }
 }
 
+/** Clips subsequent drawing to the union of the given rounded rects — used to mask the bar
+ *  layer to the funnel pill so a stack's outer corners round even when the edge segment is too
+ *  thin to round on its own. Caller owns save/restore. */
+export function clipToRoundedRects(ctx: CanvasRenderingContext2D, rects: BarRect[], cornerRadius: number): void {
+    ctx.beginPath()
+    for (const r of rects) {
+        if (r.width <= 0 || r.height <= 0) {
+            continue
+        }
+        traceRoundedBarPath(ctx, r.x, r.y, r.width, r.height, cornerRadius, r.corners)
+    }
+    ctx.clip()
+}
+
+/** Paints each track rect as a single solid colour — the neutral "remainder of the whole"
+ *  backdrop for funnel-style stacked bars (one track per band behind the stack), as opposed
+ *  to {@link drawBarTracks}'s per-series tinted+hatched treatment for grouped layouts. */
+export function drawSolidBarTracks(
+    ctx: CanvasRenderingContext2D,
+    tracks: BarRect[],
+    color: string,
+    cornerRadius: number
+): void {
+    const renderableTracks = tracks.filter((t) => t.width > 0 && t.height > 0)
+    if (renderableTracks.length === 0) {
+        return
+    }
+    ctx.save()
+    ctx.fillStyle = color
+    fillTrackRects(ctx, renderableTracks, cornerRadius)
+    ctx.restore()
+}
+
 /** Paints each track rect as a tinted base under hatched stripes. Takes laid-out rects
  *  from `computeBarTrackRect`, mirroring `drawBars`. */
 export function drawBarTracks(

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -103,6 +103,10 @@ export interface PointClickData<Meta = unknown> {
     /** Cursor position in pixels relative to the chart wrapper at click time, or `null`
      *  when unavailable. Same origin as `TooltipContext.hoverPosition`. */
     cursor: { x: number; y: number } | null
+    /** True when the click landed in the empty `barTrack` region (past the filled bar) rather
+     *  than on a bar segment — funnel-style charts route this to the "remainder" (drop-off).
+     *  Only set when a track is drawn; `series`/`dataIndex` still reference the clicked band. */
+    inTrack?: boolean
 }
 
 /** Context object passed to the `renderTooltip` render prop and tooltip event callbacks. */
@@ -199,38 +203,50 @@ export interface TooltipConfig {
     enabled?: boolean
     /** When true, clicking a data point with multiple series pins the tooltip in place. */
     pinnable?: boolean
-    /** Where the tooltip anchors vertically. `follow-data` (default) tracks the highest data point
-     *  at the hovered x; `top` fixes the tooltip to the top of the chart so it doesn't jump
-     *  vertically as the cursor moves between data points. */
-    placement?: 'follow-data' | 'top'
+    /** Where the tooltip anchors. `follow-data` (default) tracks the highest data point at the
+     *  hovered x; `top` fixes the tooltip to the top of the chart so it doesn't jump vertically
+     *  as the cursor moves between data points; `cursor` tracks the mouse, so the tooltip sits
+     *  beside the cursor and the hovered bar (chart.js-style) rather than at a fixed anchor. */
+    placement?: 'follow-data' | 'top' | 'cursor'
+}
+
+/** Bar appearance + band-layout details. Grouped under {@link BarChartConfig.bars} to keep the
+ *  config flat at the top level. `barLayout` stays top-level as the primary discriminator. */
+export interface BarsConfig {
+    /** Corner radius in px for the rounded end(s) of a bar. Defaults to 0 (square). */
+    cornerRadius?: number
+    /** How `cornerRadius` applies to a stack. `cap` (default) rounds only the far end of the
+     *  topmost segment; `pill` rounds the whole stack on both ends, resolved per band from the
+     *  visible non-zero stack (funnel-style — a 100% single segment still rounds both ends);
+     *  `none` forces square corners regardless of `cornerRadius`. */
+    rounding?: 'cap' | 'pill' | 'none'
+    /** Track behind each bar spanning the full value axis — for "share of a whole" charts.
+     *  `true` uses a default colour; `{ color }` overrides it. Grouped layouts draw a per-series
+     *  tinted+hatched track in each sub-band slot; stacked/percent draw one neutral solid track
+     *  per band behind the whole stack. Defaults to no track. */
+    track?: boolean | { color?: string }
+    /** Drop shadow under each bar so it reads as layered over a `track`. */
+    shadow?: boolean | { color: string; blur: number; offsetX?: number; offsetY?: number }
+    /** Stacked layout only — use d3.stackOffsetDiverging so negative values stack below the zero
+     *  baseline (positives above). Default `false` clamps negatives to 0. */
+    divergingStack?: boolean
+    /** Cap (px) on the band-axis range. Clusters bars at the start of the plot while gridlines
+     *  still span the full width — useful for few-category funnel-style charts. */
+    maxBandRange?: number
+    /** Inner gap between bars as a fraction of the band slot (0–1). Outer padding is half this
+     *  value, so `step = range / N`. Defaults to `DEFAULT_BAND_PADDING` in `scales.ts`. */
+    bandPadding?: number
+    /** Horizontal bar charts only — minimum px per row. When many rows would otherwise crush into
+     *  an unreadable strip, the chart expands its container height so each row has at least this
+     *  much vertical space. Defaults to `24`. Pass `0` to opt out. */
+    minBandSize?: number
 }
 
 export interface BarChartConfig extends ChartConfig {
     /** Defaults to `stacked`. */
     barLayout?: 'stacked' | 'grouped' | 'percent'
-    /** Stacked bars only round the topmost segment. */
-    barCornerRadius?: number
-    /** Draw a faint hatched track behind each bar, spanning the full plot height — for
-     *  funnel-style charts where every bar is a share of a whole. Only honored when
-     *  `barLayout: 'grouped'`; ignored for stacked/percent (the "share of a whole"
-     *  semantics don't apply when bars share a band). Defaults to `false`. */
-    barTrack?: boolean
-    /** Stacked layout only — use d3.stackOffsetDiverging so negative values stack
-     *  below the zero baseline (positives above). Default `false` clamps negatives to 0. */
-    divergingStack?: boolean
-    /** Cap (px) on the band-axis range. Clusters bars at the start of the plot while
-     *  gridlines still span the full width — useful for few-category funnel-style charts. */
-    maxBandRange?: number
-    /** Inner gap between bars as a fraction of the band slot (0–1). Outer padding is half
-     *  this value, so `step = range / N`. Defaults to `DEFAULT_BAND_PADDING` in `scales.ts`. */
-    bandPadding?: number
-    /** Drop shadow under each bar so it reads as layered over a `barTrack`. */
-    barShadow?: boolean | { color: string; blur: number; offsetX?: number; offsetY?: number }
-    /** Horizontal bar charts only — minimum px per row. When many rows would otherwise crush
-     *  into an unreadable strip, the chart expands its container height so each row has at
-     *  least this much vertical space (label height + breathing room). Defaults to `24`.
-     *  Pass `0` to opt out. */
-    minBandSize?: number
+    /** Bar appearance + band-layout details (corner rounding, track, shadow, padding…). */
+    bars?: BarsConfig
 }
 
 export interface LineChartConfig extends ChartConfig {

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -58,6 +58,7 @@ export type { BaseChartContext, ChartHoverContextValue, ChartLayoutContextValue 
 // Core types
 export type {
     BarChartConfig,
+    BarsConfig,
     ChartConfig,
     ChartDimensions,
     ChartDrawArgs,

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -7,7 +7,7 @@ import type { TooltipContext } from '../core/types'
 interface TooltipProps<Meta> {
     context: TooltipContext<Meta>
     renderTooltip: (ctx: TooltipContext<Meta>) => React.ReactNode
-    placement?: 'follow-data' | 'top'
+    placement?: 'follow-data' | 'top' | 'cursor'
 }
 
 const TOOLTIP_MIDDLEWARE = [offset(12), flip(), shift({ padding: 8 })]
@@ -20,34 +20,51 @@ export function Tooltip<Meta = unknown>({
 }: TooltipProps<Meta>): React.ReactElement {
     const { theme } = useChartLayout()
     const zIndex = theme.tooltipZIndex ?? DEFAULT_TOOLTIP_Z_INDEX
-    // `top` placement pins y to the canvas top, ignoring position.y (no per-mousemove reposition).
-    const y = placement === 'top' ? context.canvasBounds.top : context.canvasBounds.top + context.position.y
-    // Anchor at band's right edge via `right-start` so the tooltip lands beside the bar,
-    // not over it. Only used for `top` placement; `flip()` handles overflow.
-    const referenceWidth = placement === 'top' ? (context.position.width ?? 0) : 0
+    const { left: canvasLeft, top: canvasTop } = context.canvasBounds
+    // `cursor` follows the mouse (falling back to the data anchor on non-mousemove rebuilds);
+    // `top` pins y to the canvas top; `follow-data` anchors at the hovered data point.
+    const cursor = placement === 'cursor' ? context.hoverPosition : null
+    let anchorX: number
+    let anchorY: number
+    let anchorWidth: number
+    if (cursor) {
+        anchorX = canvasLeft + cursor.x
+        anchorY = canvasTop + cursor.y
+        anchorWidth = 0
+    } else if (placement === 'top') {
+        anchorX = canvasLeft + context.position.x
+        anchorY = canvasTop
+        // Anchor at the band's right edge via the reference width + `right-start` so the tooltip
+        // lands beside the bar, not over it. `flip()` handles overflow.
+        anchorWidth = context.position.width ?? 0
+    } else {
+        anchorX = canvasLeft + context.position.x
+        anchorY = canvasTop + context.position.y
+        anchorWidth = 0
+    }
+
     const virtualReference = useMemo<VirtualElement>(
         () => ({
             getBoundingClientRect() {
-                const centerX = context.canvasBounds.left + context.position.x
-                const left = centerX - referenceWidth / 2
-                const right = centerX + referenceWidth / 2
+                const left = anchorX - anchorWidth / 2
+                const right = anchorX + anchorWidth / 2
                 return {
                     x: left,
-                    y,
-                    width: referenceWidth,
+                    y: anchorY,
+                    width: anchorWidth,
                     height: 0,
-                    top: y,
+                    top: anchorY,
                     right,
-                    bottom: y,
+                    bottom: anchorY,
                     left,
                 }
             },
         }),
-        [context.position.x, y, referenceWidth, context.canvasBounds]
+        [anchorX, anchorY, anchorWidth]
     )
 
     const { refs, floatingStyles } = useFloating({
-        placement: placement === 'top' ? 'right-start' : 'right',
+        placement: placement === 'follow-data' ? 'right' : 'right-start',
         strategy: 'fixed',
         middleware: TOOLTIP_MIDDLEWARE,
     })

--- a/frontend/src/scenes/funnels/FunnelStepMore.tsx
+++ b/frontend/src/scenes/funnels/FunnelStepMore.tsx
@@ -13,9 +13,10 @@ import { funnelDataLogic } from './funnelDataLogic'
 
 type FunnelStepMoreProps = {
     stepIndex: number
+    className?: string
 }
 
-export function FunnelStepMore({ stepIndex }: FunnelStepMoreProps): JSX.Element | null {
+export function FunnelStepMore({ stepIndex, className }: FunnelStepMoreProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { querySource } = useValues(funnelDataLogic(insightProps))
 
@@ -50,7 +51,7 @@ export function FunnelStepMore({ stepIndex }: FunnelStepMoreProps): JSX.Element 
         return null
     }
 
-    return (
+    const more = (
         <More
             placement="bottom-start"
             noPadding
@@ -83,4 +84,8 @@ export function FunnelStepMore({ stepIndex }: FunnelStepMoreProps): JSX.Element 
             }
         />
     )
+
+    // Wrap so a caller's margin lands on the flex item, not the inner button (the dropdown
+    // wraps the button in its own reference element, which swallows margins applied via className).
+    return className ? <span className={`inline-flex items-center ${className}`}>{more}</span> : more
 }

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -18,9 +18,9 @@ import { StepDecorations } from './StepDecorations'
 
 const ROW_HEIGHT_PX = 76
 const BAR_PADDING = 0.6
-const GLYPH_COLUMN_WIDTH_PX = 24
+const GLYPH_COLUMN_WIDTH_PX = 40
 
-function getFillerColor(): string {
+function getTrackColor(): string {
     if (typeof document === 'undefined') {
         return 'rgba(0, 0, 0, 0.08)'
     }
@@ -40,7 +40,7 @@ export function FunnelBarHorizontalChart({
 }: ChartParams): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
-    const fillerColor = useMemo(() => getFillerColor(), [isDarkModeOn])
+    const trackColor = useMemo(() => getTrackColor(), [isDarkModeOn])
 
     const { insightProps } = useValues(insightLogic)
     const {
@@ -70,38 +70,37 @@ export function FunnelBarHorizontalChart({
                 breakdownFilter,
                 getColor: getFunnelsColor,
                 getLabel: (variant) => String(variant.breakdown_value ?? variant.name ?? ''),
-                fillerColor,
             }),
-        [steps, stepReference, breakdownFilter, getFunnelsColor, fillerColor]
+        [steps, stepReference, breakdownFilter, getFunnelsColor]
     )
 
     const chartConfig = useMemo<BarChartConfig>(
         () => ({
             barLayout: 'stacked',
-            barCornerRadius: 4,
+            bars: { cornerRadius: 6, rounding: 'pill', track: { color: trackColor }, bandPadding: BAR_PADDING },
             axisOrientation: 'horizontal',
             hideXAxis: true,
             hideYAxis: true,
             showGrid: false,
             animateHover: true,
-            bandPadding: BAR_PADDING,
             margins: { top: 0, right: 0, bottom: 0, left: GLYPH_COLUMN_WIDTH_PX },
-            tooltip: { placement: 'top' },
+            tooltip: { placement: 'cursor' },
         }),
-        []
+        [trackColor]
     )
 
     const onPointClick = (clickData: PointClickData<FunnelBarHorizontalSegmentMeta>): void => {
-        const meta = clickData.series.meta
         const step = steps[clickData.dataIndex]
-        if (!step || !meta) {
+        if (!step) {
             return
         }
-        if (meta.isDropOff) {
+        // A click in the empty track region is the drop-off remainder.
+        if (clickData.inTrack) {
             openPersonsModalForStep({ step, converted: false })
             return
         }
-        if (meta.breakdownIndex != null && step.nested_breakdown?.[meta.breakdownIndex]) {
+        const meta = clickData.series.meta
+        if (meta?.breakdownIndex != null && step.nested_breakdown?.[meta.breakdownIndex]) {
             openPersonsModalForSeries({
                 step,
                 series: step.nested_breakdown[meta.breakdownIndex],

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/StepDecorations.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/StepDecorations.tsx
@@ -66,7 +66,20 @@ export function StepDecorations({
 
                 const dimRow = isOptional ? 'opacity-60' : ''
 
-                const halfGlyph = `${GLYPH_HEIGHT_PX / 2}px`
+                // Conversion-% label for the step, placed in the empty track just past the bar so it
+                // never paints over breakdown segments. The fill fraction matches the bar's filled
+                // width (value series / stack total). Omitted when the bar leaves no room for it.
+                const barCenterY = rowHeight / 2
+                const fillFraction = Math.max(0, Math.min(1, step.conversionRates.fromBasisStep))
+                const fillPx = fillFraction * plotWidth
+                const pctLabel = formatConvertedPercentage(step)
+                const pctFitsTrack = plotWidth - fillPx >= pctLabel.length * 8 + 16
+
+                const halfGlyphPx = GLYPH_HEIGHT_PX / 2
+                // Align the step glyph with the header title rather than the bar's vertical centre,
+                // so the numbered circle reads inline with the step title. The small nudge past the
+                // line-box centre matches the title text's optical centre (text sits low in its box).
+                const glyphCenter = gapHeight / 2 + 4
                 const lineStyle = {
                     position: 'absolute' as const,
                     left: 'calc(50% - 1px)',
@@ -78,25 +91,39 @@ export function StepDecorations({
                 return (
                     <div
                         key={step.order}
+                        // Clicks on the overlay's own controls (kebab, value buttons) must not bubble to
+                        // the chart wrapper's click handler, which would also open the persons modal.
+                        onClick={(e) => e.stopPropagation()}
                         style={{ position: 'absolute', top: rowTop, left: 0, width: '100%', height: rowHeight }}
                         className="pointer-events-none [&_[role=button]]:pointer-events-auto [&_a]:pointer-events-auto [&_button]:pointer-events-auto"
                     >
                         <div
                             style={{ position: 'absolute', top: 0, left: 0, width: plotLeft, height: rowHeight }}
-                            className={clsx('flex flex-col items-center justify-center', isOptional && 'opacity-70')}
+                            className={clsx(isOptional && 'opacity-70')}
                         >
                             {stepIndex > 0 && (
-                                <div style={{ ...lineStyle, top: 0, height: `calc(50% - ${halfGlyph})` }} />
+                                <div style={{ ...lineStyle, top: 0, height: Math.max(0, glyphCenter - halfGlyphPx) }} />
                             )}
                             {isOptional && hasOptionalSteps && (
-                                <div className="absolute top-0 left-[calc(50%-1px)] w-[2px] h-full bg-[var(--color-border-primary)] opacity-50 z-[1]" />
+                                <div
+                                    className="absolute left-[calc(50%-1px)] w-[2px] bg-[var(--color-border-primary)] opacity-50 z-[1]"
+                                    style={{ top: 0, height: rowHeight }}
+                                />
                             )}
                             {isOptional && (
-                                <div className="absolute top-[calc(50%-1px)] left-[calc(50%-1px)] w-6 h-[2px] bg-[var(--color-border-primary)] opacity-50" />
+                                <div
+                                    className="absolute left-[calc(50%-1px)] w-6 h-[2px] bg-[var(--color-border-primary)] opacity-50"
+                                    style={{ top: glyphCenter - 1 }}
+                                />
                             )}
                             <div
-                                className={clsx('relative z-10 select-none', isOptional && 'ml-6')}
-                                style={{ pointerEvents: 'auto' }}
+                                className={clsx('absolute z-10 select-none', isOptional && 'ml-6')}
+                                style={{
+                                    top: glyphCenter,
+                                    left: '50%',
+                                    transform: 'translate(-50%, -50%)',
+                                    pointerEvents: 'auto',
+                                }}
                             >
                                 <SeriesGlyph variant="funnel-step-glyph">
                                     {isUnordered ? (
@@ -107,7 +134,7 @@ export function StepDecorations({
                                 </SeriesGlyph>
                             </div>
                             {stepIndex < steps.length - 1 && (
-                                <div style={{ ...lineStyle, top: `calc(50% + ${halfGlyph})`, bottom: 0 }} />
+                                <div style={{ ...lineStyle, top: glyphCenter + halfGlyphPx, bottom: 0 }} />
                             )}
                         </div>
 
@@ -131,9 +158,13 @@ export function StepDecorations({
                                 </div>
                                 {isOptional ? <div className="ml-1 text-xs">(optional)</div> : null}
                                 {!isUnordered && stepIndex > 0 && step.action_id === steps[stepIndex - 1].action_id && (
-                                    <DuplicateStepIndicator />
+                                    // pointer-events-auto so the click hits the overlay (then stops) instead of
+                                    // falling through to the canvas and opening the persons modal.
+                                    <span className="pointer-events-auto inline-flex items-center">
+                                        <DuplicateStepIndicator />
+                                    </span>
                                 )}
-                                <FunnelStepMore stepIndex={stepIndex} />
+                                <FunnelStepMore stepIndex={stepIndex} className="ml-2" />
                             </div>
                             {step.average_conversion_time && step.average_conversion_time >= Number.EPSILON ? (
                                 <div
@@ -145,6 +176,20 @@ export function StepDecorations({
                                 </div>
                             ) : null}
                         </header>
+
+                        {pctFitsTrack && (
+                            <div
+                                className={clsx('absolute text-sm font-bold whitespace-nowrap', dimRow)}
+                                style={{
+                                    top: barCenterY,
+                                    left: plotLeft + fillPx + 8,
+                                    transform: 'translateY(-50%)',
+                                    color: 'var(--text-3000)',
+                                }}
+                            >
+                                {pctLabel}
+                            </div>
+                        )}
 
                         <div
                             style={{

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
@@ -1,10 +1,6 @@
 import { EntityTypes, FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
 
-import {
-    buildFunnelBarHorizontalData,
-    FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
-    FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX,
-} from './funnelBarHorizontalTransforms'
+import { buildFunnelBarHorizontalData, FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX } from './funnelBarHorizontalTransforms'
 
 type StepOverrides = Partial<FunnelStepWithConversionMetrics> & {
     fromBasisStep: number
@@ -42,7 +38,6 @@ const options = {
     stepReference: FunnelStepReference.total,
     getColor: () => '#1d4aff',
     getLabel: (variant: FunnelStepWithConversionMetrics) => String(variant.breakdown_value ?? variant.name),
-    fillerColor: '#eef0f3',
 }
 
 describe('buildFunnelBarHorizontalData', () => {
@@ -67,32 +62,24 @@ describe('buildFunnelBarHorizontalData', () => {
             makeStep({ count: 20, fromBasisStep: 0.2, name: 'Purchased' }),
         ]
 
-        it('emits one segment series + one filler series, each with one value per step', () => {
+        it('emits a single value series with one percentage per step (remainder is the chart track)', () => {
             const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, options)
 
-            expect(series).toHaveLength(2)
+            expect(series).toHaveLength(1)
             expect(series[0].data).toEqual([100, 50, 20])
-            expect(series[1].data).toEqual([0, 50, 80])
         })
 
-        it('tags each series with its drop-off / breakdown role for click + tooltip routing', () => {
+        it('tags the segment with a null breakdownIndex for click + tooltip routing', () => {
             const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, options)
 
-            expect(series[0].meta).toEqual({ isDropOff: false, breakdownIndex: null })
-            expect(series[1].meta).toEqual({ isDropOff: true, breakdownIndex: null })
+            expect(series[0].meta).toEqual({ breakdownIndex: null })
         })
 
-        it('hides the filler from the tooltip so it doesn’t double up with FunnelTooltip’s drop-off section', () => {
-            const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, options)
-            expect(series[1].visibility?.tooltip).toBe(false)
-        })
-
-        it('colors the segment from the representative step and the filler from options.fillerColor', () => {
+        it('colors the segment from the representative step', () => {
             const getColor = jest.fn(() => '#abcabc')
             const { series } = buildFunnelBarHorizontalData(noBreakdownSteps, { ...options, getColor })
 
             expect(series[0].color).toBe('#abcabc')
-            expect(series[1].color).toBe(options.fillerColor)
             expect(getColor).toHaveBeenCalledWith(noBreakdownSteps[0])
         })
     })
@@ -117,24 +104,23 @@ describe('buildFunnelBarHorizontalData', () => {
             }),
         ]
 
-        it('emits one series per variant plus the trailing filler', () => {
+        it('emits one series per variant', () => {
             const { series } = buildFunnelBarHorizontalData(breakdownSteps, options)
 
-            expect(series).toHaveLength(3)
-            expect(series.map((s) => s.label)).toEqual(['mobile', 'desktop', 'Drop-off'])
+            expect(series).toHaveLength(2)
+            expect(series.map((s) => s.label)).toEqual(['mobile', 'desktop'])
         })
 
         it('builds per-step fractions per variant against the configured basis step', () => {
             const { series } = buildFunnelBarHorizontalData(breakdownSteps, options)
             expect(series[0].data).toEqual([60, 30])
             expect(series[1].data).toEqual([40, 10])
-            expect(series[2].data).toEqual([0, 60])
         })
 
         it('tags each segment with its source breakdownIndex', () => {
             const { series } = buildFunnelBarHorizontalData(breakdownSteps, options)
-            expect(series[0].meta).toEqual({ isDropOff: false, breakdownIndex: 0 })
-            expect(series[1].meta).toEqual({ isDropOff: false, breakdownIndex: 1 })
+            expect(series[0].meta).toEqual({ breakdownIndex: 0 })
+            expect(series[1].meta).toEqual({ breakdownIndex: 1 })
         })
 
         it('zeros a missing variant at a later step rather than rolling its count into another bar', () => {
@@ -155,10 +141,9 @@ describe('buildFunnelBarHorizontalData', () => {
             ]
 
             const { series } = buildFunnelBarHorizontalData(skewed, options)
-            expect(series).toHaveLength(3)
+            expect(series).toHaveLength(2)
             expect(series[0].data).toEqual([60, 50]) // mobile
             expect(series[1].data).toEqual([40, 0]) // desktop — missing in step 1
-            expect(series[2].data).toEqual([0, 50]) // filler
         })
     })
 
@@ -177,14 +162,13 @@ describe('buildFunnelBarHorizontalData', () => {
         ]
         const breakdownFilter = { breakdown: '$browser' }
 
-        it('collapses to one segment + filler, sourced from the single visible variant', () => {
+        it('collapses to one segment sourced from the single visible variant', () => {
             const { series } = buildFunnelBarHorizontalData(collapsedSteps, { ...options, breakdownFilter })
 
-            expect(series).toHaveLength(2)
+            expect(series).toHaveLength(1)
             expect(series[0].label).toBe('mobile')
             expect(series[0].data).toEqual([100, 50])
             expect(series[0].meta?.breakdownIndex).toBe(0)
-            expect(series[1].data).toEqual([0, 50])
         })
 
         it('falls back to the parent step’s rate when no breakdownFilter is set', () => {
@@ -236,7 +220,7 @@ describe('buildFunnelBarHorizontalData', () => {
     })
 
     describe('zero-basis-count step', () => {
-        it('emits a zero segment + full filler when basisStep.count is 0', () => {
+        it('emits zero-width segments when basisStep.count is 0 (the track fills the row)', () => {
             const steps = [
                 makeStep({
                     count: 0,
@@ -261,7 +245,6 @@ describe('buildFunnelBarHorizontalData', () => {
             expect(series.map((s) => s.data)).toEqual([
                 [0, 0],
                 [0, 0],
-                [100, 100],
             ])
         })
     })
@@ -290,7 +273,6 @@ describe('buildFunnelBarHorizontalData', () => {
             expect(series.map((s) => s.key)).toEqual([
                 `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}0`,
                 `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}1`,
-                FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
             ])
         })
     })

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
@@ -5,12 +5,10 @@ import type { BreakdownFilter } from '~/queries/schema/schema-general'
 import { FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
 
 export const FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX = 'funnel-bar-horizontal-segment-'
-export const FUNNEL_BAR_HORIZONTAL_FILLER_KEY = 'funnel-bar-horizontal-filler'
 
 const RATE_TO_PERCENT = 100
 
 export interface FunnelBarHorizontalSegmentMeta {
-    isDropOff: boolean
     breakdownIndex: number | null
 }
 
@@ -24,7 +22,6 @@ interface BuildOptions {
     breakdownFilter?: BreakdownFilter | null
     getColor: (series: FunnelStepWithConversionMetrics) => string
     getLabel: (series: FunnelStepWithConversionMetrics) => string
-    fillerColor: string
 }
 
 function isBreakdownLayout(steps: FunnelStepWithConversionMetrics[]): boolean {
@@ -79,11 +76,10 @@ function buildBreakdownSeries(
             label: options.getLabel(representative),
             data: fractions.map((f) => f * RATE_TO_PERCENT),
             color: options.getColor(representative),
-            meta: { isDropOff: false, breakdownIndex },
+            meta: { breakdownIndex },
         })
     }
 
-    series.push(buildFiller(steps, series, options.fillerColor))
     return series
 }
 
@@ -101,27 +97,8 @@ function buildSingleSeries(
         label: options.getLabel(representative),
         data: fractions.map((f) => f * RATE_TO_PERCENT),
         color: options.getColor(representative),
-        meta: { isDropOff: false, breakdownIndex: isSingleBreakdownCollapse ? 0 : null },
+        meta: { breakdownIndex: isSingleBreakdownCollapse ? 0 : null },
     }
 
-    return [segment, buildFiller(steps, [segment], options.fillerColor)]
-}
-
-function buildFiller(
-    steps: FunnelStepWithConversionMetrics[],
-    segments: Series<FunnelBarHorizontalSegmentMeta>[],
-    color: string
-): Series<FunnelBarHorizontalSegmentMeta> {
-    const fillerData = steps.map((_, stepIndex) => {
-        const covered = segments.reduce((sum, s) => sum + (s.data[stepIndex] ?? 0), 0)
-        return Math.max(0, RATE_TO_PERCENT - covered)
-    })
-    return {
-        key: FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
-        label: 'Drop-off',
-        data: fillerData,
-        color,
-        visibility: { tooltip: false },
-        meta: { isDropOff: true, breakdownIndex: null },
-    }
+    return [segment]
 }

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
@@ -16,7 +16,7 @@ import { buildFunnelHistogramData } from './funnelHistogramTransforms'
 
 const CHART_CONFIG: BarChartConfig = {
     showGrid: true,
-    barCornerRadius: 4,
+    bars: { cornerRadius: 4 },
     yTickFormatter: (value) => humanFriendlyNumber(value),
     // Value labels already show bucket counts; tooltip would just duplicate them.
     tooltip: { enabled: false },

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -24,9 +24,7 @@ const STEP_WIDTH_PX = 320
 const baseChartConfig: BarChartConfig = {
     barLayout: 'grouped',
     showGrid: true,
-    barCornerRadius: 10,
-    barTrack: true,
-    barShadow: true,
+    bars: { cornerRadius: 10, track: true, shadow: true },
     animateHover: true,
     hideXAxis: true,
     yTickFormatter: (value) => `${Math.round(value)}%`,
@@ -71,7 +69,10 @@ export function FunnelStepsBarChart({
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural
     const showTime = steps.some((step) => step.average_conversion_time != null)
     const barsWidth = steps.length * STEP_WIDTH_PX
-    const chartConfig = useMemo<BarChartConfig>(() => ({ ...baseChartConfig, maxBandRange: barsWidth }), [barsWidth])
+    const chartConfig = useMemo<BarChartConfig>(
+        () => ({ ...baseChartConfig, bars: { ...baseChartConfig.bars, maxBandRange: barsWidth } }),
+        [barsWidth]
+    )
 
     const onPointClick = useCallback(
         (clickData: PointClickData<FunnelStepsBarSeriesMeta>): void => {


### PR DESCRIPTION
## Problem

Polish layer stacked on top of the reworked horizontal funnel chart (the base PR). The step header decorations sat slightly off, the overlay controls leaked clicks into the chart, and steps had no in-chart conversion-% label.

## Changes

- Align the step number glyph with the step title (it was centered on the bar) and space out the title row + kebab menu.
- Stop overlay control clicks (kebab menu, duplicate-step info icon) from *also* opening the persons modal — they were bubbling / falling through to the chart's click handler.
- Add a per-step conversion-% label, placed in the empty track so it never covers breakdown segments.

## How did you test this code?

I'm an agent (Claude Code). These are HTML-overlay / CSS changes with no dedicated automated tests; the chart's jest suites live in the base PR. The behavior (glyph alignment, spacing, click handling, label placement) was reviewed visually in-app by the author across iterations.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Split out of the chart-rework PR so the canvas/library changes review separately from the overlay polish. The `%` label started rendered white *inside* the bar but that covered thin breakdown segments, so it moved into the empty track (dark) and is omitted when the bar leaves no room — never hiding a series. Agent-assisted; requires human review.
