### PR TITLE
fix(sharing): stub embed preview iframe in storybook snapshots

### DIFF
--- a/common/storybook/.storybook/test-runner.ts
+++ b/common/storybook/.storybook/test-runner.ts
@@ -102,6 +102,14 @@ const VIEWPORT_SETTLE_TIMEOUT_MS = 5000
 
 const ATTEMPT_COUNT_PER_ID: Record<string, number> = {}
 
+// Sharing/embed stories render a preview iframe pointing at the shared/embedded URL, which Storybook
+// can't serve, so it 404s to a browser error page whose rendering is browser-version-dependent (and so
+// produces noisy, non-deterministic snapshots). Stub those navigations with a fixed page.
+// Yellow background with default black text keeps the stub legible and obviously intentional in both
+// light and dark snapshot themes; color-scheme:light stops the browser dark-inverting the page.
+const EMBED_STUB_HTML =
+    '<!doctype html><meta charset="utf-8"><title>mock iframe</title><body style="color-scheme:light;background:#ffeb3b;margin:0">mock iframe</body>'
+
 module.exports = {
     setup() {
         expect.extend({ toMatchImageSnapshot })
@@ -110,6 +118,9 @@ module.exports = {
     },
 
     async preVisit(page, context) {
+        await page.route(/\/(embedded|shared)\//, (route) =>
+            route.fulfill({ status: 200, contentType: 'text/html', body: EMBED_STUB_HTML })
+        )
         const storyContext = await getStoryContext(page, context)
         const { viewport, viewportWidths } = storyContext.parameters?.testOptions ?? {}
         applyStoryTimeouts(page, viewportWidths)

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1301,17 +1301,17 @@ snapshots:
     components-sharing--dashboard-sharing-licensed--light:
         hash: v1.k794b7964.244e6ca15f231ef475496ee62d78fdfd26e0517880d2c8706a6f3f31c919e2a3.b2vHHk5hgXVUXqtpKW5DA3YaVqYN8svhFFhYHUi4C8w
     components-sharing--insight-sharing--dark:
-        hash: v1.k794b7964.c2e2bc39e2e4ee4fe620a84f8f6370fd827d8525ced7a15aba3ca9c049fc821a.9BfB7wnWhrE7pzLmSIV5drdOKJiSBuIT12WBvQwiKAk
+        hash: v1.k794b7964.b76d99677ad35441bed697fc944fa313a129fbf7e087fa825d56e83cf115e37d.BmbO-Rl7VAkVCn5Qu9p703I3J_eS-HbW44HHoedLXXU
     components-sharing--insight-sharing--light:
-        hash: v1.k794b7964.224d276fcd4728560f86a4829e858a086e97d00e356443034fb24bca6831729a.UJVIrPNAyOv6Wu4H14_LBF_0KkiuCIWOwJj5jkX7Mkk
+        hash: v1.k794b7964.cdfbfd1e8e7f23cc21d72124a0735b904c5b1d82500848260a601c9ef43da5d4.QeFWoouebIQeolRm8IVji2eHxxc16ye7I_ddA3D_RS4
     components-sharing--insight-sharing-licensed--dark:
-        hash: v1.k794b7964.c9aaae9370d15752ec09711146e2772db631ca64b579d554ed9d6514e0076e8e.Odh8HJvbRJX-GIo7K-fFP9a_SDCCpd1fNeMvBkL1a20
+        hash: v1.k794b7964.d31ce8cab1fdfea5351ae0966deecd1b5aeb3f6113b561a08d607efd2a2a30b2.eh2JEQzCKeWmV0ElA4Z7ARblDqtWMF2VNdUTz70cD_8
     components-sharing--insight-sharing-licensed--light:
-        hash: v1.k794b7964.59b46a6257a841f4b1d0eaa6d4e359e1e161a2f6a7053c3d6dc2b72eca34a8f9.j12bn9C6w4XhUoVkjGauGr30dEDh2ZrMq-gaCpbgorg
+        hash: v1.k794b7964.babc7dff95b18239fc429733e717d9b469b55304222edabf6890b202bd5a3f75.BtiiUo6n50whHnBG30BI6zw5j3thnFdnq9RYJqT_-i4
     components-sharing--recording-sharing-licensed--dark:
-        hash: v1.k794b7964.7a68564dcf119200b16c028826b1c185f0488f6927fd7f272ad7a6c8e25ffaa2.TDgXX_lmIivgwrDRXPA7SUO3TSiCLkev4ttYQTpboiQ
+        hash: v1.k794b7964.51cbbaf0fc021a2b1b6a958c86aac9552cf416284578013cebf588db847744a3.-kTEDvju2zH1YGEuPTb6FOtlGQ1PcoXOYuIrIaPAK7o
     components-sharing--recording-sharing-licensed--light:
-        hash: v1.k794b7964.4098b6d71afac9df56e9ced5fff64f93061bf15f1ec202547b8df95320300417.Qla56nlJ3kyQ8upt_6JH0DlLtFCc8kNYyZYN0e5391s
+        hash: v1.k794b7964.346704155419478fe5d7a4f91c20f581582cdc7a0f171da6a248bd88b7cce13c.FBW3MvZx9uaB72cb_zINeWYmxxkiOxhb8OpKfHXBuVE
     components-sparkline--bar-chart--dark:
         hash: v1.k794b7964.cb1d1d3239f78521823c1278cadb102e136422579a910c3a691c2b6b17ebb962.aj9xFX3wR7NQKuqnk4Tgypbsd2Ase4rHeCGuKjORB3w
     components-sparkline--bar-chart--light:
@@ -3911,9 +3911,9 @@ snapshots:
     replay-sharing--private-link--light:
         hash: v1.k794b7964.89afc93d038fc145c7bf3d2b24d9330627a19f19e891a6d7c6029768def56c98.Youc9RhrA6JKKnW1E9dss6s5Aq6VYP_zz2Gzpn1rfhY
     replay-sharing--public-link--dark:
-        hash: v1.k794b7964.5d6fb188942a8d9a8021e9ee9694e9eba6e322e9212be1a3009065aee87a5141.9ZmXbt6GmYAbERF78QIA8-3cgFQNnosBG4NRN9-a8Uk
+        hash: v1.k794b7964.e525359d55f191cddfaf050e4c4c643918272b56f70a1ceff0eddef8421bae8f.r5_Rt6wC8fkrN3WDopwzVyuOiZKou17pa7b6BpSFS0Q
     replay-sharing--public-link--light:
-        hash: v1.k794b7964.ed6bc7222b1c2cb6bd031d14fe4d6cbea273c49393ee02a3bfcfd9a8e1ffaea3.AQwyCpN1KUyIt7xOD2Nd6BokSideDu-UZM_x8cstNLU
+        hash: v1.k794b7964.f07a8a73e57e813eadfcb39a775ccdd9a1139487be5230dd3d282788c9c44277.vcpAhP8Yag3LRdLbwbXgiIdVRMmMQyGY9VZ8sW4iApk
     replay-tabs-collections--recordings-play-lists--dark:
         hash: v1.k794b7964.fa065688a8b2b1fb7b01210f2d5ecb71abae8317bcdc648ae22b07409a3036a1.F6uTGNycPQ5Apzjv26Cbp6PF5SqfCzFcE_bg-AFL148
     replay-tabs-collections--recordings-play-lists--light:
@@ -4875,7 +4875,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.gaL7vRk-pWoOUkiPi-NGCd1W72x-M5l9jk5Qu-UcjwI
+        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
@@ -4889,7 +4889,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
         hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.O7SwG4Drfr3z02hcLNC1LsLsGWddouhybBp4xZaUE-A
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
-        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.EIwByuofuT77yP259A9ffqfjSFwW9MrUDOvsZNA_aZM
+        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.KSiw8WpvjWXIDh87ExL4cPnopVJlTXvzU8N8ruh6Hi8
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
         hash: v1.k794b7964.d64808d2bfc36017f89b57feeaa373e20188738a622801207fa1beb59d02fdd9.cFuKF_Ow887Z3X3BoNhtTvkUWY2vips9HDBe-B02eQE
     scenes-app-insights-funnels--funnel-time-to-convert--light:

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -451,7 +451,7 @@ export function SharingModalContent({
                                                         ) : null}
                                                     </LemonButton>
                                                     {showPreview && (
-                                                        <div className="SharingPreview border-t bg-primary">
+                                                        <div className="SharingPreview border-t">
                                                             <iframe
                                                                 className="block"
                                                                 {...iframeProperties}


### PR DESCRIPTION
## Problem

The share dialogs (recording, insight, dashboard) render a preview iframe pointing at the shared/embedded URL. In Storybook, that route isn't served, so the iframe navigates to a browser **"Cannot GET /embedded/..."** error page. That error document has no background of its own, so its backdrop follows the browser's `color-scheme: light dark` default, which **changed between Chromium versions** (newer Chromium renders it light, older rendered it dark).

The result: visual-regression snapshots for the sharing stories (e.g. `components-sharing--recording-sharing-licensed--dark`, `replay-sharing--public-link--dark`) flip light/dark purely on the bundled browser version, producing noisy non-deterministic diffs. This surfaced during a Playwright/Chromium bump, where ~all sharing-preview snapshots changed.

This is **Storybook-only** — in the real app, `/embedded/<token>` serves the actual exporter, which paints its own themed background.

## Changes

- Stub `/embedded/` and `/shared/` navigations in the storybook test-runner's `preVisit` with a fixed HTML page, so the preview iframe renders deterministic content regardless of browser version.
- Revert the earlier `bg-primary` on the `.SharingPreview` container (added in #60774). It can't fix this: the iframe loads a document that paints its own background over any container color, so the container background is never visible once content loads.

A `page.route` stub is required rather than an MSW request mock — MSW's service worker does not intercept the iframe's top-level document navigation (verified), only fetch/XHR.

## How did you test this code?

I am an agent (Claude Code). Verified at the Playwright level against a locally-served Storybook on Chromium 1.60:

- **Before:** probed `components-sharing--recording-sharing-licensed` in dark mode — the preview iframe's document read `Cannot GET /embedded/...` on a white background (screenshotted).
- **After:** registered the same `page.route(/\/(embedded|shared)\//)` stub used in `preVisit` and re-probed — the iframe document now reads `MOCK`, deterministic and not browser-dependent.
- Confirmed the route regex matches `/embedded/<token>` and `/shared/<token>` but **not** `/iframe.html` (Storybook's own frame) or the `/api/.../sharing` config endpoint.
- `oxlint` clean on both changed files.

The real snapshot update happens in CI (the visual-regression job regenerates and the diff goes through Visual Review); the affected sharing stories should become stable there.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes (test-infra + small UI revert).

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) on Robbie's behalf.

Investigation chain: a Playwright bump (#60771) flipped the recording/replay share-preview snapshots dark→light. An earlier attempt (#60774) added `bg-primary` to the preview container, but that was ineffective — confirmed by rendering the actual story and reading the iframe's loaded document, which turned out to be Storybook's white "Cannot GET" error page, not an empty/transparent iframe. The container background can't cover a loaded document, and MSW request mocks don't intercept iframe document navigations, so the fix is a Playwright `page.route` stub in the test-runner plus reverting the dead `bg-primary`.
