### PR TITLE
chore: add yolo easter egg to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo 🦔


### PR DESCRIPTION
## Problem

The root `README.md` ends with a small easter egg for dedicated readers. This adds a lightweight, on-theme "yolo" sign-off as requested.

## Changes

- Append a `yolo 🦔` line to the end of `README.md`, right after the existing "dedicated README reader" easter egg.

## How did you test this code?

I'm an agent. No automated tests apply — this is a docs-only one-line change. Verified the rendered diff appends a single line at the bottom of `README.md` with no other content affected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored with PostHog Code (Claude). The user requested adding "yolo" to the PostHog README. Since the root README is a high-visibility public file, I placed the addition at the existing easter-egg footer (the "dedicated README reader" note) as the lowest-impact, on-theme spot rather than altering any user-facing product copy.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
