### PR TITLE
feat(data-warehouse): mark DoIt "Report no longer exists" as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/doit/source.py
+++ b/posthog/temporal/data_imports/sources/doit/source.py
@@ -49,6 +49,11 @@ class DoItSource(SimpleSource[DoItSourceConfig]):
 
         return schemas
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "Report no longer exists": "The DoIt report no longer exists. It may have been deleted or renamed in DoIt. Please reconnect the source or select a different report.",
+        }
+
     def source_for_pipeline(self, config: DoItSourceConfig, inputs: SourceInputs) -> SourceResponse:
         return doit_source(
             config,

--- a/posthog/temporal/data_imports/sources/doit/tests/test_doit_source.py
+++ b/posthog/temporal/data_imports/sources/doit/tests/test_doit_source.py
@@ -1,0 +1,15 @@
+from posthog.temporal.data_imports.sources.doit.source import DoItSource
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestDoItSource:
+    def setup_method(self):
+        self.source = DoItSource()
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.DOIT
+
+    def test_non_retryable_errors(self):
+        errors = self.source.get_non_retryable_errors()
+        assert "Report no longer exists" in errors

--- a/posthog/temporal/data_imports/sources/doit/tests/test_doit_source.py
+++ b/posthog/temporal/data_imports/sources/doit/tests/test_doit_source.py
@@ -1,3 +1,5 @@
+import pytest
+
 from posthog.temporal.data_imports.sources.doit.source import DoItSource
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
@@ -10,6 +12,8 @@ class TestDoItSource:
     def test_source_type(self):
         assert self.source.source_type == ExternalDataSourceType.DOIT
 
-    def test_non_retryable_errors(self):
+    @pytest.mark.parametrize("pattern", ["Report no longer exists"])
+    def test_non_retryable_errors_includes_pattern(self, pattern):
         errors = self.source.get_non_retryable_errors()
-        assert "Report no longer exists" in errors
+
+        assert pattern in errors


### PR DESCRIPTION
## Problem

The DoIt data warehouse source raises `Report no longer exists` when the configured report ID can't be resolved from DoIt's reports list — typically because the report was deleted or renamed in DoIt. This error is permanent: retrying the import will never succeed, so the source keeps burning retry attempts on a failure that can only be resolved by user action.

## Changes

Registered `Report no longer exists` as a non-retryable error on `DoItSource` via `get_non_retryable_errors()`. When the import activity hits this error (substring match), it now disables the source instead of retrying, and surfaces an actionable message telling the user to reconnect the source or pick a different report.

Added a small unit test covering the source type and the presence of the non-retryable error key.

This mirrors the existing pattern used by other sources (e.g. Stripe).

## How did you test this code?

I'm an agent (Claude Code). I added an automated unit test (`posthog/temporal/data_imports/sources/doit/tests/test_doit_source.py`) asserting the source type and that the non-retryable error is registered. I did not run the test locally — the Python environment isn't bootstrapped in this sandbox — so CI is the source of truth for execution.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code at the request of the repo owner. The change follows the established `get_non_retryable_errors()` convention; I confirmed the import activity does substring matching against the raised exception text (`"Report no longer exists"` raised in `doit.py`), so the key matches as-is. The friendly value message was added since the raw exception text is terse. No alternative approaches were rejected — this is the standard pattern across warehouse sources.
