### PR TITLE
chore(hogql): pbt parser equivalence compares rust-py vs cpp-json

### DIFF
--- a/posthog/hogql/test/test_parser_pbt.py
+++ b/posthog/hogql/test/test_parser_pbt.py
@@ -6,8 +6,8 @@ printer normalises some constructs (e.g. ``1 + 2`` → ``plus(1, 2)``), we
 compare at the *printed-string* level: ``print(parse(print(ast))) == print(ast)``.
 
 As a bonus this also tests **parser backend equivalence**: every generated
-string is parsed with both the Python and C++ backends and the results are
-compared.
+string is parsed with both the rust-py and cpp-json backends and the results
+are compared.
 """
 
 import os
@@ -312,21 +312,21 @@ def _print_hogql(node: ast.Expr) -> str:
 
 
 def _parse_both_backends(hogql_string: str) -> tuple[ast.Expr | None, ast.Expr | None]:
-    """Parse with both backends, returning (python_ast, cpp_ast).
+    """Parse with both backends, returning (rust_ast, cpp_ast).
 
     Returns None for a backend if parsing fails.
     """
-    py_ast: ast.Expr | None = None
+    rust_ast: ast.Expr | None = None
     cpp_ast: ast.Expr | None = None
     try:
-        py_ast = parse_expr(hogql_string, backend="python")
+        rust_ast = parse_expr(hogql_string, backend="rust-py")
     except BaseHogQLError:
         pass
     try:
         cpp_ast = parse_expr(hogql_string, backend="cpp-json")
     except BaseHogQLError:
         pass
-    return py_ast, cpp_ast
+    return rust_ast, cpp_ast
 
 
 def _roundtrip_check(expr: ast.Expr) -> None:
@@ -363,37 +363,37 @@ class TestParserBackendEquivalence:
 
     @given(expr=_expr_strategy())
     @settings(max_examples=2000, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-    def test_python_and_cpp_backends_agree(self, expr: ast.Expr) -> None:
+    def test_rust_py_and_cpp_backends_agree(self, expr: ast.Expr) -> None:
         try:
             hogql_string = _print_hogql(expr)
         except BaseHogQLError:
             assume(False)
             return  # type: ignore[unreachable]
 
-        py_ast, cpp_ast = _parse_both_backends(hogql_string)
+        rust_ast, cpp_ast = _parse_both_backends(hogql_string)
 
-        if py_ast is None and cpp_ast is None:
+        if rust_ast is None and cpp_ast is None:
             assume(False)
             return  # type: ignore[unreachable]
 
         # If one succeeds and the other fails, that's a bug
-        assert (py_ast is None) == (cpp_ast is None), (
+        assert (rust_ast is None) == (cpp_ast is None), (
             f"Backend disagreement on parsability of: {hogql_string!r}\n"
-            f"  Python: {'failed' if py_ast is None else 'ok'}\n"
-            f"  C++:    {'failed' if cpp_ast is None else 'ok'}"
+            f"  Rust: {'failed' if rust_ast is None else 'ok'}\n"
+            f"  C++:  {'failed' if cpp_ast is None else 'ok'}"
         )
 
-        assert py_ast is not None and cpp_ast is not None
+        assert rust_ast is not None and cpp_ast is not None
 
         # Compare by printing both back to HogQL — this normalises away
         # any minor structural differences (like start/end positions).
-        py_printed = _print_hogql(py_ast)
+        rust_printed = _print_hogql(rust_ast)
         cpp_printed = _print_hogql(cpp_ast)
 
-        assert py_printed == cpp_printed, (
+        assert rust_printed == cpp_printed, (
             f"Backend outputs differ for: {hogql_string!r}\n"
-            f"  Python backend: {py_printed!r}\n"
-            f"  C++ backend:    {cpp_printed!r}"
+            f"  Rust backend: {rust_printed!r}\n"
+            f"  C++ backend:  {cpp_printed!r}"
         )
 
 


### PR DESCRIPTION
## Problem

The parser-backend equivalence property test in `test_parser_pbt.py` compared the legacy Python ANTLR backend against `cpp-json`. As the parser work shifts toward the Rust backend, the more useful invariant to guard is that `rust-py` (the PyO3 path that builds `ast` dataclasses directly) agrees with the production `cpp-json` backend.

## Changes

Switched `TestParserBackendEquivalence` to parse each generated HogQL string with `rust-py` and `cpp-json`, then compare the re-printed output:

- `_parse_both_backends` now uses `backend="rust-py"` instead of `backend="python"`.
- Renamed the test to `test_rust_py_and_cpp_backends_agree`; updated variables (`rust_ast`) and the assertion messages (`Rust` / `C++` labels).
- Updated the module docstring.

Note: this swaps the Python backend out of the equivalence check rather than adding a second test, matching the request. If we want to keep coverage on the Python backend too, it would be easy to keep both legs side by side instead.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran in this environment:

- `RUN_PBT=1 pytest posthog/hogql/test/test_parser_pbt.py::TestParserBackendEquivalence::test_rust_py_and_cpp_backends_agree` — passed (2000 generated examples, ~29s).
- Smoke-checked that `rust-py` and `cpp-json` produce identical `to_hogql()` output for a mixed expression (arithmetic, comparison, `AND`, `arrayMap` lambda).
- `ruff check` + `ruff format --check` clean on the file.

These PBT tests stay gated behind `RUN_PBT=1` (too slow for CI at ~8 min), so this does not change CI runtime.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Robbie's direction. The ask was to repoint the existing backend-equivalence PBT test from `python` to `rust-py` while keeping `cpp-json` as the comparison baseline. Straightforward rename + backend swap; verified the `rust-py` wheel is importable in the local flox venv and that the property test passes against the current corpus before pushing. Chose a straight swap (not a second test) per the request, and flagged the dropped Python-backend coverage as a reviewer decision point.
