### PR TITLE
fix(quill): sync date picker calendars and select padding

### DIFF
--- a/packages/quill/packages/blocks/package.json
+++ b/packages/quill/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-blocks",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "private": true,
     "description": "Internal workspace package (private, not published). The highest layer of the quill design system — product-level patterns made of components + primitives (e.g. a PageHeader with title + breadcrumb + action slot, an EmptyState with icon + copy + CTA, a CommandPalette, a user-menu dropdown). Opinionated and shape-stable across products so they feel consistent. Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/package.json
+++ b/packages/quill/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-components",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "private": true,
     "description": "Internal workspace package (private, not published). The middle layer of the quill design system — higher-level compositions of primitives that wire several of them together with sensible defaults (e.g. a FormField that composes Label + Input + validation state, or a ConfirmDialog that composes Dialog + Button + destructive variant). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -19,7 +19,7 @@ import {
 import { ArrowRight, ChevronLeft, ChevronRight, SettingsIcon } from 'lucide-react'
 import * as React from 'react'
 
-import { Badge, Button, InputGroup, InputGroupNumberInput, ScrollArea, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Separator, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, cn } from '@posthog/quill-primitives'
+import { Badge, Button, InputGroup, InputGroupNumberInput, ScrollArea, Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue, Separator, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, cn } from '@posthog/quill-primitives'
 
 import { CUSTOM_RANGE, type DateTimeRange, quickRanges } from './date-time-ranges'
 import { Day, useCalendar } from './use-calendar'
@@ -51,6 +51,22 @@ const MONTH_NAMES = [
     'November',
     'December',
 ]
