### PR TITLE
fix(taxonomic-filter): make headless filter stories more deterministic

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/__mocks__/taxonomicFilterMocksDecorator.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/__mocks__/taxonomicFilterMocksDecorator.ts
@@ -10,8 +10,6 @@ export const taxonomicFilterMocksDecorator = mswDecorator({
             { id: 3, name: 'height', count: 3 },
             { id: 4, name: '$browser', count: 4 },
         ],
-        // property_definitions is consumed as a paginated { results, count } envelope
-        // (propertyDefinitionsModel reads response.results); a bare array reads as 0 properties.
         '/api/projects/:team_id/property_definitions': {
             count: 6,
             results: [

--- a/frontend/src/lib/components/TaxonomicFilter/__mocks__/taxonomicFilterMocksDecorator.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/__mocks__/taxonomicFilterMocksDecorator.ts
@@ -13,12 +13,12 @@ export const taxonomicFilterMocksDecorator = mswDecorator({
         '/api/projects/:team_id/property_definitions': {
             count: 6,
             results: [
-                { name: 'file_count', count: 205 },
-                { name: 'industry', count: 205 },
-                { name: 'name', count: 205 },
-                { name: 'plan', count: 205 },
-                { name: 'team_size', count: 205 },
-                { name: 'used_mb', count: 205 },
+                { id: 'file_count', name: 'file_count', count: 205 },
+                { id: 'industry', name: 'industry', count: 205 },
+                { id: 'name', name: 'name', count: 205 },
+                { id: 'plan', name: 'plan', count: 205 },
+                { id: 'team_size', name: 'team_size', count: 205 },
+                { id: 'used_mb', name: 'used_mb', count: 205 },
             ],
         },
         '/api/projects/:team_id/event_definitions': [

--- a/frontend/src/lib/components/TaxonomicFilter/__mocks__/taxonomicFilterMocksDecorator.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/__mocks__/taxonomicFilterMocksDecorator.ts
@@ -10,32 +10,19 @@ export const taxonomicFilterMocksDecorator = mswDecorator({
             { id: 3, name: 'height', count: 3 },
             { id: 4, name: '$browser', count: 4 },
         ],
-        '/api/projects/:team_id/property_definitions': [
-            {
-                name: 'file_count',
-                count: 205,
-            },
-            {
-                name: 'industry',
-                count: 205,
-            },
-            {
-                name: 'name',
-                count: 205,
-            },
-            {
-                name: 'plan',
-                count: 205,
-            },
-            {
-                name: 'team_size',
-                count: 205,
-            },
-            {
-                name: 'used_mb',
-                count: 205,
-            },
-        ],
+        // property_definitions is consumed as a paginated { results, count } envelope
+        // (propertyDefinitionsModel reads response.results); a bare array reads as 0 properties.
+        '/api/projects/:team_id/property_definitions': {
+            count: 6,
+            results: [
+                { name: 'file_count', count: 205 },
+                { name: 'industry', count: 205 },
+                { name: 'name', count: 205 },
+                { name: 'plan', count: 205 },
+                { name: 'team_size', count: 205 },
+                { name: 'used_mb', count: 205 },
+            ],
+        },
         '/api/projects/:team_id/event_definitions': [
             {
                 id: 'a',

--- a/frontend/src/lib/components/TaxonomicFilter/headless/TaxonomicFilterHeadless.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/TaxonomicFilterHeadless.stories.tsx
@@ -6,6 +6,7 @@ import { taxonomicFilterMocksDecorator } from 'lib/components/TaxonomicFilter/__
 
 import { actionsModel } from '~/models/actionsModel'
 
+import { __clearTaxonomicResourceCache } from '../hooks/useTaxonomicResource'
 import { TaxonomicFilterGroup, TaxonomicFilterGroupType, TaxonomicFilterValue } from '../types'
 import { TaxonomicFilterHeadless } from './index'
 
@@ -34,6 +35,15 @@ interface ContainerArgs {
 }
 
 function Container({ taxonomicGroupTypes, initialSearchQuery, suggestedFiltersLabel }: ContainerArgs): JSX.Element {
+    // The resource cache is module-scoped and survives across stories/snapshots. A request
+    // aborted by an early unmount can leave an entry empty, so a later mount renders 0 rows
+    // and never refetches within staleTime. Reset once before first mount for a more
+    // deterministic starting point (mirrors __clearTaxonomicResourceCache() in the hook's
+    // unit tests). This reduces but does not fully eliminate the underlying mount-race.
+    useState(() => {
+        __clearTaxonomicResourceCache()
+        return null
+    })
     useMountedLogic(actionsModel)
     const [lastPick, setLastPick] = useState<{
         group: string

--- a/frontend/src/lib/components/TaxonomicFilter/headless/TaxonomicFilterHeadless.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/TaxonomicFilterHeadless.stories.tsx
@@ -35,11 +35,6 @@ interface ContainerArgs {
 }
 
 function Container({ taxonomicGroupTypes, initialSearchQuery, suggestedFiltersLabel }: ContainerArgs): JSX.Element {
-    // The resource cache is module-scoped and survives across stories/snapshots. A request
-    // aborted by an early unmount can leave an entry empty, so a later mount renders 0 rows
-    // and never refetches within staleTime. Reset once before first mount for a more
-    // deterministic starting point (mirrors __clearTaxonomicResourceCache() in the hook's
-    // unit tests). This reduces but does not fully eliminate the underlying mount-race.
     useState(() => {
         __clearTaxonomicResourceCache()
         return null


### PR DESCRIPTION
## Problem

The `Filters/Taxonomic Filter (Headless)` stories produce non-deterministic visual-regression snapshots: the per-tab result counts flip between runs (e.g. **Event properties 6 vs 0**, **Events 4 vs 1**), depending on whether the data resolves before the snapshot is taken. This shows up as noisy snapshot diffs (surfaced while reviewing a Playwright/Chromium bump, though the bump didn't cause it).

I reproduced it with repeated local Storybook loads (fresh page each time): the `properties` story showed 6 properties on some loads and 0 on others, with a clean binary "loaded by ~500ms, or 0 forever" pattern, i.e. a mount-time race rather than a slow load.

## Changes

Two contributing issues, both fixed at the story/mock layer (no production logic changed):

- **Mock shape**: the `property_definitions` mock returned a bare array, but `propertyDefinitionsModel` reads a paginated `{ results, count }` envelope, so that code path read zero properties. Wrapped it in the envelope (the shape other tests/stories already mock, e.g. `taxonomicPropertyFilterLogic.test.ts`).
- **Cache reset**: `useTaxonomicResource`'s cache is module-scoped and survives across stories/snapshots. A request aborted by an early unmount can leave an entry empty, and `staleTime` then prevents a refetch within the window. The story container now resets the cache once before first mount, mirroring the `__clearTaxonomicResourceCache()` the hook's own unit tests run in `beforeEach`.

## Known limitation

This **measurably improves** stability but does **not** fully eliminate it. In local probing, `suggested-filters-with-recents` went to fully stable and `properties` from ~4/8 to ~7/8 stable runs, but a residual flake remains. The root cause is a mount-time abort race in `useTaxonomicResource` (the last-subscriber-unmount aborts the in-flight request; under React's double-mount the first fetch can be cancelled and the entry left empty). That fix belongs in the hook itself and is better owned by the headless-filter author, since the headless `useTaxonomicFilter` is still behind the `TAXONOMIC_FILTER_HEADLESS` flag and in parity work. Flagging here rather than changing shared component concurrency logic in a snapshot-determinism PR.

cc @adamleith (headless TaxonomicFilter owner) for the underlying hook race.

## How did you test this code?

I am an agent (Claude Code).

- Ran the full TaxonomicFilter unit suite locally: `jest frontend/src/lib/components/TaxonomicFilter/` → **16 suites, 362 tests, all passing**.
- Reproduced and measured the flake by serving Storybook locally and loading each affected story 8 times via Playwright (Chromium 1.60), comparing the per-tab counters before and after: before, `properties` Event properties flipped 6/0 and `events-and-actions` Events flipped 4/1; after, `suggested-filters-with-recents` fully stable and `properties`/`events-and-actions` substantially more stable (residual flake noted above).
- `oxlint` clean on both files.

The changes are story/mock-only; CI runs the same TaxonomicFilter suite plus the Storybook visual-regression job.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes (story/mock determinism fix).

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) on Robbie's behalf. Diagnosed while investigating noisy visual-regression snapshots: traced the flake to (1) a wrong mock response shape and (2) a module-scoped resource cache + mount-time abort in `useTaxonomicResource`. Scoped this PR to the safe story/mock fixes that improve determinism; left the deeper hook fix to the component owner. Verification was live-Storybook probing (the flake is timing-dependent, not reproducible by static reasoning) plus the full TaxonomicFilter jest suite.
