### PR TITLE
feat(hogql): add HogQL expression breakdowns to retention

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
@@ -50,6 +50,7 @@ export const TaxonomicBreakdownPopover = ({
             TaxonomicFilterGroupType.EventFeatureFlags,
             ...groupsTaxonomicTypes,
             TaxonomicFilterGroupType.CohortsWithAllUsers,
+            TaxonomicFilterGroupType.HogQLExpression,
             TaxonomicFilterGroupType.DataWarehousePersonProperties,
         ]
     } else {

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -4002,12 +4002,8 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
         )
 
     def test_retention_with_breakdown_hogql_expression(self):
-        """Test retention with breakdown by a HogQL expression.
-
-        The expression must be evaluated as SQL, not treated as a property name.
-        Using upper(...) makes the buckets uppercased, which only happens if the
-        expression actually runs.
-        """
+        # upper(...) makes the buckets uppercased, which only happens if the expression
+        # is evaluated as SQL rather than treated as a property name.
         _create_person(team_id=self.team.pk, distinct_ids=["person1"])
         _create_person(team_id=self.team.pk, distinct_ids=["person2"])
         _create_person(team_id=self.team.pk, distinct_ids=["person3"])

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import HogQLQueryModifiers, InCohortVia, RetentionQuery
@@ -4001,7 +4002,14 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
             ),
         )
 
-    def test_retention_with_breakdown_hogql_expression(self):
+    @parameterized.expand(
+        [
+            ("plain", "upper(properties.browser)"),
+            # The `AS` clause exercises strip_user_aliases: it must be dropped, not break the query.
+            ("with_alias", "upper(properties.browser) AS browser_upper"),
+        ]
+    )
+    def test_retention_with_breakdown_hogql_expression(self, _name: str, breakdown: str):
         # upper(...) makes the buckets uppercased, which only happens if the expression
         # is evaluated as SQL rather than treated as a property name.
         _create_person(team_id=self.team.pk, distinct_ids=["person1"])
@@ -4035,7 +4043,7 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
                     "totalIntervals": 6,
                     "period": "Day",
                 },
-                "breakdownFilter": {"breakdown": "upper(properties.browser)", "breakdown_type": "hogql"},
+                "breakdownFilter": {"breakdown": breakdown, "breakdown_type": "hogql"},
             }
         )
 

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -4001,6 +4001,66 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
             ),
         )
 
