### PR TITLE
chore(experiments): extract funnel query construction

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_funnel_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_funnel_query_builder.py
@@ -1,0 +1,1075 @@
+from typing import TYPE_CHECKING, Optional, cast
+
+from django.utils import timezone
+
+from posthog.schema import ExperimentDataWarehouseNode, ExperimentFunnelMetric, MultipleVariantHandling, StepOrderValue
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr, parse_select
+
+from posthog.hogql_queries.experiments import MULTIPLE_VARIANT_KEY
+from posthog.hogql_queries.experiments.base_query_utils import (
+    data_warehouse_node_to_filter,
+    funnel_evaluation_expr,
+    funnel_steps_to_filter,
+)
+from posthog.hogql_queries.experiments.funnel_step_builder import FunnelStepBuilder
+from posthog.hogql_queries.experiments.funnel_validation import FunnelDWValidator
+from posthog.hogql_queries.experiments.metric_source import MetricSourceInfo
+
+if TYPE_CHECKING:
+    from posthog.hogql_queries.experiments.experiment_query_builder import ExperimentQueryBuilder
+
+
+class FunnelQueryBuilder:
+    """
+    Builds funnel-metric queries (aggregate results and the metric-events
+    precomputation write query).
+
+    Funnel construction is deeply coupled to the rest of the experiment query
+    builder: it reads the metric and CUPED config, calls shared exposure and
+    metric-value helpers, and the CUPED and maturity helpers call back into the
+    funnel helpers. To keep the move behavior-preserving, this class holds a
+    reference to the owning ``ExperimentQueryBuilder`` and reaches through it for
+    that shared state and those cross-cluster helpers. The optimized
+    (single-scan) and legacy (double-scan) paths intentionally live side by side
+    here without being merged.
+    """
+
+    def __init__(self, builder: "ExperimentQueryBuilder"):
+        self._b = builder
+
+    def build_funnel_query(self) -> ast.SelectQuery:
+        """
+        Builds query for funnel metrics.
+        Dispatches to optimized (single-scan) or legacy (double-scan) path.
+        """
+        if self.should_use_optimized_funnel_query():
+            return self.build_funnel_query_optimized()
+        return self.build_funnel_query_legacy()
+
+    def should_use_optimized_funnel_query(self) -> bool:
+        """
+        Returns True when the optimized single-scan funnel query should be used.
+        The legacy path is kept for precomputed exposures, where the exposures CTE
+        reads from a cheap preaggregated table (no double-scan penalty).
+
+        Also routes to legacy path for DW funnels, which use UNION ALL pattern
+        only implemented in the legacy path.
+        """
+        if self._b.preaggregation_job_ids and not self._b.breakdowns:
+            return False
+        # Route DW funnels to legacy path which supports UNION ALL
+        if isinstance(self._b.metric, ExperimentFunnelMetric) and self.has_datawarehouse_steps():
+            return False
+        return True
+
+    def build_funnel_query_legacy(self) -> ast.SelectQuery:
+        """
+        3-CTE funnel query: exposures, metric_events, entity_metrics.
+        Called "legacy" because it predates the single-scan optimized path,
+        but this is the primary path for precomputed queries — both exposures
+        and metric_events CTEs can read from precomputed tables here.
+
+        Supports two patterns:
+        1. Events-only: Single query with boolean step columns
+        2. With DW steps: UNION ALL pattern with separate subqueries per source
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+
+        # Validate DW funnel configuration before building query
+        FunnelDWValidator.validate_funnel_metric(self._b.metric)
+
+        num_steps = len(self._b.metric.series) + 1  #  +1 as we are including exposure criteria
+
+        # Determine which query pattern to use
+        has_dw_steps = self.has_datawarehouse_steps()
+
+        # Track whether step columns need to be injected after parsing.
+        # Precomputed metric events already have steps extracted from the array.
+        inject_step_columns = True
+
+        if self._b.metric_events_preaggregation_job_ids and not has_dw_steps:
+            # Read from precomputed table instead of scanning events
+            inject_step_columns = False
+            step_extracts = ", ".join(f"arrayElement(t.steps, {i + 1}) AS step_{i}" for i in range(num_steps))
+            entity_id_cast = "toUUID(t.entity_id)" if self._b.entity_key == "person_id" else "t.entity_id"
+            session_id_col = "t.session_id AS session_id," if not self._b.funnel_steps_data_disabled else ""
+
+            # Filter by experiment date range: jobs can cover broader time ranges
+            # than the experiment for cache reusability, so we must filter on read.
+            # Upper bound includes conversion window since funnel step events can
+            # occur after experiment end.
+            conversion_window_seconds = self._b._get_conversion_window_seconds()
+            if conversion_window_seconds > 0:
+                upper_bound = f"{{metric_events_date_to}} + toIntervalSecond({conversion_window_seconds})"
+            else:
+                upper_bound = "{metric_events_date_to}"
+
+            metric_events_cte_str = f"""
+                    metric_events AS (
+                        SELECT
+                            {entity_id_cast} AS entity_id,
+                            t.timestamp AS timestamp,
+                            t.event_uuid AS uuid,
+                            {session_id_col}
+                            {step_extracts}
+                        FROM experiment_metric_events_preaggregated AS t
+                        WHERE t.job_id IN {{metric_events_job_ids}}
+                            AND t.team_id = {{metric_events_team_id}}
+                            AND t.timestamp >= {{metric_events_date_from}}
+                            AND t.timestamp <= {upper_bound}
+                    )
+            """
+        elif has_dw_steps:
+            # UNION ALL pattern for heterogeneous sources
+            # We'll inject the UNION query directly as AST after building the main query
+            metric_events_cte_str = """
+                    metric_events AS (
+                        SELECT 1 AS placeholder
+                        -- This will be replaced with UNION ALL query
+                    )
+            """
+        else:
+            session_id_column = (
+                """
+                            properties.$session_id AS session_id,"""
+                if not self._b.funnel_steps_data_disabled
+                else ""
+            )
+
+            metric_events_cte_str = f"""
+                    metric_events AS (
+                        SELECT
+                            {{entity_key}} AS entity_id,
+                            {{variant_property}} as variant,
+                            timestamp,
+                            uuid,{session_id_column}
+                            -- step_0, step_1, ... step_N columns added programmatically below
+                        FROM events
+                        WHERE ({{exposure_predicate}} OR {{funnel_steps_filter}})
+                    )
+            """
+
+        is_unordered_funnel = self._b.metric.funnel_order_type == StepOrderValue.UNORDERED
+
+        # Use separate exposures CTE to leverage precomputed exposure cache when available.
+        # The exposures query automatically falls back to scanning events if precomputation
+        # isn't enabled for the team.
+        #
+        # Unordered funnels need temporal filtering (metric_events.timestamp >= first_exposure_time)
+        # because the funnel UDF doesn't filter out events before the exposure.
+        # Ordered funnels don't need this - the UDF handles temporal ordering internally.
+
+        # Build the JOIN clause with conditional temporal filter
+        temporal_filter = "AND metric_events.timestamp >= exposures.first_exposure_time" if is_unordered_funnel else ""
+
+        # DW steps join via events_join_key (e.g. properties.$user_id) → data_warehouse_join_key
+        # (e.g. userid). The exposure CTE uses person_id (UUID) as entity_id. To bridge
+        # these, we add an exposure_identifier column and join on that instead.
+        if has_dw_steps:
+            entity_id_join = "ON toString(exposures.exposure_identifier) = metric_events.entity_id"
+        else:
+            entity_id_join = "ON exposures.entity_id = metric_events.entity_id"
+
+        if self._b.funnel_steps_data_disabled:
+            # When steps data is disabled, we skip the expensive session/event maps and
+            # the per-exposure columns that are only needed for steps_event_data.
+            # The exposures CTE already deduplicates to one row per (entity_id, variant),
+            # so removing these from GROUP BY doesn't change results.
+            extra_select_columns = ""
+            extra_group_by_columns = ""
+        else:
+            extra_select_columns = """,
+                    exposures.exposure_event_uuid AS exposure_event_uuid,
+                    exposures.exposure_session_id AS exposure_session_id,
+                    exposures.first_exposure_time AS exposure_timestamp,
+                    {uuid_to_session_map} AS uuid_to_session,
+                    {uuid_to_timestamp_map} AS uuid_to_timestamp"""
+            extra_group_by_columns = """,
+                    exposures.exposure_event_uuid,
+                    exposures.exposure_session_id,
+                    exposures.first_exposure_time"""
+
+        ctes_sql = f"""
+            exposures AS (
+                {{exposure_select_query}}
+            ),
+
+            {metric_events_cte_str},
+
+            entity_metrics AS (
+                SELECT
+                    exposures.entity_id AS entity_id,
+                    exposures.variant AS variant,
+                    {{funnel_aggregation}} AS value{extra_select_columns}
+                    -- covariate_value added programmatically below when CUPED is enabled
+                FROM exposures
+                LEFT JOIN metric_events
+                    {entity_id_join}
+                    {temporal_filter}  -- Only for unordered: filters out events before exposure
+                GROUP BY
+                    exposures.entity_id,
+                    exposures.variant{extra_group_by_columns}
+            )
+        """
+
+        # Build exposure query, adding exposure_identifier for DW funnels
+        exposure_query = self._b._get_exposure_query()
+        if has_dw_steps:
+            # All DW steps are validated to use the same events_join_key
+            first_dw_step = next(s for s in self._b.metric.series if isinstance(s, ExperimentDataWarehouseNode))
+            events_join_key_parts = cast(list[str | int], first_dw_step.events_join_key.split("."))
+
+            # Use argMin to pick one exposure_identifier per entity_id (from first exposure)
+            # This prevents fan-out when a user has multiple exposures with different join key values
+            exposure_query.select.append(
+                ast.Alias(
+                    alias="exposure_identifier",
+                    expr=ast.Call(
+                        name="argMin",
+                        args=[ast.Field(chain=events_join_key_parts), ast.Field(chain=["timestamp"])],
+                    ),
+                )
+            )
+
+        placeholders: dict[str, ast.Expr | ast.SelectQuery] = {
+            "exposure_predicate": self._b._build_exposure_predicate(),
+            "variant_property": self._b._build_variant_property(),
+            "variant_expr": self.build_variant_expr_for_funnel(),
+            "entity_key": parse_expr(self._b.entity_key),
+            "funnel_steps_filter": self.build_funnel_steps_filter(),
+            "funnel_aggregation": self.build_funnel_aggregation_expr(),
+            "num_steps_minus_1": ast.Constant(value=num_steps - 1),
+            "exposure_select_query": exposure_query,
+            "date_from": self._b.date_range_query.date_from_as_hogql(),
+            "date_to": self._b.date_range_query.date_to_as_hogql(),
+        }
+        if not self._b.funnel_steps_data_disabled:
+            placeholders["uuid_to_session_map"] = self.build_uuid_to_session_map()
+            placeholders["uuid_to_timestamp_map"] = self.build_uuid_to_timestamp_map()
+
+        if self._b.metric_events_preaggregation_job_ids:
+            placeholders["metric_events_job_ids"] = ast.Constant(value=self._b.metric_events_preaggregation_job_ids)
+            placeholders["metric_events_team_id"] = ast.Constant(value=self._b.team.id)
+            placeholders["metric_events_date_from"] = self._b.date_range_query.date_from_as_hogql()
+            placeholders["metric_events_date_to"] = self._b.date_range_query.date_to_as_hogql()
+
+        query = parse_select(
+            f"""
+            WITH
+            {ctes_sql}
+
+            SELECT
+                entity_metrics.variant AS variant,
+                count(entity_metrics.entity_id) AS num_users,
+                -- The return value from the funnel eval is zero indexed. So reaching first step means
+                -- it return 0, and so on. So reaching the last step means it will return
+                -- num_steps - 1
+                countIf(entity_metrics.value.1 = {{num_steps_minus_1}}) AS total_sum,
+                countIf(entity_metrics.value.1 = {{num_steps_minus_1}}) AS total_sum_of_squares
+                -- CUPED aggregation columns added programmatically below
+                -- step_counts added programmatically below
+                -- steps_event_data added programmatically below
+                -- breakdown columns added programmatically below
+            FROM entity_metrics
+            WHERE notEmpty(variant)
+            GROUP BY entity_metrics.variant
+            -- breakdown columns added programmatically below
+            """,
+            placeholders=placeholders,
+        )
+
+        assert isinstance(query, ast.SelectQuery)
+
+        if self._b.cuped_config.enabled:
+            self._b._inject_funnel_covariate_into_entity_metrics(
+                query,
+                events_alias="metric_events",
+                last_step_index=num_steps - 1,
+                exposure_alias="exposures",
+            )
+
+        # Inject breakdown columns into the query AST
+        if self._b.breakdown_injector:
+            self._b.breakdown_injector.inject_funnel_breakdown_columns(query)
+
+        # Inject or replace the metric_events CTE based on whether DW steps are present
+        if query.ctes and "metric_events" in query.ctes:
+            if has_dw_steps:
+                # Replace with UNION ALL query for DW funnels
+                union_query = self.build_funnel_metric_events_union_query()
+                query.ctes["metric_events"] = ast.CTE(name="metric_events", expr=union_query, cte_type="subquery")
+            else:
+                # Inject step columns into the metric_events CTE (skip when precomputed — already extracted)
+                if inject_step_columns:
+                    metric_events_cte = query.ctes["metric_events"]
+                    if isinstance(metric_events_cte, ast.CTE) and isinstance(metric_events_cte.expr, ast.SelectQuery):
+                        step_columns = self.build_funnel_step_columns()
+                        metric_events_cte.expr.select.extend(step_columns)
+
+        # Inject the additional selects we do for getting the data we need to render the funnel chart
+        # Add step counts - how many users reached each step
+        step_count_exprs = []
+        for i in range(1, num_steps):
+            step_count_exprs.append(f"countIf(entity_metrics.value.1 >= {i})")
+        step_counts_expr = f"tuple({', '.join(step_count_exprs)}) as step_counts"
+
+        query.select.append(parse_expr(step_counts_expr))
+
+        # For each step in the funnel, get at least 100 tuples of person_id, session_id, event uuid, and timestamp, that have
+        # that step as their last step in the funnel.
+        # For the users that have 0 matching steps in the funnel (-1), we return the event data for the exposure event.
+        # This is skipped when funnel_steps_data_disabled is set, as it's expensive for high-traffic experiments.
+        if not self._b.funnel_steps_data_disabled:
+            event_uuids_exprs = []
+            for i in range(1, num_steps + 1):
+                event_uuids_expr = f"""
+                    groupArraySampleIf(100)(
+                        if(
+                            entity_metrics.value.2 != '',
+                            tuple(toString(entity_metrics.entity_id), uuid_to_session[entity_metrics.value.2], entity_metrics.value.2, toString(uuid_to_timestamp[entity_metrics.value.2])),
+                            tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))
+                        ),
+                        entity_metrics.value.1 = {i} - 1
+                    )
+                """
+                event_uuids_exprs.append(event_uuids_expr)
+            event_uuids_exprs_sql = f"tuple({', '.join(event_uuids_exprs)}) as steps_event_data"
+            query.select.append(parse_expr(event_uuids_exprs_sql))
+
+        return query
+
+    def build_funnel_query_optimized(self) -> ast.SelectQuery:
+        """
+        Optimized funnel query: eliminates the second events table scan and the
+        intermediate JOIN. Uses 2 CTEs for ordered funnels, 3 for unordered:
+
+        Ordered:   base_events -> entity_metrics -> final SELECT
+        Unordered: base_events -> first_exposures -> entity_metrics -> final SELECT
+
+        base_events: single scan of events, computes step_0/step_1/variant_value inline
+        first_exposures: (unordered only) min exposure time per entity for temporal filtering
+        entity_metrics: GROUP BY entity_id, conditional aggregation for variant, funnel UDF
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+
+        num_steps = len(self._b.metric.series) + 1  # +1 as we are including exposure criteria
+
+        session_id_column = (
+            """
+                        properties.$session_id AS session_id,"""
+            if not self._b.funnel_steps_data_disabled
+            else ""
+        )
+
+        # CTE 1: base_events - single scan of events table
+        # WHERE admits both exposure and conversion events. Exclusion filters are
+        # embedded in step_0 only, not the WHERE clause, so conversion events from
+        # internal users pass through (they only matter if the user has a valid exposure).
+        base_events_cte_str = f"""
+                base_events AS (
+                    SELECT
+                        {{entity_key}} AS entity_id,
+                        {{variant_property}} AS variant_value,
+                        timestamp,
+                        uuid,{session_id_column}
+                        -- step_0, step_1, ... step_N columns added programmatically below
+                    FROM events
+                    WHERE ({{exposure_predicate}} OR {{funnel_steps_filter}})
+                )
+        """
+
+        is_unordered_funnel = self._b.metric.funnel_order_type == StepOrderValue.UNORDERED
+
+        # CTE 2: entity_metrics - GROUP BY entity_id, no JOIN
+        if self._b.funnel_steps_data_disabled:
+            extra_select_columns = ""
+        else:
+            extra_select_columns = """,
+                    argMinIf(uuid, timestamp, step_0 = 1) AS exposure_event_uuid,
+                    argMinIf(session_id, timestamp, step_0 = 1) AS exposure_session_id,
+                    minIf(timestamp, step_0 = 1) AS exposure_timestamp,
+                    {uuid_to_session_map} AS uuid_to_session,
+                    {uuid_to_timestamp_map} AS uuid_to_timestamp"""
+
+        first_exposures_cte_str, temporal_join, having_clause = self.build_funnel_optimized_temporal_setup(
+            is_unordered_funnel
+        )
+
+        ctes_sql = f"""
+            {base_events_cte_str},
+            {first_exposures_cte_str}
+            entity_metrics AS (
+                SELECT
+                    base_events.entity_id AS entity_id,
+                    {{variant_expr}} AS variant,
+                    {{funnel_aggregation}} AS value{extra_select_columns}
+                    -- covariate_value added programmatically below when CUPED is enabled
+                FROM base_events
+                {temporal_join}
+                GROUP BY base_events.entity_id{having_clause}
+            )
+        """
+
+        placeholders: dict[str, ast.Expr | ast.SelectQuery] = {
+            "exposure_predicate": self._b._build_exposure_predicate(),
+            "variant_property": self._b._build_variant_property(),
+            "variant_expr": self.build_variant_expr_for_funnel_optimized(),
+            "entity_key": parse_expr(self._b.entity_key),
+            "funnel_steps_filter": self.build_funnel_steps_filter(),
+            "funnel_aggregation": self.build_funnel_aggregation_expr_optimized(),
+            "num_steps_minus_1": ast.Constant(value=num_steps - 1),
+        }
+        if not self._b.funnel_steps_data_disabled:
+            placeholders["uuid_to_session_map"] = self.build_uuid_to_session_map_optimized()
+            placeholders["uuid_to_timestamp_map"] = self.build_uuid_to_timestamp_map_optimized()
+
+        query = parse_select(
+            f"""
+            WITH
+            {ctes_sql}
+
+            SELECT
+                entity_metrics.variant AS variant,
+                count(entity_metrics.entity_id) AS num_users,
+                -- The return value from the funnel eval is zero indexed. So reaching first step means
+                -- it return 0, and so on. So reaching the last step means it will return
+                -- num_steps - 1
+                countIf(entity_metrics.value.1 = {{num_steps_minus_1}}) AS total_sum,
+                countIf(entity_metrics.value.1 = {{num_steps_minus_1}}) AS total_sum_of_squares
+                -- CUPED aggregation columns added programmatically below
+                -- step_counts added programmatically below
+                -- steps_event_data added programmatically below
+                -- breakdown columns added programmatically below
+            FROM entity_metrics
+            WHERE notEmpty(variant)
+            GROUP BY entity_metrics.variant
+            -- breakdown columns added programmatically below
+            """,
+            placeholders=placeholders,
+        )
+
+        assert isinstance(query, ast.SelectQuery)
+
+        if self._b.cuped_config.enabled:
+            self._b._inject_funnel_covariate_into_entity_metrics(
+                query,
+                events_alias="base_events",
+                last_step_index=num_steps - 1,
+                exposure_alias="first_exposures",
+            )
+
+        # Inject breakdown columns into the query AST
+        if self._b.breakdown_injector:
+            self._b.breakdown_injector.inject_funnel_breakdown_columns_optimized(query)
+
+        # Inject step columns into the base_events CTE
+        if query.ctes and "base_events" in query.ctes:
+            base_events_cte = query.ctes["base_events"]
+            if isinstance(base_events_cte, ast.CTE) and isinstance(base_events_cte.expr, ast.SelectQuery):
+                step_columns = self.build_funnel_step_columns()
+                base_events_cte.expr.select.extend(step_columns)
+
+        # Inject maturity HAVING clause into entity_metrics CTE
+        # Use maxIf to only consider exposure events for maturity
+        maturity_having = self.build_maturity_having_clause_optimized()
+        if maturity_having is not None:
+            if query.ctes and "entity_metrics" in query.ctes:
+                entity_metrics_cte = query.ctes["entity_metrics"]
+                if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
+                    if entity_metrics_cte.expr.having is None:
+                        entity_metrics_cte.expr.having = maturity_having
+                    else:
+                        entity_metrics_cte.expr.having = ast.And(
+                            exprs=[entity_metrics_cte.expr.having, maturity_having]
+                        )
+
+        # Add step counts - how many users reached each step
+        step_count_exprs = []
+        for i in range(1, num_steps):
+            step_count_exprs.append(f"countIf(entity_metrics.value.1 >= {i})")
+        step_counts_expr = f"tuple({', '.join(step_count_exprs)}) as step_counts"
+
+        query.select.append(parse_expr(step_counts_expr))
+
+        # For each step in the funnel, get sample tuples of person_id, session_id, event uuid, and timestamp
+        if not self._b.funnel_steps_data_disabled:
+            event_uuids_exprs = []
+            for i in range(1, num_steps + 1):
+                event_uuids_expr = f"""
+                    groupArraySampleIf(100)(
+                        if(
+                            entity_metrics.value.2 != '',
+                            tuple(toString(entity_metrics.entity_id), uuid_to_session[entity_metrics.value.2], entity_metrics.value.2, toString(uuid_to_timestamp[entity_metrics.value.2])),
+                            tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))
+                        ),
+                        entity_metrics.value.1 = {i} - 1
+                    )
+                """
+                event_uuids_exprs.append(event_uuids_expr)
+            event_uuids_exprs_sql = f"tuple({', '.join(event_uuids_exprs)}) as steps_event_data"
+            query.select.append(parse_expr(event_uuids_exprs_sql))
+
+        return query
+
+    def build_funnel_optimized_temporal_setup(self, is_unordered_funnel: bool) -> tuple[str, str, str]:
+        """
+        Returns (first_exposures_cte_str, temporal_join, having_clause) for the
+        optimized funnel query.
+
+        Three call sites collapse into one place:
+
+        - Unordered funnels need temporal filtering because the UDF doesn't
+          enforce that step_0 (exposure) precedes step_1..N. We exclude events
+          before first exposure with an INNER JOIN + WHERE.
+        - CUPED needs the per-entity exposure timestamp to scope the pre-window
+          covariate, so we materialize first_exposures even when ordered. No
+          WHERE filter is added: the aggregate_funnel_array UDF anchors on
+          step_0 (date-bounded by the exposure predicate), so pre-window events
+          with step_X=1 (X>0) are never used in the post-window result.
+        - Otherwise, no first_exposures CTE; HAVING countIf(step_0 = 1) > 0
+          is the cheapest way to keep only exposed entities.
+        """
+        needs_first_exposures = is_unordered_funnel or self._b.cuped_config.enabled
+
+        first_exposures_cte_str = (
+            """
+            first_exposures AS (
+                SELECT entity_id, min(timestamp) AS first_exposure_time
+                FROM base_events
+                WHERE step_0 = 1
+                GROUP BY entity_id
+            ),"""
+            if needs_first_exposures
+            else ""
+        )
+
+        if is_unordered_funnel:
+            temporal_join = """INNER JOIN first_exposures
+                    ON base_events.entity_id = first_exposures.entity_id
+                WHERE base_events.timestamp >= first_exposures.first_exposure_time"""
+            having_clause = ""
+        elif self._b.cuped_config.enabled:
+            temporal_join = """INNER JOIN first_exposures
+                    ON base_events.entity_id = first_exposures.entity_id"""
+            having_clause = ""
+        else:
+            temporal_join = ""
+            having_clause = """
+                HAVING countIf(step_0 = 1) > 0"""
+
+        return first_exposures_cte_str, temporal_join, having_clause
+
+    def build_variant_expr_for_funnel(self) -> ast.Expr:
+        """
+        Builds the variant selection expression based on multiple variant handling.
+        """
+
+        if self._b.multiple_variant_handling == MultipleVariantHandling.FIRST_SEEN:
+            return parse_expr(
+                "argMinIf(variant, timestamp, step_0 = 1)",
+            )
+        else:
+            return parse_expr(
+                "if(uniqExactIf(variant, step_0 = 1) > 1, {multiple_key}, anyIf(variant, step_0 = 1))",
+                placeholders={
+                    "multiple_key": ast.Constant(value=MULTIPLE_VARIANT_KEY),
+                },
+            )
+
+    def get_funnel_metric_events_query_for_precomputation(self) -> tuple[str, dict[str, ast.Expr]]:
+        """
+        Returns the SELECT query that the lazy computation system wraps in an
+        INSERT INTO experiment_metric_events_preaggregated. This is the write
+        path — it scans the events table and stores one row per matching event
+        with step indicators packed into an Array(UInt8).
+
+        The query uses {time_window_min} and {time_window_max} placeholders filled
+        by the lazy computation system for each daily bucket.
+
+        Returns:
+            Tuple of (query_string, placeholders_dict)
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+
+        # Build step indicator expressions for the steps array.
+        # step_0 = exposure predicate, step_1..N = funnel step filters.
+        # These are the same expressions used in build_boolean_columns().
+        exposure_filter = self._b._build_exposure_predicate()
+        step_exprs: list[ast.Expr] = [exposure_filter]
+
+        step_builder = FunnelStepBuilder(self._b.metric.series, self._b.team)
+        for _step_index, step_source in enumerate(self._b.metric.series, start=1):
+            step_filter = step_builder._build_step_filter(step_source)
+            step_exprs.append(step_filter)
+
+        # Pack into Array(UInt8): [_toUInt8(if(step_0, 1, 0)), _toUInt8(if(step_1, 1, 0)), ...]
+        steps_array = ast.Array(
+            exprs=[
+                ast.Call(
+                    name="_toUInt8",
+                    args=[ast.Call(name="if", args=[expr, ast.Constant(value=1), ast.Constant(value=0)])],
+                )
+                for expr in step_exprs
+            ]
+        )
+
+        query_string = """
+            SELECT
+                {entity_key} AS entity_id,
+                timestamp AS timestamp,
+                uuid AS event_uuid,
+                `$session_id` AS session_id,
+                {steps_array} AS steps
+            FROM events
+            WHERE timestamp >= {time_window_min}
+                AND timestamp < {time_window_max}
+                AND ({exposure_predicate} OR {funnel_steps_filter})
+        """
+
+        placeholders: dict[str, ast.Expr] = {
+            "entity_key": parse_expr(self._b.entity_key),
+            "steps_array": steps_array,
+            "exposure_predicate": exposure_filter,
+            "funnel_steps_filter": self.build_funnel_steps_filter(),
+        }
+
+        return query_string, placeholders
+
+    def build_funnel_step_columns(self) -> list[ast.Alias]:
+        """
+        Builds list of step column AST expressions: step_0, step_1, etc.
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+
+        # Check if any step is a data warehouse node
+        has_dw_nodes = any(isinstance(step, ExperimentDataWarehouseNode) for step in self._b.metric.series)
+
+        if has_dw_nodes:
+            raise NotImplementedError(
+                "ExperimentDataWarehouseNode is not yet supported in funnel metrics. "
+                "Mixed-source UNION ALL query pattern needs to be implemented."
+            )
+
+        # Use FunnelStepBuilder abstraction for boolean columns
+        step_builder = FunnelStepBuilder(self._b.metric.series, self._b.team)
+        exposure_filter = self._b._build_exposure_predicate()
+        return step_builder.build_boolean_columns(exposure_filter)
+
+    def build_funnel_steps_filter(self) -> ast.Expr:
+        """
+        Returns the expression to filter funnel steps (matches ANY step) within
+        the time period of the experiment + the conversion window if set.
+
+        When CUPED is enabled, the lower bound is rolled back by `lookback_days`
+        so the same scan also feeds the CUPED pre-exposure window.
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+
+        conversion_window_seconds = self._b._get_conversion_window_seconds()
+        if conversion_window_seconds > 0:
+            date_to = parse_expr(
+                "{to_date} + toIntervalSecond({conversion_window_seconds})",
+                placeholders={
+                    "to_date": self._b.date_range_query.date_to_as_hogql(),
+                    "conversion_window_seconds": ast.Constant(value=conversion_window_seconds),
+                },
+            )
+        else:
+            date_to = self._b.date_range_query.date_to_as_hogql()
+
+        date_from = self._b._extend_date_from_for_funnel_cuped(self._b.date_range_query.date_from_as_hogql())
+
+        return parse_expr(
+            """
+            timestamp >= {date_from} AND timestamp <= {date_to}
+            AND {funnel_steps_filter}
+            """,
+            placeholders={
+                "date_from": date_from,
+                "date_to": date_to,
+                "funnel_steps_filter": funnel_steps_to_filter(self._b.team, self._b.metric.series),
+            },
+        )
+
+    def build_funnel_aggregation_expr(self) -> ast.Expr:
+        """
+        Returns the funnel evaluation expression using aggregate_funnel_array.
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+        return funnel_evaluation_expr(self._b.team, self._b.metric, events_alias="metric_events", include_exposure=True)
+
+    def build_uuid_to_session_map(self) -> ast.Expr:
+        """
+        Creates a map from event UUID to session ID for funnel metrics.
+        """
+        return parse_expr(
+            "mapFromArrays(groupArray(coalesce(toString(metric_events.uuid), '')), groupArray(coalesce(toString(metric_events.session_id), '')))"
+        )
+
+    def build_uuid_to_timestamp_map(self) -> ast.Expr:
+        """
+        Creates a map from event UUID to timestamp for funnel metrics.
+        """
+        return parse_expr(
+            "mapFromArrays(groupArray(coalesce(toString(metric_events.uuid), '')), groupArray(coalesce(metric_events.timestamp, toDateTime(0))))"
+        )
+
+    def has_datawarehouse_steps(self) -> bool:
+        """
+        Check if funnel metric has any datawarehouse steps.
+
+        Returns:
+            True if any step in the series is ExperimentDataWarehouseNode
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+        return any(isinstance(step, ExperimentDataWarehouseNode) for step in self._b.metric.series)
+
+    def build_funnel_metric_events_union_query(self) -> ast.SelectSetQuery:
+        """
+        Build metric_events UNION ALL query for funnels with DW steps.
+
+        Uses MetricSourceInfo and FunnelStepBuilder abstractions.
+
+        Returns:
+            SelectSetQuery with UNION ALL combining events and DW sources
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+
+        step_builder = FunnelStepBuilder(self._b.metric.series, self._b.team)
+
+        # All DW steps are validated to use the same events_join_key
+        first_dw_step = next(s for s in self._b.metric.series if isinstance(s, ExperimentDataWarehouseNode))
+        events_join_key = first_dw_step.events_join_key
+
+        # Build events subquery (always needed for exposure + event/action steps)
+        events_subquery = self.build_funnel_events_subquery_for_union(step_builder, events_join_key)
+
+        # Build DW subqueries (one per DW step)
+        dw_subqueries = []
+        for i, step in enumerate(self._b.metric.series):
+            if isinstance(step, ExperimentDataWarehouseNode):
+                dw_subquery = self.build_funnel_dw_step_subquery(step, i + 1, step_builder)
+                dw_subqueries.append(dw_subquery)
+
+        # Combine with UNION ALL
+        all_subqueries = [events_subquery, *dw_subqueries]
+        result = ast.SelectSetQuery.create_from_queries(all_subqueries, "UNION ALL")
+
+        # create_from_queries returns SelectQuery if only one query, but we always have at least 2 (events + DW)
+        assert isinstance(result, ast.SelectSetQuery)
+        return result
+
+    def build_funnel_events_subquery_for_union(
+        self, step_builder: FunnelStepBuilder, events_join_key: str
+    ) -> ast.SelectQuery:
+        """
+        Build events subquery for UNION pattern.
+
+        This subquery includes:
+        - Exposure events (step_0=1 when exposure, 0 otherwise)
+        - Event and action steps (step_N=1 when matches, 0 otherwise)
+        - DW steps (always step_N=0 in this subquery)
+
+        Args:
+            step_builder: FunnelStepBuilder instance for step columns
+            events_join_key: The event property key used to join with DW tables
+                (e.g. "properties.$user_id"). Used as entity_id so it matches the
+                DW subquery's data_warehouse_join_key.
+
+        Returns:
+            SELECT query for events table
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+
+        # Use events_join_key as entity_id so it matches the DW subquery's
+        # data_warehouse_join_key (both resolve to the same user identifier).
+        events_join_key_parts = cast(list[str | int], events_join_key.split("."))
+        entity_id_expr = ast.Call(name="toString", args=[ast.Field(chain=events_join_key_parts)])
+
+        # Build base SELECT fields
+        select_fields: list[ast.Expr] = [
+            ast.Alias(alias="entity_id", expr=entity_id_expr),
+            ast.Alias(alias="variant", expr=self._b._build_variant_property()),
+            ast.Alias(alias="timestamp", expr=ast.Field(chain=["timestamp"])),
+            ast.Alias(alias="uuid", expr=ast.Field(chain=["uuid"])),
+            ast.Alias(alias="session_id", expr=ast.Field(chain=["properties", "$session_id"])),
+        ]
+
+        # Build step columns
+        # - step_0 (exposure): if(exposure_predicate, 1, 0)
+        # - step_N (event/action): if(step_filter, 1, 0)
+        # - step_N (DW): 0 (always 0 in events subquery)
+
+        exposure_filter = self._b._build_exposure_predicate()
+
+        # step_0: exposure
+        step_0 = ast.Alias(
+            alias="step_0",
+            expr=ast.Call(
+                name="if",
+                args=[exposure_filter, ast.Constant(value=1), ast.Constant(value=0)],
+            ),
+        )
+        select_fields.append(step_0)
+
+        # Build step filters once, reuse for both SELECT and WHERE
+        step_filters: dict[int, ast.Expr] = {}
+        for i, step_source in enumerate(self._b.metric.series):
+            if not isinstance(step_source, ExperimentDataWarehouseNode):
+                step_filters[i + 1] = step_builder._build_step_filter(step_source)
+
+        # step_1, step_2, ...: event/action steps or DW steps
+        for i, step_source in enumerate(self._b.metric.series):
+            step_index = i + 1  # +1 because step_0 is exposure
+
+            if isinstance(step_source, ExperimentDataWarehouseNode):
+                # DW step: always 0 in events subquery
+                step_col = ast.Alias(
+                    alias=f"step_{step_index}",
+                    expr=ast.Constant(value=0),
+                )
+            else:
+                # Event or action step: if(step_filter, 1, 0)
+                step_col = ast.Alias(
+                    alias=f"step_{step_index}",
+                    expr=ast.Call(
+                        name="if",
+                        args=[step_filters[step_index], ast.Constant(value=1), ast.Constant(value=0)],
+                    ),
+                )
+
+            select_fields.append(step_col)
+
+        # Build WHERE clause - matches exposure OR any event/action step
+        # (DW steps will be queried separately)
+        event_action_filters = list(step_filters.values())
+
+        # Build time window filter (experiment date range + conversion window)
+        conversion_window_seconds = self._b._get_conversion_window_seconds()
+        date_to_expr: ast.Expr
+        if conversion_window_seconds > 0:
+            date_to_expr = ast.Call(
+                name="plus",
+                args=[
+                    self._b.date_range_query.date_to_as_hogql(),
+                    ast.Call(
+                        name="toIntervalSecond",
+                        args=[ast.Constant(value=conversion_window_seconds)],
+                    ),
+                ],
+            )
+        else:
+            date_to_expr = self._b.date_range_query.date_to_as_hogql()
+
+        time_range_filter = ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=self._b.date_range_query.date_from_as_hogql(),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Lt,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=date_to_expr,
+                ),
+            ]
+        )
+
+        # Combine step matching with time range
+        where: ast.Expr
+        if event_action_filters:
+            step_match = ast.Or(exprs=[self._b._build_exposure_predicate(), ast.Or(exprs=event_action_filters)])
+            where = ast.And(exprs=[time_range_filter, step_match])
+        else:
+            # Only exposure events (all steps are DW)
+            where = ast.And(exprs=[time_range_filter, self._b._build_exposure_predicate()])
+
+        # Build query
+        query = ast.SelectQuery(
+            select=select_fields,
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=where,
+        )
+
+        return query
+
+    def build_funnel_dw_step_subquery(
+        self,
+        step: ExperimentDataWarehouseNode,
+        step_index: int,
+        step_builder: FunnelStepBuilder,
+    ) -> ast.SelectQuery:
+        """
+        Build subquery for a single DW step.
+
+        Uses MetricSourceInfo and FunnelStepBuilder abstractions for normalized output.
+
+        Args:
+            step: The DW node configuration
+            step_index: The step number (1-indexed, after exposure step_0)
+            step_builder: FunnelStepBuilder instance for step columns
+
+        Returns:
+            SELECT query for DW table
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+
+        # Use MetricSourceInfo for normalized schema
+        source_info = MetricSourceInfo.from_source(step, entity_key=None)
+
+        # Build SELECT fields (entity_id, variant, timestamp, uuid, session_id)
+        # Cast to list[Expr] since Alias is a subclass of Expr
+        select_fields: list[ast.Expr] = cast(list[ast.Expr], source_info.build_select_fields())
+
+        # Add step columns (step_0=0, ..., step_N=1, ...) using FunnelStepBuilder
+        step_columns = step_builder.build_constant_columns(active_step_index=step_index)
+        select_fields.extend(step_columns)
+
+        # Build WHERE predicate
+        where = self.build_dw_step_predicate(step, source_info)
+
+        # Build query
+        query = ast.SelectQuery(
+            select=select_fields,
+            select_from=ast.JoinExpr(table=ast.Field(chain=[source_info.table_name])),
+            where=where,
+        )
+
+        return query
+
+    def build_dw_step_predicate(
+        self,
+        step: ExperimentDataWarehouseNode,
+        source_info: MetricSourceInfo,
+    ) -> ast.Expr:
+        """
+        Build WHERE predicate for DW step filtering.
+
+        Filters by:
+        - Timestamp range (experiment dates + conversion window)
+        - DW node properties (custom filters)
+
+        Args:
+            step: The DW node configuration
+            source_info: MetricSourceInfo for this DW source
+
+        Returns:
+            Filter expression
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+
+        conversion_window_seconds = self._b._get_conversion_window_seconds()
+
+        # Build timestamp filter
+        # Use unqualified field name for DW to avoid issues with dotted table names
+        timestamp_field = ast.Field(chain=[source_info.timestamp_field])
+
+        # date_from <= timestamp < date_to + conversion_window
+        date_from_expr = self._b.date_range_query.date_from_as_hogql()
+        date_to_expr = self._b.date_range_query.date_to_as_hogql()
+
+        # Add conversion window to date_to
+        date_to_with_window: ast.Expr
+        if conversion_window_seconds > 0:
+            date_to_with_window = ast.Call(
+                name="plus",
+                args=[
+                    date_to_expr,
+                    ast.Call(
+                        name="toIntervalSecond",
+                        args=[ast.Constant(value=conversion_window_seconds)],
+                    ),
+                ],
+            )
+        else:
+            date_to_with_window = date_to_expr
+
+        timestamp_filter = ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=timestamp_field,
+                    right=date_from_expr,
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Lt,
+                    left=timestamp_field,
+                    right=date_to_with_window,
+                ),
+            ]
+        )
+
+        # Build property filter from DW node
+        dw_filter = data_warehouse_node_to_filter(self._b.team, step)
+
+        # Combine filters
+        return ast.And(exprs=[timestamp_filter, dw_filter])
+
+    # --- Optimized funnel query helpers ---
+
+    def build_variant_expr_for_funnel_optimized(self) -> ast.Expr:
+        """
+        Variant expression for the optimized funnel path.
+        References variant_value (raw property) instead of variant (column in legacy metric_events).
+        """
+        if self._b.multiple_variant_handling == MultipleVariantHandling.FIRST_SEEN:
+            return parse_expr(
+                "argMinIf(variant_value, timestamp, step_0 = 1)",
+            )
+        else:
+            return parse_expr(
+                "if(uniqExactIf(variant_value, step_0 = 1) > 1, {multiple_key}, anyIf(variant_value, step_0 = 1))",
+                placeholders={
+                    "multiple_key": ast.Constant(value=MULTIPLE_VARIANT_KEY),
+                },
+            )
+
+    def build_funnel_aggregation_expr_optimized(self) -> ast.Expr:
+        """
+        Funnel aggregation for the optimized path. References base_events instead of metric_events.
+        """
+        assert isinstance(self._b.metric, ExperimentFunnelMetric)
+        return funnel_evaluation_expr(self._b.team, self._b.metric, events_alias="base_events", include_exposure=True)
+
+    def build_uuid_to_session_map_optimized(self) -> ast.Expr:
+        """
+        UUID-to-session map for the optimized path. References base_events columns.
+        """
+        return parse_expr(
+            "mapFromArrays(groupArray(coalesce(toString(uuid), '')), groupArray(coalesce(toString(session_id), '')))"
+        )
+
+    def build_uuid_to_timestamp_map_optimized(self) -> ast.Expr:
+        """
+        UUID-to-timestamp map for the optimized path. References base_events columns.
+        """
+        return parse_expr(
+            "mapFromArrays(groupArray(coalesce(toString(uuid), '')), groupArray(coalesce(timestamp, toDateTime(0))))"
+        )
+
+    def build_maturity_having_clause_optimized(self) -> Optional[ast.Expr]:
+        """
+        Maturity HAVING clause for the optimized path.
+        Uses maxIf to only consider exposure events (step_0 = 1) for maturity,
+        since entity_metrics groups over all events, not just exposures.
+        """
+        if self._b.metric is None:
+            return None
+        if not self._b.only_count_matured_users:
+            return None
+
+        maturity_seconds = self._b._get_maturity_window_seconds()
+        if maturity_seconds == 0:
+            return None
+
+        now = timezone.now().strftime("%Y-%m-%d %H:%M:%S")
+        return parse_expr(
+            "maxIf(timestamp, step_0 = 1) + toIntervalSecond({maturity_seconds}) <= toDateTime({now}, 'UTC')",
+            placeholders={
+                "maturity_seconds": ast.Constant(value=maturity_seconds),
+                "now": ast.Constant(value=now),
+            },
+        )

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -17,26 +17,23 @@ from posthog.schema import (
     FunnelConversionWindowTimeUnit,
     MultipleVariantHandling,
     StartHandling,
-    StepOrderValue,
 )
 
 from posthog.hogql import ast
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
 from posthog.hogql.parser import parse_expr, parse_select
 
-from posthog.hogql_queries.experiments import MULTIPLE_VARIANT_KEY
 from posthog.hogql_queries.experiments.base_query_utils import (
     conversion_window_to_seconds,
     data_warehouse_node_to_filter,
     event_or_action_to_filter,
-    funnel_evaluation_expr,
-    funnel_steps_to_filter,
     is_session_property_metric,
     validate_session_property,
 )
 from posthog.hogql_queries.experiments.breakdown_injector import BreakdownInjector
 from posthog.hogql_queries.experiments.cuped_config import CupedQueryConfig
 from posthog.hogql_queries.experiments.experiment_exposure_query_builder import ExposureQueryBuilder
+from posthog.hogql_queries.experiments.experiment_funnel_query_builder import FunnelQueryBuilder
 from posthog.hogql_queries.experiments.experiment_metric_values import (
     build_conversion_window_predicate,
     build_conversion_window_predicate_for_events,
@@ -52,7 +49,6 @@ from posthog.hogql_queries.experiments.experiment_query_context import (
 )
 from posthog.hogql_queries.experiments.exposure_query_logic import normalize_to_exposure_criteria
 from posthog.hogql_queries.experiments.funnel_step_builder import FunnelStepBuilder
-from posthog.hogql_queries.experiments.funnel_validation import FunnelDWValidator
 from posthog.hogql_queries.experiments.metric_source import MetricSourceInfo
 from posthog.hogql_queries.insights.utils.utils import get_start_of_interval_hogql
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -184,6 +180,14 @@ class ExperimentQueryBuilder:
             preaggregation_job_ids=self.preaggregation_job_ids,
         )
 
+    def _funnel_query_builder(self) -> FunnelQueryBuilder:
+        """Construct a FunnelQueryBuilder backed by the current builder state.
+
+        Built fresh per call so it picks up the current precomputation job IDs
+        (only known at build time).
+        """
+        return FunnelQueryBuilder(self)
+
     def get_exposure_timeseries_query(self) -> ast.SelectQuery:
         """
         Returns a query for exposure timeseries data.
