### PR TITLE
refactor(max): move homepage hands-free start into a logic listener

### DIFF
--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -29,11 +29,10 @@ import { HOMEPAGE_TAB_ID } from './constants'
 
 function IdleInput(): JSX.Element {
     const { query } = useValues(aiFirstHomepageLogic)
-    const { setQuery, submitQuery, enterAiMode, startNewConversation } = useActions(aiFirstHomepageLogic)
+    const { setQuery, submitQuery, enterAiMode, startHandsFreeChat } = useActions(aiFirstHomepageLogic)
     const { dataProcessingAccepted } = useValues(maxGlobalLogic)
     const handsFreeFlag = useFeatureFlag('MAX_HANDS_FREE')
     const { canUseHandsFree } = useValues(handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }))
-    const { enterHandsFree } = useActions(handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }))
     const inputRef = useRef<HTMLTextAreaElement>(null)
 
     const handsFreeAvailable = handsFreeFlag && canUseHandsFree && dataProcessingAccepted
@@ -136,12 +135,7 @@ function IdleInput(): JSX.Element {
                                         iconOnly
                                         data-attr="homepage-hands-free"
                                         className="shrink-0"
-                                        onClick={() => {
-                                            posthog.capture('homepage hands-free started')
-                                            startNewConversation()
-                                            submitQuery('ai')
-                                            enterHandsFree()
-                                        }}
+                                        onClick={startHandsFreeChat}
                                     >
                                         <IconMicrophone className="size-4" />
                                     </ButtonPrimitive>

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -1,7 +1,9 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
+import posthog from 'posthog-js'
 
 import { tabUiStateLogic } from 'lib/logic/tabUiStateLogic'
+import { handsFreeLogic } from 'scenes/max/handsFreeLogic'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -92,6 +94,8 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         actions: [
             maxLogic({ tabId: HOMEPAGE_TAB_ID }),
             ['openConversation', 'startNewConversation', 'setQuestion'],
+            handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }),
+            ['enterHandsFree'],
             sceneLogic,
             ['setHomepage'],
             tabUiStateLogic,
@@ -101,6 +105,7 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
 
     actions({
         submitQuery: (mode: 'search' | 'ai') => ({ mode }),
+        startHandsFreeChat: true,
         enterAiMode: (trigger: string) => ({ trigger }),
         setQuery: (query: string) => ({ query }),
         setAnimationPhase: (phase: AnimationPhase) => ({ phase }),
@@ -237,6 +242,14 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
 
             await breakpoint(200)
             actions.setAnimationPhase('content')
+        },
+        startHandsFreeChat: () => {
+            posthog.capture('homepage hands-free started')
+            // Fresh conversation first so submitQuery's create-on-demand branch is skipped,
+            // then flip into AI mode (mounting maxThreadLogic) before Scribe starts listening.
+            actions.startNewConversation()
+            actions.submitQuery('ai')
+            actions.enterHandsFree()
         },
         enterAiMode: async ({ trigger }, breakpoint) => {
             // Animate into AI mode without starting a conversation

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -245,7 +245,7 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         },
         startHandsFreeChat: () => {
             posthog.capture('homepage hands-free started')
-            // Fresh conversation first so submitQuery's create-on-demand branch is skipped,
+            // Clear any in-progress conversation so hands-free always starts a fresh thread,
             // then flip into AI mode (mounting maxThreadLogic) before Scribe starts listening.
             actions.startNewConversation()
             actions.submitQuery('ai')


### PR DESCRIPTION
## Problem

The homepage idle-input mic button (added in #60122) fired four calls inline in its `onClick` handler: `posthog.capture`, `startNewConversation()`, `submitQuery('ai')`, and `enterHandsFree()`. That is business logic living in a React handler, which our frontend convention asks us to keep in the kea logic instead.

## Changes

- Add a `startHandsFreeChat` action to `aiFirstHomepageLogic` whose listener owns the full sequence, and `connect` `handsFreeLogic`'s `enterHandsFree` so the flow lives in one place.
- The mic button is now just `onClick={startHandsFreeChat}`.
- The `handsFreeAvailable` render gate stays in the component (a render concern).

No behaviour change — the listener makes the same synchronous action calls in the same order the click handler did, so the ordering the original relied on (fresh conversation before AI-mode transition before Scribe starts) is preserved.

## How did you test this code?

I'm an agent. I regenerated kea typegen (`pnpm typegen:write`, exit 0 with `--show-ts-errors`) and confirmed `aiFirstHomepageLogicType.ts` now carries both `startHandsFreeChat` and the connected `enterHandsFree`. No automated test covers this interaction directly; I did not perform manual browser testing.

## 🤖 Agent context

Authored with PostHog Code. This is a small follow-up refactor to #60122 (which merged before the change landed): it relocates the mic button's inline `onClick` sequence into a single `startHandsFreeChat` listener on `aiFirstHomepageLogic`. Considered keeping it in the handler vs. moving to the logic; moved it to honour the "business logic in kea, not React handlers" convention. Ordering between `startNewConversation`/`submitQuery('ai')`/`enterHandsFree` was preserved deliberately and documented in a code comment.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*