### PR TITLE
fix(insights): recompute sql insight view after editor update

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -1774,7 +1774,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     lemonToast.info(
                         `You're now viewing ${savedInsight.name || savedInsight.derived_name || insightName || 'Untitled'}`
                     )
-                    router.actions.push(urls.insightView(savedInsight.short_id))
+                    // The insight GET returns the server's pre-edit cached result; force_refresh tells
+                    // insightSceneLogic to recompute the just-saved query instead of showing it stale.
+                    router.actions.push(urls.insightView(savedInsight.short_id), { force_refresh: true })
                 }
             },
             closeEditingObject: () => {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -42,7 +42,7 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { tagsModel } from '~/models/tagsModel'
-import { DashboardFilter, HogQLVariable, Node, TileFilters } from '~/queries/schema/schema-general'
+import { DashboardFilter, HogQLVariable, Node, RefreshType, TileFilters } from '~/queries/schema/schema-general'
 import {
     convertDataTableNodeToDataVisualizationNode,
     isFunnelsQuery,
@@ -134,12 +134,14 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             shortId: InsightShortId,
             filtersOverride?: DashboardFilter | null,
             variablesOverride?: Record<string, HogQLVariable> | null,
-            tileFiltersOverride?: DashboardFilter | null
+            tileFiltersOverride?: DashboardFilter | null,
+            refresh: RefreshType = 'async'
         ) => ({
             shortId,
             filtersOverride,
             variablesOverride,
             tileFiltersOverride,
+            refresh,
         }),
         updateInsight: (insightUpdate: Partial<QueryBasedInsightModel>, callback?: () => void) => ({
             insightUpdate,
@@ -176,7 +178,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             props.cachedInsight ?? createEmptyInsight(props.dashboardItemId || 'new'),
             {
                 loadInsight: async (
-                    { shortId, filtersOverride, variablesOverride, tileFiltersOverride },
+                    { shortId, filtersOverride, variablesOverride, tileFiltersOverride, refresh },
                     breakpoint
                 ) => {
                     await breakpoint(100)
@@ -184,7 +186,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                         const insight = await insightsApi.getByShortId(
                             shortId,
                             undefined,
-                            'async',
+                            refresh,
                             filtersOverride,
                             variablesOverride,
                             tileFiltersOverride

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -1,4 +1,5 @@
 import { BuiltLogic, actions, connect, kea, listeners, path, reducers, selectors, sharedListeners } from 'kea'
+import { router } from 'kea-router'
 import { objectsEqual } from 'kea-test-utils'
 
 import api from 'lib/api'
@@ -23,6 +24,7 @@ import { urls } from 'scenes/urls'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
+import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
 import { getDefaultQuery } from '~/queries/nodes/InsightViz/utils'
 import { DashboardFilter, FileSystemIconType, HogQLVariable, Node, TileFilters } from '~/queries/schema/schema-general'
 import {
@@ -124,6 +126,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             unmount,
         }),
         setFreshQuery: (freshQuery: boolean) => ({ freshQuery }),
+        setForceRefresh: (forceRefresh: boolean) => ({ forceRefresh }),
         upgradeQuery: (query: Node) => ({ query }),
     }),
     reducers({
@@ -208,6 +211,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             },
         ],
         freshQuery: [false, { setFreshQuery: (_, { freshQuery }) => freshQuery }],
+        forceRefresh: [false, { setForceRefresh: (_, { forceRefresh }) => forceRefresh }],
     }),
     selectors({
         tabId: [() => [(_, props: InsightSceneLogicProps) => props.tabId], (tabId) => tabId],
@@ -382,6 +386,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             const insightId = values.insightId ?? null
             const mountedDashboardItemId = values.insightLogicRef?.logic.props.dashboardItemId ?? null
             const propsMismatch = Boolean(insightId && mountedDashboardItemId && mountedDashboardItemId !== insightId)
+            const forceRefresh = values.forceRefresh
 
             if (logicInsightId !== insightId || propsMismatch) {
                 const oldRef = values.insightLogicRef // free old logic after mounting new one
@@ -418,8 +423,23 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     insightId as InsightShortId,
                     values.filtersOverride,
                     values.variablesOverride,
-                    values.tileFiltersOverride
+                    values.tileFiltersOverride,
+                    forceRefresh ? 'force_async' : 'async'
                 )
+            }
+
+            if (forceRefresh) {
+                // The just-saved query may differ from the server's cached result, so force a
+                // recompute of the insight's mounted data node(s) rather than rendering the stale
+                // cached response. A freshly-mounted scene auto-loads its query anyway, so this
+                // only matters when the insight view was already open.
+                if (insightId) {
+                    // Mirrors insightVizDataCollectionId: the scene's viz registers its data node
+                    // under the dashboard id (if on a dashboard) or else the insight short_id.
+                    const collectionKey = (values.dashboardId != null ? String(values.dashboardId) : null) ?? insightId
+                    dataNodeCollectionLogic.findMounted({ key: collectionKey })?.actions.reloadAll()
+                }
+                actions.setForceRefresh(false)
             }
         },
     })),
