### PR TITLE
fix(insights): keep hog-charts tooltip on screen via autoUpdate

### DIFF
--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { flip, FloatingPortal, offset, shift, useFloating, type VirtualElement } from '@floating-ui/react'
+import { autoUpdate, flip, FloatingPortal, offset, shift, useFloating, type VirtualElement } from '@floating-ui/react'
 import React, { useLayoutEffect, useMemo } from 'react'
 
 import { useChartLayout } from '../core/chart-context'
@@ -67,6 +67,11 @@ export function Tooltip<Meta = unknown>({
         placement: placement === 'follow-data' ? 'right' : 'right-start',
         strategy: 'fixed',
         middleware: TOOLTIP_MIDDLEWARE,
+        // Re-run the middleware (notably `flip`/`shift`) once the portaled tooltip reaches its
+        // real `max-content` size and whenever the page scrolls/resizes — without this the first
+        // position is computed against a still-zero-width element, so `flip` never kicks in and
+        // the tooltip can stay clipped off the right edge (e.g. on the last bar of a chart).
+        whileElementsMounted: autoUpdate,
     })
 
     useLayoutEffect(() => {


### PR DESCRIPTION
## Problem

On charts using the new hog-charts renderer (lifecycle is the visible case, behind `PRODUCT_ANALYTICS_HOG_CHARTS_LIFECYCLE`), the tooltip could render clipped off the right edge of the viewport — for example when hovering the last bar of a chart. This was surprising because the tooltip is floating-ui based and `flip()`/`shift()` should keep it on screen, as they do for `Popover` across the rest of the app.

## Changes

The hog-charts `Tooltip` (`frontend/src/lib/hog-charts/overlays/Tooltip.tsx`) called `useFloating` **without** `whileElementsMounted: autoUpdate`. The tooltip is rendered through a `FloatingPortal` with `width: max-content`, so floating-ui's initial (and only) position computation could run against a still-zero-width element. `flip()` then concluded the tooltip fit on the right and kept `right-start`, and since nothing triggered a recompute once the real content laid out, the tooltip stayed clipped.

This adds `whileElementsMounted: autoUpdate`, so the middleware re-runs once the element reaches its true size (via `ResizeObserver`) and on scroll/resize. This is the same pattern `lib/lemon-ui/Popover/Popover.tsx` already uses. The fix applies to all three placements (`top`, `cursor`, `follow-data`), so every hog-charts tooltip benefits.

## How did you test this code?

I'm an agent. I did not run the app or perform manual browser testing. There is no existing test for this component, and floating-ui positioning is not meaningfully assertable in jsdom (no layout engine), so no automated test was added. The change is a one-line config addition mirroring the established `Popover` pattern. A reviewer should visually confirm the tooltip flips/shifts on screen when hovering the rightmost bar of a lifecycle chart.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The investigation traced the off-screen lifecycle tooltip to the new floating-ui hog-charts `Tooltip` rather than the legacy Chart.js path. Root cause: missing `autoUpdate`, so `flip()` made its decision against an unmeasured (zero-width) portaled element and never recomputed. Considered whether the issue was the `right-start` placement geometry or stale `canvasBounds`, but ruled those out — the geometry is sound and the smoking gun was that the codebase's working floating-ui component (`Popover`) wires up `autoUpdate` while this one did not. Chose the minimal idiomatic fix over restructuring the placement logic.
