### PR TITLE
chore(docker): pin posthog user to fixed uid with home directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -295,8 +295,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && rm -rf /tmp/*
 
 # Install and use a non-root user.
-RUN groupadd -g 1000 posthog && \
-    useradd -r -g posthog posthog && \
+# Pin uid/gid to a fixed, host-safe value (avoid 1000, which maps to ec2-user on the nodes).
+RUN groupadd -g 10001 posthog && \
+    useradd -u 10001 -g posthog -m -d /home/posthog -s /bin/bash posthog && \
     chown posthog:posthog /code
 USER posthog
 

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -110,8 +110,8 @@ RUN apt-get update && \
 # gettext-base: Provides envsubst command used by bin/nodejs to substitute environment variables in Kafka client IDs
 
 # Install and use a non-root user
-RUN groupadd -g 10001 posthog || groupmod -n posthog $(getent group 10001 | cut -d: -f1) && \
-    useradd -u 10001 -g posthog -m -d /home/posthog posthog || usermod -l posthog -d /home/posthog -g posthog $(getent passwd 10001 | cut -d: -f1) && \
+RUN groupadd -g 10001 posthog && \
+    useradd -u 10001 -g posthog -m -d /home/posthog posthog && \
     chown -R posthog:posthog /code
 USER posthog
 

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -110,8 +110,8 @@ RUN apt-get update && \
 # gettext-base: Provides envsubst command used by bin/nodejs to substitute environment variables in Kafka client IDs
 
 # Install and use a non-root user
-RUN groupadd -g 1000 posthog || groupmod -n posthog $(getent group 1000 | cut -d: -f1) && \
-    useradd -u 1000 -g posthog posthog || usermod -l posthog -d /code -g posthog $(getent passwd 1000 | cut -d: -f1) && \
+RUN groupadd -g 10001 posthog || groupmod -n posthog $(getent group 10001 | cut -d: -f1) && \
+    useradd -u 10001 -g posthog -m -d /home/posthog posthog || usermod -l posthog -d /home/posthog -g posthog $(getent passwd 10001 | cut -d: -f1) && \
     chown -R posthog:posthog /code
 USER posthog
 

--- a/Dockerfile.recording-rasterizer
+++ b/Dockerfile.recording-rasterizer
@@ -128,8 +128,8 @@ RUN npx --yes @puppeteer/browsers install chrome-headless-shell@148.0.7778.178 \
     --path /opt/chrome-headless-shell && \
     ln -s "$(find /opt/chrome-headless-shell -name chrome-headless-shell -type f | head -1)" /usr/local/bin/chrome-headless-shell
 
-RUN groupadd -g 10001 posthog || groupmod -n posthog $(getent group 10001 | cut -d: -f1) && \
-    useradd -u 10001 -g posthog -m -d /home/posthog posthog || usermod -l posthog -d /home/posthog -g posthog $(getent passwd 10001 | cut -d: -f1) && \
+RUN groupadd -g 10001 posthog && \
+    useradd -u 10001 -g posthog -m -d /home/posthog posthog && \
     chown -R posthog:posthog /code
 USER posthog
 

--- a/Dockerfile.recording-rasterizer
+++ b/Dockerfile.recording-rasterizer
@@ -128,8 +128,8 @@ RUN npx --yes @puppeteer/browsers install chrome-headless-shell@148.0.7778.178 \
     --path /opt/chrome-headless-shell && \
     ln -s "$(find /opt/chrome-headless-shell -name chrome-headless-shell -type f | head -1)" /usr/local/bin/chrome-headless-shell
 
-RUN groupadd -g 1000 posthog || groupmod -n posthog $(getent group 1000 | cut -d: -f1) && \
-    useradd -u 1000 -g posthog posthog || usermod -l posthog -d /code -g posthog $(getent passwd 1000 | cut -d: -f1) && \
+RUN groupadd -g 10001 posthog || groupmod -n posthog $(getent group 10001 | cut -d: -f1) && \
+    useradd -u 10001 -g posthog -m -d /home/posthog posthog || usermod -l posthog -d /home/posthog -g posthog $(getent passwd 10001 | cut -d: -f1) && \
     chown -R posthog:posthog /code
 USER posthog
 


### PR DESCRIPTION
Pin the posthog user/group to uid/gid 10001 across the main, node, and recording-rasterizer images, and create a real home directory via useradd -m -d /home/posthog.

Previously the main image used useradd -r (system-assigned uid, no home) and the node images pinned 1000. Running the worker as a non-root user left HOME unresolved, so matplotlib and fontconfig caches fell back to an unwritable path. A fixed uid with a writable home resolves those caches from passwd without needing HOME set in the image, and avoids colliding with host uid 1000.
