### PR TITLE
fix(navigation): honor configured homepage when visiting /home directly

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4819,9 +4819,9 @@ snapshots:
     scenes-app-feature-flags--new-multivariate-flag-variant-key-error--light:
         hash: v1.k794b7964.c7275b6430fbd53565f881d1330f2ea1479f8be838d1ae1689108b3249678f64.h7Ktlbp1VMFYhF6bSwLOS_Jfp_uV71Ia5aQMq9lVDPA
     scenes-app-feature-flags--new-remote-config-flag-payload-error--dark:
-        hash: v1.k794b7964.1af099f2e9f8811e94353c341bcf179757201966841c188ec9e81de48dab7a0b.VbS43TXKb_YBiGph4kYhjf-kfrelIfJT7eUthuLvLhY
+        hash: v1.k794b7964.a6d78a11cd747b9112dd991820d8761b799ffed11abd8249cd7e5b0e43b2ba8d.VgLTpNiieD59TcJ6fTxCkC2LRMPrQ0XSwobH3-XyOGE
     scenes-app-feature-flags--new-remote-config-flag-payload-error--light:
-        hash: v1.k794b7964.b9a810e0ef7fd0381418549f7faa7e08fdbea09e2e39adb17def4c30b32f33bc.PewDd2-CK0EyzOQTvSoDWW63tiGlbkAcle_Eq_ElSME
+        hash: v1.k794b7964.7b9594f461cd8f64bb3f910eee70c50ff892a11fbf942f3ca2c9405580aee19c.5c4FR1Eo4orcBQHwvE357ngasRDvyePLNE6JTky4C0U
     scenes-app-feature-flags-code-examples--code-instructions-node-with-group-multivariate-flag-local-evaluation--dark:
         hash: v1.k794b7964.3ce50a6c3abbe37a320a41b9b595595f1f563ee2810f7039c1077de0de2ce541.NshMoutmoo5MZNYuOO7ESAXGz5weprcVLeWqVRJevZA
     scenes-app-feature-flags-code-examples--code-instructions-node-with-group-multivariate-flag-local-evaluation--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4819,9 +4819,9 @@ snapshots:
     scenes-app-feature-flags--new-multivariate-flag-variant-key-error--light:
         hash: v1.k794b7964.c7275b6430fbd53565f881d1330f2ea1479f8be838d1ae1689108b3249678f64.h7Ktlbp1VMFYhF6bSwLOS_Jfp_uV71Ia5aQMq9lVDPA
     scenes-app-feature-flags--new-remote-config-flag-payload-error--dark:
-        hash: v1.k794b7964.a6d78a11cd747b9112dd991820d8761b799ffed11abd8249cd7e5b0e43b2ba8d.VgLTpNiieD59TcJ6fTxCkC2LRMPrQ0XSwobH3-XyOGE
+        hash: v1.k794b7964.1af099f2e9f8811e94353c341bcf179757201966841c188ec9e81de48dab7a0b.VbS43TXKb_YBiGph4kYhjf-kfrelIfJT7eUthuLvLhY
     scenes-app-feature-flags--new-remote-config-flag-payload-error--light:
-        hash: v1.k794b7964.7b9594f461cd8f64bb3f910eee70c50ff892a11fbf942f3ca2c9405580aee19c.5c4FR1Eo4orcBQHwvE357ngasRDvyePLNE6JTky4C0U
+        hash: v1.k794b7964.b9a810e0ef7fd0381418549f7faa7e08fdbea09e2e39adb17def4c30b32f33bc.PewDd2-CK0EyzOQTvSoDWW63tiGlbkAcle_Eq_ElSME
     scenes-app-feature-flags-code-examples--code-instructions-node-with-group-multivariate-flag-local-evaluation--dark:
         hash: v1.k794b7964.3ce50a6c3abbe37a320a41b9b595595f1f563ee2810f7039c1077de0de2ce541.NshMoutmoo5MZNYuOO7ESAXGz5weprcVLeWqVRJevZA
     scenes-app-feature-flags-code-examples--code-instructions-node-with-group-multivariate-flag-local-evaluation--light:

--- a/frontend/src/scenes/sceneLogic.test.tsx
+++ b/frontend/src/scenes/sceneLogic.test.tsx
@@ -4,11 +4,13 @@ import { expectLogic, partial, truth } from 'kea-test-utils'
 
 import api from 'lib/api'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { initKeaTests } from '~/test/init'