@@ -528,6 +548,9 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             const filtersOverride = searchParams['filters_override']
             const variablesOverride = searchParams['variables_override']
             const tileFiltersOverride = searchParams['tile_filters_override']
+            // A sibling scene (e.g. the SQL editor) sets `force_refresh` when navigating here right
+            // after saving, so we recompute instead of rendering the server's pre-edit cached result.
+            const forceRefresh = Boolean(searchParams['force_refresh'])
 
             if (
                 initial ||
@@ -543,6 +566,10 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                 (dashboard ?? null) !== values.dashboardId ||
                 (dashboardName ?? null) !== values.dashboardName
             ) {
+                // Set before setSceneState so reloadInsightLogic (its listener) sees the flag.
+                if (forceRefresh && method === 'PUSH') {
+                    actions.setForceRefresh(true)
+                }
                 actions.setSceneState(
                     insightId,
                     insightMode,
@@ -558,6 +585,12 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     dashboardName,
                     sceneSource
                 )
+            }
+
+            if (forceRefresh) {
+                // Drop the one-shot flag from the URL so a reload or shared link doesn't re-trigger it.
+                const { force_refresh: _omit, ...cleanSearchParams } = router.values.searchParams
+                router.actions.replace(router.values.location.pathname, cleanSearchParams, router.values.hashParams)
             }
 
             let queryFromUrl: Node | null = null


### PR DESCRIPTION
## Problem

When you edit and save an insight from the SQL editor, it navigates you to the insight view — but the insight then loads with `refresh=async`, which returns the server's pre-edit cached result. You see the *old* numbers for your just-saved query until you manually refresh.

## Changes

- `sqlEditorLogic`: after a (non-dashboard) insight update, navigate to the insight view with a one-shot `force_refresh` search param.
- `insightSceneLogic`: when `force_refresh` is present on a `PUSH`, set a `forceRefresh` flag (before `setSceneState`, so the `reloadInsightLogic` listener sees it), then strip the param from the URL so a reload or shared link won't re-trigger it.
- `reloadInsightLogic`: when the flag is set, load the insight with `force_async` and call `dataNodeCollectionLogic.reloadAll()` (the same thing the Refresh button does) so the viz's own data node recomputes rather than showing the cached response. Clears the flag after.
- `insightLogic.loadInsight`: gains an optional `refresh: RefreshType = 'async'` arg threaded into `getByShortId` (default-preserving for all existing callers).

No client-side result cache, TTL, or stashed response — the destination just recomputes.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run:

- Regenerated kea logic types via `kea-typegen write --show-ts-errors` — clean, which validates the new action/reducer wiring and the changed `loadInsight` signature.
- Ran the frontend formatter/linter (`oxlint`/`oxfmt`) — no errors.

Not done: a full project typecheck (runs in CI) and a manual run of the edit → save → view flow in the app. The fix robustly covers the case where the insight view is already open (`reloadAll` forces the mounted data node); the freshly-mounted-scene case relies on the viz's normal auto-load and would be worth a manual confirmation.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code. This started as a review of an alternative PR (#60561) that fixed the same stale-view bug with a module-level `Map` cache (30s TTL) that carried the editor's freshly-run result to the destination scene. We judged that approach hacky — global mutable state, a TTL race, no scoping, and it papered over the refresh semantics — and chose the opposite direction: don't carry the result, just tell the destination to recompute.

Key decisions:
- Recompute-at-destination over carry-the-result: simpler, no cache/shape handling, at the cost of a brief recompute the editor already paid for.
- The real refresh lever is the viz's `dataNodeLogic` (what the SQL viz reads), not `loadInsight` — so we force the data node via `dataNodeCollectionLogic.reloadAll()`, not only the GET.
- One open question for the reviewer: whether the freshly-mounted-scene path was ever actually stale (static analysis suggested it auto-loads fresh for a changed query); this PR covers it defensively but it's the piece most worth a manual check.

Agent-assisted; requires human review.