### PR TITLE
feat(heatmaps): expose deployment region to Browserless flag eval

### DIFF
--- a/products/web_analytics/backend/tasks/heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/heatmap_screenshot.py
@@ -457,12 +457,16 @@ def _use_browserless_for_screenshot(screenshot: SavedHeatmap) -> bool:
     team = screenshot.team
     org_id = str(team.organization_id)
     project_id = str(team.id)
+    # Expose the deployment region (us/eu/dev/...) so a flag condition can target or exclude an
+    # environment — e.g. turn Browserless off in dev without touching the cloud rollout.
+    environment = (settings.CLOUD_DEPLOYMENT or "unknown").lower()
     try:
         return bool(
             posthoganalytics.feature_enabled(
                 HEATMAP_BROWSERLESS_FLAG,
                 project_id,  # bucket per team so a whole team flips together, not per user
                 groups={"organization": org_id, "project": project_id},
+                person_properties={"environment": environment},
                 group_properties={"organization": {"id": org_id}, "project": {"id": project_id}},
                 only_evaluate_locally=False,
                 send_feature_flag_events=False,

--- a/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
@@ -411,7 +411,9 @@ class TestHeatmapScreenshotTask(APIBaseTest):
     def test_use_browserless_passes_environment_property(
         self, _name: str, cloud_deployment: str | None, expected: str, mock_feature_enabled: MagicMock
     ) -> None:
-        with override_settings(HEATMAP_BROWSERLESS_URL="wss://host/chromium", DEBUG=False, CLOUD_DEPLOYMENT=cloud_deployment):
+        with override_settings(
+            HEATMAP_BROWSERLESS_URL="wss://host/chromium", DEBUG=False, CLOUD_DEPLOYMENT=cloud_deployment
+        ):
             assert _use_browserless_for_screenshot(self._make_heatmap()) is True
         _, kwargs = mock_feature_enabled.call_args
         assert kwargs["person_properties"]["environment"] == expected

--- a/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
@@ -384,7 +384,7 @@ class TestHeatmapScreenshotTask(APIBaseTest):
         assert _use_browserless_for_screenshot(self._make_heatmap()) is True
         mock_feature_enabled.assert_not_called()
 
-    @override_settings(HEATMAP_BROWSERLESS_URL="wss://host/chromium", DEBUG=False)
+    @override_settings(HEATMAP_BROWSERLESS_URL="wss://host/chromium", DEBUG=False, CLOUD_DEPLOYMENT="US")
     @patch(
         "products.web_analytics.backend.tasks.heatmap_screenshot.posthoganalytics.feature_enabled",
         return_value=True,
@@ -398,8 +398,23 @@ class TestHeatmapScreenshotTask(APIBaseTest):
         assert args[1] == str(self.team.id)
         assert kwargs["groups"]["project"] == str(self.team.id)
         assert kwargs["groups"]["organization"] == str(self.team.organization_id)
+        # The deployment region is exposed so a flag condition can target/exclude an environment
+        assert kwargs["person_properties"]["environment"] == "us"
         assert kwargs["send_feature_flag_events"] is False
         assert kwargs["only_evaluate_locally"] is False
+
+    @parameterized.expand([("us", "US", "us"), ("eu", "EU", "eu"), ("dev", "DEV", "dev"), ("unset", None, "unknown")])
+    @patch(
+        "products.web_analytics.backend.tasks.heatmap_screenshot.posthoganalytics.feature_enabled",
+        return_value=True,
+    )
+    def test_use_browserless_passes_environment_property(
+        self, _name: str, cloud_deployment: str | None, expected: str, mock_feature_enabled: MagicMock
+    ) -> None:
+        with override_settings(HEATMAP_BROWSERLESS_URL="wss://host/chromium", DEBUG=False, CLOUD_DEPLOYMENT=cloud_deployment):
+            assert _use_browserless_for_screenshot(self._make_heatmap()) is True
+        _, kwargs = mock_feature_enabled.call_args
+        assert kwargs["person_properties"]["environment"] == expected
 
     @override_settings(HEATMAP_BROWSERLESS_URL="wss://host/chromium", DEBUG=False)
     @patch(


### PR DESCRIPTION
## Problem

The `heatmap-browserless-cloud` flag is currently bucketed per team with no way to distinguish which deployment region (US, EU, dev) a team belongs to. This means we can't roll Browserless out to cloud while excluding the dev environment — the only lever is per-team or a global percentage that applies everywhere.

## Changes

When evaluating the flag in `_use_browserless_for_screenshot`, we now pass the deployment region as an `environment` person property:

- Reads `settings.CLOUD_DEPLOYMENT` (`US`, `EU`, `DEV`, ...), lowercased, falling back to `"unknown"` when unset.
- Surfaced as `person_properties={"environment": ...}` on the `feature_enabled` call.

A flag condition can now match on `environment` to target or exclude a single environment (e.g. set dev to off) independently of the cloud rollout. Local dev (`DEBUG`) and the fail-closed-on-error behaviour are unchanged.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). I could not run the suite in this environment (no Python/pytest available), but I added/updated automated tests in `test_heatmap_screenshot.py`:

- Asserted the prod flag eval now sends `person_properties["environment"] == "us"`.
- Added a parameterized test covering `US`/`EU`/`DEV`/unset → `us`/`eu`/`dev`/`unknown`.

Both files pass `py_compile`. Tests should be run via `hogli test products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py -k use_browserless`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8) from a Slack thread where the team wanted a way to exclude the dev environment from the Browserless rollout flag. `CLOUD_DEPLOYMENT` is the canonical region identifier in settings; it's passed as a person property (the flag buckets on `distinct_id = project_id`) so flag conditions can match on it server-side. The `feature_enabled` call already uses `only_evaluate_locally=False`, so no local-eval property plumbing was needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*