### PR TITLE
fix(taxonomic-filter): skip entries without a name when caching prop defs

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1975,7 +1975,11 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                     groupType === TaxonomicFilterGroupType.PersonProperties ||
                     groupType === TaxonomicFilterGroupType.NumericalEventProperties)
             ) {
-                const propertyDefinitions: PropertyDefinition[] = results.results as PropertyDefinition[]
+                // results.results can contain loading skeletons or undefined entries that have no
+                // `name`; those would crash `Object.fromEntries`/`.name` below, so skip them.
+                const propertyDefinitions = (results.results as PropertyDefinition[]).filter(
+                    (propertyDefinition) => propertyDefinition?.name
+                )
                 const apiType = groupType === TaxonomicFilterGroupType.PersonProperties ? 'person' : 'event'
                 const newPropertyDefinitions = Object.fromEntries(
                     propertyDefinitions.map((propertyDefinition) => [


### PR DESCRIPTION
## Problem

The TaxonomicFilter throws two unhandled errors while processing loaded results — `TypeError: Cannot read properties of undefined (reading 'name')` and `Iterator value undefined is not an entry object`. Both originate in `infiniteListResultsReceived` (`taxonomicFilterLogic.tsx`), where the app-wide property-definition cache is built:

```ts
const propertyDefinitions: PropertyDefinition[] = results.results as PropertyDefinition[]
const newPropertyDefinitions = Object.fromEntries(
    propertyDefinitions.map((propertyDefinition) => [`${apiType}/${propertyDefinition.name}`, propertyDefinition])
)
```

`results.results` is typed `(TaxonomicDefinitionTypes | SkeletonItem)[]` — loading skeletons (and occasional `undefined` entries) have no `name`, so `propertyDefinition.name` throws, and an `undefined` entry makes `Object.fromEntries` throw "is not an entry object". The `as PropertyDefinition[]` cast hides this from TypeScript.

## Changes

Filter `results.results` to entries that actually have a `name` before building the cache map. This only affects what gets written into the cached property metadata — it does **not** touch result ordering, promotion (`PROMOTED_PROPERTIES_BY_SEARCH_TERM`), position-0 behaviour, tab rendering, or any telemetry payload shape.

## How did you test this code?

I'm an agent (PostHog Code). I have **not** run the build or tests in this environment (frontend dependencies are not installed here). Verification so far:

- Manual review of the diff and runtime semantics: skeleton/`undefined` entries are excluded before `.map`/`Object.fromEntries`, and valid `PropertyDefinition`s are cached exactly as before.

A reviewer should run `pnpm --filter=@posthog/frontend typescript:check` and `hogli test frontend/src/lib/components/TaxonomicFilter/`, and confirm property metadata still caches correctly while a results list is mid-load.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

Authored by PostHog Code (Claude) while triaging high-volume unhandled frontend exceptions on insights pages; these two TypeErrors share this single root cause (skeleton/undefined entries leaking into the property-definition cache). Per the repo's `modifying-taxonomic-filter` guidance, the change deliberately avoids ordering/promotion/telemetry — it is purely a defensive guard. A sibling PR fixes an unrelated `LemonDropdown` `contains()` crash found in the same triage. Agent-authored — requires human review; no manual browser testing was performed in the agent environment.
