### PR TITLE
feat(data-warehouse): make slack channel tables webhook-only

### DIFF
--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -421,32 +421,27 @@ def slack_source(
         resource = rest_api_resource(config, team_id, job_id, None)
         items = lambda: resource
     else:
-        # Per-channel message endpoint
+        # Per-channel message endpoint.
+        #
+        # Slack channel tables are webhook-only: we deliberately skip the historical
+        # `conversations.history` / `conversations.replies` backfill. That backfill makes one
+        # `conversations.replies` request per threaded message, which fans out into tens of
+        # thousands of rate-limited requests on workspaces with many channels and threads.
+        # Passing `skip_initial_sync_complete_check=True` activates webhook mode from the very
+        # first sync (the same pattern the Customer.io webhook tables use). Until the webhook is
+        # configured and delivering events, the table stays empty rather than backfilling history.
         endpoint_config = messages_endpoint_config()
         sort_mode = "desc"
 
         if channel_id is None:
             raise Exception(f"channel_not_found: {endpoint}")
 
-        webhook_enabled = async_to_sync(webhook_source_manager.webhook_enabled)()
-
-        oldest_ts: str | None = None
-        if should_use_incremental_field and db_incremental_field_last_value is not None:
-            # Known limitation: incremental polling only fetches thread replies for parent messages
-            # returned by conversations.history in this window. Replies added to older parent threads
-            # (parent ts < oldest_ts) are intentionally not captured here and are expected to be
-            # addressed by webhook sources.
-            oldest_ts = str(db_incremental_field_last_value.timestamp())
-
-        resolved_id = channel_id
-        resolved_oldest_ts = oldest_ts
+        webhook_enabled = async_to_sync(webhook_source_manager.webhook_enabled)(True)
 
         def channel_items() -> Iterable[Any] | AsyncIterable[Any]:
             if webhook_enabled:
                 return webhook_source_manager.get_items(table_transformer=_webhook_table_transformer)
-            return _channel_messages_generator(
-                access_token, resolved_id, resumable_source_manager, oldest_ts=resolved_oldest_ts
-            )
+            return iter([])
 
         items = channel_items
 

--- a/posthog/temporal/data_imports/sources/slack/source.py
+++ b/posthog/temporal/data_imports/sources/slack/source.py
@@ -24,12 +24,9 @@ from posthog.temporal.data_imports.sources.common.mixins import OAuthMixin
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
-from posthog.temporal.data_imports.sources.common.webhook_s3 import (
-    WebhookSourceManager,
-    is_webhook_feature_flag_enabled,
-)
+from posthog.temporal.data_imports.sources.common.webhook_s3 import WebhookSourceManager
 from posthog.temporal.data_imports.sources.generated_configs import SlackSourceConfig
-from posthog.temporal.data_imports.sources.slack.settings import ENDPOINTS, messages_endpoint_config
+from posthog.temporal.data_imports.sources.slack.settings import ENDPOINTS
 from posthog.temporal.data_imports.sources.slack.slack import (
     SlackResumeConfig,
     get_channels,
@@ -187,21 +184,23 @@ class SlackSource(ResumableSource[SlackSourceConfig, SlackResumeConfig], Webhook
         if not access_token:
             raise ValueError("Slack access token not found")
 
-        msg_config = messages_endpoint_config()
-        webhook_flag_enabled = is_webhook_feature_flag_enabled(team_id)
         authed_user = self._get_authed_user_id(integration)
         channels = get_channels(integration.id, access_token, authed_user, force_refresh=force_refresh)
         for ch in channels:
             if ch["id"] in ENDPOINTS:
                 continue
+            # Channel message tables are webhook-only: messages arrive via the realtime webhook
+            # pipeline, not the polling sync, so incremental/append don't apply and full-refresh
+            # would only delete data and reload nothing. Webhook is the only sync method we offer
+            # (mirrors the Customer.io webhook schemas).
             schemas.append(
                 SourceSchema(
                     name=ch["id"],
                     label=ch["name"],
-                    supports_incremental=len(msg_config.incremental_fields) > 0,
-                    supports_webhooks=webhook_flag_enabled,
-                    supports_append=len(msg_config.incremental_fields) > 0,
-                    incremental_fields=msg_config.incremental_fields,
+                    supports_incremental=False,
+                    supports_append=False,
+                    supports_webhooks=True,
+                    incremental_fields=[],
                 )
             )
 

--- a/posthog/temporal/data_imports/sources/slack/test_slack.py
+++ b/posthog/temporal/data_imports/sources/slack/test_slack.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.core.cache import cache as django_cache
 
@@ -442,3 +442,44 @@ class TestSlackSourceChannelsEndpoint:
 
         assert items == sample
         mock_fetch.assert_called_once_with("token", authed_user)
+
+
+class TestSlackSourceChannelMessagesWebhookOnly:
+    def _build_channel_source(self, webhook_manager: Any) -> Any:
+        return slack_source(
+            access_token="token",
+            integration_id=42,
+            endpoint="C123",
+            team_id=1,
+            job_id="job-1",
+            webhook_source_manager=webhook_manager,
+            resumable_source_manager=MagicMock(spec=ResumableSourceManager),
+            channel_id="C123",
+        )
+
+    def test_reads_webhook_items_and_skips_backfill_when_webhook_enabled(self) -> None:
+        manager = MagicMock(spec=WebhookSourceManager)
+        manager.webhook_enabled = AsyncMock(return_value=True)
+        manager.get_items.return_value = ["webhook-item"]
+
+        with patch("posthog.temporal.data_imports.sources.slack.slack._channel_messages_generator") as mock_backfill:
+            response = self._build_channel_source(manager)
+            items = response.items()
+
+        # Webhook mode is activated from the first sync (skip the initial-sync-complete gate).
+        manager.webhook_enabled.assert_awaited_once_with(True)
+        assert items == ["webhook-item"]
+        mock_backfill.assert_not_called()
+
+    def test_returns_empty_and_never_backfills_when_webhook_not_enabled(self) -> None:
+        manager = MagicMock(spec=WebhookSourceManager)
+        manager.webhook_enabled = AsyncMock(return_value=False)
+
+        with patch("posthog.temporal.data_imports.sources.slack.slack._channel_messages_generator") as mock_backfill:
+            response = self._build_channel_source(manager)
+            items = list(response.items())
+
+        # No historical backfill: the table stays empty until webhook events arrive.
+        assert items == []
+        manager.get_items.assert_not_called()
+        mock_backfill.assert_not_called()

--- a/posthog/temporal/data_imports/sources/slack/test_slack.py
+++ b/posthog/temporal/data_imports/sources/slack/test_slack.py
@@ -373,10 +373,6 @@ class TestSlackSourceGetSchemasForceRefresh:
                 "posthog.temporal.data_imports.sources.slack.slack._fetch_all_channels",
                 side_effect=[[{"id": "C1", "name": "general"}], [{"id": "C2", "name": "renamed"}]],
             ) as mock_fetch,
-            patch(
-                "posthog.temporal.data_imports.sources.slack.source.is_webhook_feature_flag_enabled",
-                return_value=False,
-            ),
         ):
             first = source.get_schemas(config, team_id=1)
             cached = source.get_schemas(config, team_id=1)
@@ -392,6 +388,29 @@ class TestSlackSourceGetSchemasForceRefresh:
         assert channel_names(first) == {"C1"}
         assert channel_names(cached) == {"C1"}
         assert channel_names(forced) == {"C2"}
+
+    def test_channel_schemas_are_webhook_only(self) -> None:
+        from posthog.temporal.data_imports.sources.slack.source import SlackSource
+
+        config, integration = self._build_mocks()
+        source = SlackSource()
+
+        with (
+            patch.object(source, "get_oauth_integration", return_value=integration),
+            patch(
+                "posthog.temporal.data_imports.sources.slack.slack._fetch_all_channels",
+                return_value=[{"id": "C1", "name": "general"}],
+            ),
+        ):
+            schemas = source.get_schemas(config, team_id=1)
+
+        channel = next(s for s in schemas if s.name == "C1")
+        # Webhook is the only valid sync method: full-refresh would wipe the table and
+        # reload nothing, incremental/append have no polling endpoint to read from.
+        assert channel.supports_webhooks is True
+        assert channel.supports_incremental is False
+        assert channel.supports_append is False
+        assert channel.incremental_fields == []
 
 
 class TestSlackSourceChannelsEndpoint:

--- a/posthog/temporal/data_imports/sources/slack/test_slack.py
+++ b/posthog/temporal/data_imports/sources/slack/test_slack.py
@@ -476,29 +476,30 @@ class TestSlackSourceChannelMessagesWebhookOnly:
             channel_id="C123",
         )
 
