### PR TITLE
chore(user_interviews): own by individuals, stop tagging team-growth

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -198,6 +198,9 @@ tools/phrocs/ @PostHog/team-devex
 greptile.json @PostHog/team-devex
 docs/published/developing-locally.md @PostHog/team-devex
 
+# User interviews - owned by individuals (no team); product.yaml only auto-assigns team slugs
+products/user_interviews/** @pauldambra @fivestarspicy @ksvat
+
 # OpenAPI / drf-spectacular tooling - owned by @PostHog/team-devex
 posthog/api/documentation.py @PostHog/team-devex
 posthog/api/mixins.py @PostHog/team-devex

--- a/products/user_interviews/product.yaml
+++ b/products/user_interviews/product.yaml
@@ -1,3 +1,9 @@
 name: User interviews
+# Individual owners (not a team) — quoted because YAML disallows a plain scalar
+# starting with `@`. The assign-reviewers script soft-assigns these via CODEOWNERS-soft;
+# product.yaml only treats team slugs as auto-reviewers, so listing people here keeps
+# `owners` valid and documents ownership without tagging an unrelated team.
 owners:
-    - team-growth
+    - '@pauldambra'
+    - '@fivestarspicy'
+    - '@ksvat'


### PR DESCRIPTION
## Problem

Every PR touching `products/user_interviews/**` soft-tags **team-growth** for review, even though they don't own the product. The cause: `products/user_interviews/product.yaml` lists `owners: [team-growth]` — set in a bulk ownership-scaffold PR (#55428), not a deliberate choice. The auto-assigner (`.github/scripts/assign-reviewers.js`) turns each `product.yaml` owner slug into `@PostHog/<slug>` and requests review from it.

## Changes

- `products/user_interviews/product.yaml` — replace `team-growth` with the actual individual owners (`@pauldambra`, `@fivestarspicy`, `@ksvat`). Both the `product:lint:owners` check and the assigner explicitly treat `@`-prefixed entries as individuals, not teams, so **no team is auto-assigned**. `owners` stays a non-empty list of strings, so the product.yaml schema check still passes.
- `.github/CODEOWNERS-soft` — add `products/user_interviews/** @pauldambra @fivestarspicy @ksvat`. This is the surface the assigner uses to soft-tag individuals (the `product.yaml` path only auto-assigns team slugs), so these three become the soft reviewers instead of team-growth.

Net effect: user-interviews PRs soft-tag the three named individuals; team-growth is no longer pulled in.

## How did you test this code?

I'm an agent. Validated locally:

- Re-implemented the assigner's `parseOwnersFromProductYaml` against the new `product.yaml`: parses to `["@pauldambra","@fivestarspicy","@ksvat"]`, and the team-assignment filter yields `[]` — confirming no team is auto-requested.
- Confirmed the product.yaml schema check requires only a non-empty list of strings (satisfied) and that the owners-lint and assigner both skip `@`-prefixed entries.

No code paths changed — this is ownership/config only.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

Authored by PostHog Code, prompted by the observation that interview PRs kept tagging team-growth. Traced the mechanism through `assign-reviewers.js` (`loadProductYamlRules` → `@PostHog/<slug>`, skips `@`-prefixed) and the hogli `ProductYamlOwnersCheck` (tolerates `@username` as individuals). Chose to keep `owners` populated with the individuals (rather than delete it, which fails the required-field schema check) and route actual assignment through CODEOWNERS-soft, matching how the two sources are intended to divide team-vs-individual ownership.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
