### PR TITLE
chore(ai): nudge anomaly investigation agent on natural variance

### DIFF
--- a/posthog/temporal/ai/anomaly_investigation/prompts.py
+++ b/posthog/temporal/ai/anomaly_investigation/prompts.py
@@ -55,6 +55,21 @@ Magnitude check (do this before classifying):
     * the triggered value is in the single digits, or
     * the triggered value is within ~50% of recent typical buckets, or
     * the framing is "highest in window" but the runner-up is close behind.
+- Account for time-of-day and day-of-week seasonality before calling a
+  drop or spike anomalous. Human-driven metrics (creates, signups, edits,
+  posts) routinely dip on evenings and weekends. The right baseline is
+  same-hour, same-weekday history — not the all-hours or all-days mean.
+  If you find yourself comparing an evening bucket against a "typical
+  daytime baseline", or a weekend bucket against weekday volume, stop and
+  pull the like-for-like baseline first. A value that looks low against
+  the all-hours mean can be perfectly normal for that hour-of-day.
+- Be suspicious of a "cliff" framing that pivots on an unusually high
+  *prior* bucket. A return to a normal level after a one-off spike is not
+  the same as a step-change below baseline. Anchor the comparison on the
+  post-drop level vs. the seasonally-matched baseline, not on the gap
+  between the spike and what came after. If the trailing buckets sit
+  inside the typical range for their hour-of-day and day-of-week, the
+  "cliff" is the spike reverting to mean, not a regression.
 - A real true positive should be visible to a human glancing at the chart:
   a clear step-change, a sustained shift, a cliff, or a spike that is
   multiple times any other point in the window. If you have to squint, it

--- a/posthog/temporal/ai/anomaly_investigation/prompts.py
+++ b/posthog/temporal/ai/anomaly_investigation/prompts.py
@@ -55,21 +55,10 @@ Magnitude check (do this before classifying):
     * the triggered value is in the single digits, or
     * the triggered value is within ~50% of recent typical buckets, or
     * the framing is "highest in window" but the runner-up is close behind.
-- Account for time-of-day and day-of-week seasonality before calling a
-  drop or spike anomalous. Human-driven metrics (creates, signups, edits,
-  posts) routinely dip on evenings and weekends. The right baseline is
-  same-hour, same-weekday history — not the all-hours or all-days mean.
-  If you find yourself comparing an evening bucket against a "typical
-  daytime baseline", or a weekend bucket against weekday volume, stop and
-  pull the like-for-like baseline first. A value that looks low against
-  the all-hours mean can be perfectly normal for that hour-of-day.
-- Be suspicious of a "cliff" framing that pivots on an unusually high
-  *prior* bucket. A return to a normal level after a one-off spike is not
-  the same as a step-change below baseline. Anchor the comparison on the
-  post-drop level vs. the seasonally-matched baseline, not on the gap
-  between the spike and what came after. If the trailing buckets sit
-  inside the typical range for their hour-of-day and day-of-week, the
-  "cliff" is the spike reverting to mean, not a regression.
+- Many series carry natural variance the detector may not be tuned for —
+  seasonality, burstiness, occasional outlier buckets. Sense-check the
+  firing against the series' broader shape, not just the triggered point
+  and its immediate neighbours.
 - A real true positive should be visible to a human glancing at the chart:
   a clear step-change, a sustained shift, a cliff, or a spike that is
   multiple times any other point in the window. If you have to squint, it


### PR DESCRIPTION
## Problem

The anomaly investigation agent's verdict has slipped to **true positive** a few times on series that are really just naturally variable — daily/weekly seasonality, bursty traffic, occasional outlier buckets. The existing Magnitude check rubric covers low-volume Poisson noise and "highest in window" framing, but doesn't prompt the agent to step back and sense-check against the series' broader shape before classifying.

## Changes

`posthog/temporal/ai/anomaly_investigation/prompts.py` — one extra bullet in the existing Magnitude check section of `SYSTEM_PROMPT`:

> Many series carry natural variance the detector may not be tuned for — seasonality, burstiness, occasional outlier buckets. Sense-check the firing against the series' broader shape, not just the triggered point and its immediate neighbours.

Intentionally general — a nudge, not a prescriptive rule — so we don't over-steer the LLM with specific framings (seasonality recipes, cliff-after-spike heuristics, etc.) that may not generalise across metrics.

Prompt-only change, no behavioural code changes, no schema changes.

## How did you test this code?

I'm an agent — no manual testing performed. The change is contained to a single system prompt string constant in \`prompts.py\`; no tests cover the prompt text itself, and the existing tests for the workflow are unaffected. Reviewer should sanity-check the new bullet reads cleanly alongside the existing Magnitude check rubric.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Prompted by a real false-positive verdict on a recent alert investigation where the agent called a true positive on what was effectively a normal Friday-evening baseline. Initial draft added two specific bullets (seasonality + cliff-after-spike); trimmed at the author's direction to a single minimal nudge so we don't bias the LLM toward specific framings of the same underlying problem.

Agent: Claude (via PostHog Code task).