### PR TITLE
feat(phai): sandbox Max UI — thread, tool cards, and run viewer

### DIFF
--- a/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
@@ -1,4 +1,5 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+import { combineUrl } from 'kea-router'
 
 import {
     IconArrowRight,
@@ -7,14 +8,21 @@ import {
     IconDocument,
     IconPullRequest,
     IconSearch,
+    IconTerminal,
     IconWarning,
 } from '@posthog/icons'
-import { Link, Spinner, LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, Link, Spinner, LemonSelect, LemonSkeleton, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { SignalNode } from 'scenes/debug/signals/types'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
+import { SANDBOX_BIND_TASK_PARAM } from 'scenes/max/maxLogic'
+import { SandboxRunViewer } from 'scenes/max/sandbox/components/SandboxRunViewer'
+import { isTerminalRunStatus } from 'scenes/max/sandboxStreamLogic'
 import { urls } from 'scenes/urls'
+
+import { Task, TaskRunStatus } from 'products/tasks/frontend/types'
 
 import { inboxReportDetailLogic } from '../../logics/inboxReportDetailLogic'
 import { SignalCard } from '../../SignalCard'
@@ -23,7 +31,7 @@ import { deriveHeadline, parsePrRepoSlug, parsePrUrlParts } from '../../utils/re
 import { getSourceProductMeta } from '../badges/sourceProductIcons'
 import { DetailSection, RightColumnSection } from './DetailSection'
 import { ReportDetailBadges } from './ReportDetail'
-import { ReportTasksSection } from './ReportTasksSection'
+import { RELATIONSHIP_LABEL, TaskRunStatusDot } from './taskRunDisplay'
 
 /**
  * Ready-state run output: a polished outcome card that links to the produced PR or report,
@@ -121,8 +129,8 @@ function RunOutputWidget({ report }: { report: SignalReport }): JSX.Element {
 
 /**
  * Compact run-state strip: live/finished status, the produced branch (when a PR exists), and run
- * timing. Mirrors desktop's run-state header line (status · branch · timing) without rebuilding the
- * run log – the actual log lives behind the linked runs (see `ReportTasksSection`).
+ * timing. Mirrors desktop's run-state header line (status · branch · timing); the agent transcript
+ * itself renders inline below in `TaskLogSection`.
  */
 function RunStateStrip({ report }: { report: SignalReport }): JSX.Element {
     const isLive =
@@ -158,10 +166,135 @@ function RunStateStrip({ report }: { report: SignalReport }): JSX.Element {
     )
 }
 
+/** The selected run's agent transcript, or a loading / empty placeholder. */
+function TaskLogBody({
+    loading,
+    task,
+    runId,
+    replayOnly,
+}: {
+    loading: boolean
+    task: Task | null
+    runId: string | null
+    replayOnly: boolean
+}): JSX.Element {
+    if (loading) {
+        return (
+            <div className="flex flex-col gap-2">
+                <LemonSkeleton className="h-4 w-36" />
+                <LemonSkeleton className="h-28 w-full" />
+            </div>
+        )
+    }
+
+    if (task && runId) {
+        return (
+            <div className="h-[calc(100vh-22rem)] min-h-[420px] w-full overflow-y-auto rounded border border-primary bg-surface-primary">
+                {/* In-progress runs stream live; terminal runs show the static replay. */}
+                <SandboxRunViewer taskId={task.id} runId={runId} replayOnly={replayOnly} />
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-2 rounded border border-primary bg-surface-primary px-4 py-3.5">
+            <span className="font-medium text-sm text-primary">
+                {task ? 'Run hasn’t started yet' : 'Waiting for the linked task'}
+            </span>
+            <span className="max-w-2xl text-xs text-secondary leading-snug">
+                {task
+                    ? 'This task is queued – its agent log will appear here once the run starts.'
+                    : 'Once the agent links this run to a task, its agent log appears here.'}
+            </span>
+        </div>
+    )
+}
+
 /**
- * Agent run detail body. Shows the run state strip + output state, the linked run(s) (which link out
- * to the task detail page – we do NOT rebuild the run-log viewer here), and contributing evidence.
- * Mirrors desktop `AgentRunDetail`'s intent with cloud's existing task-detail run log.
+ * "Open task": continues the selected task in a new PostHog AI chat bound to it — the chat's first
+ * message creates a conversation linked to this task and resumes its run interactively. A plain click
+ * opens PostHog AI in the side panel (staying in the inbox); cmd/ctrl/middle-click follows the href to
+ * open a new tab, carrying the bind via the `bind_task` URL param. Gated to a terminal run — the live
+ * Task log already covers an in-progress run, and taking over a running automation run is out of scope.
+ */
+function OpenTaskButton({ taskId, runStatus }: { taskId: string; runStatus?: TaskRunStatus }): JSX.Element {
+    const { openSidePanelMaxWithTaskBind } = useActions(maxGlobalLogic)
+    const isTerminal = isTerminalRunStatus(runStatus)
+
+    return (
+        <LemonButton
+            size="xsmall"
+            type="secondary"
+            to={combineUrl(urls.ai(), { [SANDBOX_BIND_TASK_PARAM]: taskId }).url}
+            onClick={(e) => {
+                // Plain left-click: open the side panel in place rather than navigating to /ai.
+                // Link lets a modified click (cmd/ctrl/middle) through to the href for a new tab.
+                e.preventDefault()
+                openSidePanelMaxWithTaskBind(taskId)
+            }}
+            disabledReason={isTerminal ? undefined : 'Available once the run finishes'}
+            tooltip="Continue this task in a new PostHog AI chat"
+        >
+            Open task
+        </LemonButton>
+    )
+}
+
+/**
+ * Inline "Task log": the selected linked task's agent transcript, rendered with the shared
+ * `SandboxRunViewer` — live for an in-progress run, static replay once terminal. A `LemonSelect`
+ * switches between linked tasks (research / implementation) when there's more than one; "Open task"
+ * continues the task in a new PostHog AI chat. Mirrors desktop `AgentRunDetail`'s Task-log section.
+ */
+function TaskLogSection({ report }: { report: SignalReport }): JSX.Element {
+    const { reportTasks, reportTasksLoading, selectedTask } = useValues(
+        inboxReportDetailLogic({ reportId: report.id, report })
+    )
+    const { setSelectedTaskId } = useActions(inboxReportDetailLogic({ reportId: report.id, report }))
+
+    const task = selectedTask?.task ?? null
+    const runId = task?.latest_run?.id ?? null
+    const runStatus = task?.latest_run?.status
+    const replayOnly = isTerminalRunStatus(runStatus)
+
+    const rightSlot = task ? (
+        <div className="flex items-center gap-2">
+            {reportTasks && reportTasks.length > 1 && (
+                <LemonSelect
+                    size="small"
+                    value={task.id}
+                    onChange={(id) => setSelectedTaskId(id)}
+                    options={reportTasks.map((entry) => ({
+                        value: entry.task.id,
+                        label: (
+                            <span className="flex items-center gap-1.5">
+                                <TaskRunStatusDot status={entry.task.latest_run?.status ?? TaskRunStatus.NOT_STARTED} />
+                                {RELATIONSHIP_LABEL[entry.relationship]}
+                            </span>
+                        ),
+                    }))}
+                />
+            )}
+            <OpenTaskButton taskId={task.id} runStatus={runStatus} />
+        </div>
+    ) : null
+
+    return (
+        <DetailSection icon={<IconTerminal />} title="Task log" rightSlot={rightSlot}>
+            <TaskLogBody
+                loading={reportTasksLoading && !reportTasks}
+                task={task}
+                runId={runId}
+                replayOnly={replayOnly}
+            />
+        </DetailSection>
+    )
+}
+
+/**
+ * Agent run detail body. Shows the run state strip + output state, the linked run's agent transcript
+ * inline (`TaskLogSection`, via the shared `SandboxRunViewer`), and contributing evidence.
+ * Mirrors desktop `AgentRunDetail`.
  */
 export function AgentRunDetail({ report }: { report: SignalReport }): JSX.Element {
     const { reportSignals, reportSignalsLoading, isReResearch, priorityExplanation, actionabilityExplanation } =
@@ -190,7 +323,7 @@ export function AgentRunDetail({ report }: { report: SignalReport }): JSX.Elemen
                 <div className="flex flex-col min-w-0 gap-5">
                     <RunStateStrip report={report} />
                     <RunOutputWidget report={report} />
-                    <ReportTasksSection report={report} />
+                    <TaskLogSection report={report} />
                 </div>
 
                 <div className="flex flex-col min-w-0 gap-5">

--- a/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
@@ -1,6 +1,4 @@
-import clsx from 'clsx'
 import { useValues } from 'kea'
-import { combineUrl } from 'kea-router'
 
 import { IconChevronRight, IconTerminal } from '@posthog/icons'
 import { Link, Spinner } from '@posthog/lemon-ui'
@@ -10,37 +8,14 @@ import { urls } from 'scenes/urls'
 import { Task, TaskRunStatus } from 'products/tasks/frontend/types'
 
 import { inboxReportDetailLogic, ReportTaskEntry } from '../../logics/inboxReportDetailLogic'
-import { SignalReport, SignalReportTaskRelationship } from '../../types'
+import { SignalReport } from '../../types'
 import { RightColumnSection } from './DetailSection'
-
-const RELATIONSHIP_LABEL: Record<SignalReportTaskRelationship, string> = {
-    research: 'Research',
-    implementation: 'Implementation',
-    repo_selection: 'Repo selection',
-}
-
-const TERMINAL_STATUSES: TaskRunStatus[] = [TaskRunStatus.COMPLETED, TaskRunStatus.FAILED, TaskRunStatus.CANCELLED]
-
-function TaskRunStatusDot({ status }: { status: TaskRunStatus }): JSX.Element {
-    const terminal = TERMINAL_STATUSES.includes(status)
-    const color =
-        status === TaskRunStatus.FAILED || status === TaskRunStatus.CANCELLED
-            ? 'bg-danger'
-            : terminal
-              ? 'bg-success'
-              : 'bg-primary'
-    return (
-        <span
-            className={clsx('inline-block size-1.5 shrink-0 rounded-full', color, !terminal && 'animate-pulse')}
-            aria-hidden
-        />
-    )
-}
+import { RELATIONSHIP_LABEL, TaskRunStatusDot } from './taskRunDisplay'
 
 /**
- * Renders the report's linked tasks inline (latest status + relationship) and links out to
- * cloud's existing task detail page. The run-log/session viewer lives there; this is the doorway.
- * Only `implementation` and `research` relationships are shown, implementation-first.
+ * Renders the report's linked tasks inline (latest status + relationship). Each row opens the
+ * report's run detail (`AgentRunDetail`), where the task's run log renders inline. Only
+ * `implementation` and `research` relationships are shown, implementation-first.
  */
 export function ReportTasksSection({ report }: { report: SignalReport }): JSX.Element | null {
     const { reportTasks, reportTasksLoading } = useValues(inboxReportDetailLogic({ reportId: report.id, report }))
@@ -64,23 +39,21 @@ export function ReportTasksSection({ report }: { report: SignalReport }): JSX.El
         <RightColumnSection icon={<IconTerminal />} title="Runs">
             <div className="flex flex-col gap-0.5">
                 {reportTasks.map((entry: ReportTaskEntry) => (
-                    <TaskRow key={entry.task.id} entry={entry} />
+                    <TaskRow key={entry.task.id} entry={entry} reportId={report.id} />
                 ))}
             </div>
         </RightColumnSection>
     )
 }
 
-function TaskRow({ entry }: { entry: ReportTaskEntry }): JSX.Element {
+function TaskRow({ entry, reportId }: { entry: ReportTaskEntry; reportId: string }): JSX.Element {
     const { task, relationship } = entry
     const status = task.latest_run?.status ?? TaskRunStatus.NOT_STARTED
-    const runId = task.latest_run?.id
-    // Deep-link straight to the task's run logs in cloud's Tasks UI (selecting the latest run),
-    // rather than the in-inbox Runs route.
-    const taskLogUrl = runId ? combineUrl(urls.taskDetail(task.id), { runId }).url : urls.taskDetail(task.id)
+    // Open this report's run detail (the inbox Runs route); `inboxSceneLogic` handles the cross-tab
+    // open. The task's run log renders inline there — no need to leave the inbox for the Tasks UI.
     return (
         <Link
-            to={taskLogUrl}
+            to={urls.inboxReport('runs', reportId)}
             className="group flex items-center gap-2 rounded px-1.5 py-1 text-left text-xs no-underline transition-colors hover:bg-fill-highlight-50"
         >
             <TaskRunStatusDot status={status} />

--- a/frontend/src/scenes/inbox/components/detail/taskRunDisplay.tsx
+++ b/frontend/src/scenes/inbox/components/detail/taskRunDisplay.tsx
@@ -1,0 +1,36 @@
+import clsx from 'clsx'
+
+import { TaskRunStatus } from 'products/tasks/frontend/types'
+
+import { SignalReportTaskRelationship } from '../../types'
+
+/** Human label for a report→task relationship, shown next to a run in the inbox. */
+export const RELATIONSHIP_LABEL: Record<SignalReportTaskRelationship, string> = {
+    research: 'Research',
+    implementation: 'Implementation',
+    repo_selection: 'Repo selection',
+}
+
+/** Run statuses that count as terminal. Mirrors desktop `isTerminalStatus`. */
+export const TERMINAL_STATUSES: TaskRunStatus[] = [
+    TaskRunStatus.COMPLETED,
+    TaskRunStatus.FAILED,
+    TaskRunStatus.CANCELLED,
+]
+
+/** Small status dot: red for failed/cancelled, green for completed, pulsing blue while in motion. */
+export function TaskRunStatusDot({ status }: { status: TaskRunStatus }): JSX.Element {
+    const terminal = TERMINAL_STATUSES.includes(status)
+    const color =
+        status === TaskRunStatus.FAILED || status === TaskRunStatus.CANCELLED
+            ? 'bg-danger'
+            : terminal
+              ? 'bg-success'
+              : 'bg-primary'
+    return (
+        <span
+            className={clsx('inline-block size-1.5 shrink-0 rounded-full', color, !terminal && 'animate-pulse')}
+            aria-hidden
+        />
+    )
+}

--- a/frontend/src/scenes/inbox/logics/inboxReportDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxReportDetailLogic.ts
@@ -98,6 +98,8 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
         setOptimisticReviewers: (reviewers: EnrichedReviewer[] | null) => ({ reviewers }),
         // Debounced server-side org-member search for the add-reviewer picker.
         searchAvailableReviewers: (query: string) => ({ query }),
+        // Which linked task's run log the detail view shows; null falls back to `primaryTask`.
+        setSelectedTaskId: (taskId: string | null) => ({ taskId }),
     }),
 
     loaders(({ props }) => ({
@@ -166,6 +168,15 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
             {
                 updateReviewers: (_, { optimistic }) => optimistic,
                 setOptimisticReviewers: (_, { reviewers }) => reviewers,
+            },
+        ],
+        // Explicit task selection for the run-log viewer. Reset when the report changes so a freshly
+        // opened run starts on its `primaryTask`.
+        selectedTaskId: [
+            null as string | null,
+            {
+                setSelectedTaskId: (_, { taskId }) => taskId,
+                setReport: () => null,
             },
         ],
     }),
@@ -266,6 +277,37 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
                 })
                 return hasInFlight && hasPriorTerminal
             },
+        ],
+        // The default task whose run log is shown: prefer one still in motion, tie-break by most-recent
+        // link. Mirrors desktop `AgentRunDetail`'s `pickPrimaryTask`.
+        primaryTask: [
+            (s) => [s.reportTasks],
+            (reportTasks: ReportTaskEntry[] | null): ReportTaskEntry | null => {
+                if (!reportTasks || reportTasks.length === 0) {
+                    return null
+                }
+                return [...reportTasks].sort((a, b) => {
+                    const aInMotion = !TERMINAL_RUN_STATUSES.includes(
+                        a.task.latest_run?.status ?? TaskRunStatus.NOT_STARTED
+                    )
+                    const bInMotion = !TERMINAL_RUN_STATUSES.includes(
+                        b.task.latest_run?.status ?? TaskRunStatus.NOT_STARTED
+                    )
+                    if (aInMotion !== bInMotion) {
+                        return aInMotion ? -1 : 1
+                    }
+                    return new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+                })[0]
+            },
+        ],
+        // The linked task the viewer renders: the explicit selection if it still exists, else `primaryTask`.
+        selectedTask: [
+            (s) => [s.reportTasks, s.selectedTaskId, s.primaryTask],
+            (
+                reportTasks: ReportTaskEntry[] | null,
+                selectedTaskId: string | null,
+                primaryTask: ReportTaskEntry | null
+            ): ReportTaskEntry | null => reportTasks?.find((rt) => rt.task.id === selectedTaskId) ?? primaryTask,
         ],
     }),
 

--- a/frontend/src/scenes/max/AGENTS.md
+++ b/frontend/src/scenes/max/AGENTS.md
@@ -1,0 +1,109 @@
+# PostHog AI scene — agent guide
+
+This is the scene for **PostHog AI**, PostHog's agent. It hosts **two coexisting runtimes**, chosen per conversation by `conversation.agent_runtime` (`'langgraph' | 'sandbox'`):
+
+- **`langgraph`** — the **legacy** runtime. Frozen.
+- **`sandbox`** — the **new** runtime (Claude Code/Codex agent-server over SSE). New work goes here.
+
+> **Naming:** the user-facing product is **PostHog AI** (was "Max"). Use "PostHog AI" in all user-facing copy. The directory stays `scenes/max/`, and existing internal identifiers (`Max*` components, `MaxUIContext`, `maxThreadLogic`, `maxContextLogic`, the "Max Context" subsystem) keep their names — don't mass-rename. New code shouldn't introduce fresh "Max" branding in copy.
+
+> For the **Max Context** subsystem (how scenes expose dashboards/insights/events to the assistant), see [`README.md`](./README.md). This guide does not repeat it.
+
+## 1. Legacy vs new runtime — read this first
+
+Per-concern mapping, `langgraph` (LEGACY, frozen) → `sandbox` (NEW, build here):
+
+- **Runtime flag**: `agent_runtime === 'langgraph'` → `agent_runtime === 'sandbox'`
+- **Stream logic**: `maxThreadLogic.tsx` (LangGraph stream loop) → `sandboxStreamLogic.ts` (SSE over products/tasks)
+- **Activity renderer**: `components/Activity/LangGraphActivity.tsx` → `components/Activity/SandboxActivity.tsx`
+- **Thread renderer**: `Thread.tsx` (default path) → `Thread.tsx` → `SandboxThread()`
+- **Context shape**: rich `MaxUIContext` (full objects) → flat `AttachedContext` (typed refs, agent fetches)
+- **Approvals**: `DangerousOperationApprovalCard.tsx` / `approvalOperationUtils.ts` → `SandboxPermissionInput` / `SandboxQuestionInput`
+- **Tool widgets**: `messages/` + `messages/adapters/` → `sandboxToolRegistry` / `sandboxToolResolver`
+
+### Rule: do not extend the LangGraph path unless explicitly asked
+
+New behavior — new tools, new context types, new UI affordances — goes on the **sandbox** path. The LangGraph runtime is slated for removal once sandbox reaches parity; keeping its surface from growing makes the eventual deletion a clean removal rather than an untangling.
+
+- ✅ Bugfixes that keep existing LangGraph conversations working.
+- ❌ Net-new capability on the LangGraph path.
+- ❌ New fields on `MaxUIContext` for a sandbox feature — use `AttachedContext` instead.
+- ❌ No new MaxTools.
+
+If a task genuinely needs the LangGraph path extended, confirm that intent explicitly before touching `maxThreadLogic.tsx`, `LangGraphActivity.tsx`, `max-constants.tsx` (`EnhancedToolCall`), the `MaxUIContext` half of `maxContextLogic.ts`, or `messages/` + `messages/adapters/`.
+
+## 2. Sandbox architecture (the new path)
+
+`sandboxStreamLogic.ts` is the heart of the sandbox runtime:
+
+- **SSE connection** — a `fetch` body reader pumped through `eventsource-parser`; a reconnect resumes after the last Redis stream id via `Last-Event-ID` (capped exponential backoff + healthy-connection forgiveness + cumulative cap).
+- **Ordered, append-only `log` is the single source of truth** — every wire frame (plus a few client-injected synthetic entries) is appended, never keyed or per-entry deduped.
+- **Pure projection** `foldLogToThread(entries) → { threadItems, toolInvocations }`, memoized on `log` identity, derives the rendered thread.
+- **Keyed by `streamKey`** (conversation id for Max, task id for a generic task viewer), so concurrent streams stay independent.
+
+**Lifecycle:** `bootstrapRun` (connect SSE → buffer live frames → read the S3 `logs/` snapshot → `dedupeBufferedAgainstHistory` drains the seam) → `ingestAcpFrame` appends + fires fire-once side effects → projection → `Thread.tsx`'s `SandboxThread()` renders `threadItems`, looking up `toolInvocations` by id.
+
+**Permissions:** parse (`parsePermissionRequestFrame`) → route (`sandboxToolPolicy.defaultPermissionDecision` auto-approves built-ins + read-only PostHog `exec`, else surfaces a card) → answer (`respondToPermission`) → resolve (clears the card, pins the id so a reconnect replay can't re-surface it).
+
+**Supporting modules:** `sandboxToolPolicy`, `sandboxPermissionUtils`, `sandboxPermissionDisplayUtils`, `sandboxQuestionUtils`, `sandboxToolResolver`; types in `types/sandboxStreamTypes.ts` (folded thread shapes) + `types/sandboxWireTypes.ts` (ACP wire shapes + discriminant guards).
+
+**Wire types are loosely typed** (`notification.params` is `Record<string, unknown>`) — guard at the parse boundary with runtime `typeof`/shape checks; never assume a field is present because the type says so.
+
+## 3. Conventions for new sandbox code
+
+### Streaming/runtime logic stays in the logic, never in a component
+
+Wire parsing, log folding, SSE handling, telemetry, and permission routing belong in `sandboxStreamLogic` (or a sibling logic/util). Components **consume selectors and dispatch actions** — never parse ACP frames, hold SSE/connection state, or fold wire data in a component body.
+
+Selectors to consume: `threadItems`, `toolInvocations`, `isThinking`, `streamPhase`, `pendingPermissionRequest`, `respondingToPermission`, `contextUsage`, `resourcesUsed`.
+
+### Keep UI runtime-agnostic
+
+Render components take **plain props** — `ThreadItem`, `ToolInvocation`, `PermissionRequestRecord` — and know nothing about langgraph vs sandbox; this is what lets the legacy path be deleted later without touching shared UI. If a component must branch on runtime, branch **high** (in `Thread.tsx`, off `agent_runtime`) and pass resolved props down.
+
+### Atomic components
+
+One responsibility per component: extract each thread-item type into a **small leaf presenter**, not a giant inline `switch`/`map`. `SandboxThread()` in `Thread.tsx` (inline dispatch over 15+ item types) and the 1900-line `sandboxStreamLogic.ts` are anti-patterns to shrink, not extend.
+
+### Memoize — `threadItems` re-projects on every appended frame
+
+- Wrap leaf renderers in `React.memo`, keyed by the stable item `id`.
+- Derive per-item data with `useMemo`; wrap callbacks passed to children in `useCallback`.
+- **Subscribe narrowly** — select only what the component renders; pulling in unrelated selectors means an unrelated fold re-renders it.
+
+### Keep the projection pure
+
+`foldLogToThread` and its helpers must be **pure and deterministic** — item ids stay stable across re-folds. Never mutate thread/invocation state from a listener; derive everything in the projection. Listeners fire only **side effects** (telemetry, API calls), each with its own fire-once guard, suppressed on `source: 'replay'`.
+
+## 4. Target directory organization
+
+The `max/` root is a flat sprawl (~70 files) with sandbox code scattered across the root, `sandbox/`, `components/`, `components/Activity/`, and `types/`. **Do not big-bang-move on the active branch** — it conflicts with in-flight work. Follow this target layout incrementally: new sandbox files land in the right place; an existing file moves only when you're already editing it and the move is low-risk.
+
+Target `sandbox/` subtree:
+
+```text
+sandbox/
+  sandboxStreamLogic.ts            # stream logic + orchestration (+ .test, + generated *LogicType.ts)
+  components/                      # SandboxActivity, SandboxApproval, SandboxPermissionInput,
+                                  # SandboxQuestionInput, SandboxResourcesBar, SandboxContextUsage,
+                                  # SandboxThreadItems, SandboxQuestionRenderer
+  policy/                          # sandboxToolPolicy, sandboxPermissionUtils,
+                                  # sandboxPermissionDisplayUtils, sandboxQuestionUtils
+  types/                           # sandboxStreamTypes, sandboxWireTypes
+```
+
+## 5. Where do I add X?
+
+- **A new thread-item type** → add to the `ThreadItem` union in `types/sandboxStreamTypes.ts`, handle it in `foldLogToThread`, and add a memoized leaf renderer wired into `SandboxThread()`.
+- **A new permission affordance / auto-approval rule** → `sandboxToolPolicy.ts`, then surface it through `SandboxPermissionInput`.
+- **New telemetry** → a guarded `posthog.capture` in the relevant `sandboxStreamLogic` listener (fire-once, suppressed on replay).
+- **New context the agent should see** → extend `AttachedContext` (not `MaxUIContext`).
+
+## 6. Don'ts
+
+- Don't extend the LangGraph runtime unless explicitly asked.
+- Don't parse wire frames or hold SSE state inside a component.
+- Don't mutate thread/invocation state from a listener — derive it in the projection.
+- Don't add `MaxUIContext` fields for a sandbox feature — use `AttachedContext`.
+- Don't subscribe to all sandbox selectors when you need one.
+- Don't big-bang-move files on the active branch.

--- a/frontend/src/scenes/max/CLAUDE.md
+++ b/frontend/src/scenes/max/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 import React from 'react'
 
@@ -10,6 +10,7 @@ import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopov
 import { IconAction, IconEvent } from 'lib/lemon-ui/icons'
 
 import { ModeSelector } from './components/ModeSelector'
+import { SandboxModeToggle } from './components/SandboxModeToggle'
 import { maxContextLogic } from './maxContextLogic'
 import { maxThreadLogic } from './maxThreadLogic'
 import {
@@ -19,6 +20,7 @@ import {
     MaxInsightContext,
     MaxNotebookContext,
 } from './maxTypes'
+import { posthogAiContextLogic } from './posthogAiContextLogic'
 
 function pluralize(count: number, word: string): string {
     return `${count} ${word}${count > 1 ? 's' : ''}`
@@ -330,12 +332,45 @@ export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'de
     )
 }
 
+/**
+ * Sandbox-runtime chips, rendered from the flat `posthogAiContextLogic.chipsForDisplay`. The X on
+ * each chip dispatches `detach(key)` — one removal path, no source distinction. Coexistence
+ * sibling to `ContextTags` (LangGraph).
+ */
+export function SandboxContextTags({ size = 'default' }: { size?: 'small' | 'default' }): JSX.Element | null {
+    const { chipsForDisplay } = useValues(posthogAiContextLogic)
+    const { detach } = useActions(posthogAiContextLogic)
+
+    if (chipsForDisplay.length === 0) {
+        return null
+    }
+
+    return (
+        <>
+            {chipsForDisplay.map((chip) => (
+                <Tooltip key={chip.key} title={chip.label}>
+                    <LemonTag
+                        icon={chip.icon as JSX.Element}
+                        onClose={() => detach(chip.key)}
+                        closable
+                        closeOnClick
+                        className={clsx('flex items-center text-secondary', size === 'small' ? 'max-w-20' : 'max-w-48')}
+                    >
+                        <span className="truncate min-w-0 flex-1">{chip.label}</span>
+                    </LemonTag>
+                </Tooltip>
+            ))}
+        </>
+    )
+}
+
 interface ContextDisplayProps {
     size?: 'small' | 'default'
 }
 
 export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.Element | null {
-    const { showContextUI, contextDisabledReason } = useValues(maxThreadLogic)
+    const { showContextUI, contextDisabledReason, conversation, sandboxConversationKey } = useValues(maxThreadLogic)
+    const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
     const { hasData, contextOptions, taxonomicGroupTypes, mainTaxonomicGroupType, toolContextItems } =
         useValues(maxContextLogic)
     const { handleTaxonomicFilterChange } = useActions(maxContextLogic)
@@ -350,6 +385,7 @@ export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.E
         <div className="px-2 w-full">
             <div className="flex flex-wrap items-start gap-1 w-full">
                 <ModeSelector />
+                <SandboxModeToggle />
                 <Tooltip title={contextDisabledReason ?? 'Add context to help PostHog AI answer your question'}>
                     {/* Wrapper span prevents Base UI's Tooltip.Trigger from merging
                         props into TaxonomicPopover. Without it, mergeProps treats
@@ -372,8 +408,19 @@ export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.E
                         />
                     </span>
                 </Tooltip>
-                <ContextToolInfoTags size={size} />
-                <ContextTags size={size} />
+                {isSandboxRuntime ? (
+                    sandboxConversationKey ? (
+                        // Same key maxThreadLogic's connect() uses, so both resolve the same instance
+                        <BindLogic logic={posthogAiContextLogic} props={{ conversationId: sandboxConversationKey }}>
+                            <SandboxContextTags size={size} />
+                        </BindLogic>
+                    ) : null
+                ) : (
+                    <>
+                        <ContextToolInfoTags size={size} />
+                        <ContextTags size={size} />
+                    </>
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/max/DangerousOperationApprovalCard.tsx
+++ b/frontend/src/scenes/max/DangerousOperationApprovalCard.tsx
@@ -1,21 +1,31 @@
 import { useValues } from 'kea'
 
-import { IconWarning } from '@posthog/icons'
+import { IconNotebook, IconWarning } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 
 import { DangerousOperationResponse } from '~/queries/schema/schema-assistant-messages'
 
 import { maxThreadLogic } from './maxThreadLogic'
 
+/**
+ * `plan_approval` reuses this card for sandbox plan-mode approvals — it only swaps the icon
+ * and the awaiting copy. `dangerous_operation` is the existing LangGraph default.
+ */
+export type ApprovalCardVariant = 'dangerous_operation' | 'plan_approval'
+
 interface DangerousOperationApprovalCardProps {
     operation: DangerousOperationResponse
+    variant?: ApprovalCardVariant
 }
 
 /**
  * In-thread approval card that shows a compact summary of the approval status.
  * The actual approval interaction happens in the input area (DangerousOperationInput).
  */
-export function DangerousOperationApprovalCard({ operation }: DangerousOperationApprovalCardProps): JSX.Element {
+export function DangerousOperationApprovalCard({
+    operation,
+    variant = 'dangerous_operation',
+}: DangerousOperationApprovalCardProps): JSX.Element {
     // Read both resolvedApprovalStatuses (frontend) and pendingApprovalsData (backend)
     // to ensure we show correct status for both new and historical approvals
     const { resolvedApprovalStatuses, pendingApprovalsData, isSharedThread } = useValues(maxThreadLogic)
@@ -31,15 +41,18 @@ export function DangerousOperationApprovalCard({ operation }: DangerousOperation
 
     const subject = isSharedThread ? 'User' : 'You'
 
+    const isPlan = variant === 'plan_approval'
+    const Icon = isPlan ? IconNotebook : IconWarning
+
     // Show pending state while waiting for resolution
     if (!resolvedStatus) {
         return (
             <div className="flex text-xs text-muted">
                 <div className="flex items-center justify-center size-5">
-                    <IconWarning />
+                    <Icon />
                 </div>
                 <div className="flex items-center gap-1 flex-1 min-w-0">
-                    <span>Awaiting approval...</span>
+                    <span>{isPlan ? 'Awaiting plan approval...' : 'Awaiting approval...'}</span>
                     <Spinner className="size-3" />
                 </div>
             </div>
@@ -59,7 +72,7 @@ export function DangerousOperationApprovalCard({ operation }: DangerousOperation
     return (
         <div className="flex text-xs text-muted">
             <div className="flex items-center justify-center size-5">
-                <IconWarning />
+                <Icon />
             </div>
             <div className="flex items-center gap-1 flex-1 min-w-0">
                 <span>{text}</span>

--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -38,7 +38,7 @@ import { HistoryPreview } from './HistoryPreview'
 import { Intro } from './Intro'
 import { MaxLogicProps, SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import { MaxThreadLogicProps, maxThreadLogic } from './maxThreadLogic'
-import { Thread } from './Thread'
+import { SandboxComposerSurfaces, Thread } from './Thread'
 
 export const scene: SceneExport = {
     component: Max,
@@ -147,6 +147,7 @@ export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }:
                             </div>
                         )}
                         <Thread className={cn('p-3', sidePanel && 'p-1')} />
+                        <SandboxComposerSurfaces />
                         {!conversation?.has_unsupported_content && (
                             <SidebarQuestionInput isSticky sidePanel={sidePanel} />
                         )}

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -1,11 +1,9 @@
 import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import React, { useLayoutEffect, useMemo, useState } from 'react'
 
 import {
-    IconBrain,
-    IconCheck,
     IconChevronRight,
     IconCollapse,
     IconCopy,
@@ -27,6 +25,7 @@ import {
     LemonButtonPropsBase,
     LemonCheckbox,
     LemonDialog,
+    LemonDivider,
     LemonInput,
     LemonSkeleton,
     Tooltip,
@@ -38,11 +37,9 @@ import {
     SeriesSummary,
 } from 'lib/components/Cards/InsightCard/InsightDetails'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
-import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
 import { NotFound } from 'lib/components/NotFound'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
-import { inStorybookTestRunner } from 'lib/utils/dom'
 import { pluralize } from 'lib/utils/strings'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -69,8 +66,11 @@ import { PendingApproval, Region } from '~/types'
 
 import { LogEntry } from 'products/tasks/frontend/lib/parse-logs'
 
+import { LangGraphActivity, ShimmeringContent } from './components/Activity'
 import { FeedbackDisplay } from './components/FeedbackDisplay'
 import { MaxWebAnalyticsNudge } from './components/MaxWebAnalyticsNudge'
+import { SandboxContextUsage } from './components/SandboxContextUsage'
+import { SandboxResourcesBar } from './components/SandboxResourcesBar'
 import { ContextSummary } from './Context'
 import { DangerousOperationApprovalCard } from './DangerousOperationApprovalCard'
 import { FeedbackPrompt } from './FeedbackPrompt'
@@ -80,17 +80,16 @@ import { EnhancedToolCall, ToolRegistration, getToolDefinitionFromToolCall } fro
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { ThreadMessage, maxLogic } from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
+import { AssistantFailureMessage } from './messages/AssistantFailureMessage'
 import { MessageTemplate } from './messages/MessageTemplate'
 import { MultiQuestionFormRecap } from './messages/MultiQuestionForm'
 import { NotebookArtifactAnswer } from './messages/NotebookArtifactAnswer'
+import { ReasoningAnswer } from './messages/ReasoningAnswer'
 import { SessionSummarizationProgress } from './messages/SessionSummarizationProgress'
-import {
-    RecordingsWidget,
-    SummarizeSessionsWidget,
-    UIPayloadAnswer,
-    isRenderableUIPayloadTool,
-} from './messages/UIPayloadAnswer'
-import { VisualizationArtifactAnswer } from './messages/VisualizationArtifactAnswer'
+import { RecordingsWidget, isRenderableUIPayloadTool } from './messages/UIPayloadAnswer'
+import { VisualizationArtifact } from './messages/VisualizationArtifact'
+import { SandboxThreadView } from './sandbox/components/SandboxThreadView'
+import { sandboxStreamLogic } from './sandboxStreamLogic'
 import { MAX_SLASH_COMMANDS, SlashCommandName } from './slash-commands'
 import { TicketPrompt } from './TicketPrompt'
 import { getTicketPromptData, getTicketSummaryData, isTicketConfirmationMessage } from './ticketUtils'
@@ -117,6 +116,67 @@ function isErrorMessage(message: ThreadMessage): boolean {
 }
 
 export function Thread({ className }: { className?: string }): JSX.Element | null {
+    const { conversation, sandboxConversationKey, isConvertedConversation } = useValues(maxThreadLogic)
+    const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
+
+    const containerClassName = cn(
+        '@container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
+        className
+    )
+
+    // Born-sandbox conversation (no legacy history): render only the sandbox thread.
+    if (isSandboxRuntime && !isConvertedConversation) {
+        if (!sandboxConversationKey) {
+            return null
+        }
+        return (
+            <div className={containerClassName}>
+                {/* Same key maxThreadLogic's connect() uses, so both resolve the same instance */}
+                <BindLogic
+                    logic={sandboxStreamLogic}
+                    props={{ streamKey: sandboxConversationKey, conversationId: sandboxConversationKey }}
+                >
+                    <SandboxThreadView />
+                </BindLogic>
+            </div>
+        )
+    }
+
+    // Converted conversation: the full legacy thread, a "history was converted" divider, then the
+    // live sandbox thread — all in one scroll container so auto-scroll lands at the sandbox bottom.
+    if (isConvertedConversation) {
+        if (!sandboxConversationKey) {
+            return null
+        }
+        return (
+            <div className={containerClassName}>
+                <LegacyThread showTrailers={false} />
+                <LemonDivider dashed label="Message history was converted to the new format" className="my-3" />
+                <BindLogic
+                    logic={sandboxStreamLogic}
+                    props={{ streamKey: sandboxConversationKey, conversationId: sandboxConversationKey }}
+                >
+                    <SandboxThreadView />
+                </BindLogic>
+            </div>
+        )
+    }
+
+    // Pure LangGraph conversation.
+    return (
+        <div className={containerClassName}>
+            <LegacyThread showTrailers />
+        </div>
+    )
+}
+
+/**
+ * LangGraph thread renderer: renders `maxThreadLogic.threadGrouped` (message history), loading
+ * skeletons, or a NotFound fallback. `showTrailers` gates the feedback / ticket prompts so a
+ * converted conversation renders them once at the true bottom (below the sandbox thread), not
+ * wedged above the conversion divider.
+ */
+function LegacyThread({ showTrailers }: { showTrailers: boolean }): JSX.Element | null {
     const { conversationLoading, messagesLoading, conversationId } = useValues(maxLogic)
     const { threadGrouped, streamingActive, threadLoading, sandboxEntries } = useValues(maxThreadLogic)
     const sandboxModeEnabled = useFeatureFlag('PHAI_SANDBOX_MODE')
@@ -132,161 +192,174 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
         [threadGrouped, streamingActive]
     )
 
-    return (
-        <div
-            className={cn(
-                '@container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
-                className
-            )}
-        >
-            {(conversationLoading || messagesLoading) && threadGrouped.length === 0 ? (
-                <>
-                    <MessageGroupSkeleton groupType="human" />
-                    <MessageGroupSkeleton groupType="ai" className="opacity-80" />
-                    <MessageGroupSkeleton groupType="human" className="opacity-65" />
-                    <MessageGroupSkeleton groupType="ai" className="opacity-40" />
-                    <MessageGroupSkeleton groupType="human" className="opacity-20" />
-                    <MessageGroupSkeleton groupType="ai" className="opacity-10" />
-                    <MessageGroupSkeleton groupType="human" className="opacity-5" />
-                </>
-            ) : threadGrouped.length > 0 ? (
-                <>
-                    {(() => {
-                        // Track the current trace_id as we iterate forward through messages
-                        let currentTraceId: string | undefined
+    return (conversationLoading || messagesLoading) && threadGrouped.length === 0 ? (
+        <>
+            <MessageGroupSkeleton groupType="human" />
+            <MessageGroupSkeleton groupType="ai" className="opacity-80" />
+            <MessageGroupSkeleton groupType="human" className="opacity-65" />
+            <MessageGroupSkeleton groupType="ai" className="opacity-40" />
+            <MessageGroupSkeleton groupType="human" className="opacity-20" />
+            <MessageGroupSkeleton groupType="ai" className="opacity-10" />
+            <MessageGroupSkeleton groupType="human" className="opacity-5" />
+        </>
+    ) : threadGrouped.length > 0 ? (
+        <>
+            {(() => {
+                // Track the current trace_id as we iterate forward through messages
+                let currentTraceId: string | undefined
 
-                        return threadGrouped.map((message, index) => {
-                            // Update trace_id when we encounter a human message
-                            if (message.type === 'human' && 'trace_id' in message && message.trace_id) {
-                                currentTraceId = message.trace_id
-                            }
+                return threadGrouped.map((message, index) => {
+                    // Update trace_id when we encounter a human message
+                    if (message.type === 'human' && 'trace_id' in message && message.trace_id) {
+                        currentTraceId = message.trace_id
+                    }
 
-                            // Hide failed AI messages when retrying
-                            if (threadLoading && isErrorMessage(message)) {
-                                return null
-                            }
+                    // Hide failed AI messages when retrying
+                    if (threadLoading && isErrorMessage(message)) {
+                        return null
+                    }
 
-                            // Hide old failed attempts - only show the most recent error
-                            if (isErrorMessage(message)) {
-                                const hasNewerError = threadGrouped.slice(index + 1).some(isErrorMessage)
-                                if (hasNewerError) {
-                                    return null
-                                }
-                            }
+                    // Hide old failed attempts - only show the most recent error
+                    if (isErrorMessage(message)) {
+                        const hasNewerError = threadGrouped.slice(index + 1).some(isErrorMessage)
+                        if (hasNewerError) {
+                            return null
+                        }
+                    }
 
-                            // Hide duplicate human messages from retry pattern: Human → AI Error → Human (duplicate)
-                            // This specific pattern only occurs when "Try again" is clicked after a failure
-                            if (message.type === 'human' && 'content' in message && index >= 2) {
-                                const prevMessage = threadGrouped[index - 1]
-                                const prevPrevMessage = threadGrouped[index - 2]
+                    // Hide duplicate human messages from retry pattern: Human → AI Error → Human (duplicate)
+                    // This specific pattern only occurs when "Try again" is clicked after a failure
+                    if (message.type === 'human' && 'content' in message && index >= 2) {
+                        const prevMessage = threadGrouped[index - 1]
+                        const prevPrevMessage = threadGrouped[index - 2]
 
-                                const isRetryPattern =
-                                    isErrorMessage(prevMessage) &&
-                                    prevPrevMessage.type === 'human' &&
-                                    'content' in prevPrevMessage &&
-                                    prevPrevMessage.content === message.content
+                        const isRetryPattern =
+                            isErrorMessage(prevMessage) &&
+                            prevPrevMessage.type === 'human' &&
+                            'content' in prevPrevMessage &&
+                            prevPrevMessage.content === message.content
 
-                                if (isRetryPattern) {
-                                    return null
-                                }
-                            }
+                        if (isRetryPattern) {
+                            return null
+                        }
+                    }
 
-                            // Hide UI payload answers that are not renderable to prevent rendering an empty message component
-                            if (
-                                isAssistantToolCallMessage(message) &&
-                                (!message.ui_payload ||
-                                    !isRenderableUIPayloadTool(Object.keys(message.ui_payload)[0], message.ui_payload))
-                            ) {
-                                return null
-                            }
+                    // Hide UI payload answers that are not renderable to prevent rendering an empty message component
+                    if (
+                        isAssistantToolCallMessage(message) &&
+                        (!message.ui_payload ||
+                            !isRenderableUIPayloadTool(Object.keys(message.ui_payload)[0], message.ui_payload))
+                    ) {
+                        return null
+                    }
 
-                            const nextMessage = threadGrouped[index + 1]
-                            const isLastInGroup =
-                                !nextMessage || (message.type === 'human') !== (nextMessage.type === 'human')
+                    const nextMessage = threadGrouped[index + 1]
+                    const isLastInGroup = !nextMessage || (message.type === 'human') !== (nextMessage.type === 'human')
 
-                            // Hiding rating buttons after /feedback and /ticket command outputs
-                            const prevMessage = threadGrouped[index - 1]
-                            const isSlashCommandResponse =
-                                message.type !== 'human' &&
-                                prevMessage?.type === 'human' &&
-                                'content' in prevMessage &&
-                                (prevMessage.content.startsWith(SlashCommandName.SlashFeedback) ||
-                                    prevMessage.content.startsWith(SlashCommandName.SlashTicket))
+                    // Hiding rating buttons after /feedback and /ticket command outputs
+                    const prevMessage = threadGrouped[index - 1]
+                    const isSlashCommandResponse =
+                        message.type !== 'human' &&
+                        prevMessage?.type === 'human' &&
+                        'content' in prevMessage &&
+                        (prevMessage.content.startsWith(SlashCommandName.SlashFeedback) ||
+                            prevMessage.content.startsWith(SlashCommandName.SlashTicket))
 
-                            // Also hide for ticket confirmation messages
-                            const isTicketConfirmation = isTicketConfirmationMessage(message)
+                    // Also hide for ticket confirmation messages
+                    const isTicketConfirmation = isTicketConfirmationMessage(message)
 
-                            // Check if this message is a ticket summary that needs the ticket creation button
-                            const isTicketSummaryMessage = ticketSummaryData && ticketSummaryData.messageIndex === index
+                    // Check if this message is a ticket summary that needs the ticket creation button
+                    const isTicketSummaryMessage = ticketSummaryData && ticketSummaryData.messageIndex === index
 
-                            // For AI messages, use the current trace_id from the preceding human message
-                            const messageTraceId = message.type !== 'human' ? currentTraceId : undefined
+                    // For AI messages, use the current trace_id from the preceding human message
+                    const messageTraceId = message.type !== 'human' ? currentTraceId : undefined
 
-                            return (
-                                <React.Fragment key={`${conversationId}-${index}`}>
-                                    <TraceIdProvider value={messageTraceId}>
-                                        <Message
-                                            message={message}
-                                            nextMessage={nextMessage}
-                                            isLastInGroup={isLastInGroup}
-                                            isFinal={index === threadGrouped.length - 1}
-                                            isSlashCommandResponse={isSlashCommandResponse || isTicketConfirmation}
-                                        />
-                                    </TraceIdProvider>
-                                    {sandboxModeEnabled &&
-                                        sandboxEntries.length > 0 &&
-                                        isAssistantMessage(message) &&
-                                        message.id?.startsWith('sandbox-') &&
-                                        isLastInGroup && <SandboxActivityPanel entries={sandboxEntries} />}
-                                    {conversationId &&
-                                        isTicketSummaryMessage &&
-                                        (ticketSummaryData.discarded ? (
-                                            <p className="m-0 ml-1 mt-1 text-xs text-muted italic">
-                                                Ticket creation discarded
-                                            </p>
-                                        ) : (
-                                            <TicketPrompt
-                                                conversationId={conversationId}
-                                                traceId={traceId}
-                                                summary={ticketSummaryData.summary}
-                                            />
-                                        ))}
-                                </React.Fragment>
-                            )
-                        })
-                    })()}
-                    {conversationId && isPromptVisible && !streamingActive && (
-                        <MessageTemplate type="ai">
-                            <div className="flex flex-col gap-2">
-                                <span className="text-xs text-muted">How is PostHog AI doing? (optional)</span>
-                                <FeedbackDisplay conversationId={conversationId} />
-                            </div>
-                        </MessageTemplate>
-                    )}
-                    {conversationId && isDetailedFeedbackVisible && !streamingActive && (
-                        <FeedbackPrompt conversationId={conversationId} traceId={traceId} />
-                    )}
-                    {conversationId && isThankYouVisible && !streamingActive && (
-                        <MessageTemplate type="ai">
-                            <p className="m-0 text-sm text-secondary">Thanks for your feedback and using PostHog AI!</p>
-                        </MessageTemplate>
-                    )}
-                    {conversationId && ticketPromptData.needed && (
-                        <TicketPrompt
-                            conversationId={conversationId}
-                            traceId={traceId}
-                            initialText={ticketPromptData.initialText}
-                        />
-                    )}
-                </>
-            ) : (
-                conversationId && (
-                    <div className="flex flex-1 items-center justify-center">
-                        <NotFound object="conversation" className="m-0" />
+                    return (
+                        <React.Fragment key={`${conversationId}-${index}`}>
+                            <TraceIdProvider value={messageTraceId}>
+                                <Message
+                                    message={message}
+                                    nextMessage={nextMessage}
+                                    isLastInGroup={isLastInGroup}
+                                    isFinal={index === threadGrouped.length - 1}
+                                    isSlashCommandResponse={isSlashCommandResponse || isTicketConfirmation}
+                                />
+                            </TraceIdProvider>
+                            {sandboxModeEnabled &&
+                                sandboxEntries.length > 0 &&
+                                isAssistantMessage(message) &&
+                                message.id?.startsWith('sandbox-') &&
+                                isLastInGroup && <SandboxActivityPanel entries={sandboxEntries} />}
+                            {conversationId &&
+                                isTicketSummaryMessage &&
+                                (ticketSummaryData.discarded ? (
+                                    <p className="m-0 ml-1 mt-1 text-xs text-muted italic">Ticket creation discarded</p>
+                                ) : (
+                                    <TicketPrompt
+                                        conversationId={conversationId}
+                                        traceId={traceId}
+                                        summary={ticketSummaryData.summary}
+                                    />
+                                ))}
+                        </React.Fragment>
+                    )
+                })
+            })()}
+            {showTrailers && conversationId && isPromptVisible && !streamingActive && (
+                <MessageTemplate type="ai">
+                    <div className="flex flex-col gap-2">
+                        <span className="text-xs text-muted">How is PostHog AI doing? (optional)</span>
+                        <FeedbackDisplay conversationId={conversationId} />
                     </div>
-                )
+                </MessageTemplate>
             )}
+            {showTrailers && conversationId && isDetailedFeedbackVisible && !streamingActive && (
+                <FeedbackPrompt conversationId={conversationId} traceId={traceId} />
+            )}
+            {showTrailers && conversationId && isThankYouVisible && !streamingActive && (
+                <MessageTemplate type="ai">
+                    <p className="m-0 text-sm text-secondary">Thanks for your feedback and using PostHog AI!</p>
+                </MessageTemplate>
+            )}
+            {showTrailers && conversationId && ticketPromptData.needed && (
+                <TicketPrompt
+                    conversationId={conversationId}
+                    traceId={traceId}
+                    initialText={ticketPromptData.initialText}
+                />
+            )}
+        </>
+    ) : conversationId ? (
+        <div className="flex flex-1 items-center justify-center">
+            <NotFound object="conversation" className="m-0" />
         </div>
+    ) : null
+}
+
+/**
+ * Persistent sandbox surfaces mounted between the thread and the sticky composer: the
+ * "PostHog resources used" bar and the context-usage indicator. Both read `sandboxStreamLogic`
+ * values directly, so this binds the same logic instance `Thread`'s sandbox path uses. Renders
+ * nothing for non-sandbox conversations; the inner components hide themselves when empty.
+ */
+export function SandboxComposerSurfaces(): JSX.Element | null {
+    const { conversation, sandboxConversationKey } = useValues(maxThreadLogic)
+    const sandboxModeEnabled = useFeatureFlag('PHAI_SANDBOX_MODE')
+
+    if (conversation?.agent_runtime !== 'sandbox' || !sandboxModeEnabled || !sandboxConversationKey) {
+        return null
+    }
+
+    return (
+        <BindLogic
+            logic={sandboxStreamLogic}
+            props={{ streamKey: sandboxConversationKey, conversationId: sandboxConversationKey }}
+        >
+            <div className="w-full max-w-180 self-center mx-auto">
+                <SandboxResourcesBar />
+                <SandboxContextUsage />
+            </div>
+        </BindLogic>
     )
 }
 
@@ -678,7 +751,7 @@ const Message = React.memo(function Message({
                     } else if (isArtifactMessage(message)) {
                         if (isVisualizationArtifactContent(message.content)) {
                             return (
-                                <VisualizationArtifactAnswer
+                                <VisualizationArtifact
                                     key={key}
                                     message={message}
                                     content={message.content}
@@ -786,21 +859,20 @@ const TextAnswer = React.forwardRef<HTMLDivElement, TextAnswerProps>(function Te
           })()
         : null
 
+    if (isFailureMessage(message)) {
+        return (
+            <AssistantFailureMessage id={message.id || 'error'} content={message.content} ref={ref} action={action} />
+        )
+    }
+
     return (
         <MessageTemplate
             type="ai"
-            boxClassName={message.status === 'error' || message.type === 'ai/failure' ? 'border-danger' : undefined}
+            boxClassName={message.status === 'error' ? 'border-danger' : undefined}
             ref={ref}
             action={action}
         >
-            {message.content ? (
-                <MarkdownMessage content={message.content} id={message.id || 'in-progress'} />
-            ) : (
-                <MarkdownMessage
-                    content={message.content || '*PostHog AI has failed to generate an answer. Please try again.*'}
-                    id={message.id || 'error'}
-                />
-            )}
+            <MarkdownMessage content={message.content || ''} id={message.id || 'in-progress'} />
         </MessageTemplate>
     )
 })
@@ -931,314 +1003,6 @@ function PlanningAnswer({ toolCall, isLastPlanningMessage = true }: PlanningAnsw
     )
 }
 
-function ShimmeringContent({ children }: { children: React.ReactNode }): JSX.Element {
-    const isTextContent = typeof children === 'string'
-
-    if (isTextContent) {
-        return (
-            <span
-                className="bg-clip-text text-transparent"
-                style={{
-                    backgroundImage:
-                        'linear-gradient(in oklch 90deg, var(--text-3000), var(--muted-3000), var(--trace-3000), var(--muted-3000), var(--text-3000))',
-                    backgroundSize: '200% 100%',
-                    animation: 'shimmer 3s linear infinite',
-                }}
-            >
-                {children}
-            </span>
-        )
-    }
-
-    return (
-        <span
-            className="inline-flex min-w-0 max-w-full"
-            style={{
-                animation: 'shimmer-opacity 3s linear infinite',
-            }}
-        >
-            {children}
-        </span>
-    )
-}
-
-function handleThreeDots(content: string, isInProgress: boolean): string {
-    if (content.at(0) === '[' && content.at(-1) === ')') {
-        // Skip ... for web search `updates`, where each is a Markdown-formatted link to a search results, _not_ an action
-        return content
-    }
-    if (!content.endsWith('...') && !content.endsWith('…') && !content.endsWith('.') && isInProgress) {
-        return content + '...'
-    } else if ((content.endsWith('...') || content.endsWith('…')) && !isInProgress) {
-        return content.replace(/[…]/g, '').replace(/[.]/g, '')
-    }
-    return content
-}
-
-function AssistantActionComponent({
-    id,
-    content,
-    substeps,
-    state,
-    icon,
-    animate = true,
-    showCompletionIcon = true,
-    widget = null,
-    isResultExpanded = false,
-    toolCall = null,
-}: {
-    id: string
-    content: string
-    // actually a markdown message
-    substeps: string[]
-    state: ExecutionStatus
-    icon?: React.ReactNode
-    animate?: boolean
-    showCompletionIcon?: boolean
-    widget?: JSX.Element | null
-    isResultExpanded?: boolean
-    toolCall?: EnhancedToolCall | null
-}): JSX.Element {
-    const isPending = state === 'pending'
-    const isCompleted = state === 'completed'
-    const isInProgress = state === 'in_progress'
-    const isFailed = state === 'failed'
-    const showSubstepsChevron = !!substeps.length || !!toolCall?.result?.content
-    // Initialize with the same logic as the effect to prevent flickering
-    const [isSubstepsExpanded, setIsSubstepsExpanded] = useState(showSubstepsChevron && !(isCompleted || isFailed))
-    const [showToolCallJson, setShowToolCallJson] = useState(false)
-    const [showResultJson, setShowResultJson] = useState(false)
-
-    useLayoutEffect(() => {
-        setIsSubstepsExpanded(showSubstepsChevron && !(isCompleted || isFailed))
-    }, [showSubstepsChevron, isCompleted, isFailed])
-
-    let markdownContent = <MarkdownMessage id={id} content={content} />
-    const result = toolCall?.result
-    const uiPayload = result?.ui_payload
-    const executedSQLQuery =
-        typeof uiPayload?.execute_sql === 'string'
-            ? uiPayload.execute_sql
-            : toolCall?.name === 'execute_sql' && typeof toolCall.args.query === 'string'
-              ? toolCall.args.query
-              : null
-
-    return (
-        <div className="flex flex-col rounded transition-all duration-500 flex-1 min-w-0 gap-1 text-xs">
-            <div
-                className={clsx(
-                    'transition-all duration-500 flex select-none min-w-0',
-                    (isPending || isFailed) && 'text-muted',
-                    !isInProgress && !isPending && !isFailed && 'text-default',
-                    !showSubstepsChevron ? 'cursor-default' : 'cursor-pointer'
-                )}
-                onClick={showSubstepsChevron ? () => setIsSubstepsExpanded(!isSubstepsExpanded) : undefined}
-                aria-label={
-                    showSubstepsChevron
-                        ? isSubstepsExpanded
-                            ? 'Collapse history'
-                            : 'Expand history'
-                        : isResultExpanded
-                          ? 'Collapse result'
-                          : 'Expand result'
-                }
-            >
-                {icon && (
-                    <div className="flex items-center justify-center size-5">
-                        {isInProgress && animate ? (
-                            <ShimmeringContent>{icon}</ShimmeringContent>
-                        ) : (
-                            <span className={clsx('inline-flex', isInProgress && 'text-muted')}>{icon}</span>
-                        )}
-                    </div>
-                )}
-                <div className="flex items-center gap-1 flex-1 min-w-0 h-full">
-                    <div className="min-w-0">
-                        {isInProgress && animate ? (
-                            <ShimmeringContent>{markdownContent}</ShimmeringContent>
-                        ) : (
-                            <span className={clsx('inline-flex', isInProgress && 'text-muted')}>{markdownContent}</span>
-                        )}
-                    </div>
-                    {showSubstepsChevron && (
-                        <div className="relative flex-shrink-0 flex items-start justify-center h-full pt-px">
-                            <button className="inline-flex items-center hover:opacity-70 transition-opacity flex-shrink-0 cursor-pointer">
-                                <span
-                                    className={clsx(
-                                        'transform transition-transform',
-                                        isSubstepsExpanded && 'rotate-90'
-                                    )}
-                                >
-                                    <IconChevronRight />
-                                </span>
-                            </button>
-                        </div>
-                    )}
-                    {isCompleted && showCompletionIcon && <IconCheck className="text-success size-3" />}
-                    {isFailed && showCompletionIcon && <IconX className="text-danger size-3" />}
-                </div>
-            </div>
-            {isSubstepsExpanded && substeps && substeps.length > 0 && (
-                <div
-                    className={clsx(
-                        'space-y-1 border-l-2 border-border-secondary',
-                        icon && 'pl-3.5 ml-[calc(0.775rem)]'
-                    )}
-                >
-                    {substeps.map((substep, substepIndex) => {
-                        const isCurrentSubstep = substepIndex === substeps.length - 1
-                        const isCompletedSubstep = substepIndex < substeps.length - 1 || isCompleted
-
-                        return (
-                            <div key={substepIndex} className="animate-fade-in">
-                                <MarkdownMessage
-                                    id={id}
-                                    className={clsx(
-                                        'leading-relaxed',
-                                        isFailed && 'text-danger',
-                                        !isFailed && isCompletedSubstep && 'text-muted',
-                                        !isFailed && isCurrentSubstep && !isCompleted && 'text-secondary'
-                                    )}
-                                    content={handleThreeDots(substep ?? '', true)}
-                                />
-                            </div>
-                        )
-                    })}
-                </div>
-            )}
-            {widget}
-            {/* Render summarize_sessions UI payload outside accordion so "Open report" is always visible */}
-            {!!uiPayload?.summarize_sessions && result && (
-                <SummarizeSessionsWidget
-                    payload={uiPayload.summarize_sessions}
-                    title={toolCall?.args.summary_title as string | undefined}
-                />
-            )}
-            {toolCall && isSubstepsExpanded && (
-                <>
-                    {!!uiPayload &&
-                        isRenderableUIPayloadTool(toolCall.name, uiPayload) &&
-                        Object.entries(uiPayload)
-                            .filter(([toolName]) => toolName !== 'summarize_sessions')
-                            .map(([toolName, toolPayload]) => (
-                                <div
-                                    key={`${result?.tool_call_id}-${toolName}`}
-                                    className="ml-3 border-l-2 border-border-secondary pl-3.5"
-                                >
-                                    <UIPayloadAnswer
-                                        toolCallId={result!.tool_call_id}
-                                        toolName={toolName}
-                                        toolPayload={toolPayload}
-                                    />
-                                </div>
-                            ))}
-                    {executedSQLQuery && (
-                        <div className="ml-3 border-l-2 border-border-secondary pl-3.5 flex flex-col gap-1">
-                            <b className="text-secondary">SQL query</b>
-                            <CodeSnippet language={Language.SQL} className="text-xs" compact>
-                                {executedSQLQuery}
-                            </CodeSnippet>
-                        </div>
-                    )}
-                    <div className="ml-3 border-l-2 border-border-secondary pl-3.5 flex flex-col gap-1">
-                        <LemonButton
-                            size="xxsmall"
-                            type="tertiary"
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                setShowToolCallJson(!showToolCallJson)
-                            }}
-                            tooltip="Tool call arguments as JSON"
-                            tooltipPlacement="top-start"
-                            className="w-fit"
-                        >
-                            <span className="flex items-center gap-1">
-                                <b>Tool called:</b>
-                                <span className="text-secondary">{toolCall.name}</span>
-                                <span
-                                    className={clsx('transform transition-transform', showToolCallJson && 'rotate-90')}
-                                >
-                                    <IconChevronRight />
-                                </span>
-                            </span>
-                        </LemonButton>
-                        {showToolCallJson && (
-                            <CodeSnippet language={Language.JSON} className="text-xs">
-                                {JSON.stringify(toolCall.args, null, 2)}
-                            </CodeSnippet>
-                        )}
-                        {result && result.content && (
-                            <React.Fragment>
-                                <LemonButton
-                                    size="xxsmall"
-                                    type="tertiary"
-                                    onClick={(e) => {
-                                        e.stopPropagation()
-                                        setShowResultJson(!showResultJson)
-                                    }}
-                                    tooltip="Show tool call results"
-                                    tooltipPlacement="top-start"
-                                    className="w-fit"
-                                >
-                                    <span className="flex items-center gap-1">
-                                        <b>Tool result:</b>
-                                        <span className="text-secondary">{result.content.slice(0, 20)}...</span>
-                                        <span
-                                            className={clsx(
-                                                'transform transition-transform',
-                                                showResultJson && 'rotate-90'
-                                            )}
-                                        >
-                                            <IconChevronRight />
-                                        </span>
-                                    </span>
-                                </LemonButton>
-                                {showResultJson && (
-                                    <div className="border rounded p-2 bg-surface-primary">
-                                        <MarkdownMessage
-                                            id={`${toolCall.id}-result`}
-                                            content={result.content}
-                                            className="text-xs [&_code]:text-xs"
-                                        />
-                                    </div>
-                                )}
-                            </React.Fragment>
-                        )}
-                    </div>
-                </>
-            )}
-        </div>
-    )
-}
-
-interface ReasoningAnswerProps {
-    content: string
-    completed: boolean
-    id: string
-    showCompletionIcon?: boolean
-    animate?: boolean
-}
-
-function ReasoningAnswer({
-    content,
-    completed,
-    id,
-    showCompletionIcon = true,
-    animate = false,
-}: ReasoningAnswerProps): JSX.Element {
-    return (
-        <AssistantActionComponent
-            id={id}
-            content={completed ? 'Thought' : content}
-            substeps={completed ? [content] : []}
-            state={completed ? ExecutionStatus.Completed : ExecutionStatus.InProgress}
-            icon={<IconBrain />}
-            animate={!inStorybookTestRunner() && animate} // Avoiding flaky snapshots in Storybook
-            showCompletionIcon={showCompletionIcon}
-        />
-    )
-}
-
 interface ToolCallsAnswerProps {
     toolCalls: EnhancedToolCall[]
     registeredToolMap: Record<string, ToolRegistration>
@@ -1273,7 +1037,7 @@ function ToolCallsAnswer({ toolCalls, registeredToolMap }: ToolCallsAnswerProps)
                         const [description, widgetDef] = getToolCallDescriptionAndWidgetDef(toolCall, registeredToolMap)
                         const widget = renderToolCallWidget(widgetDef, toolCall.id)
                         return (
-                            <AssistantActionComponent
+                            <LangGraphActivity
                                 key={toolCall.id}
                                 id={toolCall.id}
                                 content={description}
@@ -1657,7 +1421,7 @@ function SuccessActions({
 function renderToolCallWidget(widgetDef: ToolCallWidgetDef | null, toolCallId: string): JSX.Element | null {
     switch (widgetDef?.widget) {
         case 'recordings':
-            return <RecordingsWidget toolCallId={toolCallId} filters={widgetDef.args} />
+            return <RecordingsWidget toolCallId={toolCallId} filters={widgetDef.args} embedded />
         case 'session_summarization':
             return <SessionSummarizationProgress updates={widgetDef.args.updates} />
         default:

--- a/frontend/src/scenes/max/components/Activity/ActivityPrimitives.test.tsx
+++ b/frontend/src/scenes/max/components/Activity/ActivityPrimitives.test.tsx
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import { Activity } from './ActivityPrimitives'
+
+function expectBefore(first: HTMLElement, second: HTMLElement): void {
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+}
+
+describe('Activity', () => {
+    it('renders details before the widget body', () => {
+        render(
+            <Activity
+                id="tool-call"
+                title={<span data-attr="header">Query trends</span>}
+                status="in_progress"
+                details={<div data-attr="details">Input</div>}
+            >
+                <div data-attr="widget">Visualization</div>
+            </Activity>
+        )
+
+        const header = screen.getByTestId('header')
+        const details = screen.getByTestId('details')
+        const widget = screen.getByTestId('widget')
+
+        expectBefore(header, details)
+        expectBefore(details, widget)
+    })
+})

--- a/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
+++ b/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
@@ -1,0 +1,318 @@
+import clsx from 'clsx'
+import React, { useLayoutEffect, useState } from 'react'
+
+import { IconCheck, IconChevronRight, IconX } from '@posthog/icons'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
+
+import { MarkdownMessage } from '../../MarkdownMessage'
+
+export type ActivityStatus = 'pending' | 'in_progress' | 'completed' | 'failed'
+
+export function ShimmeringContent({ children }: { children: React.ReactNode }): JSX.Element {
+    const isTextContent = typeof children === 'string'
+
+    if (isTextContent) {
+        return (
+            <span
+                className="bg-clip-text text-transparent"
+                style={{
+                    backgroundImage:
+                        'linear-gradient(in oklch 90deg, var(--text-3000), var(--muted-3000), var(--trace-3000), var(--muted-3000), var(--text-3000))',
+                    backgroundSize: '200% 100%',
+                    animation: 'shimmer 3s linear infinite',
+                }}
+            >
+                {children}
+            </span>
+        )
+    }
+
+    return (
+        <span
+            className="inline-flex min-w-0 max-w-full"
+            style={{
+                animation: 'shimmer-opacity 3s linear infinite',
+            }}
+        >
+            {children}
+        </span>
+    )
+}
+
+function activitySubstepText(content: string, isInProgress: boolean): string {
+    if (content.at(0) === '[' && content.at(-1) === ')') {
+        // Skip ... for web search `updates`, where each is a Markdown-formatted link to a search result.
+        return content
+    }
+    if (!content.endsWith('...') && !content.endsWith('\u2026') && !content.endsWith('.') && isInProgress) {
+        return content + '...'
+    } else if ((content.endsWith('...') || content.endsWith('\u2026')) && !isInProgress) {
+        return content.replace(/\u2026/g, '').replace(/[.]/g, '')
+    }
+    return content
+}
+
+export function ActivityStatusIcon({
+    status,
+    showCompletionIcon = true,
+    showProgressIcon = false,
+    failedIcon,
+}: {
+    status: ActivityStatus
+    showCompletionIcon?: boolean
+    showProgressIcon?: boolean
+    failedIcon?: React.ReactNode
+}): JSX.Element | null {
+    if ((status === 'pending' || status === 'in_progress') && showProgressIcon) {
+        return <Spinner className="size-3" />
+    }
+    if (status === 'completed' && showCompletionIcon) {
+        return <IconCheck className="text-success size-3" />
+    }
+    if (status === 'failed' && showCompletionIcon) {
+        return failedIcon ? <>{failedIcon}</> : <IconX className="text-danger size-3" />
+    }
+    return null
+}
+
+export function ActivityHeader({
+    title,
+    children,
+    status,
+    icon,
+    animate = true,
+    hasDetails,
+    isDetailsExpanded,
+    onToggleDetails,
+    showCompletionIcon = true,
+    showProgressIcon = false,
+    failedIcon,
+}: {
+    title: React.ReactNode
+    children?: React.ReactNode
+    status: ActivityStatus
+    icon?: React.ReactNode
+    animate?: boolean
+    hasDetails: boolean
+    isDetailsExpanded: boolean
+    onToggleDetails: () => void
+    showCompletionIcon?: boolean
+    showProgressIcon?: boolean
+    failedIcon?: React.ReactNode
+}): JSX.Element {
+    const isPending = status === 'pending'
+    const isInProgress = status === 'in_progress'
+    const isFailed = status === 'failed'
+
+    const titleNode =
+        isInProgress && animate ? (
+            <ShimmeringContent>{title}</ShimmeringContent>
+        ) : (
+            <span className={clsx('inline-flex', isInProgress && 'text-muted')}>{title}</span>
+        )
+    const statusIcon = (
+        <ActivityStatusIcon
+            status={status}
+            showCompletionIcon={showCompletionIcon}
+            showProgressIcon={showProgressIcon}
+            failedIcon={failedIcon}
+        />
+    )
+
+    return (
+        <div
+            className={clsx(
+                'transition-all duration-500 flex select-none min-w-0',
+                (isPending || isFailed) && 'text-muted',
+                !isInProgress && !isPending && !isFailed && 'text-default',
+                hasDetails ? 'cursor-pointer' : 'cursor-default',
+                hasDetails && 'rounded px-1 -mx-1 hover:bg-fill-button-tertiary-hover',
+                hasDetails && isDetailsExpanded && 'bg-fill-button-tertiary-active'
+            )}
+            onClick={hasDetails ? onToggleDetails : undefined}
+            aria-label={hasDetails ? (isDetailsExpanded ? 'Collapse history' : 'Expand history') : undefined}
+        >
+            {icon && (
+                <div className="flex items-center justify-center size-5">
+                    {isInProgress && animate ? (
+                        <ShimmeringContent>{icon}</ShimmeringContent>
+                    ) : (
+                        <span className={clsx('inline-flex', isInProgress && 'text-muted')}>{icon}</span>
+                    )}
+                </div>
+            )}
+            <div className="flex items-center gap-1 flex-1 min-w-0 h-full">
+                {children ? (
+                    // The title/subtitle column grows to fill the row, so the subtitle (second line) gets the
+                    // full available width before it truncates and the chevron stays pinned to the right.
+                    <div className="flex flex-col flex-1 min-w-0">
+                        {/* Status icon rides the first line with the title; the second line is the subtitle. */}
+                        <div className="flex items-center gap-1 min-w-0">
+                            <div className="min-w-0">{titleNode}</div>
+                            {statusIcon}
+                        </div>
+                        <div className="text-muted truncate min-w-0">{children}</div>
+                    </div>
+                ) : (
+                    <div className="min-w-0">{titleNode}</div>
+                )}
+                {hasDetails && (
+                    <div className="relative shrink-0 flex flex-col items-start justify-center h-full">
+                        <button className="inline-flex items-center hover:opacity-70 transition-opacity shrink-0 cursor-pointer">
+                            <span className={clsx('transform transition-transform', isDetailsExpanded && 'rotate-90')}>
+                                <IconChevronRight />
+                            </span>
+                        </button>
+                    </div>
+                )}
+                {!children && statusIcon}
+            </div>
+        </div>
+    )
+}
+
+export function ActivitySubsteps({
+    id,
+    substeps,
+    status,
+}: {
+    id: string
+    substeps: string[]
+    status: ActivityStatus
+}): JSX.Element {
+    const isCompleted = status === 'completed'
+    const isFailed = status === 'failed'
+
+    return (
+        <>
+            {substeps.map((substep, substepIndex) => {
+                const isCurrentSubstep = substepIndex === substeps.length - 1
+                const isCompletedSubstep = substepIndex < substeps.length - 1 || isCompleted
+
+                return (
+                    <div key={substepIndex} className="animate-fade-in">
+                        <MarkdownMessage
+                            id={id}
+                            className={clsx(
+                                'leading-relaxed',
+                                isFailed && 'text-danger',
+                                !isFailed && isCompletedSubstep && 'text-muted',
+                                !isFailed && isCurrentSubstep && !isCompleted && 'text-secondary'
+                            )}
+                            content={activitySubstepText(substep ?? '', status === 'in_progress')}
+                        />
+                    </div>
+                )
+            })}
+        </>
+    )
+}
+
+export function ActivityDetails({ children, hasIcon }: { children: React.ReactNode; hasIcon: boolean }): JSX.Element {
+    return (
+        <div className={clsx('space-y-1 border-l-2 border-border-secondary', hasIcon && 'pl-3.5 ml-[calc(0.775rem)]')}>
+            {children}
+        </div>
+    )
+}
+
+export function ActivityToggleSection({
+    title,
+    summary,
+    tooltip,
+    children,
+}: {
+    title: React.ReactNode
+    summary?: React.ReactNode
+    tooltip?: string
+    children: React.ReactNode
+}): JSX.Element {
+    const [isExpanded, setIsExpanded] = useState(false)
+
+    return (
+        <div className="flex flex-col gap-1">
+            <LemonButton
+                size="xxsmall"
+                type="tertiary"
+                onClick={(e) => {
+                    e.stopPropagation()
+                    setIsExpanded(!isExpanded)
+                }}
+                tooltip={tooltip}
+                tooltipPlacement="top-start"
+                className="w-fit"
+            >
+                <span className="flex items-center gap-1">
+                    <b>{title}</b>
+                    {summary && <span className="text-secondary">{summary}</span>}
+                    <span className={clsx('transform transition-transform', isExpanded && 'rotate-90')}>
+                        <IconChevronRight />
+                    </span>
+                </span>
+            </LemonButton>
+            {isExpanded && children}
+        </div>
+    )
+}
+
+export function Activity({
+    id,
+    title,
+    subtitle,
+    status,
+    icon,
+    animate = true,
+    showCompletionIcon = true,
+    showProgressIcon = false,
+    failedIcon,
+    substeps = [],
+    details = null,
+    children = null,
+}: {
+    id: string
+    title: React.ReactNode
+    subtitle?: React.ReactNode
+    status: ActivityStatus
+    icon?: React.ReactNode
+    animate?: boolean
+    showCompletionIcon?: boolean
+    showProgressIcon?: boolean
+    failedIcon?: React.ReactNode
+    substeps?: string[]
+    details?: React.ReactNode
+    children?: React.ReactNode
+}): JSX.Element {
+    const hasDetails = substeps.length > 0 || !!details
+    const shouldExpandDetails = hasDetails && status !== 'completed' && status !== 'failed'
+    const [isDetailsExpanded, setIsDetailsExpanded] = useState(shouldExpandDetails)
+
+    useLayoutEffect(() => {
+        setIsDetailsExpanded(shouldExpandDetails)
+    }, [shouldExpandDetails])
+
+    return (
+        <div className="flex flex-col rounded transition-all duration-500 w-full min-w-0 gap-1 text-xs">
+            <ActivityHeader
+                title={title}
+                status={status}
+                icon={icon}
+                animate={animate}
+                hasDetails={hasDetails}
+                isDetailsExpanded={isDetailsExpanded}
+                onToggleDetails={() => setIsDetailsExpanded(!isDetailsExpanded)}
+                showCompletionIcon={showCompletionIcon}
+                showProgressIcon={showProgressIcon}
+                failedIcon={failedIcon}
+            >
+                {subtitle}
+            </ActivityHeader>
+            {isDetailsExpanded && hasDetails && (
+                <ActivityDetails hasIcon={!!icon}>
+                    {substeps.length > 0 && <ActivitySubsteps id={id} substeps={substeps} status={status} />}
+                    {details}
+                </ActivityDetails>
+            )}
+            {children}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/components/Activity/LangGraphActivity.tsx
+++ b/frontend/src/scenes/max/components/Activity/LangGraphActivity.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
+
+import { TaskExecutionStatus as ExecutionStatus } from '~/queries/schema/schema-assistant-messages'
+
+import { MarkdownMessage } from '../../MarkdownMessage'
+import type { EnhancedToolCall } from '../../max-constants'
+import { SummarizeSessionsWidget, UIPayloadAnswer, isRenderableUIPayloadTool } from '../../messages/UIPayloadAnswer'
+import { Activity, ActivityToggleSection } from './ActivityPrimitives'
+
+export function LangGraphActivity({
+    id,
+    content,
+    substeps,
+    state,
+    icon,
+    animate = true,
+    showCompletionIcon = true,
+    widget = null,
+    toolCall = null,
+}: {
+    id: string
+    content: string
+    // actually a markdown message
+    substeps: string[]
+    state: ExecutionStatus
+    icon?: React.ReactNode
+    animate?: boolean
+    showCompletionIcon?: boolean
+    widget?: JSX.Element | null
+    toolCall?: EnhancedToolCall | null
+}): JSX.Element {
+    const result = toolCall?.result
+    const uiPayload = result?.ui_payload
+    const executedSQLQuery =
+        typeof uiPayload?.execute_sql === 'string'
+            ? uiPayload.execute_sql
+            : toolCall?.name === 'execute_sql' && typeof toolCall.args.query === 'string'
+              ? toolCall.args.query
+              : null
+
+    const uiPayloadBody =
+        toolCall && uiPayload && isRenderableUIPayloadTool(toolCall.name, uiPayload)
+            ? Object.entries(uiPayload)
+                  .filter(([toolName]) => toolName !== 'summarize_sessions')
+                  .map(([toolName, toolPayload]) => (
+                      <UIPayloadAnswer
+                          key={`${result?.tool_call_id}-${toolName}`}
+                          toolCallId={result!.tool_call_id}
+                          toolName={toolName}
+                          toolPayload={toolPayload}
+                          embedded
+                      />
+                  ))
+            : []
+
+    const activityChildren = (
+        <>
+            {widget}
+            {/* Render summarize_sessions UI payload outside details so "Open report" is always visible. */}
+            {!!uiPayload?.summarize_sessions && result && (
+                <SummarizeSessionsWidget
+                    payload={uiPayload.summarize_sessions}
+                    title={toolCall?.args.summary_title as string | undefined}
+                />
+            )}
+            {uiPayloadBody.length > 0 && <div className="flex flex-col gap-2 mt-1">{uiPayloadBody}</div>}
+        </>
+    )
+
+    const details =
+        toolCall || executedSQLQuery ? (
+            <div className="flex flex-col gap-1">
+                {executedSQLQuery && (
+                    <div className="flex flex-col gap-1">
+                        <b className="text-secondary">SQL query</b>
+                        <CodeSnippet language={Language.SQL} className="text-xs" compact>
+                            {executedSQLQuery}
+                        </CodeSnippet>
+                    </div>
+                )}
+                {toolCall && (
+                    <ActivityToggleSection
+                        title="Tool called:"
+                        summary={<span>{toolCall.name}</span>}
+                        tooltip="Tool call arguments as JSON"
+                    >
+                        <CodeSnippet language={Language.JSON} className="text-xs">
+                            {JSON.stringify(toolCall.args, null, 2)}
+                        </CodeSnippet>
+                    </ActivityToggleSection>
+                )}
+                {toolCall && result?.content && (
+                    <ActivityToggleSection
+                        title="Tool result:"
+                        summary={<span>{result.content.slice(0, 20)}...</span>}
+                        tooltip="Show tool call results"
+                    >
+                        <div className="border rounded p-2 bg-surface-primary">
+                            <MarkdownMessage
+                                id={`${toolCall.id}-result`}
+                                content={result.content}
+                                className="text-xs [&_code]:text-xs"
+                            />
+                        </div>
+                    </ActivityToggleSection>
+                )}
+            </div>
+        ) : null
+
+    return (
+        <Activity
+            id={id}
+            title={<MarkdownMessage id={id} content={content} />}
+            substeps={substeps}
+            status={state}
+            icon={icon}
+            animate={animate}
+            showCompletionIcon={showCompletionIcon}
+            details={details}
+        >
+            {activityChildren}
+        </Activity>
+    )
+}

--- a/frontend/src/scenes/max/components/Activity/SandboxActivity.tsx
+++ b/frontend/src/scenes/max/components/Activity/SandboxActivity.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from 'react'
+
+import { Activity } from './ActivityPrimitives'
+import type { ActivityStatus } from './ActivityPrimitives'
+
+/**
+ * Progress / status card for the sandbox runtime — a thin adapter over the shared `Activity` used by
+ * `SandboxProgressItem` and the status/substep thread items. (Tool calls render via the dedicated
+ * `SandboxToolActivity` bridge, not this.)
+ */
+export function SandboxActivity({
+    id,
+    content,
+    substeps,
+    state,
+    icon,
+    animate = true,
+    showCompletionIcon = true,
+}: {
+    id: string
+    content: ReactNode
+    substeps: string[]
+    state: ActivityStatus
+    icon?: ReactNode
+    animate?: boolean
+    showCompletionIcon?: boolean
+}): JSX.Element {
+    return (
+        <Activity
+            id={id}
+            title={content}
+            substeps={substeps}
+            status={state}
+            icon={icon}
+            animate={animate}
+            showCompletionIcon={showCompletionIcon}
+        />
+    )
+}

--- a/frontend/src/scenes/max/components/Activity/index.ts
+++ b/frontend/src/scenes/max/components/Activity/index.ts
@@ -1,0 +1,12 @@
+export {
+    Activity,
+    ActivityDetails,
+    ActivityHeader,
+    ActivityStatusIcon,
+    ActivitySubsteps,
+    ActivityToggleSection,
+    ShimmeringContent,
+} from './ActivityPrimitives'
+export type { ActivityStatus } from './ActivityPrimitives'
+export { LangGraphActivity } from './LangGraphActivity'
+export { SandboxActivity } from './SandboxActivity'

--- a/frontend/src/scenes/max/components/InputFormArea.tsx
+++ b/frontend/src/scenes/max/components/InputFormArea.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useRef, useState } from 'react'
 import useResizeObserver from 'use-resize-observer'
 
 import { IconCheck, IconWarning, IconX } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonTabs, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonTabs, LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import {
     DangerousOperationResponse,
@@ -15,6 +15,8 @@ import { MarkdownMessage } from '../MarkdownMessage'
 import { maxThreadLogic } from '../maxThreadLogic'
 import { Option, OptionSelector } from './OptionSelector'
 import { MultiFieldQuestion, QuestionField, isFieldValid } from './QuestionField'
+import { SandboxPermissionInput } from './SandboxPermissionInput'
+import { SandboxQuestionInput } from './SandboxQuestionInput'
 
 function isQuestionComplete(
     q: MultiQuestionFormQuestion,
@@ -402,10 +404,37 @@ function DangerousOperationInput({ operation }: DangerousOperationInputProps): J
     )
 }
 
+/**
+ * Compact badge showing the active ACP permission mode (e.g. plan vs default) for sandbox
+ * conversations. Hidden when no mode has been reported. Reads the mode via `maxThreadLogic`'s
+ * alias — this renders outside SandboxThread's BindLogic subtree, so it cannot bind the keyed
+ * stream logic itself.
+ */
+export function SandboxModeBadge(): JSX.Element | null {
+    const { conversation, sandboxCurrentMode } = useValues(maxThreadLogic)
+
+    if (conversation?.agent_runtime !== 'sandbox' || !sandboxCurrentMode) {
+        return null
+    }
+
+    const isPlan = sandboxCurrentMode === 'plan'
+    return (
+        <LemonTag size="small" type={isPlan ? 'highlight' : 'muted'}>
+            {isPlan ? 'Plan mode' : 'Default mode'}
+        </LemonTag>
+    )
+}
+
 export function InputFormArea(): JSX.Element | null {
     // Use raw state values instead of selector to ensure re-renders on state changes
-    const { activeMultiQuestionForm, pendingApprovalProposalId, pendingApprovalsData, resolvedApprovalStatuses } =
-        useValues(maxThreadLogic)
+    const {
+        activeMultiQuestionForm,
+        pendingApprovalProposalId,
+        pendingApprovalsData,
+        resolvedApprovalStatuses,
+        sandboxConversationKey,
+        pendingSandboxPermissionRequest,
+    } = useValues(maxThreadLogic)
 
     // Build the approval object to display - only show if not yet resolved
     // Resolved approvals are shown as summaries in the chat thread, not in the input area
@@ -429,6 +458,31 @@ export function InputFormArea(): JSX.Element | null {
             payload: approval.payload as Record<string, unknown>,
         }
     }, [pendingApprovalProposalId, pendingApprovalsData, resolvedApprovalStatuses])
+
+    // Sandbox permission requests take precedence in the input area, mirroring the LangGraph
+    // dangerous-operation flow but driven by sandboxStreamLogic. A pending request only ever
+    // originates from the sandbox stream, so its presence is sufficient — gating on `agent_runtime`
+    // would strand approvals on new conversations whose runtime isn't resolved yet.
+    if (pendingSandboxPermissionRequest) {
+        // An `AskUserQuestion` rides the same permission rails but is a question, not an approval —
+        // render the interactive question overlay instead of the approve/decline card.
+        if (pendingSandboxPermissionRequest.questions?.length) {
+            return (
+                <SandboxQuestionInput
+                    key={pendingSandboxPermissionRequest.requestId}
+                    streamKey={sandboxConversationKey}
+                    request={pendingSandboxPermissionRequest}
+                />
+            )
+        }
+        return (
+            <SandboxPermissionInput
+                key={pendingSandboxPermissionRequest.requestId}
+                streamKey={sandboxConversationKey}
+                request={pendingSandboxPermissionRequest}
+            />
+        )
+    }
 
     if (activeDangerousOperationApproval) {
         return (

--- a/frontend/src/scenes/max/components/ModeSelector.tsx
+++ b/frontend/src/scenes/max/components/ModeSelector.tsx
@@ -114,7 +114,6 @@ function buildGeneralTooltip(description: string, defaultTools: ToolDefinition[]
 interface GetModeOptionsParams {
     planModeEnabled: boolean
     researchEnabled: boolean
-    sandboxModeEnabled: boolean
     featureFlags: Record<string, boolean | string>
     hasExistingMessages: boolean
 }
@@ -122,7 +121,6 @@ interface GetModeOptionsParams {
 function getModeOptions({
     planModeEnabled,
     researchEnabled,
-    sandboxModeEnabled,
     featureFlags,
     hasExistingMessages,
 }: GetModeOptionsParams): LemonSelectSection<ModeValue>[] {
@@ -170,24 +168,6 @@ function getModeOptions({
         })
     }
 
-    if (sandboxModeEnabled && !hasExistingMessages) {
-        specialOptions.push({
-            value: 'sandbox' as ModeValue,
-            label: (
-                <span className="flex items-center gap-1">
-                    {SPECIAL_MODES.sandbox.name}
-                    {SPECIAL_MODES.sandbox.alpha && (
-                        <LemonTag size="small" type="danger">
-                            ALPHA
-                        </LemonTag>
-                    )}
-                </span>
-            ),
-            icon: SPECIAL_MODES.sandbox.icon,
-            tooltip: <div>{SPECIAL_MODES.sandbox.description}</div>,
-        })
-    }
-
     const modeEntries = Object.entries(MODE_DEFINITIONS).filter(([_, def]) => {
         if (def.flag && !featureFlags[FEATURE_FLAGS[def.flag]]) {
             return false
@@ -226,13 +206,11 @@ function getModeOptions({
 }
 
 export function ModeSelector(): JSX.Element | null {
-    const { agentMode, isSandboxMode, contextDisabledReason, conversation, threadMessageCount } =
-        useValues(maxThreadLogic)
-    const { setAgentMode, setIsSandboxMode } = useActions(maxThreadLogic)
+    const { agentMode, contextDisabledReason, conversation, threadMessageCount } = useValues(maxThreadLogic)
+    const { setAgentMode } = useActions(maxThreadLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const researchEnabled = useFeatureFlag('MAX_DEEP_RESEARCH')
     const planModeEnabled = useFeatureFlag('PHAI_PLAN_MODE')
-    const sandboxModeEnabled = useFeatureFlag('PHAI_SANDBOX_MODE')
 
     const hasExistingMessages = threadMessageCount > 0
     const modeOptions = useMemo(
@@ -240,35 +218,28 @@ export function ModeSelector(): JSX.Element | null {
             getModeOptions({
                 planModeEnabled,
                 researchEnabled,
-                sandboxModeEnabled,
                 featureFlags,
                 hasExistingMessages,
             }),
-        [planModeEnabled, researchEnabled, sandboxModeEnabled, featureFlags, hasExistingMessages]
+        [planModeEnabled, researchEnabled, featureFlags, hasExistingMessages]
     )
 
     const handleChange = useCallback(
         (value: ModeValue): void => {
             posthog.capture('phai mode switched', {
-                previous_mode: isSandboxMode ? 'sandbox' : agentMode,
+                previous_mode: agentMode,
                 new_mode: value,
             })
-            if (value === 'sandbox') {
-                setIsSandboxMode(true)
-                setAgentMode(null)
-            } else {
-                setIsSandboxMode(false)
-                setAgentMode(value as AgentMode | null)
-            }
+            setAgentMode(value as AgentMode | null)
         },
-        [agentMode, isSandboxMode, setAgentMode, setIsSandboxMode]
+        [agentMode, setAgentMode]
     )
 
     const isDeepResearch = conversation?.type === ConversationType.DeepResearch
 
     return (
         <LemonSelect
-            value={isDeepResearch ? 'research' : isSandboxMode ? 'sandbox' : agentMode}
+            value={isDeepResearch ? 'research' : agentMode}
             onChange={handleChange}
             options={modeOptions}
             size="xxsmall"

--- a/frontend/src/scenes/max/components/OptionSelector.tsx
+++ b/frontend/src/scenes/max/components/OptionSelector.tsx
@@ -176,7 +176,7 @@ export function OptionSelector({
                             autoFocus={true}
                         />
                     ) : (
-                        <span className="my-1.5">Explain what you'd like instead..</span>
+                        <span className="my-1.5">Explain what you'd like instead.</span>
                     )}
                 </label>
             )}

--- a/frontend/src/scenes/max/components/QuestionInput.test.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.test.tsx
@@ -21,7 +21,7 @@ jest.mock(
     { virtual: true }
 )
 
-describe('QuestionInput slash command autocomplete', () => {
+describe('QuestionInput', () => {
     let maxLogicInstance: ReturnType<typeof maxLogic.build>
     let threadLogicInstance: ReturnType<typeof maxThreadLogic.build>
 
@@ -61,6 +61,38 @@ describe('QuestionInput slash command autocomplete', () => {
 
     const slashCommandItem = (): HTMLElement | null => screen.queryByText('/init')
 
+    const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+    it('does not release a sandbox pre-warm when blur moves to the send button', async () => {
+        // Simulate a completed warm; a release would clear the flag (and relay-cancel the warm Run).
+        threadLogicInstance.cache.prewarmed = true
+        threadLogicInstance.cache.prewarming = false
+
+        const input = screen.getByRole('textbox') as HTMLTextAreaElement
+        const sendButton = document.querySelector('[data-attr="max-send-message"]') as HTMLElement
+        expect(sendButton).not.toBeNull()
+
+        // Clicking send blurs the textarea before the click fires the send — the warm must survive.
+        fireEvent.blur(input, { relatedTarget: sendButton })
+        await flush()
+
+        // Blur-to-send does not trigger releaseSandboxPrewarm, so the warm is untouched.
+        expect(threadLogicInstance.cache.prewarmed).toBe(true)
+    })
+
+    it('releases a sandbox pre-warm when blur leaves the input for somewhere else', async () => {
+        threadLogicInstance.cache.prewarmed = true
+        threadLogicInstance.cache.prewarming = false
+
+        const input = screen.getByRole('textbox') as HTMLTextAreaElement
+
+        fireEvent.blur(input, { relatedTarget: null })
+        await flush()
+
+        // Blur-away triggers releaseSandboxPrewarm, which clears the flag (and relay-cancels any warm Run).
+        expect(threadLogicInstance.cache.prewarmed).toBe(false)
+    })
+
     it('reopens the popover after Escape dismisses it and a fresh slash is typed', async () => {
         const input = screen.getByRole('textbox') as HTMLTextAreaElement
 
@@ -75,5 +107,40 @@ describe('QuestionInput slash command autocomplete', () => {
 
         fireEvent.change(input, { target: { value: '/' } })
         await waitFor(() => expect(slashCommandItem()).toBeInTheDocument())
+    })
+
+    describe('stop button cancel state', () => {
+        const sendButton = (): HTMLElement | null => document.querySelector('[data-attr="max-send-message"]')
+        const stopButton = (): HTMLElement | null => document.querySelector('[data-attr="max-stop-generation"]')
+
+        it('shows the stop affordance while streaming and not cancelling', async () => {
+            threadLogicInstance.actions.reconnectToStream()
+            await waitFor(() => expect(stopButton()).not.toBeNull())
+            expect(sendButton()).toBeNull()
+        })
+
+        it('shows send (not stop) while cancelLoading is true', async () => {
+            threadLogicInstance.actions.reconnectToStream()
+            threadLogicInstance.actions.setCancelLoading(true)
+
+            await waitFor(() => expect(sendButton()).not.toBeNull())
+            expect(stopButton()).toBeNull()
+            // The composer button reads "Cancelling…" via disabledReason, never "Let's bail".
+            expect(screen.queryByText("Let's bail")).not.toBeInTheDocument()
+        })
+
+        it('returns to send (not stop) after cancel resolves and loading clears', async () => {
+            threadLogicInstance.actions.reconnectToStream()
+            threadLogicInstance.actions.setCancelLoading(true)
+            await waitFor(() => expect(sendButton()).not.toBeNull())
+
+            // Cancel resolves: streaming ends and cancelLoading clears -> threadLoading false.
+            threadLogicInstance.actions.endStreaming()
+            threadLogicInstance.actions.setCancelLoading(false)
+
+            await waitFor(() => expect(sendButton()).not.toBeNull())
+            expect(stopButton()).toBeNull()
+            expect(screen.queryByText("Let's bail")).not.toBeInTheDocument()
+        })
     })
 })

--- a/frontend/src/scenes/max/components/QuestionInput.test.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.test.tsx
@@ -116,7 +116,7 @@ describe('QuestionInput', () => {
         it('shows the stop affordance while streaming and not cancelling', async () => {
             threadLogicInstance.actions.reconnectToStream()
             await waitFor(() => expect(stopButton()).not.toBeNull())
-            expect(sendButton()).toBeNull()
+            expect(sendButton()).toHaveAttribute('aria-disabled', 'true')
         })
 
         it('shows send (not stop) while cancelLoading is true', async () => {

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -166,8 +166,14 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
         queuedMessages,
         queueSubmitting,
     } = useValues(maxThreadLogic)
-    const { askMax, stopGeneration, completeThreadGeneration, setSupportOverrideEnabled, updateQueuedMessage } =
-        useActions(maxThreadLogic)
+    const {
+        askMax,
+        stopGeneration,
+        completeThreadGeneration,
+        setSupportOverrideEnabled,
+        updateQueuedMessage,
+        releaseSandboxPrewarm,
+    } = useActions(maxThreadLogic)
     const { isActive: handsFreeActive } = useValues(handsFreeLogic({ panelId: maxPanelId }))
     // Only the hands-free row needs bottom-aligned pills — it has the mic + submit pair
     // pinned to the bottom and pills sitting in normal flow look misaligned next to them.
@@ -226,7 +232,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
 
     const hasQuestion = inputValue.trim().length > 0
     const isQueueingSubmission = queueingEnabled && threadLoading && hasQuestion
-    const showStopButton = threadLoading && !isQueueingSubmission
+    const showStopButton = threadLoading && !isQueueingSubmission && !cancelLoading
 
     // Mirrors maxThreadLogic's `submissionDisabledReason` selector, but using the local input
     // value so the submit guard stays correct while the debounced sync to kea is still pending.
@@ -373,7 +379,23 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                         ref={textAreaRef}
                                         value={isSharedThread ? '' : inputValue}
                                         onChange={handleQuestionChange}
-                                        onBlur={() => debouncedSetQuestion.flush()}
+                                        onBlur={(e) => {
+                                            debouncedSetQuestion.flush()
+                                            // Release any sandbox pre-warm when the user leaves the
+                                            // input without sending. No-op on LangGraph / unwarmed
+                                            // conversations.
+                                            //
+                                            // But clicking the send button blurs the textarea *before*
+                                            // its onClick fires the send — releasing here would cancel
+                                            // the very warm Run the send is about to consume. When focus
+                                            // moves to the send button, skip the release and let the send
+                                            // path consume the warm (it does so without a DELETE).
+                                            const next = e.relatedTarget as HTMLElement | null
+                                            if (next?.closest('[data-attr="max-send-message"]')) {
+                                                return
+                                            }
+                                            releaseSandboxPrewarm()
+                                        }}
                                         onPressEnter={() => {
                                             if (
                                                 hasQuestion &&

--- a/frontend/src/scenes/max/components/SandboxApproval.test.tsx
+++ b/frontend/src/scenes/max/components/SandboxApproval.test.tsx
@@ -1,0 +1,248 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useActions, useValues } from 'kea'
+
+import type { PermissionRequestRecord, ToolInvocation } from '../types/sandboxStreamTypes'
+import { SandboxModeBadge } from './InputFormArea'
+import { SandboxPermissionInput } from './SandboxPermissionInput'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useActions: jest.fn(),
+    useValues: jest.fn(),
+}))
+
+jest.mock('use-resize-observer', () => () => ({
+    height: 160,
+    ref: { current: null },
+}))
+
+jest.mock('../maxThreadLogic', () => ({
+    maxThreadLogic: { __mock: 'maxThreadLogic' },
+}))
+
+jest.mock('../sandboxStreamLogic', () => ({
+    // Keyed logic — the component binds it with `sandboxStreamLogic({ streamKey })`.
+    sandboxStreamLogic: jest.fn(() => ({ __mock: 'sandboxStreamLogicInstance' })),
+}))
+
+jest.mock('../MarkdownMessage', () => ({
+    MarkdownMessage: ({ content }: { content: string }) => <div data-attr="markdown">{content}</div>,
+}))
+
+jest.mock('lib/components/CodeSnippet', () => ({
+    CodeSnippet: ({ children }: { children: string }) => <pre data-attr="code-snippet">{children}</pre>,
+    Language: { JSON: 'json', Text: 'text' },
+}))
+
+const rawToolCall: ToolInvocation = {
+    toolCallId: 'tc-1',
+    rawServerName: 'posthog',
+    rawToolName: 'exec',
+    input: { command: 'call insight-create {"name":"Signups"}' },
+    status: 'pending',
+    contentBlocks: [],
+}
+
+function makeRequest(overrides: Partial<PermissionRequestRecord> = {}): PermissionRequestRecord {
+    return {
+        requestId: 'req-1',
+        toolCallId: 'tc-1',
+        toolName: 'mcp__posthog__exec',
+        title: 'Create insight',
+        description: 'The agent wants to create an insight.',
+        options: [
+            { optionId: 'opt-allow', name: 'Approve', kind: 'allow_once' },
+            { optionId: 'opt-reject', name: 'Decline', kind: 'reject' },
+        ],
+        rawToolCall,
+        ...overrides,
+    }
+}
+
+describe('Sandbox approval input area', () => {
+    const respondToPermission = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(useActions as jest.Mock).mockReturnValue({ respondToPermission })
+        ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: false, currentMode: null })
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    describe('SandboxPermissionInput', () => {
+        it('renders the approval prompt with the same two permission options', () => {
+            render(<SandboxPermissionInput streamKey="conv-1" request={makeRequest()} />)
+
+            expect(screen.getByText('Approval required')).toBeInTheDocument()
+            expect(screen.getByText('posthog - insight-create (MCP)')).toBeInTheDocument()
+            expect(screen.getByText('Approve')).toBeInTheDocument()
+            expect(screen.getByText('Decline')).toBeInTheDocument()
+            expect(screen.queryByText("Explain what you'd like instead.")).not.toBeInTheDocument()
+        })
+
+        it('renders the unwrapped PostHog exec payload like PostHog Code', () => {
+            render(
+                <SandboxPermissionInput
+                    streamKey="conv-1"
+                    request={makeRequest({
+                        rawToolCall: {
+                            ...rawToolCall,
+                            input: { command: 'call execute-sql {"query":"select 1"}' },
+                        },
+                    })}
+                />
+            )
+
+            expect(screen.getByText('posthog - execute-sql (MCP)')).toBeInTheDocument()
+            expect(
+                screen.getByText((_content, element) => element?.getAttribute('data-attr') === 'code-snippet')
+                    .textContent
+            ).toEqual('{\n  "query": "select 1"\n}')
+        })
+
+        it('posts the chosen optionId on click', () => {
+            render(<SandboxPermissionInput streamKey="conv-1" request={makeRequest()} />)
+
+            fireEvent.click(screen.getByText('Approve'))
+
+            expect(respondToPermission).toHaveBeenCalledWith({
+                requestId: 'req-1',
+                optionId: 'opt-allow',
+            })
+        })
+
+        it('guards against double-submit while the reply POST is in flight', () => {
+            // The logic's respondingToPermission flag drives the loading state — it flips
+            // synchronously on dispatch and resets on success and on failure alike.
+            ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: true })
+            render(<SandboxPermissionInput streamKey="conv-1" request={makeRequest()} />)
+
+            // Loading message replaces the option list, so nothing can be clicked.
+            expect(screen.getByText('Sending response…')).toBeInTheDocument()
+            expect(screen.queryByText('Approve')).not.toBeInTheDocument()
+            expect(screen.queryByText('Decline')).not.toBeInTheDocument()
+            expect(respondToPermission).not.toHaveBeenCalled()
+        })
+
+        it('sends feedback text through the reject_with_feedback option when it is the decline path', () => {
+            render(
+                <SandboxPermissionInput
+                    streamKey="conv-1"
+                    request={makeRequest({
+                        options: [
+                            { optionId: 'opt-allow', name: 'Approve', kind: 'allow_once' },
+                            { optionId: 'opt-feedback', name: 'Decline with feedback', kind: 'reject_with_feedback' },
+                        ],
+                    })}
+                />
+            )
+
+            fireEvent.click(screen.getByText("Explain what you'd like instead."))
+            const input = screen.getByPlaceholderText('Type your answer...')
+            fireEvent.change(input, { target: { value: 'Use a funnel instead' } })
+            fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+            expect(respondToPermission).toHaveBeenCalledWith({
+                requestId: 'req-1',
+                optionId: 'opt-feedback',
+                customInput: 'Use a funnel instead',
+            })
+        })
+
+        it('renders reject_once as a one-click decline with no feedback toggle', () => {
+            const request = makeRequest({
+                options: [
+                    { optionId: 'opt-allow', name: 'Yes', kind: 'allow_once' },
+                    { optionId: 'opt-reject', name: 'No', kind: 'reject_once', customInput: true },
+                ],
+            })
+            render(<SandboxPermissionInput streamKey="conv-1" request={request} />)
+
+            // No optional-feedback affordance — the decline is a plain one-click button.
+            expect(screen.queryByText('Add feedback…')).not.toBeInTheDocument()
+            fireEvent.click(screen.getByText('No'))
+            expect(respondToPermission).toHaveBeenCalledWith({
+                requestId: 'req-1',
+                optionId: 'opt-reject',
+            })
+        })
+
+        it.each([
+            [
+                'the agent is in plan mode',
+                (): void => {
+                    ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: false, currentMode: 'plan' })
+                },
+                makeRequest(),
+            ],
+            [
+                'the tool call is tagged as a plan',
+                (): void => {},
+                makeRequest({ rawToolCall: { ...rawToolCall, kind: 'plan' } }),
+            ],
+        ])('shows plan copy when %s', (_case, arrange, request) => {
+            arrange()
+            render(<SandboxPermissionInput streamKey="conv-1" request={request} />)
+
+            expect(screen.getByText('Approve this plan?')).toBeInTheDocument()
+        })
+
+        it('does not show plan copy just because the title mentions a plan', () => {
+            render(
+                <SandboxPermissionInput
+                    streamKey="conv-1"
+                    request={makeRequest({ title: 'Create a data retention plan' })}
+                />
+            )
+
+            expect(screen.getByText('Approval required')).toBeInTheDocument()
+        })
+
+        it('falls back to showing every option when filtering would leave none', () => {
+            render(
+                <SandboxPermissionInput
+                    streamKey="conv-1"
+                    request={makeRequest({
+                        options: [{ optionId: 'opt-always', name: '', kind: 'allow_always' }],
+                    })}
+                />
+            )
+
+            expect(screen.getByText('Approve always')).toBeInTheDocument()
+        })
+    })
+
+    describe('SandboxModeBadge', () => {
+        it.each([
+            ['sandbox', 'plan', 'Plan mode'],
+            ['sandbox', 'default', 'Default mode'],
+        ])('renders the %s runtime in %s mode as a badge', (runtime, mode, label) => {
+            ;(useValues as jest.Mock).mockReturnValue({
+                conversation: { agent_runtime: runtime },
+                sandboxCurrentMode: mode,
+            })
+
+            render(<SandboxModeBadge />)
+
+            expect(screen.getByText(label)).toBeInTheDocument()
+        })
+
+        it.each([
+            ['no mode has been reported', 'sandbox', null],
+            ['the conversation is not sandbox-runtime', 'langgraph', 'plan'],
+        ])('renders nothing when %s', (_case, runtime, mode) => {
+            ;(useValues as jest.Mock).mockReturnValue({
+                conversation: { agent_runtime: runtime },
+                sandboxCurrentMode: mode,
+            })
+
+            const { container } = render(<SandboxModeBadge />)
+            expect(container).toBeEmptyDOMElement()
+        })
+    })
+})

--- a/frontend/src/scenes/max/components/SandboxContextUsage.tsx
+++ b/frontend/src/scenes/max/components/SandboxContextUsage.tsx
@@ -1,0 +1,68 @@
+import { useValues } from 'kea'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { humanFriendlyNumber } from 'lib/utils/numbers'
+
+import { sandboxStreamLogic } from '../sandboxStreamLogic'
+
+/** Compact SVG ring showing the context-window fill percentage. */
+function UsageRing({ percentage }: { percentage: number }): JSX.Element {
+    const radius = 7
+    const circumference = 2 * Math.PI * radius
+    const clamped = Math.max(0, Math.min(1, percentage / 100))
+    return (
+        <svg viewBox="0 0 18 18" className="size-4 shrink-0 -rotate-90">
+            <circle cx="9" cy="9" r={radius} fill="none" strokeWidth="2.5" className="stroke-border" />
+            <circle
+                cx="9"
+                cy="9"
+                r={radius}
+                fill="none"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeDasharray={circumference}
+                strokeDashoffset={circumference * (1 - clamped)}
+                className="stroke-accent"
+            />
+        </svg>
+    )
+}
+
+/**
+ * Context-usage indicator for sandbox conversations. Reads the latest-wins `contextUsage` snapshot
+ * and renders a fill ring + `used / size · %` label when the numeric aggregate is present, plus the
+ * run cost when known. Hidden when there is nothing to show. The breakdown popover is deferred.
+ */
+export function SandboxContextUsage(): JSX.Element | null {
+    const { contextUsage } = useValues(sandboxStreamLogic)
+
+    if (!contextUsage) {
+        return null
+    }
+
+    const { used, size, cost } = contextUsage
+    const hasRing = typeof used === 'number' && typeof size === 'number' && size > 0
+    const percentage = hasRing ? Math.round((used! / size!) * 100) : null
+    const hasCost = typeof cost === 'number'
+
+    if (!hasRing && !hasCost) {
+        return null
+    }
+
+    return (
+        <div className="flex items-center gap-2 px-3 py-1 text-xs text-muted" data-attr="max-sandbox-context-usage">
+            {hasRing && (
+                <Tooltip title="Context window usage">
+                    <span className="flex items-center gap-1.5">
+                        <UsageRing percentage={percentage!} />
+                        <span>
+                            {humanFriendlyNumber(used!)} / {humanFriendlyNumber(size!)} · {percentage}%
+                        </span>
+                    </span>
+                </Tooltip>
+            )}
+            {hasCost && <span>${cost!.toFixed(2)}</span>}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/components/SandboxModeToggle.tsx
+++ b/frontend/src/scenes/max/components/SandboxModeToggle.tsx
@@ -1,0 +1,66 @@
+import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useCallback } from 'react'
+
+import { LemonButton, LemonTag } from '@posthog/lemon-ui'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+
+import { SPECIAL_MODES } from '../max-constants'
+import { maxThreadLogic } from '../maxThreadLogic'
+
+/**
+ * Standalone control for opting a conversation into the sandbox runtime. Rendered only when the
+ * `PHAI_SANDBOX_MODE` flag is on. The runtime is stamped onto the conversation's `agent_runtime`
+ * at create-time and never changes afterwards — so for a fresh conversation this acts as a toggle,
+ * and once a conversation has started it stays locked as a read-only indicator of the runtime.
+ */
+export function SandboxModeToggle(): JSX.Element | null {
+    const { isSandboxMode, conversation, threadMessageCount, contextDisabledReason } = useValues(maxThreadLogic)
+    const { setIsSandboxMode } = useActions(maxThreadLogic)
+    const sandboxModeEnabled = useFeatureFlag('PHAI_SANDBOX_MODE')
+
+    const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
+    const isActive = isSandboxRuntime || isSandboxMode
+    const hasExistingMessages = threadMessageCount > 0
+
+    const handleToggle = useCallback((): void => {
+        const next = !isActive
+        posthog.capture('phai sandbox toggled', { enabled: next })
+        // The selected agent mode is kept — sandbox carries it through as a context note.
+        setIsSandboxMode(next)
+    }, [isActive, setIsSandboxMode])
+
+    // Hide entirely for non-sandbox conversations that have already started — there's nothing to
+    // toggle, and we only want to surface this as a locked indicator for actual sandbox runtimes.
+    if (!sandboxModeEnabled || (hasExistingMessages && !isSandboxRuntime)) {
+        return null
+    }
+
+    // Runtime is fixed once the conversation exists; until then `contextDisabledReason` still gates it.
+    const disabledReason = hasExistingMessages
+        ? 'Start a new conversation to change the runtime'
+        : contextDisabledReason
+
+    return (
+        <LemonButton
+            size="xxsmall"
+            type="tertiary"
+            icon={SPECIAL_MODES.sandbox.icon}
+            active={isActive}
+            onClick={handleToggle}
+            disabledReason={disabledReason}
+            tooltip={SPECIAL_MODES.sandbox.description}
+            className="flex-shrink-0 border [&>span]:text-secondary"
+        >
+            <span className="flex items-center gap-1">
+                {SPECIAL_MODES.sandbox.name}
+                {SPECIAL_MODES.sandbox.alpha && (
+                    <LemonTag size="small" type="danger">
+                        ALPHA
+                    </LemonTag>
+                )}
+            </span>
+        </LemonButton>
+    )
+}

--- a/frontend/src/scenes/max/components/SandboxPermissionInput.tsx
+++ b/frontend/src/scenes/max/components/SandboxPermissionInput.tsx
@@ -1,0 +1,140 @@
+import { useActions, useValues } from 'kea'
+
+import { IconWarning } from '@posthog/icons'
+import { LemonTag, Spinner } from '@posthog/lemon-ui'
+
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+
+import type { MultiQuestionFormQuestion } from '~/queries/schema/schema-assistant-messages'
+
+import { MarkdownMessage } from '../MarkdownMessage'
+import { getSandboxPermissionDisplay } from '../sandboxPermissionDisplayUtils'
+import { mapPermissionOptions, type ApprovalCardOption } from '../sandboxPermissionUtils'
+import { sandboxStreamLogic } from '../sandboxStreamLogic'
+import type { PermissionRequestRecord } from '../types/sandboxStreamTypes'
+import { QuestionField } from './QuestionField'
+
+interface SandboxPermissionInputProps {
+    streamKey: string
+    request: PermissionRequestRecord
+}
+
+const ignoreMultiSelectChange = (_value: string[]): void => undefined
+const ignoreMultiSelectSubmit = (): void => undefined
+
+function toPermissionQuestion(
+    prompt: string,
+    options: ApprovalCardOption[],
+    allowCustomAnswer: boolean
+): MultiQuestionFormQuestion {
+    return {
+        id: 'permission',
+        title: 'Approval',
+        question: prompt,
+        type: 'select',
+        options: options.map((option) => ({ value: option.label })),
+        allow_custom_answer: allowCustomAnswer,
+    }
+}
+
+/**
+ * Self-contained input-area renderer for an ACP `permission_request` on a sandbox conversation.
+ * Reuses the same `QuestionField` surface as sandbox questions while preserving the ACP option ids
+ * sent back to the runtime. `allow_always` stays hidden unless filtering would leave no choices.
+ *
+ * Submitting POSTs through `sandboxStreamLogic.respondToPermission`; the logic's
+ * `respondingToPermission` drives the loading/double-submit guard and re-enables the controls when the
+ * POST fails (the pending request only clears on success).
+ */
+export function SandboxPermissionInput({ streamKey, request }: SandboxPermissionInputProps): JSX.Element {
+    const boundLogic = sandboxStreamLogic({ streamKey })
+    const { respondToPermission } = useActions(boundLogic)
+    const { respondingToPermission, currentMode } = useValues(boundLogic)
+
+    // A request whose every option was filtered out (e.g. only `allow_always` without a rememberable
+    // preview) must still be answerable — fall back to showing everything.
+    const defaultOptions = mapPermissionOptions(request.options)
+    const mappedOptions = defaultOptions.length > 0 ? defaultOptions : mapPermissionOptions(request.options, true)
+    // Only the legacy `reject_with_feedback` kind is feedback-only — reachable solely through the
+    // text field. A `reject_once` decline is a plain one-click button with no optional-feedback toggle.
+    const feedbackOption = mappedOptions.find((o) => o.requiresFeedback)
+    // Every option except the legacy feedback-only one renders as a one-click button.
+    const buttonOptions = mappedOptions.filter((o) => !o.requiresFeedback)
+    const hasOneClickDecline = buttonOptions.some((option) => option.decision === 'declined')
+    const allowFeedback = !!feedbackOption && !hasOneClickDecline
+
+    // Plan approvals are raised while the agent is in plan mode — the mode is the grounded signal;
+    // `toolCall.kind === 'plan'` covers adapters that tag the request directly.
+    const isPlan = currentMode === 'plan' || request.rawToolCall.kind === 'plan'
+    const prompt = isPlan ? 'Approve this plan?' : 'Approval required'
+    const display = getSandboxPermissionDisplay(request)
+    const payloadLanguage = display.payload?.trim().match(/^[{[]/) ? Language.JSON : Language.Text
+
+    const respond = (optionId: string): void => {
+        if (respondingToPermission) {
+            return
+        }
+        respondToPermission({ requestId: request.requestId, optionId })
+    }
+
+    const handleAnswer = (value: string | string[] | null): void => {
+        if (respondingToPermission || value === null || Array.isArray(value)) {
+            return
+        }
+        const selectedOption = buttonOptions.find((option) => option.label === value)
+        if (selectedOption) {
+            respond(selectedOption.optionId)
+            return
+        }
+        if (allowFeedback && feedbackOption) {
+            respondToPermission({
+                requestId: request.requestId,
+                optionId: feedbackOption.optionId,
+                customInput: value,
+            })
+        }
+    }
+
+    return (
+        <div className="flex flex-col gap-2 p-3">
+            <div className="flex items-center gap-2 text-sm">
+                <IconWarning className="text-warning size-4" />
+                <LemonTag size="small" type="warning">
+                    {isPlan ? 'Plan approval' : 'Approval'}
+                </LemonTag>
+            </div>
+            <div className="font-medium text-sm">{prompt}</div>
+            {display.title && <div className="text-xs text-secondary">{display.title}</div>}
+            {(request.title || request.description) && (
+                <div className="max-h-60 overflow-y-auto text-sm">
+                    <MarkdownMessage
+                        content={request.description ?? request.title ?? ''}
+                        id={`permission-${request.requestId}`}
+                    />
+                </div>
+            )}
+            {display.payload && (
+                <div className="max-h-60 overflow-y-auto">
+                    <CodeSnippet language={payloadLanguage} className="text-xs" compact>
+                        {display.payload}
+                    </CodeSnippet>
+                </div>
+            )}
+            {respondingToPermission ? (
+                <div className="flex items-center gap-2 text-muted pt-1">
+                    <Spinner className="size-4" />
+                    <span>Sending response…</span>
+                </div>
+            ) : (
+                <QuestionField
+                    question={toPermissionQuestion(prompt, buttonOptions, allowFeedback)}
+                    value={undefined}
+                    onAnswer={handleAnswer}
+                    onChange={ignoreMultiSelectChange}
+                    onSubmit={ignoreMultiSelectSubmit}
+                    submitLabel="Send"
+                />
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/components/SandboxQuestionInput.test.tsx
+++ b/frontend/src/scenes/max/components/SandboxQuestionInput.test.tsx
@@ -1,0 +1,175 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useActions, useValues } from 'kea'
+
+import type { SandboxQuestion } from '../sandboxQuestionUtils'
+import type { PermissionRequestRecord, ToolInvocation } from '../types/sandboxStreamTypes'
+import { SandboxQuestionInput } from './SandboxQuestionInput'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useActions: jest.fn(),
+    useValues: jest.fn(),
+}))
+
+jest.mock('../sandboxStreamLogic', () => ({
+    sandboxStreamLogic: jest.fn(() => ({ __mock: 'sandboxStreamLogicInstance' })),
+}))
+
+const rawToolCall: ToolInvocation = {
+    toolCallId: 'tc-1',
+    rawServerName: 'claude',
+    rawToolName: '',
+    input: {},
+    status: 'pending',
+    contentBlocks: [],
+    meta: { claudeCode: { toolName: 'AskUserQuestion' } },
+}
+
+function makeRequest(questions: SandboxQuestion[]): PermissionRequestRecord {
+    return {
+        requestId: 'req-1',
+        toolCallId: 'tc-1',
+        toolName: 'AskUserQuestion',
+        options: questions[0].options.map((o, idx) => ({
+            optionId: `option_${idx}`,
+            name: o.label,
+            kind: 'allow_once',
+        })),
+        rawToolCall,
+        questions,
+    }
+}
+
+const goalQuestion: SandboxQuestion = {
+    question: 'Which goal matters most?',
+    header: 'Goal',
+    multiSelect: false,
+    options: [{ label: 'Activation', description: 'aha moment' }, { label: 'Revenue' }],
+}
+
+describe('SandboxQuestionInput', () => {
+    const respondToPermission = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(useActions as jest.Mock).mockReturnValue({ respondToPermission })
+        ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: false })
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('renders the header chip, question text, and options via QuestionField', () => {
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion])} />)
+
+        expect(screen.getByText('Goal')).toBeInTheDocument()
+        expect(screen.getByText('Which goal matters most?')).toBeInTheDocument()
+        expect(screen.getByText('Activation')).toBeInTheDocument()
+        expect(screen.getByText('Revenue')).toBeInTheDocument()
+        expect(screen.getByText('aha moment')).toBeInTheDocument()
+    })
+
+    it('submits a single-select answer on pick with the derived optionId', () => {
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion])} />)
+
+        // Single-select advances/submits on pick (QuestionField behaviour) — the last question submits.
+        fireEvent.click(screen.getByText('Revenue'))
+
+        expect(respondToPermission).toHaveBeenCalledWith({
+            requestId: 'req-1',
+            optionId: 'option_1',
+            answers: { 'Which goal matters most?': 'Revenue' },
+            customInput: undefined,
+        })
+    })
+
+    it('joins multiple selections for a multi-select question', () => {
+        const productsQuestion: SandboxQuestion = {
+            question: 'Which products?',
+            header: 'Products',
+            multiSelect: true,
+            options: [{ label: 'Insights' }, { label: 'Replay' }, { label: 'Flags' }],
+        }
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([productsQuestion])} />)
+
+        fireEvent.click(screen.getByText('Insights'))
+        fireEvent.click(screen.getByText('Flags'))
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        expect(respondToPermission).toHaveBeenCalledWith({
+            requestId: 'req-1',
+            optionId: 'option_0',
+            answers: { 'Which products?': 'Insights, Flags' },
+            customInput: undefined,
+        })
+    })
+
+    it('sends a free-typed answer through the custom path with option_0 fallback', () => {
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion])} />)
+
+        // Open the custom "Type your answer" field, type, and submit.
+        fireEvent.click(screen.getByText("Explain what you'd like instead."))
+        fireEvent.change(screen.getByPlaceholderText('Type your answer...'), { target: { value: 'Cut churn' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        expect(respondToPermission).toHaveBeenCalledWith({
+            requestId: 'req-1',
+            optionId: 'option_0',
+            answers: { 'Which goal matters most?': 'Cut churn' },
+            customInput: 'Cut churn',
+        })
+    })
+
+    it('does not submit a multi-select question with nothing selected', () => {
+        const productsQuestion: SandboxQuestion = {
+            question: 'Which products?',
+            header: 'Products',
+            multiSelect: true,
+            options: [{ label: 'Insights' }, { label: 'Replay' }],
+        }
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([productsQuestion])} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        expect(screen.getByText('Select at least one option')).toBeInTheDocument()
+        expect(respondToPermission).not.toHaveBeenCalled()
+    })
+
+    it('steps through multiple questions and submits all answers at once', () => {
+        const second: SandboxQuestion = {
+            question: 'Which timeframe?',
+            header: 'Timeframe',
+            multiSelect: false,
+            options: [{ label: 'Weekly' }, { label: 'Monthly' }],
+        }
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion, second])} />)
+
+        expect(screen.getByText('1/2')).toBeInTheDocument()
+        // Single-select pick auto-advances to the next question.
+        fireEvent.click(screen.getByText('Activation'))
+        expect(screen.getByText('2/2')).toBeInTheDocument()
+        expect(respondToPermission).not.toHaveBeenCalled()
+
+        // Picking the last question's answer submits all collected answers.
+        fireEvent.click(screen.getByText('Monthly'))
+
+        expect(respondToPermission).toHaveBeenCalledWith({
+            requestId: 'req-1',
+            optionId: 'option_0',
+            answers: { 'Which goal matters most?': 'Activation', 'Which timeframe?': 'Monthly' },
+            customInput: undefined,
+        })
+    })
+
+    it('shows a sending state and blocks interaction while a reply is in flight', () => {
+        ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: true })
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion])} />)
+
+        expect(screen.getByText('Sending response…')).toBeInTheDocument()
+        expect(screen.queryByText('Revenue')).not.toBeInTheDocument()
+        expect(respondToPermission).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/scenes/max/components/SandboxQuestionInput.tsx
+++ b/frontend/src/scenes/max/components/SandboxQuestionInput.tsx
@@ -1,0 +1,176 @@
+import { useActions, useValues } from 'kea'
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+import { IconChat } from '@posthog/icons'
+import { LemonTag, Spinner } from '@posthog/lemon-ui'
+
+import type { MultiQuestionFormQuestion } from '~/queries/schema/schema-assistant-messages'
+
+import { deriveQuestionOptionId, type SandboxQuestion } from '../sandboxQuestionUtils'
+import { sandboxStreamLogic } from '../sandboxStreamLogic'
+import type { PermissionRequestRecord } from '../types/sandboxStreamTypes'
+import { QuestionField } from './QuestionField'
+
+interface SandboxQuestionInputProps {
+    streamKey: string
+    request: PermissionRequestRecord
+}
+
+/** Adapt a sandbox question onto the `MultiQuestionFormQuestion` shape `QuestionField` renders. */
+function toFormQuestion(question: SandboxQuestion, index: number): MultiQuestionFormQuestion {
+    return {
+        id: String(index),
+        title: question.header ?? 'Question',
+        question: question.question,
+        type: question.multiSelect ? 'multi_select' : 'select',
+        options: question.options.map((option) => ({ value: option.label, description: option.description })),
+        allow_custom_answer: true,
+    }
+}
+
+function selectedLabels(answer: string | string[] | undefined): string[] {
+    if (Array.isArray(answer)) {
+        return answer
+    }
+    return answer ? [answer] : []
+}
+
+/**
+ * Interactive input-area overlay for an `AskUserQuestion` on a sandbox conversation. The agent (Twig)
+ * routes questions through the ACP permission framework, so this rides the same `pendingPermissionRequest`
+ * rails as `SandboxPermissionInput` but renders the question(s) instead of an approve/decline card.
+ *
+ * It reuses the LangGraph `QuestionField` (and therefore `OptionSelector` / `LemonCheckbox`) for the
+ * options, and mirrors `MultiQuestionFormInput`'s flow: single-select answers advance on pick,
+ * multi-select accumulates behind a Next/Submit button, and the footer label flips to "Submit" on the
+ * last question. On submit it replies via `respondToPermission` with the answers keyed by question
+ * text — the agent reads `_meta.answers`; `optionId` only has to be a valid offered option (derived
+ * from the first question's selection). `respondingToPermission` drives the loading / double-submit guard.
+ */
+export function SandboxQuestionInput({ streamKey, request }: SandboxQuestionInputProps): JSX.Element | null {
+    const boundLogic = sandboxStreamLogic({ streamKey })
+    const { respondToPermission } = useActions(boundLogic)
+    const { respondingToPermission } = useValues(boundLogic)
+
+    // Stable reference so the memoized callbacks below don't re-evaluate every render.
+    const questions = useMemo(() => request.questions ?? [], [request.questions])
+
+    const [currentIndex, setCurrentIndex] = useState(0)
+    const [answers, setAnswers] = useState<Record<number, string | string[]>>({})
+    const answersRef = useRef(answers)
+    answersRef.current = answers
+
+    const submit = useCallback(
+        (finalAnswers: Record<number, string | string[]>) => {
+            const answerMap: Record<string, string> = {}
+            for (let index = 0; index < questions.length; index++) {
+                const labels = selectedLabels(finalAnswers[index])
+                if (labels.length) {
+                    answerMap[questions[index].question] = labels.join(', ')
+                }
+            }
+            // Options only exist on the wire for the first question, so optionId / customInput derive
+            // from it; the answers map carries the rest for the agent.
+            const firstQuestion = questions[0]
+            const firstLabels = selectedLabels(finalAnswers[0])
+            const firstOptionLabels = new Set(firstQuestion.options.map((option) => option.label))
+            respondToPermission({
+                requestId: request.requestId,
+                optionId: deriveQuestionOptionId(firstQuestion, firstLabels),
+                answers: answerMap,
+                customInput: firstLabels.find((label) => !firstOptionLabels.has(label)),
+            })
+        },
+        [questions, request.requestId, respondToPermission]
+    )
+
+    const advanceOrSubmit = useCallback(
+        (updatedAnswers: Record<number, string | string[]>) => {
+            if (currentIndex < questions.length - 1) {
+                setCurrentIndex(currentIndex + 1)
+            } else {
+                submit(updatedAnswers)
+            }
+        },
+        [currentIndex, questions.length, submit]
+    )
+
+    const handleAnswer = useCallback(
+        (value: string | string[] | null) => {
+            if (respondingToPermission) {
+                return
+            }
+            if (value === null) {
+                const cleared = { ...answersRef.current }
+                delete cleared[currentIndex]
+                setAnswers(cleared)
+                answersRef.current = cleared
+                return
+            }
+            const updated = { ...answersRef.current, [currentIndex]: value }
+            setAnswers(updated)
+            answersRef.current = updated
+            advanceOrSubmit(updated)
+        },
+        [advanceOrSubmit, currentIndex, respondingToPermission]
+    )
+
+    const handleMultiSelectChange = useCallback(
+        (value: string[]) => {
+            const updated = { ...answersRef.current, [currentIndex]: value }
+            setAnswers(updated)
+            answersRef.current = updated
+        },
+        [currentIndex]
+    )
+
+    const handleMultiSelectSubmit = useCallback(() => {
+        if (respondingToPermission) {
+            return
+        }
+        advanceOrSubmit(answersRef.current)
+    }, [advanceOrSubmit, respondingToPermission])
+
+    // The dispatcher only mounts this when `questions` is non-empty; keep the guard for type safety.
+    const question = questions[currentIndex]
+    if (!question) {
+        return null
+    }
+
+    if (respondingToPermission) {
+        return (
+            <div className="flex items-center gap-2 text-muted p-3">
+                <Spinner className="size-4" />
+                <span>Sending response…</span>
+            </div>
+        )
+    }
+
+    const isLast = currentIndex === questions.length - 1
+
+    return (
+        <div className="flex flex-col gap-2 p-3">
+            <div className="flex items-center gap-2 text-sm">
+                <IconChat className="text-muted size-4" />
+                <LemonTag size="small" type="muted">
+                    {question.header ?? 'Question'}
+                </LemonTag>
+                {questions.length > 1 && (
+                    <span className="text-muted text-xs">
+                        {currentIndex + 1}/{questions.length}
+                    </span>
+                )}
+            </div>
+            <div className="font-medium text-sm">{question.question}</div>
+            <QuestionField
+                key={currentIndex}
+                question={toFormQuestion(question, currentIndex)}
+                value={answers[currentIndex]}
+                onAnswer={handleAnswer}
+                onChange={handleMultiSelectChange}
+                onSubmit={handleMultiSelectSubmit}
+                submitLabel={isLast ? 'Submit' : 'Next'}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/components/SandboxResourcesBar.tsx
+++ b/frontend/src/scenes/max/components/SandboxResourcesBar.tsx
@@ -1,0 +1,37 @@
+import { useValues } from 'kea'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { resolveProductMeta } from '../messages/posthogProducts'
+import { sandboxStreamLogic } from '../sandboxStreamLogic'
+
+/**
+ * Persistent "PostHog resources used" bar for sandbox conversations. Reads the session-cumulative
+ * `resourcesUsed` list (unioned by id across the whole conversation) and renders one chip per
+ * product the agent grounded an answer in. Hidden when empty. Each chip is a product icon plus a
+ * Sentence-cased label; unknown ids degrade to the wire label and a generic icon.
+ */
+export function SandboxResourcesBar(): JSX.Element | null {
+    const { resourcesUsed } = useValues(sandboxStreamLogic)
+
+    if (resourcesUsed.length === 0) {
+        return null
+    }
+
+    return (
+        <div className="flex flex-wrap items-center gap-1.5 px-3 py-1.5" data-attr="max-sandbox-resources-bar">
+            <span className="text-xs text-muted mr-0.5">PostHog resources used:</span>
+            {resourcesUsed.map((product) => {
+                const { label, Icon } = resolveProductMeta(product.id, product.label)
+                return (
+                    <Tooltip key={product.id} title={label}>
+                        <span className="inline-flex items-center gap-1 rounded border bg-surface-primary px-1.5 py-0.5 text-xs">
+                            <Icon className="size-3.5 shrink-0" />
+                            <span>{label}</span>
+                        </span>
+                    </Tooltip>
+                )
+            })}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
+++ b/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
@@ -12,7 +12,7 @@ import { cn } from 'lib/utils/css-classes'
 
 import { SuggestionGroup, maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
-import { InputFormArea } from './InputFormArea'
+import { InputFormArea, SandboxModeBadge } from './InputFormArea'
 import { QuestionInput } from './QuestionInput'
 
 export function SidebarQuestionInput({
@@ -31,7 +31,11 @@ export function SidebarQuestionInput({
         pendingApprovalProposalId,
         pendingApprovalsData,
         resolvedApprovalStatuses,
+        pendingSandboxPermissionRequest,
     } = useValues(maxThreadLogic)
+    // A pending sandbox request only originates from the sandbox stream, so its presence alone is
+    // enough — gating on `agent_runtime` would strand approvals on as-yet-unresolved conversations.
+    const hasSandboxPermissionToShow = !!pendingSandboxPermissionRequest
 
     // Check if there's a pending (not yet resolved) approval to show
     const hasApprovalToShow = useMemo(() => {
@@ -61,7 +65,7 @@ export function SidebarQuestionInput({
     }, [focusCounter]) // Update focus when focusCounter changes
 
     // Show form area directly when there's a pending form/approval (even if showInput is false)
-    if (activeMultiQuestionForm || hasApprovalToShow) {
+    if (activeMultiQuestionForm || hasApprovalToShow || hasSandboxPermissionToShow) {
         return (
             <div className="w-full max-w-180 self-center px-3 mx-auto bg-[var(--scene-layout-background)]/50 backdrop-blur-sm">
                 <div className="border border-primary rounded-lg bg-surface-primary">
@@ -78,6 +82,7 @@ export function SidebarQuestionInput({
             containerClassName={cn('mx-auto self-center backdrop-blur-sm z-50', sidePanel && 'px-0')}
             isThreadVisible={threadVisible}
         >
+            <SandboxModeBadge />
             <SuggestionsList />
         </QuestionInput>
     )

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -1460,6 +1460,11 @@ export const SPECIAL_MODES: Record<string, ModeDefinition> = {
     },
 }
 
+/** Human-readable label for an agent or special mode value (e.g. `'product_analytics'` → `'Product analytics'`). */
+export function getModeDisplayName(mode: string): string {
+    return MODE_DEFINITIONS[mode as keyof typeof MODE_DEFINITIONS]?.name ?? SPECIAL_MODES[mode]?.name ?? mode
+}
+
 /** Get tools available for a specific agent mode */
 export function getToolsForMode(mode: AgentMode): ToolDefinition[] {
     return Object.values(TOOL_DEFINITIONS).filter((tool) => tool.modes?.includes(mode))

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -104,6 +104,7 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
     })),
     actions({
         openSidePanelMax: (conversationId?: string) => ({ conversationId }),
+        openSidePanelMaxWithTaskBind: (taskId: string) => ({ taskId }),
         askSidePanelMax: (prompt: string) => ({ prompt }),
         acceptDataProcessing: (testOnlyOverride?: boolean) => ({ testOnlyOverride }),
         registerTool: (tool: ToolRegistration) => ({ tool }),
@@ -242,6 +243,22 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
                 }
                 logic.actions.openConversation(conversationId)
             }
+        },
+        // Open the side panel on a fresh chat bound to a sandbox Task (inbox "Open task" — in-place,
+        // not a new tab). The side panel doesn't sync the URL, so the binding is seeded directly here
+        // rather than via the `bind_task` param the scene route reads. `setPendingBindTaskId` runs
+        // after `startNewConversation`, which clears it.
+        openSidePanelMaxWithTaskBind: ({ taskId }) => {
+            if (!values.sidePanelOpen || values.selectedTab !== SidePanelTab.Max) {
+                actions.openSidePanel(SidePanelTab.Max)
+            }
+            let logic = maxLogic.findMounted({ panelId: SIDE_PANEL_PANEL_ID })
+            if (!logic) {
+                logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
+                logic.mount() // we're never unmounting this
+            }
+            logic.actions.startNewConversation()
+            logic.actions.setPendingBindTaskId(taskId)
         },
         loadConversationHistoryFailure: ({ errorObject }) => {
             lemonToast.error(errorObject?.data?.detail || 'Failed to load conversation history.')

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -50,6 +50,14 @@ interface StoredMaxContext {
     timestamp: number
 }
 
+/**
+ * `/ai` query param carrying a sandbox Task to bind a fresh chat to (set by inbox "Open task").
+ * A URL param (rather than sessionStorage) so the binding survives opening the chat in a new tab or
+ * window. The side panel — which doesn't sync the URL — receives the same binding via a direct
+ * `setPendingBindTaskId` (see `maxGlobalLogic.openSidePanelMaxWithTaskBind`).
+ */
+export const SANDBOX_BIND_TASK_PARAM = 'bind_task'
+
 export type MessageStatus = 'loading' | 'completed' | 'error'
 
 export type ThreadMessage = RootAssistantMessage & {
@@ -220,6 +228,7 @@ export const maxLogic = kea<maxLogicType>([
         incrActiveStreamingThreads: true,
         decrActiveStreamingThreads: true,
         setAutoRun: (autoRun: boolean) => ({ autoRun }),
+        setPendingBindTaskId: (taskId: string | null) => ({ taskId }),
     }),
 
     reducers(({ props }) => ({
@@ -245,6 +254,17 @@ export const maxLogic = kea<maxLogicType>([
                 setConversationId: (_, { conversationId }) => conversationId,
                 startNewConversation: () => null,
                 toggleConversationHistory: (state, { visible }) => (visible ? null : state),
+            },
+        ],
+
+        // A pending Task to bind a new sandbox conversation to (set by inbox "Open task"). Consumed by
+        // maxThreadLogic on the first message, which sends it as `task_id` so the open resumes that
+        // Task's run. Cleared once consumed, or when an explicit new chat starts without a bind.
+        pendingBindTaskId: [
+            null as string | null,
+            {
+                setPendingBindTaskId: (_, { taskId }) => taskId,
+                startNewConversation: () => null,
             },
         ],
 
@@ -691,6 +711,15 @@ export const maxLogic = kea<maxLogicType>([
                 actions.openConversation(search.chat)
             } else if (values.conversationHistoryVisible) {
                 actions.toggleConversationHistory()
+            }
+
+            // A fresh chat (no `chat` param) may carry a task to bind via the URL (inbox "Open task").
+            // Read it after the `startNewConversation` above (which clears it) so it survives, and the
+            // first message resumes that task's run. The param naturally drops once `setConversationId`
+            // rewrites the URL to `?chat=<id>` after the first message.
+            const bindTaskId = search[SANDBOX_BIND_TASK_PARAM]
+            if (!search.chat && bindTaskId) {
+                actions.setPendingBindTaskId(String(bindTaskId))
             }
         },
     })),

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -3,6 +3,7 @@ import { MOCK_DEFAULT_BASIC_USER } from 'lib/api.mock'
 import { router } from 'kea-router'
 import { partial } from 'kea-test-utils'
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 import React from 'react'
 
 import api, { ApiError } from 'lib/api'
@@ -33,7 +34,9 @@ import { EnhancedToolCall, TOOL_DEFINITIONS } from './max-constants'
 import { maxContextLogic } from './maxContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { maxLogic } from './maxLogic'
-import { maxThreadLogic } from './maxThreadLogic'
+import { MAX_DASHBOARD_CONTEXT_WAIT_MS, maxThreadLogic } from './maxThreadLogic'
+import { MaxContextType } from './maxTypes'
+import { sandboxStreamLogic } from './sandboxStreamLogic'
 import {
     MOCK_CONVERSATION,
     MOCK_CONVERSATION_ID,
@@ -460,24 +463,123 @@ describe('maxThreadLogic', () => {
             )
         })
 
-        it('sends the first message immediately even while the dashboard scene is still loading', async () => {
-            // Regression guard for the removed #63208 gate: on a Dashboard scene whose
-            // dashboardLogic.dashboard is still null, askMax must send synchronously (no poll/wait).
-            // If the gate were reinstated, stream would not be called until fake timers advanced.
-            const fakeDashboardLogic: any = { selectors: { maxContext: () => [] }, values: { dashboard: null } }
+        // Simulate being on a dashboard scene whose data has not loaded yet: dashboardLogic.dashboard
+        // is null, so its maxContext returns []. The first message must wait for the load, otherwise
+        // it ships with no dashboard context and Max can't see the open dashboard.
+        const mockLoadingDashboardScene = (): { values: { dashboard: any } } => {
+            const fakeDashboardLogic: any = {
+                selectors: {
+                    maxContext: () =>
+                        fakeDashboardLogic.values.dashboard
+                            ? [{ type: MaxContextType.DASHBOARD, data: fakeDashboardLogic.values.dashboard }]
+                            : [],
+                },
+                values: { dashboard: null as any },
+            }
             jest.spyOn(sceneLogic.selectors, 'activeSceneId').mockReturnValue(Scene.Dashboard)
             jest.spyOn(sceneLogic.selectors, 'activeSceneLogic').mockReturnValue(fakeDashboardLogic)
-            const streamSpy = mockStream()
+            jest.spyOn(sceneLogic.selectors, 'activeLoadedScene').mockReturnValue({
+                paramsToProps: () => ({ id: 1 }),
+                sceneParams: {},
+            } as any)
+            return fakeDashboardLogic
+        }
 
-            maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
-            logic.mount()
+        it('waits for the open dashboard to load before sending the first message (regression for #61414)', async () => {
+            jest.useFakeTimers()
+            const captureSpy = jest.spyOn(posthog, 'capture')
+            try {
+                const streamSpy = mockStream()
+                const fakeDashboardLogic = mockLoadingDashboardScene()
 
-            await expectLogic(logic, () => {
+                maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
+                logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
+                logic.mount()
+
+                // Fire the first message while the dashboard is still loading.
                 logic.actions.askMax('what am I seeing on this dashboard?')
-            }).toDispatchActions(['askMax'])
 
-            expect(streamSpy).toHaveBeenCalledTimes(1)
+                // The gate holds the send while the dashboard is loading.
+                await jest.advanceTimersByTimeAsync(300)
+                expect(streamSpy).toHaveBeenCalledTimes(0)
+
+                // Dashboard finishes loading -> gate releases -> the message sends WITH the dashboard context.
+                fakeDashboardLogic.values.dashboard = { id: 1, name: 'Test Dashboard', tiles: [] }
+                await jest.advanceTimersByTimeAsync(500)
+
+                expect(streamSpy).toHaveBeenCalledTimes(1)
+                expect(streamSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        ui_context: expect.objectContaining({
+                            dashboards: expect.arrayContaining([expect.objectContaining({ id: 1 })]),
+                        }),
+                    }),
+                    expect.any(Object)
+                )
+                // A normal load must NOT report a timeout.
+                expect(captureSpy).not.toHaveBeenCalledWith('max dashboard context wait timed out', expect.anything())
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        it('reports a telemetry event and still sends if the dashboard never loads within the cap', async () => {
+            jest.useFakeTimers()
+            const captureSpy = jest.spyOn(posthog, 'capture')
+            try {
+                const streamSpy = mockStream()
+                mockLoadingDashboardScene() // dashboard stays null past the wait cap
+
+                maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
+                logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
+                logic.mount()
+
+                logic.actions.askMax('what am I seeing on this dashboard?')
+
+                // Advance past the 8s wait cap without the dashboard ever loading.
+                await jest.advanceTimersByTimeAsync(8100)
+
+                // The cap must never block the user - the message still sends...
+                expect(streamSpy).toHaveBeenCalledTimes(1)
+                // ...but we record that the wait timed out, so the cap's impact is observable in prod.
+                expect(captureSpy).toHaveBeenCalledWith(
+                    'max dashboard context wait timed out',
+                    expect.objectContaining({ dashboard_id: 1, waited_ms: expect.any(Number) })
+                )
+                // waited_ms is real elapsed time, so it must be at least the cap (never under-reported).
+                const timeoutCall = captureSpy.mock.calls.find((c) => c[0] === 'max dashboard context wait timed out')
+                expect(timeoutCall?.[1]?.waited_ms).toBeGreaterThanOrEqual(MAX_DASHBOARD_CONTEXT_WAIT_MS)
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        it('releases the gate and sends if the user navigates away while the dashboard is still loading', async () => {
+            jest.useFakeTimers()
+            try {
+                const streamSpy = mockStream()
+                mockLoadingDashboardScene()
+
+                maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
+                logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
+                logic.mount()
+
+                logic.actions.askMax('what am I seeing on this dashboard?')
+
+                // Still on the (never-loading) dashboard -> the gate holds.
+                await jest.advanceTimersByTimeAsync(300)
+                expect(streamSpy).toHaveBeenCalledTimes(0)
+
+                // User leaves the dashboard before it ever loads. The gate re-reads the scene each tick,
+                // so it must stop waiting and send rather than block until the timeout.
+                jest.spyOn(sceneLogic.selectors, 'activeSceneId').mockReturnValue(Scene.SavedInsights)
+                jest.spyOn(sceneLogic.selectors, 'activeSceneLogic').mockReturnValue(null as any)
+                await jest.advanceTimersByTimeAsync(300)
+
+                expect(streamSpy).toHaveBeenCalledTimes(1)
+            } finally {
+                jest.useRealTimers()
+            }
         })
 
         it('sends form_answers in ui_context when provided', async () => {
@@ -1507,6 +1609,179 @@ describe('maxThreadLogic', () => {
                     status: 'completed',
                 },
             ])
+        })
+    })
+
+    describe('sandbox history-load branch', () => {
+        const SANDBOX_TASK_ID = 'task-abc'
+        const SANDBOX_RUN_ID = 'run-abc'
+
+        function sandboxConversation(currentRunId: string | null): ConversationDetail {
+            return {
+                id: MOCK_CONVERSATION_ID,
+                status: ConversationStatus.InProgress,
+                title: 'Sandbox chat',
+                user: MOCK_DEFAULT_BASIC_USER,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                type: ConversationType.Assistant,
+                agent_runtime: 'sandbox',
+                task: { id: SANDBOX_TASK_ID, latest_run: currentRunId },
+                messages: [],
+            }
+        }
+
+        it('replays logs/ then opens SSE for a non-terminal sandbox run, never reconnecting LangGraph', async () => {
+            logic.unmount()
+            jest.spyOn(api.conversations, 'get').mockResolvedValue(sandboxConversation(SANDBOX_RUN_ID))
+            const logsSpy = jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([])
+            const runSpy = jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+            const streamSpy = mockStream()
+
+            logic = maxThreadLogic({
+                conversationId: MOCK_CONVERSATION_ID,
+                panelId: 'test',
+                conversation: sandboxConversation(SANDBOX_RUN_ID),
+            })
+            logic.mount()
+            // Drain the async afterMount (loadConversation → bootstrapRun → logs/ replay → run refetch).
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            await new Promise((resolve) => setTimeout(resolve, 0))
+
+            // bootstrapRun replayed logs/ and refetched the run, then opened SSE — and the LangGraph
+            // stream was never touched (coexistence).
+            expect(logsSpy).toHaveBeenCalledWith(SANDBOX_TASK_ID, SANDBOX_RUN_ID)
+            expect(runSpy).toHaveBeenCalledWith(SANDBOX_TASK_ID, SANDBOX_RUN_ID)
+            expect(streamSpy).not.toHaveBeenCalled()
+        })
+
+        it('does not bootstrap a sandbox run without a latest_run', async () => {
+            logic.unmount()
+            jest.spyOn(api.conversations, 'get').mockResolvedValue(sandboxConversation(null))
+            const logsSpy = jest.spyOn(api.tasks.runs, 'getLogEntries')
+            const streamSpy = mockStream()
+
+            logic = maxThreadLogic({
+                conversationId: MOCK_CONVERSATION_ID,
+                panelId: 'test',
+                conversation: sandboxConversation(null),
+            })
+            logic.mount()
+            await new Promise((resolve) => setTimeout(resolve, 0))
+
+            expect(logsSpy).not.toHaveBeenCalled()
+            expect(streamSpy).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('sandbox prewarm', () => {
+        const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+        function idleSandboxConversation(): ConversationDetail {
+            return {
+                id: MOCK_CONVERSATION_ID,
+                status: ConversationStatus.Idle,
+                title: 'Sandbox chat',
+                user: MOCK_DEFAULT_BASIC_USER,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                type: ConversationType.Assistant,
+                agent_runtime: 'sandbox',
+                task: { id: 'task-1', latest_run: null },
+                messages: [],
+            }
+        }
+
+        async function mountIdleSandbox(): Promise<void> {
+            logic.unmount()
+            jest.spyOn(api.conversations, 'get').mockResolvedValue(idleSandboxConversation())
+            logic = maxThreadLogic({
+                conversationId: MOCK_CONVERSATION_ID,
+                panelId: 'test',
+                conversation: idleSandboxConversation(),
+            })
+            logic.mount()
+            await flush()
+        }
+
+        const warmHandle = {
+            task_id: 'task-1',
+            run_id: 'run-1',
+            trace_id: null,
+            run_status: 'in_progress' as const,
+            just_created_run: true,
+        }
+
+        it('releases a warm sandbox abandoned while the warm POST was still in flight', async () => {
+            await mountIdleSandbox()
+
+            // Warm = open with content: null. Keep the POST in flight so the abandon races it.
+            let resolvePrewarm: (handle: typeof warmHandle) => void = () => {}
+            const openSpy = jest
+                .spyOn(api.conversations, 'open')
+                .mockReturnValue(new Promise<typeof warmHandle>((resolve) => (resolvePrewarm = resolve)) as any)
+
+            logic.actions.prewarmSandbox()
+            await flush()
+            expect(openSpy).toHaveBeenCalledWith(MOCK_CONVERSATION_ID, {
+                content: null,
+                initial_permission_mode: 'auto',
+            })
+
+            // User abandons the input before the warm resolves — nothing is warm yet, so the release
+            // is deferred (pendingRelease), not dropped, and no cancel fires.
+            await expectLogic(logic, () => {
+                logic.actions.releaseSandboxPrewarm()
+            }).toNotHaveDispatchedActions(['cancelSandboxRun'])
+            await flush()
+
+            // The warm POST resolves — the deferred release fires cancelSandboxRun so the sandbox
+            // isn't leaked.
+            await expectLogic(logic, () => {
+                resolvePrewarm(warmHandle)
+            }).toDispatchActions(['cancelSandboxRun'])
+        })
+
+        it('does not release a warm that resolved with no pending abandon', async () => {
+            await mountIdleSandbox()
+
+            jest.spyOn(api.conversations, 'open').mockResolvedValue(warmHandle)
+
+            await expectLogic(logic, () => {
+                logic.actions.prewarmSandbox()
+            }).toNotHaveDispatchedActions(['cancelSandboxRun'])
+            await flush()
+            await flush()
+        })
+    })
+
+    describe('filteredCommands runtime filter', () => {
+        function setRuntime(runtime: 'langgraph' | 'sandbox'): void {
+            logic.actions.setConversation({
+                ...MOCK_IN_PROGRESS_CONVERSATION,
+                status: ConversationStatus.Idle,
+                agent_runtime: runtime,
+            } as Conversation)
+            // Empty question matches every command by prefix.
+            maxLogicInstance.actions.setQuestion('')
+        }
+
+        it('hides /init and /remember for sandbox conversations, keeps /usage and /feedback', async () => {
+            setRuntime('sandbox')
+            const names = logic.values.filteredCommands.map((c) => c.name)
+            expect(names).not.toContain(SlashCommandName.SlashInit)
+            expect(names).not.toContain(SlashCommandName.SlashRemember)
+            expect(names).toContain(SlashCommandName.SlashUsage)
+            expect(names).toContain(SlashCommandName.SlashFeedback)
+        })
+
+        it('keeps the full command set for langgraph conversations', async () => {
+            setRuntime('langgraph')
+            const names = logic.values.filteredCommands.map((c) => c.name)
+            expect(names).toContain(SlashCommandName.SlashInit)
+            expect(names).toContain(SlashCommandName.SlashRemember)
+            expect(names).toContain(SlashCommandName.SlashUsage)
+            expect(names).toContain(SlashCommandName.SlashFeedback)
         })
     })
 
@@ -2855,6 +3130,25 @@ describe('maxThreadLogic', () => {
         })
     })
 
+    describe('stopGeneration button state (LangGraph cancel race)', () => {
+        it('clears all loading flags after a successful cancel so the stop button returns to send', async () => {
+            jest.spyOn(api.conversations, 'cancel').mockResolvedValue(undefined)
+
+            // An in-progress conversation drives conversationLoading -> true
+            logic.actions.setConversation(MOCK_IN_PROGRESS_CONVERSATION)
+            await expectLogic(logic).toMatchValues({ conversationLoading: true })
+
+            await expectLogic(logic, () => {
+                logic.actions.stopGeneration()
+            }).toDispatchActions(['stopGeneration', 'setConversation', 'setCancelLoading'])
+
+            expect(logic.values.conversationLoading).toBe(false)
+            expect(logic.values.streamingActive).toBe(false)
+            expect(logic.values.threadLoading).toBe(false)
+            expect(logic.values.cancelLoading).toBe(false)
+        })
+    })
+
     describe('multiQuestionFormPending selector', () => {
         it('returns true when thread ends with AssistantMessage containing create_form tool call', async () => {
             // With NodeInterrupt(None), no ToolCall message is created - the thread ends with the AssistantMessage
@@ -3148,6 +3442,258 @@ describe('maxThreadLogic', () => {
                 agentMode: AgentMode.SQL,
                 agentModeLockedByUser: false,
             })
+        })
+    })
+
+    describe('sandbox streaming lock', () => {
+        const sandboxRunResponse = {
+            task_id: 'task-1',
+            run_id: 'run-1',
+            trace_id: 'trace-1',
+            run_status: 'queued' as const,
+            just_created_run: true,
+        }
+
+        beforeEach(() => {
+            // jsdom has no EventSource — a minimal stub lets openSseForRun set up its connection
+            ;(globalThis as any).EventSource = class {
+                onopen: ((event: Event) => void) | null = null
+                onmessage: ((event: MessageEvent<string>) => void) | null = null
+                addEventListener(): void {}
+                close(): void {}
+            }
+        })
+
+        afterEach(() => {
+            delete (globalThis as any).EventSource
+        })
+
+        it('holds the streaming lock until the sandbox turn completes and releases exactly once', async () => {
+            const openSpy = jest.spyOn(api.conversations, 'open').mockResolvedValue(sandboxRunResponse)
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: 'hello', conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['openSandboxSse'])
+
+            expect(openSpy).toHaveBeenCalledWith(
+                MOCK_CONVERSATION_ID,
+                expect.objectContaining({
+                    content: 'hello',
+                    initial_permission_mode: 'auto',
+                })
+            )
+
+            // The POST finished, but the turn is still streaming — the lock must still be held
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(1)
+
+            // The thread logic connects to the instance keyed by its own conversationId
+            const sandboxStreamInstance = sandboxStreamLogic({ streamKey: MOCK_CONVERSATION_ID })
+
+            // The release listeners are synchronous, so the lock state settles with the dispatch
+            sandboxStreamInstance.actions.markTurnComplete()
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
+
+            // A later terminal event must not release the (already released) lock again
+            maxLogicInstance.actions.incrActiveStreamingThreads()
+            sandboxStreamInstance.actions.handleTerminalStatus({ status: 'completed' })
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(1)
+            maxLogicInstance.actions.decrActiveStreamingThreads()
+        })
+
+        it('does not release the lock on a non-terminal task_run_state frame', async () => {
+            jest.spyOn(api.conversations, 'open').mockResolvedValue(sandboxRunResponse)
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: 'hello', conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['openSandboxSse'])
+
+            const sandboxStreamInstance = sandboxStreamLogic({ streamKey: MOCK_CONVERSATION_ID })
+
+            // queued / in_progress frames arrive before the turn is done — the lock must stay held.
+            sandboxStreamInstance.actions.handleTerminalStatus({ status: 'queued' })
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(1)
+            sandboxStreamInstance.actions.handleTerminalStatus({ status: 'in_progress' })
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(1)
+
+            // Only an actually-terminal status releases it.
+            sandboxStreamInstance.actions.handleTerminalStatus({ status: 'completed' })
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
+        })
+
+        it('releases the lock immediately and surfaces an error when the send POST fails', async () => {
+            jest.spyOn(api.conversations, 'open').mockRejectedValue(new Error('boom'))
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: 'hello', conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['pushSandboxError', 'decrActiveStreamingThreads'])
+
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
+            expect(
+                sandboxStreamLogic({ streamKey: MOCK_CONVERSATION_ID }).values.threadItems.some(
+                    (item) =>
+                        item.type === 'error' && item.errorMessage === 'Failed to send your message. Please try again.'
+                )
+            ).toEqual(true)
+        })
+
+        it('releases the lock immediately when no run was started', async () => {
+            const openSpy = jest.spyOn(api.conversations, 'open')
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: null, conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['decrActiveStreamingThreads'])
+
+            expect(openSpy).not.toHaveBeenCalled()
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
+        })
+    })
+
+    describe('sandbox streamingActive teardown', () => {
+        const sandboxRunResponse = {
+            task_id: 'task-1',
+            run_id: 'run-1',
+            trace_id: 'trace-1',
+            run_status: 'queued' as const,
+            just_created_run: true,
+        }
+
+        beforeEach(() => {
+            ;(globalThis as any).EventSource = class {
+                onopen: ((event: Event) => void) | null = null
+                onmessage: ((event: MessageEvent<string>) => void) | null = null
+                addEventListener(): void {}
+                close(): void {}
+            }
+            jest.spyOn(api.conversations, 'open').mockResolvedValue(sandboxRunResponse)
+        })
+
+        afterEach(() => {
+            delete (globalThis as any).EventSource
+        })
+
+        async function startSandboxTurn(): Promise<ReturnType<typeof sandboxStreamLogic.build>> {
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: 'hello', conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['openSandboxSse'])
+            expect(logic.values.streamingActive).toBe(true)
+            return sandboxStreamLogic({ streamKey: MOCK_CONVERSATION_ID })
+        }
+
+        it('tears down streamingActive on markTurnComplete', async () => {
+            const sandboxStreamInstance = await startSandboxTurn()
+
+            await expectLogic(logic, () => {
+                sandboxStreamInstance.actions.markTurnComplete()
+            }).toDispatchActions(['completeThreadGeneration'])
+
+            expect(logic.values.streamingActive).toBe(false)
+            expect(logic.values.threadLoading).toBe(false)
+        })
+
+        it('tears down streamingActive on handleTerminalStatus', async () => {
+            const sandboxStreamInstance = await startSandboxTurn()
+
+            await expectLogic(logic, () => {
+                sandboxStreamInstance.actions.handleTerminalStatus({ status: 'completed' })
+            }).toDispatchActions(['endStreaming'])
+
+            expect(logic.values.streamingActive).toBe(false)
+            expect(logic.values.threadLoading).toBe(false)
+        })
+
+        it('tears down streamingActive on handleStreamError', async () => {
+            const sandboxStreamInstance = await startSandboxTurn()
+
+            await expectLogic(logic, () => {
+                sandboxStreamInstance.actions.handleStreamError({
+                    errorTitle: 'Error',
+                    errorMessage: 'boom',
+                    retryable: false,
+                })
+            }).toDispatchActions(['endStreaming'])
+
+            expect(logic.values.streamingActive).toBe(false)
+            expect(logic.values.threadLoading).toBe(false)
+        })
+
+        it('markTurnComplete drains the sandbox queue combined, without an optimistic echo', async () => {
+            // No POSTHOG_AI_QUEUE_MESSAGES_SYSTEM flag — sandbox queueing is flag-independent.
+            jest.spyOn(api.conversations.queue, 'clear').mockResolvedValue({ messages: [], max_queue_messages: 2 })
+
+            const sandboxStreamInstance = await startSandboxTurn()
+            // completeThreadGeneration's queue-drain only runs with a non-null conversation.
+            // The id matches the mounted conversationId, so the setConversation listener won't clear the queue.
+            logic.actions.setConversation(MOCK_CONVERSATION)
+            logic.actions.setIsSandboxMode(true)
+            logic.actions.setQueuedMessages([
+                { id: 'queue-1', content: 'First', created_at: new Date().toISOString() },
+                { id: 'queue-2', content: 'Second', created_at: new Date().toISOString() },
+            ])
+
+            // markTurnComplete tears down streaming, then the drain clears the queue and re-sends the
+            // combined text with addToThread:false (so it renders on the live echo, not optimistically).
+            await expectLogic(logic, () => {
+                sandboxStreamInstance.actions.markTurnComplete()
+            }).toDispatchActions([
+                'completeThreadGeneration',
+                'clearQueuedMessages',
+                (action: any) => action.payload?.prompt === 'First\n\nSecond' && action.payload?.addToThread === false,
+            ])
+        })
+
+        it('handleStreamError does NOT drain the sandbox queue (no clearQueuedMessages, no askMax)', async () => {
+            featureFlagLogic.mount()
+            featureFlagLogic.actions.setFeatureFlags([], {
+                [FEATURE_FLAGS.POSTHOG_AI_QUEUE_MESSAGES_SYSTEM]: true,
+            })
+
+            const sandboxStreamInstance = await startSandboxTurn()
+            logic.actions.setIsSandboxMode(true)
+            const queueMessage = { id: 'queue-1', content: 'Next message', created_at: new Date().toISOString() }
+            logic.actions.setQueuedMessages([queueMessage])
+
+            await expectLogic(logic, () => {
+                sandboxStreamInstance.actions.handleStreamError({
+                    errorTitle: 'Error',
+                    errorMessage: 'boom',
+                    retryable: false,
+                })
+            })
+                .toDispatchActions(['endStreaming'])
+                .toNotHaveDispatchedActions(['completeThreadGeneration', 'clearQueuedMessages', 'askMax'])
+
+            expect(logic.values.streamingActive).toBe(false)
+            // The failed turn must not auto-start the queued message
+            expect(logic.values.queuedMessages).toEqual([queueMessage])
+
+            featureFlagLogic.unmount()
+        })
+
+        it('history-replay terminal events do not fire teardown while streamingActive is false', async () => {
+            // No live turn: streamingActive is false (no streamConversation was dispatched)
+            expect(logic.values.streamingActive).toBe(false)
+            const sandboxStreamInstance = sandboxStreamLogic({ streamKey: MOCK_CONVERSATION_ID })
+
+            await expectLogic(logic, () => {
+                sandboxStreamInstance.actions.handleTerminalStatus({ status: 'completed', replayedFromHistory: true })
+            }).toNotHaveDispatchedActions(['endStreaming', 'completeThreadGeneration', 'askMax'])
+
+            expect(logic.values.streamingActive).toBe(false)
         })
     })
 })

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -68,12 +68,20 @@ import { LogEntry, parseLogEvent } from 'products/tasks/frontend/lib/parse-logs'
 
 import { handsFreeLogic } from './handsFreeLogic'
 import { summariseAssistantThread } from './handsFreeUtils'
-import { EnhancedToolCall, MODE_DEFINITIONS, TOOL_DEFINITIONS, ToolRegistration } from './max-constants'
+import {
+    EnhancedToolCall,
+    MODE_DEFINITIONS,
+    TOOL_DEFINITIONS,
+    ToolRegistration,
+    getModeDisplayName,
+} from './max-constants'
 import { MaxBillingContext, MaxBillingContextSubscriptionLevel, maxBillingContextLogic } from './maxBillingContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import type { maxThreadLogicType } from './maxThreadLogicType'
-import { MaxUIContext } from './maxTypes'
+import { AttachedContext, MaxUIContext } from './maxTypes'
+import { posthogAiContextLogic } from './posthogAiContextLogic'
+import { SANDBOX_INITIAL_PERMISSION_MODE, isTerminalRunStatus, sandboxStreamLogic } from './sandboxStreamLogic'
 import { MAX_SLASH_COMMANDS, SlashCommand } from './slash-commands'
 import { getToolCallDescriptionAndWidgetDef } from './toolCallDisplay'
 import {
@@ -89,6 +97,12 @@ import { getRandomThinkingMessage } from './utils/thinkingMessages'
 
 /** Key for persisting pending AI prompts across page reloads (e.g., OAuth redirects) */
 export const PENDING_AI_PROMPT_KEY = 'posthog_ai_pending_prompt'
+
+// On a dashboard, the first message can fire before the dashboard has loaded, when
+// dashboardLogic.maxContext still returns []. askMax waits (bounded) for the load so the
+// dashboard context is included. Bounded so a stuck/failed load never blocks sending.
+export const MAX_DASHBOARD_CONTEXT_WAIT_MS = 8000
+const DASHBOARD_CONTEXT_POLL_INTERVAL_MS = 100
 
 export type MessageStatus = 'loading' | 'completed' | 'error'
 
@@ -142,7 +156,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         }
     }),
 
-    connect(({ panelId }: MaxThreadLogicProps) => ({
+    connect(({ panelId, conversationId }: MaxThreadLogicProps) => ({
         values: [
             maxGlobalLogic,
             ['dataProcessingAccepted', 'toolMap', 'tools', 'availableStaticTools'],
@@ -153,6 +167,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 'threadLogicKey as activeThreadKey',
                 'activeStreamingThreads',
                 'conversationId as parentConversationId',
+                'pendingBindTaskId',
             ],
             maxContextLogic,
             ['compiledContext'],
@@ -162,6 +177,16 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             ['featureFlags'],
             sceneLogic,
             ['sceneId'],
+            // Mounts this conversation's sandbox attachment store so its `attachments` are readable
+            // at send time even when no context-chip UI is rendered (a fresh conversation never
+            // mounts it itself).
+            posthogAiContextLogic({ conversationId }),
+            ['attachments as sandboxAttachments'],
+            // Surfaces the sandbox stream's input-area state to components outside SandboxThread's
+            // BindLogic subtree (the input area renders for LangGraph conversations too, so they
+            // can't bind the keyed stream logic themselves).
+            sandboxStreamLogic({ streamKey: conversationId, conversationId }),
+            ['pendingPermissionRequest as pendingSandboxPermissionRequest', 'currentMode as sandboxCurrentMode'],
         ],
         actions: [
             maxLogic({ panelId }),
@@ -175,9 +200,25 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 'setConversationId',
                 'setAutoRun',
                 'loadConversationHistorySuccess',
+                'setPendingBindTaskId',
             ],
             maxGlobalLogic,
             ['loadConversation'],
+            // Pulling the action in (rather than calling the instance's actions directly) mounts this
+            // conversation's stream logic as a dependency, so its listeners actually run. SandboxThread
+            // only mounts it while a sandbox conversation is rendered — too late for the first message
+            // of a new one.
+            sandboxStreamLogic({ streamKey: conversationId, conversationId }),
+            [
+                'openSseForRun as openSandboxSse',
+                'pushHumanMessage as pushSandboxHumanMessage',
+                'pushErrorItem as pushSandboxError',
+                'bootstrapRun as bootstrapSandboxRun',
+                'reset as resetSandboxStream',
+                'cancelRun as cancelSandboxRun',
+            ],
+            posthogAiContextLogic({ conversationId }),
+            ['clearAttachments as clearSandboxAttachments'],
         ],
     })),
 
@@ -199,6 +240,10 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         ) => ({ streamData, generationAttempt, addToThread }),
         stopGeneration: true,
         completeThreadGeneration: true,
+        // Narrow teardown: flips only streamingActive -> false. Used by the sandbox error/terminal
+        // listeners where completeThreadGeneration's queue-drain (auto-starting the next message)
+        // would be wrong after a failure.
+        endStreaming: true,
         addMessage: (message: ThreadMessage) => ({ message }),
         replaceMessage: (index: number, message: ThreadMessage) => ({
             index,
@@ -254,6 +299,8 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         setPendingApproval: (proposalId: string) => ({ proposalId }),
         clearPendingApproval: true,
         appendSandboxEntry: (entry: LogEntry) => ({ entry }),
+        prewarmSandbox: true,
+        releaseSandboxPrewarm: true,
         refreshSandboxEntries: true,
         resetSandboxEntries: true,
         continueAfterForm: (formAnswers: MultiQuestionFormAnswers) => ({
@@ -328,6 +375,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 reconnectToStream: () => true,
                 streamConversation: () => true,
                 completeThreadGeneration: () => false,
+                endStreaming: () => false,
             },
         ],
 
@@ -621,7 +669,24 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             const traceId = uuid()
             actions.setTraceId(traceId)
 
-            if (generationAttempt === 0 && streamData.content && addToThread) {
+            // Sandbox runtime: route the message to a non-streaming products/tasks Run, then hand the
+            // SSE connection off to sandboxStreamLogic. The LangGraph EventSource loop below is never
+            // entered for sandbox conversations.
+            //
+            // An *existing* sandbox conversation (`agent_runtime === 'sandbox'`) uses the dedicated
+            // `/sandbox/` routing endpoint. A *brand-new* conversation has no row yet — it's created
+            // lazily on the first message — so `agent_runtime` isn't known here; we detect the
+            // `is_sandbox` flag and let the conversation-create endpoint create it + return the run
+            // IDs as JSON (both endpoints return the identical { task_id, run_id, just_created_run }).
+            const isExistingSandboxConversation = values.conversation?.agent_runtime === 'sandbox'
+            const isSandboxConversation = isExistingSandboxConversation || !!isSandbox
+
+            // Echo the human message into whichever thread the renderer actually shows. A sandbox
+            // conversation renders sandboxStreamLogic's threadItems (not this logic's thread) and
+            // echoes via pushSandboxHumanMessage below; adding it to the legacy thread too would
+            // briefly show a duplicate (until the runtime resolves to the SandboxThread) that vanishes
+            // on reload, since sandbox turns live in the run log, not the legacy conversation messages.
+            if (generationAttempt === 0 && streamData.content && addToThread && !isSandboxConversation) {
                 const message: ThreadMessage = {
                     type: AssistantMessageType.Human,
                     content: streamData.content,
@@ -629,6 +694,80 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     trace_id: traceId,
                 }
                 actions.addMessage(message)
+            }
+
+            if (isSandboxConversation) {
+                // SandboxThread renders sandboxStreamLogic's threadItems, not this logic's thread,
+                // so the human message must be echoed there to show up in the UI.
+                if (generationAttempt === 0 && streamData.content && addToThread) {
+                    actions.pushSandboxHumanMessage(streamData.content)
+                    // Pull the current scene's `maxContext` into the sandbox attachments at send
+                    // (consumption) time so on-scene entities flow into `sandboxAttachments` below.
+                    // Nothing else dispatches this, so without it scene context never auto-attaches.
+                    posthogAiContextLogic({ conversationId: props.conversationId }).actions.syncSceneAttachments()
+                }
+                try {
+                    const conversationId = values.conversation?.id || values.conversationId
+                    if (conversationId && streamData.content) {
+                        // The sandbox runtime has no agent modes — they're a legacy LangGraph concept. If the
+                        // user still picked one, carry it through as a context note so the agent can acknowledge it.
+                        const attachedContext: AttachedContext[] = [...values.sandboxAttachments]
+                        if (values.agentMode) {
+                            attachedContext.push({
+                                type: 'text',
+                                value: `The user selected a mode: "${getModeDisplayName(values.agentMode)}". It was in the legacy implementation. Acknowledge the mode if the user refers to it.`,
+                            })
+                        }
+                        // Single create-or-resume opener: it creates the conversation row on first use,
+                        // starts/continues the Run, and returns the (task, run) handle. A message always
+                        // provisions a run (a null handle only happens on a warm with a full pool).
+                        const handle = await api.conversations.open(conversationId, {
+                            content: streamData.content,
+                            trace_id: traceId,
+                            attached_context: attachedContext,
+                            initial_permission_mode: SANDBOX_INITIAL_PERMISSION_MODE,
+                            // Bind a brand-new conversation to an existing Task (inbox "Open task") so the
+                            // backend resumes that Task's run. Only the first message carries it.
+                            ...(values.pendingBindTaskId ? { task_id: values.pendingBindTaskId } : {}),
+                        })
+                        if (handle) {
+                            // The sent message consumes any in-flight warm — it's now the active run, so
+                            // drop the release handle to avoid cancelling the run out from under it.
+                            cache.warmRun = null
+                            // The bind is one-shot: the conversation now exists bound to the Task, so
+                            // follow-ups target it directly — don't re-send task_id.
+                            if (values.pendingBindTaskId) {
+                                actions.setPendingBindTaskId(null)
+                            }
+                            actions.openSandboxSse({
+                                taskId: handle.task_id,
+                                runId: handle.run_id,
+                                // Fresh runs need everything from the top; follow-ups resume from latest.
+                                startLatest: !handle.just_created_run,
+                                // Correlate SSE-side telemetry with the trace this run was sent under.
+                                traceId,
+                            })
+                            // The streaming lock must span the whole SSE stream so the input stays
+                            // guarded until `_posthog/turn_complete` or a terminal/error event —
+                            // mirrors the LangGraph path holding the lock for its entire stream.
+                            // Released exactly once by the sandboxStreamLogic listeners below; the
+                            // closure nulls itself so a second terminal event is a no-op.
+                            cache.sandboxStreamRelease = (): void => {
+                                cache.sandboxStreamRelease = null
+                                actions.decrActiveStreamingThreads()
+                                releaseStreamingLock()
+                            }
+                            return
+                        }
+                    }
+                } catch (e) {
+                    posthog.captureException(e)
+                    actions.pushSandboxError('Failed to send your message. Please try again.')
+                }
+                // The POST failed or no run was started — nothing will stream, release the lock now.
+                actions.decrActiveStreamingThreads()
+                releaseStreamingLock()
+                return
             }
 
             let caughtException = false
@@ -647,10 +786,6 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
 
                 if (agentMode) {
                     apiData.agent_mode = agentMode
-                }
-
-                if (isSandbox) {
-                    apiData.is_sandbox = true
                 }
 
                 const response = await api.conversations.stream(apiData, {
@@ -849,6 +984,43 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             releaseStreamingLock() // release the lock
         },
     })),
+    // Sandbox runs stream through this conversation's sandboxStreamLogic instance, so the streaming
+    // lock taken in streamConversation can only be released when that instance signals the turn
+    // ended — on turn completion, a terminal run status, or a stream error. Its action types are
+    // per-instance (the key is in the path), so they're resolved from props at build time.
+    listeners(({ props, cache, actions, values }) => {
+        const sandboxStreamActionTypes = sandboxStreamLogic({ streamKey: props.conversationId }).actionTypes
+        // Normal turn completion: full turn-end, including the sandbox queue-drain that starts the
+        // next queued message (completeThreadGeneration's intended next-turn behavior).
+        const completeSandboxTurn = (): void => {
+            cache.sandboxStreamRelease?.()
+            if (values.streamingActive) {
+                actions.completeThreadGeneration()
+            }
+        }
+        // Error / terminal status: just stop streaming. Must NOT run completeThreadGeneration's
+        // queue-drain — auto-starting the next queued message after a failure is wrong. The
+        // streamingActive guard also keeps history-replay terminal events (replayedFromHistory,
+        // dispatched during bootstrapRun with no live turn) from firing teardown.
+        const endSandboxStream = (): void => {
+            cache.sandboxStreamRelease?.()
+            if (values.streamingActive) {
+                actions.endStreaming()
+            }
+        }
+        return {
+            [sandboxStreamActionTypes.markTurnComplete]: completeSandboxTurn,
+            // handleTerminalStatus fires for every task_run_state frame, including the initial
+            // non-terminal queued/in_progress ones — only tear down on an actually terminal
+            // status, mirroring sandboxStreamLogic's own guard.
+            [sandboxStreamActionTypes.handleTerminalStatus]: ({ status }: { status: string }) => {
+                if (isTerminalRunStatus(status)) {
+                    endSandboxStream()
+                }
+            },
+            [sandboxStreamActionTypes.handleStreamError]: endSandboxStream,
+        }
+    }),
     listeners(({ actions, values, cache, props }) => ({
         setConversation: ({ conversation }) => {
             const nextConversationId = conversation?.id ?? null
@@ -874,6 +1046,96 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.clearQueuedMessages()
             }
             // Note: pending approvals loading is handled in the reducer (pendingApprovalsData.setConversation)
+        },
+        setQuestion: ({ question }) => {
+            // Sandbox pre-warming. Debounce on the first non-whitespace keystroke so the sandbox
+            // boots while the user is still typing; release if the input empties.
+            // LangGraph conversations are unaffected.
+            if (values.conversation?.agent_runtime !== 'sandbox') {
+                return
+            }
+            // Don't warm if a run is already active — the live Run is the desired state.
+            if (values.threadLoading) {
+                return
+            }
+            if (question.trim() === '') {
+                // Input emptied — cancel a pending warm trigger and schedule release after 5s.
+                cache.disposables.dispose('prewarm-debounce')
+                if (cache.prewarmed) {
+                    cache.disposables.add(() => {
+                        const timer = setTimeout(() => actions.releaseSandboxPrewarm(), 5000)
+                        return () => clearTimeout(timer)
+                    }, 'prewarm-release')
+                }
+                return
+            }
+            // Non-empty input: cancel any pending release, then debounce the warm.
+            cache.disposables.dispose('prewarm-release')
+            if (cache.prewarmed) {
+                return
+            }
+            cache.disposables.add(() => {
+                const timer = setTimeout(() => actions.prewarmSandbox(), 250)
+                return () => clearTimeout(timer)
+            }, 'prewarm-debounce')
+        },
+        prewarmSandbox: async () => {
+            cache.disposables.dispose('prewarm-debounce')
+            if (values.conversation?.agent_runtime !== 'sandbox' || !values.conversationId) {
+                return
+            }
+            // Guard against duplicate warms and warming over an active run.
+            if (cache.prewarmed || cache.prewarming || values.threadLoading) {
+                return
+            }
+            cache.prewarming = true
+            cache.pendingRelease = false
+            try {
+                // Warm = open with no message: boots a Run that idles awaiting the first message. The
+                // returned handle lets a later release cancel exactly that Run via the relay (a full
+                // pool returns null — nothing to release).
+                const warm = await api.conversations.open(values.conversationId, {
+                    content: null,
+                    initial_permission_mode: SANDBOX_INITIAL_PERMISSION_MODE,
+                })
+                cache.warmRun = warm ? { taskId: warm.task_id, runId: warm.run_id } : null
+                cache.prewarmed = true
+                // If the user abandoned the input while this POST was in flight, the blur/empty
+                // release hit the early-exit (nothing was warm yet). Honor it now so the freshly
+                // warmed sandbox isn't leaked until the agent-server's idle self-cancel.
+                if (cache.pendingRelease) {
+                    cache.pendingRelease = false
+                    actions.releaseSandboxPrewarm()
+                }
+            } catch (e) {
+                // Pre-warming is best-effort latency optimization; a failure just means the first
+                // message takes the cold path. Don't surface it to the user.
+                posthog.captureException(e)
+            } finally {
+                cache.prewarming = false
+            }
+        },
+        releaseSandboxPrewarm: async () => {
+            cache.disposables.dispose('prewarm-debounce')
+            cache.disposables.dispose('prewarm-release')
+            if (!cache.prewarmed || !values.conversationId) {
+                // A warm POST may still be in flight — record the intent so its success handler
+                // releases the sandbox instead of dropping the request on the floor.
+                if (cache.prewarming) {
+                    cache.pendingRelease = true
+                }
+                cache.prewarmed = false
+                return
+            }
+            // A warm consumed by a sent message must not be released — only release on abandon.
+            cache.prewarmed = false
+            const warmRun = cache.warmRun as { taskId: string; runId: string } | undefined
+            cache.warmRun = null
+            if (warmRun) {
+                // Release = cancel the warm Run through the generic relay (owned by the renderer logic);
+                // it transitions to terminal and drops out of the warm-pool count.
+                actions.cancelSandboxRun(warmRun)
+            }
         },
         enqueueQueuedMessage: async ({ content, contextualTools, uiContext, billingContext, agentMode }) => {
             if (!values.queueingEnabled || !values.conversation?.id) {
@@ -1000,10 +1262,56 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.clearQueuedMessages()
             }
         },
-        askMax: async ({ prompt, addToThread = true, uiContext }) => {
+        askMax: async ({ prompt, addToThread = true, uiContext }, breakpoint) => {
             // Only process if this thread is the currently active one
             if (values.conversationId !== values.activeThreadKey) {
                 return
+            }
+            // A sent message consumes any sandbox pre-warm: the warm Run is the in-progress run the
+            // sandbox routing follows up on, so cancel pending timers and clear the flag WITHOUT
+            // issuing a release/DELETE.
+            cache.disposables.dispose('prewarm-debounce')
+            cache.disposables.dispose('prewarm-release')
+            cache.prewarmed = false
+            cache.warmRun = null
+            // A sent message consumes the warm — drop any in-flight release intent so the
+            // run the message follows up on isn't cancelled out from under it.
+            cache.pendingRelease = false
+            // Wait for the open dashboard to finish loading before collecting context (see the
+            // constants above for why). The scene is re-read every tick, so the gate releases the
+            // moment the dashboard's metadata lands — and immediately if the user navigates away
+            // mid-wait (no longer on a dashboard, or onto a different one that's already loaded).
+            const isDashboardSceneLoading = (): boolean => {
+                if (sceneLogic.values.activeSceneId !== Scene.Dashboard) {
+                    return false
+                }
+                const activeSceneLogic = sceneLogic.values.activeSceneLogic
+                if (!activeSceneLogic || !('maxContext' in activeSceneLogic.selectors)) {
+                    return false
+                }
+                return !(activeSceneLogic.values as { dashboard?: unknown }).dashboard
+            }
+            // Measure real elapsed time, not tick count: breakpoint() only guarantees a *minimum*
+            // delay, so a busy event loop would make a tick counter under-report the wait — letting
+            // it run past the cap and skewing the telemetry below. performance.now() is monotonic.
+            const dashboardWaitStart = performance.now()
+            while (
+                isDashboardSceneLoading() &&
+                performance.now() - dashboardWaitStart < MAX_DASHBOARD_CONTEXT_WAIT_MS
+            ) {
+                await breakpoint(DASHBOARD_CONTEXT_POLL_INTERVAL_MS)
+            }
+            if (isDashboardSceneLoading()) {
+                // We hit the wait cap while the dashboard was still loading, so the message ships
+                // without dashboard context (the original "Max can't see this dashboard" symptom).
+                // Capture it so we can tell whether the cap is ever the binding constraint in prod.
+                const activeLoadedScene = sceneLogic.values.activeLoadedScene
+                const sceneProps = activeLoadedScene?.paramsToProps?.(activeLoadedScene?.sceneParams) || {}
+                posthog.capture('max dashboard context wait timed out', {
+                    waited_ms: Math.round(performance.now() - dashboardWaitStart),
+                    dashboard_id: (sceneProps as { id?: number | string }).id,
+                    conversation_id: values.conversation?.id || values.conversationId,
+                })
             }
             const contextualTools = Object.fromEntries(values.tools.map((tool) => [tool.identifier, tool.context]))
             // Always send voice_mode as an explicit boolean when handsFreeLogic is mounted,
@@ -1086,6 +1394,13 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.clearPendingApproval()
                 actions.setResolvedApprovalStatus(pendingProposalId, 'auto_rejected')
             }
+            // A pending task-bind (inbox "Open task") makes this first message a sandbox task-resume:
+            // the conversation is created bound to the Task and its run is resumed. Force sandbox mode
+            // so the message routes through the sandbox `open` endpoint (which carries the task_id).
+            // Reducers apply synchronously, so the `is_sandbox` derivation below sees the new value.
+            if (values.pendingBindTaskId && !values.isSandboxMode) {
+                actions.setIsSandboxMode(true)
+            }
             const agentMode = values.agentMode
 
             // Clear the question
@@ -1132,10 +1447,24 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             }
 
             try {
-                await api.conversations.cancel(values.conversation.id)
+                if (values.conversation.agent_runtime === 'sandbox') {
+                    // Sandbox runs cancel through the generic tasks relay (the renderer owns the run id).
+                    actions.cancelSandboxRun()
+                } else {
+                    await api.conversations.cancel(values.conversation.id)
+                }
                 cache.generationController?.abort()
                 actions.clearQueuedMessages()
                 actions.resetThread()
+                // Optimistically clear the loading flags so the composer button returns to "send"
+                // immediately, instead of racing the fire-and-forget loadConversation refetch below
+                // (whose success handler is gated on streamingActive). The refetch still reconciles
+                // the true server status moments later.
+                if (values.conversation) {
+                    const canceledConversation = { ...values.conversation, status: ConversationStatus.Idle }
+                    actions.setConversation(canceledConversation)
+                    actions.updateGlobalConversationCache(canceledConversation)
+                }
             } catch (e: any) {
                 posthog.captureException(e)
                 lemonToast.error(e?.data?.detail || 'Failed to cancel the generation.')
@@ -1212,11 +1541,13 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             // Process queued messages for sandbox conversations.
             // Regular conversations handle queue consumption on the backend
             // (process_chat_agent_activity pops and starts new workflows).
-            // Sandbox mode doesn't have this, so the frontend drives it.
+            // Sandbox mode doesn't have this, so the frontend drives it: combine every queued
+            // follow-up into one send. `addToThread: false` skips the optimistic echo so the message
+            // renders only when the live stream echoes it back (stream-confirmed), not at drain time.
             if (shouldConsumeSandboxQueue) {
-                const nextMessage = values.queuedMessages[0]
-                actions.consumeQueuedMessage(nextMessage)
-                actions.askMax(nextMessage.content)
+                const combined = values.queuedMessages.map((message) => message.content).join('\n\n')
+                actions.clearQueuedMessages()
+                actions.askMax(combined, false)
             }
 
             // Must go last. Otherwise, the logic will be unmounted before the lifecycle finishes.
@@ -1445,6 +1776,19 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             (conversation, propsConversationId) => (conversation?.id ? conversation.id : propsConversationId),
         ],
 
+        // The exact id this instance was keyed with. React must bind the per-conversation sandbox
+        // logics with the same id connect() used above, or the two would resolve different instances.
+        sandboxConversationKey: [(_, p) => [p.conversationId], (conversationId): string => conversationId],
+
+        // A converted conversation: now on the sandbox runtime but still carrying its legacy
+        // LangGraph history. Drives the dual render (full legacy thread → "history was converted"
+        // divider → live sandbox thread). Reads `threadRaw`, not `threadGrouped`, so the streaming
+        // thinking-loader injected into `threadGrouped` can't be mistaken for legacy content.
+        isConvertedConversation: [
+            (s) => [s.conversation, s.threadRaw],
+            (conversation, threadRaw): boolean => conversation?.agent_runtime === 'sandbox' && threadRaw.length > 0,
+        ],
+
         effectiveApprovalStatuses: [
             (s) => [s.resolvedApprovalStatuses, s.pendingApprovalsData],
             (resolved, pendingApprovalsData): Record<string, { status: ApprovalDecisionStatus; feedback?: string }> => {
@@ -1497,8 +1841,12 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         ],
 
         queueingEnabled: [
-            (s) => [s.featureFlags],
-            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.POSTHOG_AI_QUEUE_MESSAGES_SYSTEM],
+            // Sandbox conversations always queue follow-ups sent mid-turn (the backend queue endpoints
+            // aren't flag-gated, and the sandbox runtime drives the drain itself); LangGraph stays
+            // behind the rollout flag.
+            (s) => [s.featureFlags, s.isSandboxMode],
+            (featureFlags, isSandboxMode): boolean =>
+                !!featureFlags[FEATURE_FLAGS.POSTHOG_AI_QUEUE_MESSAGES_SYSTEM] || isSandboxMode,
         ],
 
         queueIsFull: [
@@ -1770,12 +2118,13 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         ],
 
         filteredCommands: [
-            (s) => [s.question, s.featureFlags, s.threadLoading, s.billingContext],
+            (s) => [s.question, s.featureFlags, s.threadLoading, s.billingContext, s.conversation],
             (
                 question: string,
                 featureFlags: Record<string, boolean | string>,
                 threadLoading: boolean,
-                billingContext: MaxBillingContext | null
+                billingContext: MaxBillingContext | null,
+                conversation: Conversation | null
             ): SlashCommand[] => {
                 const hasPaidPlan =
                     billingContext?.subscription_level === MaxBillingContextSubscriptionLevel.PAID ||
@@ -1783,12 +2132,16 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     billingContext?.trial?.is_active ||
                     process.env.NODE_ENV === 'development'
 
+                // Sandbox runtime drops core-memory commands; LangGraph keeps the full set.
+                const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
+
                 return MAX_SLASH_COMMANDS.filter(
                     (command) =>
                         command.name.toLowerCase().startsWith(question.toLowerCase()) &&
                         (!command.flag || featureFlags[command.flag]) &&
                         (!command.requiresIdle || !threadLoading) &&
-                        (!command.requiresPaidPlan || hasPaidPlan)
+                        (!command.requiresPaidPlan || hasPaidPlan) &&
+                        (!command.hiddenInSandbox || !isSandboxRuntime)
                 )
             },
         ],
@@ -1907,6 +2260,27 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         // Grab freshly loaded conversation from cache; if missing, the load failed, so skip reconnect
         const conversation = maxGlobalLogic.values.conversationHistory.find((c) => c.id === parentConversationId)
         if (!conversation || conversation.messages === undefined) {
+            return
+        }
+
+        // Sandbox history-load branch. Sandbox conversations don't persist messages Django-side —
+        // history lives in S3 ACP logs, read via the products/tasks logs/ endpoint. Hand off to
+        // sandboxStreamLogic, which replays logs/ then opens SSE if non-terminal. The LangGraph
+        // reconnect path below is never entered for sandbox runtimes (coexistence).
+        if (conversation.agent_runtime === 'sandbox') {
+            // sandboxStreamLogic and posthogAiContextLogic are connected (so already mounted) for this
+            // conversation. Reset their per-conversation state before replaying this run's history.
+            actions.resetSandboxStream()
+            actions.clearSandboxAttachments()
+            if (conversation.task) {
+                const runId = conversation.task.latest_run
+                if (runId) {
+                    actions.bootstrapSandboxRun({
+                        taskId: conversation.task.id,
+                        runId,
+                    })
+                }
+            }
             return
         }
 

--- a/frontend/src/scenes/max/messages/AssistantFailureMessage.test.tsx
+++ b/frontend/src/scenes/max/messages/AssistantFailureMessage.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { AssistantFailureMessage } from './AssistantFailureMessage'
+
+describe('AssistantFailureMessage', () => {
+    afterEach(cleanup)
+
+    it('renders the supplied failure message', () => {
+        render(<AssistantFailureMessage id="failure-1" content="Internal error: Failed to authenticate" />)
+
+        expect(screen.getByText('Internal error: Failed to authenticate')).toBeInTheDocument()
+    })
+
+    it('falls back when no failure message is supplied', () => {
+        render(<AssistantFailureMessage id="failure-1" content={null} />)
+
+        expect(screen.getByText('*PostHog AI has failed to generate an answer. Please try again.*')).toBeInTheDocument()
+    })
+
+    it('renders an optional action', () => {
+        render(<AssistantFailureMessage id="failure-1" content="Failed" action={<button>Try again</button>} />)
+
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/max/messages/AssistantFailureMessage.tsx
+++ b/frontend/src/scenes/max/messages/AssistantFailureMessage.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import { MarkdownMessage } from '../MarkdownMessage'
+import { MessageTemplate } from './MessageTemplate'
+
+const DEFAULT_FAILURE_MESSAGE = '*PostHog AI has failed to generate an answer. Please try again.*'
+
+interface AssistantFailureMessageProps {
+    id: string
+    content?: string | null
+    action?: React.ReactNode
+}
+
+export const AssistantFailureMessage = React.forwardRef<HTMLDivElement, AssistantFailureMessageProps>(
+    function AssistantFailureMessage({ id, content, action }, ref) {
+        return (
+            <MessageTemplate type="ai" boxClassName="border-danger" ref={ref} action={action}>
+                <MarkdownMessage content={content || DEFAULT_FAILURE_MESSAGE} id={id} />
+            </MessageTemplate>
+        )
+    }
+)

--- a/frontend/src/scenes/max/messages/ReasoningAnswer.tsx
+++ b/frontend/src/scenes/max/messages/ReasoningAnswer.tsx
@@ -1,0 +1,35 @@
+import { IconBrain } from '@posthog/icons'
+
+import { inStorybookTestRunner } from 'lib/utils/dom'
+
+import { TaskExecutionStatus as ExecutionStatus } from '~/queries/schema/schema-assistant-messages'
+
+import { LangGraphActivity } from '../components/Activity'
+
+export interface ReasoningAnswerProps {
+    content: string
+    completed: boolean
+    id: string
+    showCompletionIcon?: boolean
+    animate?: boolean
+}
+
+export function ReasoningAnswer({
+    content,
+    completed,
+    id,
+    showCompletionIcon = true,
+    animate = false,
+}: ReasoningAnswerProps): JSX.Element {
+    return (
+        <LangGraphActivity
+            id={id}
+            content={completed ? 'Thought' : content}
+            substeps={completed ? [content] : []}
+            state={completed ? ExecutionStatus.Completed : ExecutionStatus.InProgress}
+            icon={<IconBrain />}
+            animate={!inStorybookTestRunner() && animate} // Avoiding flaky snapshots in Storybook
+            showCompletionIcon={showCompletionIcon}
+        />
+    )
+}

--- a/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
+++ b/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
@@ -61,20 +61,22 @@ export function UIPayloadAnswer({
     toolCallId,
     toolName,
     toolPayload,
+    embedded = false,
 }: {
     toolCallId: string
     toolName: string
     toolPayload: any
+    embedded?: boolean
 }): JSX.Element | null {
     const { conversationId } = useValues(maxLogic)
 
     if (toolName === 'search_session_recordings') {
         const filters = toolPayload as RecordingUniversalFilters
-        return <RecordingsWidget toolCallId={toolCallId} filters={filters} />
+        return <RecordingsWidget toolCallId={toolCallId} filters={filters} embedded={embedded} />
     }
     if (toolName === 'search_error_tracking_issues') {
         const filters = toolPayload as MaxErrorTrackingSearchResponse
-        return <ErrorTrackingFiltersWidget toolCallId={toolCallId} filters={filters} />
+        return <ErrorTrackingFiltersWidget toolCallId={toolCallId} filters={filters} embedded={embedded} />
     }
 
     // Check if this is a dangerous operation requiring approval
@@ -94,9 +96,11 @@ export function UIPayloadAnswer({
 export function RecordingsWidget({
     toolCallId,
     filters,
+    embedded = false,
 }: {
     toolCallId: string
     filters: RecordingUniversalFilters
+    embedded?: boolean
 }): JSX.Element {
     const { onAcceptSessionFilters } = useValues(maxLogic)
     const logicProps: SessionRecordingPlaylistLogicProps = {
@@ -105,14 +109,23 @@ export function RecordingsWidget({
         updateSearchParams: false,
         autoPlay: false,
     }
+    const content = (
+        <>
+            <RecordingsFiltersSummary filters={filters} />
+            <RecordingsListContent />
+            {onAcceptSessionFilters && <AcceptFiltersBar filters={filters} onAccept={onAcceptSessionFilters} />}
+        </>
+    )
 
     return (
         <BindLogic logic={sessionRecordingsPlaylistLogic} props={logicProps}>
-            <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
-                <RecordingsFiltersSummary filters={filters} />
-                <RecordingsListContent />
-                {onAcceptSessionFilters && <AcceptFiltersBar filters={filters} onAccept={onAcceptSessionFilters} />}
-            </MessageTemplate>
+            {embedded ? (
+                <div className="overflow-hidden rounded border bg-surface-primary">{content}</div>
+            ) : (
+                <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
+                    {content}
+                </MessageTemplate>
+            )}
         </BindLogic>
     )
 }
@@ -186,33 +199,47 @@ function RecordingsListContent(): JSX.Element {
 export function ErrorTrackingFiltersWidget({
     toolCallId,
     filters,
+    embedded = false,
 }: {
     toolCallId: string
     filters: MaxErrorTrackingSearchResponse | null | undefined
+    embedded?: boolean
 }): JSX.Element {
     const logicProps: MaxErrorTrackingWidgetLogicProps = { toolCallId, filters }
 
     if (!filters) {
+        const emptyState = (
+            <div className="py-2">
+                <EmptyMessage
+                    title="Error tracking data unavailable"
+                    description="The error tracking search could not be completed"
+                />
+            </div>
+        )
+        if (embedded) {
+            return <div className="overflow-hidden rounded border bg-surface-primary">{emptyState}</div>
+        }
         return (
             <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
-                <div className="py-2">
-                    <EmptyMessage
-                        title="Error tracking data unavailable"
-                        description="The error tracking search could not be completed"
-                    />
-                </div>
+                {emptyState}
             </MessageTemplate>
         )
     }
 
     return (
         <BindLogic logic={maxErrorTrackingWidgetLogic} props={logicProps}>
-            <ErrorTrackingFiltersWidgetContent filters={filters} />
+            <ErrorTrackingFiltersWidgetContent filters={filters} embedded={embedded} />
         </BindLogic>
     )
 }
 
-function ErrorTrackingFiltersWidgetContent({ filters }: { filters: MaxErrorTrackingSearchResponse }): JSX.Element {
+function ErrorTrackingFiltersWidgetContent({
+    filters,
+    embedded,
+}: {
+    filters: MaxErrorTrackingSearchResponse
+    embedded: boolean
+}): JSX.Element {
     const { activeSceneId } = useValues(sceneLogic)
     const isOnErrorTrackingPage = activeSceneId === Scene.ErrorTracking
 
@@ -280,8 +307,8 @@ function ErrorTrackingFiltersWidgetContent({ filters }: { filters: MaxErrorTrack
     const hasIssues = issues.length > 0
     const errorTrackingUrl = buildErrorTrackingUrl()
 
-    return (
-        <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
+    const content = (
+        <>
             {!isOnErrorTrackingPage && (
                 <div className="flex items-center justify-between px-2 pt-2">
                     <span className="text-xs font-semibold text-secondary">Error tracking</span>
@@ -314,6 +341,16 @@ function ErrorTrackingFiltersWidgetContent({ filters }: { filters: MaxErrorTrack
                     </div>
                 )}
             </div>
+        </>
+    )
+
+    if (embedded) {
+        return <div className="overflow-hidden rounded border bg-surface-primary">{content}</div>
+    }
+
+    return (
+        <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
+            {content}
         </MessageTemplate>
     )
 }

--- a/frontend/src/scenes/max/messages/VisualizationArtifact.tsx
+++ b/frontend/src/scenes/max/messages/VisualizationArtifact.tsx
@@ -1,0 +1,88 @@
+import { useActions, useValues } from 'kea'
+import React, { useLayoutEffect, useState } from 'react'
+
+import { IconCollapse, IconExpand } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
+import { Scene } from 'scenes/sceneTypes'
+
+import { ArtifactMessage, VisualizationArtifactContent } from '~/queries/schema/schema-assistant-messages'
+
+import { MessageStatus } from '../maxLogic'
+import { VisualizationWidget, getArtifactOpenTarget } from './VisualizationWidget'
+
+interface VisualizationArtifactProps {
+    message: ArtifactMessage & { status?: MessageStatus }
+    content: VisualizationArtifactContent
+    status?: MessageStatus
+    isEditingInsight: boolean
+    activeTabId?: string | null
+    activeSceneId?: string | null
+}
+
+function InsightSuggestionButton(): JSX.Element {
+    const { insight } = useValues(insightSceneLogic)
+    const insightProps = { dashboardItemId: insight?.short_id }
+    const { suggestedQuery, previousQuery } = useValues(insightLogic(insightProps))
+    const { onRejectSuggestedInsight, onReapplySuggestedInsight } = useActions(insightLogic(insightProps))
+
+    return (
+        <>
+            {suggestedQuery && (
+                <LemonButton
+                    onClick={() => {
+                        if (previousQuery) {
+                            onRejectSuggestedInsight()
+                        } else {
+                            onReapplySuggestedInsight()
+                        }
+                    }}
+                    sideIcon={previousQuery ? <IconCollapse /> : <IconExpand />}
+                    size="xsmall"
+                    tooltip={previousQuery ? 'Reject changes' : 'Reapply changes'}
+                />
+            )}
+        </>
+    )
+}
+
+/**
+ * LangGraph-runtime proxy for visualization artifacts. Owns the scene coupling — collapse while
+ * the insight editor consumes the result, the suggestion accept/reject button, and CTA hiding —
+ * and delegates rendering to the atomic `VisualizationWidget`.
+ */
+export const VisualizationArtifact = React.memo(function VisualizationArtifact({
+    message,
+    content,
+    status,
+    isEditingInsight,
+    activeTabId,
+    activeSceneId,
+}: VisualizationArtifactProps): JSX.Element | null {
+    // Controlled collapse synced to edit mode — a key-remount would refetch the query instead.
+    const [isCollapsed, setIsCollapsed] = useState(isEditingInsight)
+
+    useLayoutEffect(() => {
+        setIsCollapsed(isEditingInsight)
+    }, [isEditingInsight])
+
+    if (status !== 'completed') {
+        return null
+    }
+
+    const target = getArtifactOpenTarget(message, content)
+    const showSuggestionButton = isEditingInsight && !!activeTabId && activeSceneId === Scene.Insight
+
+    return (
+        <VisualizationWidget
+            content={content}
+            openUrl={isEditingInsight ? null : target.url}
+            openTooltip={target.tooltip}
+            isCollapsed={isCollapsed}
+            onCollapsedChange={setIsCollapsed}
+            extraActions={showSuggestionButton ? <InsightSuggestionButton /> : null}
+        />
+    )
+})

--- a/frontend/src/scenes/max/messages/VisualizationWidget.tsx
+++ b/frontend/src/scenes/max/messages/VisualizationWidget.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
-import React, { useLayoutEffect, useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 
 import { IconCollapse, IconExpand, IconEye, IconHide, IconWarning } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -12,9 +11,6 @@ import {
 } from 'lib/components/Cards/InsightCard/InsightDetails'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
-import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
-import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
@@ -28,63 +24,61 @@ import { QueryContext } from '~/queries/types'
 import { isFunnelsQuery, isHogQLQuery, isInsightVizNode } from '~/queries/utils'
 import { InsightShortId } from '~/types'
 
-import { MessageStatus } from '../maxLogic'
 import { visualizationTypeToQuery } from '../utils'
 import { MessageTemplate } from './MessageTemplate'
 
-interface VisualizationArtifactAnswerProps {
-    message: ArtifactMessage & { status?: MessageStatus }
-    content: VisualizationArtifactContent
-    status?: MessageStatus
-    isEditingInsight: boolean
-    activeTabId?: string | null
-    activeSceneId?: string | null
-}
-
-function InsightSuggestionButton(): JSX.Element {
-    const { insight } = useValues(insightSceneLogic)
-    const insightProps = { dashboardItemId: insight?.short_id }
-    const { suggestedQuery, previousQuery } = useValues(insightLogic(insightProps))
-    const { onRejectSuggestedInsight, onReapplySuggestedInsight } = useActions(insightLogic(insightProps))
-
-    return (
-        <>
-            {suggestedQuery && (
-                <LemonButton
-                    onClick={() => {
-                        if (previousQuery) {
-                            onRejectSuggestedInsight()
-                        } else {
-                            onReapplySuggestedInsight()
-                        }
-                    }}
-                    sideIcon={previousQuery ? <IconCollapse /> : <IconExpand />}
-                    size="xsmall"
-                    tooltip={previousQuery ? 'Reject changes' : 'Reapply changes'}
-                />
-            )}
-        </>
-    )
-}
-
 const QUERY_CONTEXT_POSTHOG_AI: QueryContext = { limitContext: 'posthog_ai' } as const
 
-export const VisualizationArtifactAnswer = React.memo(function VisualizationArtifactAnswer({
-    message,
+export interface VisualizationWidgetProps {
+    content: VisualizationArtifactContent
+    /** Href for the "Open as insight" CTA; null/undefined hides the button. */
+    openUrl?: string | null
+    /** Tooltip for the CTA. */
+    openTooltip?: string
+    /** Controlled collapse state; omit for uncontrolled (starts expanded). */
+    isCollapsed?: boolean
+    onCollapsedChange?: (isCollapsed: boolean) => void
+    /** Extra buttons rendered in the actions row before the CTA. */
+    extraActions?: React.ReactNode
+    /** Render only the widget body, for use inside an existing activity/message shell. */
+    embedded?: boolean
+}
+
+/** Resolves the "Open as insight" CTA target for a visualization artifact. */
+export function getArtifactOpenTarget(
+    envelope: ArtifactMessage,
+    content: VisualizationArtifactContent
+): { url: string | null; tooltip: string } {
+    if (envelope.source === ArtifactSource.Insight) {
+        return { url: urls.insightView(envelope.artifact_id as InsightShortId), tooltip: 'Open insight' }
+    }
+    const query = visualizationTypeToQuery(content)
+    return {
+        url: query ? urls.insightNew({ query: query as InsightVizNode | DataVisualizationNode }) : null,
+        tooltip: 'Open as new insight',
+    }
+}
+
+/**
+ * Atomic, runtime-agnostic visualization renderer. Runtime-specific behavior (scene coupling,
+ * status gating, suggestion flows) belongs in the proxy renderers that compose this widget.
+ */
+export const VisualizationWidget = React.memo(function VisualizationWidget({
     content,
-    status,
-    isEditingInsight,
-    activeTabId,
-    activeSceneId,
-}: VisualizationArtifactAnswerProps): JSX.Element | null {
-    const isSavedInsight = message.source === ArtifactSource.Insight
-
+    openUrl,
+    openTooltip = 'Open as new insight',
+    isCollapsed: controlledCollapsed,
+    onCollapsedChange,
+    extraActions,
+    embedded = false,
+}: VisualizationWidgetProps): JSX.Element {
     const [isSummaryShown, setIsSummaryShown] = useState(false)
-    const [isCollapsed, setIsCollapsed] = useState(isEditingInsight)
-
-    useLayoutEffect(() => {
-        setIsCollapsed(isEditingInsight)
-    }, [isEditingInsight])
+    const [internalCollapsed, setInternalCollapsed] = useState(false)
+    const isCollapsed = controlledCollapsed ?? internalCollapsed
+    const setCollapsed = (next: boolean): void => {
+        setInternalCollapsed(next)
+        onCollapsedChange?.(next)
+    }
 
     // Build query from either artifact content or inline visualization message
     const query = useMemo(() => {
@@ -94,28 +88,13 @@ export const VisualizationArtifactAnswer = React.memo(function VisualizationArti
     // Get the raw query for height calculation
     const rawQuery = content.query
 
-    if (status !== 'completed') {
-        return null
-    }
-
-    if (!query) {
-        return (
-            <MessageTemplate
-                type="ai"
-                className="w-full"
-                wrapperClassName="w-full"
-                boxClassName="flex flex-col w-full border-danger"
-            >
-                <div className="flex items-center gap-1.5">
-                    <IconWarning className="text-xl text-danger" />
-                    <span>Failed to load visualization</span>
-                </div>
-            </MessageTemplate>
-        )
-    }
-
-    return (
-        <MessageTemplate type="ai" className="w-full" wrapperClassName="w-full" boxClassName="flex flex-col w-full">
+    const renderedContent = !query ? (
+        <div className="flex items-center gap-1.5">
+            <IconWarning className="text-xl text-danger" />
+            <span>Failed to load visualization</span>
+        </div>
+    ) : (
+        <div className="flex flex-col w-full">
             {!isCollapsed && (
                 <div className={clsx('flex flex-col overflow-auto', isFunnelsQuery(rawQuery) ? 'h-[580px]' : 'h-96')}>
                     <Query query={query} readOnly embedded context={QUERY_CONTEXT_POSTHOG_AI} />
@@ -142,25 +121,19 @@ export const VisualizationArtifactAnswer = React.memo(function VisualizationArti
                     </h5>
                 )}
                 <div className="flex items-center gap-1.5">
-                    {isEditingInsight && activeTabId && activeSceneId === Scene.Insight && <InsightSuggestionButton />}
-                    {!isEditingInsight && (
+                    {extraActions}
+                    {openUrl && (
                         <LemonButton
-                            to={
-                                isSavedInsight
-                                    ? urls.insightView(message.artifact_id as InsightShortId)
-                                    : urls.insightNew({
-                                          query: query as InsightVizNode | DataVisualizationNode,
-                                      })
-                            }
+                            to={openUrl}
                             targetBlank
                             icon={<IconOpenInNew />}
                             size="xsmall"
-                            tooltip={isSavedInsight ? 'Open insight' : 'Open as new insight'}
+                            tooltip={openTooltip}
                         />
                     )}
                     <LemonButton
                         icon={isCollapsed ? <IconEye /> : <IconHide />}
-                        onClick={() => setIsCollapsed(!isCollapsed)}
+                        onClick={() => setCollapsed(!isCollapsed)}
                         size="xsmall"
                         className="-m-1 shrink"
                         tooltip={isCollapsed ? 'Show visualization' : 'Hide visualization'}
@@ -178,6 +151,29 @@ export const VisualizationArtifactAnswer = React.memo(function VisualizationArti
                     )}
                 </>
             )}
+        </div>
+    )
+
+    if (embedded) {
+        return renderedContent
+    }
+
+    if (!query) {
+        return (
+            <MessageTemplate
+                type="ai"
+                className="w-full"
+                wrapperClassName="w-full"
+                boxClassName="flex flex-col w-full border-danger"
+            >
+                {renderedContent}
+            </MessageTemplate>
+        )
+    }
+
+    return (
+        <MessageTemplate type="ai" className="w-full" wrapperClassName="w-full" boxClassName="flex flex-col w-full">
+            {renderedContent}
         </MessageTemplate>
     )
 })

--- a/frontend/src/scenes/max/messages/adapters/CreateInsightWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/CreateInsightWidget.tsx
@@ -1,0 +1,32 @@
+import { GenericMcpToolRenderer } from '../../sandbox/components/tool/GenericMcpToolRenderer'
+import { SandboxDataToolRow } from '../../sandbox/components/tool/SandboxDataToolRow'
+import type { SandboxToolRendererProps } from '../../sandbox/sandboxToolRegistry'
+import { VisualizationWidget, getArtifactOpenTarget } from '../VisualizationWidget'
+import { extractVisualizationArtifact } from './extractors'
+
+/**
+ * Renders insight create / update / read tool calls through `VisualizationWidget`. Until the
+ * artifact lands (pending / in-progress / malformed output) we fall back to the generic card so
+ * the call still renders something.
+ */
+export function CreateInsightWidget(props: SandboxToolRendererProps): JSX.Element {
+    const { message } = props
+    const artifact = message.status === 'completed' ? extractVisualizationArtifact(message) : null
+
+    if (!artifact) {
+        return <GenericMcpToolRenderer {...props} />
+    }
+
+    const target = getArtifactOpenTarget(artifact.envelope, artifact.content)
+
+    return (
+        <SandboxDataToolRow {...props}>
+            <VisualizationWidget
+                content={artifact.content}
+                openUrl={target.url}
+                openTooltip={target.tooltip}
+                embedded
+            />
+        </SandboxDataToolRow>
+    )
+}

--- a/frontend/src/scenes/max/messages/adapters/CreateNotebookWidget.test.tsx
+++ b/frontend/src/scenes/max/messages/adapters/CreateNotebookWidget.test.tsx
@@ -1,0 +1,62 @@
+import type { SandboxToolCallMessage } from '../../maxTypes'
+import { lookupSandboxToolRenderer, sandboxToolRegistry } from '../../sandbox/sandboxToolRegistry'
+import { extractNotebook } from './CreateNotebookWidget'
+
+function toolMessage(rawOutput: unknown, innerInput?: Record<string, unknown>): SandboxToolCallMessage {
+    return {
+        id: 'call-1',
+        resolvedKey: 'notebooks-create',
+        rawServerName: 'posthog',
+        rawToolName: 'mcp__posthog__exec',
+        rawInput: {},
+        innerInput,
+        rawOutput,
+        content: [],
+        status: 'completed',
+    }
+}
+
+describe('CreateNotebookWidget', () => {
+    it.each(['notebooks-create', 'notebooks-partial-update', 'notebooks-retrieve', 'notebook-edit'])(
+        'resolves %s to the notebook widget',
+        (key) => {
+            expect(sandboxToolRegistry.lookup(key)?.displayName).toBe('Notebook')
+            expect(lookupSandboxToolRenderer(key).displayName).toBe('Notebook')
+        }
+    )
+
+    it('falls back to the generic renderer for an unknown inner tool key', () => {
+        expect(lookupSandboxToolRenderer('some-unwired-tool').displayName).not.toBe('Notebook')
+    })
+
+    describe('extractNotebook', () => {
+        it('reads short_id, title, and the _posthogUrl enrichment from the REST payload', () => {
+            const notebook = extractNotebook(
+                toolMessage({
+                    id: 'b3d0f2aa-1111-2222-3333-444455556666',
+                    short_id: 'aBcDe123',
+                    title: 'Churn deep dive',
+                    content: { type: 'doc', content: [] },
+                    version: 1,
+                    _posthogUrl: 'https://us.posthog.com/project/1/notebooks/aBcDe123',
+                })
+            )
+            expect(notebook).toEqual({
+                shortId: 'aBcDe123',
+                title: 'Churn deep dive',
+                url: 'https://us.posthog.com/project/1/notebooks/aBcDe123',
+            })
+        })
+
+        it('falls back to the input title when the payload title is missing', () => {
+            const notebook = extractNotebook(toolMessage({ short_id: 'aBcDe123' }, { title: 'From input' }))
+            expect(notebook).toEqual({ shortId: 'aBcDe123', title: 'From input', url: undefined })
+        })
+
+        it('returns null for outputs without a short_id or that are not objects', () => {
+            expect(extractNotebook(toolMessage({ blocks: [], title: 'Legacy artifact shape' }))).toBeNull()
+            expect(extractNotebook(toolMessage('created notebook aBcDe123'))).toBeNull()
+            expect(extractNotebook(toolMessage(undefined))).toBeNull()
+        })
+    })
+})

--- a/frontend/src/scenes/max/messages/adapters/CreateNotebookWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/CreateNotebookWidget.tsx
@@ -1,0 +1,76 @@
+import { IconNotebook } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { urls } from 'scenes/urls'
+
+import { GenericMcpToolRenderer } from '../../sandbox/components/tool/GenericMcpToolRenderer'
+import { SandboxDataToolRow } from '../../sandbox/components/tool/SandboxDataToolRow'
+import type { SandboxToolRendererProps } from '../../sandbox/sandboxToolRegistry'
+
+/** The notebook fields the widget renders, pulled from the REST payload. */
+export interface NotebookExtraction {
+    shortId: string
+    title?: string
+    url?: string
+}
+
+/**
+ * Pulls the rendered fields out of a notebook tool's `rawOutput` — the REST notebook payload
+ * (`short_id`, `title`, ProseMirror `content`, …) plus the MCP server's `_posthogUrl` enrichment.
+ * `short_id` is required: outputs without it aren't a notebook payload and fall back to the
+ * generic card.
+ */
+export function extractNotebook(message: SandboxToolRendererProps['message']): NotebookExtraction | null {
+    const output = message.rawOutput
+    if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        return null
+    }
+
+    const { short_id, title, _posthogUrl } = output as { short_id?: unknown; title?: unknown; _posthogUrl?: unknown }
+    if (typeof short_id !== 'string') {
+        return null
+    }
+
+    const inputTitle = message.innerInput?.title
+    return {
+        shortId: short_id,
+        title: typeof title === 'string' ? title : typeof inputTitle === 'string' ? inputTitle : undefined,
+        url: typeof _posthogUrl === 'string' ? _posthogUrl : undefined,
+    }
+}
+
+/**
+ * Notebook create / update / get tool calls. The tool already persisted the notebook server-side,
+ * so v1 is a status line + "Open notebook" CTA — no inline preview, since the REST `content` is a
+ * ProseMirror document, not the assistant block format `NotebookArtifactAnswer` renders.
+ * Pre-completion or malformed output falls back to the generic card.
+ */
+export function CreateNotebookWidget(props: SandboxToolRendererProps): JSX.Element {
+    const { message } = props
+    const notebook = message.status === 'completed' ? extractNotebook(message) : null
+
+    if (!notebook) {
+        return <GenericMcpToolRenderer {...props} />
+    }
+
+    return (
+        <SandboxDataToolRow {...props}>
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-1.5">
+                    <IconNotebook className="text-base" />
+                    <span className="font-medium">{notebook.title || 'Notebook ready'}</span>
+                </div>
+                <LemonButton
+                    to={notebook.url ?? urls.notebook(notebook.shortId)}
+                    targetBlank
+                    icon={<IconOpenInNew />}
+                    size="xsmall"
+                    tooltip="Open notebook"
+                >
+                    Open notebook
+                </LemonButton>
+            </div>
+        </SandboxDataToolRow>
+    )
+}

--- a/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.test.tsx
+++ b/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.test.tsx
@@ -1,0 +1,163 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import type { SandboxToolCallMessage } from '../../maxTypes'
+import { EditDiffRenderer } from './EditDiffRenderer'
+
+// Monaco can't render in jsdom — stand it in for a marker that echoes the diff props we care about.
+jest.mock('lib/components/MonacoDiffEditor', () => ({
+    __esModule: true,
+    default: ({
+        original,
+        modified,
+        language,
+        theme,
+    }: {
+        original?: string
+        modified?: string
+        language?: string
+        theme?: string
+    }) => (
+        <div
+            data-attr="monaco-diff"
+            data-original={original}
+            data-modified={modified}
+            data-language={language}
+            data-theme={theme}
+        />
+    ),
+}))
+
+// Force the lazy-mount gate open so the editor instantiates.
+jest.mock('react-intersection-observer', () => ({
+    useInView: () => ({ ref: () => {}, inView: true }),
+}))
+
+// Drive the app theme without mounting themeLogic (and its scene/user deps). The arrow reads
+// `mockDarkMode` lazily at render time, so flipping it per test works.
+let mockDarkMode = false
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useValues: () => ({ isDarkModeOn: mockDarkMode }),
+}))
+
+function makeMessage(overrides: Partial<SandboxToolCallMessage> = {}): SandboxToolCallMessage {
+    return {
+        id: 'tc-1',
+        resolvedKey: 'Edit',
+        rawServerName: 'posthog',
+        rawToolName: 'Edit',
+        rawInput: {},
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+// The diff lives in the Activity's collapsible body, which auto-collapses once the call completes —
+// expand it so the editor + stats render.
+function renderExpanded(message: SandboxToolCallMessage): void {
+    render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
+    fireEvent.click(screen.getByRole('button'))
+}
+
+describe('EditDiffRenderer', () => {
+    afterEach(() => {
+        cleanup()
+        mockDarkMode = false
+    })
+
+    it('renders an inline diff with +/- stats for an Edit with a diff block', () => {
+        renderExpanded(
+            makeMessage({
+                title: 'Edit `foo.ts`',
+                content: [{ type: 'diff', path: 'foo.ts', oldText: 'a\nb', newText: 'a\nb\nc' }],
+            })
+        )
+
+        const editor = screen.getByTestId('monaco-diff')
+        expect(editor).toBeInTheDocument()
+        expect(editor).toHaveAttribute('data-original', 'a\nb')
+        expect(editor).toHaveAttribute('data-modified', 'a\nb\nc')
+        expect(editor).toHaveAttribute('data-language', 'typescript')
+        expect(editor).toHaveAttribute('data-theme', 'vs')
+        expect(screen.getByText('foo.ts')).toBeInTheDocument()
+        expect(screen.getByText('+1')).toBeInTheDocument()
+        expect(screen.getByText('-0')).toBeInTheDocument()
+    })
+
+    it('reads "Edited a file" in the header', () => {
+        render(
+            <EditDiffRenderer
+                message={makeMessage({ content: [{ type: 'diff', path: 'foo.ts', oldText: 'a', newText: 'b' }] })}
+                displayName="Edit"
+                isLastInGroup
+            />
+        )
+        expect(screen.getByText('Edited a file')).toBeInTheDocument()
+    })
+
+    it('renders one editor per diff block for a MultiEdit', () => {
+        renderExpanded(
+            makeMessage({
+                resolvedKey: 'MultiEdit',
+                content: [
+                    { type: 'diff', path: 'foo.ts', oldText: 'a', newText: 'b' },
+                    { type: 'content', content: { type: 'diff', path: 'foo.ts', oldText: 'b', newText: 'c' } },
+                ],
+            })
+        )
+
+        expect(screen.getAllByTestId('monaco-diff')).toHaveLength(2)
+    })
+
+    it('reads "Created a file" with all-added stats and an empty original for a new file (Write)', () => {
+        const message = makeMessage({
+            resolvedKey: 'Write',
+            content: [{ type: 'diff', path: 'new.py', oldText: null, newText: 'print(1)\nprint(2)' }],
+        })
+        render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
+        expect(screen.getByText('Created a file')).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button'))
+        const editor = screen.getByTestId('monaco-diff')
+        expect(editor).toHaveAttribute('data-original', '')
+        expect(editor).toHaveAttribute('data-language', 'python')
+        expect(screen.getByText('+2')).toBeInTheDocument()
+    })
+
+    it('resolves filename and language from rawInput.file_path when the diff block has no path', () => {
+        renderExpanded(
+            makeMessage({
+                content: [{ type: 'diff', oldText: 'a', newText: 'b' }],
+                rawInput: { file_path: 'main.go' },
+            })
+        )
+
+        expect(screen.getByText('main.go')).toBeInTheDocument()
+        expect(screen.getByTestId('monaco-diff')).toHaveAttribute('data-language', 'go')
+    })
+
+    it('falls back to the generic tool card (no editor) when there is no diff block', () => {
+        // A built-in Edit carries its name in `claudeToolName` with an empty wire `toolName`.
+        const message = makeMessage({
+            title: 'Edit `foo.ts`',
+            claudeToolName: 'Edit',
+            rawToolName: '',
+            content: [{ type: 'text', text: 'no diff yet' }],
+        })
+        render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
+
+        expect(screen.queryByTestId('monaco-diff')).not.toBeInTheDocument()
+        // The generic card still renders the rich tool title as its header.
+        expect(screen.getByText('Edit `foo.ts`')).toBeInTheDocument()
+    })
+
+    it('uses the dark Monaco theme when the app is in dark mode', () => {
+        mockDarkMode = true
+        renderExpanded(makeMessage({ content: [{ type: 'diff', path: 'foo.ts', oldText: 'a', newText: 'b' }] }))
+
+        expect(screen.getByTestId('monaco-diff')).toHaveAttribute('data-theme', 'vs-dark')
+    })
+})

--- a/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.tsx
+++ b/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.tsx
@@ -1,0 +1,124 @@
+import { useValues } from 'kea'
+import type { editor } from 'monaco-editor'
+import { useInView } from 'react-intersection-observer'
+
+import { IconPencil } from '@posthog/icons'
+
+import MonacoDiffEditor from 'lib/components/MonacoDiffEditor'
+
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+
+import { GenericMcpToolRenderer } from '../../sandbox/components/tool/GenericMcpToolRenderer'
+import { SandboxFilePath } from '../../sandbox/components/tool/SandboxFilePath'
+import { SandboxToolActivity } from '../../sandbox/components/tool/SandboxToolActivity'
+import type { SandboxToolRendererProps } from '../../sandbox/sandboxToolRegistry'
+import { findAllDiffContent, getDiffStats, languageFromPath, type ToolCallDiffContent } from '../../toolDiffContent'
+
+// A stripped-down, unified diff that reads cleanly embedded in a chat card — mirrors the look of the
+// sandbox agent's own diff UI (unified style, soft-wrapped, compact font, no editor chrome). Module-level
+// so the object identity is stable across renders: MonacoDiffEditor calls `updateOptions` whenever this
+// prop changes, and a fresh literal each render would thrash it during streaming.
+const DIFF_EDITOR_OPTIONS: editor.IDiffEditorConstructionOptions = {
+    readOnly: true,
+    renderSideBySide: false,
+    hideUnchangedRegions: { enabled: true },
+    diffAlgorithm: 'advanced',
+    wordWrap: 'on',
+    diffWordWrap: 'inherit',
+    fontSize: 12,
+    lineNumbers: 'on',
+    minimap: { enabled: false },
+    renderOverviewRuler: false,
+    overviewRulerLanes: 0,
+    overviewRulerBorder: false,
+    hideCursorInOverviewRuler: true,
+    scrollBeyondLastLine: false,
+    folding: false,
+    glyphMargin: false,
+    renderLineHighlight: 'none',
+    renderGutterMenu: false,
+    guides: { indentation: false },
+    padding: { top: 4, bottom: 4 },
+    // Don't trap the thread's scroll when the cursor is over the diff.
+    scrollbar: { alwaysConsumeMouseWheel: false, vertical: 'auto', horizontal: 'auto' },
+}
+
+function DiffEditor({ diff, path }: { diff: ToolCallDiffContent; path?: string }): JSX.Element {
+    // Lazy-mount: only instantiate the Monaco diff editor once the card scrolls near the viewport.
+    const { ref, inView } = useInView({ rootMargin: '500px', triggerOnce: true })
+    // Match the surrounding app theme — without this Monaco falls back to its default `vs` (white) theme.
+    const { isDarkModeOn } = useValues(themeLogic)
+
+    return (
+        <div ref={ref} className="w-full min-w-0">
+            {inView ? (
+                <MonacoDiffEditor
+                    original={diff.oldText ?? ''}
+                    value={diff.newText ?? ''}
+                    modified={diff.newText ?? ''}
+                    language={languageFromPath(path)}
+                    theme={isDarkModeOn ? 'vs-dark' : 'vs'}
+                    options={DIFF_EDITOR_OPTIONS}
+                />
+            ) : (
+                <div className="h-24 rounded border border-border-secondary" />
+            )}
+        </div>
+    )
+}
+
+/** +added / -removed mono stat chip for a diff. */
+function DiffStats({ added, removed }: { added: number; removed: number }): JSX.Element {
+    return (
+        <span className="font-mono text-xs shrink-0">
+            <span className="text-success">+{added}</span> <span className="text-danger">-{removed}</span>
+        </span>
+    )
+}
+
+/**
+ * Renderer for Edit / Write / MultiEdit / NotebookEdit. The header reads "Edited a file" / "Created a
+ * file" (or "Edited N files"); expanding the card reveals the filename, line stats, and an inline visual
+ * diff per file. Without `type: "diff"` content blocks it degrades to the generic card.
+ */
+export function EditDiffRenderer(props: SandboxToolRendererProps): JSX.Element {
+    const { message, icon, turnComplete, turnCancelled } = props
+    const diffs = findAllDiffContent(message.content)
+
+    if (diffs.length === 0) {
+        return <GenericMcpToolRenderer {...props} />
+    }
+
+    const fallbackPath = typeof message.rawInput.file_path === 'string' ? message.rawInput.file_path : undefined
+    const isCreate = diffs.length === 1 && diffs[0].oldText == null
+    const title = diffs.length > 1 ? `Edited ${diffs.length} files` : isCreate ? 'Created a file' : 'Edited a file'
+
+    const body = (
+        <div className="flex flex-col gap-3 w-full min-w-0">
+            {diffs.map((diff, index) => {
+                const path = diff.path ?? fallbackPath
+                const stats = getDiffStats(diff.oldText, diff.newText)
+                return (
+                    <div key={index} className="flex flex-col gap-1 w-full min-w-0">
+                        <div className="flex items-center gap-2 min-w-0">
+                            {path && <SandboxFilePath path={path} />}
+                            <DiffStats added={stats.added} removed={stats.removed} />
+                        </div>
+                        <DiffEditor diff={diff} path={path} />
+                    </div>
+                )
+            })}
+        </div>
+    )
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconPencil />}
+            title={title}
+            body={body}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        />
+    )
+}

--- a/frontend/src/scenes/max/messages/adapters/ErrorTrackingWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/ErrorTrackingWidget.tsx
@@ -1,0 +1,26 @@
+import { GenericMcpToolRenderer } from '../../sandbox/components/tool/GenericMcpToolRenderer'
+import { SandboxDataToolRow } from '../../sandbox/components/tool/SandboxDataToolRow'
+import type { SandboxToolRendererProps } from '../../sandbox/sandboxToolRegistry'
+import { ErrorTrackingFiltersWidget } from '../UIPayloadAnswer'
+import { extractErrorTrackingResponse } from './extractors'
+
+/**
+ * Error-tracking search / filter tool calls. `rawOutput` is a `MaxErrorTrackingSearchResponse`
+ * directly; `ErrorTrackingFiltersWidget` renders the filter chips + paginated issue list (and
+ * pushes filters into the error-tracking scene when it is active). Pre-completion or missing output
+ * falls back to the generic card.
+ */
+export function ErrorTrackingWidget(props: SandboxToolRendererProps): JSX.Element {
+    const { message } = props
+    const filters = message.status === 'completed' ? extractErrorTrackingResponse(message) : null
+
+    if (!filters) {
+        return <GenericMcpToolRenderer {...props} />
+    }
+
+    return (
+        <SandboxDataToolRow {...props}>
+            <ErrorTrackingFiltersWidget toolCallId={message.id} filters={filters} embedded />
+        </SandboxDataToolRow>
+    )
+}

--- a/frontend/src/scenes/max/messages/adapters/QueryWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/QueryWidget.tsx
@@ -1,0 +1,25 @@
+import { GenericMcpToolRenderer } from '../../sandbox/components/tool/GenericMcpToolRenderer'
+import { SandboxDataToolRow } from '../../sandbox/components/tool/SandboxDataToolRow'
+import type { SandboxToolRendererProps } from '../../sandbox/sandboxToolRegistry'
+import { VisualizationWidget } from '../VisualizationWidget'
+import { extractQueryResult } from './extractors'
+
+/**
+ * Renders the MCP query-wrapper tools (query-trends, query-funnel, ...) through
+ * `VisualizationWidget` as inline ephemeral visualizations. Pending calls and outputs without an
+ * inline renderer fall back to the generic card.
+ */
+export function QueryWidget(props: SandboxToolRendererProps): JSX.Element {
+    const { message } = props
+    const result = message.status === 'completed' ? extractQueryResult(message) : null
+
+    if (!result) {
+        return <GenericMcpToolRenderer {...props} />
+    }
+
+    return (
+        <SandboxDataToolRow {...props}>
+            <VisualizationWidget content={result.content} openUrl={result.url} openTooltip="Open as insight" embedded />
+        </SandboxDataToolRow>
+    )
+}

--- a/frontend/src/scenes/max/messages/adapters/SearchSessionRecordingsWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/SearchSessionRecordingsWidget.tsx
@@ -1,0 +1,25 @@
+import { GenericMcpToolRenderer } from '../../sandbox/components/tool/GenericMcpToolRenderer'
+import { SandboxDataToolRow } from '../../sandbox/components/tool/SandboxDataToolRow'
+import type { SandboxToolRendererProps } from '../../sandbox/sandboxToolRegistry'
+import { RecordingsWidget } from '../UIPayloadAnswer'
+import { extractRecordingFilters } from './extractors'
+
+/**
+ * Session-recording search / filter tool calls. The resolved `RecordingUniversalFilters` come back
+ * in `rawOutput.filters`; `RecordingsWidget` renders the live playlist inline. Pre-completion or a
+ * missing filter object falls back to the generic card.
+ */
+export function SearchSessionRecordingsWidget(props: SandboxToolRendererProps): JSX.Element {
+    const { message } = props
+    const filters = message.status === 'completed' ? extractRecordingFilters(message) : null
+
+    if (!filters) {
+        return <GenericMcpToolRenderer {...props} />
+    }
+
+    return (
+        <SandboxDataToolRow {...props}>
+            <RecordingsWidget toolCallId={message.id} filters={filters} embedded />
+        </SandboxDataToolRow>
+    )
+}

--- a/frontend/src/scenes/max/messages/adapters/UpsertDashboardWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/UpsertDashboardWidget.tsx
@@ -1,0 +1,42 @@
+import { IconDashboard } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { urls } from 'scenes/urls'
+
+import { GenericMcpToolRenderer } from '../../sandbox/components/tool/GenericMcpToolRenderer'
+import { SandboxDataToolRow } from '../../sandbox/components/tool/SandboxDataToolRow'
+import type { SandboxToolRendererProps } from '../../sandbox/sandboxToolRegistry'
+import { extractDashboard } from './extractors'
+
+/**
+ * Dashboard create / update tool calls. v1 is a status line + "View dashboard" CTA (a full
+ * dashboard embed is deliberately deferred). Pre-completion or malformed output falls back to
+ * the generic card.
+ */
+export function UpsertDashboardWidget(props: SandboxToolRendererProps): JSX.Element {
+    const { message } = props
+    const dashboard = message.status === 'completed' ? extractDashboard(message) : null
+
+    if (!dashboard) {
+        return <GenericMcpToolRenderer {...props} />
+    }
+
+    const to = dashboard.url ?? (dashboard.id !== undefined ? urls.dashboard(dashboard.id) : undefined)
+
+    return (
+        <SandboxDataToolRow {...props}>
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-1.5">
+                    <IconDashboard className="text-base" />
+                    <span className="font-medium">{dashboard.name || 'Dashboard ready'}</span>
+                </div>
+                {to && (
+                    <LemonButton to={to} targetBlank icon={<IconOpenInNew />} size="xsmall" tooltip="Open dashboard">
+                        View dashboard
+                    </LemonButton>
+                )}
+            </div>
+        </SandboxDataToolRow>
+    )
+}

--- a/frontend/src/scenes/max/messages/adapters/extractors.test.ts
+++ b/frontend/src/scenes/max/messages/adapters/extractors.test.ts
@@ -1,0 +1,188 @@
+import { ArtifactSource } from '~/queries/schema/schema-assistant-messages'
+
+import type { SandboxToolCallMessage } from '../../maxTypes'
+import {
+    extractDashboard,
+    extractErrorTrackingResponse,
+    extractQueryResult,
+    extractRecordingFilters,
+    extractVisualizationArtifact,
+} from './extractors'
+
+function toolMessage(
+    rawOutput: unknown,
+    innerInput?: Record<string, unknown>,
+    resolvedKey = 'test-tool'
+): SandboxToolCallMessage {
+    return {
+        id: 'call-1',
+        resolvedKey,
+        rawServerName: 'posthog',
+        rawToolName: 'mcp__posthog__exec',
+        rawInput: {},
+        innerInput,
+        rawOutput,
+        content: [],
+        status: 'completed',
+    }
+}
+
+describe('mcp tool adapter extractors', () => {
+    describe('extractVisualizationArtifact', () => {
+        it('classifies a REST insight payload with short_id as a saved insight', () => {
+            const artifact = extractVisualizationArtifact(
+                toolMessage({ short_id: 'abc12345', name: 'Signups', query: { kind: 'TrendsQuery' } })
+            )
+            expect(artifact?.envelope.source).toBe(ArtifactSource.Insight)
+            expect(artifact?.envelope.artifact_id).toBe('abc12345')
+            expect(artifact?.content.name).toBe('Signups')
+        })
+
+        it('classifies a query-only output as ephemeral', () => {
+            const artifact = extractVisualizationArtifact(toolMessage({ query: { kind: 'TrendsQuery' }, results: [] }))
+            expect(artifact?.envelope.source).toBe(ArtifactSource.State)
+            expect(artifact?.envelope.artifact_id).toBe('call-1')
+        })
+
+        it('returns null when the output has no query', () => {
+            expect(extractVisualizationArtifact(toolMessage({ id: 1, name: 'No query here' }))).toBeNull()
+            expect(extractVisualizationArtifact(toolMessage(undefined))).toBeNull()
+        })
+    })
+
+    describe('extractDashboard', () => {
+        it('reads id and the _posthogUrl enrichment from the REST payload', () => {
+            const dashboard = extractDashboard(
+                toolMessage({ id: 42, name: 'KPIs', _posthogUrl: 'https://us.posthog.com/project/1/dashboard/42' })
+            )
+            expect(dashboard).toEqual({
+                id: 42,
+                name: 'KPIs',
+                url: 'https://us.posthog.com/project/1/dashboard/42',
+            })
+        })
+
+        it('falls back to legacy dashboard_id / url fields and the input name', () => {
+            const dashboard = extractDashboard(
+                toolMessage({ dashboard_id: '7', url: '/dashboard/7' }, { name: 'From input' })
+            )
+            expect(dashboard).toEqual({ id: '7', name: 'From input', url: '/dashboard/7' })
+        })
+    })
+
+    describe('extractRecordingFilters', () => {
+        it('maps the query-wrapper output back to universal filters', () => {
+            const filters = extractRecordingFilters(
+                toolMessage({
+                    query: {
+                        kind: 'RecordingsQuery',
+                        date_from: '-7d',
+                        filter_test_accounts: true,
+                        properties: [{ type: 'person', key: 'email', operator: 'icontains', value: 'posthog' }],
+                    },
+                    results: [],
+                    _posthogUrl: 'https://us.posthog.com/project/1/replay',
+                })
+            )
+            expect(filters?.date_from).toBe('-7d')
+            expect(filters?.filter_test_accounts).toBe(true)
+            expect(filters?.filter_group.values).toEqual([
+                {
+                    type: 'AND',
+                    values: [{ type: 'person', key: 'email', operator: 'icontains', value: 'posthog' }],
+                },
+            ])
+        })
+
+        it('passes through a ready-made universal filters object', () => {
+            const universal = {
+                date_from: '-3d',
+                duration: [],
+                filter_group: { type: 'AND', values: [] },
+            }
+            expect(extractRecordingFilters(toolMessage({ filters: universal }))).toBe(universal)
+        })
+
+        it('returns null for outputs carrying neither shape', () => {
+            expect(extractRecordingFilters(toolMessage({ results: [] }))).toBeNull()
+            expect(extractRecordingFilters(toolMessage({ filters: { some: 'garbage' } }))).toBeNull()
+            expect(extractRecordingFilters(toolMessage(undefined))).toBeNull()
+        })
+    })
+
+    describe('extractErrorTrackingResponse', () => {
+        it('accepts outputs carrying known search-response fields', () => {
+            const response = { status: 'active', search_query: 'TypeError', issues: [] }
+            expect(extractErrorTrackingResponse(toolMessage(response))).toBe(response)
+        })
+
+        it('rejects outputs without any known field', () => {
+            expect(extractErrorTrackingResponse(toolMessage({ results: [{ id: 'issue-1' }] }))).toBeNull()
+            expect(extractErrorTrackingResponse(toolMessage(undefined))).toBeNull()
+        })
+    })
+
+    describe('extractQueryResult', () => {
+        it.each(['TrendsQuery', 'FunnelsQuery', 'RetentionQuery', 'StickinessQuery', 'PathsQuery', 'LifecycleQuery'])(
+            'passes a bare %s through for InsightVizNode wrapping downstream',
+            (kind) => {
+                const result = extractQueryResult(
+                    toolMessage({
+                        query: { kind, series: [] },
+                        results: [],
+                        _posthogUrl: 'https://us.posthog.com/insights/new',
+                    })
+                )
+                expect(result?.content.query).toEqual({ kind, series: [] })
+                expect(result?.url).toBe('https://us.posthog.com/insights/new')
+            }
+        )
+
+        it('wraps a TracesQuery in a DataTableNode', () => {
+            const result = extractQueryResult(toolMessage({ query: { kind: 'TracesQuery' }, results: [] }))
+            expect(result?.content.query).toEqual({ kind: 'DataTableNode', source: { kind: 'TracesQuery' } })
+            expect(result?.url).toBeNull()
+        })
+
+        it('uses the tool input when optimized streamed results omit structured raw output', () => {
+            const result = extractQueryResult(
+                toolMessage(undefined, { kind: 'TrendsQuery', series: [], output_format: 'optimized' }, 'query-trends')
+            )
+            expect(result?.content.query).toEqual({ kind: 'TrendsQuery', series: [] })
+            expect(result?.url).toBeNull()
+        })
+
+        it('infers the query kind from the wrapper tool key when the input omits kind', () => {
+            const result = extractQueryResult(toolMessage(undefined, { series: [] }, 'query-trends'))
+            expect(result?.content.query).toEqual({ kind: 'TrendsQuery', series: [] })
+        })
+
+        it('wraps the actors wrapper output (ActorsQuery envelope) untouched in a DataTableNode', () => {
+            const actorsQuery = {
+                kind: 'ActorsQuery',
+                source: { kind: 'InsightActorsQuery', source: { kind: 'TrendsQuery' } },
+                select: ['actor'],
+            }
+            const result = extractQueryResult(
+                toolMessage({ query: actorsQuery, results: { columns: [], results: [] } })
+            )
+            expect(result?.content.query).toEqual({ kind: 'DataTableNode', source: actorsQuery })
+        })
+
+        it('wraps a bare InsightActorsQuery in an ActorsQuery before the DataTableNode', () => {
+            const insightActors = { kind: 'InsightActorsQuery', source: { kind: 'TrendsQuery' } }
+            const result = extractQueryResult(toolMessage({ query: insightActors }))
+            expect(result?.content.query).toEqual({
+                kind: 'DataTableNode',
+                source: { kind: 'ActorsQuery', source: insightActors, select: ['actor'] },
+            })
+        })
+
+        it('returns null for kinds without an inline renderer or malformed outputs', () => {
+            expect(extractQueryResult(toolMessage({ query: { kind: 'TraceQuery', traceId: 't1' } }))).toBeNull()
+            expect(extractQueryResult(toolMessage({ results: [] }))).toBeNull()
+            expect(extractQueryResult(toolMessage({ query: 'not-an-object' }))).toBeNull()
+            expect(extractQueryResult(toolMessage(undefined))).toBeNull()
+        })
+    })
+})

--- a/frontend/src/scenes/max/messages/adapters/extractors.ts
+++ b/frontend/src/scenes/max/messages/adapters/extractors.ts
@@ -1,0 +1,231 @@
+import { recordingsQueryToUniversalFilters } from 'scenes/session-recordings/filters/recordingsQueryConversions'
+
+import { MaxErrorTrackingSearchResponse } from '~/queries/schema/schema-assistant-error-tracking'
+import {
+    ArtifactContentType,
+    ArtifactMessage,
+    ArtifactSource,
+    AssistantMessageType,
+    VisualizationArtifactContent,
+} from '~/queries/schema/schema-assistant-messages'
+import { DataTableNode, NodeKind, RecordingsQuery } from '~/queries/schema/schema-general'
+import { isInsightQueryNode } from '~/queries/utils'
+import { RecordingUniversalFilters } from '~/types'
+
+import type { SandboxToolCallMessage } from '../../maxTypes'
+
+/**
+ * Shared shape extractors for the sandbox MCP tool renderer widgets. Each turns a flattened
+ * `SandboxToolCallMessage` (built by `sandboxStreamLogic` from ACP frames) into the props the atomic
+ * `messages/*` widgets expect.
+ */
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === 'string' ? value : undefined
+}
+
+const QUERY_WRAPPER_KIND_BY_TOOL_KEY: Record<string, NodeKind> = {
+    'query-trends': NodeKind.TrendsQuery,
+    'query-funnel': NodeKind.FunnelsQuery,
+    'query-retention': NodeKind.RetentionQuery,
+    'query-stickiness': NodeKind.StickinessQuery,
+    'query-paths': NodeKind.PathsQuery,
+    'query-lifecycle': NodeKind.LifecycleQuery,
+    'query-llm-traces-list': NodeKind.TracesQuery,
+    'query-trends-actors': NodeKind.InsightActorsQuery,
+    'query-lifecycle-actors': NodeKind.InsightActorsQuery,
+    'query-paths-actors': NodeKind.InsightActorsQuery,
+    'query-retention-actors': NodeKind.InsightActorsQuery,
+}
+
+function queryFromToolInput(message: SandboxToolCallMessage): Record<string, unknown> | null {
+    const input = asRecord(message.innerInput)
+    if (!input) {
+        return null
+    }
+
+    const query = { ...input }
+    delete query.output_format
+
+    if (typeof query.kind === 'string') {
+        return query
+    }
+
+    const inferredKind = QUERY_WRAPPER_KIND_BY_TOOL_KEY[message.resolvedKey]
+    return inferredKind ? { ...query, kind: inferredKind } : null
+}
+
+/** The artifact envelope + content the visualization widget proxies consume. */
+export interface VisualizationArtifactExtraction {
+    envelope: ArtifactMessage
+    content: VisualizationArtifactContent
+}
+
+/**
+ * Pulls a `VisualizationArtifactContent` out of an insight tool's `rawOutput`. The backend MCP
+ * server returns the artifact directly in the existing schema shape. Saved insights
+ * (create / update / get) carry a `short_id` in the REST payload (or an explicit `artifact_id`);
+ * query-only outputs carry neither and render inline as ephemeral visualizations.
+ */
+export function extractVisualizationArtifact(message: SandboxToolCallMessage): VisualizationArtifactExtraction | null {
+    const output = asRecord(message.rawOutput)
+    if (!output) {
+        return null
+    }
+
+    const query = output.query
+    if (!query) {
+        return null
+    }
+
+    const artifactId = asString(output.artifact_id) ?? asString(output.short_id) ?? message.id
+    const isSaved = asString(output.short_id) !== undefined || asString(output.artifact_id) !== undefined
+    const source = isSaved ? ArtifactSource.Insight : ArtifactSource.State
+
+    const content: VisualizationArtifactContent = {
+        content_type: ArtifactContentType.Visualization,
+        query: query as VisualizationArtifactContent['query'],
+        name: asString(output.name) ?? asString(message.innerInput?.name) ?? null,
+        description: asString(output.description) ?? null,
+    }
+
+    const envelope: ArtifactMessage = {
+        type: AssistantMessageType.Artifact,
+        id: message.id,
+        artifact_id: artifactId,
+        source,
+        content,
+    }
+
+    return { envelope, content }
+}
+
+/** A query-wrapper tool result mapped onto renderable visualization content. */
+export interface QueryResultExtraction {
+    content: VisualizationArtifactContent
+    /** The MCP server's `_posthogUrl` enrichment — the "open as insight" CTA target. */
+    url: string | null
+}
+
+/**
+ * Maps a query-wrapper tool's output (`{query, results, _posthogUrl}`) onto visualization
+ * content. Insight queries pass through bare (the widget wraps them in `InsightVizNode`);
+ * table-renderable kinds are wrapped in a `DataTableNode` here. Kinds without an inline
+ * renderer (e.g. a single LLM trace) return null and fall back to the generic card.
+ */
+export function extractQueryResult(message: SandboxToolCallMessage): QueryResultExtraction | null {
+    const output = asRecord(message.rawOutput)
+    const query = (output ? asRecord(output.query) : null) ?? queryFromToolInput(message)
+    if (!query || typeof query.kind !== 'string') {
+        return null
+    }
+
+    let renderable: VisualizationArtifactContent['query'] | null = null
+    if (isInsightQueryNode(query)) {
+        renderable = query as VisualizationArtifactContent['query']
+    } else if (query.kind === NodeKind.TracesQuery || query.kind === NodeKind.ActorsQuery) {
+        // The actors wrappers echo a ready-made ActorsQuery envelope; traces come back bare.
+        renderable = { kind: NodeKind.DataTableNode, source: query } as unknown as DataTableNode
+    } else if (query.kind === NodeKind.InsightActorsQuery) {
+        // Defensive: a bare InsightActorsQuery isn't a table source — wrap it in an ActorsQuery first.
+        renderable = {
+            kind: NodeKind.DataTableNode,
+            source: { kind: NodeKind.ActorsQuery, source: query, select: ['actor'] },
+        } as unknown as DataTableNode
+    }
+
+    if (!renderable) {
+        return null
+    }
+
+    return {
+        content: {
+            content_type: ArtifactContentType.Visualization,
+            query: renderable,
+            name: null,
+            description: null,
+        },
+        url: asString(output?._posthogUrl) ?? null,
+    }
+}
+
+/** Dashboard create/update output — the REST payload (`id`, `name`) plus the MCP server's `_posthogUrl` enrichment. */
+export interface DashboardExtraction {
+    id?: string | number
+    name?: string
+    url?: string
+}
+
+export function extractDashboard(message: SandboxToolCallMessage): DashboardExtraction | null {
+    const output = asRecord(message.rawOutput)
+    if (!output) {
+        return null
+    }
+    const id = (output.id ?? output.dashboard_id) as string | number | undefined
+    return {
+        id,
+        name: asString(output.name) ?? asString(message.innerInput?.name),
+        url: asString(output._posthogUrl) ?? asString(output.url),
+    }
+}
+
+/**
+ * Resolves the `RecordingUniversalFilters` the playlist widget renders. The query-wrapper tool
+ * echoes the executed `RecordingsQuery` back under `rawOutput.query`, which we convert; a
+ * ready-made universal filters object under `rawOutput.filters` is passed through. Anything else
+ * falls back to the generic card rather than feeding the playlist a shape it can't use.
+ */
+export function extractRecordingFilters(message: SandboxToolCallMessage): RecordingUniversalFilters | null {
+    const output = asRecord(message.rawOutput)
+    if (!output) {
+        return null
+    }
+
+    const directFilters = asRecord(output.filters)
+    if (directFilters && 'filter_group' in directFilters && Array.isArray(directFilters.duration)) {
+        return directFilters as unknown as RecordingUniversalFilters
+    }
+
+    const query = asRecord(output.query)
+    if (query && query.kind === NodeKind.RecordingsQuery) {
+        const recordingsQuery = query as unknown as RecordingsQuery
+        // The shared converter intentionally drops list-level fields (its caller manages them
+        // separately) — carry them over so the widget reflects what the agent actually searched.
+        return {
+            ...recordingsQueryToUniversalFilters(recordingsQuery),
+            date_from: recordingsQuery.date_from ?? null,
+            date_to: recordingsQuery.date_to ?? null,
+            order: recordingsQuery.order,
+            order_direction: recordingsQuery.order_direction,
+            limit: recordingsQuery.limit,
+            session_ids: recordingsQuery.session_ids,
+        }
+    }
+
+    return null
+}
+
+const ERROR_TRACKING_RESPONSE_KEYS: readonly (keyof MaxErrorTrackingSearchResponse)[] = [
+    'issues',
+    'search_query',
+    'status',
+    'date_from',
+    'order_by',
+]
+
+/**
+ * Error-tracking search output is a `MaxErrorTrackingSearchResponse` (a filters echo plus issue
+ * previews) for `ErrorTrackingFiltersWidget`. Outputs that carry none of its fields — e.g. a raw
+ * REST issues list — fall back to the generic card instead of rendering empty filter chips.
+ */
+export function extractErrorTrackingResponse(message: SandboxToolCallMessage): MaxErrorTrackingSearchResponse | null {
+    const output = asRecord(message.rawOutput)
+    if (!output || !ERROR_TRACKING_RESPONSE_KEYS.some((key) => key in output)) {
+        return null
+    }
+    return output as MaxErrorTrackingSearchResponse
+}

--- a/frontend/src/scenes/max/messages/posthogProducts.ts
+++ b/frontend/src/scenes/max/messages/posthogProducts.ts
@@ -1,0 +1,74 @@
+/**
+ * PostHog product taxonomy for the sandbox resources bar. Ported from the agent's
+ * `POSTHOG_PRODUCTS` (ids + labels are authoritative there) with icons sourced from
+ * `@posthog/icons`. The `_posthog/resources_used` wire frame already carries `{id, label}`, so this
+ * map is the icon source plus a fallback label for any id the wire omits. Labels are NOT a
+ * mechanical sentence-casing of the id (e.g. `llm_analytics → "AI observability"`,
+ * `cdp → "Data pipelines"`, acronyms stay all-caps), so they are copied verbatim.
+ */
+import {
+    IconAI,
+    IconCursor,
+    IconDatabase,
+    IconFlask,
+    IconGraph,
+    IconHogQL,
+    IconLogomark,
+    IconMessage,
+    IconPlug,
+    IconPulse,
+    IconRewind,
+    IconServer,
+    IconToggle,
+    IconWarning,
+} from '@posthog/icons'
+
+export type PostHogProductId =
+    | 'product_analytics'
+    | 'web_analytics'
+    | 'feature_flags'
+    | 'experiments'
+    | 'error_tracking'
+    | 'session_replay'
+    | 'surveys'
+    | 'llm_analytics'
+    | 'data_warehouse'
+    | 'cdp'
+    | 'logs'
+    | 'apm'
+    | 'sql'
+    | 'posthog'
+
+export interface PostHogProductMeta {
+    label: string
+    Icon: typeof IconGraph
+}
+
+export const POSTHOG_PRODUCTS: Record<PostHogProductId, PostHogProductMeta> = {
+    product_analytics: { label: 'Product analytics', Icon: IconGraph },
+    web_analytics: { label: 'Web analytics', Icon: IconPulse },
+    feature_flags: { label: 'Feature flags', Icon: IconToggle },
+    experiments: { label: 'Experiments', Icon: IconFlask },
+    error_tracking: { label: 'Error tracking', Icon: IconWarning },
+    session_replay: { label: 'Session replay', Icon: IconRewind },
+    surveys: { label: 'Surveys', Icon: IconMessage },
+    llm_analytics: { label: 'AI observability', Icon: IconAI },
+    data_warehouse: { label: 'Data warehouse', Icon: IconDatabase },
+    cdp: { label: 'Data pipelines', Icon: IconPlug },
+    logs: { label: 'Logs', Icon: IconServer },
+    apm: { label: 'APM', Icon: IconCursor },
+    sql: { label: 'SQL', Icon: IconHogQL },
+    posthog: { label: 'PostHog', Icon: IconLogomark },
+}
+
+/** Fallback icon for ids absent from the taxonomy — degrade gracefully rather than disappearing. */
+export const FALLBACK_PRODUCT_ICON = IconLogomark
+
+/** Resolve a product id to its icon + display label, tolerating unknown ids (uses the wire label). */
+export function resolveProductMeta(id: string, wireLabel?: string): PostHogProductMeta {
+    const known = POSTHOG_PRODUCTS[id as PostHogProductId]
+    if (known) {
+        return { label: wireLabel || known.label, Icon: known.Icon }
+    }
+    return { label: wireLabel || id, Icon: FALLBACK_PRODUCT_ICON }
+}

--- a/frontend/src/scenes/max/posthogAiContextLogic.tsx
+++ b/frontend/src/scenes/max/posthogAiContextLogic.tsx
@@ -1,0 +1,155 @@
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import posthog from 'posthog-js'
+import type { ReactNode } from 'react'
+
+import { IconDashboard, IconGraph, IconNotebook } from '@posthog/icons'
+
+import { IconAction, IconEvent } from 'lib/lemon-ui/icons'
+import { sceneLogic } from 'scenes/sceneLogic'
+
+import { AttachedContext, MaxContextInput, MaxContextType } from './maxTypes'
+import type { posthogAiContextLogicType } from './posthogAiContextLogicType'
+
+export interface PosthogAiContextLogicProps {
+    conversationId: string
+}
+
+/** Stable dedupe + chip key for an attachment: `${type}:${id ?? value}`. */
+export function attachedContextKey(item: AttachedContext): string {
+    return `${item.type}:${item.id ?? item.value ?? ''}`
+}
+
+/**
+ * Projects a rich scene `MaxContextInput` down to the flat `AttachedContext` shape the sandbox
+ * runtime sends. Strips nested entity data — the agent fetches details via its read tools.
+ * Returns null for inputs that have no flat representation.
+ */
+export function projectToAttachedContext(item: MaxContextInput): AttachedContext | null {
+    switch (item.type) {
+        case MaxContextType.DASHBOARD:
+            return { type: 'dashboard', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.INSIGHT:
+            return { type: 'insight', id: item.data.short_id, name: item.data.name ?? undefined }
+        case MaxContextType.EVENT:
+            return { type: 'event', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.ACTION:
+            return { type: 'action', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.ERROR_TRACKING_ISSUE:
+            return { type: 'error_tracking_issue', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.EVALUATION:
+            return { type: 'evaluation', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.NOTEBOOK:
+            return { type: 'notebook', id: item.data.short_id, name: item.data.title ?? undefined }
+        default:
+            return null
+    }
+}
+
+function iconForType(type: AttachedContext['type']): ReactNode {
+    switch (type) {
+        case 'dashboard':
+            return <IconDashboard />
+        case 'insight':
+            return <IconGraph />
+        case 'event':
+            return <IconEvent />
+        case 'action':
+            return <IconAction />
+        case 'notebook':
+            return <IconNotebook />
+        default:
+            return <IconGraph />
+    }
+}
+
+function labelForItem(item: AttachedContext): string {
+    if (item.type === 'text') {
+        return item.value ?? 'Text'
+    }
+    if (item.name) {
+        return item.name
+    }
+    return `${item.type} ${item.id ?? ''}`.trim()
+}
+
+/**
+ * Sandbox-runtime context store. Holds one flat `attachments` reducer plus a scene-pull
+ * listener that reads the existing scenes' `maxContext` selectors and projects their rich
+ * items down to `AttachedContext` at consumption time — zero scene-side edits.
+ *
+ * Coexistence sibling to `maxContextLogic.ts`; used only when `agent_runtime === 'sandbox'`.
+ *
+ * Keyed by conversation id so each conversation keeps its own attachment set.
+ */
+export const posthogAiContextLogic = kea<posthogAiContextLogicType>([
+    props({} as PosthogAiContextLogicProps),
+    key((props) => props.conversationId),
+    path((key) => ['scenes', 'max', 'posthogAiContextLogic', key]),
+    connect(() => ({
+        values: [sceneLogic, ['activeSceneLogic']],
+    })),
+    actions({
+        /** Dedup-add. Called by scene sync AND by the TaxonomicFilter affordance. */
+        attach: (item: AttachedContext) => ({ item }),
+        /** Remove by `${type}:${id ?? value}` key. */
+        detach: (key: string) => ({ key }),
+        /** Convenience reset, e.g. on a new conversation. */
+        clearAttachments: true,
+        /** Router/scene listener — projects every current-scene item and attaches it. */
+        syncSceneAttachments: true,
+    }),
+    reducers({
+        attachments: [
+            [] as AttachedContext[],
+            {
+                attach: (state, { item }) => {
+                    const key = attachedContextKey(item)
+                    // Text items are never deduped — repeated text is intentional.
+                    if (item.type !== 'text' && state.some((existing) => attachedContextKey(existing) === key)) {
+                        return state
+                    }
+                    return [...state, item]
+                },
+                detach: (state, { key }) => state.filter((item) => attachedContextKey(item) !== key),
+                clearAttachments: () => [],
+            },
+        ],
+    }),
+    selectors({
+        chipsForDisplay: [
+            (s) => [s.attachments],
+            // No onRemove closures here — removal dispatches `detach(key)` on the consumer's
+            // bound instance, so chips stay instance-agnostic data.
+            (attachments): { key: string; label: string; icon: ReactNode }[] =>
+                attachments.map((item) => ({
+                    key: attachedContextKey(item),
+                    label: labelForItem(item),
+                    icon: iconForType(item.type),
+                })),
+        ],
+    }),
+    listeners(({ values, actions }) => ({
+        syncSceneAttachments: () => {
+            const activeSceneLogic = values.activeSceneLogic
+            if (!activeSceneLogic || !('maxContext' in activeSceneLogic.selectors)) {
+                return
+            }
+            let sceneItems: MaxContextInput[] = []
+            try {
+                // BuiltLogic exposes selector results on `.values`; props are already bound.
+                sceneItems = (activeSceneLogic.values as { maxContext?: MaxContextInput[] }).maxContext ?? []
+            } catch (error) {
+                // The scene's maxContext selector threw (e.g. dereferencing still-loading state).
+                // Capture so the dropped attach is observable instead of silent; nothing to attach.
+                posthog.captureException(error)
+                return
+            }
+            for (const item of sceneItems) {
+                const projected = projectToAttachedContext(item)
+                if (projected) {
+                    actions.attach(projected)
+                }
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/max/sandbox/SandboxGitArtifacts.test.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxGitArtifacts.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { SandboxPullRequestCard } from './SandboxPullRequestCard'
+import { SandboxRunContext } from './SandboxRunContext'
+
+const PR_URL = 'https://github.com/PostHog/posthog/pull/123'
+
+// Visibility is the caller's concern (SandboxThread mounts these only when the run reports the
+// relevant artifact), so these cover only that each renders its data when mounted.
+describe('sandbox git artifacts', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('SandboxRunContext renders the working and base branch', () => {
+        render(<SandboxRunContext branch="feat/x" baseBranch="master" repo="PostHog/posthog" />)
+        expect(screen.getByText('feat/x')).toBeInTheDocument()
+        expect(screen.getByText('master')).toBeInTheDocument()
+        expect(screen.getByText('PostHog/posthog')).toBeInTheDocument()
+    })
+
+    it('SandboxRunContext renders just the branch when there is no base or repo', () => {
+        render(<SandboxRunContext branch="feat/x" />)
+        expect(screen.getByText('feat/x')).toBeInTheDocument()
+    })
+
+    it('SandboxPullRequestCard renders the success card and a link to the PR', () => {
+        render(<SandboxPullRequestCard prUrl={PR_URL} branch="feat/x" />)
+        expect(screen.getByText('Pull request opened')).toBeInTheDocument()
+        expect(screen.getByText('feat/x')).toBeInTheDocument()
+        expect(screen.getByRole('link', { name: /Open on GitHub/ })).toHaveAttribute('href', PR_URL)
+    })
+})

--- a/frontend/src/scenes/max/sandbox/SandboxPullRequestCard.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxPullRequestCard.tsx
@@ -1,0 +1,40 @@
+import { memo } from 'react'
+
+import { IconCheckCircle, IconExternal, IconPullRequest } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+/**
+ * Post-turn "Pull request opened" card for a sandbox coding run — the web port of PostHog Code's
+ * `GitActionResult`, adapted to LemonUI. Plain props, `React.memo`'d — `prUrl` is required, so the
+ * caller decides whether to mount it (only once a run has opened a PR and is no longer thinking).
+ * Frontend-only: it shows the link + branch, no diff stats (those need a backend wire field; see the
+ * logic's follow-ups).
+ */
+export const SandboxPullRequestCard = memo(function SandboxPullRequestCard({
+    prUrl,
+    branch,
+}: {
+    prUrl: string
+    branch?: string
+}): JSX.Element {
+    return (
+        <div
+            className="flex flex-col gap-2 rounded-lg border border-success bg-success-highlight p-3"
+            data-attr="max-sandbox-pr-card"
+        >
+            <div className="flex items-center gap-2">
+                <IconCheckCircle className="size-4 shrink-0 text-success" />
+                <span className="text-sm font-medium text-success">Pull request opened</span>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+                <span className="flex items-center gap-1.5 text-xs text-muted">
+                    <IconPullRequest className="size-3.5 shrink-0" />
+                    {branch ? <span className="font-mono">{branch}</span> : null}
+                </span>
+                <LemonButton type="secondary" size="xsmall" icon={<IconExternal />} to={prUrl} targetBlank>
+                    Open on GitHub
+                </LemonButton>
+            </div>
+        </div>
+    )
+})

--- a/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.test.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.test.tsx
@@ -1,0 +1,99 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import type { SandboxToolCallMessage } from '../maxTypes'
+import { SandboxQuestionRenderer } from './SandboxQuestionRenderer'
+
+function makeMessage(overrides: Partial<SandboxToolCallMessage> = {}): SandboxToolCallMessage {
+    return {
+        id: 'tc-1',
+        resolvedKey: 'AskUserQuestion',
+        rawServerName: '',
+        rawToolName: 'AskUserQuestion',
+        claudeToolName: 'AskUserQuestion',
+        rawInput: {
+            questions: [
+                {
+                    question: 'Which goal matters most?',
+                    header: 'Goal',
+                    multiSelect: false,
+                    options: [{ label: 'Activation' }, { label: 'Revenue' }],
+                },
+            ],
+        },
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+function renderCard(message: SandboxToolCallMessage): void {
+    render(<SandboxQuestionRenderer message={message} isLastInGroup displayName="Question" />)
+}
+
+describe('SandboxQuestionRenderer', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('previews the answer on the second line and shows the full Q&A on expand', () => {
+        renderCard(makeMessage({ rawOutput: { answers: { 'Which goal matters most?': 'Revenue' } } }))
+
+        // Preview on the header's second line (always visible).
+        expect(screen.getByText('Revenue')).toBeInTheDocument()
+        // The full question + answer live in the collapsible body.
+        expect(screen.queryByText('Which goal matters most?')).not.toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button'))
+        expect(screen.getByText('Which goal matters most?')).toBeInTheDocument()
+        expect(screen.getAllByText('Revenue').some((el) => el.classList.contains('font-medium'))).toBe(true)
+        // The header label ("Goal") is dropped from the recap.
+        expect(screen.queryByText('Goal')).not.toBeInTheDocument()
+    })
+
+    it('does not render a body while the question is still being asked', () => {
+        renderCard(makeMessage({ status: 'in_progress', rawOutput: undefined }))
+
+        expect(screen.queryByText('Which goal matters most?')).not.toBeInTheDocument()
+        expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('recaps each answer for a multi-question request', () => {
+        renderCard(
+            makeMessage({
+                rawInput: {
+                    questions: [
+                        { question: 'Goal?', header: 'Goal', multiSelect: false, options: [{ label: 'Revenue' }] },
+                        { question: 'When?', header: 'When', multiSelect: false, options: [{ label: 'Weekly' }] },
+                    ],
+                },
+                rawOutput: { answers: { 'Goal?': 'Revenue', 'When?': 'Weekly' } },
+            })
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+        expect(screen.getByText('Revenue')).toBeInTheDocument()
+        expect(screen.getByText('Weekly')).toBeInTheDocument()
+    })
+
+    it('falls back to a joined answer string when there is no per-question map', () => {
+        renderCard(makeMessage({ rawOutput: { text: 'User picked Revenue' } }))
+
+        expect(screen.getByText('User picked Revenue')).toBeInTheDocument()
+    })
+
+    it('shows the error message when the call failed', () => {
+        renderCard(makeMessage({ status: 'failed', rawOutput: undefined, error: { message: 'Question timed out' } }))
+
+        expect(screen.getByText('Question timed out')).toBeInTheDocument()
+    })
+
+    it('falls back to the generic tool card when the input has no questions', () => {
+        renderCard(makeMessage({ rawInput: {}, rawOutput: undefined }))
+
+        // The generic card renders instead of the question recap.
+        expect(screen.getByText('Question')).toBeInTheDocument()
+        expect(screen.queryByText('Which goal matters most?')).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.tsx
@@ -1,0 +1,65 @@
+import { IconAI } from '@posthog/icons'
+
+import {
+    extractSandboxQuestionAnswer,
+    parseSandboxQuestionAnswers,
+    parseSandboxQuestions,
+} from '../sandboxQuestionUtils'
+import { GenericMcpToolRenderer } from './components/tool/GenericMcpToolRenderer'
+import { SandboxToolActivity } from './components/tool/SandboxToolActivity'
+import { truncateText } from './components/tool/toolContentUtils'
+import type { SandboxToolRendererProps } from './sandboxToolRegistry'
+
+/**
+ * Thread recap for the `AskUserQuestion` Claude built-in. The interactive answering happens in the
+ * input overlay (`SandboxQuestionInput`); this is the transcript record: the chosen answers preview on
+ * the header's second line, and the full question + answer in the expandable body. Malformed input
+ * falls back to the generic tool card.
+ */
+export function SandboxQuestionRenderer(props: SandboxToolRendererProps): JSX.Element {
+    const { message, icon, displayName, turnComplete, turnCancelled } = props
+    const questions = parseSandboxQuestions(message.rawInput)
+
+    if (questions.length === 0) {
+        return <GenericMcpToolRenderer {...props} />
+    }
+
+    const answersByKey = parseSandboxQuestionAnswers(message.rawOutput)
+    // When the result didn't carry a per-question map, fall back to a single joined answer string
+    // (the agent's `extractAnswer`) attributed to the first question, so the answer is never lost.
+    const fallbackAnswer =
+        Object.keys(answersByKey).length === 0 ? extractSandboxQuestionAnswer(message.rawOutput) : null
+
+    const answered = questions
+        .map((question, index) => {
+            const answer = answersByKey[question.question] ?? (index === 0 ? fallbackAnswer : null)
+            return answer ? { question: question.question, answer } : null
+        })
+        .filter((entry): entry is { question: string; answer: string } => entry !== null)
+
+    const answerPreview = answered.map((entry) => entry.answer).join(', ')
+
+    const body =
+        answered.length > 0 ? (
+            <div className="flex flex-col gap-3">
+                {answered.map((entry, index) => (
+                    <div key={index} className="flex flex-col gap-1 text-xs">
+                        <div className="text-muted">{entry.question}</div>
+                        <span className="font-medium text-secondary">{entry.answer}</span>
+                    </div>
+                ))}
+            </div>
+        ) : undefined
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconAI />}
+            title={message.title || displayName || 'Question'}
+            subtitle={answerPreview ? truncateText(answerPreview, 120) : undefined}
+            body={body}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        />
+    )
+}

--- a/frontend/src/scenes/max/sandbox/SandboxRunContext.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxRunContext.tsx
@@ -1,0 +1,41 @@
+import { memo } from 'react'
+
+import { IconGitBranch } from '@posthog/icons'
+
+/**
+ * Pre-turn header for a sandbox coding run: a one-line "Working on <repo> · <branch> → <base>"
+ * summary. Plain props, `React.memo`'d — `branch` is required, so the caller decides whether to mount
+ * it (only when a run reports git context). This complements — does not replace — the
+ * `_posthog/progress` provisioning steps.
+ */
+export const SandboxRunContext = memo(function SandboxRunContext({
+    branch,
+    baseBranch,
+    repo,
+}: {
+    branch: string
+    baseBranch?: string
+    repo?: string
+}): JSX.Element {
+    return (
+        <div className="flex items-center gap-1.5 px-3 py-1 text-xs text-muted" data-attr="max-sandbox-run-context">
+            <IconGitBranch className="size-3.5 shrink-0" />
+            <span className="min-w-0 truncate">
+                Working on{' '}
+                {repo ? (
+                    <>
+                        <span className="font-medium">{repo}</span>
+                        {' · '}
+                    </>
+                ) : null}
+                <span className="font-mono">{branch}</span>
+                {baseBranch ? (
+                    <>
+                        {' → '}
+                        <span className="font-mono">{baseBranch}</span>
+                    </>
+                ) : null}
+            </span>
+        </div>
+    )
+})

--- a/frontend/src/scenes/max/sandbox/SandboxThreadItems.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxThreadItems.tsx
@@ -1,0 +1,61 @@
+import { IconCheck, IconWarning, IconX } from '@posthog/icons'
+import { Spinner } from '@posthog/lemon-ui'
+
+import { cn } from 'lib/utils/css-classes'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
+
+import type { ThreadItem } from '../types/sandboxStreamTypes'
+
+/** Inline `_posthog/status` item — a spinner while compacting, a generic status line otherwise. */
+export function SandboxStatusItem({ item }: { item: ThreadItem }): JSX.Element {
+    const isCompacting = item.status === 'compacting' && !item.isComplete
+    return (
+        <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted">
+            {isCompacting ? (
+                <>
+                    <Spinner className="size-3" />
+                    <span>Compacting conversation history…</span>
+                </>
+            ) : (
+                <span>Status: {item.status}</span>
+            )}
+        </div>
+    )
+}
+
+/** Inline `_posthog/compact_boundary` item — the post-compaction rule. */
+export function SandboxCompactBoundaryItem({ item }: { item: ThreadItem }): JSX.Element {
+    return (
+        <div className="flex items-center gap-2 py-1 text-xs text-muted">
+            <div className="h-px grow bg-border" />
+            <span className="shrink-0">
+                Conversation compacted
+                {item.trigger ? ` (${item.trigger})` : ''}
+                {typeof item.preTokens === 'number'
+                    ? ` · ~${humanFriendlyNumber(item.preTokens)} tokens summarized`
+                    : ''}
+            </span>
+            <div className="h-px grow bg-border" />
+        </div>
+    )
+}
+
+/** Inline `_posthog/task_notification` item — a colored rule by status (completed/failed/stopped). */
+export function SandboxTaskNotificationItem({ item }: { item: ThreadItem }): JSX.Element {
+    const colorClass =
+        item.status === 'completed' ? 'text-success' : item.status === 'failed' ? 'text-danger' : 'text-warning'
+    const icon =
+        item.status === 'completed' ? (
+            <IconCheck className="size-3" />
+        ) : item.status === 'failed' ? (
+            <IconX className="size-3" />
+        ) : (
+            <IconWarning className="size-3" />
+        )
+    return (
+        <div className={cn('flex items-center justify-center gap-1.5 py-1 text-xs', colorClass)}>
+            {icon}
+            <span>{item.summary || `Task ${item.status}`}</span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/sandbox/components/SandboxRunViewer.tsx
+++ b/frontend/src/scenes/max/sandbox/components/SandboxRunViewer.tsx
@@ -1,0 +1,92 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { Spinner } from '@posthog/lemon-ui'
+
+import { cn } from 'lib/utils/css-classes'
+
+import { sandboxStreamLogic } from '../../sandboxStreamLogic'
+import { SandboxThreadView } from './SandboxThreadView'
+
+export interface SandboxRunViewerProps {
+    taskId: string
+    runId: string
+    /** Stable logic key; defaults to `runId` (the run is the unit being viewed). */
+    streamKey?: string
+    /** Telemetry tag only — omit for conversation-less runs (automation, Slack, signals, PR-triggered). */
+    conversationId?: string
+    /**
+     * Replay the persisted `logs/` snapshot once and never open SSE (default `true`, the safe choice
+     * for a static run viewer). Pass `false` for an in-progress run to stream live frames over SSE,
+     * falling back to replay automatically once the run goes terminal. Folded into the logic key, so a
+     * live and a replay viewer of the same run can never share state.
+     */
+    replayOnly?: boolean
+    className?: string
+}
+
+/**
+ * Embeddable read-only viewer of a task run's agent thread. Binds a `sandboxStreamLogic` instance
+ * (keyed apart from any other stream of the same run) and renders the shared `SandboxThreadView`. With
+ * the default `replayOnly`, it replays the persisted `logs/` snapshot once — no SSE. With
+ * `replayOnly={false}` it streams an in-progress run live (and replays once terminal). No permissions,
+ * no composer. Drop in anywhere with just `(taskId, runId)`.
+ */
+export function SandboxRunViewer({
+    taskId,
+    runId,
+    streamKey,
+    conversationId,
+    replayOnly = true,
+    className,
+}: SandboxRunViewerProps): JSX.Element {
+    return (
+        <BindLogic logic={sandboxStreamLogic} props={{ streamKey: streamKey ?? runId, conversationId, replayOnly }}>
+            <SandboxRunViewerContent taskId={taskId} runId={runId} replayOnly={replayOnly} className={className} />
+        </BindLogic>
+    )
+}
+
+function SandboxRunViewerContent({
+    taskId,
+    runId,
+    replayOnly,
+    className,
+}: {
+    taskId: string
+    runId: string
+    replayOnly: boolean
+    className?: string
+}): JSX.Element {
+    const { bootstrapLoading, threadItems } = useValues(sandboxStreamLogic)
+    const { bootstrapRun, reset } = useActions(sandboxStreamLogic)
+
+    useEffect(() => {
+        // Reset first so a reused instance (stable streamKey, changed run) replays/streams the new run
+        // cleanly; the bound logic keys read-only instances apart from any live stream of the same run.
+        // `replayOnly` is in the deps so a status transition (live → terminal) re-bootstraps the right
+        // mode — the bound logic re-keys on it, so `bootstrapRun`/`reset` are fresh references anyway.
+        reset()
+        bootstrapRun({ taskId, runId })
+    }, [taskId, runId, replayOnly, bootstrapRun, reset])
+
+    const showSpinner = bootstrapLoading && threadItems.length === 0
+
+    return (
+        <div
+            className={cn(
+                '@container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
+                className
+            )}
+        >
+            {showSpinner ? (
+                <div className="flex justify-center py-8">
+                    <Spinner className="text-2xl" />
+                </div>
+            ) : (
+                // An error surfaces as a `handleStreamError` item folded into the thread, so it renders here too.
+                <SandboxThreadView />
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/sandbox/components/SandboxThreadView.tsx
+++ b/frontend/src/scenes/max/sandbox/components/SandboxThreadView.tsx
@@ -1,0 +1,218 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { IconWrench } from '@posthog/icons'
+
+import { TaskExecutionStatus as ExecutionStatus } from '~/queries/schema/schema-assistant-messages'
+
+import { SandboxActivity } from '../../components/Activity'
+import { MarkdownMessage } from '../../MarkdownMessage'
+import type { SandboxToolCallMessage } from '../../maxTypes'
+import { AssistantFailureMessage } from '../../messages/AssistantFailureMessage'
+import { MessageTemplate } from '../../messages/MessageTemplate'
+import { ReasoningAnswer } from '../../messages/ReasoningAnswer'
+import { sandboxStreamLogic } from '../../sandboxStreamLogic'
+import type { SandboxProgressStep, ThreadItem as SandboxThreadItem } from '../../types/sandboxStreamTypes'
+import { getRandomThinkingMessage } from '../../utils/thinkingMessages'
+import { SandboxPullRequestCard } from '../SandboxPullRequestCard'
+import { SandboxRunContext } from '../SandboxRunContext'
+import { SandboxCompactBoundaryItem, SandboxStatusItem, SandboxTaskNotificationItem } from '../SandboxThreadItems'
+import { resolveToolCall } from '../sandboxToolResolver'
+import { SandboxToolCall } from './tool/SandboxToolCall'
+
+/** Maps a raw merged `ToolInvocation` into the flat `SandboxToolCallMessage` the registry renderers read. */
+function toolInvocationToMessage(
+    invocation: ReturnType<typeof sandboxStreamLogic.values.toolInvocations.get>
+): SandboxToolCallMessage | null {
+    if (!invocation) {
+        return null
+    }
+    const resolved = resolveToolCall(invocation)
+    return {
+        id: invocation.toolCallId,
+        resolvedKey: resolved.resolvedKey,
+        rawServerName: invocation.rawServerName,
+        rawToolName: invocation.rawToolName,
+        innerToolName: resolved.innerToolName,
+        claudeToolName: resolved.claudeToolName,
+        rawInput: invocation.input,
+        innerInput: resolved.innerInput,
+        rawOutput: invocation.output,
+        content: invocation.contentBlocks,
+        status: invocation.status,
+        title: invocation.title,
+        kind: invocation.kind,
+        locations: invocation.locations,
+        error: invocation.error,
+    }
+}
+
+/**
+ * Sandbox-runtime thread presenter. Reads `sandboxStreamLogic.values.threadItems` (assistant text,
+ * tool-invocation references, run separators, inline errors) from whatever `sandboxStreamLogic`
+ * instance is bound above it — a live PostHog AI conversation or a read-only run viewer — and
+ * dispatches tool cards through the sandbox tool registry. Conversation-agnostic by design: it knows
+ * only the bound stream logic, never langgraph vs sandbox or the conversation.
+ */
+export function SandboxThreadView(): JSX.Element {
+    // Drive the thinking indicator from real agent progress: show the latest `_posthog/progress`
+    // message while the run is active, falling back to the canned rotation.
+    const {
+        threadItems,
+        toolInvocations,
+        currentProgress,
+        isThinking,
+        streamPhase,
+        runArtifacts,
+        turnComplete,
+        currentRunStatus,
+    } = useValues(sandboxStreamLogic)
+    const turnCancelled = currentRunStatus === 'cancelled'
+    const hasActiveProgressItem = threadItems.some(
+        (item) => item.type === 'progress' && item.progressSteps?.some((step) => step.status === 'in_progress')
+    )
+
+    return (
+        <>
+            {runArtifacts.branch && (
+                <SandboxRunContext
+                    branch={runArtifacts.branch}
+                    baseBranch={runArtifacts.baseBranch}
+                    repo={runArtifacts.repo}
+                />
+            )}
+            {threadItems.map((item, index) => {
+                if (item.type === 'human_message') {
+                    return (
+                        <MessageTemplate key={item.id} type="human">
+                            <MarkdownMessage content={item.text || '*No text.*'} id={item.id} />
+                        </MessageTemplate>
+                    )
+                }
+                if (item.type === 'assistant_message') {
+                    return (
+                        <MessageTemplate key={item.id} type="ai">
+                            <MarkdownMessage content={item.text ?? ''} id={item.id} />
+                        </MessageTemplate>
+                    )
+                }
+                if (item.type === 'assistant_thought') {
+                    // Empty chunks prime the stream before any reasoning text arrives — skip them so
+                    // a contentless "Thought" never shows; the bottom indicator covers that gap.
+                    if (!item.text?.trim()) {
+                        return null
+                    }
+                    // Collapse to "Thought" once a later block starts or the run stops thinking —
+                    // mirrors the LangGraph thread's reasoning-complete rule.
+                    const completed = index !== threadItems.length - 1 || !isThinking
+                    return (
+                        <ReasoningAnswer
+                            key={item.id}
+                            content={item.text}
+                            id={item.id}
+                            completed={completed}
+                            showCompletionIcon={false}
+                        />
+                    )
+                }
+                if (item.type === 'tool_invocation' && item.toolCallId) {
+                    const message = toolInvocationToMessage(toolInvocations.get(item.toolCallId))
+                    if (!message) {
+                        return null
+                    }
+                    return (
+                        <SandboxToolCall
+                            key={item.id}
+                            message={message}
+                            turnComplete={turnComplete}
+                            turnCancelled={turnCancelled}
+                        />
+                    )
+                }
+                if (item.type === 'error') {
+                    return <AssistantFailureMessage key={item.id} id={item.id} content={item.errorMessage} />
+                }
+                if (item.type === 'status') {
+                    return <SandboxStatusItem key={item.id} item={item} />
+                }
+                if (item.type === 'compact_boundary') {
+                    return <SandboxCompactBoundaryItem key={item.id} item={item} />
+                }
+                if (item.type === 'task_notification') {
+                    return <SandboxTaskNotificationItem key={item.id} item={item} />
+                }
+                if (item.type === 'progress') {
+                    return <SandboxProgressItem key={item.id} item={item} />
+                }
+                return null
+            })}
+            {streamPhase === 'thinking' && !hasActiveProgressItem && (
+                <SandboxThinkingIndicator progress={currentProgress} />
+            )}
+            {/* Post-turn only: a reconnect refetch can fold in a pr_url mid-run, so gate on !isThinking. */}
+            {!isThinking && runArtifacts.prUrl && (
+                <SandboxPullRequestCard prUrl={runArtifacts.prUrl} branch={runArtifacts.branch} />
+            )}
+        </>
+    )
+}
+
+function progressStepText(step: SandboxProgressStep): string {
+    return step.detail ? `${step.label}\n\n${step.detail}` : step.label
+}
+
+function resolveSandboxProgressState(steps: SandboxProgressStep[]): ExecutionStatus {
+    if (steps.some((step) => step.status === 'failed')) {
+        return ExecutionStatus.Failed
+    }
+    if (steps.some((step) => step.status === 'in_progress')) {
+        return ExecutionStatus.InProgress
+    }
+    if (steps.length > 0 && steps.every((step) => step.status === 'pending')) {
+        return ExecutionStatus.Pending
+    }
+    return ExecutionStatus.Completed
+}
+
+function resolveSandboxProgressHeadline(steps: SandboxProgressStep[]): string {
+    const active = steps.find((step) => step.status === 'in_progress')
+    if (active) {
+        return active.label
+    }
+    return steps.at(-1)?.label ?? 'Working'
+}
+
+function SandboxProgressItem({ item }: { item: SandboxThreadItem }): JSX.Element | null {
+    const steps = item.progressSteps ?? []
+    if (!steps.length) {
+        return null
+    }
+
+    const headline = resolveSandboxProgressHeadline(steps)
+    const substeps = steps.length > 1 ? steps.map(progressStepText) : []
+    const state = resolveSandboxProgressState(steps)
+
+    return (
+        <SandboxActivity
+            id={item.id}
+            content={headline}
+            substeps={substeps}
+            state={state}
+            icon={<IconWrench />}
+            showCompletionIcon={true}
+        />
+    )
+}
+
+/**
+ * Bottom-of-thread "what's it doing right now" line for sandbox conversations. Reflects the latest
+ * `_posthog/progress` message when present, otherwise the canned thinking rotation.
+ */
+function SandboxThinkingIndicator({ progress }: { progress: string | null }): JSX.Element {
+    // One roll per mount — re-rolling on every progress transition would visibly swap the verb.
+    const fallbackMessage = useMemo(() => getRandomThinkingMessage(), [])
+    const message = progress?.trim() ? progress : fallbackMessage
+    // Match the LangGraph loader: a bubble-free reasoning line (muted brain icon + muted text),
+    // static (no shimmer), via the shared Activity primitive — not a MessageTemplate bubble.
+    return <ReasoningAnswer content={message} id="sandbox-thinking" completed={false} showCompletionIcon={false} />
+}

--- a/frontend/src/scenes/max/sandbox/components/tool/GenericMcpToolRenderer.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/GenericMcpToolRenderer.tsx
@@ -1,0 +1,67 @@
+import clsx from 'clsx'
+import { memo } from 'react'
+
+import { IconWrench } from '@posthog/icons'
+
+import type { SandboxToolRendererProps } from '../../sandboxToolRegistry'
+import { SandboxToolActivity } from './SandboxToolActivity'
+import { compactInput, formatInput, getContentText, stripCodeFences } from './toolContentUtils'
+import { ToolOutput } from './ToolOutput'
+
+/**
+ * The catch-all tool card — user-installed MCP tools, unmapped PostHog `exec` inner tools, and Claude
+ * built-ins without a bespoke renderer. PostHog `exec` inner tools read `Call <tool>`; other MCP tools
+ * read `Call <server> – <tool> (MCP)`; non-MCP built-ins show their friendly title. A compact input
+ * preview sits on the second line and the body shows any text output. Replaces the old
+ * `FallbackMcpToolRenderer`.
+ */
+export const GenericMcpToolRenderer = memo(function GenericMcpToolRenderer(
+    props: SandboxToolRendererProps
+): JSX.Element {
+    const { message, icon, displayName, turnComplete, turnCancelled } = props
+
+    const isPostHogExec = !!message.innerToolName
+    const isMcp =
+        isPostHogExec || (!!message.rawServerName && !!message.rawToolName && message.rawServerName !== 'claude')
+    const serverName = isPostHogExec ? 'posthog' : message.rawServerName
+    const toolLabel =
+        message.innerToolName || message.rawToolName || message.claudeToolName || displayName || message.resolvedKey
+    const inputForPreview = message.innerInput ?? message.rawInput
+    const hasInput = !!inputForPreview && Object.keys(inputForPreview).length > 0
+    const preview = hasInput ? compactInput(inputForPreview) : ''
+    const output = stripCodeFences(getContentText(message.content))
+
+    // Plain neutral title text, matching the built-in tool cards (e.g. "Read N lines"). A single text
+    // node is also one flex item, so the header's `inline-flex` wrapper keeps the spaces intact.
+    const title = isPostHogExec
+        ? `Call ${toolLabel}`
+        : isMcp
+          ? `Call ${serverName} – ${toolLabel} (MCP)`
+          : message.title || displayName || toolLabel
+
+    // Subagent / MCP / unmapped tools show both the full input and the text output in the body.
+    const formattedInput = hasInput ? formatInput(inputForPreview) : ''
+    const body =
+        formattedInput || output ? (
+            <div className="flex flex-col gap-2 min-w-0">
+                {formattedInput && <ToolOutput>{formattedInput}</ToolOutput>}
+                {output && (
+                    <div className={clsx('min-w-0', formattedInput && 'border-t border-border-secondary pt-2')}>
+                        <ToolOutput>{output}</ToolOutput>
+                    </div>
+                )}
+            </div>
+        ) : undefined
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconWrench />}
+            title={title}
+            subtitle={preview ? <span className="font-mono">{preview}</span> : undefined}
+            body={body}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        />
+    )
+})

--- a/frontend/src/scenes/max/sandbox/components/tool/SandboxDataToolRow.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/SandboxDataToolRow.tsx
@@ -1,0 +1,26 @@
+import { type PropsWithChildren } from 'react'
+
+import type { SandboxToolRendererProps } from '../../sandboxToolRegistry'
+import { SandboxToolActivity } from './SandboxToolActivity'
+
+/**
+ * Shared shell for the data-tool adapters (insight, dashboard, recordings, query, error tracking,
+ * notebook). Renders the registry icon + tool title as the header and the adapter's visualization as
+ * always-visible content below it (via the Activity bridge), keeping data tools consistent with the
+ * per-tool cards while each adapter keeps its own lazy chunk.
+ */
+export function SandboxDataToolRow({ children, ...props }: PropsWithChildren<SandboxToolRendererProps>): JSX.Element {
+    const { message, icon, displayName, turnComplete, turnCancelled } = props
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon}
+            title={message.title || displayName || 'Tool'}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        >
+            {children}
+        </SandboxToolActivity>
+    )
+}

--- a/frontend/src/scenes/max/sandbox/components/tool/SandboxFilePath.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/SandboxFilePath.tsx
@@ -1,0 +1,21 @@
+import { IconDocument } from '@posthog/icons'
+
+import { getFilename } from './toolContentUtils'
+
+/**
+ * Non-clickable file reference chip — a document icon, the bold filename, and a dimmed parent
+ * directory that ellipsizes on overflow. There is no file-open panel in the sandbox UI, so unlike
+ * the agent's own FileMentionChip this is purely informational.
+ */
+export function SandboxFilePath({ path }: { path: string }): JSX.Element {
+    const filename = getFilename(path)
+    const dir = path.slice(0, path.length - filename.length).replace(/\/+$/, '')
+
+    return (
+        <span className="inline-flex items-center gap-1 min-w-0 max-w-full font-mono text-xs">
+            <IconDocument className="shrink-0 text-muted size-3.5" />
+            <span className="font-medium text-secondary shrink-0">{filename}</span>
+            {dir && <span className="text-muted truncate">{dir}</span>}
+        </span>
+    )
+}

--- a/frontend/src/scenes/max/sandbox/components/tool/SandboxToolActivity.test.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/SandboxToolActivity.test.tsx
@@ -1,0 +1,70 @@
+import '@testing-library/jest-dom'
+
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import type { SandboxToolCallMessage } from '../../../maxTypes'
+import { SandboxToolActivity } from './SandboxToolActivity'
+
+function makeMessage(overrides: Partial<SandboxToolCallMessage> = {}): SandboxToolCallMessage {
+    return {
+        id: 'tc-1',
+        resolvedKey: 'Bash',
+        rawServerName: 'claude',
+        rawToolName: '',
+        rawInput: {},
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+describe('SandboxToolActivity', () => {
+    it('renders the title and subtitle (second line)', () => {
+        render(<SandboxToolActivity message={makeMessage()} title="Terminal" subtitle="ls -la" />)
+        expect(screen.getByText('Terminal')).toBeInTheDocument()
+        expect(screen.getByText('ls -la')).toBeInTheDocument()
+    })
+
+    it('keeps the body collapsed once completed and expands on click', () => {
+        render(<SandboxToolActivity message={makeMessage()} title="Terminal" body={<div>command output</div>} />)
+        expect(screen.queryByText('command output')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button'))
+        expect(screen.getByText('command output')).toBeInTheDocument()
+    })
+
+    it('auto-expands the body while the tool is running', () => {
+        render(
+            <SandboxToolActivity
+                message={makeMessage({ status: 'in_progress' })}
+                title="Terminal"
+                body={<div>streaming…</div>}
+            />
+        )
+        expect(screen.getByText('streaming…')).toBeInTheDocument()
+    })
+
+    it('renders children always-visible without expanding', () => {
+        render(
+            <SandboxToolActivity message={makeMessage()} title="Insight">
+                <div>the visualization</div>
+            </SandboxToolActivity>
+        )
+        expect(screen.getByText('the visualization')).toBeInTheDocument()
+    })
+
+    it('surfaces the failure message', () => {
+        render(
+            <SandboxToolActivity
+                message={makeMessage({ status: 'failed', error: { message: 'boom' } })}
+                title="Terminal"
+                body={<div>partial</div>}
+            />
+        )
+        expect(screen.getByText('boom')).toBeInTheDocument()
+    })
+
+    it('marks a turn-cancelled tool', () => {
+        render(<SandboxToolActivity message={makeMessage({ status: 'in_progress' })} title="Terminal" turnCancelled />)
+        expect(screen.getByText('(cancelled)')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/max/sandbox/components/tool/SandboxToolActivity.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/SandboxToolActivity.tsx
@@ -1,0 +1,96 @@
+import { type ReactNode } from 'react'
+
+import { IconWarning, IconWrench } from '@posthog/icons'
+
+import { Activity } from '../../../components/Activity'
+import type { ActivityStatus } from '../../../components/Activity'
+import type { SandboxToolCallMessage } from '../../../maxTypes'
+import { resolveToolCallStatus } from './toolContentUtils'
+
+export interface SandboxToolActivityProps {
+    message: SandboxToolCallMessage
+    /** Registry icon; defaults to the generic wrench. */
+    icon?: ReactNode
+    /** Header line 1. */
+    title: ReactNode
+    /** Header line 2 — the tool's salient input (command, path, url, …) where applicable. */
+    subtitle?: ReactNode
+    /** Collapsible body: streamed/expandable output (Bash output, file preview, diff, …). */
+    body?: ReactNode
+    /** Always-visible content below the header: data visualizations, the question recap, …. */
+    children?: ReactNode
+    /** Turn-level signals so a still-incomplete tool reads as loading vs cancelled vs idle. */
+    turnComplete?: boolean
+    turnCancelled?: boolean
+}
+
+/**
+ * Bridges a sandbox tool call onto the shared `Activity` accordion: maps the tool's status to
+ * Activity's status/icons, surfaces a failure line, and routes per-tool content to either the
+ * collapsible body (`body` → Activity `details`, auto-expands while running) or the always-visible
+ * region (`children`). Every sandbox tool card renders through this.
+ */
+export function SandboxToolActivity({
+    message,
+    icon,
+    title,
+    subtitle,
+    body,
+    children,
+    turnComplete,
+    turnCancelled,
+}: SandboxToolActivityProps): JSX.Element {
+    const { isLoading, isFailed, wasCancelled } = resolveToolCallStatus(message.status, !!turnCancelled, !!turnComplete)
+    const status: ActivityStatus = isFailed ? 'failed' : isLoading ? 'in_progress' : 'completed'
+
+    // Activity has no "cancelled" status — render it as a neutral terminal row (no check) with a marker
+    // on the subtitle, or the title when there's no subtitle.
+    const cancelledMarker = wasCancelled ? <span className="text-muted"> (cancelled)</span> : null
+    const renderedTitle =
+        !subtitle && cancelledMarker ? (
+            <>
+                {title}
+                {cancelledMarker}
+            </>
+        ) : (
+            title
+        )
+    const renderedSubtitle =
+        subtitle && cancelledMarker ? (
+            <>
+                {subtitle}
+                {cancelledMarker}
+            </>
+        ) : (
+            subtitle
+        )
+
+    // The failure message lives in the always-visible region so it shows even though a failed tool's
+    // details auto-collapse.
+    const errorLine =
+        isFailed && message.error?.message ? <div className="text-danger">{message.error.message}</div> : null
+    const alwaysVisible = errorLine ? (
+        <div className="flex flex-col gap-2">
+            {errorLine}
+            {children}
+        </div>
+    ) : (
+        (children ?? null)
+    )
+
+    return (
+        <Activity
+            id={message.id}
+            title={renderedTitle}
+            subtitle={renderedSubtitle}
+            status={status}
+            icon={icon ?? <IconWrench />}
+            showProgressIcon
+            showCompletionIcon={!wasCancelled}
+            failedIcon={<IconWarning className="text-danger size-3" />}
+            details={body}
+        >
+            {alwaysVisible}
+        </Activity>
+    )
+}

--- a/frontend/src/scenes/max/sandbox/components/tool/SandboxToolCall.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/SandboxToolCall.tsx
@@ -1,0 +1,37 @@
+import { Suspense, memo } from 'react'
+
+import type { SandboxToolCallMessage } from '../../../maxTypes'
+import { lookupSandboxToolRenderer } from '../../sandboxToolRegistry'
+import { ToolCardSkeleton } from './ToolCardSkeleton'
+
+export interface SandboxToolCallProps {
+    message: SandboxToolCallMessage
+    /** Turn-level signals for resolving a still-incomplete tool as loading vs cancelled vs idle. */
+    turnComplete?: boolean
+    turnCancelled?: boolean
+}
+
+/**
+ * Eager dispatch for a single sandbox tool call: resolves the registry entry by `resolvedKey`, then
+ * renders its (lazy) renderer inside a `Suspense` boundary that shows a `ToolCardSkeleton` while the
+ * chunk loads. Replaces the inline `tool_invocation` branch in `SandboxThread`.
+ */
+export const SandboxToolCall = memo(function SandboxToolCall({
+    message,
+    turnComplete,
+    turnCancelled,
+}: SandboxToolCallProps): JSX.Element {
+    const entry = lookupSandboxToolRenderer(message.resolvedKey)
+    return (
+        <Suspense fallback={<ToolCardSkeleton icon={entry.icon} displayName={entry.displayName} />}>
+            <entry.Renderer
+                message={message}
+                isLastInGroup
+                icon={entry.icon}
+                displayName={entry.displayName}
+                turnComplete={turnComplete}
+                turnCancelled={turnCancelled}
+            />
+        </Suspense>
+    )
+})

--- a/frontend/src/scenes/max/sandbox/components/tool/ToolCardSkeleton.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/ToolCardSkeleton.tsx
@@ -1,0 +1,18 @@
+import { Spinner } from '@posthog/lemon-ui'
+
+/**
+ * Eager, dependency-light placeholder shown while a tool renderer's lazy chunk loads. A single
+ * Activity-style header line (registry icon + name + spinner, no body) — must not import the lazy
+ * renderers, or it would defeat the code split it stands in for.
+ */
+export function ToolCardSkeleton({ icon, displayName }: { icon?: JSX.Element; displayName?: string }): JSX.Element {
+    return (
+        <div className="flex items-center select-none min-w-0 text-xs">
+            <div className="flex items-center justify-center size-5 text-muted">{icon}</div>
+            <div className="flex items-center gap-1 flex-1 min-w-0">
+                <span className="text-muted truncate">{displayName ?? 'Tool'}</span>
+                <Spinner className="size-3 shrink-0" />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/sandbox/components/tool/ToolOutput.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/ToolOutput.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react'
+
+/** Monospace, scrollable output block for a tool card's collapsible body (terminal/search/fetch). */
+export function ToolOutput({ children }: { children: ReactNode }): JSX.Element {
+    return (
+        <pre className="m-0 font-mono text-xs leading-relaxed text-secondary whitespace-pre-wrap break-all max-h-64 overflow-auto">
+            {children}
+        </pre>
+    )
+}

--- a/frontend/src/scenes/max/sandbox/components/tool/builtinToolRenderers.test.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/builtinToolRenderers.test.tsx
@@ -1,0 +1,205 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import type { SandboxToolCallMessage } from '../../../maxTypes'
+import { BuiltinToolRenderer } from './builtinToolRenderers'
+import { GenericMcpToolRenderer } from './GenericMcpToolRenderer'
+
+function textBlock(text: string): unknown {
+    return { type: 'content', content: { type: 'text', text } }
+}
+
+function imageBlock(data: string, mimeType: string): unknown {
+    return { type: 'content', content: { type: 'image', data, mimeType } }
+}
+
+function makeMessage(overrides: Partial<SandboxToolCallMessage> = {}): SandboxToolCallMessage {
+    return {
+        id: 'tc-1',
+        resolvedKey: 'Bash',
+        rawServerName: 'claude',
+        rawToolName: '',
+        rawInput: {},
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+describe('builtin tool renderers', () => {
+    afterEach(() => cleanup())
+
+    it('renders a Bash command in the header and its output on expand', () => {
+        render(
+            <BuiltinToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    claudeToolName: 'Bash',
+                    resolvedKey: 'Bash',
+                    rawInput: { command: 'pnpm build' },
+                    content: [textBlock('build succeeded')],
+                })}
+            />
+        )
+        expect(screen.getByText('pnpm build')).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button'))
+        expect(screen.getByText('build succeeded')).toBeInTheDocument()
+    })
+
+    it('summarizes a Read call with its line count and file chip', () => {
+        render(
+            <BuiltinToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    claudeToolName: 'Read',
+                    resolvedKey: 'Read',
+                    locations: [{ path: 'frontend/app.ts' }],
+                    content: [textBlock('const a = 1\nconst b = 2')],
+                })}
+            />
+        )
+        expect(screen.getByText('Read 2 lines')).toBeInTheDocument()
+        expect(screen.getByText('app.ts')).toBeInTheDocument()
+    })
+
+    it('previews a Read image', () => {
+        render(
+            <BuiltinToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    claudeToolName: 'Read',
+                    resolvedKey: 'Read',
+                    locations: [{ path: 'shot.png' }],
+                    content: [imageBlock('AAAA', 'image/png')],
+                })}
+            />
+        )
+        expect(screen.getByText('Read image')).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button'))
+        expect(screen.getByAltText('shot.png')).toBeInTheDocument()
+    })
+
+    it('counts search results in the header', () => {
+        render(
+            <BuiltinToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    claudeToolName: 'Grep',
+                    resolvedKey: 'Grep',
+                    title: 'Grep TODO',
+                    content: [textBlock('a.ts:1\nb.ts:4\nc.ts:9')],
+                })}
+            />
+        )
+        expect(screen.getByText('Grep TODO')).toBeInTheDocument()
+        expect(screen.getByText('3 results')).toBeInTheDocument()
+    })
+
+    it('titles a subagent "type: description" and shows its prompt + output on expand', () => {
+        render(
+            <BuiltinToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    claudeToolName: 'Task',
+                    resolvedKey: 'Task',
+                    title: 'Review the diff',
+                    rawInput: {
+                        subagent_type: 'code-reviewer',
+                        description: 'Review the diff',
+                        prompt: 'Please review the recent changes',
+                    },
+                    content: [textBlock('Looks good to me')],
+                })}
+            />
+        )
+        expect(screen.getByText('code-reviewer: Review the diff')).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button'))
+        expect(screen.getByText('Please review the recent changes')).toBeInTheDocument()
+        expect(screen.getByText('Looks good to me')).toBeInTheDocument()
+    })
+
+    it('does not duplicate an echo subagent whose output repeats the prompt', () => {
+        render(
+            <BuiltinToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    claudeToolName: 'Task',
+                    resolvedKey: 'Task',
+                    rawInput: { subagent_type: 'echo', description: 'echo it', prompt: 'ping' },
+                    content: [textBlock('ping')],
+                })}
+            />
+        )
+        fireEvent.click(screen.getByRole('button'))
+        expect(screen.getAllByText('ping')).toHaveLength(1)
+    })
+
+    it.each([
+        ['tools', 'List tools', '__posthog_exec_tools__'],
+        ['info execute-sql', 'Read execute-sql', '__posthog_exec_info__'],
+        ['schema insight-create field', 'Inspect insight-create.field', '__posthog_exec_schema__'],
+        ['bogus', 'Run command', '__posthog_exec_unknown__'],
+    ])('labels the PostHog exec verb "%s" as "%s"', (command, label, resolvedKey) => {
+        render(
+            <BuiltinToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    resolvedKey,
+                    rawServerName: 'posthog',
+                    rawToolName: 'exec',
+                    rawInput: { command },
+                })}
+            />
+        )
+        expect(screen.getByText(label)).toBeInTheDocument()
+    })
+
+    it('shows the search regex as the PostHog exec subtitle', () => {
+        render(
+            <BuiltinToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    resolvedKey: '__posthog_exec_search__',
+                    rawServerName: 'posthog',
+                    rawToolName: 'exec',
+                    rawInput: { command: 'search funnel' },
+                })}
+            />
+        )
+        expect(screen.getByText('Search tools')).toBeInTheDocument()
+        expect(screen.getByText('funnel')).toBeInTheDocument()
+    })
+
+    it('renders an unmapped MCP tool with a Call server – tool (MCP) header', () => {
+        render(
+            <GenericMcpToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    resolvedKey: 'do_thing',
+                    rawServerName: 'user-mcp',
+                    rawToolName: 'do_thing',
+                    rawInput: { foo: 'bar' },
+                })}
+            />
+        )
+        expect(screen.getByText('Call user-mcp – do_thing (MCP)')).toBeInTheDocument()
+    })
+
+    it('renders an unmapped PostHog exec inner tool as "Call <tool>" without the MCP suffix', () => {
+        render(
+            <GenericMcpToolRenderer
+                isLastInGroup
+                message={makeMessage({
+                    resolvedKey: 'read-data-schema',
+                    rawServerName: 'posthog',
+                    rawToolName: 'exec',
+                    innerToolName: 'read-data-schema',
+                    rawInput: { command: 'call read-data-schema' },
+                })}
+            />
+        )
+        expect(screen.getByText('Call read-data-schema')).toBeInTheDocument()
+        expect(screen.queryByText(/\(MCP\)/)).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/max/sandbox/components/tool/builtinToolRenderers.tsx
+++ b/frontend/src/scenes/max/sandbox/components/tool/builtinToolRenderers.tsx
@@ -1,0 +1,262 @@
+import clsx from 'clsx'
+import { memo } from 'react'
+
+import { IconDocument, IconGlobe, IconSearch, IconTerminal, IconWrench } from '@posthog/icons'
+
+import { CodeSnippet } from 'lib/components/CodeSnippet/CodeSnippet'
+// IconRobot is not exported from @posthog/icons — it lives only in the legacy lib icon set.
+import { IconRobot } from 'lib/lemon-ui/icons'
+
+import { languageFromPath } from '../../../toolDiffContent'
+import { getPostHogExecDisplay } from '../../posthogExecDisplay'
+import type { SandboxToolRendererProps } from '../../sandboxToolRegistry'
+import { GenericMcpToolRenderer } from './GenericMcpToolRenderer'
+import { SandboxFilePath } from './SandboxFilePath'
+import { SandboxToolActivity } from './SandboxToolActivity'
+import {
+    MAX_COMMAND_LENGTH,
+    MAX_URL_LENGTH,
+    getCommandOutput,
+    getContentImage,
+    getContentText,
+    getFilename,
+    getLineCount,
+    getReadToolContent,
+    getResultCount,
+    stripAnsi,
+    stripCodeFences,
+    truncateText,
+} from './toolContentUtils'
+import { ToolOutput } from './ToolOutput'
+
+function asString(value: unknown): string {
+    return typeof value === 'string' ? value : ''
+}
+
+function firstLocationPath(props: SandboxToolRendererProps): string | undefined {
+    return props.message.locations?.[0]?.path ?? (asString(props.message.rawInput.file_path) || undefined)
+}
+
+/** Bash / BashOutput / KillShell — command on the second line, ANSI-stripped output in the body. */
+const BashToolRenderer = memo(function BashToolRenderer(props: SandboxToolRendererProps): JSX.Element {
+    const { message, icon, turnComplete, turnCancelled } = props
+    const command = asString(message.rawInput.command)
+    const description = asString(message.rawInput.description)
+    const output = stripAnsi(stripCodeFences(getCommandOutput(message.content, command, message.rawOutput)))
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconTerminal />}
+            title={description || message.title || 'Terminal'}
+            subtitle={
+                command ? (
+                    <span className="font-mono" title={command}>
+                        {command}
+                    </span>
+                ) : undefined
+            }
+            body={output ? <ToolOutput>{output}</ToolOutput> : undefined}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        />
+    )
+})
+
+/** Read / NotebookRead — line/image summary on line 1, file chip on line 2, preview in the body. */
+const ReadToolRenderer = memo(function ReadToolRenderer(props: SandboxToolRendererProps): JSX.Element {
+    const { message, icon, turnComplete, turnCancelled } = props
+    const path = firstLocationPath(props)
+    const image = getContentImage(message.content)
+    const text = image ? '' : getReadToolContent(message.content)
+    const lineCount = getLineCount(text)
+
+    const title = image
+        ? 'Read image'
+        : lineCount > 0
+          ? `Read ${lineCount} ${lineCount === 1 ? 'line' : 'lines'}`
+          : 'Read'
+
+    let body: JSX.Element | undefined
+    if (image) {
+        body = (
+            <img
+                src={`data:${image.mimeType};base64,${image.base64}`}
+                alt={path ? getFilename(path) : 'Read image'}
+                className="max-h-96 max-w-full object-contain rounded bg-surface-secondary p-2"
+            />
+        )
+    } else if (text) {
+        body = (
+            <CodeSnippet language={languageFromPath(path)} compact maxLinesWithoutExpansion={20}>
+                {text}
+            </CodeSnippet>
+        )
+    }
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconDocument />}
+            title={title}
+            subtitle={path ? <SandboxFilePath path={path} /> : undefined}
+            body={body}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        />
+    )
+})
+
+/** Grep / Glob / LS — result count on line 2, matched lines in the body. */
+const SearchToolRenderer = memo(function SearchToolRenderer(props: SandboxToolRendererProps): JSX.Element {
+    const { message, icon, displayName, turnComplete, turnCancelled } = props
+    const output = getContentText(message.content)
+    const count = getResultCount(output)
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconSearch />}
+            title={message.title || displayName || 'Search'}
+            subtitle={output ? `${count} ${count === 1 ? 'result' : 'results'}` : undefined}
+            body={output ? <ToolOutput>{output}</ToolOutput> : undefined}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        />
+    )
+})
+
+/**
+ * Task / Agent — a delegated subagent run. The header reads `{subagent_type}: {description}`, and the
+ * body carries the prompt the subagent was handed plus its returned output. The description lives only
+ * in the title (not echoed as a subtitle or input dump), so the card no longer duplicates it.
+ */
+const SubagentToolRenderer = memo(function SubagentToolRenderer(props: SandboxToolRendererProps): JSX.Element {
+    const { message, icon, turnComplete, turnCancelled } = props
+    const subagentType = asString(message.rawInput.subagent_type)
+    const description = asString(message.rawInput.description) || message.title || ''
+    const prompt = asString(message.rawInput.prompt)
+    const output = stripCodeFences(getContentText(message.content))
+    // An echo-style subagent returns its prompt verbatim — don't render the same text twice.
+    const showOutput = !!output && output.trim() !== prompt.trim()
+
+    const title =
+        subagentType && description ? `${subagentType}: ${description}` : subagentType || description || 'Subagent'
+
+    const body =
+        prompt || showOutput ? (
+            <div className="flex flex-col gap-2 min-w-0">
+                {prompt && <ToolOutput>{prompt}</ToolOutput>}
+                {showOutput && (
+                    <div className={clsx('min-w-0', prompt && 'border-t border-border-secondary pt-2')}>
+                        <ToolOutput>{output}</ToolOutput>
+                    </div>
+                )}
+            </div>
+        ) : undefined
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconRobot />}
+            title={title}
+            body={body}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        />
+    )
+})
+
+/** WebFetch / WebSearch — linked URL (or query) on line 2, fetched content in the body. */
+const FetchToolRenderer = memo(function FetchToolRenderer(props: SandboxToolRendererProps): JSX.Element {
+    const { message, icon, turnComplete, turnCancelled } = props
+    const url = asString(message.rawInput.url)
+    const query = asString(message.rawInput.query)
+    const output = stripCodeFences(getContentText(message.content))
+    const isSearch = !url && !!query
+    // Render the URL as plain mono text — not a highlighted, openable link.
+    const target = url || query
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconGlobe />}
+            title={message.title || (isSearch ? 'Web search' : 'Fetched')}
+            subtitle={
+                target ? (
+                    <span className="font-mono" title={target}>
+                        {truncateText(target, MAX_URL_LENGTH)}
+                    </span>
+                ) : undefined
+            }
+            body={output ? <ToolOutput>{output}</ToolOutput> : undefined}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        />
+    )
+})
+
+/**
+ * PostHog single-exec discovery verbs (`tools` / `search` / `info` / `schema`, plus the `unknown`
+ * fallback). `getPostHogExecDisplay` turns the `command` into a friendly label ("List tools",
+ * "Search tools", "Read <tool>", "Inspect <tool>.<field>") and an optional input preview; the
+ * discovery output renders in the body. The `call` verb never reaches here — it resolves to its inner
+ * tool's renderer instead.
+ */
+const PostHogExecRenderer = memo(function PostHogExecRenderer(props: SandboxToolRendererProps): JSX.Element {
+    const { message, icon, turnComplete, turnCancelled } = props
+    const display = getPostHogExecDisplay(message.rawInput)
+    const input = display?.input
+    const output = stripCodeFences(getContentText(message.content))
+
+    return (
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconWrench />}
+            title={display?.label || message.title || 'Run command'}
+            subtitle={
+                input ? (
+                    <span className="font-mono" title={input}>
+                        {truncateText(input, MAX_COMMAND_LENGTH)}
+                    </span>
+                ) : undefined
+            }
+            body={output ? <ToolOutput>{output}</ToolOutput> : undefined}
+            turnComplete={turnComplete}
+            turnCancelled={turnCancelled}
+        />
+    )
+})
+
+/**
+ * Single lazy entry covering every Claude built-in plus the generic MCP fallback — mirrors the agent
+ * UI's `ToolCallBlock` dispatch. Switches on the resolved tool name; anything unrecognised renders
+ * through `GenericMcpToolRenderer`. Registered for each built-in key and as the registry's default.
+ */
+export const BuiltinToolRenderer = memo(function BuiltinToolRenderer(props: SandboxToolRendererProps): JSX.Element {
+    if (props.message.resolvedKey.startsWith('__posthog_exec_')) {
+        return <PostHogExecRenderer {...props} />
+    }
+    const name = props.message.claudeToolName ?? props.message.resolvedKey
+    switch (name) {
+        case 'Bash':
+        case 'BashOutput':
+        case 'KillShell':
+            return <BashToolRenderer {...props} />
+        case 'Read':
+        case 'NotebookRead':
+            return <ReadToolRenderer {...props} />
+        case 'Grep':
+        case 'Glob':
+        case 'LS':
+            return <SearchToolRenderer {...props} />
+        case 'Task':
+        case 'Agent':
+            return <SubagentToolRenderer {...props} />
+        case 'WebFetch':
+        case 'WebSearch':
+            return <FetchToolRenderer {...props} />
+        default:
+            return <GenericMcpToolRenderer {...props} />
+    }
+})

--- a/frontend/src/scenes/max/sandbox/components/tool/toolContentUtils.test.ts
+++ b/frontend/src/scenes/max/sandbox/components/tool/toolContentUtils.test.ts
@@ -1,0 +1,167 @@
+import {
+    compactInput,
+    findResourceLink,
+    formatInput,
+    getCommandOutput,
+    getContentImage,
+    getContentText,
+    getFilename,
+    getLineCount,
+    getReadToolContent,
+    getResultCount,
+    resolveToolCallStatus,
+    stripAnsi,
+    stripCodeFences,
+    truncateText,
+} from './toolContentUtils'
+
+describe('toolContentUtils', () => {
+    describe('resolveToolCallStatus', () => {
+        it('treats an in-progress tool as loading while the turn is live', () => {
+            expect(resolveToolCallStatus('in_progress', false, false)).toEqual({
+                isLoading: true,
+                wasCancelled: false,
+                isFailed: false,
+                isComplete: false,
+            })
+        })
+
+        it('treats an incomplete tool as cancelled once the turn was cancelled', () => {
+            const flags = resolveToolCallStatus('pending', true, false)
+            expect(flags.wasCancelled).toBe(true)
+            expect(flags.isLoading).toBe(false)
+        })
+
+        it('stops spinning a still-incomplete tool once the turn completes', () => {
+            const flags = resolveToolCallStatus('in_progress', false, true)
+            expect(flags.isLoading).toBe(false)
+            expect(flags.wasCancelled).toBe(false)
+        })
+
+        it('maps terminal statuses directly', () => {
+            expect(resolveToolCallStatus('failed', false, false).isFailed).toBe(true)
+            expect(resolveToolCallStatus('completed', false, false).isComplete).toBe(true)
+        })
+    })
+
+    describe('getContentText', () => {
+        it('unwraps the ACP content envelope', () => {
+            expect(getContentText([{ type: 'content', content: { type: 'text', text: 'hi' } }])).toBe('hi')
+        })
+
+        it('reads a flat text block and returns the first one', () => {
+            expect(
+                getContentText([
+                    { type: 'text', text: 'first' },
+                    { type: 'text', text: 'second' },
+                ])
+            ).toBe('first')
+        })
+
+        it('returns empty string when no text block is present', () => {
+            expect(
+                getContentText([{ type: 'content', content: { type: 'image', data: 'x', mimeType: 'image/png' } }])
+            ).toBe('')
+        })
+    })
+
+    describe('getCommandOutput', () => {
+        it('drops a leading content block that echoes the command', () => {
+            const content = [
+                { type: 'text', text: 'ls -la' },
+                { type: 'text', text: 'total 8\nfile.ts' },
+            ]
+            expect(getCommandOutput(content, 'ls -la', undefined)).toBe('total 8\nfile.ts')
+        })
+
+        it('strips a "command\\noutput" prefix from a single block', () => {
+            expect(getCommandOutput([{ type: 'text', text: 'pwd\n/home/user' }], 'pwd', undefined)).toBe('/home/user')
+        })
+
+        it('returns plain output unchanged when it does not echo the command', () => {
+            expect(getCommandOutput([{ type: 'text', text: 'build succeeded' }], 'pnpm build', undefined)).toBe(
+                'build succeeded'
+            )
+        })
+
+        it('falls back to a string rawOutput when the command produced no content', () => {
+            expect(getCommandOutput([{ type: 'text', text: 'echo hi' }], 'echo hi', 'hi')).toBe('hi')
+        })
+    })
+
+    describe('getReadToolContent', () => {
+        it('strips system reminders, code fences, and line-number gutters', () => {
+            const raw =
+                '```python\n     1→import os\n     2→print(os.getcwd())\n```\n<system-reminder>be careful</system-reminder>'
+            expect(getReadToolContent([{ type: 'text', text: raw }])).toBe('import os\nprint(os.getcwd())')
+        })
+    })
+
+    describe('getContentImage', () => {
+        it('returns the base64 + mime of the first image block', () => {
+            expect(
+                getContentImage([{ type: 'content', content: { type: 'image', data: 'AAAA', mimeType: 'image/png' } }])
+            ).toEqual({ base64: 'AAAA', mimeType: 'image/png' })
+        })
+
+        it('returns null when there is no image block', () => {
+            expect(getContentImage([{ type: 'text', text: 'no image' }])).toBeNull()
+        })
+    })
+
+    describe('findResourceLink', () => {
+        it('returns the first resource_link block', () => {
+            expect(
+                findResourceLink([{ type: 'resource_link', uri: 'https://x.com', name: 'X', description: 'a site' }])
+            ).toEqual({ uri: 'https://x.com', name: 'X', description: 'a site' })
+        })
+    })
+
+    describe('stripAnsi', () => {
+        it('removes SGR colour codes', () => {
+            expect(stripAnsi('[31mred[0m text')).toBe('red text')
+        })
+    })
+
+    describe('stripCodeFences', () => {
+        it('removes leading and trailing fences', () => {
+            expect(stripCodeFences('```ts\nconst a = 1\n```')).toBe('const a = 1')
+        })
+
+        it('leaves unfenced text untouched', () => {
+            expect(stripCodeFences('plain text')).toBe('plain text')
+        })
+    })
+
+    describe('counts and truncation', () => {
+        it('counts non-empty result lines', () => {
+            expect(getResultCount('a.ts\n\nb.ts\nc.ts\n')).toBe(3)
+        })
+
+        it('counts total lines, treating blank text as zero', () => {
+            expect(getLineCount('one\ntwo')).toBe(2)
+            expect(getLineCount('   ')).toBe(0)
+        })
+
+        it('truncates with an ellipsis only when over the limit', () => {
+            expect(truncateText('short', 10)).toBe('short')
+            expect(truncateText('abcdef', 3)).toBe('abc…')
+        })
+
+        it('extracts the basename', () => {
+            expect(getFilename('a/b/c.ts')).toBe('c.ts')
+            expect(getFilename('flat.ts')).toBe('flat.ts')
+        })
+    })
+
+    describe('input previews', () => {
+        it('compacts input JSON to a single truncated line', () => {
+            expect(compactInput({ a: 1 })).toBe('{"a":1}')
+            expect(compactInput({ key: 'a-very-long-value-that-keeps-going-and-going-and-going' }, 10)).toHaveLength(11)
+        })
+
+        it('pretty-prints input JSON', () => {
+            expect(formatInput({ a: 1 })).toBe('{\n  "a": 1\n}')
+        })
+    })
+})

--- a/frontend/src/scenes/max/sandbox/components/tool/toolContentUtils.ts
+++ b/frontend/src/scenes/max/sandbox/components/tool/toolContentUtils.ts
@@ -1,0 +1,204 @@
+import type { SandboxToolCallMessage } from '../../../maxTypes'
+
+/** Compact single-line preview length for a generic MCP tool's input JSON. */
+export const INPUT_PREVIEW_MAX_LENGTH = 60
+/** Max characters of a Bash command rendered inline before truncation. */
+export const MAX_COMMAND_LENGTH = 120
+/** Max characters of a fetched URL rendered inline before truncation. */
+export const MAX_URL_LENGTH = 60
+
+export interface ToolCallStatusFlags {
+    isLoading: boolean
+    isFailed: boolean
+    wasCancelled: boolean
+    isComplete: boolean
+}
+
+/**
+ * Resolves the four visual states a tool card can be in from its wire status plus the turn-level
+ * signals. A tool left `pending`/`in_progress` is *loading* while the turn is live, but *cancelled*
+ * once the turn was cancelled, and simply idle once the turn completed without it finishing. Pure —
+ * not a hook despite reading like one, so it is safe to call conditionally.
+ */
+export function resolveToolCallStatus(
+    status: SandboxToolCallMessage['status'],
+    turnCancelled: boolean,
+    turnComplete: boolean
+): ToolCallStatusFlags {
+    const incomplete = status === 'pending' || status === 'in_progress'
+    return {
+        isLoading: incomplete && !turnCancelled && !turnComplete,
+        wasCancelled: incomplete && turnCancelled,
+        isFailed: status === 'failed',
+        isComplete: status === 'completed',
+    }
+}
+
+/** Unwraps the ACP `{ type: 'content', content: {...} }` envelope; flat blocks pass through. */
+function unwrapBlock(block: unknown): unknown {
+    if (!block || typeof block !== 'object') {
+        return block
+    }
+    if ((block as { type?: unknown }).type === 'content' && 'content' in block) {
+        return (block as { content: unknown }).content
+    }
+    return block
+}
+
+/** Text of every text content block (ACP-nested or flat), in order. */
+export function getAllText(content: unknown[]): string[] {
+    const texts: string[] = []
+    for (const block of content) {
+        const inner = unwrapBlock(block)
+        if (inner && typeof inner === 'object' && (inner as { type?: unknown }).type === 'text') {
+            const text = (inner as { text?: unknown }).text
+            if (typeof text === 'string') {
+                texts.push(text)
+            }
+        }
+    }
+    return texts
+}
+
+/** Text of the first text content block (ACP-nested or flat), or '' when none carries text. */
+export function getContentText(content: unknown[]): string {
+    return getAllText(content)[0] ?? ''
+}
+
+/**
+ * Output of a Bash-style command. The agent prepends the executed command as its own content block
+ * (or a `command\n…` prefix), so drop a leading line that echoes the command — leaving just stdout.
+ * Falls back to a string `rawOutput` when the command produced no content blocks.
+ */
+export function getCommandOutput(content: unknown[], command: string, rawOutput: unknown): string {
+    const blocks = getAllText(content)
+    const cmd = command.trim()
+    const trimmed = cmd && blocks[0]?.trim() === cmd ? blocks.slice(1) : blocks
+    let output = trimmed.join('\n')
+    if (cmd && output.trimStart().startsWith(cmd)) {
+        output = output.trimStart().slice(cmd.length).replace(/^\n+/, '')
+    }
+    if (!output.trim() && typeof rawOutput === 'string') {
+        output = rawOutput
+    }
+    return output
+}
+
+export interface ToolImageContent {
+    base64: string
+    mimeType: string
+}
+
+/** First image content block decoded to its base64 + mime type, or null when none is present. */
+export function getContentImage(content: unknown[]): ToolImageContent | null {
+    for (const block of content) {
+        const inner = unwrapBlock(block)
+        if (inner && typeof inner === 'object' && (inner as { type?: unknown }).type === 'image') {
+            const { data, mimeType } = inner as { data?: unknown; mimeType?: unknown }
+            if (typeof data === 'string' && typeof mimeType === 'string') {
+                return { base64: data, mimeType }
+            }
+        }
+    }
+    return null
+}
+
+export interface ToolResourceLink {
+    uri: string
+    name?: string
+    description?: string
+}
+
+/** First `resource_link` content block (a fetched/linked resource), or null. */
+export function findResourceLink(content: unknown[]): ToolResourceLink | null {
+    for (const block of content) {
+        const inner = unwrapBlock(block)
+        if (inner && typeof inner === 'object' && (inner as { type?: unknown }).type === 'resource_link') {
+            const { uri, name, description } = inner as { uri?: unknown; name?: unknown; description?: unknown }
+            if (typeof uri === 'string') {
+                return {
+                    uri,
+                    name: typeof name === 'string' ? name : undefined,
+                    description: typeof description === 'string' ? description : undefined,
+                }
+            }
+        }
+    }
+    return null
+}
+
+/** Strips a leading ```lang fence and a trailing ``` fence from a fenced code block. */
+export function stripCodeFences(text: string): string {
+    return text
+        .trim()
+        .replace(/^```[^\n]*\n?/, '')
+        .replace(/\n?```$/, '')
+        .trim()
+}
+
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_RE = /\x1b\[[0-9;]*m/g
+
+/** Removes ANSI SGR colour codes from terminal output so it reads cleanly in a card. */
+export function stripAnsi(text: string): string {
+    return text.replace(ANSI_ESCAPE_RE, '')
+}
+
+const SYSTEM_REMINDER_RE = /<system-reminder>[\s\S]*?<\/system-reminder>/g
+// `cat -n`-style gutter the Read tool prepends to each line: optional indent, line number, U+2192 arrow.
+const READ_LINE_MARKER_RE = /^\s*\d+→/gm
+
+/**
+ * Cleans the Read tool's output for display: drops injected `<system-reminder>` blocks, the code
+ * fences the agent wraps file contents in, and the per-line `NNN→` gutter — leaving the raw file text.
+ */
+export function getReadToolContent(content: unknown[]): string {
+    return stripCodeFences(getContentText(content).replace(SYSTEM_REMINDER_RE, ''))
+        .replace(READ_LINE_MARKER_RE, '')
+        .trim()
+}
+
+/** Basename of a path (everything after the last slash). */
+export function getFilename(path: string): string {
+    const segments = path.split('/')
+    return segments[segments.length - 1] || path
+}
+
+/** Number of lines in a block of text; empty/whitespace-only text counts as zero. */
+export function getLineCount(text: string): number {
+    if (!text.trim()) {
+        return 0
+    }
+    return text.split('\n').length
+}
+
+/** Number of non-empty lines — the search-result count for Grep/Glob/LS output. */
+export function getResultCount(text: string): number {
+    return text.split('\n').filter((line) => line.trim().length > 0).length
+}
+
+/** Truncates `text` to `max` characters, appending an ellipsis when it overflows. */
+export function truncateText(text: string, max: number, suffix = '…'): string {
+    if (text.length <= max) {
+        return text
+    }
+    return text.slice(0, max) + suffix
+}
+
+/** Pretty-prints a tool input object as indented JSON for the expanded body. */
+export function formatInput(input: unknown): string {
+    try {
+        return JSON.stringify(input, null, 2)
+    } catch {
+        return String(input)
+    }
+}
+
+/** Single-line, truncated JSON preview of a tool input — the generic MCP card's header hint. */
+export function compactInput(input: unknown, max = INPUT_PREVIEW_MAX_LENGTH): string {
+    try {
+        return truncateText(JSON.stringify(input) ?? '', max)
+    } catch {
+        return ''
+    }
+}

--- a/frontend/src/scenes/max/sandbox/sandboxToolRegistry.test.tsx
+++ b/frontend/src/scenes/max/sandbox/sandboxToolRegistry.test.tsx
@@ -1,0 +1,154 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import type { SandboxToolCallMessage } from '../maxTypes'
+import { SandboxToolCall } from './components/tool/SandboxToolCall'
+import { lookupSandboxToolRenderer, sandboxToolRegistry } from './sandboxToolRegistry'
+
+function makeMessage(overrides: Partial<SandboxToolCallMessage> = {}): SandboxToolCallMessage {
+    return {
+        id: 'tc-1',
+        resolvedKey: 'Edit',
+        rawServerName: 'posthog',
+        rawToolName: '',
+        rawInput: {},
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+describe('sandboxToolRegistry', () => {
+    // Renderers are lazy() chunks, so entry.Renderer is an opaque LazyExoticComponent — assert on the
+    // stable metadata (key → displayName/icon) the registry contributes, not on renderer identity.
+    const dataToolCases: [string, string][] = [
+        ['insight-create', 'Insight'],
+        ['insight-update', 'Insight'],
+        ['insight-get', 'Insight'],
+        ['create_insight', 'Insight'],
+        ['dashboard-create', 'Dashboard'],
+        ['dashboard-update', 'Dashboard'],
+        ['upsert_dashboard', 'Dashboard'],
+        ['query-session-recordings-list', 'Session recordings'],
+        ['search_session_recordings', 'Session recordings'],
+        ['filter_session_recordings', 'Session recordings'],
+        ['query-error-tracking-issues-list', 'Error tracking'],
+        ['search_error_tracking_issues', 'Error tracking'],
+        ['filter_error_tracking_issues', 'Error tracking'],
+        ['query-trends', 'Trends query'],
+        ['query-funnel', 'Funnel query'],
+        ['notebooks-create', 'Notebook'],
+        ['notebook-edit', 'Notebook'],
+    ]
+
+    it.each(dataToolCases)('resolves %s to a registered entry with displayName "%s"', (key, displayName) => {
+        const entry = sandboxToolRegistry.lookup(key)
+        expect(entry).not.toBeNull()
+        expect(entry?.displayName).toEqual(displayName)
+        expect(lookupSandboxToolRenderer(key).displayName).toEqual(displayName)
+    })
+
+    it('leaves unknown / unregistered tool names unregistered, resolving to the key as displayName', () => {
+        expect(sandboxToolRegistry.lookup('mcp__user-installed__something')).toBeNull()
+        // The synthesized fallback uses the resolved key as its displayName.
+        expect(lookupSandboxToolRenderer('mcp__user-installed__something').displayName).toEqual(
+            'mcp__user-installed__something'
+        )
+        expect(lookupSandboxToolRenderer('experiment-create').displayName).toEqual('experiment-create')
+        expect(sandboxToolRegistry.lookup('insight-query')).toBeNull()
+        expect(sandboxToolRegistry.lookup('read_insight')).toBeNull()
+        expect(sandboxToolRegistry.lookup('query-llm-trace')).toBeNull()
+    })
+
+    // Claude built-ins are keyed by their stable SDK name; the registry contributes a friendly
+    // displayName + icon (not the wrench fallback's key/wrench).
+    const builtinCases: [string, string][] = [
+        ['Read', 'Read'],
+        ['NotebookRead', 'Read'],
+        ['Edit', 'Edit'],
+        ['Write', 'Edit'],
+        ['NotebookEdit', 'Edit'],
+        ['MultiEdit', 'Edit'],
+        ['Grep', 'Search'],
+        ['Glob', 'Search'],
+        ['LS', 'Search'],
+        ['Bash', 'Terminal'],
+        ['BashOutput', 'Terminal'],
+        ['KillShell', 'Terminal'],
+        ['WebSearch', 'Web'],
+        ['WebFetch', 'Web'],
+        ['Task', 'Subagent'],
+        ['Agent', 'Subagent'],
+        ['TaskCreate', 'Tasks'],
+        ['TodoWrite', 'Tasks'],
+        ['Skill', 'Skill'],
+        ['ToolSearch', 'Tool search'],
+        ['ExitPlanMode', 'Plan'],
+        ['AskUserQuestion', 'Question'],
+    ]
+
+    it.each(builtinCases)('resolves built-in %s to a registered entry with displayName "%s"', (key, displayName) => {
+        const entry = sandboxToolRegistry.lookup(key)
+        expect(entry).not.toBeNull()
+        expect(entry?.displayName).toEqual(displayName)
+        expect(lookupSandboxToolRenderer(key).displayName).toEqual(displayName)
+    })
+
+    // PostHog single-exec discovery verbs are keyed by their sentinel key (from `resolveToolKey`); the
+    // registry gives each a fitting icon + displayName instead of the wrench fallback.
+    const execVerbCases: [string, string][] = [
+        ['__posthog_exec_tools__', 'List tools'],
+        ['__posthog_exec_search__', 'Search tools'],
+        ['__posthog_exec_info__', 'Read tool'],
+        ['__posthog_exec_schema__', 'Inspect schema'],
+        ['__posthog_exec_unknown__', 'Run command'],
+    ]
+
+    it.each(execVerbCases)('resolves exec verb %s to a registered entry with displayName "%s"', (key, displayName) => {
+        const entry = sandboxToolRegistry.lookup(key)
+        expect(entry).not.toBeNull()
+        expect(entry?.displayName).toEqual(displayName)
+        expect(lookupSandboxToolRenderer(key).displayName).toEqual(displayName)
+    })
+
+    it('falls back to the wrench card (key as displayName) for an unmapped built-in-looking name', () => {
+        expect(sandboxToolRegistry.lookup('NotARealTool')).toBeNull()
+        expect(lookupSandboxToolRenderer('NotARealTool').displayName).toEqual('NotARealTool')
+    })
+
+    // Render-level: SandboxToolCall resolves the entry, loads the lazy renderer behind a Suspense
+    // skeleton, and the resolved renderer reaches the screen. The skeleton shows the displayName first.
+    describe('lazy dispatch', () => {
+        it('renders a Bash call through its dedicated card once the chunk loads', async () => {
+            render(
+                <SandboxToolCall
+                    message={makeMessage({
+                        resolvedKey: 'Bash',
+                        claudeToolName: 'Bash',
+                        rawInput: { command: 'echo hello-bash' },
+                    })}
+                />
+            )
+            // Skeleton first (registry displayName), then the resolved card with the command. The
+            // generous timeout covers jest compiling the lazy chunk's heavy deps on first load.
+            expect(screen.getByText('Terminal')).toBeInTheDocument()
+            expect(await screen.findByText('echo hello-bash', {}, { timeout: 10000 })).toBeInTheDocument()
+        })
+
+        it('renders an unmapped MCP tool through the generic card', async () => {
+            render(
+                <SandboxToolCall
+                    message={makeMessage({
+                        resolvedKey: 'do_thing',
+                        rawServerName: 'user-mcp',
+                        rawToolName: 'do_thing',
+                    })}
+                />
+            )
+            expect(
+                await screen.findByText('Call user-mcp – do_thing (MCP)', {}, { timeout: 10000 })
+            ).toBeInTheDocument()
+        })
+    })
+})

--- a/frontend/src/scenes/max/sandbox/sandboxToolRegistry.tsx
+++ b/frontend/src/scenes/max/sandbox/sandboxToolRegistry.tsx
@@ -1,0 +1,273 @@
+import { type ComponentType, type LazyExoticComponent, lazy } from 'react'
+
+import {
+    IconAI,
+    IconDashboard,
+    IconDocument,
+    IconEye,
+    IconFunnels,
+    IconGlobe,
+    IconGraph,
+    IconLifecycle,
+    IconListCheck,
+    IconLlmAnalytics,
+    IconMagicWand,
+    IconNotebook,
+    IconPencil,
+    IconPerson,
+    IconRetention,
+    IconRewindPlay,
+    IconSearch,
+    IconStickiness,
+    IconTerminal,
+    IconTrends,
+    IconUserPaths,
+    IconWarning,
+    IconWrench,
+} from '@posthog/icons'
+
+// IconRobot is not exported from @posthog/icons — it lives only in the legacy lib icon set.
+import { IconRobot } from 'lib/lemon-ui/icons'
+
+import type { SandboxToolCallMessage } from '../maxTypes'
+
+export interface SandboxToolRendererProps {
+    message: SandboxToolCallMessage
+    isLastInGroup: boolean
+    /**
+     * Resolved registry entry's icon — the registry's contribution to the card. Renderers use it for
+     * the header icon (built-ins get their friendly icon instead of the generic wrench). Optional so
+     * direct mounts default to the renderer's own fallback icon.
+     */
+    icon?: JSX.Element
+    /** Resolved registry entry's stable display name, used as the header label when no title exists. */
+    displayName?: string
+    /** Turn-level signals so a still-incomplete tool reads as loading vs cancelled vs idle. */
+    turnComplete?: boolean
+    turnCancelled?: boolean
+}
+
+/** A renderer reachable eagerly or via a lazy chunk — both render identically in `SandboxToolCall`. */
+type SandboxToolRendererComponent =
+    | ComponentType<SandboxToolRendererProps>
+    | LazyExoticComponent<ComponentType<SandboxToolRendererProps>>
+
+export interface SandboxToolRegistryEntry {
+    /**
+     * Registry key. For single-exec PostHog tools, this is the **inner** tool name parsed from
+     * `rawInput.command` (e.g. "execute-sql", "insight-create"); for `exec`'s discovery verbs,
+     * the sentinel "__posthog_exec_tools__" etc.; for non-exec MCP tools and Claude built-ins,
+     * the wire `toolName` directly (e.g. "TodoWrite", "WebSearch").
+     */
+    key: string
+    /** Display name / icon for fallback rendering and for the tool-call header line. */
+    displayName: string
+    icon: JSX.Element
+    Renderer: SandboxToolRendererComponent
+}
+
+export interface SandboxToolRegistry {
+    register: (entry: SandboxToolRegistryEntry) => void
+    lookup: (toolName: string) => SandboxToolRegistryEntry | null
+}
+
+class MapBackedRegistry implements SandboxToolRegistry {
+    private entries = new Map<string, SandboxToolRegistryEntry>()
+
+    register(entry: SandboxToolRegistryEntry): void {
+        this.entries.set(entry.key, entry)
+    }
+
+    lookup(toolName: string): SandboxToolRegistryEntry | null {
+        return this.entries.get(toolName) ?? null
+    }
+}
+
+// Renderers are code-split: the static graph below carries only icons, types, and lazy factories, so a
+// sandbox conversation pulls a renderer's chunk on first use, not at thread mount. The built-in tools
+// and the generic MCP card share one chunk (`builtinToolRenderers`); each heavy data-tool adapter and
+// the Monaco-backed diff renderer stay in their own chunks.
+const BuiltinToolRenderer = lazy(() =>
+    import('./components/tool/builtinToolRenderers').then((m) => ({ default: m.BuiltinToolRenderer }))
+)
+const EditToolRenderer = lazy(() =>
+    import('../messages/adapters/EditDiffRenderer').then((m) => ({ default: m.EditDiffRenderer }))
+)
+const InsightRenderer = lazy(() =>
+    import('../messages/adapters/CreateInsightWidget').then((m) => ({ default: m.CreateInsightWidget }))
+)
+const DashboardRenderer = lazy(() =>
+    import('../messages/adapters/UpsertDashboardWidget').then((m) => ({ default: m.UpsertDashboardWidget }))
+)
+const SessionRecordingsRenderer = lazy(() =>
+    import('../messages/adapters/SearchSessionRecordingsWidget').then((m) => ({
+        default: m.SearchSessionRecordingsWidget,
+    }))
+)
+const ErrorTrackingRenderer = lazy(() =>
+    import('../messages/adapters/ErrorTrackingWidget').then((m) => ({ default: m.ErrorTrackingWidget }))
+)
+const NotebookRenderer = lazy(() =>
+    import('../messages/adapters/CreateNotebookWidget').then((m) => ({ default: m.CreateNotebookWidget }))
+)
+const QueryRenderer = lazy(() => import('../messages/adapters/QueryWidget').then((m) => ({ default: m.QueryWidget })))
+const QuestionRenderer = lazy(() =>
+    import('./SandboxQuestionRenderer').then((m) => ({ default: m.SandboxQuestionRenderer }))
+)
+
+/**
+ * Single module-level registry of tool-name → renderer entry. All entries are registered at module
+ * load — no dynamic registration, no hooks, no scene callbacks. Custom adapters are registered per
+ * tool; any tool without one falls through to the built-in renderer's generic MCP card.
+ */
+export const sandboxToolRegistry: SandboxToolRegistry = new MapBackedRegistry()
+
+// Custom adapters are registered here as they land. The single-exec inner tool names exist in two
+// conventions — hyphenated (the MCP yaml definitions) and snake_case (legacy Max tools) — so we
+// register both aliases where both are real tool names.
+
+// --- Data tools: insight ---
+// VisualizationWidget renderer — create / update / read insight.
+for (const key of ['insight-create', 'insight-update', 'insight-get', 'create_insight']) {
+    sandboxToolRegistry.register({
+        key,
+        displayName: 'Insight',
+        icon: <IconGraph />,
+        Renderer: InsightRenderer,
+    })
+}
+
+// --- Data tools: dashboard ---
+for (const key of ['dashboard-create', 'dashboard-update', 'upsert_dashboard']) {
+    sandboxToolRegistry.register({
+        key,
+        displayName: 'Dashboard',
+        icon: <IconDashboard />,
+        Renderer: DashboardRenderer,
+    })
+}
+
+// --- Data tools: session recordings ---
+for (const key of ['query-session-recordings-list', 'search_session_recordings', 'filter_session_recordings']) {
+    sandboxToolRegistry.register({
+        key,
+        displayName: 'Session recordings',
+        icon: <IconRewindPlay />,
+        Renderer: SessionRecordingsRenderer,
+    })
+}
+
+// --- Data tools: error tracking ---
+for (const key of [
+    'query-error-tracking-issues-list',
+    'query-error-tracking-issue',
+    'query-error-tracking-issue-events',
+    'search_error_tracking_issues',
+    'filter_error_tracking_issues',
+]) {
+    sandboxToolRegistry.register({
+        key,
+        displayName: 'Error tracking',
+        icon: <IconWarning />,
+        Renderer: ErrorTrackingRenderer,
+    })
+}
+
+// --- Data tools: notebooks ---
+// The generated CRUD tools and the handwritten notebook-edit (the collab-safe content editor)
+// all return the same REST notebook payload.
+for (const key of ['notebooks-create', 'notebooks-partial-update', 'notebooks-retrieve', 'notebook-edit']) {
+    sandboxToolRegistry.register({
+        key,
+        displayName: 'Notebook',
+        icon: <IconNotebook />,
+        Renderer: NotebookRenderer,
+    })
+}
+
+// --- Data tools: query wrappers ---
+// VisualizationWidget renderer — analytics and product queries executed inline by the agent.
+const QUERY_WRAPPER_TOOLS: { key: string; displayName: string; icon: JSX.Element }[] = [
+    { key: 'query-trends', displayName: 'Trends query', icon: <IconTrends /> },
+    { key: 'query-funnel', displayName: 'Funnel query', icon: <IconFunnels /> },
+    { key: 'query-retention', displayName: 'Retention query', icon: <IconRetention /> },
+    { key: 'query-stickiness', displayName: 'Stickiness query', icon: <IconStickiness /> },
+    { key: 'query-paths', displayName: 'Paths query', icon: <IconUserPaths /> },
+    { key: 'query-lifecycle', displayName: 'Lifecycle query', icon: <IconLifecycle /> },
+    { key: 'query-llm-traces-list', displayName: 'LLM traces', icon: <IconLlmAnalytics /> },
+    { key: 'query-trends-actors', displayName: 'Trends persons', icon: <IconPerson /> },
+    { key: 'query-lifecycle-actors', displayName: 'Lifecycle persons', icon: <IconPerson /> },
+    { key: 'query-paths-actors', displayName: 'Paths persons', icon: <IconPerson /> },
+]
+for (const { key, displayName, icon } of QUERY_WRAPPER_TOOLS) {
+    sandboxToolRegistry.register({ key, displayName, icon, Renderer: QueryRenderer })
+}
+
+// --- Claude built-in tools ---
+// Keyed by the stable SDK tool name (reachable via `_meta.claudeCode.toolName`). Bash/Read/Search/Web
+// get a dedicated per-tool card; the rest fall through to the generic MCP card — all inside the single
+// `BuiltinToolRenderer` chunk, which switches on the resolved tool name. The registry supplies the
+// friendly icon + a stable `displayName` for frames whose `title` is empty. `Skill` is registered
+// speculatively (not enumerated in the agent's tools.ts) — zero cost if never emitted. File-editing
+// built-ins are split out below into the dedicated diff renderer.
+const BUILTIN_TOOLS: { keys: string[]; displayName: string; icon: JSX.Element }[] = [
+    { keys: ['Read', 'NotebookRead'], displayName: 'Read', icon: <IconEye /> },
+    { keys: ['Grep', 'Glob', 'LS'], displayName: 'Search', icon: <IconSearch /> },
+    { keys: ['Bash', 'BashOutput', 'KillShell'], displayName: 'Terminal', icon: <IconTerminal /> },
+    { keys: ['WebSearch', 'WebFetch'], displayName: 'Web', icon: <IconGlobe /> },
+    { keys: ['Task', 'Agent'], displayName: 'Subagent', icon: <IconRobot /> },
+    {
+        keys: ['TaskCreate', 'TaskUpdate', 'TaskGet', 'TaskList', 'TodoWrite'],
+        displayName: 'Tasks',
+        icon: <IconListCheck />,
+    },
+    { keys: ['Skill'], displayName: 'Skill', icon: <IconMagicWand /> },
+    { keys: ['ToolSearch'], displayName: 'Tool search', icon: <IconSearch /> },
+    { keys: ['ExitPlanMode'], displayName: 'Plan', icon: <IconDocument /> },
+]
+for (const { keys, displayName, icon } of BUILTIN_TOOLS) {
+    for (const key of keys) {
+        sandboxToolRegistry.register({ key, displayName, icon, Renderer: BuiltinToolRenderer })
+    }
+}
+
+// File-editing built-ins render an inline visual diff when the agent attaches `type: "diff"` content
+// blocks; EditDiffRenderer falls back to the generic card when none are present.
+for (const key of ['Edit', 'Write', 'NotebookEdit', 'MultiEdit']) {
+    sandboxToolRegistry.register({ key, displayName: 'Edit', icon: <IconPencil />, Renderer: EditToolRenderer })
+}
+
+// PostHog single-exec discovery verbs. `resolveToolKey` parses `exec tools|search|info|schema` into
+// these sentinel keys; PostHogExecRenderer (inside the built-in chunk) derives the friendly label and
+// input preview from the command. Registered so they get a fitting icon instead of the wrench fallback.
+const POSTHOG_EXEC_VERBS: { key: string; displayName: string; icon: JSX.Element }[] = [
+    { key: '__posthog_exec_tools__', displayName: 'List tools', icon: <IconListCheck /> },
+    { key: '__posthog_exec_search__', displayName: 'Search tools', icon: <IconSearch /> },
+    { key: '__posthog_exec_info__', displayName: 'Read tool', icon: <IconDocument /> },
+    { key: '__posthog_exec_schema__', displayName: 'Inspect schema', icon: <IconDocument /> },
+    { key: '__posthog_exec_unknown__', displayName: 'Run command', icon: <IconWrench /> },
+]
+for (const { key, displayName, icon } of POSTHOG_EXEC_VERBS) {
+    sandboxToolRegistry.register({ key, displayName, icon, Renderer: BuiltinToolRenderer })
+}
+
+// AskUserQuestion (the agent asking the user to pick between options) gets a bespoke renderer that
+// lays the question + options out like the LangGraph question recap, rather than the generic JSON card.
+sandboxToolRegistry.register({
+    key: 'AskUserQuestion',
+    displayName: 'Question',
+    icon: <IconAI />,
+    Renderer: QuestionRenderer,
+})
+
+/** Looks up the renderer entry for a resolved tool key, falling back to the generic built-in card. */
+export function lookupSandboxToolRenderer(resolvedKey: string): SandboxToolRegistryEntry {
+    return (
+        sandboxToolRegistry.lookup(resolvedKey) ?? {
+            key: resolvedKey,
+            displayName: resolvedKey,
+            icon: <IconWrench />,
+            Renderer: BuiltinToolRenderer,
+        }
+    )
+}

--- a/frontend/src/scenes/max/sandboxPermissionDisplayUtils.test.ts
+++ b/frontend/src/scenes/max/sandboxPermissionDisplayUtils.test.ts
@@ -1,0 +1,91 @@
+import { getPostHogExecDisplay, getSandboxPermissionDisplay } from './sandboxPermissionDisplayUtils'
+import type { PermissionRequestRecord, ToolInvocation } from './types/sandboxStreamTypes'
+
+const rawToolCall: ToolInvocation = {
+    toolCallId: 'tc-1',
+    rawServerName: 'posthog',
+    rawToolName: 'exec',
+    resolvedKey: 'execute-sql',
+    input: {},
+    status: 'pending',
+    contentBlocks: [],
+}
+
+function makeRequest(overrides: Partial<PermissionRequestRecord> = {}): PermissionRequestRecord {
+    return {
+        requestId: 'req-1',
+        toolCallId: 'tc-1',
+        toolName: 'mcp__posthog__exec',
+        options: [
+            { optionId: 'opt-allow', name: 'Approve', kind: 'allow_once' },
+            { optionId: 'opt-reject', name: 'Decline', kind: 'reject' },
+        ],
+        rawToolCall,
+        ...overrides,
+    }
+}
+
+describe('sandboxPermissionDisplayUtils', () => {
+    it('unwraps PostHog exec call commands into an MCP title and pretty JSON payload', () => {
+        const display = getSandboxPermissionDisplay(
+            makeRequest({
+                rawToolCall: {
+                    ...rawToolCall,
+                    input: { command: 'call execute-sql {"query":"select 1"}' },
+                },
+            })
+        )
+
+        expect(display).toEqual({
+            title: 'posthog - execute-sql (MCP)',
+            payload: '{\n  "query": "select 1"\n}',
+        })
+    })
+
+    it('prefers explicit PostHog exec input when present', () => {
+        expect(
+            getPostHogExecDisplay({
+                command: 'call execute-sql {"query":"wrapped"}',
+                input: { query: 'explicit' },
+            })
+        ).toEqual({
+            label: 'execute-sql',
+            input: '{"query":"explicit"}',
+        })
+    })
+
+    it('keeps non-JSON PostHog exec args displayable', () => {
+        const display = getSandboxPermissionDisplay(
+            makeRequest({
+                rawToolCall: {
+                    ...rawToolCall,
+                    input: { command: 'search query-' },
+                },
+            })
+        )
+
+        expect(display).toEqual({
+            title: 'posthog - Search tools (MCP)',
+            payload: 'query-',
+        })
+    })
+
+    it('formats generic MCP tool input as JSON', () => {
+        const display = getSandboxPermissionDisplay(
+            makeRequest({
+                toolName: 'mcp__github__create_issue',
+                rawToolCall: {
+                    ...rawToolCall,
+                    rawServerName: 'github',
+                    rawToolName: 'create_issue',
+                    input: { owner: 'PostHog', repo: 'posthog' },
+                },
+            })
+        )
+
+        expect(display).toEqual({
+            title: 'github - create_issue (MCP)',
+            payload: '{\n  "owner": "PostHog",\n  "repo": "posthog"\n}',
+        })
+    })
+})

--- a/frontend/src/scenes/max/sandboxPermissionDisplayUtils.test.ts
+++ b/frontend/src/scenes/max/sandboxPermissionDisplayUtils.test.ts
@@ -5,7 +5,6 @@ const rawToolCall: ToolInvocation = {
     toolCallId: 'tc-1',
     rawServerName: 'posthog',
     rawToolName: 'exec',
-    resolvedKey: 'execute-sql',
     input: {},
     status: 'pending',
     contentBlocks: [],

--- a/frontend/src/scenes/max/sandboxPermissionDisplayUtils.ts
+++ b/frontend/src/scenes/max/sandboxPermissionDisplayUtils.ts
@@ -1,0 +1,69 @@
+import { POSTHOG_EXEC_TOOL_RE, formatPostHogExecBody, getPostHogExecDisplay } from './sandbox/posthogExecDisplay'
+import type { PermissionRequestRecord } from './types/sandboxStreamTypes'
+
+// Re-exported so existing importers (and tests) keep resolving the exec display from here.
+export { getPostHogExecDisplay } from './sandbox/posthogExecDisplay'
+
+export interface SandboxPermissionDisplay {
+    title?: string
+    payload?: string
+}
+
+function parseMcpToolKey(toolName: string): { serverName: string; toolName: string } | null {
+    const parts = toolName.split('__')
+    if (parts.length < 3 || parts[0] !== 'mcp') {
+        return null
+    }
+    return {
+        serverName: parts[1],
+        toolName: parts.slice(2).join('__'),
+    }
+}
+
+function formatInput(rawInput: unknown): string | undefined {
+    if (!rawInput || typeof rawInput !== 'object') {
+        return undefined
+    }
+    try {
+        const json = JSON.stringify(rawInput, null, 2)
+        return json === '{}' ? undefined : json
+    } catch {
+        return undefined
+    }
+}
+
+export function getSandboxPermissionDisplay(request: PermissionRequestRecord): SandboxPermissionDisplay {
+    const mcpTool = parseMcpToolKey(request.toolName)
+    if (!mcpTool) {
+        return {
+            title: request.title ?? request.rawToolCall.title ?? request.toolName,
+            payload: formatInput(request.rawToolCall.input),
+        }
+    }
+
+    if (POSTHOG_EXEC_TOOL_RE.test(request.toolName)) {
+        const posthogDisplay = getPostHogExecDisplay(request.rawToolCall.input)
+        if (posthogDisplay) {
+            return {
+                title: `posthog - ${posthogDisplay.label} (MCP)`,
+                payload: formatPostHogExecBody(posthogDisplay.input),
+            }
+        }
+        const resolvedName =
+            request.rawToolCall.innerToolName ??
+            (request.rawToolCall.resolvedKey.startsWith('__posthog_exec_')
+                ? undefined
+                : request.rawToolCall.resolvedKey)
+        if (resolvedName) {
+            return {
+                title: `posthog - ${resolvedName} (MCP)`,
+                payload: formatInput(request.rawToolCall.innerInput ?? request.rawToolCall.input),
+            }
+        }
+    }
+
+    return {
+        title: `${mcpTool.serverName} - ${mcpTool.toolName} (MCP)`,
+        payload: formatInput(request.rawToolCall.input),
+    }
+}

--- a/frontend/src/scenes/max/sandboxPermissionDisplayUtils.ts
+++ b/frontend/src/scenes/max/sandboxPermissionDisplayUtils.ts
@@ -1,4 +1,5 @@
 import { POSTHOG_EXEC_TOOL_RE, formatPostHogExecBody, getPostHogExecDisplay } from './sandbox/posthogExecDisplay'
+import { resolveToolCall } from './sandbox/sandboxToolResolver'
 import type { PermissionRequestRecord } from './types/sandboxStreamTypes'
 
 // Re-exported so existing importers (and tests) keep resolving the exec display from here.
@@ -49,15 +50,14 @@ export function getSandboxPermissionDisplay(request: PermissionRequestRecord): S
                 payload: formatPostHogExecBody(posthogDisplay.input),
             }
         }
+        const resolved = resolveToolCall(request.rawToolCall)
         const resolvedName =
-            request.rawToolCall.innerToolName ??
-            (request.rawToolCall.resolvedKey.startsWith('__posthog_exec_')
-                ? undefined
-                : request.rawToolCall.resolvedKey)
+            resolved.innerToolName ??
+            (resolved.resolvedKey.startsWith('__posthog_exec_') ? undefined : resolved.resolvedKey)
         if (resolvedName) {
             return {
                 title: `posthog - ${resolvedName} (MCP)`,
-                payload: formatInput(request.rawToolCall.innerInput ?? request.rawToolCall.input),
+                payload: formatInput(resolved.innerInput ?? request.rawToolCall.input),
             }
         }
     }

--- a/frontend/src/scenes/max/sandboxPermissionUtils.test.ts
+++ b/frontend/src/scenes/max/sandboxPermissionUtils.test.ts
@@ -1,0 +1,67 @@
+import { mapPermissionOption, mapPermissionOptions } from './sandboxPermissionUtils'
+import type { PermissionOption } from './types/sandboxWireTypes'
+
+describe('sandboxPermissionUtils', () => {
+    describe('mapPermissionOption', () => {
+        it.each<[string, Partial<ReturnType<typeof mapPermissionOption>>]>([
+            [
+                'allow_once',
+                {
+                    decision: 'approved',
+                    primary: true,
+                    remembered: false,
+                    requiresFeedback: false,
+                    supportsFeedback: false,
+                },
+            ],
+            ['allow_always', { decision: 'approved', primary: false, remembered: true }],
+            ['reject', { decision: 'declined', primary: false, requiresFeedback: false, supportsFeedback: false }],
+            ['reject_with_feedback', { decision: 'declined', requiresFeedback: true, supportsFeedback: false }],
+        ])('maps the known kind %s onto the card model', (kind, expected) => {
+            expect(mapPermissionOption({ optionId: 'x', name: '', kind })).toMatchObject(expected)
+        })
+
+        it('treats reject_once as a one-click decline that supports optional feedback via customInput', () => {
+            expect(
+                mapPermissionOption({ optionId: 'r', name: 'No', kind: 'reject_once', customInput: true })
+            ).toMatchObject({
+                decision: 'declined',
+                requiresFeedback: false,
+                supportsFeedback: true,
+            })
+            // Without customInput it is still a plain decline, just no feedback field.
+            expect(mapPermissionOption({ optionId: 'r', name: 'No', kind: 'reject_once' })).toMatchObject({
+                decision: 'declined',
+                requiresFeedback: false,
+                supportsFeedback: false,
+            })
+        })
+
+        it.each([
+            ['allow_for_session', 'approved'],
+            ['deny_forever', 'declined'],
+        ])('classifies the unknown kind %s by prefix instead of dropping it', (kind, decision) => {
+            expect(mapPermissionOption({ optionId: 'x', name: '', kind }).decision).toEqual(decision)
+        })
+
+        it.each([
+            ['allow_once', 'Approve'],
+            ['allow_always', 'Approve always'],
+            ['reject_once', 'Decline'],
+            ['reject_with_feedback', 'Decline with feedback…'],
+        ])('falls back to a default label for %s when the wire omits a name', (kind, label) => {
+            expect(mapPermissionOption({ optionId: 'a', name: '', kind }).label).toEqual(label)
+        })
+    })
+
+    describe('mapPermissionOptions', () => {
+        it('hides allow_always unless the tool preview opts into remembering', () => {
+            const options: PermissionOption[] = [
+                { optionId: 'a', name: '', kind: 'allow_once' },
+                { optionId: 'd', name: '', kind: 'allow_always' },
+            ]
+            expect(mapPermissionOptions(options).map((o) => o.optionId)).toEqual(['a'])
+            expect(mapPermissionOptions(options, true).map((o) => o.optionId)).toEqual(['a', 'd'])
+        })
+    })
+})

--- a/frontend/src/scenes/max/sandboxPermissionUtils.ts
+++ b/frontend/src/scenes/max/sandboxPermissionUtils.ts
@@ -1,0 +1,74 @@
+import type { PermissionOption } from './types/sandboxWireTypes'
+
+/**
+ * The card-facing decision a user can take on a sandbox ACP `permission_request` option. The
+ * sandbox runtime surfaces richer ACP option kinds that all map down onto approve / decline.
+ */
+export type ApprovalDecision = 'approved' | 'declined'
+
+/**
+ * One control the sandbox approval card renders, derived from an ACP `permission_request` option.
+ * The card forwards `optionId` back verbatim on the `permission_response` — the kind only drives
+ * the UI affordance and the resolution status recorded locally.
+ */
+export interface ApprovalCardOption {
+    optionId: string
+    label: string
+    /** Resolution status the card records once this option is chosen. */
+    decision: ApprovalDecision
+    /** Primary CTA styling (the single `allow_once`/approve path). */
+    primary: boolean
+    /** `allow_always` — only shown when the tool preview opts in via `remember: true`. */
+    remembered: boolean
+    /** Legacy `reject_with_feedback` — actionable only through the feedback text input, never a plain button. */
+    requiresFeedback: boolean
+    /** `reject_once` carrying `_meta.customInput` — a one-click decline that ALSO offers an optional feedback input. */
+    supportsFeedback: boolean
+}
+
+/**
+ * Maps an ACP `permission_request` option onto the sandbox approval card's option model. The
+ * affordance is resolved by prefix, not exact kind: `allow*` is an approval, everything else a
+ * decline. This keeps adapter vocabulary drift (`reject` → `reject_once`, future renames) from
+ * dropping options. `allow_always` is the one kind that needs exact matching — it drives the
+ * rememberable hiding (hidden unless `allowRemember`; still returned, flagged via `remembered`).
+ */
+export function mapPermissionOption(option: PermissionOption): ApprovalCardOption {
+    if (option.kind.startsWith('allow')) {
+        const remembered = option.kind === 'allow_always'
+        return {
+            optionId: option.optionId,
+            label: option.name || (remembered ? 'Approve always' : 'Approve'),
+            decision: 'approved',
+            primary: !remembered,
+            remembered,
+            requiresFeedback: false,
+            supportsFeedback: false,
+        }
+    }
+
+    // Decline. The legacy `reject_with_feedback` kind is feedback-only (no plain button); the current
+    // adapter's `reject_once` stays a one-click decline and advertises optional feedback via
+    // `_meta.customInput` (parsed onto `option.customInput`).
+    const requiresFeedback = option.kind === 'reject_with_feedback'
+    return {
+        optionId: option.optionId,
+        label: option.name || (requiresFeedback ? 'Decline with feedback…' : 'Decline'),
+        decision: 'declined',
+        primary: false,
+        remembered: false,
+        requiresFeedback,
+        supportsFeedback: !requiresFeedback && option.customInput === true,
+    }
+}
+
+/**
+ * Maps the full ACP `options[]` to card options, dropping `allow_always` unless the tool preview
+ * opted into a rememberable decision (`allowRemember`).
+ */
+export function mapPermissionOptions(
+    options: PermissionOption[],
+    allowRemember: boolean = false
+): ApprovalCardOption[] {
+    return options.map(mapPermissionOption).filter((option) => !option.remembered || allowRemember)
+}

--- a/frontend/src/scenes/max/slash-commands.tsx
+++ b/frontend/src/scenes/max/slash-commands.tsx
@@ -16,6 +16,12 @@ export interface SlashCommand {
     requiresIdle?: boolean
     /** If true, this command is only available for users on paid plans or with an active trial */
     requiresPaidPlan?: boolean
+    /**
+     * If true, this command is hidden for sandbox-runtime conversations.
+     * Core-memory commands (`/init`, `/remember`) are not yet supported under sandbox AI.
+     * LangGraph conversations are unaffected.
+     */
+    hiddenInSandbox?: boolean
 }
 
 export const MAX_SLASH_COMMANDS: SlashCommand[] = [
@@ -23,12 +29,14 @@ export const MAX_SLASH_COMMANDS: SlashCommand[] = [
         name: SlashCommandName.SlashInit,
         description: 'Set up knowledge about your product & business',
         icon: <IconRocket />,
+        hiddenInSandbox: true,
     },
     {
         name: SlashCommandName.SlashRemember,
         arg: '[information]',
         description: "Add [information] to PostHog AI's project-level memory",
         icon: <IconMemory />,
+        hiddenInSandbox: true,
     },
     {
         name: SlashCommandName.SlashUsage,

--- a/frontend/src/scenes/max/toolDiffContent.test.ts
+++ b/frontend/src/scenes/max/toolDiffContent.test.ts
@@ -1,0 +1,64 @@
+import { Language } from 'lib/components/CodeSnippet/CodeSnippet'
+
+import { findAllDiffContent, getDiffStats, languageFromPath } from './toolDiffContent'
+
+const flatDiff = { type: 'diff', path: 'a.ts', oldText: 'old', newText: 'new' }
+const nestedDiff = { type: 'content', content: { type: 'diff', path: 'b.py', oldText: null, newText: 'print(1)' } }
+const textBlock = { type: 'text', text: 'hello' }
+
+describe('toolDiffContent', () => {
+    describe('findAllDiffContent', () => {
+        it('collects every diff block (flat + nested), in order — MultiEdit emits one per edit', () => {
+            const second = { type: 'diff', path: 'a.ts', oldText: 'b', newText: 'c' }
+            expect(findAllDiffContent([flatDiff, textBlock, nestedDiff, second])).toEqual([
+                { type: 'diff', path: 'a.ts', oldText: 'old', newText: 'new' },
+                { type: 'diff', path: 'b.py', oldText: null, newText: 'print(1)' },
+                { type: 'diff', path: 'a.ts', oldText: 'b', newText: 'c' },
+            ])
+        })
+
+        it.each([
+            ['non-diff blocks', [textBlock, { type: 'content', content: textBlock }]],
+            ['empty content', []],
+            ['non-object members', [null, undefined, 'string', 42]],
+        ])('returns an empty array for %s', (_label, content) => {
+            expect(findAllDiffContent(content as unknown[])).toEqual([])
+        })
+    })
+
+    describe('getDiffStats', () => {
+        it.each([
+            ['pure addition', 'a\nb', 'a\nb\nc', { added: 1, removed: 0 }],
+            ['pure removal', 'a\nb\nc', 'a\nb', { added: 0, removed: 1 }],
+            ['changed line', 'a\nb\nc', 'a\nB\nc', { added: 1, removed: 1 }],
+            ['new file (null old)', null, 'a\nb\nc', { added: 3, removed: 0 }],
+            ['new file (empty old)', '', 'a\nb', { added: 2, removed: 0 }],
+            ['no change', 'a\nb', 'a\nb', { added: 0, removed: 0 }],
+        ])('counts %s', (_label, oldText, newText, expected) => {
+            expect(getDiffStats(oldText, newText)).toEqual(expected)
+        })
+    })
+
+    describe('languageFromPath', () => {
+        it.each([
+            ['foo.ts', Language.TypeScript],
+            ['foo.tsx', Language.TypeScript],
+            ['foo.py', Language.Python],
+            ['foo.js', Language.JavaScript],
+            ['foo.jsx', Language.JavaScript],
+            ['foo.json', Language.JSON],
+            ['foo.sql', Language.SQL],
+            ['foo.go', Language.Go],
+            ['foo.yaml', Language.YAML],
+            ['foo.yml', Language.YAML],
+            ['foo.sh', Language.Bash],
+            ['foo.rb', Language.Ruby],
+            ['nested/dir/Component.TSX', Language.TypeScript],
+            ['Dockerfile', Language.Text],
+            ['foo.unknownext', Language.Text],
+            [undefined, Language.Text],
+        ])('maps %s to the expected language', (path, expected) => {
+            expect(languageFromPath(path)).toBe(expected)
+        })
+    })
+})

--- a/frontend/src/scenes/max/toolDiffContent.ts
+++ b/frontend/src/scenes/max/toolDiffContent.ts
@@ -1,0 +1,135 @@
+import { Language } from 'lib/components/CodeSnippet/CodeSnippet'
+
+/**
+ * A normalized `type: "diff"` tool-call content block, as emitted by the sandbox agent's Claude
+ * adapter for Edit/Write/MultiEdit/NotebookEdit calls. `oldText` is `null` for a brand-new file.
+ */
+export interface ToolCallDiffContent {
+    type: 'diff'
+    path?: string
+    oldText?: string | null
+    newText?: string
+}
+
+/**
+ * Unwraps the ACP `{ type: 'content', content: {...} }` envelope — diff blocks may arrive flat or
+ * nested under that wrapper.
+ */
+function unwrapBlock(block: unknown): unknown {
+    if (!block || typeof block !== 'object') {
+        return block
+    }
+    if ((block as { type?: unknown }).type === 'content' && 'content' in block) {
+        return (block as { content: unknown }).content
+    }
+    return block
+}
+
+function asDiffContent(block: unknown): ToolCallDiffContent | null {
+    const inner = unwrapBlock(block)
+    if (!inner || typeof inner !== 'object' || (inner as { type?: unknown }).type !== 'diff') {
+        return null
+    }
+    const { path, oldText, newText } = inner as { path?: unknown; oldText?: unknown; newText?: unknown }
+    return {
+        type: 'diff',
+        path: typeof path === 'string' ? path : undefined,
+        oldText: oldText === null ? null : typeof oldText === 'string' ? oldText : undefined,
+        newText: typeof newText === 'string' ? newText : undefined,
+    }
+}
+
+/** Every `type: "diff"` block — MultiEdit emits one per edit; the single-edit case is `[0]`. */
+export function findAllDiffContent(content: unknown[]): ToolCallDiffContent[] {
+    const diffs: ToolCallDiffContent[] = []
+    for (const block of content) {
+        const diff = asDiffContent(block)
+        if (diff) {
+            diffs.push(diff)
+        }
+    }
+    return diffs
+}
+
+/**
+ * Line-level +added/-removed counts via a line-frequency diff. Ported from the ../code EditToolView:
+ * a missing/empty `oldText` means a new file, so every line is an addition.
+ */
+export function getDiffStats(
+    oldText: string | null | undefined,
+    newText: string | null | undefined
+): { added: number; removed: number } {
+    const oldLines = oldText ? oldText.split('\n') : []
+    const newLines = newText ? newText.split('\n') : []
+
+    if (!oldText) {
+        return { added: newLines.length, removed: 0 }
+    }
+
+    const oldCounts = new Map<string, number>()
+    for (const line of oldLines) {
+        oldCounts.set(line, (oldCounts.get(line) ?? 0) + 1)
+    }
+
+    const newCounts = new Map<string, number>()
+    for (const line of newLines) {
+        newCounts.set(line, (newCounts.get(line) ?? 0) + 1)
+    }
+
+    let added = 0
+    let removed = 0
+
+    for (const [line, count] of newCounts) {
+        const oldCount = oldCounts.get(line) ?? 0
+        if (count > oldCount) {
+            added += count - oldCount
+        }
+    }
+
+    for (const [line, count] of oldCounts) {
+        const newCount = newCounts.get(line) ?? 0
+        if (count > newCount) {
+            removed += count - newCount
+        }
+    }
+
+    return { added, removed }
+}
+
+// The Language enum string values double as valid Monaco language ids, which is what
+// MonacoDiffEditor.language wants.
+const EXTENSION_LANGUAGE_MAP: Record<string, Language> = {
+    ts: Language.TypeScript,
+    tsx: Language.TypeScript,
+    mts: Language.TypeScript,
+    cts: Language.TypeScript,
+    js: Language.JavaScript,
+    jsx: Language.JavaScript,
+    mjs: Language.JavaScript,
+    cjs: Language.JavaScript,
+    py: Language.Python,
+    json: Language.JSON,
+    sql: Language.SQL,
+    go: Language.Go,
+    yaml: Language.YAML,
+    yml: Language.YAML,
+    sh: Language.Bash,
+    bash: Language.Bash,
+    rb: Language.Ruby,
+    java: Language.Java,
+    kt: Language.Kotlin,
+    php: Language.PHP,
+    cs: Language.CSharp,
+    swift: Language.Swift,
+    html: Language.HTML,
+    xml: Language.XML,
+}
+
+/** Maps a file path's extension to a Monaco language id, defaulting to plain text. */
+export function languageFromPath(path?: string): Language {
+    const ext = path?.split('.').pop()?.toLowerCase()
+    if (!ext) {
+        return Language.Text
+    }
+    return EXTENSION_LANGUAGE_MAP[ext] ?? Language.Text
+}

--- a/frontend/src/scenes/max/utils/thinkingMessages.ts
+++ b/frontend/src/scenes/max/utils/thinkingMessages.ts
@@ -36,6 +36,9 @@ export const THINKING_MESSAGES = [
     'Swizzling', // techy weirdness
     'Grokking', // deep understanding
     'Hedging', // hedgehog pun
+    'Posthogging', // brand pun
+    'Self-driving', // autonomy pun
+    'Signaling', // signals pun
     'Scheming', // clever planning
     'Unfurling', // opening up ideas
     'Puzzling', // solving something tricky


### PR DESCRIPTION
## Problem

Top layer of the split of the PostHog AI sandbox feature. This PR was formerly the entire ~19k-line sandbox diff; it has been narrowed to just the UI by extracting the backend and streaming-core layers below it. Stacked on the streaming-core PR (#65166), which is stacked on the backend PR (#65164).

## Changes

The React/UI layer for sandbox conversations in Max:

- `scenes/max/` — Max thread, composer, mode and permission inputs, message renderers and adapters
- `scenes/max/sandbox/` — sandbox thread, tool cards and renderers, run context, PR card, embeddable run viewer
- `scenes/inbox/` — run-detail wiring for inline sandbox run logs
- assorted UI fixes (thinking loader, failure messages, permission/question inputs)

Builds on the streaming-core (#65166) and backend (#65164) layers. No behavior change versus the original combined branch — this is a pure re-slice along subsystem lines.

## How did you test this code?

Authored by an agent (Claude Code). This branch's content is identical to the pre-split combined branch (verified with `git diff` against a backup of the original tip — empty). The frontend typecheck and jest suites were run on the combined feature prior to the split.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Narrowed from the full sandbox feature to just the UI layer by Claude Code for @skoob13, by extracting the backend (#65164) and streaming-core (#65166) layers via `gt split --by-file` and retargeting this PR's base to the streaming-core branch. Two already-merged child branches (inbox-run-log, sandbox-followup-queue) were removed after verifying their work is already contained in this branch.
