### PR TITLE
feat(cdp): add a fallback logic in the templates for ad conversion destinations

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/google_ads/google.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_ads/google.template.test.ts
@@ -80,6 +80,57 @@ describe('google template', () => {
         expect(fetchResponse.error).toBeUndefined()
     })
 
+    it('falls back to USD for unsupported currency codes', async () => {
+        const response = await tester.invokeMapping(
+            'Conversion',
+            {
+                oauth: {
+                    access_token: 'access-token',
+                },
+                customerId: '1231231234/5675675678',
+                conversionActionId: '123456789',
+                event: '{event.properties}',
+            },
+            createAdDestinationPayload({
+                event: {
+                    properties: {
+                        currency: 'XYZ',
+                        value: '80',
+                        value_usd: '100',
+                    },
+                },
+            }),
+            {
+                currencyCode: '{event.properties.currency}',
+                conversionValue: '{event.properties.value}',
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
+            {
+              "body": "{"conversions":[{"gclid":"google-id","conversion_action":"customers/1231231234/conversionActions/123456789","conversion_date_time":"2025-01-01 00:00:00+00:00","conversion_value":"100","currency_code":"USD"}],"partialFailure":true}",
+              "headers": {
+                "Authorization": "Bearer access-token",
+                "Content-Type": "application/json",
+                "login-customer-id": "5675675678",
+              },
+              "method": "POST",
+              "type": "fetch",
+              "url": "https://googleads.googleapis.com/v21/customers/1231231234:uploadClickConversions",
+            }
+        `)
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 200,
+            body: { status: 'OK' },
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toBeUndefined()
+    })
+
     it('works with empty properties', async () => {
         const response = await tester.invokeMapping(
             'Conversion',

--- a/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
@@ -83,6 +83,30 @@ if (empty(inputs.gclid)) {
     return
 }
 
+// Subset of ISO 4217 codes supported via Google Ads CurrencyConstant
+let GOOGLE_ADS_CURRENCIES := [
+    'AED','AFN','ALL','AMD','ANG','AOA','ARS','AUD','AWG','AZN','BAM','BBD','BDT','BGN','BHD',
+    'BIF','BMD','BND','BOB','BRL','BSD','BTN','BWP','BZD','CAD','CDF','CHF','CLP','CNY','COP',
+    'CRC','CVE','CZK','DJF','DKK','DOP','DZD','EGP','ERN','ETB','EUR','FJD','GBP','GEL','GHS',
+    'GMD','GNF','GTQ','GYD','HKD','HNL','HRK','HTG','HUF','IDR','ILS','INR','IQD','IRR','ISK',
+    'JMD','JOD','JPY','KES','KGS','KHR','KMF','KRW','KWD','KYD','KZT','LAK','LBP','LKR','LRD',
+    'LSL','LYD','MAD','MDL','MGA','MKD','MMK','MNT','MOP','MRU','MUR','MVR','MWK','MXN','MYR',
+    'MZN','NAD','NGN','NIO','NOK','NPR','NZD','OMR','PAB','PEN','PGK','PHP','PKR','PLN','PYG',
+    'QAR','RON','RSD','RUB','RWF','SAR','SBD','SCR','SDG','SEK','SGD','SHP','SLL','SOS','SRD',
+    'SSP','STN','SYP','SZL','THB','TJS','TND','TOP','TRY','TTD','TWD','TZS','UAH','UGX','UYU',
+    'UZS','VES','VND','VUV','WST','XAF','XCD','XOF','XPF','YER','ZAR','ZMW','ZWL','USD'
+]
+
+let txCurrency := upper(inputs.currencyCode ?? 'USD')
+let txConversionValue := inputs.conversionValue
+
+if (not has(GOOGLE_ADS_CURRENCIES, txCurrency)) {
+    txCurrency := 'USD'
+
+    // Add an input variable that maps to event.properties for this conversion value
+    txConversionValue := inputs.event.value_usd
+}
+
 let body := {
     'conversions': [
         {
@@ -94,11 +118,11 @@ let body := {
     'partialFailure': true
 }
 
-if (not empty(inputs.conversionValue)) {
-    body.conversions[1].conversion_value := inputs.conversionValue
+if (not empty(txConversionValue)) {
+    body.conversions[1].conversion_value := txConversionValue
 }
 if (not empty(inputs.currencyCode)) {
-    body.conversions[1].currency_code := inputs.currencyCode
+    body.conversions[1].currency_code := txCurrency
 }
 if (not empty(inputs.orderId)) {
     body.conversions[1].order_id := inputs.orderId

--- a/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
@@ -103,7 +103,7 @@ let txConversionValue := inputs.conversionValue
 if (not has(GOOGLE_ADS_CURRENCIES, txCurrency)) {
     txCurrency := 'USD'
 
-    // Add an input variable that maps to event.properties for this conversion value
+    // Fall back to the pre-converted USD value
     txConversionValue := inputs.event.value_usd
 }
 

--- a/nodejs/src/cdp/templates/_destinations/linkedin_ads/linkedin.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/linkedin_ads/linkedin.template.test.ts
@@ -65,6 +65,42 @@ describe('linkedin template', () => {
         expect(fetchResponse.error).toBeUndefined()
     })
 
+    it('falls back to USD for unsupported currency codes', async () => {
+        const response = await tester.invoke(
+            buildInputs({
+                currencyCode: 'XYZ',
+                conversionValue: '80',
+                event: {
+                    value_usd: '100',
+                },
+            })
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
+            {
+              "body": "{"conversion":"urn:lla:llaPartnerConversion:conversion-rule-12345","conversionHappenedAt":1737464596570,"user":{"userIds":[{"idType":"SHA256_EMAIL","idValue":"3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98"},{"idType":"LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID","idValue":"abc"}],"userInfo":{"lastName":"AI","firstName":"Max","companyName":"PostHog","countryCode":"US"}},"eventId":"event-12345","conversionValue":{"currencyCode":"USD","amount":"100"}}",
+              "headers": {
+                "Authorization": "Bearer oauth-1234",
+                "Content-Type": "application/json",
+                "LinkedIn-Version": "202508",
+              },
+              "method": "POST",
+              "type": "fetch",
+              "url": "https://api.linkedin.com/rest/conversionEvents",
+            }
+        `)
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 200,
+            body: { status: 'OK' },
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toBeUndefined()
+    })
+
     it('does not contain empty objects', async () => {
         const response = await tester.invoke(
             buildInputs({

--- a/nodejs/src/cdp/templates/_destinations/linkedin_ads/linkedin.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/linkedin_ads/linkedin.template.ts
@@ -11,6 +11,22 @@ export const template: HogFunctionTemplate = {
     category: ['Advertisement'],
     code_language: 'hog',
     code: `
+// LinkedIn ad account billing currencies (see learn.microsoft.com linkedin/shared/references/v2/ads/supported-currencies)
+let LINKEDIN_AD_ACCOUNT_CURRENCIES := [
+    'AED','ARS','AUD','BRL','CAD','CHF','CLP','CNY','COP','DKK','EGP','EUR','GBP','HKD','IDR','INR',
+    'JPY','KRW','MXN','MYR','NOK','NZD','PEN','PLN','SAR','SEK','SGD','THB','TRY','USD','ZAR'
+]
+
+let txCurrency := upper(inputs.currencyCode ?? 'USD')
+let txAmount := inputs.conversionValue
+
+if (not empty(inputs.currencyCode) and not has(LINKEDIN_AD_ACCOUNT_CURRENCIES, txCurrency)) {
+    txCurrency := 'USD'
+
+    // Add an input variable that maps to event.properties for this conversion value
+    txAmount := inputs.event.value_usd
+}
+
 let body := {
     'conversion': f'urn:lla:llaPartnerConversion:{inputs.conversionRuleId}',
     'conversionHappenedAt': inputs.conversionDateTime,
@@ -24,10 +40,10 @@ if (not empty(inputs.conversionValue) or not empty(inputs.currencyCode)) {
     body.conversionValue := {}
 }
 if (not empty(inputs.currencyCode)) {
-    body.conversionValue.currencyCode := inputs.currencyCode
+    body.conversionValue.currencyCode := txCurrency
 }
 if (not empty(inputs.conversionValue)) {
-    body.conversionValue.amount := inputs.conversionValue
+    body.conversionValue.amount := txAmount
 }
 
 let userInfo := {}

--- a/nodejs/src/cdp/templates/_destinations/linkedin_ads/linkedin.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/linkedin_ads/linkedin.template.ts
@@ -20,10 +20,10 @@ let LINKEDIN_AD_ACCOUNT_CURRENCIES := [
 let txCurrency := upper(inputs.currencyCode ?? 'USD')
 let txAmount := inputs.conversionValue
 
-if (not empty(inputs.currencyCode) and not has(LINKEDIN_AD_ACCOUNT_CURRENCIES, txCurrency)) {
+if (not has(LINKEDIN_AD_ACCOUNT_CURRENCIES, txCurrency)) {
     txCurrency := 'USD'
 
-    // Add an input variable that maps to event.properties for this conversion value
+    // Fall back to the pre-converted USD value
     txAmount := inputs.event.value_usd
 }
 

--- a/nodejs/src/cdp/templates/_destinations/reddit_ads/reddit.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/reddit_ads/reddit.template.test.ts
@@ -33,7 +33,7 @@ describe('reddit template', () => {
                         price: 30,
                         quantity: 1,
                         coupon: 'BLACKFRIDAY',
-                        currency: 'usd',
+                        currency: 'USD',
                         position: 3,
                         value: 30,
                         url: 'https://posthog.com/merch?product=tactical-black-t-shirt',
@@ -51,7 +51,53 @@ describe('reddit template', () => {
         expect(response.finished).toEqual(false)
         expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
             {
-              "body": "{"test_mode":false,"events":[{"event_at":"2025-01-01T00:00:00Z","event_type":{"tracking_type":"ViewContent"},"user":{"email":"example@posthog.com","screen_dimensions":{"width":null,"height":null}},"event_metadata":{"conversion_id":"event-id","products":[{"id":"1bdfef47c9724b58b6831933","category":"merch","name":"Tactical black t-shirt"}],"value":30,"currency":"usd"},"click_id":"reddit-id"}]}",
+              "body": "{"test_mode":false,"events":[{"event_at":"2025-01-01T00:00:00Z","event_type":{"tracking_type":"ViewContent"},"user":{"email":"example@posthog.com","screen_dimensions":{"width":null,"height":null}},"event_metadata":{"conversion_id":"event-id","products":[{"id":"1bdfef47c9724b58b6831933","category":"merch","name":"Tactical black t-shirt"}],"value":30,"currency":"USD"},"click_id":"reddit-id"}]}",
+              "headers": {
+                "Authorization": "Bearer access-token",
+                "Content-Type": "application/json",
+                "User-Agent": "hog:com.posthog.cdp:0.0.1 (by /u/PostHogTeam)",
+              },
+              "method": "POST",
+              "type": "fetch",
+              "url": "https://ads-api.reddit.com/api/v2.0/conversions/events/pixel-id",
+            }
+        `)
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 200,
+            body: { status: 'OK' },
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toBeUndefined()
+    })
+
+    it('falls back to USD for unsupported currency codes', async () => {
+        const response = await tester.invokeMapping(
+            'Product Viewed',
+            {
+                accountId: 'pixel-id',
+                conversionsAccessToken: 'access-token',
+            },
+            createAdDestinationPayload({
+                event: {
+                    timestamp: '2025-01-01T00:00:00Z',
+                },
+            }),
+            {
+                eventProperties: {
+                    currency: 'XYZ',
+                    value: 80,
+                    value_usd: 100,
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
+            {
+              "body": "{"test_mode":false,"events":[{"event_at":"2025-01-01T00:00:00Z","event_type":{"tracking_type":"ViewContent"},"user":{"email":"example@posthog.com","screen_dimensions":{"width":null,"height":null}},"event_metadata":{"value":100,"currency":"USD"},"click_id":"reddit-id"}]}",
               "headers": {
                 "Authorization": "Bearer access-token",
                 "Content-Type": "application/json",

--- a/nodejs/src/cdp/templates/_destinations/reddit_ads/reddit.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/reddit_ads/reddit.template.ts
@@ -58,10 +58,34 @@ let RDT_ALLOWED_EVENT_NAMES := [
     'Custom',
 ];
 
+// ISO 4217 allowlist for currency fallback (Reddit CAPI requires ISO 4217)
+let REDDIT_CURRENCIES := [
+    'AED','ARS','AUD','BDT','BHD','BIF','BOB','BRL','CAD','CHF','CLP','CNY','COP','CRC','CZK','DKK','DZD',
+    'EGP','EUR','GBP','GTQ','HKD','HNL','HUF','IDR','ILS','INR','ISK','JPY','KES','KHR','KRW','KWD','KZT',
+    'MAD','MOP','MXN','MYR','NGN','NIO','NOK','NZD','OMR','PEN','PHP','PKR','PLN','PYG','QAR','RON','RUB',
+    'SAR','SEK','SGD','THB','TRY','TWD','UAH','USD','VES','VND','ZAR'
+]
+
+let txCurrency := upper(inputs.eventProperties.currency ?? 'USD')
+let txValue := inputs.eventProperties.value
+
+if (not has(REDDIT_CURRENCIES, txCurrency)) {
+    txCurrency := 'USD'
+    
+    // Add an input variable that maps to inputs.eventProperties for this conversion value
+    txValue := inputs.eventProperties.value_usd
+}
+
 let eventProperties := {};
 for (let key, value in inputs.eventProperties) {
     if (not empty(value)) {
-        eventProperties[key] := value;
+        if (key == 'currency') {
+            eventProperties[key] := txCurrency
+        } else if (key == 'value') {
+            eventProperties[key] := txValue
+        } else if (key != 'value_usd') {
+            eventProperties[key] := value
+        }
     }
 }
 

--- a/nodejs/src/cdp/templates/_destinations/reddit_ads/reddit.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/reddit_ads/reddit.template.ts
@@ -72,7 +72,7 @@ let txValue := inputs.eventProperties.value
 if (not has(REDDIT_CURRENCIES, txCurrency)) {
     txCurrency := 'USD'
     
-    // Add an input variable that maps to inputs.eventProperties for this conversion value
+    // Fall back to the pre-converted USD value
     txValue := inputs.eventProperties.value_usd
 }
 

--- a/nodejs/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.test.ts
@@ -60,7 +60,49 @@ describe('snapchat template', () => {
         expect(response.finished).toEqual(false)
         expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
             {
-              "body": "{"data":[{"event_name":"VIEW_CONTENT","action_source":"WEB","event_time":1735689600,"event_source_url":"https://posthog.com/merch?product=tactical-black-t-shirt","user_data":{"em":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","ph":"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646","sc_click_id":"snapchat-id","fn":"9baf3a40312f39849f46dad1040f2f039f1cffa1238c41e9db675315cfad39b6","ln":"32e83e92d45d71f69dcf9d214688f0375542108631b45d344e5df2eb91c11566","external_id":"b5400f5d931b20e0e905cc4a009a428ce3427b3110e3a2a1cfc7e6349beabc10"},"custom_data":{"value":30,"currency":"usd","content_ids":"43431-18","content_category":"merch","contents":[{"item_price":30,"id":"43431-18","quantity":1,"delivery_category":"normal"}],"num_items":1,"event_id":"event-id"}}]}",
+              "body": "{"data":[{"event_name":"VIEW_CONTENT","action_source":"WEB","event_time":1735689600,"event_source_url":"https://posthog.com/merch?product=tactical-black-t-shirt","user_data":{"em":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","ph":"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646","sc_click_id":"snapchat-id","fn":"9baf3a40312f39849f46dad1040f2f039f1cffa1238c41e9db675315cfad39b6","ln":"32e83e92d45d71f69dcf9d214688f0375542108631b45d344e5df2eb91c11566","external_id":"b5400f5d931b20e0e905cc4a009a428ce3427b3110e3a2a1cfc7e6349beabc10"},"custom_data":{"value":30,"currency":"USD","content_ids":"43431-18","content_category":"merch","contents":[{"item_price":30,"id":"43431-18","quantity":1,"delivery_category":"normal"}],"num_items":1,"event_id":"event-id"}}]}",
+              "headers": {
+                "Content-Type": "application/json",
+              },
+              "method": "POST",
+              "type": "fetch",
+              "url": "https://tr.snapchat.com/v3/pixel-id/events?access_token=access-token",
+            }
+        `)
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 200,
+            body: { status: 'OK' },
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toBeUndefined()
+    })
+
+    it('falls back to USD for unsupported currency codes', async () => {
+        const response = await tester.invokeMapping(
+            'Product Viewed',
+            {
+                oauth: {
+                    access_token: 'access-token',
+                },
+                pixelId: 'pixel-id',
+            },
+            createAdDestinationPayload(),
+            {
+                customData: {
+                    currency: 'XYZ',
+                    value: 80,
+                    value_usd: 100,
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
+            {
+              "body": "{"data":[{"event_name":"VIEW_CONTENT","action_source":"WEB","event_time":1735689600,"event_source_url":null,"user_data":{"em":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","ph":"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646","sc_click_id":"snapchat-id","fn":"9baf3a40312f39849f46dad1040f2f039f1cffa1238c41e9db675315cfad39b6","ln":"32e83e92d45d71f69dcf9d214688f0375542108631b45d344e5df2eb91c11566","external_id":"b5400f5d931b20e0e905cc4a009a428ce3427b3110e3a2a1cfc7e6349beabc10"},"custom_data":{"value":100,"currency":"USD"}}]}",
               "headers": {
                 "Content-Type": "application/json",
               },

--- a/nodejs/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.ts
@@ -114,7 +114,8 @@ let txValue := inputs.customData.value
 
 if (not has(SNAPCHAT_CURRENCIES, txCurrency)) {
     txCurrency := 'USD'
-    // Add an input variable that maps to inputs.customData for this conversion value
+
+    // Fall back to the pre-converted USD value
     txValue := inputs.customData.value_usd
 }
 

--- a/nodejs/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.ts
@@ -101,6 +101,23 @@ if (empty(inputs.pixelId) or empty(inputs.oauth.access_token)) {
     throw Error('Pixel ID and access token are required')
 }
 
+// Subset of ISO 4217 codes from Snap Conversions API custom_data.currency docs
+let SNAPCHAT_CURRENCIES := [
+    'USD','AED','AUD','BGN','BRL','CAD','CHF','CLP','CNY','COP','CZK','DKK','EGP','EUR','GBP','GIP',
+    'HKD','HRK','HUF','IDR','ILS','INR','JPY','KRW','KWD','KZT','LBP','MXN','MYR','NGN','NOK','NZD',
+    'PEN','PHP','PKR','PLN','QAR','RON','RUB','SAR','SEK','SGD','THB','TRY','TWD','TZS','UAH','VND',
+    'ZAR','ALL','BHD','DZD','GHS','IQD','ISK','JOD','KES','MAD','OMR','XOF'
+]
+
+let txCurrency := upper(inputs.customData.currency ?? 'USD')
+let txValue := inputs.customData.value
+
+if (not has(SNAPCHAT_CURRENCIES, txCurrency)) {
+    txCurrency := 'USD'
+    // Add an input variable that maps to inputs.customData for this conversion value
+    txValue := inputs.customData.value_usd
+}
+
 let body := {
     'data': [
         {
@@ -122,7 +139,13 @@ for (let key, value in inputs.userData) {
 
 for (let key, value in inputs.customData) {
     if (not empty(value)) {
-        body.data.1.custom_data[key] := value
+        if (key == 'currency') {
+            body.data.1.custom_data[key] := txCurrency
+        } else if (key == 'value') {
+            body.data.1.custom_data[key] := txValue
+        } else if (key != 'value_usd') {
+            body.data.1.custom_data[key] := value
+        }
     }
 }
 

--- a/nodejs/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.test.ts
@@ -33,7 +33,7 @@ describe('tiktok template', () => {
                         price: 30,
                         quantity: 1,
                         coupon: 'BLACKFRIDAY',
-                        currency: 'usd',
+                        currency: 'USD',
                         position: 3,
                         value: 30,
                         url: 'https://posthog.com/merch?product=tactical-black-t-shirt',
@@ -50,7 +50,48 @@ describe('tiktok template', () => {
         expect(response.finished).toEqual(false)
         expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
             {
-              "body": "{"event_source":"web","event_source_id":"pixel-id","data":[{"event":"ViewContent","event_time":1735689600,"event_id":"event-id","user":{"email":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","first_name":"9baf3a40312f39849f46dad1040f2f039f1cffa1238c41e9db675315cfad39b6","last_name":"32e83e92d45d71f69dcf9d214688f0375542108631b45d344e5df2eb91c11566","phone":"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8","external_id":"b5400f5d931b20e0e905cc4a009a428ce3427b3110e3a2a1cfc7e6349beabc10","ttclid":"tiktok-id"},"properties":{"content_ids":["43431-18"],"contents":[{"price":30,"content_id":"43431-18","content_category":"merch","content_name":"Tactical black t-shirt","brand":"PostHog"}],"content_type":"product","currency":"usd","value":30,"num_items":1},"page":{"url":"https://posthog.com/merch?product=tactical-black-t-shirt"}}]}",
+              "body": "{"event_source":"web","event_source_id":"pixel-id","data":[{"event":"ViewContent","event_time":1735689600,"event_id":"event-id","user":{"email":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","first_name":"9baf3a40312f39849f46dad1040f2f039f1cffa1238c41e9db675315cfad39b6","last_name":"32e83e92d45d71f69dcf9d214688f0375542108631b45d344e5df2eb91c11566","phone":"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8","external_id":"b5400f5d931b20e0e905cc4a009a428ce3427b3110e3a2a1cfc7e6349beabc10","ttclid":"tiktok-id"},"properties":{"content_ids":["43431-18"],"contents":[{"price":30,"content_id":"43431-18","content_category":"merch","content_name":"Tactical black t-shirt","brand":"PostHog"}],"content_type":"product","currency":"USD","value":30,"num_items":1},"page":{"url":"https://posthog.com/merch?product=tactical-black-t-shirt"}}]}",
+              "headers": {
+                "Access-Token": "access-token",
+                "Content-Type": "application/json",
+              },
+              "method": "POST",
+              "type": "fetch",
+              "url": "https://business-api.tiktok.com/open_api/v1.3/event/track/",
+            }
+        `)
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 200,
+            body: { status: 'OK' },
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toBeUndefined()
+    })
+
+    it('falls back to USD for unsupported currency codes', async () => {
+        const response = await tester.invokeMapping(
+            'Product Viewed',
+            {
+                accessToken: 'access-token',
+                pixelId: 'pixel-id',
+            },
+            createAdDestinationPayload(),
+            {
+                propertyProperties: {
+                    currency: 'XYZ',
+                    value: 80,
+                    value_usd: 100,
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
+            {
+              "body": "{"event_source":"web","event_source_id":"pixel-id","data":[{"event":"ViewContent","event_time":1735689600,"event_id":"event-id","user":{"email":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","first_name":"9baf3a40312f39849f46dad1040f2f039f1cffa1238c41e9db675315cfad39b6","last_name":"32e83e92d45d71f69dcf9d214688f0375542108631b45d344e5df2eb91c11566","phone":"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8","external_id":"b5400f5d931b20e0e905cc4a009a428ce3427b3110e3a2a1cfc7e6349beabc10","ttclid":"tiktok-id"},"properties":{"value":100,"currency":"USD"},"page":{}}]}",
               "headers": {
                 "Access-Token": "access-token",
                 "Content-Type": "application/json",

--- a/nodejs/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
@@ -79,6 +79,23 @@ if (empty(inputs.pixelId) or empty(inputs.accessToken)) {
     throw Error('Pixel ID and access token are required')
 }
 
+// Supported currency enum from TikTok Events API (ads.tiktok.com help article on parameters)
+let TIKTOK_CURRENCIES := [
+    'AED','ARS','AUD','BDT','BHD','BIF','BOB','BRL','CAD','CHF','CLP','CNY','COP','CRC','CZK','DKK','DZD',
+    'EGP','EUR','GBP','GTQ','HKD','HNL','HUF','IDR','ILS','INR','ISK','JPY','KES','KHR','KRW','KWD','KZT',
+    'MAD','MOP','MXN','MYR','NGN','NIO','NOK','NZD','OMR','PEN','PHP','PKR','PLN','PYG','QAR','RON','RUB',
+    'SAR','SEK','SGD','THB','TRY','TWD','UAH','USD','VES','VND','ZAR'
+]
+
+let txCurrency := upper(inputs.propertyProperties.currency ?? 'USD')
+let txValue := inputs.propertyProperties.value
+
+if (not has(TIKTOK_CURRENCIES, txCurrency)) {
+    txCurrency := 'USD'
+    // Add an input variable that maps to inputs.propertyProperties for this conversion value
+    txValue := inputs.propertyProperties.value_usd
+}
+
 let body := {
     'event_source': 'web',
     'event_source_id': inputs.pixelId,
@@ -106,7 +123,13 @@ for (let key, value in inputs.userProperties) {
 
 for (let key, value in inputs.propertyProperties) {
     if (not empty(value)) {
-        body.data.1.properties[key] := value
+        if (key == 'currency') {
+            body.data.1.properties[key] := txCurrency
+        } else if (key == 'value') {
+            body.data.1.properties[key] := txValue
+        } else if (key != 'value_usd') {
+            body.data.1.properties[key] := value
+        }
     }
 }
 

--- a/nodejs/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
@@ -92,7 +92,8 @@ let txValue := inputs.propertyProperties.value
 
 if (not has(TIKTOK_CURRENCIES, txCurrency)) {
     txCurrency := 'USD'
-    // Add an input variable that maps to inputs.propertyProperties for this conversion value
+    
+    // Fall back to the pre-converted USD value
     txValue := inputs.propertyProperties.value_usd
 }
 

--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -27,11 +27,19 @@ let META_CURRENCIES := [
 /* ---------- 1. Work out the value / currency with fallback ---------- */
 let txCurrency := upper(inputs.customData.currency ?? 'USD')
 let txPrice    := inputs.customData.price
-let usdBackup  := inputs.customData.price_usd ?? txPrice
 
 if (not has(META_CURRENCIES, txCurrency)) {
     txCurrency := 'USD'
-    txPrice := usdBackup
+
+    // Fall back to the pre-converted USD value
+    txPrice := inputs.customData.price_usd
+}
+
+let customData := {}
+
+if(not empty(txCurrency) and not empty(txPrice)) {
+    customData['currency'] := txCurrency
+    customData['price'] := txPrice
 }
 
 let body := {
@@ -42,10 +50,7 @@ let body := {
             'event_time': inputs.eventTime,
             'action_source': inputs.actionSource,
             'user_data': {},
-            'custom_data': {
-                'currency': txCurrency,
-                'price': txPrice
-            }
+            'custom_data': customData
         }
     ],
     'access_token': inputs.accessToken

--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -11,6 +11,29 @@ template: HogFunctionTemplateDC = HogFunctionTemplateDC(
     category=["Advertisement"],
     code_language="hog",
     code="""
+let META_CURRENCIES := [
+  'AED','AFN','ALL','AMD','ANG','AOA','ARS','AUD','AWG','AZN','BAM','BBD','BDT','BGN','BHD',
+  'BIF','BMD','BND','BOB','BRL','BSD','BTN','BWP','BZD','CAD','CDF','CHF','CLP','CNY','COP',
+  'CRC','CVE','CZK','DJF','DKK','DOP','DZD','EGP','ERN','ETB','EUR','FJD','GBP','GEL','GHS',
+  'GMD','GNF','GTQ','GYD','HKD','HNL','HRK','HTG','HUF','IDR','ILS','INR','IQD','IRR','ISK',
+  'JMD','JOD','JPY','KES','KGS','KHR','KMF','KRW','KWD','KYD','KZT','LAK','LBP','LKR','LRD',
+  'LSL','LYD','MAD','MDL','MGA','MKD','MMK','MNT','MOP','MRU','MUR','MVR','MWK','MXN','MYR',
+  'MZN','NAD','NGN','NIO','NOK','NPR','NZD','OMR','PAB','PEN','PGK','PHP','PKR','PLN','PYG',
+  'QAR','RON','RSD','RUB','RWF','SAR','SBD','SCR','SDG','SEK','SGD','SHP','SLL','SOS','SRD',
+  'SSP','STN','SYP','SZL','THB','TJS','TND','TOP','TRY','TTD','TWD','TZS','UAH','UGX','UYU',
+  'UZS','VES','VND','VUV','WST','XAF','XCD','XOF','XPF','YER','ZAR','ZMW','ZWL','USD'
+]
+
+/* ---------- 1. Work out the value / currency with fallback ---------- */
+let txCurrency := upper(inputs.customData.currency ?? 'USD')
+let txPrice    := inputs.customData.price
+let usdBackup  := inputs.customData.price_usd ?? txPrice
+
+if (not has(META_CURRENCIES, txCurrency)) {
+    txCurrency := 'USD'
+    txPrice := usdBackup
+}
+
 let body := {
     'data': [
         {
@@ -19,7 +42,10 @@ let body := {
             'event_time': inputs.eventTime,
             'action_source': inputs.actionSource,
             'user_data': {},
-            'custom_data': {}
+            'custom_data': {
+                'currency': txCurrency,
+                'price': txPrice
+            }
         }
     ],
     'access_token': inputs.accessToken
@@ -55,7 +81,7 @@ for (let key, value in inputs.userData) {
 }
 
 for (let key, value in inputs.customData) {
-    if (not empty(value)) {
+    if (key != 'price' and key != 'currency' and key != 'price_usd' and not empty(value)) {
         body.data.1.custom_data[key] := parseValueIfArray(value)
     }
 }

--- a/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
@@ -136,3 +136,18 @@ class TestTemplateMetaAds(BaseHogFunctionTemplateTest):
         assert custom_data["currency"] == "EUR"
         assert custom_data["value"] == 99.8
         assert custom_data["quantity"] == 2
+
+    def test_unsupported_currency_falls_back_to_usd(self):
+        self.mock_fetch_response = lambda *args: {"status": 200, "body": {"ok": True}}  # type: ignore
+        self.run_function(
+            self._inputs(
+                customData={
+                    "currency": "XYZ",
+                    "price": 80,
+                    "price_usd": 100,
+                }
+            )
+        )
+        custom_data = self.get_mock_fetch_calls()[0][1]["body"]["data"][0]["custom_data"]
+        assert custom_data["currency"] == "USD"
+        assert custom_data["price"] == 100


### PR DESCRIPTION


<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
This PR should fix the issue #31893. It introduces some template changes to add some guardrails when handling ad conversion events.

## Changes
Add some snippets in the templates for the following platforms: 

Platform | Template ID | Source file | Existing tests | Status 
-- | -- | -- | -- | --
Meta | template-meta-ads | `posthog/cdp/templates/meta_ads/template_meta_ads.py` | `posthog/cdp/templates/meta_ads/test_template_meta_ads.py` | **DONE**
Google Ads | template-google-ads | `nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts` | `nodejs/src/cdp/templates/_destinations/google_ads/google.template.test.ts` | **DONE**
LinkedIn | template-linkedin-ads | `nodejs/src/cdp/templates/_destinations/linkedin_ads/linkedin.template.ts` | `nodejs/src/cdp/templates/_destinations/linkedin_ads/linkedin.template.test.ts` | **DONE**
Snapchat | template-snapchat-ads | `nodejs/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.ts` | `nodejs/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.test.ts` | **DONE**
TikTok | template-tiktok-ads | `nodejs/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts` | `nodejs/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.test.ts` | **DONE**
Reddit | template-reddit-conversions-api | `nodejs/src/cdp/templates/_destinations/reddit_ads/reddit.template.ts` | `nodejs/src/cdp/templates/_destinations/reddit_ads/reddit.template.test.ts` | **DONE**

## How did you test this code?

I am relying on the unit tests to verify that the Hog code is being correctly evaluated.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
