### PR TITLE
chore(hog-charts): group BarChart bar options under `bars` config

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
@@ -50,7 +50,7 @@ export const Grouped: Story = {
 export const WithBarTrack: Story = {
     render: () => {
         const theme = useReactiveTheme()
-        const config: BarChartConfig = { barLayout: 'grouped', showGrid: true, barTrack: true, barCornerRadius: 6 }
+        const config: BarChartConfig = { barLayout: 'grouped', showGrid: true, bars: { track: true, cornerRadius: 6 } }
         return (
             <Stage>
                 <BarChart series={THREE_SERIES} labels={DAYS} config={config} theme={theme} />
@@ -242,7 +242,7 @@ export const LargeDataset: Story = {
 export const CustomCornerRadius: Story = {
     render: () => {
         const theme = useReactiveTheme()
-        const config: BarChartConfig = { barLayout: 'grouped', showGrid: true, barCornerRadius: 12 }
+        const config: BarChartConfig = { barLayout: 'grouped', showGrid: true, bars: { cornerRadius: 12 } }
         return (
             <Stage>
                 <BarChart series={TWO_SERIES} labels={DAYS} config={config} theme={theme} />

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../core/scales'
 import type {
     BarChartConfig,
+    BarsConfig,
     ChartDimensions,
     ChartDrawArgs,
     ChartScales,
@@ -91,7 +92,7 @@ const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
 // Reserve room for chart-edge margins + worst-case x-axis title margin (matches useChartMargins).
 const HORIZONTAL_CHART_MARGIN_PX = DEFAULT_MARGINS.top + DEFAULT_MARGINS.bottom + X_AXIS_TITLE_MARGIN
 
-function resolveBarShadow(barShadow: BarChartConfig['barShadow']): BarShadow | undefined {
+function resolveBarShadow(barShadow: BarsConfig['shadow']): BarShadow | undefined {
     if (barShadow === true) {
         return DEFAULT_BAR_SHADOW
     }
@@ -124,16 +125,18 @@ function BarChartInner<Meta = unknown>({
         yScaleType = 'linear',
         showGrid = false,
         barLayout = 'stacked',
-        barCornerRadius = 0,
-        barTrack = false,
         axisOrientation = 'vertical',
         xTickFormatter,
+    } = config ?? {}
+    const {
+        cornerRadius: barCornerRadius = 0,
+        track: barTrack = false,
+        shadow: barShadow,
         divergingStack = false,
         maxBandRange,
         bandPadding,
-        barShadow,
         minBandSize,
-    } = config ?? {}
+    } = config?.bars ?? {}
     const isHorizontal = axisOrientation === 'horizontal'
 
     const resolvedMinBandSize = minBandSize ?? (isHorizontal ? HORIZONTAL_MIN_BAND_SIZE_DEFAULT : 0)

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -111,11 +111,10 @@ export function TimeSeriesBarChart<Meta = unknown>({
         yAxisLabel: yAxis?.label,
         showGrid: yAxis?.showGrid,
         barLayout,
-        barCornerRadius,
         axisOrientation,
         showCrosshair,
         tooltip: tooltipConfig,
-        divergingStack,
+        bars: { cornerRadius: barCornerRadius, divergingStack },
     }
 
     return (

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -3,7 +3,7 @@ import * as d3 from 'd3'
 import type { ChartDimensions, ChartScales, ResolveValueFn, Series } from './types'
 import { DEFAULT_Y_AXIS_ID } from './types'
 
-/** Inner padding fraction applied to the band scale when `BarChartConfig.bandPadding` is unset. */
+/** Inner padding fraction applied to the band scale when `BarChartConfig.bars.bandPadding` is unset. */
 export const DEFAULT_BAND_PADDING = 0.2
 
 type D3YScale = d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -205,32 +205,39 @@ export interface TooltipConfig {
     placement?: 'follow-data' | 'top'
 }
 
-export interface BarChartConfig extends ChartConfig {
-    /** Defaults to `stacked`. */
-    barLayout?: 'stacked' | 'grouped' | 'percent'
-    /** Stacked bars only round the topmost segment. */
-    barCornerRadius?: number
+/** Bar appearance + band-layout details. Grouped under {@link BarChartConfig.bars} to keep the
+ *  config flat at the top level. `barLayout` stays top-level as the primary discriminator. */
+export interface BarsConfig {
+    /** Corner radius in px for the rounded end(s) of a bar. Stacked bars only round the topmost
+     *  segment. Defaults to 0 (square). */
+    cornerRadius?: number
     /** Draw a faint hatched track behind each bar, spanning the full plot height — for
      *  funnel-style charts where every bar is a share of a whole. Only honored when
      *  `barLayout: 'grouped'`; ignored for stacked/percent (the "share of a whole"
      *  semantics don't apply when bars share a band). Defaults to `false`. */
-    barTrack?: boolean
-    /** Stacked layout only — use d3.stackOffsetDiverging so negative values stack
-     *  below the zero baseline (positives above). Default `false` clamps negatives to 0. */
+    track?: boolean
+    /** Drop shadow under each bar so it reads as layered over a `track`. */
+    shadow?: boolean | { color: string; blur: number; offsetX?: number; offsetY?: number }
+    /** Stacked layout only — use d3.stackOffsetDiverging so negative values stack below the zero
+     *  baseline (positives above). Default `false` clamps negatives to 0. */
     divergingStack?: boolean
-    /** Cap (px) on the band-axis range. Clusters bars at the start of the plot while
-     *  gridlines still span the full width — useful for few-category funnel-style charts. */
+    /** Cap (px) on the band-axis range. Clusters bars at the start of the plot while gridlines
+     *  still span the full width — useful for few-category funnel-style charts. */
     maxBandRange?: number
-    /** Inner gap between bars as a fraction of the band slot (0–1). Outer padding is half
-     *  this value, so `step = range / N`. Defaults to `DEFAULT_BAND_PADDING` in `scales.ts`. */
+    /** Inner gap between bars as a fraction of the band slot (0–1). Outer padding is half this
+     *  value, so `step = range / N`. Defaults to `DEFAULT_BAND_PADDING` in `scales.ts`. */
     bandPadding?: number
-    /** Drop shadow under each bar so it reads as layered over a `barTrack`. */
-    barShadow?: boolean | { color: string; blur: number; offsetX?: number; offsetY?: number }
-    /** Horizontal bar charts only — minimum px per row. When many rows would otherwise crush
-     *  into an unreadable strip, the chart expands its container height so each row has at
-     *  least this much vertical space (label height + breathing room). Defaults to `24`.
-     *  Pass `0` to opt out. */
+    /** Horizontal bar charts only — minimum px per row. When many rows would otherwise crush into
+     *  an unreadable strip, the chart expands its container height so each row has at least this
+     *  much vertical space (label height + breathing room). Defaults to `24`. Pass `0` to opt out. */
     minBandSize?: number
+}
+
+export interface BarChartConfig extends ChartConfig {
+    /** Defaults to `stacked`. */
+    barLayout?: 'stacked' | 'grouped' | 'percent'
+    /** Bar appearance + band-layout details (corner rounding, track, shadow, padding…). */
+    bars?: BarsConfig
 }
 
 export interface LineChartConfig extends ChartConfig {

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -58,6 +58,7 @@ export type { BaseChartContext, ChartHoverContextValue, ChartLayoutContextValue 
 // Core types
 export type {
     BarChartConfig,
+    BarsConfig,
     ChartConfig,
     ChartDimensions,
     ChartDrawArgs,

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -78,13 +78,12 @@ export function FunnelBarHorizontalChart({
     const chartConfig = useMemo<BarChartConfig>(
         () => ({
             barLayout: 'stacked',
-            barCornerRadius: 4,
+            bars: { cornerRadius: 4, bandPadding: BAR_PADDING },
             axisOrientation: 'horizontal',
             hideXAxis: true,
             hideYAxis: true,
             showGrid: false,
             animateHover: true,
-            bandPadding: BAR_PADDING,
             margins: { top: 0, right: 0, bottom: 0, left: GLYPH_COLUMN_WIDTH_PX },
             tooltip: { placement: 'top' },
         }),

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
@@ -16,7 +16,7 @@ import { buildFunnelHistogramData } from './funnelHistogramTransforms'
 
 const CHART_CONFIG: BarChartConfig = {
     showGrid: true,
-    barCornerRadius: 4,
+    bars: { cornerRadius: 4 },
     yTickFormatter: (value) => humanFriendlyNumber(value),
     // Value labels already show bucket counts; tooltip would just duplicate them.
     tooltip: { enabled: false },

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -24,9 +24,7 @@ const STEP_WIDTH_PX = 320
 const baseChartConfig: BarChartConfig = {
     barLayout: 'grouped',
     showGrid: true,
-    barCornerRadius: 10,
-    barTrack: true,
-    barShadow: true,
+    bars: { cornerRadius: 10, track: true, shadow: true },
     animateHover: true,
     hideXAxis: true,
     yTickFormatter: (value) => `${Math.round(value)}%`,
@@ -71,7 +69,10 @@ export function FunnelStepsBarChart({
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural
     const showTime = steps.some((step) => step.average_conversion_time != null)
     const barsWidth = steps.length * STEP_WIDTH_PX
-    const chartConfig = useMemo<BarChartConfig>(() => ({ ...baseChartConfig, maxBandRange: barsWidth }), [barsWidth])
+    const chartConfig = useMemo<BarChartConfig>(
+        () => ({ ...baseChartConfig, bars: { ...baseChartConfig.bars, maxBandRange: barsWidth } }),
+        [barsWidth]
+    )
 
     const onPointClick = useCallback(
         (clickData: PointClickData<FunnelStepsBarSeriesMeta>): void => {


### PR DESCRIPTION
## Problem

The horizontal-funnel rework (#60762) grew large because it bundles a behaviour-preserving config refactor together with genuinely new rendering behaviour. This PR carves off the mechanical part so it can review on its own and land first, shrinking the follow-up to just the new funnel behaviour.

## Changes

Group the flat `BarChartConfig` bar options under a single `bars: BarsConfig` object:

| Before (`BarChartConfig.*`) | After (`BarChartConfig.bars.*`) |
|---|---|
| `barCornerRadius` | `cornerRadius` |
| `barTrack` | `track` |
| `barShadow` | `shadow` |
| `divergingStack` | `divergingStack` |
| `maxBandRange` | `maxBandRange` |
| `bandPadding` | `bandPadding` |
| `minBandSize` | `minBandSize` |

`barLayout` stays top-level as the primary discriminator.

No behaviour change. `BarChart.tsx` keeps its existing internal variable names via destructuring aliases, so the render path is byte-for-byte equivalent. All consumers move to the grouped shape: `TimeSeriesBarChart`, `FunnelHistogramChart`, `FunnelStepsBarChart`, `FunnelBarHorizontalChart`, and the `BarChart` stories. `TimeSeriesBarChart`'s public component props (`barCornerRadius`, `divergingStack`) are intentionally unchanged, so `TrendsLifecycleChart` needs no edit.

This is a pure regrouping — `rounding`, track colour, and cursor-tooltip placement are new capabilities that stay in the follow-up funnel PR.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). This sandbox has no `node_modules`, so I could not run jest/tsc locally — CI will typecheck and run the existing hog-charts and funnel suites. The change is a mechanical rename verified by an exhaustive repo-wide grep for every old flat key to confirm no consumer was missed and the only remaining references are the internal destructuring aliases.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8) at the request of the PR author, who wanted to split a reviewable chunk off #60762 and land it first. I chose the `bars` config grouping as the split target because it is behaviour-preserving (fast, low-risk review) and is the foundation the rest of the work sits on, so merging it strips the largest block of mechanical noise out of the feature PR. The smaller cursor-tooltip addition was considered as an alternative but shrinks the feature PR less.

Agent-assisted; requires human review.
