### PR TITLE
fix(lemon-ui): guard non-Node relatedTarget in LemonDropdown hover

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.tsx
@@ -78,7 +78,13 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
                     onClickInside?.(e)
                 }}
                 onMouseLeaveInside={(e) => {
-                    if (trigger === 'hover' && !referenceRef.current?.contains(e.relatedTarget as Node)) {
+                    // relatedTarget is null when leaving the window and isn't always a Node, so
+                    // Node.contains() would throw — treat anything that isn't a contained Node as "left".
+                    const relatedTarget = e.relatedTarget
+                    if (
+                        trigger === 'hover' &&
+                        !(relatedTarget instanceof Node && referenceRef.current?.contains(relatedTarget))
+                    ) {
                         setVisible(false)
                     }
                     onMouseLeaveInside?.(e)
@@ -102,7 +108,11 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
                         }
                     },
                     onMouseLeave: (e: React.MouseEvent): void => {
-                        if (trigger === 'hover' && !floatingRef.current?.contains(e.relatedTarget as Node)) {
+                        const relatedTarget = e.relatedTarget
+                        if (
+                            trigger === 'hover' &&
+                            !(relatedTarget instanceof Node && floatingRef.current?.contains(relatedTarget))
+                        ) {
                             setVisible(false)
                         }
                     },


### PR DESCRIPTION
## Problem

Hover-triggered `LemonDropdown`s throw an unhandled `TypeError: Failed to execute 'contains' on 'Node': parameter 1 is not of type 'Node'`. The two hover-close handlers pass the mouse event's `relatedTarget` straight into `Node.contains()` via an `as Node` cast:

```ts
if (trigger === 'hover' && !floatingRef.current?.contains(e.relatedTarget as Node)) { ... }
```

`relatedTarget` is `null` when the pointer leaves to outside the document, and in some browsers/cases it isn't a `Node` at all. `Node.contains()` then throws. The `as Node` cast hides this from TypeScript but not at runtime. Because `LemonDropdown` is a shared component used across the app, this is a frequent, broad source of uncaught exceptions.

## Changes

Guard both hover-close paths (`onMouseLeaveInside` and the reference element's `onMouseLeave`) with an `instanceof Node` check before calling `contains()`. Anything that isn't a Node contained by the dropdown is treated as the pointer having left the element — preserving the existing close-on-leave behaviour while no longer throwing.

## How did you test this code?

I'm an agent (PostHog Code). I have **not** run the build or tests in this environment (frontend dependencies are not installed here). Verification so far is limited to:

- Manual review of the diff and the runtime semantics (null / non-Node `relatedTarget` no longer reaches `Node.contains()`; behaviour is unchanged when `relatedTarget` is a contained `Node`).

A reviewer should run `pnpm --filter=@posthog/frontend typescript:check` and exercise a hover dropdown (move the pointer out of the window / onto a non-element target) to confirm.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

Authored by PostHog Code (Claude) while triaging the highest-volume unhandled frontend exceptions on insights pages. This `contains()` TypeError surfaced as one of the top issues. The fix is a minimal defensive guard in the shared `LemonDropdown`; no behaviour change intended beyond not throwing. A sibling PR addresses an unrelated TaxonomicFilter crash found in the same triage. Agent-authored — requires human review; no manual browser testing was performed in the agent environment.
