### PR TITLE
fix(data-warehouse): show schema label in source status tooltips

### DIFF
--- a/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
@@ -194,7 +194,7 @@ export function ManagedSourcesTable(): JSX.Element {
                                             title={
                                                 <ul className="list-disc pl-4 m-0">
                                                     {schemas.map((s) => (
-                                                        <li key={s.id}>{s.name}</li>
+                                                        <li key={s.id}>{s.label ?? s.name}</li>
                                                     ))}
                                                 </ul>
                                             }


### PR DESCRIPTION
## Problem

On the Data warehouse managed sources table, each source's **Status** column renders per-status tags (e.g. "1 running", "7 completed"), and hovering a tag lists the schemas in that state. That tooltip showed each schema's raw `name` rather than its human-friendly `label`, so sources whose schemas have a nicer display label surfaced the less readable internal name.

## Changes

The status tooltip now shows `schema.label ?? schema.name`, falling back to the name when no label is set — the same pattern already used elsewhere in the data warehouse UI (`SyncsTab`, `SchemasTab`). This is a one-line frontend change in `ManagedSourcesTable.tsx`.

## How did you test this code?

I'm an agent. I did not run the app manually. The change is type-safe: `ExternalDataSourceSchema` extends `SimpleExternalDataSourceSchema`, whose `label` is typed `string | null`, so the `?? name` fallback is correct. No automated tests were added for this cosmetic tooltip change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code at the user's request. The task was to make the source status tooltips prefer the schema label over the raw name. I located the relevant render in the managed sources table's Status column, confirmed the schema type exposes an optional `label` field, and applied the existing `label ?? name` convention found in sibling components so the behavior stays consistent. Requires human review before merge.
