### PR TITLE
fix(activity-log): don't fetch (and toast) when paywalled

### DIFF
--- a/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
@@ -269,8 +269,6 @@ export const ActivityLog = ({ scope, id, caption, startingPage = 1 }: ActivityLo
     return (
         <div className="ActivityLog" data-attr="activity-log">
             {caption && <div className="page-caption">{caption}</div>}
-            {/* Mount the activity-fetching contents inside the gate so we never fire the (always-402)
-                request when the org lacks the plan — the upsell CTA is enough on its own. */}
             <PayGateMini
                 feature={AvailableFeature.AUDIT_LOGS}
                 overrideShouldShowGate={user?.is_impersonated || !!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}

--- a/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
@@ -20,7 +20,6 @@ import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { billingLogic } from 'scenes/billing/billingLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
@@ -258,15 +257,10 @@ export const ActivityLogRow = ({
 }
 
 export const ActivityLog = ({ scope, id, caption, startingPage = 1 }: ActivityLogProps): JSX.Element | null => {
-    const logic = activityLogLogic({ scope, id, caption, startingPage })
-    const { humanizedActivity, activityLoading, pagination, highlightedActivityId } = useValues(logic)
     const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const { billingLoading } = useValues(billingLogic)
 
     const hasAccess = userHasAccess(AccessControlResourceType.ActivityLog, AccessControlLevel.Viewer)
-
-    const paginationState = usePagination(humanizedActivity || [], pagination)
 
     if (!hasAccess) {
         return <AccessDenied object="activity logs" />
@@ -275,32 +269,45 @@ export const ActivityLog = ({ scope, id, caption, startingPage = 1 }: ActivityLo
     return (
         <div className="ActivityLog" data-attr="activity-log">
             {caption && <div className="page-caption">{caption}</div>}
-            {(activityLoading && humanizedActivity.length === 0) || billingLoading ? (
-                <Loading />
-            ) : (
-                <PayGateMini
-                    feature={AvailableFeature.AUDIT_LOGS}
-                    overrideShouldShowGate={user?.is_impersonated || !!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
-                >
-                    {humanizedActivity.length === 0 ? (
-                        <Empty scope={scope} />
-                    ) : (
-                        <>
-                            <div className="deprecated-space-y-2">
-                                {humanizedActivity.map((logItem, index) => (
-                                    <ActivityLogRow
-                                        key={logItem.id || index}
-                                        logItem={logItem}
-                                        highlighted={logItem.id === highlightedActivityId}
-                                    />
-                                ))}
-                            </div>
-                            <LemonDivider />
-                            <PaginationControl {...paginationState} nouns={['activity', 'activities']} />
-                        </>
-                    )}
-                </PayGateMini>
-            )}
+            {/* Mount the activity-fetching contents inside the gate so we never fire the (always-402)
+                request when the org lacks the plan — the upsell CTA is enough on its own. */}
+            <PayGateMini
+                feature={AvailableFeature.AUDIT_LOGS}
+                overrideShouldShowGate={user?.is_impersonated || !!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
+            >
+                <ActivityLogContents scope={scope} id={id} caption={caption} startingPage={startingPage} />
+            </PayGateMini>
         </div>
+    )
+}
+
+const ActivityLogContents = ({ scope, id, caption, startingPage = 1 }: ActivityLogProps): JSX.Element => {
+    const logic = activityLogLogic({ scope, id, caption, startingPage })
+    const { humanizedActivity, activityLoading, pagination, highlightedActivityId } = useValues(logic)
+
+    const paginationState = usePagination(humanizedActivity || [], pagination)
+
+    if (activityLoading && humanizedActivity.length === 0) {
+        return <Loading />
+    }
+
+    if (humanizedActivity.length === 0) {
+        return <Empty scope={scope} />
+    }
+
+    return (
+        <>
+            <div className="deprecated-space-y-2">
+                {humanizedActivity.map((logItem, index) => (
+                    <ActivityLogRow
+                        key={logItem.id || index}
+                        logItem={logItem}
+                        highlighted={logItem.id === highlightedActivityId}
+                    />
+                ))}
+            </div>
+            <LemonDivider />
+            <PaginationControl {...paginationState} nouns={['activity', 'activities']} />
+        </>
     )
 }


### PR DESCRIPTION
## Problem

On the History tab of any scene gated behind the audit-logs paywall (e.g. the Endpoints scene), an org without the required plan saw **two** things at once on Cloud:

1. ✅ The `PayGateMini` upsell CTA ("Activity logs — Subscribe to the Scale addon — View plans") — correct, and enough on its own.
2. ❌ A red error toast: _"Fetch activity failed: Audit logs requires a paid PostHog plan. Please upgrade to access this feature."_ — noise.

The CTA already communicates the gate, so the error toast is redundant and confusing.

<img width="971" height="701" alt="image" src="https://github.com/user-attachments/assets/1628166a-e9f7-4505-815f-2c7d03ab344c" />


## Changes

`ActivityLog` mounted `activityLogLogic` unconditionally, so its `afterMount` autofetch fired regardless of the gate. On Cloud the backend returns `402`, which kea-loaders surfaces as the "Fetch activity failed" toast.

`PayGateMini` only renders its `children` when access is granted. So the fix is structural: the activity-fetching/rendering now lives in a child component (`ActivityLogContents`) rendered **inside** `PayGateMini`. When the org is gated, that child never mounts, the logic never mounts, and **the request never fires** — no wasted `402`, no toast. When access is granted, behavior is identical to before.

This affects every `ActivityLog` History tab (all usages share the same `AUDIT_LOGS` gate), not just Endpoints. The shared `activityLogLogic` is left untouched, so the other direct consumers of it are unaffected.

## How did you test this code?

I'm an agent. I did **not** perform manual testing — the local environment has no `node_modules`, so I couldn't run the formatter, `typescript:check`, or Jest. The change is a small structural refactor of an existing component (no logic changes), relying on `PayGateMini`'s documented behavior of only rendering children when access is granted. Reviewer should verify in a Cloud-like environment that the History tab shows only the CTA (no error toast) for a plan-less org, and renders activity normally for an entitled org.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The first attempt swallowed the `402` inside `activityLogLogic`'s loader and returned empty results. On reviewer pushback ("should we even send this request?") that approach was rejected as a code smell — it fired a request known to fail and masked a real error class on shared generic logic used by 4 other consumers. The chosen approach instead prevents the request from ever mounting when gated, by relocating the fetching component inside `PayGateMini`'s children. Reverted the logic-level change entirely; the only diff is in `ActivityLog.tsx`.
