### PR TITLE
fix(hogql): preserve table filters with column aliases

### DIFF
--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -29,14 +29,21 @@ from posthog.models.team.team import WeekStartDay
 from posthog.models.utils import UUIDT
 
 
+def _table_filter_type(table_type: ast.TableOrSelectType) -> ast.TableOrSelectType:
+    if isinstance(table_type, ast.ColumnAliasedTableType):
+        return ast.TableAliasType(alias=table_type.alias, table_type=table_type.table_type)
+    return table_type
+
+
 def team_id_guard_for_table(table_type: ast.TableOrSelectType, context: HogQLContext) -> ast.Expr:
     """Add a mandatory "and(team_id, ...)" filter around the expression."""
     if not context.team_id:
         raise InternalHogQLError("context.team_id not found")
 
+    field_table_type = _table_filter_type(table_type)
     return ast.CompareOperation(
         op=ast.CompareOperationOp.Eq,
-        left=ast.Field(chain=["team_id"], type=ast.FieldType(name="team_id", table_type=table_type)),
+        left=ast.Field(chain=["team_id"], type=ast.FieldType(name="team_id", table_type=field_table_type)),
         right=ast.Constant(value=context.team_id),
         type=ast.BooleanType(),
     )

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -199,6 +199,11 @@ class TestPrinter(BaseTest):
         self.assertNotIn("e.a", printed)
         self.assertNotIn("e.c", printed)
 
+    def test_column_aliases_keep_table_filter_column(self):
+        printed = self._select("select b from events as e (a, b, c, d, f, g, h, i, j, team_id)")
+        self.assertIn("WHERE equals(e.team_id,", printed)
+        self.assertNotIn("WHERE equals(e.person_mode,", printed)
+
     def test_column_aliases_unqualified_refs(self):
         printed = self._select("select a, b from events as e (a, b, c)")
         self.assertIn("e.uuid", printed)


### PR DESCRIPTION
## Problem

Column alias handling in HogQL can rename table fields for query output and predicate printing. Table-level filters should continue to reference the underlying table field even when a query uses column aliases.

## Changes

- Keep table-level filter fields bound to the table alias without applying column alias remapping.
- Add regression coverage for column aliases on the events table to ensure generated filters keep using the expected table field.
- Leave regular column alias behavior unchanged for selected fields and user-authored predicates.

## How did you test this code?

- `hogli test posthog/hogql/printer/test/test_printer.py -k column_aliases`
- `hogli test posthog/hogql/test/test_resolver.py -k column_aliases`
- `uv run ruff check posthog/hogql/printer/clickhouse.py posthog/hogql/printer/test/test_printer.py`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this is an internal HogQL printer behavior fix.

## 🤖 Agent context

Codex helped trace and adjust this. The regression was added before the code change and failed against the previous output, then passed after the printer adjustment.