@@ -295,9 +299,7 @@ class ExperimentQueryBuilder:
         Builds query for funnel metrics.
         Dispatches to optimized (single-scan) or legacy (double-scan) path.
         """
-        if self._should_use_optimized_funnel_query():
-            return self._build_funnel_query_optimized()
-        return self._build_funnel_query_legacy()
+        return self._funnel_query_builder().build_funnel_query()
 
     def _should_use_optimized_funnel_query(self) -> bool:
         """
@@ -308,12 +310,7 @@ class ExperimentQueryBuilder:
         Also routes to legacy path for DW funnels, which use UNION ALL pattern
         only implemented in the legacy path.
         """
-        if self.preaggregation_job_ids and not self.breakdowns:
-            return False
-        # Route DW funnels to legacy path which supports UNION ALL
-        if isinstance(self.metric, ExperimentFunnelMetric) and self._has_datawarehouse_steps():
-            return False
-        return True
+        return self._funnel_query_builder().should_use_optimized_funnel_query()
 
     def _build_funnel_query_legacy(self) -> ast.SelectQuery:
         """
@@ -326,270 +323,7 @@ class ExperimentQueryBuilder:
         1. Events-only: Single query with boolean step columns
         2. With DW steps: UNION ALL pattern with separate subqueries per source
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-
-        # Validate DW funnel configuration before building query
-        FunnelDWValidator.validate_funnel_metric(self.metric)
-
-        num_steps = len(self.metric.series) + 1  #  +1 as we are including exposure criteria
-
-        # Determine which query pattern to use
-        has_dw_steps = self._has_datawarehouse_steps()
-
-        # Track whether step columns need to be injected after parsing.
-        # Precomputed metric events already have steps extracted from the array.
-        inject_step_columns = True
-
-        if self.metric_events_preaggregation_job_ids and not has_dw_steps:
-            # Read from precomputed table instead of scanning events
-            inject_step_columns = False
-            step_extracts = ", ".join(f"arrayElement(t.steps, {i + 1}) AS step_{i}" for i in range(num_steps))
-            entity_id_cast = "toUUID(t.entity_id)" if self.entity_key == "person_id" else "t.entity_id"
-            session_id_col = "t.session_id AS session_id," if not self.funnel_steps_data_disabled else ""
-
-            # Filter by experiment date range: jobs can cover broader time ranges
-            # than the experiment for cache reusability, so we must filter on read.
-            # Upper bound includes conversion window since funnel step events can
-            # occur after experiment end.
-            conversion_window_seconds = self._get_conversion_window_seconds()
-            if conversion_window_seconds > 0:
-                upper_bound = f"{{metric_events_date_to}} + toIntervalSecond({conversion_window_seconds})"
-            else:
-                upper_bound = "{metric_events_date_to}"
-
-            metric_events_cte_str = f"""
-                    metric_events AS (
-                        SELECT
-                            {entity_id_cast} AS entity_id,
-                            t.timestamp AS timestamp,
-                            t.event_uuid AS uuid,
-                            {session_id_col}
-                            {step_extracts}
-                        FROM experiment_metric_events_preaggregated AS t
-                        WHERE t.job_id IN {{metric_events_job_ids}}
-                            AND t.team_id = {{metric_events_team_id}}
-                            AND t.timestamp >= {{metric_events_date_from}}
-                            AND t.timestamp <= {upper_bound}
-                    )
-            """
-        elif has_dw_steps:
-            # UNION ALL pattern for heterogeneous sources
-            # We'll inject the UNION query directly as AST after building the main query
-            metric_events_cte_str = """
-                    metric_events AS (
-                        SELECT 1 AS placeholder
-                        -- This will be replaced with UNION ALL query
-                    )
-            """
-        else:
-            session_id_column = (
-                """
-                            properties.$session_id AS session_id,"""
-                if not self.funnel_steps_data_disabled
-                else ""
-            )
-
-            metric_events_cte_str = f"""
-                    metric_events AS (
-                        SELECT
-                            {{entity_key}} AS entity_id,
-                            {{variant_property}} as variant,
-                            timestamp,
-                            uuid,{session_id_column}
-                            -- step_0, step_1, ... step_N columns added programmatically below
-                        FROM events
-                        WHERE ({{exposure_predicate}} OR {{funnel_steps_filter}})
-                    )
-            """
-
-        is_unordered_funnel = self.metric.funnel_order_type == StepOrderValue.UNORDERED
-
-        # Use separate exposures CTE to leverage precomputed exposure cache when available.
-        # The exposures query automatically falls back to scanning events if precomputation
-        # isn't enabled for the team.
-        #
-        # Unordered funnels need temporal filtering (metric_events.timestamp >= first_exposure_time)
-        # because the funnel UDF doesn't filter out events before the exposure.
-        # Ordered funnels don't need this - the UDF handles temporal ordering internally.
-
-        # Build the JOIN clause with conditional temporal filter
-        temporal_filter = "AND metric_events.timestamp >= exposures.first_exposure_time" if is_unordered_funnel else ""
-
-        # DW steps join via events_join_key (e.g. properties.$user_id) → data_warehouse_join_key
-        # (e.g. userid). The exposure CTE uses person_id (UUID) as entity_id. To bridge
-        # these, we add an exposure_identifier column and join on that instead.
-        if has_dw_steps:
-            entity_id_join = "ON toString(exposures.exposure_identifier) = metric_events.entity_id"
-        else:
-            entity_id_join = "ON exposures.entity_id = metric_events.entity_id"
-
-        if self.funnel_steps_data_disabled:
-            # When steps data is disabled, we skip the expensive session/event maps and
-            # the per-exposure columns that are only needed for steps_event_data.
-            # The exposures CTE already deduplicates to one row per (entity_id, variant),
-            # so removing these from GROUP BY doesn't change results.
-            extra_select_columns = ""
-            extra_group_by_columns = ""
-        else:
-            extra_select_columns = """,
-                    exposures.exposure_event_uuid AS exposure_event_uuid,
-                    exposures.exposure_session_id AS exposure_session_id,
-                    exposures.first_exposure_time AS exposure_timestamp,
-                    {uuid_to_session_map} AS uuid_to_session,
-                    {uuid_to_timestamp_map} AS uuid_to_timestamp"""
-            extra_group_by_columns = """,
-                    exposures.exposure_event_uuid,
-                    exposures.exposure_session_id,
-                    exposures.first_exposure_time"""
-
-        ctes_sql = f"""
-            exposures AS (
-                {{exposure_select_query}}
-            ),
-
-            {metric_events_cte_str},
-
-            entity_metrics AS (
-                SELECT
-                    exposures.entity_id AS entity_id,
-                    exposures.variant AS variant,
-                    {{funnel_aggregation}} AS value{extra_select_columns}
-                    -- covariate_value added programmatically below when CUPED is enabled
-                FROM exposures
-                LEFT JOIN metric_events
-                    {entity_id_join}
-                    {temporal_filter}  -- Only for unordered: filters out events before exposure
-                GROUP BY
-                    exposures.entity_id,
-                    exposures.variant{extra_group_by_columns}
-            )
-        """
-
-        # Build exposure query, adding exposure_identifier for DW funnels
-        exposure_query = self._get_exposure_query()
-        if has_dw_steps:
-            # All DW steps are validated to use the same events_join_key
-            first_dw_step = next(s for s in self.metric.series if isinstance(s, ExperimentDataWarehouseNode))
-            events_join_key_parts = cast(list[str | int], first_dw_step.events_join_key.split("."))
-
-            # Use argMin to pick one exposure_identifier per entity_id (from first exposure)
-            # This prevents fan-out when a user has multiple exposures with different join key values
-            exposure_query.select.append(
-                ast.Alias(
-                    alias="exposure_identifier",
-                    expr=ast.Call(
-                        name="argMin",
-                        args=[ast.Field(chain=events_join_key_parts), ast.Field(chain=["timestamp"])],
-                    ),
-                )
-            )
-
-        placeholders: dict[str, ast.Expr | ast.SelectQuery] = {
-            "exposure_predicate": self._build_exposure_predicate(),
-            "variant_property": self._build_variant_property(),
-            "variant_expr": self._build_variant_expr_for_funnel(),
-            "entity_key": parse_expr(self.entity_key),
-            "funnel_steps_filter": self._build_funnel_steps_filter(),
-            "funnel_aggregation": self._build_funnel_aggregation_expr(),
-            "num_steps_minus_1": ast.Constant(value=num_steps - 1),
-            "exposure_select_query": exposure_query,
-            "date_from": self.date_range_query.date_from_as_hogql(),
-            "date_to": self.date_range_query.date_to_as_hogql(),
-        }
-        if not self.funnel_steps_data_disabled:
-            placeholders["uuid_to_session_map"] = self._build_uuid_to_session_map()
-            placeholders["uuid_to_timestamp_map"] = self._build_uuid_to_timestamp_map()
-
-        if self.metric_events_preaggregation_job_ids:
-            placeholders["metric_events_job_ids"] = ast.Constant(value=self.metric_events_preaggregation_job_ids)
-            placeholders["metric_events_team_id"] = ast.Constant(value=self.team.id)
-            placeholders["metric_events_date_from"] = self.date_range_query.date_from_as_hogql()
-            placeholders["metric_events_date_to"] = self.date_range_query.date_to_as_hogql()
-
-        query = parse_select(
-            f"""
-            WITH
-            {ctes_sql}
-
-            SELECT
-                entity_metrics.variant AS variant,
-                count(entity_metrics.entity_id) AS num_users,
-                -- The return value from the funnel eval is zero indexed. So reaching first step means
-                -- it return 0, and so on. So reaching the last step means it will return
-                -- num_steps - 1
-                countIf(entity_metrics.value.1 = {{num_steps_minus_1}}) AS total_sum,
-                countIf(entity_metrics.value.1 = {{num_steps_minus_1}}) AS total_sum_of_squares
-                -- CUPED aggregation columns added programmatically below
-                -- step_counts added programmatically below
-                -- steps_event_data added programmatically below
-                -- breakdown columns added programmatically below
-            FROM entity_metrics
-            WHERE notEmpty(variant)
-            GROUP BY entity_metrics.variant
-            -- breakdown columns added programmatically below
-            """,
-            placeholders=placeholders,
-        )
-
-        assert isinstance(query, ast.SelectQuery)
-
-        if self.cuped_config.enabled:
-            self._inject_funnel_covariate_into_entity_metrics(
-                query,
-                events_alias="metric_events",
-                last_step_index=num_steps - 1,
-                exposure_alias="exposures",
-            )
-
-        # Inject breakdown columns into the query AST
-        if self.breakdown_injector:
-            self.breakdown_injector.inject_funnel_breakdown_columns(query)
-
-        # Inject or replace the metric_events CTE based on whether DW steps are present
-        if query.ctes and "metric_events" in query.ctes:
-            if has_dw_steps:
-                # Replace with UNION ALL query for DW funnels
-                union_query = self._build_funnel_metric_events_union_query()
-                query.ctes["metric_events"] = ast.CTE(name="metric_events", expr=union_query, cte_type="subquery")
-            else:
-                # Inject step columns into the metric_events CTE (skip when precomputed — already extracted)
-                if inject_step_columns:
-                    metric_events_cte = query.ctes["metric_events"]
-                    if isinstance(metric_events_cte, ast.CTE) and isinstance(metric_events_cte.expr, ast.SelectQuery):
-                        step_columns = self._build_funnel_step_columns()
-                        metric_events_cte.expr.select.extend(step_columns)
-
-        # Inject the additional selects we do for getting the data we need to render the funnel chart
-        # Add step counts - how many users reached each step
-        step_count_exprs = []
-        for i in range(1, num_steps):
-            step_count_exprs.append(f"countIf(entity_metrics.value.1 >= {i})")
-        step_counts_expr = f"tuple({', '.join(step_count_exprs)}) as step_counts"
-
-        query.select.append(parse_expr(step_counts_expr))
-
-        # For each step in the funnel, get at least 100 tuples of person_id, session_id, event uuid, and timestamp, that have
-        # that step as their last step in the funnel.
-        # For the users that have 0 matching steps in the funnel (-1), we return the event data for the exposure event.
-        # This is skipped when funnel_steps_data_disabled is set, as it's expensive for high-traffic experiments.
-        if not self.funnel_steps_data_disabled:
-            event_uuids_exprs = []
-            for i in range(1, num_steps + 1):
-                event_uuids_expr = f"""
-                    groupArraySampleIf(100)(
-                        if(
-                            entity_metrics.value.2 != '',
-                            tuple(toString(entity_metrics.entity_id), uuid_to_session[entity_metrics.value.2], entity_metrics.value.2, toString(uuid_to_timestamp[entity_metrics.value.2])),
-                            tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))
-                        ),
-                        entity_metrics.value.1 = {i} - 1
-                    )
-                """
-                event_uuids_exprs.append(event_uuids_expr)
-            event_uuids_exprs_sql = f"tuple({', '.join(event_uuids_exprs)}) as steps_event_data"
-            query.select.append(parse_expr(event_uuids_exprs_sql))
-
-        return query
+        return self._funnel_query_builder().build_funnel_query_legacy()
 
     def _build_funnel_query_optimized(self) -> ast.SelectQuery:
         """
@@ -603,166 +337,7 @@ class ExperimentQueryBuilder:
         first_exposures: (unordered only) min exposure time per entity for temporal filtering
         entity_metrics: GROUP BY entity_id, conditional aggregation for variant, funnel UDF
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-
-        num_steps = len(self.metric.series) + 1  # +1 as we are including exposure criteria
-
-        session_id_column = (
-            """
-                        properties.$session_id AS session_id,"""
-            if not self.funnel_steps_data_disabled
-            else ""
-        )
-
-        # CTE 1: base_events - single scan of events table
-        # WHERE admits both exposure and conversion events. Exclusion filters are
-        # embedded in step_0 only, not the WHERE clause, so conversion events from
-        # internal users pass through (they only matter if the user has a valid exposure).
-        base_events_cte_str = f"""
-                base_events AS (
-                    SELECT
-                        {{entity_key}} AS entity_id,
-                        {{variant_property}} AS variant_value,
-                        timestamp,
-                        uuid,{session_id_column}
-                        -- step_0, step_1, ... step_N columns added programmatically below
-                    FROM events
-                    WHERE ({{exposure_predicate}} OR {{funnel_steps_filter}})
-                )
-        """
-
-        is_unordered_funnel = self.metric.funnel_order_type == StepOrderValue.UNORDERED
-
-        # CTE 2: entity_metrics - GROUP BY entity_id, no JOIN
-        if self.funnel_steps_data_disabled:
-            extra_select_columns = ""
-        else:
-            extra_select_columns = """,
-                    argMinIf(uuid, timestamp, step_0 = 1) AS exposure_event_uuid,
-                    argMinIf(session_id, timestamp, step_0 = 1) AS exposure_session_id,
-                    minIf(timestamp, step_0 = 1) AS exposure_timestamp,
-                    {uuid_to_session_map} AS uuid_to_session,
-                    {uuid_to_timestamp_map} AS uuid_to_timestamp"""
-
-        first_exposures_cte_str, temporal_join, having_clause = self._build_funnel_optimized_temporal_setup(
-            is_unordered_funnel
-        )
-
-        ctes_sql = f"""
-            {base_events_cte_str},
-            {first_exposures_cte_str}
-            entity_metrics AS (
-                SELECT
-                    base_events.entity_id AS entity_id,
-                    {{variant_expr}} AS variant,
-                    {{funnel_aggregation}} AS value{extra_select_columns}
-                    -- covariate_value added programmatically below when CUPED is enabled
-                FROM base_events
-                {temporal_join}
-                GROUP BY base_events.entity_id{having_clause}
-            )
-        """
-
-        placeholders: dict[str, ast.Expr | ast.SelectQuery] = {
-            "exposure_predicate": self._build_exposure_predicate(),
-            "variant_property": self._build_variant_property(),
-            "variant_expr": self._build_variant_expr_for_funnel_optimized(),
-            "entity_key": parse_expr(self.entity_key),
-            "funnel_steps_filter": self._build_funnel_steps_filter(),
-            "funnel_aggregation": self._build_funnel_aggregation_expr_optimized(),
-            "num_steps_minus_1": ast.Constant(value=num_steps - 1),
-        }
-        if not self.funnel_steps_data_disabled:
-            placeholders["uuid_to_session_map"] = self._build_uuid_to_session_map_optimized()
-            placeholders["uuid_to_timestamp_map"] = self._build_uuid_to_timestamp_map_optimized()
-
-        query = parse_select(
-            f"""
-            WITH
-            {ctes_sql}
-
-            SELECT
-                entity_metrics.variant AS variant,
-                count(entity_metrics.entity_id) AS num_users,
-                -- The return value from the funnel eval is zero indexed. So reaching first step means
-                -- it return 0, and so on. So reaching the last step means it will return
-                -- num_steps - 1
-                countIf(entity_metrics.value.1 = {{num_steps_minus_1}}) AS total_sum,
-                countIf(entity_metrics.value.1 = {{num_steps_minus_1}}) AS total_sum_of_squares
-                -- CUPED aggregation columns added programmatically below
-                -- step_counts added programmatically below
-                -- steps_event_data added programmatically below
-                -- breakdown columns added programmatically below
-            FROM entity_metrics
-            WHERE notEmpty(variant)
-            GROUP BY entity_metrics.variant
-            -- breakdown columns added programmatically below
-            """,
-            placeholders=placeholders,
-        )
-
-        assert isinstance(query, ast.SelectQuery)
-
-        if self.cuped_config.enabled:
-            self._inject_funnel_covariate_into_entity_metrics(
-                query,
-                events_alias="base_events",
-                last_step_index=num_steps - 1,
-                exposure_alias="first_exposures",
-            )
-
-        # Inject breakdown columns into the query AST
-        if self.breakdown_injector:
-            self.breakdown_injector.inject_funnel_breakdown_columns_optimized(query)
-
-        # Inject step columns into the base_events CTE
-        if query.ctes and "base_events" in query.ctes:
-            base_events_cte = query.ctes["base_events"]
-            if isinstance(base_events_cte, ast.CTE) and isinstance(base_events_cte.expr, ast.SelectQuery):
-                step_columns = self._build_funnel_step_columns()
-                base_events_cte.expr.select.extend(step_columns)
-
-        # Inject maturity HAVING clause into entity_metrics CTE
-        # Use maxIf to only consider exposure events for maturity
-        maturity_having = self._build_maturity_having_clause_optimized()
-        if maturity_having is not None:
-            if query.ctes and "entity_metrics" in query.ctes:
-                entity_metrics_cte = query.ctes["entity_metrics"]
-                if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
-                    if entity_metrics_cte.expr.having is None:
-                        entity_metrics_cte.expr.having = maturity_having
-                    else:
-                        entity_metrics_cte.expr.having = ast.And(
-                            exprs=[entity_metrics_cte.expr.having, maturity_having]
-                        )
-
-        # Add step counts - how many users reached each step
-        step_count_exprs = []
-        for i in range(1, num_steps):
-            step_count_exprs.append(f"countIf(entity_metrics.value.1 >= {i})")
-        step_counts_expr = f"tuple({', '.join(step_count_exprs)}) as step_counts"
-
-        query.select.append(parse_expr(step_counts_expr))
-
-        # For each step in the funnel, get sample tuples of person_id, session_id, event uuid, and timestamp
-        if not self.funnel_steps_data_disabled:
-            event_uuids_exprs = []
-            for i in range(1, num_steps + 1):
-                event_uuids_expr = f"""
-                    groupArraySampleIf(100)(
-                        if(
-                            entity_metrics.value.2 != '',
-                            tuple(toString(entity_metrics.entity_id), uuid_to_session[entity_metrics.value.2], entity_metrics.value.2, toString(uuid_to_timestamp[entity_metrics.value.2])),
-                            tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))
-                        ),
-                        entity_metrics.value.1 = {i} - 1
-                    )
-                """
-                event_uuids_exprs.append(event_uuids_expr)
-            event_uuids_exprs_sql = f"tuple({', '.join(event_uuids_exprs)}) as steps_event_data"
-            query.select.append(parse_expr(event_uuids_exprs_sql))
-
-        return query
+        return self._funnel_query_builder().build_funnel_query_optimized()
 
     def _get_session_property_ctes(self) -> str:
         """
