### PR TITLE
refactor(signals): route emit_signal through backend facade

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/emit_signal.py
+++ b/posthog/temporal/ai_observability/eval_reports/emit_signal.py
@@ -191,7 +191,7 @@ async def emit_eval_report_signal_activity(inputs: EmitEvalReportSignalInputs) -
 
     summary = await summarize_report_for_signal(inputs, content)
 
-    from products.signals.backend.api import emit_signal
+    from products.signals.backend.facade.api import emit_signal
 
     await emit_signal(
         team=team,

--- a/posthog/temporal/ai_observability/eval_reports/test/test_emit_signal.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_emit_signal.py
@@ -157,7 +157,7 @@ class TestEmitEvalReportSignalActivity:
             patch(
                 "posthog.temporal.ai_observability.eval_reports.emit_signal.summarize_report_for_signal"
             ) as mock_summarize,
-            patch("products.signals.backend.api.emit_signal", new_callable=AsyncMock) as mock_emit,
+            patch("products.signals.backend.facade.api.emit_signal", new_callable=AsyncMock) as mock_emit,
         ):
             await emit_eval_report_signal_activity(inputs)
         mock_summarize.assert_not_called()
@@ -186,7 +186,7 @@ class TestEmitEvalReportSignalActivity:
             patch(
                 "posthog.temporal.ai_observability.eval_reports.emit_signal.EvaluationReportRun.objects.values_list"
             ) as mock_values_list,
-            patch("products.signals.backend.api.emit_signal", new_callable=AsyncMock) as mock_emit,
+            patch("products.signals.backend.facade.api.emit_signal", new_callable=AsyncMock) as mock_emit,
         ):
             mock_values_list.return_value.get.return_value = _make_content()
             await emit_eval_report_signal_activity(inputs)
@@ -231,7 +231,7 @@ class TestEmitEvalReportSignalActivity:
             patch(
                 "posthog.temporal.ai_observability.eval_reports.emit_signal.EvaluationReportRun.objects.values_list"
             ) as mock_values_list,
-            patch("products.signals.backend.api.emit_signal", new_callable=AsyncMock) as mock_emit,
+            patch("products.signals.backend.facade.api.emit_signal", new_callable=AsyncMock) as mock_emit,
         ):
             mock_values_list.return_value.get.return_value = _make_content()
             await emit_eval_report_signal_activity(inputs)
@@ -248,7 +248,7 @@ class TestEvalReportSignalSchemaContract:
     """
 
     def test_evaluation_report_variant_is_registered(self):
-        from products.signals.backend.api import _SIGNAL_VARIANT_LOOKUP
+        from products.signals.backend.facade.api import _SIGNAL_VARIANT_LOOKUP
 
         variant = _SIGNAL_VARIANT_LOOKUP.get(("llm_analytics", "evaluation_report"))
         assert variant is not None, (
@@ -258,7 +258,7 @@ class TestEvalReportSignalSchemaContract:
 
     def test_activity_payload_validates_against_variant(self):
         """Construct the exact emit_signal kwargs the activity sends and validate them."""
-        from products.signals.backend.api import _SIGNAL_VARIANT_LOOKUP
+        from products.signals.backend.facade.api import _SIGNAL_VARIANT_LOOKUP
 
         variant = _SIGNAL_VARIANT_LOOKUP[("llm_analytics", "evaluation_report")]
         payload = {

--- a/posthog/temporal/data_imports/signals/pipeline.py
+++ b/posthog/temporal/data_imports/signals/pipeline.py
@@ -18,7 +18,7 @@ from posthog.models import Organization, Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.data_imports.signals.registry import SignalEmitter, SignalEmitterOutput, SignalSourceTableConfig
 
-from products.signals.backend.api import emit_signal
+from products.signals.backend.facade.api import emit_signal
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a7b_emit_session_problem_signals.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a7b_emit_session_problem_signals.py
@@ -7,7 +7,7 @@ from posthog.session_recordings.queries.session_replay_events import SessionRepl
 from posthog.sync import database_sync_to_async
 from posthog.temporal.session_replay.session_summary.types.video import SessionProblem, VideoSummarySingleSessionInputs
 
-from products.signals.backend.api import emit_signal
+from products.signals.backend.facade.api import emit_signal
 
 logger = structlog.get_logger(__name__)
 

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -167,7 +167,7 @@ def _emit_endpoint_failure_signal(
 
     Fails silently — signal emission must never mask the underlying error.
     """
-    from products.signals.backend.api import emit_signal
+    from products.signals.backend.facade.api import emit_signal
 
     try:
         error_class = type(exc).__name__

