### PR TITLE
chore(devex): set team-posthog-ai as tasks product owner

### DIFF
--- a/products/tasks/product.yaml
+++ b/products/tasks/product.yaml
@@ -1,3 +1,3 @@
 name: Tasks
 owners:
-    - team-platform-features
+    - team-posthog-ai


### PR DESCRIPTION
## Problem

The reviewer auto-assigner reads product ownership from each `products/<name>/product.yaml`. For `products/tasks` it was requesting `team-platform-features`. The value was a default seeded by the bulk product.yaml commit (#55428), not a deliberate ownership call — so tasks PRs were routed to a team that doesn't work on the code.

## Changes

Set the `products/tasks` owner to `team-posthog-ai`. The tasks product is the PostHog Code cloud-runs product, maintained by the PostHog AI / Code teams (top contributors over the last 6 months: Alessandro, Josh, Georgiy, Rafa, Jonathan, Charles, Peter et al). This makes reviewer auto-assignment route tasks PRs to a team that actually owns the code.

## How did you test this code?

Agent-authored (Claude Code). No automated tests — this is a single ownership config value. Verified the slug `team-posthog-ai` matches the one already used in `products/posthog_ai/product.yaml`.

## 🤖 Agent context

Authored with Claude Code. 