@@ -1615,35 +1190,7 @@ class ExperimentQueryBuilder:
         - Otherwise, no first_exposures CTE; HAVING countIf(step_0 = 1) > 0
           is the cheapest way to keep only exposed entities.
         """
-        needs_first_exposures = is_unordered_funnel or self.cuped_config.enabled
-
-        first_exposures_cte_str = (
-            """
-            first_exposures AS (
-                SELECT entity_id, min(timestamp) AS first_exposure_time
-                FROM base_events
-                WHERE step_0 = 1
-                GROUP BY entity_id
-            ),"""
-            if needs_first_exposures
-            else ""
-        )
-
-        if is_unordered_funnel:
-            temporal_join = """INNER JOIN first_exposures
-                    ON base_events.entity_id = first_exposures.entity_id
-                WHERE base_events.timestamp >= first_exposures.first_exposure_time"""
-            having_clause = ""
-        elif self.cuped_config.enabled:
-            temporal_join = """INNER JOIN first_exposures
-                    ON base_events.entity_id = first_exposures.entity_id"""
-            having_clause = ""
-        else:
-            temporal_join = ""
-            having_clause = """
-                HAVING countIf(step_0 = 1) > 0"""
-
-        return first_exposures_cte_str, temporal_join, having_clause
+        return self._funnel_query_builder().build_funnel_optimized_temporal_setup(is_unordered_funnel)
 
     def _build_metric_predicate(
         self,
@@ -1736,18 +1283,7 @@ class ExperimentQueryBuilder:
         """
         Builds the variant selection expression based on multiple variant handling.
         """
-
-        if self.multiple_variant_handling == MultipleVariantHandling.FIRST_SEEN:
-            return parse_expr(
-                "argMinIf(variant, timestamp, step_0 = 1)",
-            )
-        else:
-            return parse_expr(
-                "if(uniqExactIf(variant, step_0 = 1) > 1, {multiple_key}, anyIf(variant, step_0 = 1))",
-                placeholders={
-                    "multiple_key": ast.Constant(value=MULTIPLE_VARIANT_KEY),
-                },
-            )
+        return self._funnel_query_builder().build_variant_expr_for_funnel()
 
     def _build_exposure_event_predicate(self) -> ast.Expr:
         """