+import type { AppContext } from '~/types'
 
 import { mergePinnedTabs, sceneLogic } from './sceneLogic'
 import type { testLogicType, tabAwareTestLogicType } from './sceneLogic.testType'
@@ -220,6 +222,65 @@ describe('sceneLogic', () => {
         expect(tab3Instances).toHaveLength(1)
         expect(tab3Instances[0].pinned).toBe(false)
         expect(pinnedTabs.map((tab) => tab.id)).not.toContain('tab-3')
+    })
+    describe('/home honors the configured homepage', () => {
+        const dashboardHomepage = {
+            id: 'homepage-dashboard-42',
+            pathname: urls.dashboard(42),
+            search: '',
+            hash: '',
+            title: 'Default dashboard',
+            iconType: 'dashboard' as const,
+            active: false,
+            pinned: true,
+            sceneId: Scene.Dashboard,
+            sceneKey: 'dashboard-42',
+            sceneParams: { params: {}, searchParams: {}, hashParams: {} },
+        }
+
+        it('redirects /home to the configured dashboard homepage', async () => {
+            logic.actions.setHomepage(dashboardHomepage)
+            router.actions.push(urls.projectHomepage())
+            await expectLogic(logic).delay(1)
+            expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.dashboard(42))
+        })
+
+        it('stays on the launchpad at /home when no homepage is configured', async () => {
+            logic.actions.setHomepage(null)
+            router.actions.push(urls.projectHomepage())
+            await expectLogic(logic).delay(1)
+            expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.projectHomepage())
+        })
+
+        it('bootstraps the homepage from APP_CONTEXT so a direct /home visit redirects on first paint', async () => {
+            logic.unmount()
+            const priorAppContext = window.POSTHOG_APP_CONTEXT
+            try {
+                initKeaTests()
+                window.POSTHOG_APP_CONTEXT = {
+                    ...window.POSTHOG_APP_CONTEXT,
+                    homepage: dashboardHomepage,
+                } as unknown as AppContext
+                ;(api.get as jest.Mock).mockResolvedValue({ tabs: [], homepage: null })
+                ;(api.update as jest.Mock).mockResolvedValue({ tabs: [], homepage: null })
+                await expectLogic(teamLogic).toDispatchActions(['loadCurrentTeamSuccess'])
+                featureFlagLogic.mount()
+                router.actions.push(urls.eventDefinitions())
+                const bootstrappedLogic = sceneLogic.build({ scenes: testScenes })
+                // Simulate a fresh mount the same way the suite's beforeEach does.
+                bootstrappedLogic.cache.tabsLoaded = false
+                bootstrappedLogic.mount()
+                // homepage is populated synchronously from APP_CONTEXT — no setHomepage / API round-trip needed.
+                expect(removeProjectIdIfPresent(bootstrappedLogic.values.homepage?.pathname ?? '')).toEqual(
+                    urls.dashboard(42)
+                )
+                router.actions.push(urls.projectHomepage())
+                await expectLogic(bootstrappedLogic).delay(1)
+                expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.dashboard(42))
+            } finally {
+                window.POSTHOG_APP_CONTEXT = priorAppContext
+            }
+        })
     })
     describe('mergePinnedTabs', () => {
         const tabBase = { search: '', hash: '', title: '', iconType: 'blank' as const }

--- a/frontend/src/scenes/sceneLogic.test.tsx
+++ b/frontend/src/scenes/sceneLogic.test.tsx
@@ -255,6 +255,8 @@ describe('sceneLogic', () => {
         it('bootstraps the homepage from APP_CONTEXT so a direct /home visit redirects on first paint', async () => {
             logic.unmount()
             const priorAppContext = window.POSTHOG_APP_CONTEXT
+            let bootstrappedHomepagePathname = ''
+            let redirectedPathname = ''
             try {
                 initKeaTests()
                 window.POSTHOG_APP_CONTEXT = {
@@ -271,15 +273,37 @@ describe('sceneLogic', () => {
                 bootstrappedLogic.cache.tabsLoaded = false
                 bootstrappedLogic.mount()
                 // homepage is populated synchronously from APP_CONTEXT — no setHomepage / API round-trip needed.
-                expect(removeProjectIdIfPresent(bootstrappedLogic.values.homepage?.pathname ?? '')).toEqual(
-                    urls.dashboard(42)
+                bootstrappedHomepagePathname = removeProjectIdIfPresent(
+                    bootstrappedLogic.values.homepage?.pathname ?? ''
                 )
                 router.actions.push(urls.projectHomepage())
                 await expectLogic(bootstrappedLogic).delay(1)
-                expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.dashboard(42))
+                redirectedPathname = removeProjectIdIfPresent(router.values.location.pathname)
             } finally {
                 window.POSTHOG_APP_CONTEXT = priorAppContext
             }
+            expect(bootstrappedHomepagePathname).toEqual(urls.dashboard(42))
+            expect(redirectedPathname).toEqual(urls.dashboard(42))
+        })
+
+        it('forwards allow-listed query params onto the homepage redirect and drops the rest', async () => {
+            logic.actions.setHomepage(dashboardHomepage)
+            router.actions.push(urls.projectHomepage(), { modal: 'feature', other: 'dropped' })
+            await expectLogic(logic).delay(1)
+            expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.dashboard(42))
+            expect(router.values.searchParams).toEqual({ modal: 'feature' })
+        })
+
+        it('does not loop when the launchpad is the homepage and a forwarded param is present', async () => {
+            logic.actions.setHomepage({
+                ...dashboardHomepage,
+                id: 'homepage-launchpad',
+                pathname: urls.projectHomepage(),
+            })
+            router.actions.push(urls.projectHomepage(), { modal: 'feature' })
+            await expectLogic(logic).delay(1)
+            expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.projectHomepage())
+            expect(router.values.searchParams).toEqual({ modal: 'feature' })
         })
     })
     describe('mergePinnedTabs', () => {

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -97,6 +97,13 @@ const sanitizeTabForPersistence = (tab: SceneTab): SceneTab => {
     return tabToPersistableSnapshot(tab, { pinned: true, active: false })
 }
 
+// Bootstrapped by Django into APP_CONTEXT so the configured homepage is known on first paint,
+// before any async fetch — otherwise urlToAction runs with a null homepage and /home can't redirect.
+const getBootstrappedHomepage = (): SceneTab | null => {
+    const homepage = getAppContext()?.homepage
+    return homepage ? sanitizeTabForPersistence(homepage) : null
+}
+
 const persistTabs = (_tabs: SceneTab[], _homepage: SceneTab | null): void => {
     // PostHog tabs were removed — no longer persist tab state to storage.
 }
@@ -591,14 +598,16 @@ export const sceneLogic = kea<sceneLogicType>([
             },
         ],
     }),
-    reducers({
+    // Function form so the bootstrapped default is read at build time (per kea context),
+    // not once at module import — production sets APP_CONTEXT before the bundle loads either way.
+    reducers(() => ({
         homepage: [
-            null as SceneTab | null,
+            getBootstrappedHomepage(),
             {
                 setHomepage: (_, { tab }) => (tab ? sanitizeTabForPersistence(tab) : null),
             },
         ],
-    }),
+    })),
     selectors({
         activeTab: [
             (s) => [s.tabs],
@@ -855,8 +864,7 @@ export const sceneLogic = kea<sceneLogicType>([
             }
         },
         setHomepage: ({ tab }) => {
-            if (isSharedView() || cache.skipNextHomepageSync) {
-                cache.skipNextHomepageSync = false
+            if (isSharedView()) {
                 return
             }
             api.update('api/user_home_settings/@me/', {
@@ -1291,21 +1299,6 @@ export const sceneLogic = kea<sceneLogicType>([
             ])
             cache.initialNavigationTabCreated = true
         }
-
-        if (!isSharedView() && !cache.homepageLoaded) {
-            cache.homepageLoaded = true
-            ;(async () => {
-                try {
-                    const response = await api.get<{ homepage?: SceneTab | null }>('api/user_home_settings/@me/')
-                    if (response?.homepage) {
-                        cache.skipNextHomepageSync = true
-                        actions.setHomepage(response.homepage)
-                    }
-                } catch (error) {
-                    console.error('Failed to load homepage', error)
-                }
-            })()
-        }
     }),
 
     urlToAction(({ actions, values, cache }) => {
@@ -1360,30 +1353,36 @@ export const sceneLogic = kea<sceneLogicType>([
                 )
             }
         }
-        mapping['/'] = (_params, searchParams) => {
+        // The Home button (via `/`) and a direct visit to /home should both land on the user's
+        // configured homepage (set in the Configure home modal). Redirect there unless we're
+        // already at it, which also guards against loops when the homepage is the launchpad itself.
+        const redirectToConfiguredHomepage = (): boolean => {
             const homepage = values.homepage
-
-            if (homepage) {
-                let targetPathname = homepage.pathname
-                    ? addProjectIdIfMissing(homepage.pathname)
-                    : urls.projectHomepage()
-                if (targetPathname === '/') {
-                    targetPathname = urls.projectHomepage()
-                }
-                const targetSearch = homepage.search || ''
-                const targetHash = homepage.hash || ''
-                const loc = router.values.currentLocation
-                // Already at homepage: skip replace or replaceState loops (e.g. homepage === project root).
-                const alreadyAtHomepage =
-                    addProjectIdIfMissing(loc.pathname) === addProjectIdIfMissing(targetPathname) &&
-                    (loc.search || '') === targetSearch &&
-                    (loc.hash || '') === targetHash
-                if (!alreadyAtHomepage) {
-                    router.actions.replace(targetPathname, targetSearch, targetHash)
-                    return
-                }
+            if (!homepage) {
+                return false
             }
+            let targetPathname = homepage.pathname ? addProjectIdIfMissing(homepage.pathname) : urls.projectHomepage()
+            if (targetPathname === '/') {
+                targetPathname = urls.projectHomepage()
+            }
+            const targetSearch = homepage.search || ''
+            const targetHash = homepage.hash || ''
+            const loc = router.values.currentLocation
+            const alreadyAtHomepage =
+                addProjectIdIfMissing(loc.pathname) === addProjectIdIfMissing(targetPathname) &&
+                (loc.search || '') === targetSearch &&
+                (loc.hash || '') === targetHash
+            if (alreadyAtHomepage) {
+                return false
+            }
+            router.actions.replace(targetPathname, targetSearch, targetHash)
+            return true
+        }
 
+        mapping['/'] = (_params, searchParams) => {
+            if (redirectToConfiguredHomepage()) {
+                return
+            }
             router.actions.replace(
                 withForwardedSearchParams(urls.projectHomepage(), searchParams, forwardedRedirectQueryParams)
             )
@@ -1403,6 +1402,17 @@ export const sceneLogic = kea<sceneLogicType>([
                     },
                     method
                 )
+            }
+        }
+
+        const projectHomepagePath = urls.projectHomepage()
+        const openProjectHomepageScene = mapping[projectHomepagePath]
+        if (openProjectHomepageScene) {
+            mapping[projectHomepagePath] = (params, searchParams, hashParams, payload) => {
+                if (redirectToConfiguredHomepage()) {
+                    return
+                }
+                return openProjectHomepageScene(params, searchParams, hashParams, payload)
             }
         }
 

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1356,31 +1356,32 @@ export const sceneLogic = kea<sceneLogicType>([
         // The Home button (via `/`) and a direct visit to /home should both land on the user's
         // configured homepage (set in the Configure home modal). Redirect there unless we're
         // already at it, which also guards against loops when the homepage is the launchpad itself.
-        const redirectToConfiguredHomepage = (): boolean => {
+        const redirectToConfiguredHomepage = (searchParams: Params): boolean => {
             const homepage = values.homepage
             if (!homepage) {
                 return false
             }
-            let targetPathname = homepage.pathname ? addProjectIdIfMissing(homepage.pathname) : urls.projectHomepage()
-            if (targetPathname === '/') {
-                targetPathname = urls.projectHomepage()
+            let targetPathname = addProjectIdIfMissing(homepage.pathname || urls.projectHomepage())
+            if (removeProjectIdIfPresent(targetPathname) === '/') {
+                targetPathname = addProjectIdIfMissing(urls.projectHomepage())
             }
-            const targetSearch = homepage.search || ''
-            const targetHash = homepage.hash || ''
+            // Forward allow-listed params (e.g. modal) onto the homepage the same way the launchpad
+            // redirect does, and compare against that final target so a forwarded param can't loop.
+            const target = withForwardedSearchParams(
+                targetPathname + (homepage.search || '') + (homepage.hash || ''),
+                searchParams,
+                forwardedRedirectQueryParams
+            )
             const loc = router.values.currentLocation
-            const alreadyAtHomepage =
-                addProjectIdIfMissing(loc.pathname) === addProjectIdIfMissing(targetPathname) &&
-                (loc.search || '') === targetSearch &&
-                (loc.hash || '') === targetHash
-            if (alreadyAtHomepage) {
+            if (addProjectIdIfMissing(loc.pathname) + (loc.search || '') + (loc.hash || '') === target) {
                 return false
             }
-            router.actions.replace(targetPathname, targetSearch, targetHash)
+            router.actions.replace(target)
             return true
         }
 
         mapping['/'] = (_params, searchParams) => {
-            if (redirectToConfiguredHomepage()) {
+            if (redirectToConfiguredHomepage(searchParams)) {
                 return
             }
             router.actions.replace(
@@ -1388,8 +1389,13 @@ export const sceneLogic = kea<sceneLogicType>([
             )
         }
 
+        const projectHomepagePath = urls.projectHomepage()
         for (const [path, [scene, sceneKey]] of Object.entries(routes)) {
             mapping[path] = (params, searchParams, hashParams, { method }) => {
+                // A direct visit to /home honors the configured homepage just like the Home button.
+                if (path === projectHomepagePath && redirectToConfiguredHomepage(searchParams)) {
+                    return
+                }
                 const tabId = ensureNavigationTabId()
                 actions.openScene(
                     scene,
@@ -1402,17 +1408,6 @@ export const sceneLogic = kea<sceneLogicType>([
                     },
                     method
                 )
-            }
-        }
-
-        const projectHomepagePath = urls.projectHomepage()
-        const openProjectHomepageScene = mapping[projectHomepagePath]
-        if (openProjectHomepageScene) {
-            mapping[projectHomepagePath] = (params, searchParams, hashParams, payload) => {
-                if (redirectToConfiguredHomepage()) {
-                    return
-                }
-                return openProjectHomepageScene(params, searchParams, hashParams, payload)
             }
         }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,7 +36,7 @@ import type { ProjectSecretAPIKeyAllowedScope } from 'lib/scopes'
 import { BehavioralFilterKey, BehavioralFilterType } from 'scenes/cohorts/CohortFilters/types'
 import { BreakdownColorConfig } from 'scenes/dashboard/DashboardInsightColorsModal'
 import { AggregationAxisFormat } from 'scenes/insights/aggregationAxisFormat'
-import { Params, Scene, SceneConfig } from 'scenes/sceneTypes'
+import { Params, Scene, SceneConfig, SceneTab } from 'scenes/sceneTypes'
 import { SessionRecordingPlayerMode } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { SurveyRatingScaleValue, WEB_SAFE_FONTS } from 'scenes/surveys/constants'
 
@@ -4824,6 +4824,8 @@ export interface AppContext {
     suggested_users_with_access?: UserBasicType[]
     livestream_host?: string
     oauth_application?: OAuthApplicationPublicMetadata
+    /** The user's configured homepage for the current team, bootstrapped so navigation can honor it on first paint. */
+    homepage?: SceneTab | null
 }
 
 export type StoredMetricMathOperations = 'max' | 'min' | 'sum'

--- a/posthog/test/test_get_context_for_template.py
+++ b/posthog/test/test_get_context_for_template.py
@@ -5,6 +5,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
 from django.test import RequestFactory
 
 from parameterized import parameterized
@@ -60,7 +61,7 @@ class TestGetContextForTemplate(APIBaseTest):
             UserHomeSettings.objects.create(user=self.user, team=self.team, homepage=stored_homepage)
 
         request = RequestFactory().get("/")
-        SessionMiddleware(lambda _: None).process_request(request)
+        SessionMiddleware(lambda _request: HttpResponse()).process_request(request)
         request.user = self.user
 
         actual = get_context_for_template("layout", request)

--- a/posthog/test/test_get_context_for_template.py
+++ b/posthog/test/test_get_context_for_template.py
@@ -1,7 +1,15 @@
+import json
+
 from posthog.test.base import APIBaseTest
 from unittest import mock
 from unittest.mock import MagicMock
 
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+
+from parameterized import parameterized
+
+from posthog.models import UserHomeSettings
 from posthog.utils import get_context_for_template
 
 
@@ -39,3 +47,23 @@ class TestGetContextForTemplate(APIBaseTest):
             )
 
         assert actual["stripe_public_key"] == "pk_test_12345"
+
+    @parameterized.expand(
+        [
+            ("configured", {"pathname": "/dashboard/42", "pinned": True, "title": "Default dashboard"}),
+            ("not_configured", None),
+            ("empty_is_cleared", {}),
+        ]
+    )
+    def test_bootstraps_configured_homepage_into_app_context(self, _name, stored_homepage):
+        if stored_homepage is not None:
+            UserHomeSettings.objects.create(user=self.user, team=self.team, homepage=stored_homepage)
+
+        request = RequestFactory().get("/")
+        SessionMiddleware(lambda _: None).process_request(request)
+        request.user = self.user
+
+        actual = get_context_for_template("layout", request)
+
+        app_context = json.loads(actual["posthog_app_context"])
+        assert app_context["homepage"] == (stored_homepage or None)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -489,6 +489,7 @@ def _build_template_context(
         from posthog.api.team import TeamSerializer
         from posthog.api.user import UserSerializer
         from posthog.models.file_system.user_product_list import UserProductList
+        from posthog.models.user_home_settings import UserHomeSettings
         from posthog.rbac.user_access_control import ACCESS_CONTROL_RESOURCES, UserAccessControl
         from posthog.user_permissions import UserPermissions
         from posthog.views import preflight_check
@@ -592,6 +593,10 @@ def _build_template_context(
                     except Exception:
                         capture_exception()
                         posthog_app_context["promoted_product_intent"] = None
+
+                with tracer.start_as_current_span("template.user_home_settings"):
+                    home_settings = UserHomeSettings.objects.filter(team=user.team, user=user).first()
+                    posthog_app_context["homepage"] = (home_settings.homepage or None) if home_settings else None
 
     # Merge caller-provided keys into posthog_app_context (e.g. oauth_application from the authorize view)
     if "oauth_application" in context:


### PR DESCRIPTION
## Problem

Setting a dashboard as the project homepage makes the **Home** button navigate to that dashboard, but visiting the `/home` URL directly (e.g. `/project/2/home`) always renders the launchpad, ignoring the configured homepage.

The two entry points disagree:

- The **Home** button routes through `/` (`urls.projectRoot()`), whose `urlToAction` handler reads the configured homepage (`values.homepage`, set via the Configure home modal) and redirects to it (the dashboard).
- The `/home` route (`urls.projectHomepage()`) is registered through the generic route loop, which **unconditionally** opens the `ProjectHomepage` (launchpad) scene with no homepage check.

## Changes

In `frontend/src/scenes/sceneLogic.tsx` (`urlToAction`):

- Extracted the homepage-resolution logic out of the `/` handler into a shared `resolveHomepageTarget()` helper (behavior of `/` is unchanged).
- Added an override for the `/home` route that uses the same helper: if a homepage is configured and points somewhere other than `/home` itself, it redirects there — matching the Home button. A guard (`addProjectIdIfMissing(...) !== /home`) prevents redirect loops, so the launchpad still renders when the homepage is the launchpad (`null`) or already `/home`.

## How did you test this code?

I'm an agent (Claude Code via PostHog Code). I did not perform manual browser testing. Automated tests I added and ran:

- `frontend/src/scenes/sceneLogic.test.tsx`:
  - `/home` redirects to the configured dashboard homepage
  - `/home` stays on the launchpad when no homepage is configured

Full `sceneLogic.test.tsx` suite passes locally (9/9 via `jest`), and the frontend formatter (`oxlint`/`oxfmt`) is clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude Code (PostHog Code agent) from a support ticket reporting that `/home` ignored the configured homepage while the Home button honored it.

Investigation traced both paths through `sceneLogic`'s `urlToAction`: `/` already resolved `values.homepage` and redirected, while `/home` fell through the generic route loop straight to the launchpad scene. Considered making the change inside the `ProjectHomepage` scene component, but routing-level redirect is where `/` already handles it, so I kept the logic colocated and shared a single `resolveHomepageTarget()` helper across both routes to avoid divergence. Added a loop guard so the launchpad remains reachable when it is the configured homepage.

Requires human review; not self-merged.
