### PR TITLE
chore(llma): clarify file path param naming in skill-store skills

### DIFF
--- a/products/ai_observability/skills/skills-store/SKILL.md
+++ b/products/ai_observability/skills/skills-store/SKILL.md
@@ -25,6 +25,7 @@ PostHog is the primary store for team-shared skills — always use the PostHog M
 | `posthog:llma-skill-file-delete` | Remove one bundled file from a skill                       |
 | `posthog:llma-skill-file-rename` | Rename one bundled file (move without rewriting content)   |
 | `posthog:llma-skill-duplicate`   | Duplicate an existing skill under a new name               |
+| `posthog:llma-skill-archive`     | Archive all versions of a skill by name (cannot be undone) |
 
 Skills use progressive disclosure: discover by description, fetch the body only when relevant, and pull individual files on demand. Do not fetch every file eagerly.
 
@@ -165,6 +166,16 @@ posthog:llma-skill-update
 
 Non-targeted files carry forward unchanged. `file_edits` cannot add, remove, or rename files — use the per-file tools below for that.
 
+### File-path parameter naming
+
+The file-path parameter has two names depending on where it sits in the request, so don't guess:
+
+- **`file_path`** — `llma-skill-file-get` and `llma-skill-file-delete` (the path is part of the URL).
+- **`path`** — `llma-skill-file-create`, plus the `files=[{path, …}]` array and `file_edits=[{path, …}]` (body fields on a file object).
+- **`old_path` / `new_path`** — `llma-skill-file-rename`.
+
+Passing `path` to file-get produces a `/files/undefined/` 404. When in doubt, check the tool's input schema.
+
 ### Adding, removing, or renaming a file
 
 Atomic per-file tools — each publishes a new version and returns the updated skill (read its `version` to chain further edits via `base_version`):
@@ -187,6 +198,15 @@ posthog:llma-skill-file-rename
 ### Replacing the whole bundle (rare)
 
 Passing `files` to `llma-skill-update` replaces ALL bundled files — anything not in the array is dropped. Only use this when you intentionally want to wipe and reseed the bundle. For everything else, prefer `file_edits` or the per-file CRUD tools above.
+
+## Archiving a skill
+
+`llma-skill-archive` hides every active version of a skill by name. It cannot be undone — the skill disappears from `llma-skill-list` and `llma-skill-get` for the whole team. Use it to retire a skill entirely; to remove a single file use `llma-skill-file-delete`, and to roll back content publish a new version instead.
+
+```json
+posthog:llma-skill-archive
+{ "skill_name": "make-fractals" }
+```
 
 ## Porting a local skill
 

--- a/products/ai_observability/skills/working-with-skills/SKILL.md
+++ b/products/ai_observability/skills/working-with-skills/SKILL.md
@@ -60,6 +60,9 @@ Editing an existing skill?
 
 Want a fork as the starting point?
   └─► llma-skill-duplicate               (then update the copy)
+
+Done with a skill entirely?
+  └─► llma-skill-archive                 (hides ALL versions; cannot be undone)
 ```
 
 If you find yourself reaching for `update(body=...)` plus a sprawling `files=[...]`
@@ -230,6 +233,24 @@ posthog:llma-skill-update
 }
 ```
 
+### File-path parameter naming (read this before guessing)
+
+The same concept — a bundled file's path — is named differently depending on
+**where it travels in the request**, and this trips up agents working from
+memory. There is one rule:
+
+- **`file_path`** — when the path is part of the **URL** (`llma-skill-file-get`,
+  `llma-skill-file-delete`). These read/delete one file addressed by its path.
+- **`path`** — when the path is a **body field**: `llma-skill-file-create`, the
+  `files=[{path, content, content_type}]` array, and `file_edits=[{path, edits}]`.
+- **`old_path` / `new_path`** — body fields on `llma-skill-file-rename`.
+
+Mnemonic: `path` is the field name on a file *object* (it sits next to
+`content`), so everything that carries a file object uses `path`; the two
+tools that address a file by URL use `file_path`. When unsure, check the
+tool's input schema rather than guessing — passing `path` to file-get yields a
+`/files/undefined/` 404.
+
 ### Adding, removing, renaming files
 
 Each is its own call, each publishes a new version:
@@ -317,6 +338,26 @@ Skipping `base_version` does _not_ speed things up — it just turns a clean
   into `references/` and `scripts/` rather than letting it grow.
 - **Mixing `body` and `edits` in one update call** — they're mutually exclusive.
   Pick one.