@@ -1813,51 +1349,7 @@ class ExperimentQueryBuilder:
         Returns:
             Tuple of (query_string, placeholders_dict)
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-
-        # Build step indicator expressions for the steps array.
-        # step_0 = exposure predicate, step_1..N = funnel step filters.
-        # These are the same expressions used in build_boolean_columns().
-        exposure_filter = self._build_exposure_predicate()
-        step_exprs: list[ast.Expr] = [exposure_filter]
-
-        step_builder = FunnelStepBuilder(self.metric.series, self.team)
-        for _step_index, step_source in enumerate(self.metric.series, start=1):
-            step_filter = step_builder._build_step_filter(step_source)
-            step_exprs.append(step_filter)
-
-        # Pack into Array(UInt8): [_toUInt8(if(step_0, 1, 0)), _toUInt8(if(step_1, 1, 0)), ...]
-        steps_array = ast.Array(
-            exprs=[
-                ast.Call(
-                    name="_toUInt8",
-                    args=[ast.Call(name="if", args=[expr, ast.Constant(value=1), ast.Constant(value=0)])],
-                )
-                for expr in step_exprs
-            ]
-        )
-
-        query_string = """
-            SELECT
-                {entity_key} AS entity_id,
-                timestamp AS timestamp,
-                uuid AS event_uuid,
-                `$session_id` AS session_id,
-                {steps_array} AS steps
-            FROM events
-            WHERE timestamp >= {time_window_min}
-                AND timestamp < {time_window_max}
-                AND ({exposure_predicate} OR {funnel_steps_filter})
-        """
-
-        placeholders: dict[str, ast.Expr] = {
-            "entity_key": parse_expr(self.entity_key),
-            "steps_array": steps_array,
-            "exposure_predicate": exposure_filter,
-            "funnel_steps_filter": self._build_funnel_steps_filter(),
-        }
-
-        return query_string, placeholders
+        return self._funnel_query_builder().get_funnel_metric_events_query_for_precomputation()
 
     def _build_variant_expr_for_mean(self) -> ast.Expr:
         """
@@ -1869,21 +1361,7 @@ class ExperimentQueryBuilder:
         """
         Builds list of step column AST expressions: step_0, step_1, etc.
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-
-        # Check if any step is a data warehouse node
-        has_dw_nodes = any(isinstance(step, ExperimentDataWarehouseNode) for step in self.metric.series)
-
-        if has_dw_nodes:
-            raise NotImplementedError(
-                "ExperimentDataWarehouseNode is not yet supported in funnel metrics. "
-                "Mixed-source UNION ALL query pattern needs to be implemented."
-            )
-
-        # Use FunnelStepBuilder abstraction for boolean columns
-        step_builder = FunnelStepBuilder(self.metric.series, self.team)
-        exposure_filter = self._build_exposure_predicate()
-        return step_builder.build_boolean_columns(exposure_filter)
+        return self._funnel_query_builder().build_funnel_step_columns()
 
     def _build_funnel_steps_filter(self) -> ast.Expr:
         """
@@ -1893,56 +1371,25 @@ class ExperimentQueryBuilder:
         When CUPED is enabled, the lower bound is rolled back by `lookback_days`
         so the same scan also feeds the CUPED pre-exposure window.
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-
-        conversion_window_seconds = self._get_conversion_window_seconds()
-        if conversion_window_seconds > 0:
-            date_to = parse_expr(
-                "{to_date} + toIntervalSecond({conversion_window_seconds})",
-                placeholders={
-                    "to_date": self.date_range_query.date_to_as_hogql(),
-                    "conversion_window_seconds": ast.Constant(value=conversion_window_seconds),
-                },
-            )
-        else:
-            date_to = self.date_range_query.date_to_as_hogql()
-
-        date_from = self._extend_date_from_for_funnel_cuped(self.date_range_query.date_from_as_hogql())
-
-        return parse_expr(
-            """
-            timestamp >= {date_from} AND timestamp <= {date_to}
-            AND {funnel_steps_filter}
-            """,
-            placeholders={
-                "date_from": date_from,
-                "date_to": date_to,
-                "funnel_steps_filter": funnel_steps_to_filter(self.team, self.metric.series),
-            },
-        )
+        return self._funnel_query_builder().build_funnel_steps_filter()
 
     def _build_funnel_aggregation_expr(self) -> ast.Expr:
         """
         Returns the funnel evaluation expression using aggregate_funnel_array.
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-        return funnel_evaluation_expr(self.team, self.metric, events_alias="metric_events", include_exposure=True)
+        return self._funnel_query_builder().build_funnel_aggregation_expr()
 
     def _build_uuid_to_session_map(self) -> ast.Expr:
         """
         Creates a map from event UUID to session ID for funnel metrics.
         """
