### PR TITLE
feat(cdp): detect browser forks in User Agent Populator plugin

### DIFF
--- a/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.test.ts
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.test.ts
@@ -274,6 +274,12 @@ describe('useragent-plugin', () => {
             '17.4',
         ],
         [
+            'DuckDuckGo on Android',
+            'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/116.0.0.0 Mobile DuckDuckGo/5 Safari/537.36',
+            'DuckDuckGo',
+            '5',
+        ],
+        [
             'Brave on iOS',
             'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Brave/1.64 Safari/604.1',
             'Brave',

--- a/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.test.ts
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.test.ts
@@ -248,6 +248,101 @@ describe('useragent-plugin', () => {
         )
     })
 
+    test.each([
+        [
+            'Vivaldi',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Vivaldi/6.7.3329.41',
+            'Vivaldi',
+            '6.7',
+        ],
+        [
+            'Yandex',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 YaBrowser/24.4.0.0 Safari/537.36',
+            'Yandex',
+            '24.4',
+        ],
+        [
+            'Naver Whale',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Whale/3.25.232.19 Safari/537.36',
+            'Whale',
+            '3.25',
+        ],
+        [
+            'DuckDuckGo on iOS',
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Ddg/17.4 Mobile/15E148 Safari/605.1.15',
+            'DuckDuckGo',
+            '17.4',
+        ],
+        [
+            'Brave on iOS',
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Brave/1.64 Safari/604.1',
+            'Brave',
+            '1.64',
+        ],
+        [
+            'Pale Moon',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Goanna/6.4 Firefox/102.0 PaleMoon/33.0.0',
+            'Pale Moon',
+            '33.0',
+        ],
+        [
+            'Waterfox',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:115.0) Gecko/20100101 Firefox/115.0 Waterfox/115.13.0',
+            'Waterfox',
+            '115.13',
+        ],
+    ])('should detect %s fork instead of bucketing as Chrome/Firefox/Safari', (_label, ua, browser, version) => {
+        const event = {
+            properties: {
+                $useragent: ua,
+                $lib: 'posthog-node',
+            },
+        } as unknown as PluginEvent
+
+        const processedEvent = processEvent(event, makeMeta())
+        expect(processedEvent.properties!).toStrictEqual(
+            expect.objectContaining({
+                $browser: browser,
+                $browser_version: version,
+            })
+        )
+    })
+
+    test('should report a null version for the Waterfox classic-series marker', () => {
+        const event = {
+            properties: {
+                $useragent:
+                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:78.0) Gecko/20100101 Firefox/78.0 Waterfox/G6.0.13',
+                $lib: 'posthog-node',
+            },
+        } as unknown as PluginEvent
+
+        const processedEvent = processEvent(event, makeMeta())
+        expect(processedEvent.properties!).toStrictEqual(
+            expect.objectContaining({
+                $browser: 'Waterfox',
+                $browser_version: null,
+            })
+        )
+    })
+
+    test('should not detect desktop Brave (no UA marker) — falls through to Chrome', () => {
+        const event = {
+            properties: {
+                $useragent:
+                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+                $lib: 'posthog-node',
+            },
+        } as unknown as PluginEvent
+
+        const processedEvent = processEvent(event, makeMeta())
+        expect(processedEvent.properties!).toStrictEqual(
+            expect.objectContaining({
+                $browser: 'chrome',
+            })
+        )
+    })
+
     describe('enableSegmentAnalyticsJs is true', () => {
         test('should add user agent details when segment_userAgent property exists', () => {
             const event = {

--- a/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.ts
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.ts
@@ -93,6 +93,7 @@ export function processEvent(event: PluginEvent, { global, logger }: UserAgentMe
     }
 
     const agentInfo = detect(userAgent)
+    const browserFork = detectBrowserFork(userAgent)
     const device = detectDevice(userAgent)
     const deviceType = detectDeviceType(userAgent)
 
@@ -124,9 +125,52 @@ export function processEvent(event: PluginEvent, { global, logger }: UserAgentMe
         properties['$browser_type'] = agentInfo.type
     }
 
+    // Override $browser for Chromium / Firefox forks that detect-browser buckets
+    // as Chrome / Firefox / Safari. $os and $browser_type still come from
+    // detect-browser above.
+    if (browserFork) {
+        properties['$browser'] = browserFork.name
+        properties['$browser_version'] = browserFork.version
+    }
+
     event.properties = properties
 
     return event
+}
+
+// Chromium and Firefox forks that stamp themselves into the UA string. We detect
+// them here because detect-browser buckets them as Chrome / Firefox / Safari.
+// Ported from posthog-js so server-populated $browser matches what the SDK sets
+// client-side:
+// https://github.com/PostHog/posthog-js/blob/master/packages/core/src/utils/user-agent-utils.ts
+//
+// Desktop / Android Brave is intentionally invisible in the UA (posthog-js detects
+// it via navigator.brave, which isn't available server-side), so it still falls
+// through to Chrome here. Only Brave on iOS carries a `Brave/` marker.
+//
+// Order mirrors posthog-js: each fork's marker also contains Chrome/, Firefox/ or
+// a Safari token, so the fork must be matched before the generic browser would be.
+const BROWSER_FORKS: { name: string; marker: RegExp; versionRegex: RegExp }[] = [
+    { name: 'Vivaldi', marker: /Vivaldi\//, versionRegex: /Vivaldi\/(\d+(?:\.\d+)?)/ },
+    { name: 'Yandex', marker: /YaBrowser\//, versionRegex: /YaBrowser\/(\d+(?:\.\d+)?)/ },
+    { name: 'Whale', marker: /Whale\//, versionRegex: /Whale\/(\d+(?:\.\d+)?)/ },
+    { name: 'DuckDuckGo', marker: /DuckDuckGo\/|Ddg\//, versionRegex: /(?:DuckDuckGo|Ddg)\/(\d+(?:\.\d+)?)/ },
+    { name: 'Brave', marker: /Brave\//, versionRegex: /Brave\/(\d+(?:\.\d+)?)/ },
+    { name: 'Pale Moon', marker: /PaleMoon\//, versionRegex: /PaleMoon\/(\d+(?:\.\d+)?)/ },
+    { name: 'Waterfox', marker: /Waterfox\//, versionRegex: /Waterfox\/(\d+(?:\.\d+)?)/ },
+]
+
+// Returns the fork name and its parsed version, or null when no fork marker matches.
+// version is null when the marker is present but carries no numeric version (e.g.
+// Waterfox's `Waterfox/G6.0.13` classic-series marker) — honest rather than faked.
+function detectBrowserFork(userAgent: string): { name: string; version: string | null } | null {
+    for (const { name, marker, versionRegex } of BROWSER_FORKS) {
+        if (marker.test(userAgent)) {
+            const match = userAgent.match(versionRegex)
+            return { name, version: match ? match[1] : null }
+        }
+    }
+    return null
 }
 
 // detectDevice and detectDeviceType from https://github.com/PostHog/posthog-js/blob/9abedce5ac877caeb09205c4b693988fc09a63ca/src/utils.js#L808-L837


### PR DESCRIPTION
## Problem

The optional **User Agent Populator** CDP transformation plugin derives `$browser` / `$browser_version` from a raw user-agent string using the `detect-browser` library. That library buckets Chromium and Firefox forks (Vivaldi, Yandex, Naver Whale, DuckDuckGo, Pale Moon, Waterfox, Brave) as plain Chrome / Firefox / Safari.

posthog-js was just updated to recognise these forks (PostHog/posthog-js#3708), so events whose `$browser` is set client-side by the SDK now diverge from events whose `$browser` is populated server-side by this plugin. This re-syncs the server-side path so `$browser`-based breakdowns are consistent regardless of where the property was set.

## Changes

- Added a UA-marker fork override ported from posthog-js, applied **after** `detect-browser` so `$os` and `$browser_type` continue to come from the library. Only `$browser` and `$browser_version` are overridden when a fork marker is present.
- Detected forks and their UA markers: Vivaldi (`Vivaldi/`), Yandex (`YaBrowser/`), Naver Whale (`Whale/`), DuckDuckGo (`DuckDuckGo/` or `Ddg/`), Pale Moon (`PaleMoon/`), Waterfox (`Waterfox/`), and Brave on iOS (`Brave/`).
- Browser names match posthog-js exactly so SDK-set and server-populated values line up.
- Versions are parsed from the marker and left `null` when the marker carries no numeric version (e.g. Waterfox's `Waterfox/G6.0.13` classic series) — honest rather than faked.

### Deliberate gap: desktop / Android Brave

posthog-js detects desktop/Android Brave via the `navigator.brave` hint, since it's Chromium-based and invisible in the UA string. That hint doesn't exist server-side, so desktop/Android Brave still falls through to Chrome here. Only Brave on iOS (which stamps `Brave/X` into the UA) is detected. This matches what's actually knowable from a UA string alone.

This is an opt-in transformation plugin and is not part of the default ingestion pipeline.

## How did you test this code?

I'm an agent. I added and ran automated Jest tests for this plugin (`nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.test.ts`) — all 19 pass, including a parameterized case per fork, the Waterfox classic-series `null`-version case, and a desktop-Brave-falls-through-to-Chrome case. I did not perform manual end-to-end testing. Prettier and eslint were run on the touched files with no changes/errors.

## 🤖 Agent context

Authored by an agent (Claude, via PostHog Code) in response to a question about whether a CDP/ingestion-side user-agent parser needed updating to match posthog-js#3708.

Key findings/decisions:
- The default ingestion pipeline does **not** parse user agents — `$browser`/`$os`/etc. are SDK-set and passed through verbatim. The only server-side parser is this opt-in CDP plugin.
- The posthog-js PR changed *browser* detection (not the `detectDevice`/`detectDeviceType` regexes), so the fix targets the browser path.
- Rather than replace `detect-browser` wholesale (which would also mean re-implementing OS/`$browser_type` detection), I layered a minimal UA-marker fork override on top, mirroring posthog-js's marker set, ordering, and naming. This keeps the change surgical and preserves existing `$os`/`$browser_type` behaviour.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*