### PR TITLE
fix(plugins): prevent ValueError in split_url_and_private_token for URLs with multiple '?'

### DIFF
--- a/posthog/plugins/test/test_utils.py
+++ b/posthog/plugins/test/test_utils.py
@@ -12,6 +12,7 @@ from posthog.plugins.utils import (
     get_file_from_zip_archive,
     parse_url,
     put_json_into_zip_archive,
+    split_url_and_private_token,
 )
 
 from .mock import mocked_plugin_requests_get
@@ -657,6 +658,12 @@ class TestPluginsUtils(BaseTest):
         self.assertEqual(plugin_json_tgz["name"], "helloworldplugin")
         self.assertEqual(plugin_json_tgz["url"], "https://github.com/PostHog/helloworldplugin")
         self.assertEqual(plugin_json_tgz["description"], "Greet the World and Foo a Bar, JS edition!")
+
+    def test_split_url_and_private_token_multiple_question_marks(self, mock_get):
+        # A URL with two '?' characters must not raise ValueError (maxsplit=1 fix)
+        url, token = split_url_and_private_token("https://github.com/PostHog/plugin?private_token=abc?extra")
+        self.assertEqual(url, "https://github.com/PostHog/plugin")
+        self.assertEqual(token, "abc?extra")  # parse_qs treats 'abc?extra' as the full value
 
     def test_put_json_into_zip_archive(self, mock_get):
         archive = base64.b64decode(HELLO_WORLD_PLUGIN_GITHUB_ZIP[1])

--- a/posthog/plugins/utils.py
+++ b/posthog/plugins/utils.py
@@ -183,7 +183,7 @@ def parse_url(url: str, get_latest_if_none=False) -> dict[str, Optional[str]]:
 def split_url_and_private_token(url: str) -> tuple[str, Optional[str]]:
     private_token = None
     if "?" in url:
-        url, query = url.split("?")
+        url, query = url.split("?", 1)
         params = {k: v[0] for k, v in parse_qs(query).items()}
         private_token = params.get("private_token", None)
     return url.strip("/"), private_token


### PR DESCRIPTION
## What's broken

`split_url_and_private_token()` in `posthog/plugins/utils.py` raises `ValueError: too many values to unpack (expected 2)` when a plugin URL contains more than one `?` character — for example `https://github.com/PostHog/plugin?private_token=abc?extra`. This function is invoked by `parse_github_url`, `parse_gitlab_url`, and `parse_npm_url`, so the crash surfaces at any plugin installation or validation endpoint that accepts user-supplied URLs.

## Why it happens

`url.split("?")` without a `maxsplit` argument returns more than two elements when the URL contains two or more `?` chars. The two-variable unpacking `url, query = url.split("?")` then raises `ValueError`.

## Fix

Change `url.split("?")` to `url.split("?", 1)` on line 186 of `posthog/plugins/utils.py`. This ensures the split always produces exactly two parts: the URL before the first `?` and everything after it as the raw query string. `parse_qs` correctly handles the remainder.

## Test

Added `test_split_url_and_private_token_multiple_question_marks` to `posthog/plugins/test/test_utils.py`. It passes a URL with two `?` characters and asserts that no exception is raised and the parsed URL and token are correct.

Fixes #60823