-        return parse_expr(
-            "mapFromArrays(groupArray(coalesce(toString(metric_events.uuid), '')), groupArray(coalesce(toString(metric_events.session_id), '')))"
-        )
+        return self._funnel_query_builder().build_uuid_to_session_map()
 
     def _build_uuid_to_timestamp_map(self) -> ast.Expr:
         """
         Creates a map from event UUID to timestamp for funnel metrics.
         """
-        return parse_expr(
-            "mapFromArrays(groupArray(coalesce(toString(metric_events.uuid), '')), groupArray(coalesce(metric_events.timestamp, toDateTime(0))))"
-        )
+        return self._funnel_query_builder().build_uuid_to_timestamp_map()
 
     def _has_datawarehouse_steps(self) -> bool:
         """
@@ -1951,8 +1398,7 @@ class ExperimentQueryBuilder:
         Returns:
             True if any step in the series is ExperimentDataWarehouseNode
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-        return any(isinstance(step, ExperimentDataWarehouseNode) for step in self.metric.series)
+        return self._funnel_query_builder().has_datawarehouse_steps()
 
     def _build_funnel_metric_events_union_query(self) -> ast.SelectSetQuery:
         """
@@ -1963,31 +1409,7 @@ class ExperimentQueryBuilder:
         Returns:
             SelectSetQuery with UNION ALL combining events and DW sources
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-
-        step_builder = FunnelStepBuilder(self.metric.series, self.team)
-
-        # All DW steps are validated to use the same events_join_key
-        first_dw_step = next(s for s in self.metric.series if isinstance(s, ExperimentDataWarehouseNode))
-        events_join_key = first_dw_step.events_join_key
-
-        # Build events subquery (always needed for exposure + event/action steps)
-        events_subquery = self._build_funnel_events_subquery_for_union(step_builder, events_join_key)
-
-        # Build DW subqueries (one per DW step)
-        dw_subqueries = []
-        for i, step in enumerate(self.metric.series):
-            if isinstance(step, ExperimentDataWarehouseNode):
-                dw_subquery = self._build_funnel_dw_step_subquery(step, i + 1, step_builder)
-                dw_subqueries.append(dw_subquery)
-
-        # Combine with UNION ALL
-        all_subqueries = [events_subquery, *dw_subqueries]
-        result = ast.SelectSetQuery.create_from_queries(all_subqueries, "UNION ALL")
-
-        # create_from_queries returns SelectQuery if only one query, but we always have at least 2 (events + DW)
-        assert isinstance(result, ast.SelectSetQuery)
-        return result
+        return self._funnel_query_builder().build_funnel_metric_events_union_query()
 
     def _build_funnel_events_subquery_for_union(
         self, step_builder: FunnelStepBuilder, events_join_key: str
@@ -2009,120 +1431,7 @@ class ExperimentQueryBuilder:
         Returns:
             SELECT query for events table
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-
-        # Use events_join_key as entity_id so it matches the DW subquery's
-        # data_warehouse_join_key (both resolve to the same user identifier).
-        events_join_key_parts = cast(list[str | int], events_join_key.split("."))
-        entity_id_expr = ast.Call(name="toString", args=[ast.Field(chain=events_join_key_parts)])
-
-        # Build base SELECT fields
-        select_fields: list[ast.Expr] = [
-            ast.Alias(alias="entity_id", expr=entity_id_expr),
-            ast.Alias(alias="variant", expr=self._build_variant_property()),
-            ast.Alias(alias="timestamp", expr=ast.Field(chain=["timestamp"])),
-            ast.Alias(alias="uuid", expr=ast.Field(chain=["uuid"])),
-            ast.Alias(alias="session_id", expr=ast.Field(chain=["properties", "$session_id"])),
-        ]
-
-        # Build step columns
-        # - step_0 (exposure): if(exposure_predicate, 1, 0)
-        # - step_N (event/action): if(step_filter, 1, 0)
-        # - step_N (DW): 0 (always 0 in events subquery)
-
-        exposure_filter = self._build_exposure_predicate()
-
-        # step_0: exposure
-        step_0 = ast.Alias(
-            alias="step_0",
-            expr=ast.Call(
-                name="if",
-                args=[exposure_filter, ast.Constant(value=1), ast.Constant(value=0)],
-            ),
-        )
-        select_fields.append(step_0)
-
-        # Build step filters once, reuse for both SELECT and WHERE
-        step_filters: dict[int, ast.Expr] = {}
-        for i, step_source in enumerate(self.metric.series):
-            if not isinstance(step_source, ExperimentDataWarehouseNode):
-                step_filters[i + 1] = step_builder._build_step_filter(step_source)
-
-        # step_1, step_2, ...: event/action steps or DW steps
-        for i, step_source in enumerate(self.metric.series):
-            step_index = i + 1  # +1 because step_0 is exposure
-
-            if isinstance(step_source, ExperimentDataWarehouseNode):
-                # DW step: always 0 in events subquery
-                step_col = ast.Alias(
-                    alias=f"step_{step_index}",
-                    expr=ast.Constant(value=0),
-                )
-            else:
-                # Event or action step: if(step_filter, 1, 0)
-                step_col = ast.Alias(
-                    alias=f"step_{step_index}",
-                    expr=ast.Call(
-                        name="if",
-                        args=[step_filters[step_index], ast.Constant(value=1), ast.Constant(value=0)],
-                    ),
-                )
-
-            select_fields.append(step_col)
-
-        # Build WHERE clause - matches exposure OR any event/action step
-        # (DW steps will be queried separately)
-        event_action_filters = list(step_filters.values())
-
-        # Build time window filter (experiment date range + conversion window)
-        conversion_window_seconds = self._get_conversion_window_seconds()
-        date_to_expr: ast.Expr
-        if conversion_window_seconds > 0:
-            date_to_expr = ast.Call(
-                name="plus",
-                args=[
-                    self.date_range_query.date_to_as_hogql(),
-                    ast.Call(
-                        name="toIntervalSecond",
-                        args=[ast.Constant(value=conversion_window_seconds)],
-                    ),
-                ],
-            )
-        else:
-            date_to_expr = self.date_range_query.date_to_as_hogql()
-
-        time_range_filter = ast.And(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=self.date_range_query.date_from_as_hogql(),
-                ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=date_to_expr,
-                ),
-            ]
-        )
-
-        # Combine step matching with time range
-        where: ast.Expr
-        if event_action_filters:
-            step_match = ast.Or(exprs=[self._build_exposure_predicate(), ast.Or(exprs=event_action_filters)])
-            where = ast.And(exprs=[time_range_filter, step_match])
-        else:
-            # Only exposure events (all steps are DW)
-            where = ast.And(exprs=[time_range_filter, self._build_exposure_predicate()])
-
-        # Build query
-        query = ast.SelectQuery(
-            select=select_fields,
-            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
-            where=where,
-        )
-
-        return query
+        return self._funnel_query_builder().build_funnel_events_subquery_for_union(step_builder, events_join_key)
 
     def _build_funnel_dw_step_subquery(
         self,
@@ -2143,30 +1452,7 @@ class ExperimentQueryBuilder:
         Returns:
             SELECT query for DW table
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-
-        # Use MetricSourceInfo for normalized schema
-        source_info = MetricSourceInfo.from_source(step, entity_key=None)
-
-        # Build SELECT fields (entity_id, variant, timestamp, uuid, session_id)
-        # Cast to list[Expr] since Alias is a subclass of Expr
-        select_fields: list[ast.Expr] = cast(list[ast.Expr], source_info.build_select_fields())
-
-        # Add step columns (step_0=0, ..., step_N=1, ...) using FunnelStepBuilder
-        step_columns = step_builder.build_constant_columns(active_step_index=step_index)
-        select_fields.extend(step_columns)
-
-        # Build WHERE predicate
-        where = self._build_dw_step_predicate(step, source_info)
-
-        # Build query
-        query = ast.SelectQuery(
-            select=select_fields,
-            select_from=ast.JoinExpr(table=ast.Field(chain=[source_info.table_name])),
-            where=where,
-        )
-
-        return query
+        return self._funnel_query_builder().build_funnel_dw_step_subquery(step, step_index, step_builder)
 
     def _build_dw_step_predicate(
         self,
@@ -2187,54 +1473,7 @@ class ExperimentQueryBuilder:
         Returns:
             Filter expression
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-
-        conversion_window_seconds = self._get_conversion_window_seconds()
-
-        # Build timestamp filter
-        # Use unqualified field name for DW to avoid issues with dotted table names
-        timestamp_field = ast.Field(chain=[source_info.timestamp_field])
-
-        # date_from <= timestamp < date_to + conversion_window
-        date_from_expr = self.date_range_query.date_from_as_hogql()
-        date_to_expr = self.date_range_query.date_to_as_hogql()
-
-        # Add conversion window to date_to
-        date_to_with_window: ast.Expr
-        if conversion_window_seconds > 0:
-            date_to_with_window = ast.Call(
-                name="plus",
-                args=[
-                    date_to_expr,
-                    ast.Call(
-                        name="toIntervalSecond",
-                        args=[ast.Constant(value=conversion_window_seconds)],
-                    ),
-                ],
-            )
-        else:
-            date_to_with_window = date_to_expr
-
-        timestamp_filter = ast.And(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.GtEq,
-                    left=timestamp_field,
-                    right=date_from_expr,
-                ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=timestamp_field,
-                    right=date_to_with_window,
-                ),
-            ]
-        )
-
-        # Build property filter from DW node
-        dw_filter = data_warehouse_node_to_filter(self.team, step)
-
-        # Combine filters
-        return ast.And(exprs=[timestamp_filter, dw_filter])
+        return self._funnel_query_builder().build_dw_step_predicate(step, source_info)
 
     # --- Optimized funnel query helpers ---
 
