### PR TITLE
feat(web-analytics): make heatmap chromium sandbox configurable

### DIFF
--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -130,3 +130,7 @@ HEATMAP_BROWSERLESS_BLOCK_ADS = get_from_env("HEATMAP_BROWSERLESS_BLOCK_ADS", Fa
 HEATMAP_BROWSERLESS_BLOCK_CONSENT_MODALS = get_from_env(
     "HEATMAP_BROWSERLESS_BLOCK_CONSENT_MODALS", True, type_cast=str_to_bool
 )
+# Pass --no-sandbox to the local heatmap Chromium. Defaults True (required where the container
+# can't create the unprivileged user namespace the Chromium sandbox needs). Set False to keep the
+# sandbox once the runtime allows it (seccomp profile permitting userns clone, non-root user).
+HEATMAP_CHROMIUM_NO_SANDBOX = get_from_env("HEATMAP_CHROMIUM_NO_SANDBOX", True, type_cast=str_to_bool)

--- a/products/web_analytics/backend/tasks/heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/heatmap_screenshot.py
@@ -476,9 +476,10 @@ def _launch_local_browser(p: Playwright) -> Browser:
     launch_args = [
         "--force-device-scale-factor=1",
         "--disable-dev-shm-usage",
-        "--no-sandbox",
         "--disable-gpu",
     ]
+    if settings.HEATMAP_CHROMIUM_NO_SANDBOX:
+        launch_args.append("--no-sandbox")
     proxy_url = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
     proxy_config = ProxySettings(server=proxy_url) if proxy_url else None
     return p.chromium.launch(

--- a/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
@@ -16,6 +16,7 @@ from products.web_analytics.backend.tasks.heatmap_screenshot import (
     BrowserlessPermanentError,
     _browserless_screenshot,
     _build_browserless_screenshot_url,
+    _launch_local_browser,
     _redact_browserless_url,
     _resolve_widths,
     _sanitize_browserless_error,
@@ -556,3 +557,23 @@ class TestBrowserlessUrlHelpers(SimpleTestCase):
         assert "token=REDACTED" in sanitized
         # The real failure reason is preserved so the error is debuggable
         assert "401" in sanitized
+
+
+# Pure-function test for the local Chromium launcher — no DB, so it runs on SimpleTestCase.
+class TestLaunchLocalBrowser(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("sandbox_on_by_default", None, True),
+            ("no_sandbox_enabled", True, True),
+            ("no_sandbox_disabled", False, False),
+        ]
+    )
+    def test_no_sandbox_flag_respects_setting(
+        self, _name: str, setting_value: bool | None, should_include: bool
+    ) -> None:
+        overrides = {} if setting_value is None else {"HEATMAP_CHROMIUM_NO_SANDBOX": setting_value}
+        with override_settings(**overrides):
+            p = MagicMock()
+            _launch_local_browser(p)
+            launch_args = p.chromium.launch.call_args.kwargs["args"]
+            assert ("--no-sandbox" in launch_args) is should_include


### PR DESCRIPTION
Gate the `--no-sandbox` launch flag for the local heatmap Chromium behind a new `HEATMAP_CHROMIUM_NO_SANDBOX` setting. Lets the sandbox be re-enabled per-environment once the runtime permits it.
