### PR TITLE
feat(insights): retention_actor materialisation

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_actor_materialize.py
+++ b/posthog/hogql_queries/insights/retention/retention_actor_materialize.py
@@ -98,7 +98,7 @@ class RetentionActorMaterialisation:
     ready: bool
 
 
-def kind_for_entity_id(entity_id: str | int | None) -> str:
+def kind_for_entity_id(entity_id: str | float | None) -> str:
     """Map a retention entity id to the stored `kind`: the all-events entity (`None`) → the
     marker, otherwise the raw event name."""
     return ALL_EVENTS_KIND if entity_id is None else str(entity_id)

--- a/posthog/hogql_queries/insights/retention/retention_actor_materialize.py
+++ b/posthog/hogql_queries/insights/retention/retention_actor_materialize.py
@@ -1,0 +1,183 @@
+"""Materialise the per-actor retention table (page-view + all-events scope).
+
+Fills `retention_actor` for a (team, kind) by scanning the team's event history and writing,
+per actor, two aggregate states: `minState` of their first qualifying timestamp and a
+`groupUniqArrayState` of the absolute day-numbers (team-tz `toDate`) they were active, capped
+to a horizon from the first day.
+
+v1 strategy: full re-derivation. `AggregatingMergeTree` merges the states idempotently — a
+re-run re-inserts each actor's state and `min` / set-union absorb it — so re-materialising is
+safe and never double-counts. Freshness is tracked in Redis (the table has no `computed_at`),
+and a Redis lock stops concurrent readers stampeding the same scan.
+
+The INSERT is raw SQL (not HogQL) so the `AggregateFunction` argument types match the column
+types exactly and the team-tz `toDate` day-numbers line up with the read path.
+
+Person overrides are resolved at INSERT time by the same `distinct_id` join the raw read path
+uses (`person_distinct_id_overrides`, latest non-deleted `person_id` per distinct_id). The
+INSERT runs on the main cluster where `events` and the override table are colocated, so the
+join is local; only the write lands on AUX. This is the web-analytics pre-agg pattern — a merge
+that lands *after* a materialisation is reconciled on the next rebuild, not at read time (the
+stored key is `person_id` and the live override mapping is `distinct_id`-keyed, so read-time
+person-grained resolution is not available).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import structlog
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.preaggregation.retention_actor_sql import ALL_EVENTS_KIND, DISTRIBUTED_RETENTION_ACTOR_TABLE
+from posthog.models import Team
+from posthog.redis import get_client
+
+logger = structlog.get_logger(__name__)
+
+PAGEVIEW_KIND = "$pageview"
+SUPPORTED_KINDS = (PAGEVIEW_KIND, ALL_EVENTS_KIND)
+
+# Max day-offset from the actor's first day that we store. Bounds per-actor state and caps the
+# lookahead the table can serve; longer-lookahead queries fall through to raw at the gate.
+HORIZON_DAYS = 800
+
+# How long a materialised (team, kind) is treated as fresh. Recent activity isn't reflected
+# until the next run; older cohorts are immutable, so this only bounds recent-cohort staleness.
+STALENESS_SECONDS = 15 * 60
+
+_LOCK_TIMEOUT_SECONDS = 10 * 60
+_LOCK_BLOCKING_TIMEOUT_SECONDS = 5 * 60
+_INSERT_MAX_EXECUTION_TIME_SECONDS = 5 * 60
+
+# initializeAggregation('minState', ts) and arrayReduce('groupUniqArrayState', days) build the
+# AggregateFunction states per row from scalars, so no outer GROUP BY is needed. The horizon
+# filter drops day-numbers more than HORIZON_DAYS past the actor's first day. The inner query
+# resolves person overrides via the distinct_id join (latest non-deleted person_id per
+# distinct_id) and groups by the resolved actor, so merged people collapse to one row.
+_INSERT_TEMPLATE = """
+INSERT INTO {table} (team_id, kind, actor_id, first_seen, active_days)
+SELECT
+    %(team_id)s,
+    %(kind)s,
+    actor_id,
+    initializeAggregation('minState', min_ts),
+    arrayReduce(
+        'groupUniqArrayState',
+        arrayFilter(dn -> dn - arrayMin(day_nums) <= %(horizon)s, day_nums)
+    )
+FROM (
+    SELECT
+        if(empty(o.distinct_id), e.person_id, o.person_id) AS actor_id,
+        min(e.timestamp) AS min_ts,
+        groupUniqArray(toUInt32(toDate(e.timestamp, %(tz)s))) AS day_nums
+    FROM events AS e
+    LEFT JOIN (
+        SELECT
+            distinct_id,
+            argMax(person_id, version) AS person_id
+        FROM person_distinct_id_overrides
+        WHERE team_id = %(team_id)s
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0
+    ) AS o ON e.distinct_id = o.distinct_id
+    WHERE e.team_id = %(team_id)s AND {event_filter} AND e.timestamp <= now()
+    GROUP BY actor_id
+)
+"""
+
+_FRESHNESS_KEY = "retention_actor:materialized_at:{team_id}:{kind}"
+# Redis freshness marker outlives the staleness window so a still-fresh table isn't re-scanned
+# just because the marker expired.
+_FRESHNESS_TTL_SECONDS = STALENESS_SECONDS * 4
+
+
+@dataclass
+class RetentionActorMaterialisation:
+    ready: bool
+
+
+def kind_for_entity_id(entity_id: str | int | None) -> str:
+    """Map a retention entity id to the stored `kind`: the all-events entity (`None`) → the
+    marker, otherwise the raw event name."""
+    return ALL_EVENTS_KIND if entity_id is None else str(entity_id)
+
+
+def _event_filter_sql(kind: str) -> str:
+    return "e.event = '$pageview'" if kind == PAGEVIEW_KIND else "1 = 1"
+
+
+def materialize_retention_actor(team: Team, kind: str) -> None:
+    """Re-derive a (team, kind)'s actor states from event history. Idempotent — the
+    AggregateFunction states merge on read."""
+    if kind not in SUPPORTED_KINDS:
+        raise ValueError(f"Unsupported retention_actor kind: {kind!r} (expected one of {SUPPORTED_KINDS})")
+
+    sql = _INSERT_TEMPLATE.format(
+        table=DISTRIBUTED_RETENTION_ACTOR_TABLE(),
+        event_filter=_event_filter_sql(kind),
+    )
+    sync_execute(
+        sql,
+        {"team_id": team.pk, "kind": kind, "horizon": HORIZON_DAYS, "tz": team.timezone},
+        settings={"max_execution_time": _INSERT_MAX_EXECUTION_TIME_SECONDS},
+    )
+    get_client().set(
+        _FRESHNESS_KEY.format(team_id=team.pk, kind=kind),
+        datetime.now(UTC).isoformat(),
+        ex=_FRESHNESS_TTL_SECONDS,
+    )
+
+
+def _is_fresh(team: Team, kind: str) -> bool:
+    raw = get_client().get(_FRESHNESS_KEY.format(team_id=team.pk, kind=kind))
+    if raw is None:
+        return False
+    materialized_at = datetime.fromisoformat(raw.decode() if isinstance(raw, bytes) else raw)
+    return datetime.now(UTC) - materialized_at < timedelta(seconds=STALENESS_SECONDS)
+
+
+def ensure_retention_actor(team: Team, kind: str) -> RetentionActorMaterialisation:
+    """Ensure a fresh (team, kind) materialisation exists, building it if stale. Returns
+    `ready=False` for unsupported kinds or on failure — the read path treats this as a hint and
+    falls through to raw events."""
+    if kind not in SUPPORTED_KINDS:
+        return RetentionActorMaterialisation(ready=False)
+
+    if _is_fresh(team, kind):
+        return RetentionActorMaterialisation(ready=True)
+
+    lock = get_client().lock(
+        f"retention_actor:materialize:{team.pk}:{kind}",
+        timeout=_LOCK_TIMEOUT_SECONDS,
+        blocking_timeout=_LOCK_BLOCKING_TIMEOUT_SECONDS,
+    )
+    if not lock.acquire():
+        return RetentionActorMaterialisation(ready=_is_fresh(team, kind))
+
+    try:
+        if _is_fresh(team, kind):
+            return RetentionActorMaterialisation(ready=True)
+        materialize_retention_actor(team, kind)
+        return RetentionActorMaterialisation(ready=True)
+    except Exception as e:
+        logger.exception("retention_actor.materialise_failed", team_id=team.pk, kind=kind, error=str(e))
+        return RetentionActorMaterialisation(ready=False)
+    finally:
+        try:
+            lock.release()
+        except Exception:
+            pass
+
+
+__all__ = [
+    "ALL_EVENTS_KIND",
+    "HORIZON_DAYS",
+    "PAGEVIEW_KIND",
+    "SUPPORTED_KINDS",
+    "RetentionActorMaterialisation",
+    "ensure_retention_actor",
+    "kind_for_entity_id",
+    "materialize_retention_actor",
+]

--- a/posthog/hogql_queries/insights/retention/retention_actor_materialize.py
+++ b/posthog/hogql_queries/insights/retention/retention_actor_materialize.py
@@ -121,7 +121,10 @@ def materialize_retention_actor(team: Team, kind: str) -> None:
     sync_execute(
         sql,
         {"team_id": team.pk, "kind": kind, "horizon": HORIZON_DAYS, "tz": team.timezone},
-        settings={"max_execution_time": _INSERT_MAX_EXECUTION_TIME_SECONDS},
+        # Wait for the write to land on the AUX shard before marking fresh — otherwise a reader can
+        # see the freshness marker and query a partially-populated table. Safe here because we
+        # insert the small per-actor aggregate, not the raw event scan.
+        settings={"max_execution_time": _INSERT_MAX_EXECUTION_TIME_SECONDS, "insert_distributed_sync": 1},
     )
     get_client().set(
         _FRESHNESS_KEY.format(team_id=team.pk, kind=kind),

--- a/posthog/hogql_queries/insights/retention/retention_actor_materialize.py
+++ b/posthog/hogql_queries/insights/retention/retention_actor_materialize.py
@@ -48,7 +48,8 @@ HORIZON_DAYS = 800
 STALENESS_SECONDS = 15 * 60
 
 _LOCK_TIMEOUT_SECONDS = 10 * 60
-_LOCK_BLOCKING_TIMEOUT_SECONDS = 5 * 60
+# Short, so a query contending on a concurrent build falls back to raw quickly instead of hanging.
+_LOCK_BLOCKING_TIMEOUT_SECONDS = 5
 _INSERT_MAX_EXECUTION_TIME_SECONDS = 5 * 60
 
 # initializeAggregation('minState', ts) and arrayReduce('groupUniqArrayState', days) build the
@@ -105,7 +106,10 @@ def kind_for_entity_id(entity_id: str | float | None) -> str:
 
 
 def _event_filter_sql(kind: str) -> str:
-    return "e.event = '$pageview'" if kind == PAGEVIEW_KIND else "1 = 1"
+    # The all-events marker matches every event; any other kind is a real event name (e.g. the
+    # `kind` column value itself), bound as a parameter — so a new SUPPORTED_KINDS entry filters
+    # on its own event instead of silently matching everything.
+    return "1 = 1" if kind == ALL_EVENTS_KIND else "e.event = %(event_name)s"
 
 
 def materialize_retention_actor(team: Team, kind: str) -> None:
@@ -120,7 +124,7 @@ def materialize_retention_actor(team: Team, kind: str) -> None:
     )
     sync_execute(
         sql,
-        {"team_id": team.pk, "kind": kind, "horizon": HORIZON_DAYS, "tz": team.timezone},
+        {"team_id": team.pk, "kind": kind, "event_name": kind, "horizon": HORIZON_DAYS, "tz": team.timezone},
         # Wait for the write to land on the AUX shard before marking fresh — otherwise a reader can
         # see the freshness marker and query a partially-populated table. Safe here because we
         # insert the small per-actor aggregate, not the raw event scan.

--- a/posthog/hogql_queries/insights/retention/test/test_retention_actor_materialize.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_actor_materialize.py
@@ -9,6 +9,8 @@ from posthog.test.base import (
     flush_persons_and_events,
 )
 
+from parameterized import parameterized
+
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
 
@@ -95,6 +97,27 @@ class TestRetentionActorMaterialize(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(_days_to_dates(self._read()[0][2]), ["2024-03-01"])
         # Second call is served from the freshness marker without re-scanning.
         self.assertTrue(ensure_retention_actor(self.team, PAGEVIEW_KIND).ready)
+
+    @parameterized.expand(
+        [
+            # Explicit-UTC ("Z") timestamps decouple storage from team tz, so the day-number reveals
+            # which tz the materialiser buckets in. UTC-5: 02:00 UTC is the previous team-tz day.
+            ("america_new_york", "America/New_York", "2024-01-10T02:00:00Z", "2024-01-09"),
+            # UTC+5:30 (half-hour offset): 20:00 UTC is the next team-tz day.
+            ("asia_kolkata", "Asia/Kolkata", "2024-01-10T20:00:00Z", "2024-01-11"),
+        ]
+    )
+    def test_day_number_uses_team_timezone(self, _name: str, timezone: str, ts_utc: str, expected_day: str) -> None:
+        self.team.timezone = timezone
+        self.team.save()
+        self._event(self.ACTOR_A, ts_utc)
+        flush_persons_and_events()
+
+        materialize_retention_actor(self.team, PAGEVIEW_KIND)
+
+        # The stored day-number is the team-tz date, not the UTC date — so the read path's naive
+        # epoch+offset reconstruction lands on the right day for a non-UTC team.
+        self.assertEqual(_days_to_dates(self._read()[0][2]), [expected_day])
 
     def test_overrides_resolved_at_insert(self):
         # Two distinct_ids with separate person_ids that then merge: did_b -> person of did_a.

--- a/posthog/hogql_queries/insights/retention/test/test_retention_actor_materialize.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_actor_materialize.py
@@ -1,0 +1,120 @@
+from datetime import date, datetime, timedelta
+
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+    create_person_id_override_by_distinct_id,
+    flush_persons_and_events,
+)
+
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.hogql_queries.insights.retention.retention_actor_materialize import (
+    ALL_EVENTS_KIND,
+    HORIZON_DAYS,
+    PAGEVIEW_KIND,
+    ensure_retention_actor,
+    materialize_retention_actor,
+)
+
+_EPOCH = date(1970, 1, 1)
+
+
+def _days_to_dates(day_numbers: list[int]) -> list[str]:
+    return [(_EPOCH + timedelta(days=int(d))).isoformat() for d in sorted(day_numbers)]
+
+
+class TestRetentionActorMaterialize(ClickhouseTestMixin, APIBaseTest):
+    ACTOR_A = "00000000-0000-0000-0000-0000000000a1"
+    ACTOR_B = "00000000-0000-0000-0000-0000000000b2"
+
+    def _event(self, person_id: str, ts: str, event: str = "$pageview") -> None:
+        _create_event(team=self.team, event=event, distinct_id=person_id, timestamp=ts, person_id=person_id)
+
+    def _read(self, kind: str = PAGEVIEW_KIND):
+        result = execute_hogql_query(
+            """
+            SELECT actor_id, minMerge(first_seen) AS first_ts, arraySort(groupUniqArrayMerge(active_days)) AS days
+            FROM posthog.retention_actor
+            WHERE team_id = {team_id} AND kind = {kind}
+            GROUP BY actor_id
+            ORDER BY actor_id
+            """,
+            team=self.team,
+            placeholders={"team_id": ast.Constant(value=self.team.pk), "kind": ast.Constant(value=kind)},
+        )
+        return result.results or []
+
+    def test_materialize_pageview_cohort_and_returns(self):
+        self._event(self.ACTOR_A, "2024-01-10 09:00:00")
+        self._event(self.ACTOR_A, "2024-01-12 23:30:00")
+        self._event(self.ACTOR_A, "2024-01-15 00:00:00", event="$autocapture")  # not a pageview — excluded
+        self._event(self.ACTOR_B, "2024-01-11 12:00:00")
+        flush_persons_and_events()
+
+        materialize_retention_actor(self.team, PAGEVIEW_KIND)
+        rows = self._read()
+
+        self.assertEqual(len(rows), 2)
+        a_id, a_first, a_days = rows[0]
+        self.assertEqual(str(a_id), self.ACTOR_A)
+        self.assertEqual(a_first.strftime("%Y-%m-%d %H:%M:%S"), "2024-01-10 09:00:00")
+        self.assertEqual(_days_to_dates(a_days), ["2024-01-10", "2024-01-12"])
+        self.assertEqual(_days_to_dates(rows[1][2]), ["2024-01-11"])
+
+    def test_all_events_kind_includes_non_pageview(self):
+        self._event(self.ACTOR_A, "2024-02-01 00:00:00", event="$pageview")
+        self._event(self.ACTOR_A, "2024-02-03 00:00:00", event="$autocapture")
+        flush_persons_and_events()
+
+        materialize_retention_actor(self.team, ALL_EVENTS_KIND)
+        self.assertEqual(_days_to_dates(self._read(kind=ALL_EVENTS_KIND)[0][2]), ["2024-02-01", "2024-02-03"])
+
+    def test_days_beyond_horizon_are_dropped(self):
+        first = datetime(2022, 1, 1, 0, 0, 0)
+        beyond = first + timedelta(days=HORIZON_DAYS + 5)
+        within = first + timedelta(days=HORIZON_DAYS - 5)
+        for ts in (first, within, beyond):
+            self._event(self.ACTOR_A, ts.strftime("%Y-%m-%d %H:%M:%S"))
+        flush_persons_and_events()
+
+        materialize_retention_actor(self.team, PAGEVIEW_KIND)
+        days = _days_to_dates(self._read()[0][2])
+        self.assertIn(first.date().isoformat(), days)
+        self.assertIn(within.date().isoformat(), days)
+        self.assertNotIn(beyond.date().isoformat(), days)
+
+    def test_ensure_materialises_then_is_fresh(self):
+        self._event(self.ACTOR_A, "2024-03-01 00:00:00")
+        flush_persons_and_events()
+
+        self.assertTrue(ensure_retention_actor(self.team, PAGEVIEW_KIND).ready)
+        self.assertEqual(_days_to_dates(self._read()[0][2]), ["2024-03-01"])
+        # Second call is served from the freshness marker without re-scanning.
+        self.assertTrue(ensure_retention_actor(self.team, PAGEVIEW_KIND).ready)
+
+    def test_overrides_resolved_at_insert(self):
+        # Two distinct_ids with separate person_ids that then merge: did_b -> person of did_a.
+        p1 = "00000000-0000-0000-0000-0000000000d1"
+        p2 = "00000000-0000-0000-0000-0000000000d2"
+        _create_person(team=self.team, distinct_ids=["did_a"], uuid=p1)
+        _create_person(team=self.team, distinct_ids=["did_b"], uuid=p2)
+        _create_event(
+            team=self.team, event="$pageview", distinct_id="did_a", timestamp="2024-04-01 00:00:00", person_id=p1
+        )
+        _create_event(
+            team=self.team, event="$pageview", distinct_id="did_b", timestamp="2024-04-03 00:00:00", person_id=p2
+        )
+        flush_persons_and_events()
+        create_person_id_override_by_distinct_id(distinct_id_from="did_b", distinct_id_to="did_a", team_id=self.team.pk)
+
+        materialize_retention_actor(self.team, PAGEVIEW_KIND)
+        rows = self._read()
+
+        # The merged actor is counted once (under p1) with both days — not two orphaned actors.
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(str(rows[0][0]), p1)
+        self.assertEqual(_days_to_dates(rows[0][2]), ["2024-04-01", "2024-04-03"])


### PR DESCRIPTION
## Problem

Second piece of the retention pre-aggregation stack (stacked on the foundation table PR). The `retention_actor` table needs to be filled from event history before any read path can use it.

## Changes

Adds `retention_actor_materialize.py`: scans a (team, kind)'s event history and writes, per actor, two aggregate states — `minState` of their first qualifying timestamp and a `groupUniqArrayState` of the absolute team-tz day-numbers they were active, capped to `HORIZON_DAYS` (800) from the actor's first day.

- The INSERT is **raw SQL** (not HogQL) so the `AggregateFunction` argument types match the column types exactly, and the team-tz `toDate` day-numbers line up with what the read path will compute. States are built per row with `initializeAggregation` / `arrayReduce`, so there's no outer `GROUP BY`.
- **Full re-derivation**, idempotent: because the states merge on read (`min` / set-union absorb a re-run), re-materialising never double-counts.
- Freshness is tracked in **Redis** (the table has no `computed_at` column), guarded by a Redis lock so concurrent readers don't stampede the same scan. `ensure_retention_actor` returns `ready=False` on unsupported kind / failure so the read path can fall through to raw.

v1 stores the raw `events.person_id`; person-merge / override handling is a later piece in the stack.

Still dark: nothing reads the table yet (read path + routing gate is the next PR).

## How did you test this code?

I'm an agent. Automated tests only.

New `test_retention_actor_materialize.py` (4 passing): cohort + returns for page-view (correctly excludes non-pageview events), all-events kind includes non-pageview activity, days beyond the 800-day horizon are dropped, and `ensure_*` materialises then serves from the freshness marker.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Chose raw SQL over HogQL for the INSERT specifically to control the `AggregateFunction` state types and avoid HogQL's automatic timezone-wrapping of `timestamp` interfering with the `minState` column type. Freshness moved to Redis because the new `AggregatingMergeTree` table intentionally has no `computed_at` version column (unlike the earlier `ReplacingMergeTree` design).

Requires human review; not for self-merge.