@@ -2243,40 +1482,25 @@ class ExperimentQueryBuilder:
         Variant expression for the optimized funnel path.
         References variant_value (raw property) instead of variant (column in legacy metric_events).
         """
-        if self.multiple_variant_handling == MultipleVariantHandling.FIRST_SEEN:
-            return parse_expr(
-                "argMinIf(variant_value, timestamp, step_0 = 1)",
-            )
-        else:
-            return parse_expr(
-                "if(uniqExactIf(variant_value, step_0 = 1) > 1, {multiple_key}, anyIf(variant_value, step_0 = 1))",
-                placeholders={
-                    "multiple_key": ast.Constant(value=MULTIPLE_VARIANT_KEY),
-                },
-            )
+        return self._funnel_query_builder().build_variant_expr_for_funnel_optimized()
 
     def _build_funnel_aggregation_expr_optimized(self) -> ast.Expr:
         """
         Funnel aggregation for the optimized path. References base_events instead of metric_events.
         """
-        assert isinstance(self.metric, ExperimentFunnelMetric)
-        return funnel_evaluation_expr(self.team, self.metric, events_alias="base_events", include_exposure=True)
+        return self._funnel_query_builder().build_funnel_aggregation_expr_optimized()
 
     def _build_uuid_to_session_map_optimized(self) -> ast.Expr:
         """
         UUID-to-session map for the optimized path. References base_events columns.
         """
-        return parse_expr(
-            "mapFromArrays(groupArray(coalesce(toString(uuid), '')), groupArray(coalesce(toString(session_id), '')))"
-        )
+        return self._funnel_query_builder().build_uuid_to_session_map_optimized()
 
     def _build_uuid_to_timestamp_map_optimized(self) -> ast.Expr:
         """
         UUID-to-timestamp map for the optimized path. References base_events columns.
         """
-        return parse_expr(
-            "mapFromArrays(groupArray(coalesce(toString(uuid), '')), groupArray(coalesce(timestamp, toDateTime(0))))"
-        )
+        return self._funnel_query_builder().build_uuid_to_timestamp_map_optimized()
 
     def _build_maturity_having_clause_optimized(self) -> Optional[ast.Expr]:
         """