+
+// Tailwind `lg` breakpoint — matches the `lg:` classes that switch this picker
+// between a single calendar and the side-by-side dual-calendar layout.
+const LG_QUERY = '(min-width: 64rem)'
+
+function useMediaQuery(query: string): boolean {
+    const [matches, setMatches] = React.useState(false)
+    React.useEffect(() => {
+        const mql = window.matchMedia(query)
+        const update = (): void => setMatches(mql.matches)
+        update()
+        mql.addEventListener('change', update)
+        return () => mql.removeEventListener('change', update)
+    }, [query])
+    return matches
+}
 
 export interface DateTimeValue {
     start: Date
@@ -231,7 +247,7 @@ function Calendar({
             <div className="flex justify-center items-center py-1 gap-1">
                 <Button
                     variant="default"
-                    size="icon-xs"
+                    size="icon-sm"
                     onClick={handlePrev}
                     disabled={disablePrev}
                     aria-label="Previous month"
@@ -250,16 +266,18 @@ function Calendar({
                         </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                        {monthOptions.map(({ key, year, month }) => (
-                            <SelectItem key={key} value={key} disabled={key === siblingKey}>
-                                {MONTH_NAMES[month]} {year}
-                            </SelectItem>
-                        ))}
+                        <SelectGroup>
+                            {monthOptions.map(({ key, year, month }) => (
+                                <SelectItem key={key} value={key} disabled={key === siblingKey}>
+                                    {MONTH_NAMES[month]} {year}
+                                </SelectItem>
+                            ))}
+                        </SelectGroup>
                     </SelectContent>
                 </Select>
                 <Button
                     variant="default"
-                    size="icon-xs"
+                    size="icon-sm"
                     onClick={handleNext}
                     disabled={disableNext}
                     aria-label="Next month"
@@ -467,6 +485,10 @@ export function DateTimePicker({
 }: DateTimePickerProps): React.ReactElement {
     const maxDate = maxDateProp ?? new Date()
     const hasExplicitMaxDate = maxDateProp !== undefined
+    // The second calendar only renders at `lg`; below it (and in compact) there's
+    // a single calendar, so the "can't pick the sibling's month" constraint shouldn't apply.
+    const isLargeScreen = useMediaQuery(LG_QUERY)
+    const twoCalendars = !compact && isLargeScreen
     const [start, setStart] = React.useState<Date>(value.start)
     const [end, setEnd] = React.useState<Date>(value.end)
     const [range, setRange] = React.useState<DateTimeRange>(value.range)
@@ -502,6 +524,21 @@ export function DateTimePicker({
         setRange(CUSTOM_RANGE)
     }
 
+    // Move the visible calendar(s) so an edited date stays in view. With two
+    // calendars, start drives the left and end the right; with one, the single
+    // (right) calendar follows whichever edge changed.
+    const revealStart = (date: Date): void => {
+        const month = new Date(getYear(date), getMonth(date), 1)
+        if (twoCalendars) {
+            setLeftViewing(month)
+        } else {
+            setRightViewing(month)
+        }
+    }
+    const revealEnd = (date: Date): void => {
+        setRightViewing(new Date(getYear(date), getMonth(date), 1))
+    }
+
     const handleStartChange = (next: Date): void => {
         if (start.getTime() === next.getTime()) {
             return
@@ -511,8 +548,10 @@ export function DateTimePicker({
         if (next.getTime() > end.getTime()) {
             setStart(end)
             setEnd(next)
+            revealEnd(next)
         } else {
             setStart(next)
+            revealStart(next)
         }
     }
 
@@ -525,8 +564,10 @@ export function DateTimePicker({
         if (next.getTime() < start.getTime()) {
             setEnd(start)
             setStart(next)
+            revealStart(next)
         } else {
             setEnd(next)
+            revealEnd(next)
         }
     }
 
@@ -536,6 +577,7 @@ export function DateTimePicker({
             setStart(now)
         }
         setEnd(now)
+        revealEnd(now)
     }
 
     const handleQuickRange = (next: DateTimeRange): void => {
@@ -647,7 +689,7 @@ export function DateTimePicker({
                                 maxDate={maxDate}
                                 onSelect={handleSelect}
                                 onViewChange={setRightViewing}
-                                siblingViewing={compact ? undefined : leftViewing}
+                                siblingViewing={twoCalendars ? leftViewing : undefined}
                                 weekStartsOn={weekStartsOn}
                             />
                         </div>

--- a/packages/quill/packages/primitives/package.json
+++ b/packages/quill/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-primitives",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "private": true,
     "description": "Internal workspace package (private, not published). The lowest layer of the quill design system — unstyled Base UI primitives wrapped with quill's Tailwind classes (Button, Card, Dialog, Input, Popover, Combobox, etc.). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "description": "PostHog's unified design system — primitives, components, and blocks designed to be compiled by the consumer's Tailwind v4.",
     "license": "MIT",
     "repository": {

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.3.0-beta.10",
+    "version": "0.3.0-beta.11",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem

Three issues in the quill `DateTimePicker`:

1. The month/year `Select` rendered its items without padding because they weren't wrapped in a `SelectGroup` (the padding lives on the group).
2. At narrow widths (and below the `lg` breakpoint), only one calendar is shown, but the "can't pick the sibling calendar's month" constraint was still applied — disabling a valid month (e.g. April) even though the second calendar wasn't visible.
3. Editing the numeric date inputs updated `start`/`end` state but never moved the calendars, so the calendars didn't follow the typed date.

## Changes

- Wrap the month/year options in `SelectGroup` so the dropdown gets the standard list padding.
- Gate the sibling-month constraint on the layout actually showing two calendars, via a small `useMediaQuery` hook matching the Tailwind `lg` breakpoint. Below `lg` (or in compact mode) no sibling is passed.
- Sync the visible calendar(s) when a date input changes: `start` reveals the left calendar (the single calendar below `lg`), `end`/`Now` reveal the right calendar, following the edge the edited value lands on after any start/end swap.
- Bump all quill packages to `0.3.0-beta.11`.

Stacked on top of `quill-table-primitive` (#60763).

## How did you test this code?

I'm an agent. I ran the package typecheck (`tsc --noEmit` on `@posthog/quill-components`) — no new errors (one unrelated pre-existing `onValueChange` type error remains). No automated tests cover this component; I did not perform manual browser testing.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The three fixes came from screenshots of the live picker. Key decision: rather than reading viewport width imperatively, mirror the existing `lg:` Tailwind classes with a `useMediaQuery('(min-width: 64rem)')` hook so the JS two-calendar logic stays in lock-step with the CSS layout. Calendar sync reuses the existing `Calendar` effect that re-syncs `viewing` when `defaultViewing`'s month changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