+- **Guessing `path` vs `file_path`** — file-get and file-delete take `file_path`
+  (it's in the URL); create, rename (`old_path`/`new_path`), `files`, and
+  `file_edits` take `path` (it's a body field). See "File-path parameter
+  naming" above.
+
+## Archiving a skill
+
+`llma-skill-archive` hides **every** active version of a skill by name. It is
+not version-scoped and **cannot be undone** — the skill drops out of
+`llma-skill-list` and `llma-skill-get` for the whole team.
+
+```json
+posthog:llma-skill-archive
+{ "skill_name": "my-skill" }
+```
+
+Before archiving, `llma-skill-get` the skill if you need to inspect or copy it
+first. Archiving is the right tool for retiring a skill entirely; to remove a
+single bundled file use `llma-skill-file-delete`, and to roll back content
+publish a new version rather than archiving.
 
 ## Porting a local SKILL.md tree into PostHog
 

--- a/products/ai_observability/skills/working-with-skills/SKILL.md
+++ b/products/ai_observability/skills/working-with-skills/SKILL.md
@@ -245,7 +245,7 @@ memory. There is one rule:
   `files=[{path, content, content_type}]` array, and `file_edits=[{path, edits}]`.
 - **`old_path` / `new_path`** — body fields on `llma-skill-file-rename`.
 
-Mnemonic: `path` is the field name on a file *object* (it sits next to
+Mnemonic: `path` is the field name on a file _object_ (it sits next to
 `content`), so everything that carries a file object uses `path`; the two
 tools that address a file by URL use `file_path`. When unsure, check the
 tool's input schema rather than guessing — passing `path` to file-get yields a


### PR DESCRIPTION
## Problem

Agents authoring and maintaining PostHog LLM analytics skills via the `llma-skill-*` MCP tools kept getting the bundled-file path parameter wrong — passing `path` to `llma-skill-file-get` yields a `/files/undefined/` 404. The two skills that document this surface (`skills-store`, `working-with-skills`) didn't explain *why* the name differs between tools, so agents guessed from memory and got it wrong repeatedly.

The split is real but it's a REST artifact, not a bug:

- `file_path` — on `llma-skill-file-get` / `llma-skill-file-delete`, where the path is a **URL segment**.
- `path` — on `llma-skill-file-create`, the `files=[{path, …}]` array, and `file_edits=[{path, …}]`, where it's a **body field** on a file object (sitting next to `content`).
- `old_path` / `new_path` — body fields on `llma-skill-file-rename`.

Separately, `llma-skill-archive` is an enabled MCP tool that **neither** skill documented.

## Changes

Documentation-only, no API change:

- Added an explicit "file-path parameter naming" section to both skills stating the `path` vs `file_path` rule, with the mnemonic (anything carrying a file *object* uses `path`; the two tools that address a file by URL use `file_path`) and the `/files/undefined/` 404 failure mode.
- Documented `llma-skill-archive` — added it to the `skills-store` tool table and the `working-with-skills` decision tree, plus a short "Archiving a skill" section in each noting it hides all versions and cannot be undone.

The underlying API was left unchanged: the param names are already explicit in each tool's generated input schema, the names follow correct REST conventions, and `path` is already the dominant name (file object, manifest, create, `file_edits`). Unifying the API on `path` (renaming the URL capture group on get/delete) remains a possible follow-up but is a generated-client behavior change, so it was deliberately scoped out of this docs fix.

## How did you test this code?

I'm an agent. No automated tests apply to these markdown skill files (the only checked-in copies are the source `SKILL.md` files edited here; there is no generated artifact to resync, and the `services/mcp` generated-tools test is unaffected). Verified the param-name claims against the source of truth — the `LLMSkillViewSet` URL patterns and serializers in `products/ai_observability/backend/api/` and the generated MCP tool in `services/mcp/src/tools/generated/ai_observability.ts`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by PostHog Code (Claude) in response to a support thread where an agent repeatedly guessed the wrong file-path parameter name when maintaining LLM analytics skills.

Investigated end-to-end before changing anything: confirmed the two skill docs were already internally consistent and matched the API, traced the `path`/`file_path` split to the REST design (URL segment vs body field), and found `llma-skill-archive` was an enabled-but-undocumented tool. Considered three cleanup options — (A) unify the API on `path`, (B) unify on `file_path`, (C) document the split — and chose C as the lowest-risk fix that addresses the actual failure mode (agents guessing rather than reading schemas), with A noted as an optional follow-up. Rejected B because it would force the file-object key to `file_path` everywhere and create more internal inconsistency.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
