### PR TITLE
feat(replay): pin a primary property from the session replay inspector

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3048,6 +3048,9 @@ const api = {
             const params = names && names.length > 0 ? toParams({ names }, true) : ''
             return new ApiRequest().eventDefinitions().withAction('primary_properties').withQueryString(params).get()
         },
+        async byName({ name }: { name: string }): Promise<EventDefinition> {
+            return new ApiRequest().eventDefinitions().withAction('by_name').withQueryString(toParams({ name })).get()
+        },
         async getMetrics({
             eventDefinitionId,
         }: {

--- a/frontend/src/lib/components/SimpleKeyValueList.tsx
+++ b/frontend/src/lib/components/SimpleKeyValueList.tsx
@@ -1,5 +1,5 @@
 // A React component that renders a list of key-value pairs in a simple way.
-import { ReactNode, useMemo } from 'react'
+import { ReactNode, useMemo, useState } from 'react'
 
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
@@ -19,10 +19,40 @@ export interface SimpleKeyValueListProps {
     promotedKeys?: string[]
     sortItems?: boolean
     /**
-     * Optional action rendered at the end of each row. Revealed on row hover so it stays out of the
-     * way until needed (the action itself decides whether to also show when not hovered).
+     * Optional action rendered at the end of each row. The second argument is whether the row is
+     * currently hovered, so the action can reveal itself on hover without reaching for a CSS class.
      */
-    rowActions?: (key: string) => ReactNode
+    rowActions?: (key: string, isRowHovered: boolean) => ReactNode
+}
+
+function SimpleKeyValueRow({
+    name,
+    value,
+    rowActions,
+}: {
+    name: string
+    value: any
+    rowActions?: (key: string, isRowHovered: boolean) => ReactNode
+}): JSX.Element {
+    const [isHovered, setIsHovered] = useState(false)
+    const isComplexStructure = Array.isArray(value) || isObject(value)
+    return (
+        <div
+            className="flex gap-4 items-start justify-between overflow-hidden"
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+        >
+            <span className="font-semibold flex items-center gap-1 min-w-0">
+                <PropertyKeyInfo value={name} />
+                {rowActions ? rowActions(name, isHovered) : null}
+            </span>
+            {isComplexStructure ? (
+                <JSONViewer src={value} collapsed={1} />
+            ) : (
+                <pre className="text-primary-alt break-all mb-0">{String(value)}</pre>
+            )}
+        </div>
+    )
 }
 
 export function SimpleKeyValueList({
@@ -64,22 +94,9 @@ export function SimpleKeyValueList({
     return (
         <div className="text-xs deprecated-space-y-1 max-w-full">
             {header}
-            {sortedItemsPromotedFirst.map(([key, value]) => {
-                const isComplexStructure = Array.isArray(value) || isObject(value)
-                return (
-                    <div key={key} className="group/kv-row flex gap-4 items-start justify-between overflow-hidden">
-                        <span className="font-semibold flex items-center gap-1 min-w-0">
-                            <PropertyKeyInfo value={key} />
-                            {rowActions ? rowActions(key) : null}
-                        </span>
-                        {isComplexStructure ? (
-                            <JSONViewer src={value} collapsed={1} />
-                        ) : (
-                            <pre className="text-primary-alt break-all mb-0">{String(value)}</pre>
-                        )}
-                    </div>
-                )
-            })}
+            {sortedItemsPromotedFirst.map(([key, value]) => (
+                <SimpleKeyValueRow key={key} name={key} value={value} rowActions={rowActions} />
+            ))}
             {Object.keys(item).length === 0 && emptyMessage}
         </div>
     )

--- a/frontend/src/lib/components/SimpleKeyValueList.tsx
+++ b/frontend/src/lib/components/SimpleKeyValueList.tsx
@@ -18,6 +18,11 @@ export interface SimpleKeyValueListProps {
      */
     promotedKeys?: string[]
     sortItems?: boolean
+    /**
+     * Optional action rendered at the end of each row. Revealed on row hover so it stays out of the
+     * way until needed (the action itself decides whether to also show when not hovered).
+     */
+    rowActions?: (key: string) => ReactNode
 }
 
 export function SimpleKeyValueList({
@@ -26,6 +31,7 @@ export function SimpleKeyValueList({
     promotedKeys,
     header,
     sortItems = true,
+    rowActions,
 }: SimpleKeyValueListProps): JSX.Element {
     const sortedItemsPromotedFirst = useMemo(() => {
         const sortedItems = sortItems
@@ -61,9 +67,10 @@ export function SimpleKeyValueList({
             {sortedItemsPromotedFirst.map(([key, value]) => {
                 const isComplexStructure = Array.isArray(value) || isObject(value)
                 return (
-                    <div key={key} className="flex gap-4 items-start justify-between overflow-hidden">
-                        <span className="font-semibold">
+                    <div key={key} className="group/kv-row flex gap-4 items-start justify-between overflow-hidden">
+                        <span className="font-semibold flex items-center gap-1 min-w-0">
                             <PropertyKeyInfo value={key} />
+                            {rowActions ? rowActions(key) : null}
                         </span>
                         {isComplexStructure ? (
                             <JSONViewer src={value} collapsed={1} />

--- a/frontend/src/models/primaryEventPropertiesModel.test.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.test.ts
@@ -1,0 +1,80 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { primaryEventPropertiesModel } from '~/models/primaryEventPropertiesModel'
+import { initKeaTests } from '~/test/init'
+
+describe('the primary event properties model', () => {
+    let logic: ReturnType<typeof primaryEventPropertiesModel.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/event_definitions/primary_properties/': () => [
+                    200,
+                    { primary_properties: { my_event: 'existing_prop' } },
+                ],
+                '/api/projects/:team_id/event_definitions/by_name/': () => [200, { id: 'def-1', name: 'my_event' }],
+            },
+            patch: {
+                '/api/projects/:team_id/event_definitions/:id/': (req) => [
+                    200,
+                    {
+                        id: 'def-1',
+                        name: 'my_event',
+                        primary_property: (req.body as Record<string, any>).primary_property,
+                    },
+                ],
+            },
+        })
+        initKeaTests()
+        logic = primaryEventPropertiesModel()
+        logic.mount()
+    })
+
+    it('only loads team overrides for events without a taxonomy default', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.ensureLoadedForEvents(['my_event', '$pageview'])
+        })
+            .toDispatchActions(['loadPrimaryPropertiesSuccess'])
+            .toMatchValues({
+                primaryProperties: { my_event: 'existing_prop' },
+                loadedEventNames: ['my_event'],
+            })
+    })
+
+    it('optimistically applies the pin and keeps it when the request succeeds', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setPrimaryProperty('my_event', 'chosen_prop')
+        })
+            .toDispatchActions([
+                'setPrimaryProperty',
+                logic.actionCreators.applyOptimisticPrimaryProperty('my_event', 'chosen_prop'),
+                'finishSavingPrimaryProperty',
+            ])
+            .toMatchValues({
+                primaryProperties: { my_event: 'chosen_prop' },
+                savingPrimaryPropertyForEvents: [],
+            })
+    })
+
+    it('reverts the pin when the request fails', async () => {
+        useMocks({
+            patch: { '/api/projects/:team_id/event_definitions/:id/': () => [403, { detail: 'nope' }] },
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.setPrimaryProperty('my_event', 'chosen_prop')
+        })
+            .toDispatchActions([
+                'setPrimaryProperty',
+                logic.actionCreators.applyOptimisticPrimaryProperty('my_event', 'chosen_prop'),
+                logic.actionCreators.applyOptimisticPrimaryProperty('my_event', null),
+                'finishSavingPrimaryProperty',
+            ])
+            .toMatchValues({
+                primaryProperties: {},
+                savingPrimaryPropertyForEvents: [],
+            })
+    })
+})

--- a/frontend/src/models/primaryEventPropertiesModel.test.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.test.ts
@@ -84,6 +84,20 @@ describe('the primary event properties model', () => {
             })
     })
 
+    it('does not mark events as loaded when the load request fails, so they can be retried', async () => {
+        useMocks({
+            get: { '/api/projects/:team_id/event_definitions/primary_properties/': () => [500, {}] },
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.loadPrimaryProperties(['flaky_event'])
+        })
+            .toDispatchActions(['loadPrimaryProperties'])
+            .delay(0)
+
+        expect(logic.values.loadedEventNames).toEqual([])
+    })
+
     it('lets a later server refresh override a pinned value without a stale optimistic shadow', async () => {
         await expectLogic(logic, () => {
             logic.actions.setPrimaryProperty('my_event', 'chosen_prop')

--- a/frontend/src/models/primaryEventPropertiesModel.test.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.test.ts
@@ -51,6 +51,14 @@ describe('the primary event properties model', () => {
             .toMatchValues({ primaryProperties: { my_event: 'chosen_prop' } })
     })
 
+    it('reports loading while a pin update is in flight', async () => {
+        logic.actions.updatePrimaryProperty({ eventName: 'my_event', propertyKey: 'chosen_prop' })
+        expect(logic.values.primaryPropertiesLoading).toBe(true)
+
+        await expectLogic(logic).toDispatchActions(['updatePrimaryPropertySuccess'])
+        expect(logic.values.primaryPropertiesLoading).toBe(false)
+    })
+
     it('removes the entry when unpinned', async () => {
         logic.actions.loadPrimaryPropertiesSuccess({ my_event: 'existing_prop' }, { names: ['my_event'] })
 

--- a/frontend/src/models/primaryEventPropertiesModel.test.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.test.ts
@@ -98,6 +98,36 @@ describe('the primary event properties model', () => {
         expect(logic.values.loadedEventNames).toEqual([])
     })
 
+    it('a save completed during an in-flight refresh is not clobbered by the stale refresh result', async () => {
+        let releaseLoad: (() => void) | undefined
+        const loadGate = new Promise<void>((resolve) => {
+            releaseLoad = resolve
+        })
+        useMocks({
+            get: {
+                '/api/projects/:team_id/event_definitions/by_name/': () => [200, { id: 'def-1', name: 'my_event' }],
+                '/api/projects/:team_id/event_definitions/primary_properties/': async () => {
+                    await loadGate
+                    return [200, { primary_properties: {} }]
+                },
+            },
+        })
+
+        logic.actions.loadPrimaryProperties(['my_event'])
+        await expectLogic(logic).toDispatchActions(['loadPrimaryProperties'])
+
+        await expectLogic(logic, () => {
+            logic.actions.setPrimaryProperty('my_event', 'fresh')
+        }).toDispatchActions(['finishSavingPrimaryProperty'])
+        expect(logic.values.primaryProperties).toEqual({ my_event: 'fresh' })
+
+        releaseLoad?.()
+        await expectLogic(logic).delay(0)
+
+        expect(logic.values.primaryProperties).toEqual({ my_event: 'fresh' })
+        expect(logic.values.loadedPrimaryProperties).toEqual({ my_event: 'fresh' })
+    })
+
     it('lets a later server refresh override a pinned value without a stale optimistic shadow', async () => {
         await expectLogic(logic, () => {
             logic.actions.setPrimaryProperty('my_event', 'chosen_prop')

--- a/frontend/src/models/primaryEventPropertiesModel.test.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.test.ts
@@ -36,24 +36,28 @@ describe('the primary event properties model', () => {
         await expectLogic(logic, () => {
             logic.actions.ensureLoadedForEvents(['my_event', '$pageview'])
         })
-            .toDispatchActions(['loadPrimaryPropertiesSuccess'])
+            .toDispatchActions(['primaryPropertiesLoaded'])
             .toMatchValues({
                 primaryProperties: { my_event: 'existing_prop' },
                 loadedEventNames: ['my_event'],
             })
     })
 
-    it('optimistically applies the pin and keeps it when the request succeeds', async () => {
+    it('optimistically applies the pin and folds it into loaded state when the request succeeds', async () => {
         await expectLogic(logic, () => {
             logic.actions.setPrimaryProperty('my_event', 'chosen_prop')
         })
             .toDispatchActions([
                 'setPrimaryProperty',
                 logic.actionCreators.applyOptimisticPrimaryProperty('my_event', 'chosen_prop'),
+                logic.actionCreators.setLoadedPrimaryProperty('my_event', 'chosen_prop'),
+                'clearOptimisticPrimaryProperty',
                 'finishSavingPrimaryProperty',
             ])
             .toMatchValues({
                 primaryProperties: { my_event: 'chosen_prop' },
+                loadedPrimaryProperties: { my_event: 'chosen_prop' },
+                optimisticPrimaryProperties: {},
                 savingPrimaryPropertyForEvents: [],
             })
     })
@@ -69,12 +73,36 @@ describe('the primary event properties model', () => {
             .toDispatchActions([
                 'setPrimaryProperty',
                 logic.actionCreators.applyOptimisticPrimaryProperty('my_event', 'chosen_prop'),
-                logic.actionCreators.applyOptimisticPrimaryProperty('my_event', null),
+                'clearOptimisticPrimaryProperty',
                 'finishSavingPrimaryProperty',
             ])
             .toMatchValues({
                 primaryProperties: {},
+                loadedPrimaryProperties: {},
+                optimisticPrimaryProperties: {},
                 savingPrimaryPropertyForEvents: [],
             })
+    })
+
+    it('lets a later server refresh override a pinned value without a stale optimistic shadow', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setPrimaryProperty('my_event', 'chosen_prop')
+        }).toDispatchActions(['finishSavingPrimaryProperty'])
+        expect(logic.values.primaryProperties).toEqual({ my_event: 'chosen_prop' })
+
+        useMocks({
+            get: {
+                '/api/projects/:team_id/event_definitions/primary_properties/': () => [
+                    200,
+                    { primary_properties: { my_event: 'changed_elsewhere' } },
+                ],
+            },
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.loadPrimaryProperties(['my_event'])
+        }).toDispatchActions(['primaryPropertiesLoaded'])
+
+        expect(logic.values.primaryProperties).toEqual({ my_event: 'changed_elsewhere' })
     })
 })

--- a/frontend/src/models/primaryEventPropertiesModel.test.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.test.ts
@@ -98,6 +98,34 @@ describe('the primary event properties model', () => {
         expect(logic.values.loadedEventNames).toEqual([])
     })
 
+    it('reverts and does not attempt an update when the event definition lookup fails', async () => {
+        let updateAttempted = false
+        useMocks({
+            get: {
+                '/api/projects/:team_id/event_definitions/by_name/': () => [404, { detail: 'not found' }],
+            },
+            patch: {
+                '/api/projects/:team_id/event_definitions/:id/': () => {
+                    updateAttempted = true
+                    return [200, {}]
+                },
+            },
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.setPrimaryProperty('missing_event', 'some_prop')
+        }).toDispatchActions([
+            'setPrimaryProperty',
+            logic.actionCreators.applyOptimisticPrimaryProperty('missing_event', 'some_prop'),
+            'clearOptimisticPrimaryProperty',
+            'finishSavingPrimaryProperty',
+        ])
+
+        expect(updateAttempted).toBe(false)
+        expect(logic.values.primaryProperties).toEqual({})
+        expect(logic.values.savingPrimaryPropertyForEvents).toEqual([])
+    })
+
     it('a save completed during an in-flight refresh is not clobbered by the stale refresh result', async () => {
         let releaseLoad: (() => void) | undefined
         const loadGate = new Promise<void>((resolve) => {

--- a/frontend/src/models/primaryEventPropertiesModel.test.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.test.ts
@@ -36,74 +36,48 @@ describe('the primary event properties model', () => {
         await expectLogic(logic, () => {
             logic.actions.ensureLoadedForEvents(['my_event', '$pageview'])
         })
-            .toDispatchActions(['primaryPropertiesLoaded'])
+            .toDispatchActions(['loadPrimaryPropertiesSuccess'])
             .toMatchValues({
                 primaryProperties: { my_event: 'existing_prop' },
                 loadedEventNames: ['my_event'],
             })
     })
 
-    it('optimistically applies the pin and folds it into loaded state when the request succeeds', async () => {
+    it('folds the API response into the loaded map when a pin succeeds', async () => {
         await expectLogic(logic, () => {
-            logic.actions.setPrimaryProperty('my_event', 'chosen_prop')
+            logic.actions.updatePrimaryProperty({ eventName: 'my_event', propertyKey: 'chosen_prop' })
         })
-            .toDispatchActions([
-                'setPrimaryProperty',
-                logic.actionCreators.applyOptimisticPrimaryProperty('my_event', 'chosen_prop'),
-                logic.actionCreators.setLoadedPrimaryProperty('my_event', 'chosen_prop'),
-                'clearOptimisticPrimaryProperty',
-                'finishSavingPrimaryProperty',
-            ])
-            .toMatchValues({
-                primaryProperties: { my_event: 'chosen_prop' },
-                loadedPrimaryProperties: { my_event: 'chosen_prop' },
-                optimisticPrimaryProperties: {},
-                savingPrimaryPropertyForEvents: [],
-            })
+            .toDispatchActions(['updatePrimaryProperty', 'updatePrimaryPropertySuccess'])
+            .toMatchValues({ primaryProperties: { my_event: 'chosen_prop' } })
     })
 
-    it('reverts the pin when the request fails', async () => {
+    it('removes the entry when unpinned', async () => {
+        logic.actions.loadPrimaryPropertiesSuccess({ my_event: 'existing_prop' }, { names: ['my_event'] })
+
+        await expectLogic(logic, () => {
+            logic.actions.updatePrimaryProperty({ eventName: 'my_event', propertyKey: null })
+        })
+            .toDispatchActions(['updatePrimaryPropertySuccess'])
+            .toMatchValues({ primaryProperties: {} })
+    })
+
+    it('leaves the loaded map unchanged when the update request fails', async () => {
         useMocks({
             patch: { '/api/projects/:team_id/event_definitions/:id/': () => [403, { detail: 'nope' }] },
         })
+        logic.actions.loadPrimaryPropertiesSuccess({ my_event: 'existing_prop' }, { names: ['my_event'] })
 
         await expectLogic(logic, () => {
-            logic.actions.setPrimaryProperty('my_event', 'chosen_prop')
+            logic.actions.updatePrimaryProperty({ eventName: 'my_event', propertyKey: 'chosen_prop' })
         })
-            .toDispatchActions([
-                'setPrimaryProperty',
-                logic.actionCreators.applyOptimisticPrimaryProperty('my_event', 'chosen_prop'),
-                'clearOptimisticPrimaryProperty',
-                'finishSavingPrimaryProperty',
-            ])
-            .toMatchValues({
-                primaryProperties: {},
-                loadedPrimaryProperties: {},
-                optimisticPrimaryProperties: {},
-                savingPrimaryPropertyForEvents: [],
-            })
+            .toDispatchActions(['updatePrimaryProperty', 'updatePrimaryPropertySuccess'])
+            .toMatchValues({ primaryProperties: { my_event: 'existing_prop' } })
     })
 
-    it('does not mark events as loaded when the load request fails, so they can be retried', async () => {
-        useMocks({
-            get: { '/api/projects/:team_id/event_definitions/primary_properties/': () => [500, {}] },
-        })
-
-        await expectLogic(logic, () => {
-            logic.actions.loadPrimaryProperties(['flaky_event'])
-        })
-            .toDispatchActions(['loadPrimaryProperties'])
-            .delay(0)
-
-        expect(logic.values.loadedEventNames).toEqual([])
-    })
-
-    it('reverts and does not attempt an update when the event definition lookup fails', async () => {
+    it('does not attempt an update when the event definition lookup fails', async () => {
         let updateAttempted = false
         useMocks({
-            get: {
-                '/api/projects/:team_id/event_definitions/by_name/': () => [404, { detail: 'not found' }],
-            },
+            get: { '/api/projects/:team_id/event_definitions/by_name/': () => [404, { detail: 'not found' }] },
             patch: {
                 '/api/projects/:team_id/event_definitions/:id/': () => {
                     updateAttempted = true
@@ -113,68 +87,23 @@ describe('the primary event properties model', () => {
         })
 
         await expectLogic(logic, () => {
-            logic.actions.setPrimaryProperty('missing_event', 'some_prop')
-        }).toDispatchActions([
-            'setPrimaryProperty',
-            logic.actionCreators.applyOptimisticPrimaryProperty('missing_event', 'some_prop'),
-            'clearOptimisticPrimaryProperty',
-            'finishSavingPrimaryProperty',
-        ])
+            logic.actions.updatePrimaryProperty({ eventName: 'missing_event', propertyKey: 'some_prop' })
+        })
+            .toDispatchActions(['updatePrimaryProperty', 'updatePrimaryPropertySuccess'])
+            .toMatchValues({ primaryProperties: {} })
 
         expect(updateAttempted).toBe(false)
-        expect(logic.values.primaryProperties).toEqual({})
-        expect(logic.values.savingPrimaryPropertyForEvents).toEqual([])
     })
 
-    it('a save completed during an in-flight refresh is not clobbered by the stale refresh result', async () => {
-        let releaseLoad: (() => void) | undefined
-        const loadGate = new Promise<void>((resolve) => {
-            releaseLoad = resolve
-        })
+    it('does not mark events as loaded when the load request fails, so they can be retried', async () => {
         useMocks({
-            get: {
-                '/api/projects/:team_id/event_definitions/by_name/': () => [200, { id: 'def-1', name: 'my_event' }],
-                '/api/projects/:team_id/event_definitions/primary_properties/': async () => {
-                    await loadGate
-                    return [200, { primary_properties: {} }]
-                },
-            },
-        })
-
-        logic.actions.loadPrimaryProperties(['my_event'])
-        await expectLogic(logic).toDispatchActions(['loadPrimaryProperties'])
-
-        await expectLogic(logic, () => {
-            logic.actions.setPrimaryProperty('my_event', 'fresh')
-        }).toDispatchActions(['finishSavingPrimaryProperty'])
-        expect(logic.values.primaryProperties).toEqual({ my_event: 'fresh' })
-
-        releaseLoad?.()
-        await expectLogic(logic).delay(0)
-
-        expect(logic.values.primaryProperties).toEqual({ my_event: 'fresh' })
-        expect(logic.values.loadedPrimaryProperties).toEqual({ my_event: 'fresh' })
-    })
-
-    it('lets a later server refresh override a pinned value without a stale optimistic shadow', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.setPrimaryProperty('my_event', 'chosen_prop')
-        }).toDispatchActions(['finishSavingPrimaryProperty'])
-        expect(logic.values.primaryProperties).toEqual({ my_event: 'chosen_prop' })
-
-        useMocks({
-            get: {
-                '/api/projects/:team_id/event_definitions/primary_properties/': () => [
-                    200,
-                    { primary_properties: { my_event: 'changed_elsewhere' } },
-                ],
-            },
+            get: { '/api/projects/:team_id/event_definitions/primary_properties/': () => [500, {}] },
         })
 
         await expectLogic(logic, () => {
-            logic.actions.loadPrimaryProperties(['my_event'])
-        }).toDispatchActions(['primaryPropertiesLoaded'])
+            logic.actions.loadPrimaryProperties({ names: ['flaky_event'] })
+        }).toDispatchActions(['loadPrimaryPropertiesFailure'])
 
-        expect(logic.values.primaryProperties).toEqual({ my_event: 'changed_elsewhere' })
+        expect(logic.values.loadedEventNames).toEqual([])
     })
 })

--- a/frontend/src/models/primaryEventPropertiesModel.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.ts
@@ -139,14 +139,21 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
         setPrimaryProperty: async ({ eventName, propertyKey }) => {
             actions.applyOptimisticPrimaryProperty(eventName, propertyKey)
             try {
-                const definition = await api.eventDefinitions.byName({ name: eventName })
+                let definitionId: string
+                try {
+                    definitionId = (await api.eventDefinitions.byName({ name: eventName })).id
+                } catch (error) {
+                    posthog.captureException(error, { action: 'set-primary-property', stage: 'lookup' })
+                    lemonToast.error(`We couldn't find a definition for "${eventName}" yet. Please try again shortly.`)
+                    return
+                }
                 await api.eventDefinitions.update({
-                    eventDefinitionId: definition.id,
+                    eventDefinitionId: definitionId,
                     eventDefinitionData: { primary_property: propertyKey },
                 })
                 actions.setLoadedPrimaryProperty(eventName, propertyKey)
             } catch (error) {
-                posthog.captureException(error, { action: 'set-primary-property' })
+                posthog.captureException(error, { action: 'set-primary-property', stage: 'update' })
                 lemonToast.error('Could not update the pinned property. Please try again.')
             } finally {
                 actions.clearOptimisticPrimaryProperty(eventName)

--- a/frontend/src/models/primaryEventPropertiesModel.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.ts
@@ -1,4 +1,5 @@
 import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -73,6 +74,15 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
                 finishSavingPrimaryProperty: (state, { eventName }) => state.filter((name) => name !== eventName),
             },
         ],
+        primaryPropertySaveVersions: [
+            {} as Record<string, number>,
+            {
+                setLoadedPrimaryProperty: (state, { eventName }) => ({
+                    ...state,
+                    [eventName]: (state[eventName] ?? 0) + 1,
+                }),
+            },
+        ],
     }),
     selectors({
         primaryProperties: [
@@ -109,10 +119,22 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
             if (names.length === 0) {
                 return
             }
+            const versionsAtRequest = values.primaryPropertySaveVersions
             try {
                 const response = await api.eventDefinitions.primaryProperties({ names })
-                actions.primaryPropertiesLoaded(names, response.primary_properties)
-            } catch {}
+                const supersededBySave = (name: string): boolean =>
+                    (values.primaryPropertySaveVersions[name] ?? 0) !== (versionsAtRequest[name] ?? 0)
+                const namesToApply = names.filter((name) => !supersededBySave(name))
+                if (namesToApply.length === 0) {
+                    return
+                }
+                const propertiesToApply = Object.fromEntries(
+                    Object.entries(response.primary_properties).filter(([name]) => !supersededBySave(name))
+                )
+                actions.primaryPropertiesLoaded(namesToApply, propertiesToApply)
+            } catch (error) {
+                posthog.captureException(error, { action: 'load-primary-properties' })
+            }
         },
         setPrimaryProperty: async ({ eventName, propertyKey }) => {
             actions.applyOptimisticPrimaryProperty(eventName, propertyKey)
@@ -123,7 +145,8 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
                     eventDefinitionData: { primary_property: propertyKey },
                 })
                 actions.setLoadedPrimaryProperty(eventName, propertyKey)
-            } catch {
+            } catch (error) {
+                posthog.captureException(error, { action: 'set-primary-property' })
                 lemonToast.error('Could not update the pinned property. Please try again.')
             } finally {
                 actions.clearOptimisticPrimaryProperty(eventName)

--- a/frontend/src/models/primaryEventPropertiesModel.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.ts
@@ -49,7 +49,7 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
         loadedEventNames: [
             [] as string[],
             {
-                loadPrimaryProperties: (state, { names }) => Array.from(new Set([...state, ...names])),
+                primaryPropertiesLoaded: (state, { names }) => Array.from(new Set([...state, ...names])),
             },
         ],
         optimisticPrimaryProperties: [
@@ -109,8 +109,10 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
             if (names.length === 0) {
                 return
             }
-            const response = await api.eventDefinitions.primaryProperties({ names })
-            actions.primaryPropertiesLoaded(names, response.primary_properties)
+            try {
+                const response = await api.eventDefinitions.primaryProperties({ names })
+                actions.primaryPropertiesLoaded(names, response.primary_properties)
+            } catch {}
         },
         setPrimaryProperty: async ({ eventName, propertyKey }) => {
             actions.applyOptimisticPrimaryProperty(eventName, propertyKey)

--- a/frontend/src/models/primaryEventPropertiesModel.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.ts
@@ -1,5 +1,4 @@
 import { actions, kea, listeners, path, reducers, selectors } from 'kea'
-import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -12,30 +11,41 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
     actions({
         ensureLoadedForEvents: (eventNames: string[]) => ({ eventNames }),
         refreshLoadedPrimaryProperties: true,
+        loadPrimaryProperties: (names: string[]) => ({ names }),
+        primaryPropertiesLoaded: (names: string[], primaryProperties: Record<string, string>) => ({
+            names,
+            primaryProperties,
+        }),
         setPrimaryProperty: (eventName: string, propertyKey: string | null) => ({ eventName, propertyKey }),
         applyOptimisticPrimaryProperty: (eventName: string, propertyKey: string | null) => ({
             eventName,
             propertyKey,
         }),
+        clearOptimisticPrimaryProperty: (eventName: string) => ({ eventName }),
+        setLoadedPrimaryProperty: (eventName: string, propertyKey: string | null) => ({ eventName, propertyKey }),
         finishSavingPrimaryProperty: (eventName: string) => ({ eventName }),
     }),
-    loaders(({ values }) => ({
-        loadedPrimaryProperties: {
-            __default: {} as Record<string, string>,
-            loadPrimaryProperties: async ({ names }: { names: string[] }) => {
-                if (names.length === 0) {
-                    return values.loadedPrimaryProperties
-                }
-                const response = await api.eventDefinitions.primaryProperties({ names })
-                const next = { ...values.loadedPrimaryProperties }
-                for (const name of names) {
-                    delete next[name]
-                }
-                return { ...next, ...response.primary_properties }
-            },
-        },
-    })),
     reducers({
+        loadedPrimaryProperties: [
+            {} as Record<string, string>,
+            {
+                primaryPropertiesLoaded: (state, { names, primaryProperties }) => {
+                    const next = { ...state }
+                    for (const name of names) {
+                        delete next[name]
+                    }
+                    return { ...next, ...primaryProperties }
+                },
+                setLoadedPrimaryProperty: (state, { eventName, propertyKey }) => {
+                    if (propertyKey) {
+                        return { ...state, [eventName]: propertyKey }
+                    }
+                    const next = { ...state }
+                    delete next[eventName]
+                    return next
+                },
+            },
+        ],
         loadedEventNames: [
             [] as string[],
             {
@@ -49,6 +59,11 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
                     ...state,
                     [eventName]: propertyKey,
                 }),
+                clearOptimisticPrimaryProperty: (state, { eventName }) => {
+                    const next = { ...state }
+                    delete next[eventName]
+                    return next
+                },
             },
         ],
         savingPrimaryPropertyForEvents: [
@@ -82,16 +97,22 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
                 (name) => !!name && !hasTaxonomyPrimaryProperty(name) && !loaded.has(name)
             )
             if (namesToLoad.length > 0) {
-                actions.loadPrimaryProperties({ names: namesToLoad })
+                actions.loadPrimaryProperties(namesToLoad)
             }
         },
         refreshLoadedPrimaryProperties: () => {
             if (values.loadedEventNames.length > 0) {
-                actions.loadPrimaryProperties({ names: values.loadedEventNames })
+                actions.loadPrimaryProperties(values.loadedEventNames)
             }
         },
+        loadPrimaryProperties: async ({ names }) => {
+            if (names.length === 0) {
+                return
+            }
+            const response = await api.eventDefinitions.primaryProperties({ names })
+            actions.primaryPropertiesLoaded(names, response.primary_properties)
+        },
         setPrimaryProperty: async ({ eventName, propertyKey }) => {
-            const previous = values.primaryProperties[eventName] ?? null
             actions.applyOptimisticPrimaryProperty(eventName, propertyKey)
             try {
                 const definition = await api.eventDefinitions.byName({ name: eventName })
@@ -99,10 +120,11 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
                     eventDefinitionId: definition.id,
                     eventDefinitionData: { primary_property: propertyKey },
                 })
+                actions.setLoadedPrimaryProperty(eventName, propertyKey)
             } catch {
-                actions.applyOptimisticPrimaryProperty(eventName, previous)
                 lemonToast.error('Could not update the pinned property. Please try again.')
             } finally {
+                actions.clearOptimisticPrimaryProperty(eventName)
                 actions.finishSavingPrimaryProperty(eventName)
             }
         },

--- a/frontend/src/models/primaryEventPropertiesModel.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.ts
@@ -1,7 +1,8 @@
-import { actions, kea, listeners, path, reducers } from 'kea'
+import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { hasTaxonomyPrimaryProperty } from 'lib/utils/primaryEventProperty'
 
 import type { primaryEventPropertiesModelType } from './primaryEventPropertiesModelType'
@@ -11,16 +12,22 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
     actions({
         ensureLoadedForEvents: (eventNames: string[]) => ({ eventNames }),
         refreshLoadedPrimaryProperties: true,
+        setPrimaryProperty: (eventName: string, propertyKey: string | null) => ({ eventName, propertyKey }),
+        applyOptimisticPrimaryProperty: (eventName: string, propertyKey: string | null) => ({
+            eventName,
+            propertyKey,
+        }),
+        finishSavingPrimaryProperty: (eventName: string) => ({ eventName }),
     }),
     loaders(({ values }) => ({
-        primaryProperties: {
+        loadedPrimaryProperties: {
             __default: {} as Record<string, string>,
             loadPrimaryProperties: async ({ names }: { names: string[] }) => {
                 if (names.length === 0) {
-                    return values.primaryProperties
+                    return values.loadedPrimaryProperties
                 }
                 const response = await api.eventDefinitions.primaryProperties({ names })
-                const next = { ...values.primaryProperties }
+                const next = { ...values.loadedPrimaryProperties }
                 for (const name of names) {
                     delete next[name]
                 }
@@ -33,6 +40,38 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
             [] as string[],
             {
                 loadPrimaryProperties: (state, { names }) => Array.from(new Set([...state, ...names])),
+            },
+        ],
+        optimisticPrimaryProperties: [
+            {} as Record<string, string | null>,
+            {
+                applyOptimisticPrimaryProperty: (state, { eventName, propertyKey }) => ({
+                    ...state,
+                    [eventName]: propertyKey,
+                }),
+            },
+        ],
+        savingPrimaryPropertyForEvents: [
+            [] as string[],
+            {
+                setPrimaryProperty: (state, { eventName }) => Array.from(new Set([...state, eventName])),
+                finishSavingPrimaryProperty: (state, { eventName }) => state.filter((name) => name !== eventName),
+            },
+        ],
+    }),
+    selectors({
+        primaryProperties: [
+            (s) => [s.loadedPrimaryProperties, s.optimisticPrimaryProperties],
+            (loaded, optimistic): Record<string, string> => {
+                const merged = { ...loaded }
+                for (const [eventName, propertyKey] of Object.entries(optimistic)) {
+                    if (propertyKey) {
+                        merged[eventName] = propertyKey
+                    } else {
+                        delete merged[eventName]
+                    }
+                }
+                return merged
             },
         ],
     }),
@@ -49,6 +88,22 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
         refreshLoadedPrimaryProperties: () => {
             if (values.loadedEventNames.length > 0) {
                 actions.loadPrimaryProperties({ names: values.loadedEventNames })
+            }
+        },
+        setPrimaryProperty: async ({ eventName, propertyKey }) => {
+            const previous = values.primaryProperties[eventName] ?? null
+            actions.applyOptimisticPrimaryProperty(eventName, propertyKey)
+            try {
+                const definition = await api.eventDefinitions.byName({ name: eventName })
+                await api.eventDefinitions.update({
+                    eventDefinitionId: definition.id,
+                    eventDefinitionData: { primary_property: propertyKey },
+                })
+            } catch {
+                actions.applyOptimisticPrimaryProperty(eventName, previous)
+                lemonToast.error('Could not update the pinned property. Please try again.')
+            } finally {
+                actions.finishSavingPrimaryProperty(eventName)
             }
         },
     })),

--- a/frontend/src/models/primaryEventPropertiesModel.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.ts
@@ -1,4 +1,5 @@
-import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, kea, listeners, path, reducers } from 'kea'
+import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
@@ -12,91 +13,62 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
     actions({
         ensureLoadedForEvents: (eventNames: string[]) => ({ eventNames }),
         refreshLoadedPrimaryProperties: true,
-        loadPrimaryProperties: (names: string[]) => ({ names }),
-        primaryPropertiesLoaded: (names: string[], primaryProperties: Record<string, string>) => ({
-            names,
-            primaryProperties,
-        }),
-        setPrimaryProperty: (eventName: string, propertyKey: string | null) => ({ eventName, propertyKey }),
-        applyOptimisticPrimaryProperty: (eventName: string, propertyKey: string | null) => ({
-            eventName,
-            propertyKey,
-        }),
-        clearOptimisticPrimaryProperty: (eventName: string) => ({ eventName }),
-        setLoadedPrimaryProperty: (eventName: string, propertyKey: string | null) => ({ eventName, propertyKey }),
-        finishSavingPrimaryProperty: (eventName: string) => ({ eventName }),
     }),
-    reducers({
-        loadedPrimaryProperties: [
-            {} as Record<string, string>,
-            {
-                primaryPropertiesLoaded: (state, { names, primaryProperties }) => {
-                    const next = { ...state }
-                    for (const name of names) {
-                        delete next[name]
-                    }
-                    return { ...next, ...primaryProperties }
-                },
-                setLoadedPrimaryProperty: (state, { eventName, propertyKey }) => {
-                    if (propertyKey) {
-                        return { ...state, [eventName]: propertyKey }
-                    }
-                    const next = { ...state }
-                    delete next[eventName]
-                    return next
-                },
+    loaders(({ values }) => ({
+        primaryProperties: {
+            __default: {} as Record<string, string>,
+            loadPrimaryProperties: async ({ names }: { names: string[] }) => {
+                if (names.length === 0) {
+                    return values.primaryProperties
+                }
+                const response = await api.eventDefinitions.primaryProperties({ names })
+                const next = { ...values.primaryProperties }
+                for (const name of names) {
+                    delete next[name]
+                }
+                return { ...next, ...response.primary_properties }
             },
-        ],
+            updatePrimaryProperty: async ({
+                eventName,
+                propertyKey,
+            }: {
+                eventName: string
+                propertyKey: string | null
+            }) => {
+                let definitionId: string
+                try {
+                    definitionId = (await api.eventDefinitions.byName({ name: eventName })).id
+                } catch (error) {
+                    posthog.captureException(error, { action: 'update-primary-property', stage: 'lookup' })
+                    lemonToast.error(`We couldn't find a definition for "${eventName}" yet. Please try again shortly.`)
+                    return values.primaryProperties
+                }
+                try {
+                    const updated = await api.eventDefinitions.update({
+                        eventDefinitionId: definitionId,
+                        eventDefinitionData: { primary_property: propertyKey },
+                    })
+                    const next = { ...values.primaryProperties }
+                    if (updated.primary_property) {
+                        next[eventName] = updated.primary_property
+                    } else {
+                        delete next[eventName]
+                    }
+                    return next
+                } catch (error) {
+                    posthog.captureException(error, { action: 'update-primary-property', stage: 'update' })
+                    lemonToast.error('Could not update the pinned property. Please try again.')
+                    return values.primaryProperties
+                }
+            },
+        },
+    })),
+    reducers({
         loadedEventNames: [
             [] as string[],
             {
-                primaryPropertiesLoaded: (state, { names }) => Array.from(new Set([...state, ...names])),
-            },
-        ],
-        optimisticPrimaryProperties: [
-            {} as Record<string, string | null>,
-            {
-                applyOptimisticPrimaryProperty: (state, { eventName, propertyKey }) => ({
-                    ...state,
-                    [eventName]: propertyKey,
-                }),
-                clearOptimisticPrimaryProperty: (state, { eventName }) => {
-                    const next = { ...state }
-                    delete next[eventName]
-                    return next
-                },
-            },
-        ],
-        savingPrimaryPropertyForEvents: [
-            [] as string[],
-            {
-                setPrimaryProperty: (state, { eventName }) => Array.from(new Set([...state, eventName])),
-                finishSavingPrimaryProperty: (state, { eventName }) => state.filter((name) => name !== eventName),
-            },
-        ],
-        primaryPropertySaveVersions: [
-            {} as Record<string, number>,
-            {
-                setLoadedPrimaryProperty: (state, { eventName }) => ({
-                    ...state,
-                    [eventName]: (state[eventName] ?? 0) + 1,
-                }),
-            },
-        ],
-    }),
-    selectors({
-        primaryProperties: [
-            (s) => [s.loadedPrimaryProperties, s.optimisticPrimaryProperties],
-            (loaded, optimistic): Record<string, string> => {
-                const merged = { ...loaded }
-                for (const [eventName, propertyKey] of Object.entries(optimistic)) {
-                    if (propertyKey) {
-                        merged[eventName] = propertyKey
-                    } else {
-                        delete merged[eventName]
-                    }
-                }
-                return merged
+                loadPrimaryPropertiesSuccess: (state, { payload }) =>
+                    Array.from(new Set([...state, ...(payload?.names ?? [])])),
             },
         ],
     }),
@@ -107,58 +79,16 @@ export const primaryEventPropertiesModel = kea<primaryEventPropertiesModelType>(
                 (name) => !!name && !hasTaxonomyPrimaryProperty(name) && !loaded.has(name)
             )
             if (namesToLoad.length > 0) {
-                actions.loadPrimaryProperties(namesToLoad)
+                actions.loadPrimaryProperties({ names: namesToLoad })
             }
         },
         refreshLoadedPrimaryProperties: () => {
             if (values.loadedEventNames.length > 0) {
-                actions.loadPrimaryProperties(values.loadedEventNames)
+                actions.loadPrimaryProperties({ names: values.loadedEventNames })
             }
         },
-        loadPrimaryProperties: async ({ names }) => {
-            if (names.length === 0) {
-                return
-            }
-            const versionsAtRequest = values.primaryPropertySaveVersions
-            try {
-                const response = await api.eventDefinitions.primaryProperties({ names })
-                const supersededBySave = (name: string): boolean =>
-                    (values.primaryPropertySaveVersions[name] ?? 0) !== (versionsAtRequest[name] ?? 0)
-                const namesToApply = names.filter((name) => !supersededBySave(name))
-                if (namesToApply.length === 0) {
-                    return
-                }
-                const propertiesToApply = Object.fromEntries(
-                    Object.entries(response.primary_properties).filter(([name]) => !supersededBySave(name))
-                )
-                actions.primaryPropertiesLoaded(namesToApply, propertiesToApply)
-            } catch (error) {
-                posthog.captureException(error, { action: 'load-primary-properties' })
-            }
-        },
-        setPrimaryProperty: async ({ eventName, propertyKey }) => {
-            actions.applyOptimisticPrimaryProperty(eventName, propertyKey)
-            try {
-                let definitionId: string
-                try {
-                    definitionId = (await api.eventDefinitions.byName({ name: eventName })).id
-                } catch (error) {
-                    posthog.captureException(error, { action: 'set-primary-property', stage: 'lookup' })
-                    lemonToast.error(`We couldn't find a definition for "${eventName}" yet. Please try again shortly.`)
-                    return
-                }
-                await api.eventDefinitions.update({
-                    eventDefinitionId: definitionId,
-                    eventDefinitionData: { primary_property: propertyKey },
-                })
-                actions.setLoadedPrimaryProperty(eventName, propertyKey)
-            } catch (error) {
-                posthog.captureException(error, { action: 'set-primary-property', stage: 'update' })
-                lemonToast.error('Could not update the pinned property. Please try again.')
-            } finally {
-                actions.clearOptimisticPrimaryProperty(eventName)
-                actions.finishSavingPrimaryProperty(eventName)
-            }
+        loadPrimaryPropertiesFailure: ({ errorObject }) => {
+            posthog.captureException(errorObject, { action: 'load-primary-properties' })
         },
     })),
 ])

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
@@ -224,9 +224,9 @@ function SingleEventDetail({ item }: ItemEventProps): JSX.Element {
 
     const primaryPropertyActions =
         canPinPrimaryProperty && isString(eventName)
-            ? (key: string): JSX.Element | null =>
+            ? (key: string, isRowHovered: boolean): JSX.Element | null =>
                   key in item.data.properties ? (
-                      <PinPrimaryPropertyButton eventName={eventName} propertyKey={key} />
+                      <PinPrimaryPropertyButton eventName={eventName} propertyKey={key} isRowHovered={isRowHovered} />
                   ) : null
             : undefined
 

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
@@ -15,8 +15,10 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { SimpleKeyValueList } from 'lib/components/SimpleKeyValueList'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TitledSnack } from 'lib/components/TitledSnack'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { autoCaptureEventToDescription, capitalizeFirstLetter, ceilMsToClosestSecond, isString } from 'lib/utils'
 import { AutocapturePreviewImage } from 'lib/utils/autocapture-previews'
 import { getPrimaryPropertyForEvent } from 'lib/utils/primaryEventProperty'
@@ -29,6 +31,7 @@ import { ItemTimeDisplay } from '../../../components/ItemTimeDisplay'
 import { sessionRecordingPlayerLogic } from '../../sessionRecordingPlayerLogic'
 import { InspectorListItemEvent } from '../playerInspectorLogic'
 import { AIEventExpanded, AIEventSummary } from './AIEventItems'
+import { PinPrimaryPropertyButton } from './PinPrimaryPropertyButton'
 
 export interface ItemEventProps {
     item: InspectorListItemEvent
@@ -215,6 +218,18 @@ export function ItemEventMenu({ item }: ItemEventProps): JSX.Element {
 }
 
 function SingleEventDetail({ item }: ItemEventProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const canPinPrimaryProperty = !!featureFlags[FEATURE_FLAGS.PROMOTED_EVENT_PROPERTIES_EDIT]
+    const eventName = item.data.event
+
+    const primaryPropertyActions =
+        canPinPrimaryProperty && isString(eventName)
+            ? (key: string): JSX.Element | null =>
+                  key in item.data.properties ? (
+                      <PinPrimaryPropertyButton eventName={eventName} propertyKey={key} />
+                  ) : null
+            : undefined
+
     return item.data.fullyLoaded ? (
         <EventPropertyTabs
             size="small"
@@ -265,6 +280,14 @@ function SingleEventDetail({ item }: ItemEventProps): JSX.Element {
                         )
                     case 'error_display':
                         return <ErrorDisplay eventProperties={properties} eventId={idFrom(event as ErrorEventType)} />
+                    case 'properties':
+                        return (
+                            <SimpleKeyValueList
+                                item={properties}
+                                promotedKeys={promotedKeys}
+                                rowActions={primaryPropertyActions}
+                            />
+                        )
                     default:
                         return <SimpleKeyValueList item={properties} promotedKeys={promotedKeys} />
                 }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.test.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.test.tsx
@@ -61,7 +61,7 @@ describe('PinPrimaryPropertyButton', () => {
 
     it.each(revealCases)('$name', ({ pinned, hovered, hidden }) => {
         if (pinned) {
-            logic.actions.primaryPropertiesLoaded(['my_event'], { my_event: 'my_prop' })
+            logic.actions.loadPrimaryPropertiesSuccess({ my_event: 'my_prop' }, { names: ['my_event'] })
         }
 
         const container = renderButton('my_event', 'my_prop', hovered)

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.test.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.test.tsx
@@ -1,0 +1,74 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { getPrimaryPropertyForEvent } from 'lib/utils/primaryEventProperty'
+
+import { primaryEventPropertiesModel } from '~/models/primaryEventPropertiesModel'
+import { initKeaTests } from '~/test/init'
+
+import { PinPrimaryPropertyButton } from './PinPrimaryPropertyButton'
+
+const INTERACTIVE = '[data-attr="replay-pin-primary-property"]'
+const BUILT_IN = '[data-attr="replay-pin-primary-property-builtin"]'
+
+describe('PinPrimaryPropertyButton', () => {
+    let logic: ReturnType<typeof primaryEventPropertiesModel.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = primaryEventPropertiesModel()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    const renderButton = (eventName: string, propertyKey: string, isRowHovered: boolean): HTMLElement =>
+        render(
+            <Provider>
+                <PinPrimaryPropertyButton eventName={eventName} propertyKey={propertyKey} isRowHovered={isRowHovered} />
+            </Provider>
+        ).container
+
+    it('shows a disabled built-in pin for the taxonomy primary property', () => {
+        const taxonomyKey = getPrimaryPropertyForEvent('$pageview')
+        expect(taxonomyKey).toBeTruthy()
+
+        const container = renderButton('$pageview', taxonomyKey!, false)
+
+        const builtIn = container.querySelector(BUILT_IN)
+        expect(builtIn).toBeInTheDocument()
+        expect(builtIn).toHaveAttribute('aria-disabled', 'true')
+        expect(container.querySelector(INTERACTIVE)).not.toBeInTheDocument()
+    })
+
+    it('renders nothing for non-primary rows of a taxonomy-locked event', () => {
+        const taxonomyKey = getPrimaryPropertyForEvent('$pageview')
+        const container = renderButton('$pageview', `${taxonomyKey}_something_else`, true)
+
+        expect(container.querySelector(BUILT_IN)).not.toBeInTheDocument()
+        expect(container.querySelector(INTERACTIVE)).not.toBeInTheDocument()
+    })
+
+    const revealCases: { name: string; pinned: boolean; hovered: boolean; hidden: boolean }[] = [
+        { name: 'hidden when not pinned and the row is not hovered', pinned: false, hovered: false, hidden: true },
+        { name: 'revealed when the row is hovered', pinned: false, hovered: true, hidden: false },
+        { name: 'always shown when pinned, even without hover', pinned: true, hovered: false, hidden: false },
+    ]
+
+    it.each(revealCases)('$name', ({ pinned, hovered, hidden }) => {
+        if (pinned) {
+            logic.actions.primaryPropertiesLoaded(['my_event'], { my_event: 'my_prop' })
+        }
+
+        const container = renderButton('my_event', 'my_prop', hovered)
+
+        const button = container.querySelector(INTERACTIVE)
+        expect(button).toBeInTheDocument()
+        expect(container.querySelector(BUILT_IN)).not.toBeInTheDocument()
+        expect(button?.classList.contains('opacity-0')).toBe(hidden)
+    })
+})

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.tsx
@@ -16,8 +16,8 @@ export function PinPrimaryPropertyButton({
     propertyKey: string
     isRowHovered: boolean
 }): JSX.Element | null {
-    const { primaryProperties, savingPrimaryPropertyForEvents } = useValues(primaryEventPropertiesModel)
-    const { setPrimaryProperty } = useActions(primaryEventPropertiesModel)
+    const { primaryProperties, primaryPropertiesLoading } = useValues(primaryEventPropertiesModel)
+    const { updatePrimaryProperty } = useActions(primaryEventPropertiesModel)
 
     if (hasTaxonomyPrimaryProperty(eventName)) {
         if (getPrimaryPropertyForEvent(eventName) !== propertyKey) {
@@ -37,7 +37,6 @@ export function PinPrimaryPropertyButton({
 
     const currentPrimary = primaryProperties[eventName] ?? null
     const isPinned = currentPrimary === propertyKey
-    const saving = savingPrimaryPropertyForEvents.includes(eventName)
 
     const tooltip = isPinned
         ? `Unpin "${propertyKey}" — it will stop showing next to ${eventName} events`
@@ -50,10 +49,10 @@ export function PinPrimaryPropertyButton({
             size="xsmall"
             noPadding
             active={isPinned}
-            loading={saving}
+            loading={primaryPropertiesLoading}
             icon={isPinned ? <IconPinFilled /> : <IconPin />}
             tooltip={tooltip}
-            onClick={() => setPrimaryProperty(eventName, isPinned ? null : propertyKey)}
+            onClick={() => updatePrimaryProperty({ eventName, propertyKey: isPinned ? null : propertyKey })}
             className={isPinned || isRowHovered ? undefined : 'opacity-0 focus:opacity-100'}
             data-attr="replay-pin-primary-property"
         />

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.tsx
@@ -1,0 +1,56 @@
+import { useActions, useValues } from 'kea'
+
+import { IconPin, IconPinFilled } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { getPrimaryPropertyForEvent, hasTaxonomyPrimaryProperty } from 'lib/utils/primaryEventProperty'
+
+import { primaryEventPropertiesModel } from '~/models/primaryEventPropertiesModel'
+
+export function PinPrimaryPropertyButton({
+    eventName,
+    propertyKey,
+}: {
+    eventName: string
+    propertyKey: string
+}): JSX.Element | null {
+    const { primaryProperties, savingPrimaryPropertyForEvents } = useValues(primaryEventPropertiesModel)
+    const { setPrimaryProperty } = useActions(primaryEventPropertiesModel)
+
+    if (hasTaxonomyPrimaryProperty(eventName)) {
+        if (getPrimaryPropertyForEvent(eventName) !== propertyKey) {
+            return null
+        }
+        return (
+            <LemonButton
+                size="xsmall"
+                noPadding
+                icon={<IconPinFilled />}
+                disabledReason="Built-in primary property — can't be changed"
+            />
+        )
+    }
+
+    const currentPrimary = primaryProperties[eventName] ?? null
+    const isPinned = currentPrimary === propertyKey
+    const saving = savingPrimaryPropertyForEvents.includes(eventName)
+
+    const tooltip = isPinned
+        ? `Unpin "${propertyKey}" — it will stop showing next to ${eventName} events`
+        : currentPrimary
+          ? `Pin "${propertyKey}" as the primary property, replacing "${currentPrimary}". Shown next to ${eventName} events for your whole team.`
+          : `Pin "${propertyKey}" so its value always shows next to ${eventName} events — here and on the timeline. Applies for your whole team.`
+
+    return (
+        <LemonButton
+            size="xsmall"
+            noPadding
+            active={isPinned}
+            loading={saving}
+            icon={isPinned ? <IconPinFilled /> : <IconPin />}
+            tooltip={tooltip}
+            onClick={() => setPrimaryProperty(eventName, isPinned ? null : propertyKey)}
+            className={isPinned ? undefined : 'opacity-0 focus:opacity-100 group-hover/kv-row:opacity-100'}
+        />
+    )
+}

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.tsx
@@ -10,9 +10,11 @@ import { primaryEventPropertiesModel } from '~/models/primaryEventPropertiesMode
 export function PinPrimaryPropertyButton({
     eventName,
     propertyKey,
+    isRowHovered,
 }: {
     eventName: string
     propertyKey: string
+    isRowHovered: boolean
 }): JSX.Element | null {
     const { primaryProperties, savingPrimaryPropertyForEvents } = useValues(primaryEventPropertiesModel)
     const { setPrimaryProperty } = useActions(primaryEventPropertiesModel)
@@ -50,7 +52,7 @@ export function PinPrimaryPropertyButton({
             icon={isPinned ? <IconPinFilled /> : <IconPin />}
             tooltip={tooltip}
             onClick={() => setPrimaryProperty(eventName, isPinned ? null : propertyKey)}
-            className={isPinned ? undefined : 'opacity-0 focus:opacity-100 group-hover/kv-row:opacity-100'}
+            className={isPinned || isRowHovered ? undefined : 'opacity-0 focus:opacity-100'}
         />
     )
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PinPrimaryPropertyButton.tsx
@@ -27,8 +27,10 @@ export function PinPrimaryPropertyButton({
             <LemonButton
                 size="xsmall"
                 noPadding
+                active
                 icon={<IconPinFilled />}
                 disabledReason="Built-in primary property — can't be changed"
+                data-attr="replay-pin-primary-property-builtin"
             />
         )
     }
@@ -53,6 +55,7 @@ export function PinPrimaryPropertyButton({
             tooltip={tooltip}
             onClick={() => setPrimaryProperty(eventName, isPinned ? null : propertyKey)}
             className={isPinned || isRowHovered ? undefined : 'opacity-0 focus:opacity-100'}
+            data-attr="replay-pin-primary-property"
         />
     )
 }


### PR DESCRIPTION
## Problem

Power users repeatedly scan the same property to make sense of an event in the session replay inspector. Promoting that property to the event's _primary property_ surfaces its value next to the event everywhere it matters (inspector rows, seekbar tooltips). Until now the only place to set it was the event-definition edit page — a surface very few people visit — so the payoff and the control lived far apart. This adds a way to promote a property from the exact place the payoff is felt.

## Changes

- Hover-revealed pin on each event-property row in the replay inspector's **Properties** tab. One click promotes the property to the event's primary property; clicking again unpins.
- Respects taxonomy-locked events: the built-in primary property shows a disabled "Built-in — can't be changed" pin, and every other row shows no pin.
- `SimpleKeyValueList` gained a generic `rowActions(key, isRowHovered)` slot — the row owns its own hover state and hands it to the action, so the reveal is a typed boolean rather than a shared CSS class.
- `primaryEventPropertiesModel` is a kea **loader**: `primaryProperties` is the single source of truth, with a `loadPrimaryProperties` action (read) and an `updatePrimaryProperty` action (write — resolves the definition by name, PATCHes, and folds the value the API returns back into the map). A failed update returns the unchanged map, so there's nothing to reconcile. The pin shows the loader's loading state on click; lookup vs update failures keep distinct messages and are captured to error tracking.
- Gated behind the existing `promoted-event-properties-edit` flag, and the pin carries a `data-attr` so pin/unpin adoption can be tracked.

_No UI screenshots: I'm an agent and did not capture them — flagging for the reviewer._

## How did you test this code?

I'm an agent; automated checks only, no manual UI testing:

- Model tests for `primaryEventPropertiesModel`: load filtering, update-folds-API-response, unpin, update-failure-leaves-map-unchanged, lookup-failure-skips-update, failed-load-stays-retryable, and the loading lifecycle.
- A parameterized component test for `PinPrimaryPropertyButton` (built-in disabled pin, null on non-primary taxonomy rows, hover/pinned reveal).
- `oxlint` clean and repo-wide `tsc` shows no new errors in the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude). The user asked to roll the promoted-properties flag out to 100% (done separately via the feature-flag API) and to design a UX for prompting people to set a primary property. We rejected a behaviour-detection approach (too ambiguous about intent) in favour of a discoverable hover affordance where the payoff is felt.

The model went through one wrong turn worth noting for reviewers: an initial version used an optimistic overlay (separate loaded/optimistic reducers + a merge selector + a save-version race guard). That design generated its own reconciliation and race bugs, so on review it was reverted to a plain kea loader whose value is the single source of truth — simpler, and the bug class disappears. Other decisions: taxonomy-locked events disable/hide the pin rather than silently no-op; the hover-reveal coupling was replaced with a typed `isRowHovered` arg; failures are captured with a per-stage tag.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
