### PR TITLE
feat(heatmaps): pass deploy region to browserless rollout flag

### DIFF
--- a/products/web_analytics/backend/tasks/heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/heatmap_screenshot.py
@@ -23,6 +23,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.ph_client import ph_scoped_capture
 from posthog.security.url_validation import is_url_allowed, should_block_url
 from posthog.tasks.utils import CeleryQueue
+from posthog.utils import get_instance_region
 
 from products.web_analytics.backend.api.heatmaps_utils import DEFAULT_TARGET_WIDTHS, MAX_TARGET_WIDTHS
 from products.web_analytics.backend.models import HeatmapSnapshot, SavedHeatmap
@@ -457,13 +458,20 @@ def _use_browserless_for_screenshot(screenshot: SavedHeatmap) -> bool:
     team = screenshot.team
     org_id = str(team.organization_id)
     project_id = str(team.id)
+    # Expose the deploy region (US / EU / DEV) so the flag can target by environment, e.g. to keep
+    # the rollout off the dev environment while it's at 100% in prod.
+    region = get_instance_region() or "DEV"
     try:
         return bool(
             posthoganalytics.feature_enabled(
                 HEATMAP_BROWSERLESS_FLAG,
                 project_id,  # bucket per team so a whole team flips together, not per user
                 groups={"organization": org_id, "project": project_id},
-                group_properties={"organization": {"id": org_id}, "project": {"id": project_id}},
+                person_properties={"region": region},
+                group_properties={
+                    "organization": {"id": org_id, "region": region},
+                    "project": {"id": project_id, "region": region},
+                },
                 only_evaluate_locally=False,
                 send_feature_flag_events=False,
             )

--- a/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
@@ -401,6 +401,24 @@ class TestHeatmapScreenshotTask(APIBaseTest):
         assert kwargs["send_feature_flag_events"] is False
         assert kwargs["only_evaluate_locally"] is False
 
+    @parameterized.expand([("US", "US"), ("EU", "EU"), (None, "DEV")])
+    @override_settings(HEATMAP_BROWSERLESS_URL="wss://host/chromium", DEBUG=False)
+    @patch(
+        "products.web_analytics.backend.tasks.heatmap_screenshot.posthoganalytics.feature_enabled",
+        return_value=True,
+    )
+    def test_use_browserless_passes_region_property_to_flag(
+        self, cloud_deployment: str | None, expected_region: str, mock_feature_enabled: MagicMock
+    ) -> None:
+        # The deploy region is exposed to the flag (person + group properties) so it can target by
+        # environment, e.g. excluding DEV while prod is at 100%.
+        with override_settings(CLOUD_DEPLOYMENT=cloud_deployment):
+            assert _use_browserless_for_screenshot(self._make_heatmap()) is True
+        _, kwargs = mock_feature_enabled.call_args
+        assert kwargs["person_properties"]["region"] == expected_region
+        assert kwargs["group_properties"]["organization"]["region"] == expected_region
+        assert kwargs["group_properties"]["project"]["region"] == expected_region
+
     @override_settings(HEATMAP_BROWSERLESS_URL="wss://host/chromium", DEBUG=False)
     @patch(
         "products.web_analytics.backend.tasks.heatmap_screenshot.posthoganalytics.feature_enabled",


### PR DESCRIPTION
## Problem

The `heatmap-browserless-cloud` flag is currently rolled out to 100% of projects across all environments. We need a way to scope the rollout by environment — for example, to keep the new Browserless path off the dev (AWS dev) environment for testing while leaving prod at 100% — but the flag evaluation didn't carry any signal of which environment it was running in.

## Changes

`_use_browserless_for_screenshot` now resolves the deploy region via `get_instance_region()` (`US` / `EU` / `DEV`, defaulting to `DEV` when `CLOUD_DEPLOYMENT` is unset) and passes it to the flag evaluation as both a `person_properties["region"]` and a `group_properties.{organization,project}.region` value. This lets a flag release condition target by environment (e.g. `region is not DEV`) without changing the per-team bucketing key.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). No test runner was available in this environment, so I did not run the suite. I added a parameterized test (`test_use_browserless_passes_region_property_to_flag`) covering `US`/`EU`/`DEV` and verified both files byte-compile. The change is additive to the existing flag call — bucketing key, groups, and the fail-closed behavior are unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored with Claude Code (Opus 4.8) at the request of the heatmaps/Browserless rollout thread. The region is exposed on both person and group properties so the flag can be targeted however the release condition is defined (the flag buckets per project via the organization/project groups). `get_instance_region()` returns `None` off Cloud, so the code falls back to `DEV`, which keeps local/hobby deploys grouped with the dev environment for targeting purposes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