+    def test_retention_with_breakdown_hogql_expression(self):
+        """Test retention with breakdown by a HogQL expression.
+
+        The expression must be evaluated as SQL, not treated as a property name.
+        Using upper(...) makes the buckets uppercased, which only happens if the
+        expression actually runs.
+        """
+        _create_person(team_id=self.team.pk, distinct_ids=["person1"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person2"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person3"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person4"])
+
+        _create_events(
+            self.team,
+            [
+                # Chrome cohort
+                ("person1", _date(0), {"browser": "Chrome"}),  # Day 0
+                ("person1", _date(1), {"browser": "Chrome"}),  # Day 1
+                ("person1", _date(3), {"browser": "Chrome"}),  # Day 3
+                ("person3", _date(0), {"browser": "Chrome"}),  # Day 0
+                ("person3", _date(2), {"browser": "Chrome"}),  # Day 2
+                # Safari cohort
+                ("person2", _date(0), {"browser": "Safari"}),  # Day 0
+                ("person2", _date(1), {"browser": "Safari"}),  # Day 1
+                ("person2", _date(4), {"browser": "Safari"}),  # Day 4
+                # Firefox cohort
+                ("person4", _date(0), {"browser": "Firefox"}),  # Day 0
+                ("person4", _date(5), {"browser": "Firefox"}),  # Day 5
+            ],
+        )
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_to": _date(5, hour=0)},
+                "retentionFilter": {
+                    "totalIntervals": 6,
+                    "period": "Day",
+                },
+                "breakdownFilter": {"breakdown": "upper(properties.browser)", "breakdown_type": "hogql"},
+            }
+        )
+
+        breakdown_values = {c.get("breakdown_value") for c in result}
+        self.assertEqual(breakdown_values, {"CHROME", "SAFARI", "FIREFOX"})
+
+        chrome_cohorts = pluck([c for c in result if c.get("breakdown_value") == "CHROME"], "values", "count")
+        self.assertEqual(
+            chrome_cohorts,
+            pad(
+                [
+                    [2, 1, 1, 1, 0, 0],
+                    [1, 0, 1, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                ]
+            ),
+        )
+
     def test_retention_with_breakdown_event_properties_and_minimum_occurrences(self):
         """Test retention with breakdown by event properties"""
         _create_person(team_id=self.team.pk, distinct_ids=["person1"])

--- a/posthog/hogql_queries/insights/retention/utils.py
+++ b/posthog/hogql_queries/insights/retention/utils.py
@@ -1,6 +1,10 @@
 from typing import cast
 
 from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr
+
+from posthog.clickhouse.query_tagging import tag_contains_user_hogql
+from posthog.hogql_queries.insights.utils.breakdowns import strip_user_aliases
 
 
 def breakdown_extract_expr(property_name: str, breakdown_type: str, group_type_index: int | None = None) -> ast.Expr:
@@ -9,27 +13,35 @@ def breakdown_extract_expr(property_name: str, breakdown_type: str, group_type_i
         # so we just return the cohort ID as a constant
         return ast.Constant(value=str(property_name))
 
-    if breakdown_type == "person":
-        if property_name.startswith("$virt_"):
-            # Virtual properties exist as expression fields on the persons table
-            properties_chain = ["person", property_name]
-        else:
-            properties_chain = ["person", "properties", property_name]
-    elif breakdown_type == "data_warehouse_person_property":
-        properties_chain = ["person", *property_name.split(".")]
-    elif breakdown_type == "group":
-        if property_name.startswith("$virt_"):
-            # Virtual properties exist as expression fields on the groups table
-            properties_chain = [f"groups_{group_type_index}", property_name]
-        else:
-            properties_chain = [f"groups_{group_type_index}", "properties", property_name]
+    if breakdown_type == "hogql":
+        # The value is a raw HogQL expression, not a property name. Parse it and
+        # strip any display-only `AS` aliases the user added, which would otherwise
+        # break the surrounding toString()/argMinIf() wrapping.
+        tag_contains_user_hogql()
+        property_field: ast.Expr = strip_user_aliases(parse_expr(property_name))
     else:
-        # Default to event properties
-        properties_chain = ["events", "properties", property_name]
+        if breakdown_type == "person":
+            if property_name.startswith("$virt_"):
+                # Virtual properties exist as expression fields on the persons table
+                properties_chain = ["person", property_name]
+            else:
+                properties_chain = ["person", "properties", property_name]
+        elif breakdown_type == "data_warehouse_person_property":
+            properties_chain = ["person", *property_name.split(".")]
+        elif breakdown_type == "group":
+            if property_name.startswith("$virt_"):
+                # Virtual properties exist as expression fields on the groups table
+                properties_chain = [f"groups_{group_type_index}", property_name]
+            else:
+                properties_chain = [f"groups_{group_type_index}", "properties", property_name]
+        else:
+            # Default to event properties
+            properties_chain = ["events", "properties", property_name]
+
+        property_field = ast.Field(chain=cast(list[str | int], properties_chain))
 
     # Convert the property to String first, then handle NULLs.
     # This avoids potential type mismatches (e.g., mixing Float64 and String for NULLs).
-    property_field = ast.Field(chain=cast(list[str | int], properties_chain))
     to_string_expr = ast.Call(name="toString", args=[property_field])
     # Replace NULL with empty string ''
     return ast.Call(name="ifNull", args=[to_string_expr, ast.Constant(value="")])


### PR DESCRIPTION
## Problem

Retention insights support breakdowns by event property, person property, feature flag, group, cohort, and data-warehouse person property, but not by a custom HogQL/SQL expression. Trends already supports this (the "HogQL expression" option in the breakdown picker), and users have asked for the same on retention so they can break down by a derived or computed value rather than a single raw property.

## Changes

Two small additions, one on each side of the stack:

- **Backend** (`posthog/hogql_queries/insights/retention/utils.py`): `breakdown_extract_expr` now handles `breakdown_type == "hogql"`. The value is parsed as a HogQL expression via `parse_expr` (with display-only `AS` aliases stripped, matching trends), instead of falling through to the event-property branch where the whole expression was misread as a property name. The parsed expression flows through the same `toString()` / `ifNull()` wrapping as every other breakdown type, so `breakdown_value` stays a String and the response shape is unchanged. `tag_contains_user_hogql()` is called for the same query tagging trends applies to user-supplied HogQL.
- **Frontend** (`TaxonomicBreakdownPopover.tsx`): adds `TaxonomicFilterGroupType.HogQLExpression` to the taxonomic group types offered in the retention breakdown picker, in the same relative position it occupies for trends. No reordering of existing options.

The schema already carried `breakdownFilter: BreakdownFilter` on `RetentionQuery` and `MultipleBreakdownType.HOGQL`, so no schema or migration changes were needed. HogQL breakdowns are not cohort breakdowns, so they route through the standard `_base_query()` path; the cohort-specific union path is untouched.

## How did you test this code?

**Automated (agent-run):**

- Added `test_retention_with_breakdown_hogql_expression`, which breaks down by `upper(properties.browser)` and asserts the buckets come back uppercased (`CHROME` / `SAFARI` / `FIREFOX`). That only happens if the expression is evaluated as SQL rather than read as a property name. It also checks the retention matrix for one bucket. Passes locally.
- Re-ran the full retention breakdown suite (`-k breakdown`). Every non-actor breakdown test passes (event, person, group, cohort, data-warehouse, virtual property). The actor-query tests fail only because the local personhog gRPC service was down; confirmed they fail identically on master without this change, so it is an environment limitation, not a regression. They run against personhog in CI.
- Pre-commit hooks pass: Python type-check (`ty check`), ruff lint/format, JS formatting.

**Manual:**

- Ran the local dev stack on this branch, opened a retention insight, and confirmed "SQL expression" now appears as an option in the Breakdown picker (it was absent before this change).
- Entered `upper(properties.$browser)` as the breakdown and confirmed the retention chart split into the expected computed buckets.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Co-authored by Claude Code (Opus 4.8)

Investigation found that retention breakdown support was effectively complete except for the HogQL/SQL expression type: the backend `breakdown_extract_expr` had no `hogql` branch (so a HogQL breakdown was silently misinterpreted as an event-property name), and the frontend breakdown picker omitted the `HogQLExpression` group for retention only. The trends implementation (`posthog/hogql_queries/insights/trends/breakdown.py`) was used as the reference for parsing and alias-stripping behavior so the two stay consistent.

A note for the security-minded reviewer: parsing user input as HogQL is intentional and matches trends. HogQL is resolved and printed through the standard pipeline that scopes to the team, enforces field-access rules, and parameterizes literals; `strip_user_aliases` removes display-only `AS` clauses that would corrupt the wrapping SQL.

Considered but left out of scope: multiple simultaneous HogQL breakdowns (retention is single-breakdown only today) and any interaction with the in-progress retention pre-aggregation read path (HogQL breakdowns fall back to the standard query path).
