### PR TITLE
feat(insights): retention curve read path + gate

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -22347,6 +22347,10 @@
                     "description": "Try to automatically convert HogQL queries to use preaggregated tables at the AST level *",
                     "type": "boolean"
                 },
+                "useRetentionPreAggregation": {
+                    "description": "Whether to read first-occurrence retention from the pre-aggregated retention_curve table",
+                    "type": "boolean"
+                },
                 "useWebAnalyticsPreAggregatedTables": {
                     "type": "boolean"
                 }

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -418,6 +418,8 @@ export interface DataNode<R extends Record<string, any> = Record<string, any>> e
 
 /** HogQL Query Options are automatically set per team. However, they can be overridden in the query. */
 export interface HogQLQueryModifiers {
+    /** Whether to read first-occurrence retention from the pre-aggregated retention_curve table */
+    useRetentionPreAggregation?: boolean
     personsOnEventsMode?:
         | 'disabled' // `disabled` is deprecated and set for removal - `person_id_override_properties_joined` is its faster functional equivalent
         | 'person_id_no_override_properties_on_events'

--- a/posthog/hogql_queries/insights/retention/retention_base_query_preagg.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_preagg.py
@@ -1,0 +1,120 @@
+"""Pre-aggregated retention base query (per-person curve).
+
+Produces a SelectQuery in the same shape `RetentionFixedIntervalBaseQueryBuilder` emits, but
+reads one row per person from `retention_curve` instead of scanning events. Each curve row
+holds `first_seen_day` (all-history) + `active_offsets` (day-offsets active since then), so
+we reconstruct the per-person array of start-of-interval datetimes the legacy builder derives
+from raw events, then reuse the legacy builder's helpers to compute `start_interval_index`
+and `intervals_from_base`.
+
+Scope (gate-enforced): first-occurrence retention (`retention_first_time` /
+`retention_first_ever_occurrence`) for page-view or all-events, both entities the same kind.
+Because `first_seen_day` is the all-history first day, the cohort anchor is exact — the
+"looks-new-but-isn't" error a windowed materialisation hits does not apply here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr, parse_select
+
+from posthog.hogql_queries.insights.retention.retention_curve_materialize import kind_for_entity_id
+
+if TYPE_CHECKING:
+    from posthog.hogql_queries.insights.retention.retention_base_query_fixed import (
+        RetentionFixedIntervalBaseQueryBuilder,
+    )
+
+PREAGG_TABLE = "retention_curve"
+
+# Verbatim from RetentionFixedIntervalBaseQueryBuilder.build_base_query — the exploded,
+# 0-based cohort interval index. Reused as-is so the pre-agg path matches the legacy path;
+# `is_valid_start_interval` is injected (first-occurrence: `_start_event_timestamps[1] =
+# interval_date`).
+_START_INTERVAL_INDEX_SQL = """
+arrayJoin(
+    arrayFilter(
+        x -> x > -1,
+        arrayMap(
+            (interval_index, interval_date, _start_event_timestamps) ->
+                if(
+                    {is_valid_start_interval},
+                    interval_index - 1,
+                    -1
+                ),
+            arrayEnumerate(date_range),
+            date_range,
+            arrayResize(
+                [start_event_timestamps],
+                length(date_range),
+                start_event_timestamps
+            )
+        )
+    )
+)
+"""
+
+
+def build_preagg_base_query(builder: RetentionFixedIntervalBaseQueryBuilder) -> ast.SelectQuery:
+    runner = builder.runner
+    kind = kind_for_entity_id(runner.start_event.id)
+
+    # Per-person active intervals: map each day-offset to first_seen_day + offset, truncate to
+    # the query interval (day/week/month, team tz), dedupe + sort. Several day-offsets in the
+    # same week/month collapse to one — correct per-person rollup. Used as BOTH start and
+    # return timestamps (same kind, gate-enforced).
+    interval_of_offset = runner.query_date_range.get_start_of_interval_hogql(
+        source=parse_expr("first_seen_day + toIntervalDay(off)")
+    )
+    active_intervals = parse_expr(
+        "arraySort(arrayDistinct(arrayMap(off -> {interval_of_offset}, active_offsets)))",
+        {"interval_of_offset": interval_of_offset},
+    )
+
+    is_valid_start_interval = builder._is_valid_start_interval_expr("_start_event_timestamps")
+    intervals_from_base_expr, _retention_value_expr = builder._get_intervals_from_base_exprs()
+
+    # FINAL is disallowed in HogQL, so dedupe the ReplacingMergeTree rows explicitly: keep the
+    # newest (max computed_at) row per person, then filter the cohort window on the deduped
+    # first_seen_day in the outer query.
+    select_query = parse_select(
+        """
+        SELECT
+            actor_id,
+            {start_event_timestamps} AS start_event_timestamps,
+            {date_range} AS date_range,
+            {return_event_timestamps} AS return_event_timestamps,
+            {start_interval_index} AS start_interval_index,
+            {intervals_from_base} AS intervals_from_base
+        FROM (
+            SELECT
+                person_id AS actor_id,
+                argMax(first_seen_day, computed_at) AS first_seen_day,
+                argMax(active_offsets, computed_at) AS active_offsets
+            FROM posthog.retention_curve
+            WHERE team_id = {team_id} AND kind = {kind}
+            GROUP BY person_id
+        )
+        WHERE first_seen_day >= {first_seen_lower}
+            AND first_seen_day < {first_seen_upper}
+        """,
+        placeholders={
+            "start_event_timestamps": active_intervals,
+            "date_range": builder._date_range_alias().expr,
+            "return_event_timestamps": active_intervals,
+            "start_interval_index": parse_expr(
+                _START_INTERVAL_INDEX_SQL, {"is_valid_start_interval": is_valid_start_interval}
+            ),
+            "intervals_from_base": intervals_from_base_expr,
+            "team_id": ast.Constant(value=runner.team.pk),
+            "kind": ast.Constant(value=kind),
+            "first_seen_lower": ast.Call(
+                name="toDate", args=[runner.query_date_range.date_from_to_start_of_interval_hogql()]
+            ),
+            "first_seen_upper": ast.Call(name="toDate", args=[ast.Constant(value=runner.query_date_range.date_to())]),
+        },
+    )
+    assert isinstance(select_query, ast.SelectQuery)
+    return select_query

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -34,8 +34,15 @@ from posthog.hogql.timings import HogQLTimings
 
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
 from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RetentionFixedIntervalBaseQueryBuilder
+from posthog.hogql_queries.insights.retention.retention_base_query_preagg import build_preagg_base_query
 from posthog.hogql_queries.insights.retention.retention_base_query_rolling import (
     RetentionRollingIntervalBaseQueryBuilder,
+)
+from posthog.hogql_queries.insights.retention.retention_curve_materialize import (
+    HORIZON_DAYS,
+    SUPPORTED_KINDS,
+    ensure_retention_curve,
+    kind_for_entity_id,
 )
 from posthog.hogql_queries.insights.retention.retention_validation_rules import DisallowCumulativeWith24HourWindows
 from posthog.hogql_queries.insights.utils.breakdowns import (
@@ -412,11 +419,56 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
 
         return refresh_frequency
 
+    @cached_property
+    def should_use_retention_preagg(self) -> bool:
+        # Routing gate for the per-person retention_curve. Conservative on purpose — each
+        # condition rules out a shape v1 can't answer. Expand by extending the curve, not by
+        # relaxing checks here.
+        if not self.modifiers.useRetentionPreAggregation:
+            return False
+        # First-occurrence only; recurring re-cohorts every period and falls through to raw.
+        if not (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
+            return False
+        # 24h windows and custom brackets have per-interval shapes the curve doesn't reproduce.
+        if self.is_24h_window_calculation or self.is_custom_bracket_retention:
+            return False
+        # Person retention only.
+        if self.group_type_index is not None:
+            return False
+        # Property aggregation / minimum-occurrences / property filters need event data the
+        # curve doesn't store.
+        if self.has_property_aggregation:
+            return False
+        if (self.query.retentionFilter.minimumOccurrences or 1) > 1:
+            return False
+        if self.query.properties or self.start_event.properties or self.return_event.properties:
+            return False
+        # Both entities must be the same materialised kind (page-view or all-events).
+        if self.start_event.type != EntityType.EVENTS or self.return_event.type != EntityType.EVENTS:
+            return False
+        start_kind = kind_for_entity_id(self.start_event.id)
+        if not (start_kind == kind_for_entity_id(self.return_event.id) and start_kind in SUPPORTED_KINDS):
+            return False
+        # Curve only holds offsets up to the horizon; longer lookaheads fall through to raw.
+        return self._max_lookahead_days() <= HORIZON_DAYS
+
+    def _max_lookahead_days(self) -> int:
+        interval_days = {"day": 1, "week": 7, "month": 31}.get(self.query_date_range.interval_name, 1)
+        return self.query_date_range.lookahead * interval_days
+
     def _base_query(
         self,
         start_interval_index_filter: Optional[int] = None,
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
+        if self.should_use_retention_preagg:
+            preagg_query = self._build_preagg_base_query(
+                start_interval_index_filter=start_interval_index_filter,
+                selected_breakdown_value=selected_breakdown_value,
+            )
+            if preagg_query is not None:
+                return preagg_query
+            # Materialisation not ready or shape unsupported — raw events are always correct.
         builder_class = (
             RetentionRollingIntervalBaseQueryBuilder
             if self.is_24h_window_calculation
@@ -426,6 +478,19 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             start_interval_index_filter=start_interval_index_filter,
             selected_breakdown_value=selected_breakdown_value,
         )
+
+    def _build_preagg_base_query(
+        self,
+        start_interval_index_filter: Optional[int] = None,
+        selected_breakdown_value: str | list[str] | int | None = None,
+    ) -> ast.SelectQuery | None:
+        # Actor drill-down post-filters (HAVING) aren't reproduced on the curve path yet.
+        if start_interval_index_filter is not None or selected_breakdown_value is not None:
+            return None
+        materialisation = ensure_retention_curve(self.team, kind_for_entity_id(self.start_event.id))
+        if not materialisation.ready:
+            return None
+        return build_preagg_base_query(RetentionFixedIntervalBaseQueryBuilder(self))
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
         with self.timings.measure("retention_query"):

--- a/posthog/hogql_queries/insights/retention/test/test_retention_preagg_read_path.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_preagg_read_path.py
@@ -1,0 +1,124 @@
+from datetime import UTC, datetime
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
+
+from parameterized import parameterized
+
+from posthog.schema import HogQLQueryModifiers, RetentionQuery
+
+from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
+
+PAGEVIEW = {"id": "$pageview", "type": "events"}
+ALL_EVENTS = {"id": None, "name": "All events", "type": "events"}
+
+
+def _ts(day: int, hour: int = 5) -> str:
+    return datetime(2023, 9, day, hour, tzinfo=UTC).isoformat()
+
+
+class TestRetentionPreaggReadPath(ClickhouseTestMixin, APIBaseTest):
+    def _seed(self):
+        # All first-events are inside the window, so first-occurrence cohorting matches raw.
+        for distinct_id, pageview_days, other_days in [
+            ("p1", [3, 4, 6], [3]),
+            ("p2", [3], [5]),
+            ("p3", [4, 5], []),
+            ("p4", [], [3, 4]),  # never a pageview — only in all-events
+        ]:
+            _create_person(team_id=self.team.pk, distinct_ids=[distinct_id])
+            for d in pageview_days:
+                _create_event(team=self.team, event="$pageview", distinct_id=distinct_id, timestamp=_ts(d))
+            for d in other_days:
+                _create_event(team=self.team, event="custom", distinct_id=distinct_id, timestamp=_ts(d))
+        flush_persons_and_events()
+
+    def _run(self, *, entity, retention_type, use_preagg):
+        query = {
+            "kind": "RetentionQuery",
+            "dateRange": {"date_from": _ts(3, 0), "date_to": _ts(9, 0)},
+            "retentionFilter": {
+                "period": "Day",
+                "totalIntervals": 7,
+                "retentionType": retention_type,
+                "targetEntity": entity,
+                "returningEntity": entity,
+            },
+        }
+        return RetentionQueryRunner(
+            team=self.team,
+            query=RetentionQuery(**query),
+            modifiers=HogQLQueryModifiers(useRetentionPreAggregation=use_preagg),
+        )
+
+    @staticmethod
+    def _counts(results):
+        return [[v["count"] for v in row["values"]] for row in results]
+
+    @parameterized.expand(
+        [
+            ("first_time_pageview", "retention_first_time", PAGEVIEW),
+            ("first_time_all_events", "retention_first_time", ALL_EVENTS),
+            ("first_ever_pageview", "retention_first_ever_occurrence", PAGEVIEW),
+            ("first_ever_all_events", "retention_first_ever_occurrence", ALL_EVENTS),
+        ]
+    )
+    def test_preagg_matches_raw_events(self, _name, retention_type, entity):
+        self._seed()
+        raw = (
+            self._run(entity=entity, retention_type=retention_type, use_preagg=False)
+            .calculate()
+            .model_dump()["results"]
+        )
+        preagg_runner = self._run(entity=entity, retention_type=retention_type, use_preagg=True)
+        self.assertTrue(preagg_runner.should_use_retention_preagg)
+        preagg = preagg_runner.calculate().model_dump()["results"]
+
+        self.assertEqual(self._counts(raw), self._counts(preagg))
+        # Sanity: there is some retention to compare (not an all-zero matrix).
+        self.assertGreater(sum(sum(v["count"] for v in row["values"]) for row in raw), 0)
+
+    def test_actor_with_pre_window_history_excluded(self):
+        # The case the per-day grain gets wrong: p_old's first pageview predates the window but
+        # they're active inside it. First-occurrence retention must NOT cohort them in-window.
+        self._seed()
+        _create_person(team_id=self.team.pk, distinct_ids=["p_old"])
+        _create_event(team=self.team, event="$pageview", distinct_id="p_old", timestamp=_ts(1))  # before date_from
+        _create_event(team=self.team, event="$pageview", distinct_id="p_old", timestamp=_ts(4))  # inside window
+        flush_persons_and_events()
+
+        raw = (
+            self._run(entity=PAGEVIEW, retention_type="retention_first_time", use_preagg=False)
+            .calculate()
+            .model_dump()["results"]
+        )
+        preagg_runner = self._run(entity=PAGEVIEW, retention_type="retention_first_time", use_preagg=True)
+        self.assertTrue(preagg_runner.should_use_retention_preagg)
+        preagg = preagg_runner.calculate().model_dump()["results"]
+        self.assertEqual(self._counts(raw), self._counts(preagg))
+
+    def test_gate(self):
+        self._seed()
+        # recurring → raw events
+        self.assertFalse(
+            self._run(
+                entity=PAGEVIEW, retention_type="retention_recurring", use_preagg=True
+            ).should_use_retention_preagg
+        )
+        # first_ever → allowed
+        self.assertTrue(
+            self._run(
+                entity=PAGEVIEW, retention_type="retention_first_ever_occurrence", use_preagg=True
+            ).should_use_retention_preagg
+        )
+        # custom event → raw events
+        self.assertFalse(
+            self._run(
+                entity={"id": "custom", "type": "events"}, retention_type="retention_first_time", use_preagg=True
+            ).should_use_retention_preagg
+        )
+        # modifier off → raw events
+        self.assertFalse(
+            self._run(
+                entity=PAGEVIEW, retention_type="retention_first_time", use_preagg=False
+            ).should_use_retention_preagg
+        )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7489,6 +7489,10 @@ class HogQLQueryModifiers(BaseModel):
         default=None,
         description=("Try to automatically convert HogQL queries to use preaggregated tables at the AST level *"),
     )
+    useRetentionPreAggregation: bool | None = Field(
+        default=None,
+        description=("Whether to read first-occurrence retention from the pre-aggregated retention_curve table"),
+    )
     useWebAnalyticsPreAggregatedTables: bool | None = None
 
 

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -743,6 +743,8 @@ export interface HogQLQueryModifiersApi {
     usePreaggregatedIntermediateResults?: boolean | null
     /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
     usePreaggregatedTableTransforms?: boolean | null
+    /** Whether to read first-occurrence retention from the pre-aggregated retention_curve table */
+    useRetentionPreAggregation?: boolean | null
     useWebAnalyticsPreAggregatedTables?: boolean | null
 }
 

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -450,6 +450,8 @@ export interface HogQLQueryModifiersApi {
     usePreaggregatedIntermediateResults?: boolean | null
     /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
     usePreaggregatedTableTransforms?: boolean | null
+    /** Whether to read first-occurrence retention from the pre-aggregated retention_curve table */
+    useRetentionPreAggregation?: boolean | null
     useWebAnalyticsPreAggregatedTables?: boolean | null
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -403,6 +403,8 @@ export namespace Schemas {
       usePreaggregatedIntermediateResults?: boolean | null;
       /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
       usePreaggregatedTableTransforms?: boolean | null;
+      /** Whether to read first-occurrence retention from the pre-aggregated retention_curve table */
+      useRetentionPreAggregation?: boolean | null;
       useWebAnalyticsPreAggregatedTables?: boolean | null;
     }
 


### PR DESCRIPTION
## Problem

We have a per-person `retention_curve` pre-aggregation table (#60697) and its full-history materialisation (#60778), but nothing reads from it yet. This PR adds the read path so first-occurrence retention can be served from the curve instead of scanning raw events, gated behind a modifier so it stays dark until we explicitly enable it per team.

## Changes

- New `retention_base_query_preagg.py` — `build_preagg_base_query` reads one row per person from `retention_curve`, reconstructs the per-person array of start-of-interval datetimes from `first_seen_day + active_offsets`, and reuses the legacy fixed-interval builder's expressions (`_is_valid_start_interval_expr`, `_get_intervals_from_base_exprs`, `_date_range_alias`, the `start_interval_index` arrayJoin) so the output matches the raw path exactly.
  - `FINAL` is disallowed in HogQL, so the ReplacingMergeTree is deduped explicitly with `argMax(first_seen_day, computed_at)` / `argMax(active_offsets, computed_at)` over `GROUP BY person_id`, with the cohort window filtered on the deduped `first_seen_day` in the outer query.
- `retention_query_runner.py` — a conservative routing gate (`should_use_retention_preagg`) that only takes the curve path for first-occurrence page-view / all-events person retention with no property filters, aggregation, minimum-occurrences, custom brackets, 24h windows, or lookahead beyond the curve horizon. Anything else falls through to raw events, which are always correct. Dispatch calls `ensure_retention_curve` and falls back to raw if the materialisation isn't ready.
- Schema: `useRetentionPreAggregation` modifier added to `HogQLQueryModifiers` (off by default), regenerated into `schema.py` / `schema.json`.

The cohort pre-window exclusion (an actor whose first event predates the window must not be cohorted in-window) is handled exactly by the `first_seen_day` window filter, since `first_seen_day` is the all-history anchor.

## How did you test this code?

I'm an agent (Claude Code). I ran these automated tests locally; I did not do manual UI testing.

- New `test_retention_preagg_read_path.py` — parity (gate-off vs gate-on) for first_time / first_ever × pageview / all-events, the pre-window-history actor exclusion case, and the routing gate. 6 passed.
- `test_retention_curve_materialize.py` — 5 passed.
- The broader `test_retention_query_runner.py` suite has 12 pre-existing failures on the base commit (unrelated: breakdown / custom-bracket / group-aggregation cases); they fail identically with this PR's runner changes stashed.

## 🤖 Agent context

Authored by Claude Code. The handoff suspected a "returns undercounted" matrix mismatch needing a first-time `if(has(...))` wrapper; that turned out to be a stale symptom. The two real blockers were the `FINAL` keyword (rejected by the HogQL printer → switched to `argMax` dedup) and `toDateTime` on a `Date` column (HogQL maps it to a string-only parser → switched to direct `Date + toIntervalDay` arithmetic). The `if(has(...))` wrapper was not needed once the `first_seen_day` window filter was in place. Human review required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