@@ -2284,23 +1508,7 @@ class ExperimentQueryBuilder:
         Uses maxIf to only consider exposure events (step_0 = 1) for maturity,
         since entity_metrics groups over all events, not just exposures.
         """
-        if self.metric is None:
-            return None
-        if not self.only_count_matured_users:
-            return None
-
-        maturity_seconds = self._get_maturity_window_seconds()
-        if maturity_seconds == 0:
-            return None
-
-        now = timezone.now().strftime("%Y-%m-%d %H:%M:%S")
-        return parse_expr(
-            "maxIf(timestamp, step_0 = 1) + toIntervalSecond({maturity_seconds}) <= toDateTime({now}, 'UTC')",
-            placeholders={
-                "maturity_seconds": ast.Constant(value=maturity_seconds),
-                "now": ast.Constant(value=now),
-            },
-        )
+        return self._funnel_query_builder().build_maturity_having_clause_optimized()
 
     def _build_retention_query(self) -> ast.SelectQuery:
         """


### PR DESCRIPTION
## Problem

This is PR 4 of an 8-PR stacked, behavior-preserving refactor that breaks the ~3000-line `experiment_query_builder.py` god class into cohesive modules, following the team's hybrid refactor plan. It isolates the funnel-query cluster — the largest single concern in the builder — into its own module so the funnel construction (legacy double-scan, optimized single-scan, data-warehouse UNION, and the metric-events precomputation write path) can be read and evolved independently of exposure, mean, retention, and CUPED logic.

