### PR TITLE
chore(replay-vision): remove dead indexer types from frontend

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3899,13 +3899,13 @@ snapshots:
     replay-scenes-group--group-recording-tab-multiple-and-not-found--light:
         hash: v1.k794b7964.d8056449450e1b9fca8334a799cc94c07c1f822da9f89286d0e87c5ffb7347f7.2Mj0yI-YAk501nE-4iQlOTqLRw6h8NBK8D_3gJRjQVA
     replay-scenes-person--person-recording-tab-empty--dark:
-        hash: v1.k794b7964.ace0d8cafaecebabcd55ea6909690ee6428ebc52384c463c1e176b06d2e03a1f.6I5gEHazGQ60ArmwFnEFfWNyJS-T2xlSVMbEYk8LTCM
+        hash: v1.k794b7964.43e828f5b46ddc1083a260cd4be8de2850990821fc36977fcd851ba68198ed25.FzBCtfzt5Kfgr1E63iZCpq3wjR5ecj6uOOkE7HkEVEk
     replay-scenes-person--person-recording-tab-empty--light:
-        hash: v1.k794b7964.52c19d8b739c74cc16baa252f96beea6879cb39402bfe76d24e251680658e804.X9m7B_OvJcHVdvlhILEseh7OAsqkTm2zMhLVb27NONk
+        hash: v1.k794b7964.b3392ad236efbbc0204754911236ad5ceaf9886ce94b69241fe0be5bbdef15cf.Sr8yONKPSivQbpBk0cDTuGMesSZN-xwJRpWotn_FuQU
     replay-scenes-person--person-recording-tab-multiple-and-not-found--dark:
-        hash: v1.k794b7964.ad20974bc8359c768b36b300158ca7f17d6ee5e658baddea54c08e5edb163b4c.C4FKX_HCHZgDgubTlTRcEw449hqOcoD_ptCpbWpURiE
+        hash: v1.k794b7964.2ace4df8fdcf5b5cf0c6cfba4269b5f5421b69e80681a7602a9954bdeeef7738.4jvTXHtHzGTPqj6W7OY__J_l5hB6yMdbNzaQhYpaj-E
     replay-scenes-person--person-recording-tab-multiple-and-not-found--light:
-        hash: v1.k794b7964.7971eb327021ba8ada4b3e6efa457074c35b2eceeee29eb65ec3202a511a7aff.rF2OKRjWsIWulZwhaHonm44vd9mZD3mCa0drOiBitko
+        hash: v1.k794b7964.0a94e0a53667154ea4670930964f887dfa0fb46e6f8216d1e4c4a0eeb5110eb9.VQO_J1-7LbYh3orK-NzIak5axhKj0CncMv-xr07zx_A
     replay-sharing--private-link--dark:
         hash: v1.k794b7964.1f6922ffd3028c6009f63d7c73edb3138f41dd971be364e3e0c78e608577f611.XsnlRF6f_3C5MFQlVuUeGgQ1lQuKYwgWYvl0507yIds
     replay-sharing--private-link--light:
@@ -4889,7 +4889,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
         hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
-        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.EIwByuofuT77yP259A9ffqfjSFwW9MrUDOvsZNA_aZM
+        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
         hash: v1.k794b7964.d64808d2bfc36017f89b57feeaa373e20188738a622801207fa1beb59d02fdd9.cFuKF_Ow887Z3X3BoNhtTvkUWY2vips9HDBe-B02eQE
     scenes-app-insights-funnels--funnel-time-to-convert--light:

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -3,7 +3,7 @@ import { RecordingsQuery } from '~/queries/schema/schema-general'
 import { ScannerModelEnumApi } from '../generated/api.schemas'
 import type { PatchedReplayScannerApi, ReplayScannerApi } from '../generated/api.schemas'
 
-export type ScannerType = 'monitor' | 'classifier' | 'scorer' | 'summarizer' | 'indexer'
+export type ScannerType = 'monitor' | 'classifier' | 'scorer' | 'summarizer'
 
 export type EnabledFilter = 'enabled' | 'disabled'
 
@@ -159,17 +159,11 @@ export interface ScorerScannerConfig {
     scale: { min: number; max: number; label?: string }
 }
 
-export interface IndexerScannerConfig {
-    prompt: string
-    emits_embeddings: boolean
-}
-
 export type ScannerConfig =
     | MonitorScannerConfig
     | SummarizerScannerConfig
     | ClassifierScannerConfig
     | ScorerScannerConfig
-    | IndexerScannerConfig
 
 export interface BaseReplayScanner {
     id: string
@@ -209,12 +203,7 @@ export interface ScorerScanner extends BaseReplayScanner {
     scanner_config: ScorerScannerConfig
 }
 
-export interface IndexerScanner extends BaseReplayScanner {
-    scanner_type: 'indexer'
-    scanner_config: IndexerScannerConfig
-}
-
-export type ReplayScanner = MonitorScanner | SummarizerScanner | ClassifierScanner | ScorerScanner | IndexerScanner
+export type ReplayScanner = MonitorScanner | SummarizerScanner | ClassifierScanner | ScorerScanner
 
 export type { VisionQuotaApi as VisionQuota } from '../generated/api.schemas'
 


### PR DESCRIPTION
## Problem

The `indexer` scanner was removed in #60442 (backend migrations 0008/0009 drop the choice and delete any existing rows). The follow-up hotfix #60751 re-added `'indexer'` to `ScannerType`, plus `IndexerScannerConfig` and `IndexerScanner`, purely to unblock master after #60442 landed without updating the consuming type/usages.

After #60605 stripped the last actual consumer (the `IndexerScannerConfig` import in `scannerTemplates.ts`), those types are dead — there are no remaining references anywhere in the codebase outside the historical migrations.

## Changes

Drop the dead types from `products/replay_vision/frontend/replay_scanners/types.ts`:

- Remove `'indexer'` from the `ScannerType` union.
- Remove `IndexerScannerConfig` interface and its membership in `ScannerConfig`.
- Remove `IndexerScanner` interface and its membership in `ReplayScanner`.

Net diff is one file, +2/-13.

## How did you test this code?

Agent-authored. Automated only:

- Verified with a repo-wide grep (`products/`, `services/`, `frontend/src/`) that nothing other than `types.ts` itself and the historical backend migrations references `indexer` / `Indexer` / `IndexerScanner` / `IndexerScannerConfig`.
- `pnpm typescript:check` introduces no new replay_vision errors. The remaining errors (`posthog-js`, `react-window`, `@posthog/products-error-tracking/frontend/utils` not found) also fire on a clean checkout of master and are unrelated local-env module resolution noise.
- `pnpm jest products/replay_vision/` — 2 suites, 25 tests, all passing.
- `oxlint` clean on the touched file.

No manual UI testing — pure type-only cleanup with no runtime change.

## Publish to changelog?

no

## 🤖 Agent context

Tool: Claude Code (Opus). Single-file revert of the `indexer` re-introduction from #60751, now that #60605 removed the last consumer and the situation is stable. Pre-flight grep was the safety step missed when #60442 first broke master.