### PR TITLE
fix: Raise if data_interval_end is in the future

### DIFF
--- a/posthog/batch_exports/api/file_download.py
+++ b/posthog/batch_exports/api/file_download.py
@@ -105,6 +105,11 @@ class FileDownloadBatchExportOnDemandSerializer(serializers.Serializer):
         if data["data_interval_end"] - data["data_interval_start"] > FILE_DOWNLOAD_MAX_RANGE:
             raise ValidationError("data interval range too big")
 
+        if data["data_interval_end"] > dt.datetime.now(dt.UTC):
+            raise ValidationError(
+                f"The provided 'data_interval_end' ({data['data_interval_end'].isoformat()}) is in the future"
+            )
+
         return data
 
     def create(self, validated_data: dict) -> BatchExportRun:

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -175,7 +175,7 @@ async def execute_batch_export_using_internal_stage(
                 initial_interval=dt.timedelta(seconds=initial_retry_interval_seconds),
                 maximum_interval=dt.timedelta(seconds=maximum_stage_retry_interval_seconds),
                 maximum_attempts=maximum_attempts,
-                non_retryable_error_types=["InvalidFilterError"],
+                non_retryable_error_types=["InvalidFilterError", "DataIntervalEndInFutureError"],
             ),
         )
         batch_export_inputs.stage_folder = stage_folder

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -70,6 +70,13 @@ from products.batch_exports.backend.temporal.utils import set_status_to_running_
 LOGGER = get_write_only_logger()
 
 
+class DataIntervalEndInFutureError(Exception):
+    """Raised when a batch export's 'data_interval_end' is after now."""
+
+    def __init__(self, data_interval_end: dt.datetime) -> None:
+        super().__init__(f"The provided 'data_interval_end' ({data_interval_end.isoformat()}) is in the future")
+
+
 def _is_local_dev_or_test() -> bool:
     return settings.DEBUG or settings.TEST
 
@@ -492,6 +499,11 @@ async def _write_batch_export_record_batches_to_internal_stage(
     else:
         delta = dt.timedelta(minutes=1)
     end_at = full_range[1]
+
+    if _is_local_dev_or_test() is False and end_at > dt.datetime.now(dt.UTC):
+        # Some tests create data in the future, so we do not check this.
+        raise DataIntervalEndInFutureError(end_at)
+
     await wait_for_delta_past_data_interval_end(end_at, delta)
 
     done_ranges: list[tuple[dt.datetime, dt.datetime]] = []

--- a/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_api.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_api.py
@@ -360,6 +360,45 @@ async def test_file_download_create_rejects_when_concurrency_limit_reached(
 
 
 @pytest.mark.django_db(transaction=True)
+async def test_file_download_create_rejects_future_data_interval_end(
+    async_client: AsyncClient,
+    team,
+    user,
+):
+    now = dt.datetime.now(dt.UTC)
+
+    await async_client.aforce_login(user)
+
+    with unittest.mock.patch("posthog.batch_exports.api.file_download.start_file_download_batch_export") as mock_start:
+        data_interval_end_iso = (now + dt.timedelta(hours=1)).isoformat()
+        response = await async_client.post(
+            f"/api/projects/{team.pk}/file_download_batch_exports",
+            {
+                "file": {
+                    "format": "Parquet",
+                    "compression": "zstd",
+                },
+                "model": "events",
+                "data_interval_start": (now - dt.timedelta(hours=1)).isoformat(),
+                "data_interval_end": data_interval_end_iso,
+            },
+            content_type="application/json",
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json()["detail"] == f"The provided 'data_interval_end' ({data_interval_end_iso}) is in the future"
+
+    mock_start.assert_not_called()
+    assert (
+        await BatchExportRun.objects.filter(
+            batch_export_on_demand__team_id=team.pk,
+            batch_export_on_demand__destination__type=BatchExportDestination.Destination.FILE_DOWNLOAD,
+        ).acount()
+        == 0
+    )
+
+
+@pytest.mark.django_db(transaction=True)
 async def test_file_download_list_returns_run_ids_and_statuses(
     async_client: AsyncClient,
     team,

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
@@ -20,6 +20,8 @@ from posthog.temporal.common.clickhouse import ClickHouseClient
 from products.batch_exports.backend.service import BackfillDetails, BatchExportModel
 from products.batch_exports.backend.temporal.pipeline.internal_stage import (
     BatchExportInsertIntoInternalStageInputs,
+    DataIntervalEndInFutureError,
+    _write_batch_export_record_batches_to_internal_stage,
     insert_into_internal_stage_activity,
 )
 from products.batch_exports.backend.temporal.pipeline.producer import Producer
@@ -173,6 +175,33 @@ async def test_insert_into_stage_activity_executes_the_expected_query_for_sessio
             "product": "batch_export",
         }
     )
+
+
+async def test_write_batch_export_record_batches_to_internal_stage_rejects_future_data_interval_end():
+    data_interval_start = dt.datetime.now(dt.UTC) - dt.timedelta(hours=1)
+    data_interval_end = dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)
+
+    with (
+        patch(
+            "products.batch_exports.backend.temporal.pipeline.internal_stage.wait_for_delta_past_data_interval_end"
+        ) as mock_wait,
+        patch("products.batch_exports.backend.temporal.pipeline.internal_stage.get_client") as mock_get_client,
+        override_settings(DEBUG=False, TEST=False),
+    ):
+        with pytest.raises(DataIntervalEndInFutureError, match="The provided 'data_interval_end'.*is in the future"):
+            await _write_batch_export_record_batches_to_internal_stage(
+                query_or_model="SELECT 1",
+                full_range=(data_interval_start, data_interval_end),
+                query_parameters={},
+                team_id=1,
+                batch_export_id=str(uuid.uuid4()),
+                data_interval_start=data_interval_start.isoformat(),
+                data_interval_end=data_interval_end.isoformat(),
+                s3_staging_folder_url="s3://bucket/folder",
+            )
+
+    mock_wait.assert_not_called()
+    mock_get_client.assert_not_called()
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

This check was already done for regular batch exports, this commit extends the check to also be applied in the internal stage activity, and in the batch export on demand API.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

See above.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added unit tests.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Yeah, should mention this in a FAQ or somewhere small.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Some help with test boilerplate, but changes are pretty minimal anyways.
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