## Changes

- Added `posthog/hogql_queries/experiments/experiment_funnel_query_builder.py` with a new `FunnelQueryBuilder` class holding all funnel-query construction: `build_funnel_query` and its dispatch, the legacy and optimized paths, `build_funnel_optimized_temporal_setup`, step-column/steps-filter/aggregation builders, the uuid→session and uuid→timestamp maps (legacy + optimized), data-warehouse helpers (`has_datawarehouse_steps`, the metric-events UNION query, the events and DW step subqueries, the DW step predicate), the variant expressions (legacy + optimized), the optimized maturity HAVING clause, and `get_funnel_metric_events_query_for_precomputation`.
- `ExperimentQueryBuilder` shrank correspondingly: each moved method now keeps a thin delegating wrapper of the same name and signature that calls `self._funnel_query_builder().<method>()`. A `_funnel_query_builder()` factory mirrors the existing `_exposure_query_builder()` pattern and builds the helper fresh per call so it picks up build-time precomputation job IDs.
- This is a mechanical, behavior-preserving move: method bodies are byte-identical except for `self.` → `self._b.` rewrites (the new class reaches back through `self._b` for shared exposure, metric-value, CUPED, maturity, and breakdown state that still lives on the builder). Generated ClickHouse SQL is unchanged — the experiment snapshot tests pass with no `.ambr` diffs.
- Delegating wrappers were kept on `ExperimentQueryBuilder` so the `ExperimentFunnelActorsQueryBuilder` subclass (which inherits `_build_funnel_step_columns`) and internal callers (`experiment_query_runner.py` and the preaggregation test, via the public `get_funnel_metric_events_query_for_precomputation`) keep working unchanged.
- The optimized and legacy funnel paths are kept side by side and intentionally not merged (deferred per decision point C). The four CUPED funnel helpers remain on the builder and move later in PR 7.

## How did you test this code?

Authored by an AI agent (Claude Code) in an automated multi-agent workflow — no manual testing was performed. The following automated tests were run locally and pass, with no snapshot (`.ambr`) changes:

- `posthog/hogql_queries/experiments/test/experiment_query_runner/test_funnel_metric.py`
- `posthog/hogql_queries/experiments/test/test_experiment_actors_query.py`
- `posthog/hogql_queries/experiments/test/test_experiment_funnel_metric_events_preaggregation.py`

(58 tests passed, 169 snapshots passed, zero snapshot files written.)

## 🤖 Agent context

Authored by Claude Code via a stacked-PR refactor workflow; PR 4 of 8, stacked on `refactor/exp-qb-3-metric-values`. Mechanical, behavior-preserving extraction — generated SQL is unchanged (experiment snapshot tests pass with no `.ambr` diffs) and delegating wrappers were kept on `ExperimentQueryBuilder` so `ExperimentFunnelActorsQueryBuilder` and internal callers keep working. Implementation note: unlike PR 3's free-function module, the funnel cluster was extracted as a `FunnelQueryBuilder` class holding a back-reference to the owning `ExperimentQueryBuilder` (`self._b`), because funnel construction is bidirectionally coupled to shared exposure/metric-value/CUPED/maturity helpers and the `breakdown_injector` that remain on the builder; the back-reference keeps the move purely mechanical (`self.` → `self._b.` only). The optimized and legacy paths were left side by side (deferred per decision point C), and the four CUPED funnel helpers stay on the builder for PR 7. Agent-authored and requires human review — do not self-merge or auto-approve.