-    def test_reads_webhook_items_and_skips_backfill_when_webhook_enabled(self) -> None:
+    @parameterized.expand(
+        [
+            ("webhook_enabled", True, ["webhook-item"], True),
+            ("webhook_disabled", False, [], False),
+        ]
+    )
+    def test_channel_messages_are_webhook_only_and_never_backfill(
+        self,
+        _name: str,
+        webhook_on: bool,
+        expected_items: list[Any],
+        expect_get_items_called: bool,
+    ) -> None:
         manager = MagicMock(spec=WebhookSourceManager)
-        manager.webhook_enabled = AsyncMock(return_value=True)
+        manager.webhook_enabled = AsyncMock(return_value=webhook_on)
         manager.get_items.return_value = ["webhook-item"]
-
-        with patch("posthog.temporal.data_imports.sources.slack.slack._channel_messages_generator") as mock_backfill:
-            response = self._build_channel_source(manager)
-            items = response.items()
-
-        # Webhook mode is activated from the first sync (skip the initial-sync-complete gate).
-        manager.webhook_enabled.assert_awaited_once_with(True)
-        assert items == ["webhook-item"]
-        mock_backfill.assert_not_called()
-
-    def test_returns_empty_and_never_backfills_when_webhook_not_enabled(self) -> None:
-        manager = MagicMock(spec=WebhookSourceManager)
-        manager.webhook_enabled = AsyncMock(return_value=False)
 
         with patch("posthog.temporal.data_imports.sources.slack.slack._channel_messages_generator") as mock_backfill:
             response = self._build_channel_source(manager)
             items = list(response.items())
 
