### PR TITLE
feat(insights): retention pre-agg read path + routing gate

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -22879,6 +22879,10 @@
                     "description": "Try to automatically convert HogQL queries to use preaggregated tables at the AST level *",
                     "type": "boolean"
                 },
+                "useRetentionPreAggregation": {
+                    "description": "Serve covered retention queries from the pre-aggregated retention_actor table (off by default) *",
+                    "type": "boolean"
+                },
                 "useWebAnalyticsPreAggregatedTables": {
                     "type": "boolean"
                 }

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -449,6 +449,8 @@ export interface HogQLQueryModifiers {
     useMaterializedViews?: boolean
     customChannelTypeRules?: CustomChannelRule[]
     useWebAnalyticsPreAggregatedTables?: boolean
+    /** Serve covered retention queries from the pre-aggregated retention_actor table (off by default) **/
+    useRetentionPreAggregation?: boolean
     formatCsvAllowDoubleQuotes?: boolean
     convertToProjectTimezone?: boolean
     /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level **/

--- a/posthog/hogql_queries/insights/retention/retention_actor_read.py
+++ b/posthog/hogql_queries/insights/retention/retention_actor_read.py
@@ -57,9 +57,17 @@ arrayJoin(
 )
 """
 
-# Absolute day-number -> Date. toDate has no integer overload in HogQL, so reconstruct via
-# Date + interval arithmetic from the epoch (day-numbers are days since 1970-01-01).
+# Absolute day-number -> Date (the actor's team-tz calendar day). toDate has no integer overload
+# in HogQL, so reconstruct via Date + interval arithmetic from the epoch (days since 1970-01-01).
+# Used for the cohort-window bound check, which compares against toDate(...) bounds in the same
+# calendar space.
 _DATE_OF_DAYNUM = "toDate('1970-01-01') + toIntervalDay({daynum})"
+
+# Same day as a team-tz-aware DateTime, so get_start_of_interval_hogql yields interval starts that
+# match the legacy `date_range` (whose entries are team-tz). The toString round-trip makes the
+# printer parse it in the team timezone; a naive Date source prints as UTC-midnight and its
+# interval starts never equal the team-tz date_range for a non-UTC team (→ empty result).
+_DATETIME_OF_DAYNUM = "toDateTime(toString(toDate('1970-01-01') + toIntervalDay({daynum})))"
 
 
 def build_preagg_base_query(builder: RetentionFixedIntervalBaseQueryBuilder) -> ast.SelectQuery:
@@ -70,7 +78,7 @@ def build_preagg_base_query(builder: RetentionFixedIntervalBaseQueryBuilder) -> 
     # interval (day/week/month, team tz), dedupe + sort. Several days in the same week/month
     # collapse to one — correct per-actor rollup. Used as BOTH start and return timestamps.
     interval_of_daynum = runner.query_date_range.get_start_of_interval_hogql(
-        source=parse_expr(_DATE_OF_DAYNUM, {"daynum": ast.Field(chain=["dn"])})
+        source=parse_expr(_DATETIME_OF_DAYNUM, {"daynum": ast.Field(chain=["dn"])})
     )
     active_intervals = parse_expr(
         "arraySort(arrayDistinct(arrayMap(dn -> {interval_of_daynum}, day_nums)))",

--- a/posthog/hogql_queries/insights/retention/retention_actor_read.py
+++ b/posthog/hogql_queries/insights/retention/retention_actor_read.py
@@ -1,0 +1,124 @@
+"""Pre-aggregated retention base query (per-actor `retention_actor` table).
+
+Produces a SelectQuery in the same shape `RetentionFixedIntervalBaseQueryBuilder` emits, but
+reads one row per actor from `retention_actor` instead of scanning events. Each actor's
+`active_days` (a `groupUniqArray` set-state of absolute team-tz day-numbers, horizon-capped
+from their first day) is merged at read, mapped back to dates, truncated to the query interval,
+and reused as BOTH the start and return interval set — then the legacy builder's helpers
+compute `start_interval_index` and `intervals_from_base`.
+
+The cohort anchor is `arrayMin(active_days)` — the actor's all-history first qualifying day.
+Because the horizon cap is taken from that first day, the first day is always present in the
+set, so `arrayMin` equals the all-history first occurrence exactly (no "looks-new-but-isn't"
+boundary error). `first_seen` (the minState column) is reserved for merge resolution and is not
+needed here.
+
+Scope (gate-enforced): first-occurrence retention for page-view or all-events, both entities
+the same kind, no event-property filters.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr, parse_select
+
+from posthog.hogql_queries.insights.retention.retention_actor_materialize import kind_for_entity_id
+
+if TYPE_CHECKING:
+    from posthog.hogql_queries.insights.retention.retention_base_query_fixed import (
+        RetentionFixedIntervalBaseQueryBuilder,
+    )
+
+# Verbatim from RetentionFixedIntervalBaseQueryBuilder — the exploded, 0-based cohort interval
+# index. Reused as-is so the pre-agg path matches the legacy path; `is_valid_start_interval` is
+# injected (first-occurrence: `_start_event_timestamps[1] = interval_date`).
+_START_INTERVAL_INDEX_SQL = """
+arrayJoin(
+    arrayFilter(
+        x -> x > -1,
+        arrayMap(
+            (interval_index, interval_date, _start_event_timestamps) ->
+                if(
+                    {is_valid_start_interval},
+                    interval_index - 1,
+                    -1
+                ),
+            arrayEnumerate(date_range),
+            date_range,
+            arrayResize(
+                [start_event_timestamps],
+                length(date_range),
+                start_event_timestamps
+            )
+        )
+    )
+)
+"""
+
+# Absolute day-number -> Date. toDate has no integer overload in HogQL, so reconstruct via
+# Date + interval arithmetic from the epoch (day-numbers are days since 1970-01-01).
+_DATE_OF_DAYNUM = "toDate('1970-01-01') + toIntervalDay({daynum})"
+
+
+def build_preagg_base_query(builder: RetentionFixedIntervalBaseQueryBuilder) -> ast.SelectQuery:
+    runner = builder.runner
+    kind = kind_for_entity_id(runner.start_event.id)
+
+    # Per-actor active intervals: map each active day-number to its Date, truncate to the query
+    # interval (day/week/month, team tz), dedupe + sort. Several days in the same week/month
+    # collapse to one — correct per-actor rollup. Used as BOTH start and return timestamps.
+    interval_of_daynum = runner.query_date_range.get_start_of_interval_hogql(
+        source=parse_expr(_DATE_OF_DAYNUM, {"daynum": ast.Field(chain=["dn"])})
+    )
+    active_intervals = parse_expr(
+        "arraySort(arrayDistinct(arrayMap(dn -> {interval_of_daynum}, day_nums)))",
+        {"interval_of_daynum": interval_of_daynum},
+    )
+
+    # Cohort anchor day = the actor's first active day-number, as a Date.
+    first_seen_day = parse_expr(_DATE_OF_DAYNUM, {"daynum": parse_expr("arrayMin(day_nums)")})
+
+    is_valid_start_interval = builder._is_valid_start_interval_expr("_start_event_timestamps")
+    intervals_from_base_expr, _retention_value_expr = builder._get_intervals_from_base_exprs()
+
+    select_query = parse_select(
+        """
+        SELECT
+            actor_id,
+            {start_event_timestamps} AS start_event_timestamps,
+            {date_range} AS date_range,
+            {return_event_timestamps} AS return_event_timestamps,
+            {start_interval_index} AS start_interval_index,
+            {intervals_from_base} AS intervals_from_base
+        FROM (
+            SELECT
+                actor_id,
+                groupUniqArrayMerge(active_days) AS day_nums
+            FROM posthog.retention_actor
+            WHERE team_id = {team_id} AND kind = {kind}
+            GROUP BY actor_id
+        )
+        WHERE {first_seen_day} >= {first_seen_lower}
+            AND {first_seen_day} < {first_seen_upper}
+        """,
+        placeholders={
+            "start_event_timestamps": active_intervals,
+            "date_range": builder._date_range_alias().expr,
+            "return_event_timestamps": active_intervals,
+            "start_interval_index": parse_expr(
+                _START_INTERVAL_INDEX_SQL, {"is_valid_start_interval": is_valid_start_interval}
+            ),
+            "intervals_from_base": intervals_from_base_expr,
+            "first_seen_day": first_seen_day,
+            "team_id": ast.Constant(value=runner.team.pk),
+            "kind": ast.Constant(value=kind),
+            "first_seen_lower": ast.Call(
+                name="toDate", args=[runner.query_date_range.date_from_to_start_of_interval_hogql()]
+            ),
+            "first_seen_upper": ast.Call(name="toDate", args=[ast.Constant(value=runner.query_date_range.date_to())]),
+        },
+    )
+    assert isinstance(select_query, ast.SelectQuery)
+    return select_query

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -33,6 +33,13 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
+from posthog.hogql_queries.insights.retention.retention_actor_materialize import (
+    HORIZON_DAYS,
+    SUPPORTED_KINDS,
+    ensure_retention_actor,
+    kind_for_entity_id,
+)
+from posthog.hogql_queries.insights.retention.retention_actor_read import build_preagg_base_query
 from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RetentionFixedIntervalBaseQueryBuilder
 from posthog.hogql_queries.insights.retention.retention_base_query_rolling import (
     RetentionRollingIntervalBaseQueryBuilder,
@@ -412,11 +419,69 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
 
         return refresh_frequency
 
+    @cached_property
+    def should_use_retention_preagg(self) -> bool:
+        # Conservative gate for the pre-aggregated retention_actor path — each check rules out a
+        # shape v1 can't reproduce. Coverage expands by extending the table, not relaxing these.
+        if not self.modifiers.useRetentionPreAggregation:
+            return False
+        # First-occurrence only; recurring re-cohorts every period and falls through to raw.
+        if not (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
+            return False
+        if self.is_24h_window_calculation or self.is_custom_bracket_retention:
+            return False
+        # Person retention only.
+        if self.group_type_index is not None:
+            return False
+        if self.has_property_aggregation:
+            return False
+        if (self.query.retentionFilter.minimumOccurrences or 1) > 1:
+            return False
+        # v1 materialises the unfiltered event population, so any filter that narrows it → raw
+        # (event-property, person/cohort, and test-account filters are all deferred).
+        if self.query.properties or self.start_event.properties or self.return_event.properties:
+            return False
+        if self.query.filterTestAccounts:
+            return False
+        # Both entities must be the same materialised kind (page-view or all-events).
+        if self.start_event.type != EntityType.EVENTS or self.return_event.type != EntityType.EVENTS:
+            return False
+        start_kind = kind_for_entity_id(self.start_event.id)
+        if not (start_kind == kind_for_entity_id(self.return_event.id) and start_kind in SUPPORTED_KINDS):
+            return False
+        # The table only holds days up to the horizon; longer lookaheads fall through to raw.
+        return self._max_lookahead_days() <= HORIZON_DAYS
+
+    def _max_lookahead_days(self) -> int:
+        interval_days = {"day": 1, "week": 7, "month": 31}.get(self.query_date_range.interval_name, 1)
+        return self.query_date_range.lookahead * interval_days
+
+    def _build_preagg_base_query(
+        self,
+        start_interval_index_filter: Optional[int] = None,
+        selected_breakdown_value: str | list[str] | int | None = None,
+    ) -> ast.SelectQuery | None:
+        # Actor drill-down post-filters (HAVING) aren't reproduced on the pre-agg path yet.
+        if start_interval_index_filter is not None or selected_breakdown_value is not None:
+            return None
+        materialisation = ensure_retention_actor(self.team, kind_for_entity_id(self.start_event.id))
+        if not materialisation.ready:
+            return None
+        return build_preagg_base_query(RetentionFixedIntervalBaseQueryBuilder(self))
+
     def _base_query(
         self,
         start_interval_index_filter: Optional[int] = None,
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
+        if self.should_use_retention_preagg:
+            preagg_query = self._build_preagg_base_query(
+                start_interval_index_filter=start_interval_index_filter,
+                selected_breakdown_value=selected_breakdown_value,
+            )
+            if preagg_query is not None:
+                return preagg_query
+            # Materialisation not ready or shape unsupported — raw events are always correct.
         builder_class = (
             RetentionRollingIntervalBaseQueryBuilder
             if self.is_24h_window_calculation

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -433,6 +433,10 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         # Person retention only.
         if self.group_type_index is not None:
             return False
+        # Breakdowns split the cohort grid per value; the pre-agg base query doesn't produce a
+        # breakdown_value, so let these fall through to raw.
+        if has_breakdown_filter(self.query.breakdownFilter):
+            return False
         if self.has_property_aggregation:
             return False
         if (self.query.retentionFilter.minimumOccurrences or 1) > 1:

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -457,6 +457,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return self._max_lookahead_days() <= HORIZON_DAYS
 
     def _max_lookahead_days(self) -> int:
+        # month=31 over-estimates on purpose, so a borderline range errs toward raw, not past the horizon.
         interval_days = {"day": 1, "week": 7, "month": 31}.get(self.query_date_range.interval_name, 1)
         return self.query_date_range.lookahead * interval_days
 

--- a/posthog/hogql_queries/insights/retention/test/test_retention_actor_read.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_actor_read.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
 
+from parameterized import parameterized
+
 from posthog.schema import HogQLQueryModifiers
 
 from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
@@ -79,6 +81,28 @@ class TestRetentionActorReadParity(ClickhouseTestMixin, APIBaseTest):
             {
                 "dateRange": {"date_from": "2024-01-01", "date_to": "2024-02-05"},
                 "retentionFilter": {"period": "Week", "totalIntervals": 5, "retentionType": "retention_first_time"},
+            }
+        )
+
+    @parameterized.expand(
+        [
+            # Near-midnight team-local events whose stored UTC instant lands on a different
+            # calendar day — so a path that bucketed in UTC instead of team tz would diverge.
+            ("america_new_york_late", "America/New_York", 23),
+            ("asia_kolkata_early", "Asia/Kolkata", 2),
+        ]
+    )
+    def test_parity_non_utc_team(self, _name: str, timezone: str, hour: int) -> None:
+        self.team.timezone = timezone
+        self.team.save()
+        for uid, days in ((A, [0, 1, 3]), (B, [1, 2]), (C, [0, 5])):
+            for d in days:
+                self._event(uid, d, hour=hour)
+        flush_persons_and_events()
+        self._assert_parity(
+            {
+                "dateRange": {"date_from": "2024-01-01", "date_to": "2024-01-08"},
+                "retentionFilter": {"period": "Day", "totalIntervals": 7, "retentionType": "retention_first_time"},
             }
         )
 

--- a/posthog/hogql_queries/insights/retention/test/test_retention_actor_read.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_actor_read.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
+
+from posthog.schema import HogQLQueryModifiers
+
+from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
+
+A = "00000000-0000-0000-0000-0000000000a1"
+B = "00000000-0000-0000-0000-0000000000b2"
+C = "00000000-0000-0000-0000-0000000000c3"
+
+
+class TestRetentionActorReadParity(ClickhouseTestMixin, APIBaseTest):
+    """The pre-agg read path must produce byte-identical results to the raw-events path for the
+    gated-in shapes. Each case runs the same query with the modifier off (raw) and on (pre-agg)
+    and asserts the count matrices match."""
+
+    def setUp(self):
+        super().setUp()
+        self._created: set[str] = set()
+
+    def _event(self, uid: str, day: int, event: str = "$pageview", hour: int = 8) -> None:
+        if uid not in self._created:
+            _create_person(team=self.team, distinct_ids=[uid], uuid=uid)
+            self._created.add(uid)
+        ts = datetime(2024, 1, 1 + day, hour, 0).strftime("%Y-%m-%d %H:%M:%S")
+        _create_event(team=self.team, event=event, distinct_id=uid, timestamp=ts, person_id=uid)
+
+    def _counts(self, query: dict, preagg: bool) -> list[list[int]]:
+        runner = RetentionQueryRunner(
+            team=self.team, query=query, modifiers=HogQLQueryModifiers(useRetentionPreAggregation=preagg)
+        )
+        results = runner.calculate().model_dump()["results"]
+        return [[v["count"] for v in row["values"]] for row in results]
+
+    def _seed(self) -> None:
+        for uid, days in ((A, [0, 1, 3]), (B, [1, 2]), (C, [0, 5])):
+            for d in days:
+                self._event(uid, d)
+        flush_persons_and_events()
+
+    def _assert_parity(self, query: dict) -> None:
+        raw = self._counts(query, preagg=False)
+        pre = self._counts(query, preagg=True)
+        self.assertEqual(raw, pre)
+        # Guard against the degenerate all-zero matrix passing trivially.
+        self.assertTrue(any(any(c for c in row) for row in raw), "expected some non-zero retention counts")
+
+    def test_parity_first_time_day(self):
+        self._seed()
+        self._assert_parity(
+            {
+                "dateRange": {"date_from": "2024-01-01", "date_to": "2024-01-08"},
+                "retentionFilter": {"period": "Day", "totalIntervals": 7, "retentionType": "retention_first_time"},
+            }
+        )
+
+    def test_parity_first_ever_day(self):
+        self._seed()
+        self._assert_parity(
+            {
+                "dateRange": {"date_from": "2024-01-01", "date_to": "2024-01-08"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 7,
+                    "retentionType": "retention_first_ever_occurrence",
+                },
+            }
+        )
+
+    def test_parity_first_time_week(self):
+        # Cohorts and returns spanning multiple weeks.
+        for uid, days in ((A, [0, 1, 8, 15]), (B, [2, 9]), (C, [0, 16])):
+            for d in days:
+                self._event(uid, d)
+        flush_persons_and_events()
+        self._assert_parity(
+            {
+                "dateRange": {"date_from": "2024-01-01", "date_to": "2024-02-05"},
+                "retentionFilter": {"period": "Week", "totalIntervals": 5, "retentionType": "retention_first_time"},
+            }
+        )
+
+    def test_gate_off_uses_raw(self):
+        # With the modifier off, the pre-agg path must not be taken — results still correct.
+        self._seed()
+        runner = RetentionQueryRunner(
+            team=self.team,
+            query={
+                "dateRange": {"date_from": "2024-01-01", "date_to": "2024-01-08"},
+                "retentionFilter": {"period": "Day", "totalIntervals": 7, "retentionType": "retention_first_time"},
+            },
+            modifiers=HogQLQueryModifiers(useRetentionPreAggregation=False),
+        )
+        self.assertFalse(runner.should_use_retention_preagg)

--- a/posthog/hogql_queries/insights/retention/test/test_retention_actor_read.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_actor_read.py
@@ -106,6 +106,43 @@ class TestRetentionActorReadParity(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
+    def _gate(self, *, query_overrides: dict | None = None, retention_overrides: dict | None = None) -> bool:
+        query = {
+            "dateRange": {"date_from": "2024-01-01", "date_to": "2024-01-08"},
+            "retentionFilter": {
+                "period": "Day",
+                "totalIntervals": 7,
+                "retentionType": "retention_first_time",
+                **(retention_overrides or {}),
+            },
+            **(query_overrides or {}),
+        }
+        runner = RetentionQueryRunner(
+            team=self.team, query=query, modifiers=HogQLQueryModifiers(useRetentionPreAggregation=True)
+        )
+        return runner.should_use_retention_preagg
+
+    def test_gate_on_for_covered_shape(self):
+        # Anchor: the plain covered shape (modifier on) does take the pre-agg path, so the
+        # fallback assertions below aren't passing vacuously.
+        self.assertTrue(self._gate())
+
+    @parameterized.expand(
+        [
+            ("breakdown", {"breakdownFilter": {"breakdown": "$browser", "breakdown_type": "event"}}, {}),
+            ("group_aggregation", {"aggregation_group_type_index": 0}, {}),
+            ("test_accounts", {"filterTestAccounts": True}, {}),
+            ("property_filter", {"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]}, {}),
+            ("min_occurrences", {}, {"minimumOccurrences": 2}),
+        ]
+    )
+    def test_gate_falls_back_for_unsupported_shapes(
+        self, _name: str, query_overrides: dict, retention_overrides: dict
+    ) -> None:
+        # Each shape the pre-agg can't reproduce must fall through to raw, not slip past the gate
+        # and crash on the read path.
+        self.assertFalse(self._gate(query_overrides=query_overrides, retention_overrides=retention_overrides))
+
     def test_gate_off_uses_raw(self):
         # With the modifier off, the pre-agg path must not be taken — results still correct.
         self._seed()

--- a/posthog/hogql_queries/insights/retention/test/test_retention_actor_read.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_actor_read.py
@@ -134,6 +134,8 @@ class TestRetentionActorReadParity(ClickhouseTestMixin, APIBaseTest):
             ("test_accounts", {"filterTestAccounts": True}, {}),
             ("property_filter", {"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]}, {}),
             ("min_occurrences", {}, {"minimumOccurrences": 2}),
+            ("24h_window", {}, {"timeWindowMode": "24_hour_windows"}),
+            ("custom_bracket", {}, {"retentionCustomBrackets": [7, 2]}),
         ]
     )
     def test_gate_falls_back_for_unsupported_shapes(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5176,6 +5176,12 @@ class HogQLQueryModifiers(BaseModel):
         default=None,
         description=("Try to automatically convert HogQL queries to use preaggregated tables at the AST level *"),
     )
+    useRetentionPreAggregation: bool | None = Field(
+        default=None,
+        description=(
+            "Serve covered retention queries from the pre-aggregated retention_actor table (off by default) *"
+        ),
+    )
     useWebAnalyticsPreAggregatedTables: bool | None = None
 
 

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -961,6 +961,8 @@ export interface HogQLQueryModifiersApi {
     usePreaggregatedIntermediateResults?: boolean | null
     /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
     usePreaggregatedTableTransforms?: boolean | null
+    /** Serve covered retention queries from the pre-aggregated retention_actor table (off by default) * */
+    useRetentionPreAggregation?: boolean | null
     useWebAnalyticsPreAggregatedTables?: boolean | null
 }
 

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -457,6 +457,8 @@ export interface HogQLQueryModifiersApi {
     usePreaggregatedIntermediateResults?: boolean | null
     /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
     usePreaggregatedTableTransforms?: boolean | null
+    /** Serve covered retention queries from the pre-aggregated retention_actor table (off by default) * */
+    useRetentionPreAggregation?: boolean | null
     useWebAnalyticsPreAggregatedTables?: boolean | null
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -408,6 +408,8 @@ export namespace Schemas {
       usePreaggregatedIntermediateResults?: boolean | null;
       /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
       usePreaggregatedTableTransforms?: boolean | null;
+      /** Serve covered retention queries from the pre-aggregated retention_actor table (off by default) * */
+      useRetentionPreAggregation?: boolean | null;
       useWebAnalyticsPreAggregatedTables?: boolean | null;
     }
 


### PR DESCRIPTION
## Problem

Third piece of the retention pre-aggregation stack (on top of the table + materialisation PRs). This is where the pre-agg actually serves queries — reading `retention_actor` instead of scanning events, behind a conservative routing gate and an off-by-default modifier.

## Changes

- **`retention_actor_read.py`** — produces a base query in the same shape the legacy fixed-interval builder emits, but reads one row per actor: `groupUniqArrayMerge(active_days)` → map each absolute day-number back to a date (`Date + toIntervalDay`, since `toDate` has no integer overload in HogQL) → truncate to the query interval → reuse as both the start and return interval set. It reuses the legacy builder's `start_interval_index` / `intervals_from_base` / `date_range` helpers verbatim, so the retention matrix matches the raw path. The cohort anchor is `arrayMin(active_days)` — because the horizon cap is taken from the actor's first day, that first day is always in the set, so this is the exact all-history first occurrence.
- **Routing gate** (`should_use_retention_preagg` + dispatch in `_base_query`): only takes the pre-agg path for first-occurrence retention, page-view/all-events, person retention, no property/test-account filters, no property-aggregation or minimum-occurrences, and lookahead within the horizon. Anything else — or a not-yet-materialised team — falls through to raw, which is always correct.
- **`useRetentionPreAggregation`** HogQL modifier, off by default; regenerated into `schema.py` / `schema.json`.

Still off in production: nothing enables the modifier yet. Person-merge handling and the property-filter allow-list are later pieces.

## How did you test this code?

I'm an agent. Automated tests only.

`test_retention_actor_read.py` (4 passing): asserts **byte-identical** count matrices between the raw and pre-agg paths for first-time × day, first-ever × day, and first-time × week, plus a gate-off check. Ran a 17-test subset of the existing raw retention suite — all pass (the gate is off by default, so the raw path is unchanged).

Note: full parity matrix (non-UTC team, month interval, person-merge) and person-merge correctness are the next PRs in the stack.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Reused the existing fixed-interval builder's interval machinery so the matrix shape is identical to raw by construction. Surfaced and worked around a HogQL limitation while building: `toDate` has no integer overload, so absolute day-numbers are converted back to dates via `Date + toIntervalDay`. Cohort derivation uses `arrayMin(active_days)` rather than the stored `first_seen` minState — equivalent for the in-scope shapes given the horizon cap, and avoids a timezone round-trip; `first_seen` is reserved for the upcoming merge-resolution work.

Requires human review; not for self-merge.
