### PR TITLE
fix(exports): keep user-facing links public when SITE_URL is internal

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -28,7 +28,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.jwt import PosthogJwtAudience, encode_jwt
 from posthog.models.exported_asset import ExportedAsset, save_content_from_file
-from posthog.utils import absolute_uri
+from posthog.tasks.exports.exporter_utils import exporter_absolute_uri
 
 from ...exceptions import ClickHouseQuerySizeExceeded
 from ...hogql.constants import CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL, CSV_EXPORT_BREAKDOWN_LIMIT_LOW, CSV_EXPORT_LIMIT
@@ -654,7 +654,7 @@ def make_api_call(
     next_url: Optional[str],
     path: str,
 ) -> requests.models.Response:
-    request_url: str = absolute_uri(next_url or path)
+    request_url: str = exporter_absolute_uri(next_url or path)
     url = add_query_params(
         request_url,
         {get_limit_param_key(request_url): str(limit), "is_csv_export": "1"},

--- a/posthog/tasks/exports/exporter_utils.py
+++ b/posthog/tasks/exports/exporter_utils.py
@@ -6,7 +6,15 @@ from django.conf import settings
 import requests
 import structlog
 
+from posthog.utils import absolute_uri
+
 logger = structlog.get_logger(__name__)
+
+
+def exporter_absolute_uri(url: str) -> str:
+    """The exporters fetch the web app over HTTP, so they load pages from `SITE_URL` (which may be a
+    cluster-internal address) rather than the public user-facing URL used for links."""
+    return absolute_uri(url, base_url=settings.SITE_URL)
 
 
 _site_reachable: Optional[bool] = None

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -30,8 +30,7 @@ from posthog.models.exported_asset import ExportedAsset, get_render_access_token
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 from posthog.security.url_validation import is_url_allowed
 from posthog.tasks.exporter import EXPORT_TIMER
-from posthog.tasks.exports.exporter_utils import log_error_if_site_url_not_reachable
-from posthog.utils import absolute_uri
+from posthog.tasks.exports.exporter_utils import exporter_absolute_uri, log_error_if_site_url_not_reachable
 
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.product_analytics.backend.api.insight_variable import map_stale_to_latest
@@ -163,7 +162,7 @@ def _export_to_png(
             show_legend = exported_asset.insight.show_legend
             legend_param = "&legend=true" if show_legend else ""
             cache_keys_param = _build_cache_keys_param(insight_cache_keys)
-            url_to_render = absolute_uri(f"/exporter?token={access_token}{legend_param}{cache_keys_param}")
+            url_to_render = exporter_absolute_uri(f"/exporter?token={access_token}{legend_param}{cache_keys_param}")
             wait_for_css_selector = ".ExportedInsight"
             query = exported_asset.insight.query or {}
             source = query.get("source", query)  # This to handle the InsightVizNode wrapper
@@ -179,12 +178,12 @@ def _export_to_png(
             screenshot_width = 4000 if is_left_to_right_funnel else 800
         elif exported_asset.dashboard is not None:
             cache_keys_param = _build_cache_keys_param(insight_cache_keys)
-            url_to_render = absolute_uri(f"/exporter?token={access_token}{cache_keys_param}")
+            url_to_render = exporter_absolute_uri(f"/exporter?token={access_token}{cache_keys_param}")
             wait_for_css_selector = ".InsightCard"
             screenshot_width = 1920
         elif exported_asset.export_context and exported_asset.export_context.get("session_recording_id"):
             # Handle replay export using /exporter route (same as insights/dashboards)
-            url_to_render = absolute_uri(
+            url_to_render = exporter_absolute_uri(
                 f"/exporter?token={access_token}&t={exported_asset.export_context.get('timestamp') or 0}&fullscreen=true"
             )
             wait_for_css_selector = exported_asset.export_context.get("css_selector", ".replayer-wrapper")
@@ -210,7 +209,7 @@ def _export_to_png(
             # the `/exporter` query string.
             encoded_page_url = quote(heatmap_url, safe="")
             encoded_data_url = quote(exported_asset.export_context.get("heatmap_data_url") or "", safe="")
-            url_to_render = absolute_uri(
+            url_to_render = exporter_absolute_uri(
                 f"/exporter?token={access_token}&pageURL={encoded_page_url}&dataURL={encoded_data_url}"
             )
             wait_for_css_selector = exported_asset.export_context.get("css_selector", ".heatmaps-ready")

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -202,6 +202,40 @@ class TestImageExporter(APIBaseTest):
         assert "test_cache_key_123" in url_to_render, f"URL should contain the cache key: {url_to_render}"
 
     @patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight")
+    def test_export_renders_from_site_url_not_public_url(
+        self,
+        mock_calculate: Any,
+        mock_remove: Any,
+        mock_open: Any,
+        mock_screenshot_asset: Any,
+    ) -> None:
+        """On Cloud the headless browser must load from the reachable SITE_URL, not the public region URL."""
+        insight = Insight.objects.create(
+            team=self.team,
+            name="Test Insight",
+            query={"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT 1 as value"}},
+        )
+        exported_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            insight=insight,
+        )
+
+        mock_calculate.return_value = make_insight_result("test_cache_key")
+
+        with self.settings(
+            OBJECT_STORAGE_ENABLED=False,
+            CLOUD_DEPLOYMENT="US",
+            SITE_URL="http://posthog-web-django.posthog.svc.cluster.local:8000",
+        ):
+            image_exporter.export_image(exported_asset)
+
+        url_to_render = mock_screenshot_asset.call_args[0][1]
+        assert url_to_render.startswith("http://posthog-web-django.posthog.svc.cluster.local:8000/exporter"), (
+            f"URL should be rendered from SITE_URL, not the public region URL: {url_to_render}"
+        )
+
+    @patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight")
     def test_dashboard_export_captures_all_cache_keys(
         self,
         mock_calculate: Any,

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -34,6 +34,7 @@ from posthog.utils import (
     get_default_event_name,
     get_ip_address,
     get_js_url,
+    get_public_site_url,
     get_short_user_agent,
     load_data_from_request,
     refresh_requested_by_client,
@@ -133,6 +134,35 @@ class TestAbsoluteUrls(TestCase):
         with self.settings(SITE_URL="https://app.posthog.com"):
             with pytest.raises(PotentialSecurityProblemException):
                 absolute_uri(url)
+
+    @parameterized.expand(
+        [
+            ("us_cloud", "US", "http://internal.svc.cluster.local:8000", "https://us.posthog.com"),
+            ("eu_cloud", "EU", "http://internal.svc.cluster.local:8000", "https://eu.posthog.com"),
+            ("lowercase_region", "us", "http://internal.svc.cluster.local:8000", "https://us.posthog.com"),
+            ("dev_cloud_uses_site_url", "DEV", "https://dev.posthog.com", "https://dev.posthog.com"),
+            ("self_hosted_uses_site_url", None, "https://posthog.example.com", "https://posthog.example.com"),
+        ]
+    )
+    def test_get_public_site_url(self, _name: str, cloud_deployment: str | None, site_url: str, expected: str) -> None:
+        with self.settings(CLOUD_DEPLOYMENT=cloud_deployment, SITE_URL=site_url):
+            self.assertEqual(expected, get_public_site_url())
+
+    def test_absolute_uri_uses_public_site_url_on_cloud(self) -> None:
+        with self.settings(CLOUD_DEPLOYMENT="US", SITE_URL="http://internal.svc.cluster.local:8000"):
+            self.assertEqual("https://us.posthog.com/insights/abc", absolute_uri("/insights/abc"))
+
+    def test_absolute_uri_uses_base_url_override(self) -> None:
+        with self.settings(CLOUD_DEPLOYMENT="US", SITE_URL="http://internal.svc.cluster.local:8000"):
+            self.assertEqual(
+                "http://internal.svc.cluster.local:8000/exporter?token=abc",
+                absolute_uri("/exporter?token=abc", base_url="http://internal.svc.cluster.local:8000"),
+            )
+
+    def test_absolute_uri_base_url_override_enforces_host_check_against_base(self) -> None:
+        with self.settings(CLOUD_DEPLOYMENT="US", SITE_URL="http://internal.svc.cluster.local:8000"):
+            with pytest.raises(PotentialSecurityProblemException):
+                absolute_uri("https://us.posthog.com/path", base_url="http://internal.svc.cluster.local:8000")
 
 
 class TestFormatUrls(TestCase):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -111,31 +111,52 @@ class PotentialSecurityProblemException(Exception):
     pass
 
 
-def absolute_uri(url: Optional[str] = None) -> str:
+def get_public_site_url() -> str:
+    """Public, user-facing base URL for links in emails, subscriptions, digests, and integrations.
+
+    On Cloud the image and CSV exporters need HTTP access to the web app, so operators may set
+    `SITE_URL` to a cluster-internal Service address. User-facing links must not leak that address,
+    so on Cloud we resolve the public domain from `CLOUD_DEPLOYMENT` instead. Everywhere else
+    `SITE_URL` is already the public URL.
     """
-    Returns an absolutely-formatted URL based on the `SITE_URL` config.
+    region = (settings.CLOUD_DEPLOYMENT or "").upper()
+    if region == "US":
+        return "https://us.posthog.com"
+    if region == "EU":
+        return "https://eu.posthog.com"
+    return settings.SITE_URL
+
+
+def absolute_uri(url: Optional[str] = None, *, base_url: Optional[str] = None) -> str:
+    """
+    Returns an absolutely-formatted URL based on the public site URL.
+
+    The default base is the public, user-facing URL (`get_public_site_url()`), so links resolve
+    correctly even when `SITE_URL` is a cluster-internal address. Pass `base_url` to render against
+    a specific base instead -- the exporters use this to load pages over the reachable `SITE_URL`.
 
     If the provided URL is already absolutely formatted
-    it does not allow anything except the hostname of the SITE_URL config
+    it does not allow anything except the hostname of the base URL.
     """
+    base = base_url or get_public_site_url()
+
     if not url:
-        return settings.SITE_URL
+        return base
 
     if has_authority_bypass_chars(url):
         raise PotentialSecurityProblemException(f"It is forbidden to provide an absolute URI using {url}")
 
     provided_url = urlparse(url)
     if provided_url.hostname and provided_url.scheme:
-        site_url = urlparse(settings.SITE_URL)
-        provided_url = provided_url
+        parsed_base = urlparse(base)
         if (
-            site_url.hostname != provided_url.hostname
-            or site_url.port != provided_url.port
-            or site_url.scheme != provided_url.scheme
+            parsed_base.hostname != provided_url.hostname
+            or parsed_base.port != provided_url.port
+            or parsed_base.scheme != provided_url.scheme
         ):
             raise PotentialSecurityProblemException(f"It is forbidden to provide an absolute URI using {url}")
 
-    return urljoin(settings.SITE_URL.rstrip("/") + "/", url.lstrip("/"))
+    return urljoin(base.rstrip("/") + "/", url.lstrip("/"))
 
 
 def get_previous_day(at: Optional[datetime.datetime] = None) -> tuple[datetime.datetime, datetime.datetime]:


### PR DESCRIPTION
## Problem

A subscription to an "exceptions" insight delivered a link to an error-tracking issue that pointed at an internal cluster address (`http://posthog-web-django.posthog.svc.cluster.local:8000/project/2/error_tracking/...`) instead of the public app URL.

Root cause: the image (and CSV) exporter requires `SITE_URL` to be HTTP-reachable from the worker pods. On deployments where workers can't reach the public domain, operators set `SITE_URL` to the cluster-internal Service address so exports keep working. But `SITE_URL` is also the base for every user-facing link PostHog builds — subscription/digest emails, the issue-assigned email, the error-tracking weekly digest, and integrations. So the internal host leaks into all outbound links.

## Changes

The exporter is already correct to load over `SITE_URL`; the conflict is that user-facing links were also built from it. On Cloud we already know the public domain from `CLOUD_DEPLOYMENT`, so we don't need a new setting to recover it.

- `get_public_site_url()` resolves the public, user-facing base URL: `https://us.posthog.com` / `https://eu.posthog.com` on Cloud (`CLOUD_DEPLOYMENT` is `US`/`EU`), and `SITE_URL` everywhere else.
- `absolute_uri()` now defaults its base to `get_public_site_url()`, so every user-facing link is fixed at once. It also gains a `base_url` override, and the host-safety check runs against whichever base is used.
- The image and CSV exporters opt out of the public default via a single shared `exporter_absolute_uri()` helper, so the headless browser and the CSV pagination fetch keep loading pages over the reachable `SITE_URL`.

This is the inverse of the original approach (a new `EXPORTER_INTERNAL_URL` env var): no new setting, no `exporter_utils` signature churn, and — crucially — **no deploy-config change required**. The public domain is already known from `CLOUD_DEPLOYMENT`, which the PostHog charts mark as `required` on Cloud, so the leak is fixed automatically on Cloud US/EU.

> Trade-off: this auto-fixes Cloud US/EU only. Self-hosted instances that point `SITE_URL` at an internal address fall through to `SITE_URL` unchanged (they control their own URL and have no region split). The reported bug was on Cloud.

## How did you test this code?

I'm an agent. I added and ran automated tests in a local Django environment (Postgres up); I did not perform manual testing.

- `posthog/test/test_utils.py`: `get_public_site_url()` region resolution (US/EU/lowercase/DEV/self-hosted), `absolute_uri()` using the public URL on Cloud, the `base_url` override, and the host check enforced against the override base. **Ran: 14 passed.**
- `posthog/tasks/exports/test/test_image_exporter.py`: the headless browser renders from `SITE_URL` even when `CLOUD_DEPLOYMENT` would resolve a different public URL. **Ran: passed.**
- `posthog/tasks/exports/test/test_csv_exporter_url_sanitising.py`: unchanged behavior through the shared helper. **Ran: 10 passed.**

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No new env var, so no self-host configuration docs change is needed.

## 🤖 Agent context

Authored by PostHog Code (Opus 4.8) at the request of @pauldambra, adopting and simplifying an earlier agent-authored PR that introduced a new `EXPORTER_INTERNAL_URL` setting.

The earlier approach kept `SITE_URL` public and pointed a new internal-only env var at the in-cluster address for the exporter. This revision inverts that: keep the exporter on `SITE_URL` (already reachable in-cluster) and derive the *public* link base from `CLOUD_DEPLOYMENT`. Chosen because it needs no new setting and no operator config change to take effect, and it fixes every user-facing link site through one function rather than per-send-site.

Verified via the PostHog charts that `CLOUD_DEPLOYMENT` is reliable on Cloud: `charts/posthog-app/templates/configmap-env.yaml` renders it with `| required`, the prod values set `US`/`EU`, and the posthog-app deployments load that configmap via `envFrom` on web and worker pods — exactly where the exporter and link-building run.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
