### PR TITLE
fix(phai): allow lifecycle/stickiness/paths queries in VisualizationBlock

### DIFF
--- a/ee/hogai/core/test/test_artifacts.py
+++ b/ee/hogai/core/test/test_artifacts.py
@@ -7,8 +7,13 @@ from pydantic import ValidationError
 from posthog.schema import (
     AssistantTrendsQuery,
     DocumentArtifactContent,
+    EventsNode,
+    LifecycleQuery,
     MarkdownBlock,
+    PathsFilter,
+    PathsQuery,
     SessionReplayBlock,
+    StickinessQuery,
     TrendsQuery,
     VisualizationArtifactContent,
     VisualizationBlock,
@@ -30,6 +35,21 @@ class TestDocumentBlocks(BaseTest):
 
     def test_visualization_block_valid(self):
         query = AssistantTrendsQuery(series=[])
+        block = VisualizationBlock(query=query)
+        self.assertEqual(block.type, "visualization")
+        self.assertEqual(block.query, query)
+
+    @parameterized.expand(
+        [
+            ("lifecycle", LifecycleQuery(series=[EventsNode(event="$pageview")])),
+            ("stickiness", StickinessQuery(series=[EventsNode(event="$pageview")])),
+            ("paths", PathsQuery(pathsFilter=PathsFilter())),
+        ]
+    )
+    def test_visualization_block_accepts_saved_insight_query_types(self, _name, query):
+        # Saved insights can be Lifecycle/Stickiness/Paths queries (concrete, non-Assistant types).
+        # These must be valid members of the VisualizationBlock.query union, otherwise enriching a
+        # notebook artifact that references such an insight raises a ValidationError.
         block = VisualizationBlock(query=query)
         self.assertEqual(block.type, "visualization")
         self.assertEqual(block.query, query)

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -41632,6 +41632,15 @@
                             "$ref": "#/definitions/RetentionQuery"
                         },
                         {
+                            "$ref": "#/definitions/StickinessQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/PathsQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/LifecycleQuery"
+                        },
+                        {
                             "$ref": "#/definitions/HogQLQuery"
                         },
                         {

--- a/frontend/src/queries/schema/schema-assistant-artifacts.ts
+++ b/frontend/src/queries/schema/schema-assistant-artifacts.ts
@@ -3,11 +3,14 @@ import { AnyAssistantGeneratedQuery } from './schema-assistant-messages'
 import {
     FunnelsQuery,
     HogQLQuery,
+    LifecycleQuery,
+    PathsQuery,
     RetentionQuery,
     RevenueAnalyticsGrossRevenueQuery,
     RevenueAnalyticsMRRQuery,
     RevenueAnalyticsMetricsQuery,
     RevenueAnalyticsTopCustomersQuery,
+    StickinessQuery,
     TrendsQuery,
 } from './schema-general'
 
@@ -24,6 +27,9 @@ export interface VisualizationBlock {
         | TrendsQuery
         | FunnelsQuery
         | RetentionQuery
+        | StickinessQuery
+        | PathsQuery
+        | LifecycleQuery
         | HogQLQuery
         | RevenueAnalyticsGrossRevenueQuery
         | RevenueAnalyticsMetricsQuery

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -25008,35 +25008,6 @@ class QueryResponseAlternative74(BaseModel):
     ]
 
 
-class VisualizationBlock(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    query: (
-        TrendsQuery
-        | FunnelsQuery
-        | RetentionQuery
-        | HogQLQuery
-        | RevenueAnalyticsGrossRevenueQuery
-        | RevenueAnalyticsMetricsQuery
-        | RevenueAnalyticsMRRQuery
-        | RevenueAnalyticsTopCustomersQuery
-        | DataVisualizationNode
-        | AssistantTrendsQuery
-        | AssistantFunnelsQuery
-        | AssistantRetentionQuery
-        | AssistantStickinessQuery
-        | AssistantPathsQuery
-        | AssistantLifecycleQuery
-        | AssistantHogQLQuery
-    ) = Field(
-        ...,
-        description="The query to render (same as VisualizationArtifactContent.query)",
-    )
-    title: str | None = Field(default=None, description="Optional title for the visualization")
-    type: Literal["visualization"] = "visualization"
-
-
 class CachedExperimentFunnelsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -25255,21 +25226,6 @@ class LegacyExperimentQueryResponse(BaseModel):
         default=None,
         description=("Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics."),
     )
-
-
-class NotebookArtifactContent(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    blocks: list[MarkdownBlock | VisualizationBlock | SessionReplayBlock | LoadingBlock | ErrorBlock] = Field(
-        ..., description="Structured blocks for the notebook content"
-    )
-    content_type: Literal["notebook"] = Field(default="notebook", description="Notebook")
-    is_saved: bool | None = Field(
-        default=None,
-        description=("Whether this notebook has been saved to the database (not stored, set during enrichment)"),
-    )
-    title: str | None = Field(default=None, description="Title for the notebook")
 
 
 class PathsQuery(BaseModel):
@@ -25554,6 +25510,38 @@ class QueryResponseAlternative(
     )
 
 
+class VisualizationBlock(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    query: (
+        TrendsQuery
+        | FunnelsQuery
+        | RetentionQuery
+        | StickinessQuery
+        | PathsQuery
+        | LifecycleQuery
+        | HogQLQuery
+        | RevenueAnalyticsGrossRevenueQuery
+        | RevenueAnalyticsMetricsQuery
+        | RevenueAnalyticsMRRQuery
+        | RevenueAnalyticsTopCustomersQuery
+        | DataVisualizationNode
+        | AssistantTrendsQuery
+        | AssistantFunnelsQuery
+        | AssistantRetentionQuery
+        | AssistantStickinessQuery
+        | AssistantPathsQuery
+        | AssistantLifecycleQuery
+        | AssistantHogQLQuery
+    ) = Field(
+        ...,
+        description="The query to render (same as VisualizationArtifactContent.query)",
+    )
+    title: str | None = Field(default=None, description="Optional title for the visualization")
+    type: Literal["visualization"] = "visualization"
+
+
 class VisualizationItem(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -25746,13 +25734,6 @@ class DatabaseSchemaQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class DocumentArtifactContent(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    blocks: list[MarkdownBlock | VisualizationBlock | SessionReplayBlock | LoadingBlock | ErrorBlock]
-
-
 class ExperimentFunnelsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -25863,6 +25844,21 @@ class MultiVisualizationMessage(BaseModel):
     visualizations: list[VisualizationItem]
 
 
+class NotebookArtifactContent(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    blocks: list[MarkdownBlock | VisualizationBlock | SessionReplayBlock | LoadingBlock | ErrorBlock] = Field(
+        ..., description="Structured blocks for the notebook content"
+    )
+    content_type: Literal["notebook"] = Field(default="notebook", description="Notebook")
+    is_saved: bool | None = Field(
+        default=None,
+        description=("Whether this notebook has been saved to the database (not stored, set during enrichment)"),
+    )
+    title: str | None = Field(default=None, description="Title for the notebook")
+
+
 class WebVitalsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -25922,6 +25918,13 @@ class IsExperimentFunnelsQuery(BaseModel):
 
 class IsExperimentTrendsQuery(BaseModel):
     namedArgs: NamedArgs2 | None = None
+
+
+class DocumentArtifactContent(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    blocks: list[MarkdownBlock | VisualizationBlock | SessionReplayBlock | LoadingBlock | ErrorBlock]
 
 
 class ExperimentActorsQuery(BaseModel):


### PR DESCRIPTION
## Problem

Max (the AI assistant) intermittently fails with **"PostHog AI has failed to generate an answer. Please try again."** when a conversation references a saved insight whose query is a `LifecycleQuery`, `StickinessQuery`, or `PathsQuery` (for example a Growth accounting lifecycle insight).

Root cause: the `VisualizationBlock.query` union was missing those three concrete query types, even though:

- `is_supported_query()` (`ee/hogai/context/insight/query_executor.py`) returns `True` for them, and
- `VisualizationItem.answer` already includes them.

So the notebook artifact handler (`ee/hogai/artifacts/handlers/notebook.py`) passed the `is_supported_query` guard and then called `VisualizationBlock(query=...)` with the concrete query. Pydantic rejected it with a union `ValidationError` (16 errors). The unhandled exception crashed the `memory_collector` node and cascaded to a `CancelledError` on `root`, aborting the whole run. Because the offending insight stays in the conversation history, every retry fails identically.

## Changes

- Add `StickinessQuery | PathsQuery | LifecycleQuery` to the `VisualizationBlock.query` union in `frontend/src/queries/schema/schema-assistant-artifacts.ts`, bringing it in line with `VisualizationItem.answer`.
- Regenerate `frontend/src/queries/schema.json` and `posthog/schema.py` from the schema source.
- Add a parameterized regression test in `ee/hogai/core/test/test_artifacts.py` that constructs a `VisualizationBlock` from lifecycle / stickiness / paths queries.

No frontend UI changes.

## How did you test this code?

I'm an agent. I did **not** run the full Django test suite (no app environment available in this session). I verified the change by:

- Regenerating `schema.json` via `ts-json-schema-generator` and `schema.py` via `datamodel-codegen` (the repo's standard codegen), confirming the only semantic diff is the three added union members (remaining `schema.py` diff is generator-determined class ordering).
- Loading the regenerated `posthog/schema.py` standalone and confirming `VisualizationBlock(query=...)` now validates for `LifecycleQuery`, `StickinessQuery`, and `PathsQuery(pathsFilter=...)` — the previously-crashing `LifecycleQuery` case in particular.

The added test should be run in CI (`ee/hogai/core/test/test_artifacts.py`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code (PostHog Code), triggered from a Slack thread asking to investigate a Max trace that kept failing with "failed to generate an answer". The agent inspected the LLM trace, isolated the `memory_collector` `ValidationError` and the cascading `root` `CancelledError`, traced it to the `VisualizationBlock.query` union omitting concrete lifecycle/stickiness/paths types, and aligned it with the already-correct `VisualizationItem.answer` union.

Considered isolating `memory_collector` failures so a non-critical node can't cancel `root` — recommended as a follow-up but intentionally left out to keep this PR a focused schema fix. Also left a pre-existing duplicate `LifecycleQuery` entry in `is_supported_query()` untouched.

Requires human review and validation against the live assistant graph.