-        # No historical backfill: the table stays empty until webhook events arrive.
-        assert items == []
-        manager.get_items.assert_not_called()
+        # Webhook mode is activated from the first sync (skip the initial-sync-complete gate).
+        # When disabled the table stays empty until webhook events arrive — never a historical backfill.
+        manager.webhook_enabled.assert_awaited_once_with(True)
+        assert items == expected_items
+        assert manager.get_items.called == expect_get_items_called
         mock_backfill.assert_not_called()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-delete-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-delete-tile.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A unique integer value identifying this dashboard.",
+            "type": "number"
+        },
+        "tile_id": {
+            "description": "ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs.",
+            "type": "number"
+        }
+    },
+    "required": ["id", "tile_id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Slack channel tables are configured as webhook (Events API) sources, but the **first** sync of each channel still runs a one-time historical backfill via `conversations.history` + `conversations.replies` before webhook mode takes over (gated on `initial_sync_complete`).

That backfill is expensive and rate-limit-bound: `conversations.history` does not return thread replies inline, so the source issues **one `conversations.replies` request per threaded message**. On workspaces with many channels and heavily-threaded history this fans out into a very large number of requests against a per-token rate limit, so backfills are slow, spend most of their time in `Retry-After` backoff, and add sustained load — all to fetch history that the webhook-only use cases (e.g. monitoring a channel as a signals source) don't need.

## Changes

Make Slack channel-message tables **webhook-only**: skip the historical backfill entirely and rely on the webhook for ingestion.

- `slack_source` now calls `webhook_enabled(skip_initial_sync_complete_check=True)` for the per-channel endpoint, so webhook mode is active from the first sync instead of only after a backfill completes.
- When the webhook isn't configured/delivering yet, the channel path returns an empty iterator rather than backfilling — the table stays empty until events arrive.
- This mirrors the existing pattern used by the **Customer.io** webhook event tables (`customer_io/source.py`), which already skip backfill the same way.
- `$users` and `$channels` endpoints are unchanged (still REST).

The historical backfill generator (`_channel_messages_generator` and helpers) is intentionally **left in place and still unit-tested** — it's just no longer wired into the source path. That keeps the change small and easily revertable, and leaves the door open for a future per-source "skip historical backfill" toggle rather than a hard removal.

### Trade-off (deliberate)

Webhook-only means **no historical messages** are imported — only messages that arrive after the webhook is live. This is the right model for the channel-as-a-stream use cases; it is not suitable for analysing a channel's past history. The webhook must be configured (Events API request URL + enabled webhook function + feature flag) for any data to flow.

## How did you test this code?

I'm an agent (Claude Code); I did not manually test. Automated only:

- Added two tests in `test_slack.py` covering the per-channel path: webhook-enabled reads webhook items and never calls the backfill generator; webhook-not-enabled returns empty and never backfills.
- Ran the full Slack source suite locally: `hogli test posthog/temporal/data_imports/sources/slack/test_slack.py` → **21 passed**.
- `ruff check` / `ruff format` clean; lint-staged `ty` typecheck passed on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude Code (Opus) at the request of the maintainer, after investigating why a Slack source sync was slow. Root cause: the per-thread `conversations.replies` fan-out during the initial backfill.

Key decision: rather than add a new toggle or rip out the backfill machinery, follow the existing in-repo precedent — the Customer.io webhook tables already skip backfill via `webhook_enabled(skip_initial_sync_complete_check=True)`. The Slack channel path now adopts the same shape. The backfill generator + its tests are retained (unreachable from production) so the change is minimal and trivially revertable, and a per-schema toggle can be layered on later if some users do want history.