--- a/products/endpoints/backend/tests/test_endpoint_execution.py
+++ b/products/endpoints/backend/tests/test_endpoint_execution.py
@@ -2186,7 +2186,7 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
         endpoint = self._make_simple_hogql_endpoint("failure_signal_swallow")
 
         with mock.patch(
-            "products.signals.backend.api.emit_signal",
+            "products.signals.backend.facade.api.emit_signal",
             side_effect=RuntimeError("signal layer exploded"),
         ):
             _emit_endpoint_failure_signal(self.team, endpoint, RuntimeError("original"), materialized=False, version=1)

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -18,9 +18,6 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.client import async_connect
 
 from products.signals.backend.models import SignalSourceConfig
-from products.signals.backend.temporal.buffer import BufferSignalsWorkflow
-from products.signals.backend.temporal.emitter import SignalEmitterInput, SignalEmitterWorkflow
-from products.signals.backend.temporal.types import BufferSignalsInput, EmitSignalInputs
 
 logger = structlog.get_logger(__name__)
 
@@ -87,6 +84,12 @@ async def emit_signal(
             extra={"html_url": "https://github.com/posthog/posthog/issues/12345", "number": 12345, ...},
         )
     """
+    # Deferred: the temporal package imports the facade back (reingestion -> emit_signal), so
+    # importing these workflows at module scope forms a circular import and drags the whole
+    # temporal stack onto the Django startup path. Resolved lazily at call time instead.
+    from products.signals.backend.temporal.buffer import BufferSignalsWorkflow  # noqa: PLC0415
+    from products.signals.backend.temporal.emitter import SignalEmitterInput, SignalEmitterWorkflow  # noqa: PLC0415
+    from products.signals.backend.temporal.types import BufferSignalsInput, EmitSignalInputs  # noqa: PLC0415
 
     organization = await database_sync_to_async(lambda: team.organization)()
     if not organization.is_ai_data_processing_approved:

--- a/products/signals/backend/management/commands/ingest_signals_json.py
+++ b/products/signals/backend/management/commands/ingest_signals_json.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from posthog.models import Team
 
-from products.signals.backend.api import emit_signal
+from products.signals.backend.facade.api import emit_signal
 
 
 class Command(BaseCommand):

--- a/products/signals/backend/scout_harness/tools/emit.py
+++ b/products/signals/backend/scout_harness/tools/emit.py
@@ -129,9 +129,8 @@ async def emit_finding(
         )
         return EmitResult(finding_id=finding_id, emitted=False, skipped_reason=preflight)
 
-    # Defer the import: products.signals.backend.api transitively imports temporal
-    # workflows, which we don't want loaded at module import time inside the harness.
-    from products.signals.backend.api import emit_signal
+    # Deferred to keep the harness module import lightweight — emitting is an opt-in path here.
+    from products.signals.backend.facade.api import emit_signal
 
     source_id = f"run:{run.id}:finding:{finding_id}"
     await emit_signal(
@@ -210,7 +209,7 @@ def emit_finding_sync(
         )
         return EmitResult(finding_id=finding_id, emitted=False, skipped_reason=preflight)
 
-    from products.signals.backend.api import emit_signal
+    from products.signals.backend.facade.api import emit_signal
 
     source_id = f"run:{run.id}:finding:{finding_id}"
     async_to_sync(emit_signal)(

--- a/products/signals/backend/temporal/backfill_error_tracking.py
+++ b/products/signals/backend/temporal/backfill_error_tracking.py
@@ -93,7 +93,7 @@ async def emit_backfill_signal_activity(input: EmitBackfillSignalInput) -> None:
     """Emit an issue_created signal for a single error tracking issue."""
     from posthog.models import Team
 
-    from products.signals.backend.api import emit_signal
+    from products.signals.backend.facade.api import emit_signal
 
     team = await Team.objects.aget(id=input.team_id)
 

--- a/products/signals/backend/temporal/emit_eval_signal.py
+++ b/products/signals/backend/temporal/emit_eval_signal.py
@@ -146,7 +146,7 @@ async def emit_eval_signal_activity(inputs: EmitEvalSignalInputs) -> None:
     if summary.significance < 0.1:
         return
 
-    from products.signals.backend.api import emit_signal
+    from products.signals.backend.facade.api import emit_signal
 
     await emit_signal(
         team=team,

--- a/products/signals/backend/temporal/reingestion.py
+++ b/products/signals/backend/temporal/reingestion.py
@@ -18,7 +18,7 @@ from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.scoped import scoped_temporal
 
-from products.signals.backend.api import emit_signal
+from products.signals.backend.facade.api import emit_signal
 from products.signals.backend.models import SignalReport, SignalReportArtefact
 from products.signals.backend.temporal.clickhouse import execute_hogql_query_with_retry
 from products.signals.backend.temporal.grouping_v2 import TeamSignalGroupingV2Workflow

--- a/products/signals/backend/test/test_api.py
+++ b/products/signals/backend/test/test_api.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pydantic
 import temporalio.exceptions
 
-from products.signals.backend.api import emit_signal
+from products.signals.backend.facade.api import emit_signal
 from products.signals.backend.models import SignalSourceConfig
 from products.signals.backend.temporal.buffer import BufferSignalsWorkflow
 from products.signals.backend.temporal.emitter import SignalEmitterWorkflow
@@ -85,7 +85,7 @@ class TestEmitSignalValidation:
         ]
 
         with (
-            patch("products.signals.backend.api.async_connect", return_value=client),
+            patch("products.signals.backend.facade.api.async_connect", return_value=client),
             patch.object(SignalSourceConfig, "is_source_enabled", return_value=True),
         ):
             await emit_signal(
@@ -117,7 +117,7 @@ class TestEmitSignalValidation:
         client = AsyncMock()
 
         with (
-            patch("products.signals.backend.api.async_connect", return_value=client),
+            patch("products.signals.backend.facade.api.async_connect", return_value=client),
             patch.object(SignalSourceConfig, "is_source_enabled", return_value=True),
         ):
             with pytest.raises(pydantic.ValidationError):
@@ -143,9 +143,9 @@ class TestEmitSignalAnalytics:
         ]
 
         with (
-            patch("products.signals.backend.api.async_connect", return_value=client),
+            patch("products.signals.backend.facade.api.async_connect", return_value=client),
             patch.object(SignalSourceConfig, "is_source_enabled", return_value=True),
-            patch("products.signals.backend.api.posthoganalytics.capture") as capture,
+            patch("products.signals.backend.facade.api.posthoganalytics.capture") as capture,
         ):
             await emit_signal(
                 team=team_stub,

--- a/products/signals/backend/test/test_scout_harness_api.py
+++ b/products/signals/backend/test/test_scout_harness_api.py
@@ -200,7 +200,7 @@ class TestScoutHarnessEmitFindingAPI(APIBaseTest):
 
     def test_emit_finding_calls_emit_signal_with_deterministic_source_id(self) -> None:
         run = _make_run(self.team)
-        with patch("products.signals.backend.api.emit_signal", new_callable=AsyncMock) as mock_emit:
+        with patch("products.signals.backend.facade.api.emit_signal", new_callable=AsyncMock) as mock_emit:
             response = self.client.post(self._emit_signal_url(str(run.id)), data=self._payload(), format="json")
         assert response.status_code == status.HTTP_200_OK
         body = response.json()

--- a/products/signals/backend/test/test_scout_harness_tools.py
+++ b/products/signals/backend/test/test_scout_harness_tools.py
@@ -463,7 +463,7 @@ async def arun_emit(ateam_emit):
 async def test_emit_finding_happy_path_calls_emit_signal_with_deterministic_source_id(ateam_emit, arun_emit):
     evidence = [EvidenceEntry(source_product="error_tracking", summary="500s spike on /checkout")]
 
-    with patch("products.signals.backend.api.emit_signal", new=AsyncMock()) as mock_emit:
+    with patch("products.signals.backend.facade.api.emit_signal", new=AsyncMock()) as mock_emit:
         result = await emit_finding(
             team=ateam_emit,
             run=arun_emit,
@@ -496,7 +496,7 @@ async def test_emit_finding_happy_path_calls_emit_signal_with_deterministic_sour
 @pytest.mark.asyncio
 @pytest.mark.django_db
 async def test_emit_finding_validation_error_does_not_emit(ateam_emit, arun_emit):
-    with patch("products.signals.backend.api.emit_signal", new=AsyncMock()) as mock_emit:
+    with patch("products.signals.backend.facade.api.emit_signal", new=AsyncMock()) as mock_emit:
         with pytest.raises(InvalidEmitError):
             await emit_finding(
                 team=ateam_emit,
@@ -517,7 +517,7 @@ async def test_emit_finding_propagates_emit_signal_exception(ateam_emit, arun_em
     # does NOT dedupe on source_id — a failed downstream emit surfaces back to the
     # caller, and a retry with the same finding_id would emit a second signal.
     boom = AsyncMock(side_effect=RuntimeError("temporal exploded"))
-    with patch("products.signals.backend.api.emit_signal", new=boom):
+    with patch("products.signals.backend.facade.api.emit_signal", new=boom):
         with pytest.raises(RuntimeError, match="temporal"):
             await emit_finding(
                 team=ateam_emit,
@@ -533,7 +533,7 @@ async def test_emit_finding_propagates_emit_signal_exception(ateam_emit, arun_em
 @pytest.mark.asyncio
 @pytest.mark.django_db
 async def test_emit_finding_auto_generates_finding_id_when_not_provided(ateam_emit, arun_emit):
-    with patch("products.signals.backend.api.emit_signal", new=AsyncMock()):
+    with patch("products.signals.backend.facade.api.emit_signal", new=AsyncMock()):
         result = await emit_finding(
             team=ateam_emit,
             run=arun_emit,
@@ -559,7 +559,7 @@ async def test_emit_finding_returns_skipped_when_ai_processing_not_approved(arun
     org.is_ai_data_processing_approved = False
     await database_sync_to_async(org.save)()
 
-    with patch("products.signals.backend.api.emit_signal", new=AsyncMock()) as mock_emit:
+    with patch("products.signals.backend.facade.api.emit_signal", new=AsyncMock()) as mock_emit:
         result = await emit_finding(
             team=ateam_emit,
             run=arun_emit,
@@ -587,7 +587,7 @@ async def test_emit_finding_returns_skipped_when_source_disabled(arun_emit, atea
         ).update
     )(enabled=False)
 
-    with patch("products.signals.backend.api.emit_signal", new=AsyncMock()) as mock_emit:
+    with patch("products.signals.backend.facade.api.emit_signal", new=AsyncMock()) as mock_emit:
         result = await emit_finding(
             team=ateam_emit,
             run=arun_emit,
@@ -619,7 +619,7 @@ async def test_emit_finding_rejects_team_run_mismatch(aorganization_emit, ateam_
 
     other_team = await database_sync_to_async(Team.objects.create)(organization=aorganization_emit, name="other-team")
 
-    with patch("products.signals.backend.api.emit_signal", new=AsyncMock()) as mock_emit:
+    with patch("products.signals.backend.facade.api.emit_signal", new=AsyncMock()) as mock_emit:
         with pytest.raises(RuntimeError, match="does not own run"):
             await emit_finding(
                 team=other_team,
@@ -650,7 +650,7 @@ def test_emit_finding_sync_rejects_team_run_mismatch(db) -> None:
             skill_version=1,
         )
 
-    with patch("products.signals.backend.api.emit_signal", new=AsyncMock()) as mock_emit:
+    with patch("products.signals.backend.facade.api.emit_signal", new=AsyncMock()) as mock_emit:
         with pytest.raises(RuntimeError, match="does not own run"):
             emit_finding_sync(
                 team=other_team,

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -50,7 +50,7 @@ from posthog.temporal.common.client import sync_connect
 from posthog.user_permissions import UserPermissions
 
 from products.data_warehouse.backend.data_load.service import trigger_external_data_workflow
-from products.signals.backend.api import emit_signal
+from products.signals.backend.facade.api import emit_signal
 from products.signals.backend.implementation_pr import fetch_implementation_pr_urls_for_reports
 from products.signals.backend.models import (
     InvalidStatusTransition,


### PR DESCRIPTION
## Problem

Part of a broader effort to cut `django.setup()` import time (which took it from ~11.8s to ~5s overall). `emit_signal` lived in `products/signals/backend/api.py`, which imported the signals temporal workflows at module scope. That formed a latent circular import — `api -> temporal package -> reingestion -> api.emit_signal` — that only held together by import-order luck and dragged the whole signals temporal workflow stack onto the import path of anything that touched `emit_signal` (which is a lot: other products, core temporal workers, the scout harness). Any shift in import order would both expose the cycle as a hard `ImportError` and re-pay that startup cost.

It's also a cross-boundary API that should sit behind a facade per the product-isolation guidelines, so the cleanup and the isolation step are the same move.

## Changes

Move `emit_signal` to `products/signals/backend/facade/api.py` and route all callers through it. The temporal workflow imports it needs are deferred into the function body, so the facade imports nothing temporal at module scope — the cycle is gone, importing the facade is cheap, and the signals workflow stack no longer rides onto startup via this path. Pure rename plus deferred imports; no behaviour change.

## How did you test this code?

I'm an agent (Claude Code). Automated only: `products/signals/backend/test/test_api.py` (9 passed), `ruff`/`ty` clean via lint-staged, and I verified the facade, `signals.views`, and the temporal package all import without the old circular-import error. No manual testing; relying on CI for the full suite.

## Docs update

No user-facing change.

## 🤖 Agent context

Surfaced while profiling Django startup import cost (`python -X importtime` plus an `__import__`-hook tracer to find what drags heavy modules onto the startup path). This latent cycle was masked by import order and would bite the moment the order shifted — deferring the temporal imports behind the facade removes the cycle and completes a planned isolation step in one go. Kept separate from the larger startup-perf PR (the lazy API router and friends) because it's a self-contained refactor the signals owners can review on its own. Agent-assisted, human-reviewed — not self-merged.
