### PR TITLE
feat(posthog-ai): frontend sandbox foundations bundle

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6618,6 +6618,33 @@ const api = {
             return new ApiRequest().conversation(conversationId).withAction('sandbox').create({ data })
         },
 
+        /**
+         * First message of a NEW sandbox conversation. The `/sandbox/` routing endpoint requires an
+         * existing conversation row, but a new conversation isn't created until its first message —
+         * so the first turn goes through the conversation-create endpoint with `is_sandbox: true`,
+         * which creates the conversation and routes to `handle_sandbox_message`, returning the same
+         * run IDs (not an SSE stream). Read them directly so the frontend can bootstrap the sandbox
+         * stream. Follow-ups use `sandbox()`. See 02_CORE.md §§ 3, 4.
+         */
+        async sandboxCreate(data: {
+            content: string
+            conversation: string
+            trace_id: string
+            attached_context?: AttachedContext[]
+        }): Promise<{
+            task_id: string
+            run_id: string
+            trace_id: string
+            run_status: 'queued' | 'in_progress'
+            just_created_run: boolean
+        }> {
+            const response = await api.createResponse(new ApiRequest().conversations().assembleFullUrl(), {
+                ...data,
+                is_sandbox: true,
+            })
+            return response.json()
+        },
+
         cancel(conversationId: string): Promise<void> {
             return new ApiRequest().conversation(conversationId).withAction('cancel').update()
         },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -247,7 +247,7 @@ import type {
 } from 'products/workflows/frontend/Workflows/hogflows/types'
 
 import { AgentMode } from '../queries/schema'
-import type { MaxUIContext } from '../scenes/max/maxTypes'
+import type { AttachedContext, MaxUIContext } from '../scenes/max/maxTypes'
 import { AlertSimulationResult, AlertType, AlertTypeWrite } from './components/Alerts/types'
 import {
     ErrorTrackingFingerprint,
@@ -6593,6 +6593,29 @@ const api = {
             options?: ApiMethodOptions
         ): Promise<Response> {
             return api.createResponse(new ApiRequest().conversations().assembleFullUrl(), data, options)
+        },
+
+        /**
+         * Sandbox-runtime message routing endpoint (`agent_runtime === 'sandbox'`). Non-streaming:
+         * wraps + dedupes context, creates/continues the backing products/tasks Run, and returns the
+         * IDs the frontend needs to open SSE directly against the products/tasks stream endpoint.
+         * See docs/internal/posthog-ai-migration/02_CORE.md § 4.
+         */
+        sandbox(
+            conversationId: string,
+            data: {
+                content: string
+                trace_id: string
+                attached_context?: AttachedContext[]
+            }
+        ): Promise<{
+            task_id: string
+            run_id: string
+            trace_id: string
+            run_status: 'queued' | 'in_progress'
+            just_created_run: boolean
+        }> {
+            return new ApiRequest().conversation(conversationId).withAction('sandbox').create({ data })
         },
 
         cancel(conversationId: string): Promise<void> {

--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -19,6 +19,7 @@ import {
     MaxInsightContext,
     MaxNotebookContext,
 } from './maxTypes'
+import { posthogAiContextLogic } from './posthogAiContextLogic'
 
 function pluralize(count: number, word: string): string {
     return `${count} ${word}${count > 1 ? 's' : ''}`
@@ -330,12 +331,44 @@ export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'de
     )
 }
 
+/**
+ * Sandbox-runtime chips, rendered from the flat `posthogAiContextLogic.chipsForDisplay`. The X on
+ * each chip dispatches `detach(key)` — one removal path, no source distinction. Coexistence
+ * sibling to `ContextTags` (LangGraph). See docs/internal/posthog-ai-migration/01_CONTEXT.md § 3.3.
+ */
+export function SandboxContextTags({ size = 'default' }: { size?: 'small' | 'default' }): JSX.Element | null {
+    const { chipsForDisplay } = useValues(posthogAiContextLogic)
+
+    if (chipsForDisplay.length === 0) {
+        return null
+    }
+
+    return (
+        <>
+            {chipsForDisplay.map((chip) => (
+                <Tooltip key={chip.key} title={chip.label}>
+                    <LemonTag
+                        icon={chip.icon as JSX.Element}
+                        onClose={chip.onRemove}
+                        closable
+                        closeOnClick
+                        className={clsx('flex items-center text-secondary', size === 'small' ? 'max-w-20' : 'max-w-48')}
+                    >
+                        <span className="truncate min-w-0 flex-1">{chip.label}</span>
+                    </LemonTag>
+                </Tooltip>
+            ))}
+        </>
+    )
+}
+
 interface ContextDisplayProps {
     size?: 'small' | 'default'
 }
 
 export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.Element | null {
-    const { showContextUI, contextDisabledReason } = useValues(maxThreadLogic)
+    const { showContextUI, contextDisabledReason, conversation } = useValues(maxThreadLogic)
+    const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
     const { hasData, contextOptions, taxonomicGroupTypes, mainTaxonomicGroupType, toolContextItems } =
         useValues(maxContextLogic)
     const { handleTaxonomicFilterChange } = useActions(maxContextLogic)
@@ -372,8 +405,14 @@ export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.E
                         />
                     </span>
                 </Tooltip>
-                <ContextToolInfoTags size={size} />
-                <ContextTags size={size} />
+                {isSandboxRuntime ? (
+                    <SandboxContextTags size={size} />
+                ) : (
+                    <>
+                        <ContextToolInfoTags size={size} />
+                        <ContextTags size={size} />
+                    </>
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 import React from 'react'
 
@@ -338,6 +338,7 @@ export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'de
  */
 export function SandboxContextTags({ size = 'default' }: { size?: 'small' | 'default' }): JSX.Element | null {
     const { chipsForDisplay } = useValues(posthogAiContextLogic)
+    const { detach } = useActions(posthogAiContextLogic)
 
     if (chipsForDisplay.length === 0) {
         return null
@@ -349,7 +350,7 @@ export function SandboxContextTags({ size = 'default' }: { size?: 'small' | 'def
                 <Tooltip key={chip.key} title={chip.label}>
                     <LemonTag
                         icon={chip.icon as JSX.Element}
-                        onClose={chip.onRemove}
+                        onClose={() => detach(chip.key)}
                         closable
                         closeOnClick
                         className={clsx('flex items-center text-secondary', size === 'small' ? 'max-w-20' : 'max-w-48')}
@@ -367,7 +368,7 @@ interface ContextDisplayProps {
 }
 
 export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.Element | null {
-    const { showContextUI, contextDisabledReason, conversation } = useValues(maxThreadLogic)
+    const { showContextUI, contextDisabledReason, conversation, sandboxConversationKey } = useValues(maxThreadLogic)
     const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
     const { hasData, contextOptions, taxonomicGroupTypes, mainTaxonomicGroupType, toolContextItems } =
         useValues(maxContextLogic)
@@ -406,7 +407,12 @@ export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.E
                     </span>
                 </Tooltip>
                 {isSandboxRuntime ? (
-                    <SandboxContextTags size={size} />
+                    sandboxConversationKey ? (
+                        // Same key maxThreadLogic's connect() uses, so both resolve the same instance
+                        <BindLogic logic={posthogAiContextLogic} props={{ conversationId: sandboxConversationKey }}>
+                            <SandboxContextTags size={size} />
+                        </BindLogic>
+                    ) : null
                 ) : (
                     <>
                         <ContextToolInfoTags size={size} />

--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -334,7 +334,7 @@ export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'de
 /**
  * Sandbox-runtime chips, rendered from the flat `posthogAiContextLogic.chipsForDisplay`. The X on
  * each chip dispatches `detach(key)` — one removal path, no source distinction. Coexistence
- * sibling to `ContextTags` (LangGraph). See docs/internal/posthog-ai-migration/01_CONTEXT.md § 3.3.
+ * sibling to `ContextTags` (LangGraph).
  */
 export function SandboxContextTags({ size = 'default' }: { size?: 'small' | 'default' }): JSX.Element | null {
     const { chipsForDisplay } = useValues(posthogAiContextLogic)

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -79,6 +79,8 @@ import { ToolRegistration, getToolDefinitionFromToolCall } from './max-constants
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { ThreadMessage, maxLogic } from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
+import type { McpToolCallMessage } from './maxTypes'
+import { lookupMcpToolRenderer } from './mcpToolRegistry'
 import { MessageTemplate } from './messages/MessageTemplate'
 import { MultiQuestionFormRecap } from './messages/MultiQuestionForm'
 import { NotebookArtifactAnswer } from './messages/NotebookArtifactAnswer'
@@ -90,6 +92,7 @@ import {
     isRenderableUIPayloadTool,
 } from './messages/UIPayloadAnswer'
 import { VisualizationArtifactAnswer } from './messages/VisualizationArtifactAnswer'
+import { sandboxStreamLogic } from './sandboxStreamLogic'
 import { MAX_SLASH_COMMANDS, SlashCommandName } from './slash-commands'
 import { TicketPrompt } from './TicketPrompt'
 import { getTicketPromptData, getTicketSummaryData, isTicketConfirmationMessage } from './ticketUtils'
@@ -114,9 +117,74 @@ function isErrorMessage(message: ThreadMessage): boolean {
     return message.type !== 'human' && (message.status === 'error' || message.type === 'ai/failure')
 }
 
+/** Maps a merged `ToolInvocation` into the flat `McpToolCallMessage` the registry renderers read. */
+function toolInvocationToMessage(
+    invocation: ReturnType<typeof sandboxStreamLogic.values.toolInvocations.get>
+): McpToolCallMessage | null {
+    if (!invocation) {
+        return null
+    }
+    return {
+        id: invocation.toolCallId,
+        resolvedKey: invocation.resolvedKey,
+        rawServerName: invocation.rawServerName,
+        rawToolName: invocation.rawToolName,
+        innerToolName: invocation.innerToolName,
+        rawInput: invocation.input,
+        innerInput: invocation.innerInput,
+        rawOutput: invocation.output,
+        content: invocation.contentBlocks,
+        status: invocation.status,
+        title: invocation.title,
+        kind: invocation.kind,
+    }
+}
+
+/**
+ * Sandbox-runtime thread renderer. Reads `sandboxStreamLogic.values.threadItems` (assistant text,
+ * tool-invocation references, run separators, inline errors) and dispatches tool cards through
+ * `mcpToolRegistry`. Coexistence sibling to the LangGraph thread render path; selected by
+ * `conversation.agent_runtime === 'sandbox'`. See docs/internal/posthog-ai-migration/02_CORE.md
+ * § 7.3 and 03_RICH_UI.md § 2.3.
+ */
+function SandboxThread(): JSX.Element {
+    const { threadItems, toolInvocations } = useValues(sandboxStreamLogic)
+
+    return (
+        <>
+            {threadItems.map((item) => {
+                if (item.type === 'assistant_message') {
+                    return (
+                        <MessageTemplate key={item.id} type="ai">
+                            <MarkdownMessage content={item.text ?? ''} id={item.id} />
+                        </MessageTemplate>
+                    )
+                }
+                if (item.type === 'tool_invocation' && item.toolCallId) {
+                    const message = toolInvocationToMessage(toolInvocations.get(item.toolCallId))
+                    if (!message) {
+                        return null
+                    }
+                    const entry = lookupMcpToolRenderer(message.resolvedKey)
+                    return <entry.Renderer key={item.id} message={message} isLastInGroup />
+                }
+                if (item.type === 'error') {
+                    return (
+                        <MessageTemplate key={item.id} type="ai" boxClassName="text-danger">
+                            {item.errorMessage}
+                        </MessageTemplate>
+                    )
+                }
+                return null
+            })}
+        </>
+    )
+}
+
 export function Thread({ className }: { className?: string }): JSX.Element | null {
     const { conversationLoading, messagesLoading, conversationId } = useValues(maxLogic)
-    const { threadGrouped, streamingActive, threadLoading, sandboxEntries } = useValues(maxThreadLogic)
+    const { threadGrouped, streamingActive, threadLoading, sandboxEntries, conversation } = useValues(maxThreadLogic)
+    const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
     const sandboxModeEnabled = useFeatureFlag('PHAI_SANDBOX_MODE')
     const { isPromptVisible, isDetailedFeedbackVisible, isThankYouVisible, traceId } = useFeedback(conversationId)
 
@@ -129,6 +197,19 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
         () => getTicketSummaryData(threadGrouped, streamingActive),
         [threadGrouped, streamingActive]
     )
+
+    if (isSandboxRuntime) {
+        return (
+            <div
+                className={cn(
+                    '@container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
+                    className
+                )}
+            >
+                <SandboxThread />
+            </div>
+        )
+    }
 
     return (
         <div

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -145,8 +145,7 @@ function toolInvocationToMessage(
  * Sandbox-runtime thread renderer. Reads `sandboxStreamLogic.values.threadItems` (assistant text,
  * tool-invocation references, run separators, inline errors) and dispatches tool cards through
  * `mcpToolRegistry`. Coexistence sibling to the LangGraph thread render path; selected by
- * `conversation.agent_runtime === 'sandbox'`. See docs/internal/posthog-ai-migration/02_CORE.md
- * § 7.3 and 03_RICH_UI.md § 2.3.
+ * `conversation.agent_runtime === 'sandbox'`.
  */
 function SandboxThread(): JSX.Element {
     const { threadItems, toolInvocations } = useValues(sandboxStreamLogic)

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -137,6 +137,7 @@ function toolInvocationToMessage(
         status: invocation.status,
         title: invocation.title,
         kind: invocation.kind,
+        error: invocation.error,
     }
 }
 
@@ -153,6 +154,13 @@ function SandboxThread(): JSX.Element {
     return (
         <>
             {threadItems.map((item) => {
+                if (item.type === 'human_message') {
+                    return (
+                        <MessageTemplate key={item.id} type="human">
+                            <MarkdownMessage content={item.text || '*No text.*'} id={item.id} />
+                        </MessageTemplate>
+                    )
+                }
                 if (item.type === 'assistant_message') {
                     return (
                         <MessageTemplate key={item.id} type="ai">

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import React, { useLayoutEffect, useMemo, useState } from 'react'
 
@@ -190,7 +190,8 @@ function SandboxThread(): JSX.Element {
 
 export function Thread({ className }: { className?: string }): JSX.Element | null {
     const { conversationLoading, messagesLoading, conversationId } = useValues(maxLogic)
-    const { threadGrouped, streamingActive, threadLoading, sandboxEntries, conversation } = useValues(maxThreadLogic)
+    const { threadGrouped, streamingActive, threadLoading, sandboxEntries, conversation, sandboxConversationKey } =
+        useValues(maxThreadLogic)
     const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
     const sandboxModeEnabled = useFeatureFlag('PHAI_SANDBOX_MODE')
     const { isPromptVisible, isDetailedFeedbackVisible, isThankYouVisible, traceId } = useFeedback(conversationId)
@@ -206,6 +207,9 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
     )
 
     if (isSandboxRuntime) {
+        if (!sandboxConversationKey) {
+            return null
+        }
         return (
             <div
                 className={cn(
@@ -213,7 +217,10 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
                     className
                 )}
             >
-                <SandboxThread />
+                {/* Same key maxThreadLogic's connect() uses, so both resolve the same instance */}
+                <BindLogic logic={sandboxStreamLogic} props={{ conversationId: sandboxConversationKey }}>
+                    <SandboxThread />
+                </BindLogic>
             </div>
         )
     }

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -31,6 +31,7 @@ import { maxContextLogic } from './maxContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { maxLogic } from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
+import { sandboxStreamLogic } from './sandboxStreamLogic'
 import {
     MOCK_CONVERSATION,
     MOCK_CONVERSATION_ID,
@@ -2967,6 +2968,87 @@ describe('maxThreadLogic', () => {
                 agentMode: AgentMode.SQL,
                 agentModeLockedByUser: false,
             })
+        })
+    })
+
+    describe('sandbox streaming lock', () => {
+        const sandboxRunResponse = {
+            task_id: 'task-1',
+            run_id: 'run-1',
+            trace_id: 'trace-1',
+            run_status: 'queued' as const,
+            just_created_run: true,
+        }
+
+        beforeEach(() => {
+            // jsdom has no EventSource — a minimal stub lets openSseForRun set up its connection
+            ;(globalThis as any).EventSource = class {
+                onopen: ((event: Event) => void) | null = null
+                onmessage: ((event: MessageEvent<string>) => void) | null = null
+                addEventListener(): void {}
+                close(): void {}
+            }
+        })
+
+        afterEach(() => {
+            delete (globalThis as any).EventSource
+        })
+
+        it('holds the streaming lock until the sandbox turn completes and releases exactly once', async () => {
+            jest.spyOn(api.conversations, 'sandboxCreate').mockResolvedValue(sandboxRunResponse)
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: 'hello', conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['openSandboxSse'])
+
+            // The POST finished, but the turn is still streaming — the lock must still be held
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(1)
+
+            // The release listeners are synchronous, so the lock state settles with the dispatch
+            sandboxStreamLogic.actions.markTurnComplete()
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
+
+            // A later terminal event must not release the (already released) lock again
+            maxLogicInstance.actions.incrActiveStreamingThreads()
+            sandboxStreamLogic.actions.handleTerminalStatus({ status: 'completed' })
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(1)
+            maxLogicInstance.actions.decrActiveStreamingThreads()
+        })
+
+        it('releases the lock immediately and surfaces an error when the send POST fails', async () => {
+            jest.spyOn(api.conversations, 'sandboxCreate').mockRejectedValue(new Error('boom'))
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: 'hello', conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['pushSandboxError', 'decrActiveStreamingThreads'])
+
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
+            expect(
+                sandboxStreamLogic.values.threadItems.some(
+                    (item) =>
+                        item.type === 'error' && item.errorMessage === 'Failed to send your message. Please try again.'
+                )
+            ).toEqual(true)
+        })
+
+        it('releases the lock immediately when no run was started', async () => {
+            const sandboxCreateSpy = jest.spyOn(api.conversations, 'sandboxCreate')
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: null, conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['decrActiveStreamingThreads'])
+
+            expect(sandboxCreateSpy).not.toHaveBeenCalled()
+            expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
         })
     })
 })

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -3007,13 +3007,16 @@ describe('maxThreadLogic', () => {
             // The POST finished, but the turn is still streaming — the lock must still be held
             expect(maxLogicInstance.values.activeStreamingThreads).toEqual(1)
 
+            // The thread logic connects to the instance keyed by its own conversationId
+            const sandboxStreamInstance = sandboxStreamLogic({ conversationId: MOCK_CONVERSATION_ID })
+
             // The release listeners are synchronous, so the lock state settles with the dispatch
-            sandboxStreamLogic.actions.markTurnComplete()
+            sandboxStreamInstance.actions.markTurnComplete()
             expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
 
             // A later terminal event must not release the (already released) lock again
             maxLogicInstance.actions.incrActiveStreamingThreads()
-            sandboxStreamLogic.actions.handleTerminalStatus({ status: 'completed' })
+            sandboxStreamInstance.actions.handleTerminalStatus({ status: 'completed' })
             expect(maxLogicInstance.values.activeStreamingThreads).toEqual(1)
             maxLogicInstance.actions.decrActiveStreamingThreads()
         })
@@ -3030,7 +3033,7 @@ describe('maxThreadLogic', () => {
 
             expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
             expect(
-                sandboxStreamLogic.values.threadItems.some(
+                sandboxStreamLogic({ conversationId: MOCK_CONVERSATION_ID }).values.threadItems.some(
                     (item) =>
                         item.type === 'error' && item.errorMessage === 'Failed to send your message. Please try again.'
                 )

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -644,7 +644,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
 
             // Sandbox runtime: route the message to a non-streaming products/tasks Run, then hand the
             // SSE connection off to sandboxStreamLogic. The LangGraph EventSource loop below is never
-            // entered for sandbox conversations. See 02_CORE.md §§ 4, 7.1.
+            // entered for sandbox conversations.
             //
             // An *existing* sandbox conversation (`agent_runtime === 'sandbox'`) uses the dedicated
             // `/sandbox/` routing endpoint. A *brand-new* conversation has no row yet — it's created

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -186,7 +186,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             // the logic as a dependency, so its listeners actually run. SandboxThread only mounts it
             // while a sandbox conversation is rendered — too late for the first message of a new one.
             sandboxStreamLogic,
-            ['openSseForRun as openSandboxSse'],
+            [
+                'openSseForRun as openSandboxSse',
+                'pushHumanMessage as pushSandboxHumanMessage',
+                'pushErrorItem as pushSandboxError',
+            ],
         ],
     })),
 
@@ -649,6 +653,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             // IDs as JSON (both endpoints return the identical { task_id, run_id, just_created_run }).
             const isExistingSandboxConversation = values.conversation?.agent_runtime === 'sandbox'
             if (isExistingSandboxConversation || isSandbox) {
+                // SandboxThread renders sandboxStreamLogic's threadItems, not this logic's thread,
+                // so the human message must be echoed there too to show up in the UI.
+                if (generationAttempt === 0 && streamData.content && addToThread) {
+                    actions.pushSandboxHumanMessage(streamData.content)
+                }
                 try {
                     const conversationId = values.conversation?.id || values.conversationId
                     if (conversationId && streamData.content) {
@@ -670,13 +679,25 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                             // Fresh runs need everything from the top; follow-ups resume from latest.
                             startLatest: !just_created_run,
                         })
+                        // The streaming lock must span the whole SSE stream so the input stays
+                        // guarded until `_posthog/turn_complete` or a terminal/error event —
+                        // mirrors the LangGraph path holding the lock for its entire stream.
+                        // Released exactly once by the sandboxStreamLogic listeners below; the
+                        // closure nulls itself so a second terminal event is a no-op.
+                        cache.sandboxStreamRelease = (): void => {
+                            cache.sandboxStreamRelease = null
+                            actions.decrActiveStreamingThreads()
+                            releaseStreamingLock()
+                        }
+                        return
                     }
                 } catch (e) {
                     posthog.captureException(e)
-                } finally {
-                    actions.decrActiveStreamingThreads()
-                    releaseStreamingLock()
+                    actions.pushSandboxError('Failed to send your message. Please try again.')
                 }
+                // The POST failed or no run was started — nothing will stream, release the lock now.
+                actions.decrActiveStreamingThreads()
+                releaseStreamingLock()
                 return
             }
 
@@ -696,10 +717,6 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
 
                 if (agentMode) {
                     apiData.agent_mode = agentMode
-                }
-
-                if (isSandbox) {
-                    apiData.is_sandbox = true
                 }
 
                 const response = await api.conversations.stream(apiData, {
@@ -896,6 +913,21 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             }
             cache.generationController = undefined
             releaseStreamingLock() // release the lock
+        },
+        // Sandbox runs stream through sandboxStreamLogic, so the streaming lock taken in
+        // streamConversation can only be released when that logic signals the turn ended —
+        // on turn completion, a terminal run status, or a stream error.
+        [sandboxStreamLogic.actionTypes.markTurnComplete]: () => {
+            const { cache } = logic as BuiltLogic<maxThreadLogicType>
+            cache.sandboxStreamRelease?.()
+        },
+        [sandboxStreamLogic.actionTypes.handleTerminalStatus]: () => {
+            const { cache } = logic as BuiltLogic<maxThreadLogicType>
+            cache.sandboxStreamRelease?.()
+        },
+        [sandboxStreamLogic.actionTypes.handleStreamError]: () => {
+            const { cache } = logic as BuiltLogic<maxThreadLogicType>
+            cache.sandboxStreamRelease?.()
         },
     })),
     listeners(({ actions, values, cache, props }) => ({

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -74,6 +74,8 @@ import { maxGlobalLogic } from './maxGlobalLogic'
 import { SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import type { maxThreadLogicType } from './maxThreadLogicType'
 import { MaxUIContext } from './maxTypes'
+import { posthogAiContextLogic } from './posthogAiContextLogic'
+import { sandboxStreamLogic } from './sandboxStreamLogic'
 import { MAX_SLASH_COMMANDS, SlashCommand } from './slash-commands'
 import { EnhancedToolCall, getToolCallDescriptionAndWidget } from './Thread'
 import {
@@ -625,6 +627,34 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     trace_id: traceId,
                 }
                 actions.addMessage(message)
+            }
+
+            // Sandbox runtime: POST the non-streaming /sandbox/ routing endpoint, then hand the SSE
+            // connection off to sandboxStreamLogic. The LangGraph EventSource loop below is never
+            // entered for sandbox conversations. See 02_CORE.md § 7.1.
+            if (values.conversation?.agent_runtime === 'sandbox') {
+                try {
+                    const conversationId = values.conversation?.id || values.conversationId
+                    if (conversationId && streamData.content) {
+                        const { task_id, run_id, just_created_run } = await api.conversations.sandbox(conversationId, {
+                            content: streamData.content,
+                            trace_id: traceId,
+                            attached_context: posthogAiContextLogic.values.attachments,
+                        })
+                        sandboxStreamLogic.actions.openSseForRun({
+                            taskId: task_id,
+                            runId: run_id,
+                            // Fresh runs need everything from the top; follow-ups resume from latest.
+                            startLatest: !just_created_run,
+                        })
+                    }
+                } catch (e) {
+                    posthog.captureException(e)
+                } finally {
+                    actions.decrActiveStreamingThreads()
+                    releaseStreamingLock()
+                }
+                return
             }
 
             let caughtException = false

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -142,7 +142,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         }
     }),
 
-    connect(({ panelId }: MaxThreadLogicProps) => ({
+    connect(({ panelId, conversationId }: MaxThreadLogicProps) => ({
         values: [
             maxGlobalLogic,
             ['dataProcessingAccepted', 'toolMap', 'tools', 'availableStaticTools'],
@@ -162,9 +162,10 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             ['featureFlags'],
             sceneLogic,
             ['sceneId'],
-            // Mounts the sandbox attachment store so its `attachments` are readable at send time
-            // even when no context-chip UI is rendered (a fresh conversation never mounts it itself).
-            posthogAiContextLogic,
+            // Mounts this conversation's sandbox attachment store so its `attachments` are readable
+            // at send time even when no context-chip UI is rendered (a fresh conversation never
+            // mounts it itself).
+            posthogAiContextLogic({ conversationId }),
             ['attachments as sandboxAttachments'],
         ],
         actions: [
@@ -182,10 +183,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             ],
             maxGlobalLogic,
             ['loadConversation'],
-            // Pulling the action in (rather than calling sandboxStreamLogic.actions.* directly) mounts
-            // the logic as a dependency, so its listeners actually run. SandboxThread only mounts it
-            // while a sandbox conversation is rendered — too late for the first message of a new one.
-            sandboxStreamLogic,
+            // Pulling the action in (rather than calling the instance's actions directly) mounts this
+            // conversation's stream logic as a dependency, so its listeners actually run. SandboxThread
+            // only mounts it while a sandbox conversation is rendered — too late for the first message
+            // of a new one.
+            sandboxStreamLogic({ conversationId }),
             [
                 'openSseForRun as openSandboxSse',
                 'pushHumanMessage as pushSandboxHumanMessage',
@@ -914,22 +916,19 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             cache.generationController = undefined
             releaseStreamingLock() // release the lock
         },
-        // Sandbox runs stream through sandboxStreamLogic, so the streaming lock taken in
-        // streamConversation can only be released when that logic signals the turn ended —
-        // on turn completion, a terminal run status, or a stream error.
-        [sandboxStreamLogic.actionTypes.markTurnComplete]: () => {
-            const { cache } = logic as BuiltLogic<maxThreadLogicType>
-            cache.sandboxStreamRelease?.()
-        },
-        [sandboxStreamLogic.actionTypes.handleTerminalStatus]: () => {
-            const { cache } = logic as BuiltLogic<maxThreadLogicType>
-            cache.sandboxStreamRelease?.()
-        },
-        [sandboxStreamLogic.actionTypes.handleStreamError]: () => {
-            const { cache } = logic as BuiltLogic<maxThreadLogicType>
-            cache.sandboxStreamRelease?.()
-        },
     })),
+    // Sandbox runs stream through this conversation's sandboxStreamLogic instance, so the streaming
+    // lock taken in streamConversation can only be released when that instance signals the turn
+    // ended — on turn completion, a terminal run status, or a stream error. Its action types are
+    // per-instance (the key is in the path), so they're resolved from props at build time.
+    listeners(({ props, cache }) => {
+        const sandboxStreamActionTypes = sandboxStreamLogic({ conversationId: props.conversationId }).actionTypes
+        return {
+            [sandboxStreamActionTypes.markTurnComplete]: () => cache.sandboxStreamRelease?.(),
+            [sandboxStreamActionTypes.handleTerminalStatus]: () => cache.sandboxStreamRelease?.(),
+            [sandboxStreamActionTypes.handleStreamError]: () => cache.sandboxStreamRelease?.(),
+        }
+    }),
     listeners(({ actions, values, cache, props }) => ({
         setConversation: ({ conversation }) => {
             const nextConversationId = conversation?.id ?? null
@@ -1456,6 +1455,10 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             (s, p) => [s.conversation, p.conversationId],
             (conversation, propsConversationId) => (conversation?.id ? conversation.id : propsConversationId),
         ],
+
+        // The exact id this instance was keyed with. React must bind the per-conversation sandbox
+        // logics with the same id connect() used above, or the two would resolve different instances.
+        sandboxConversationKey: [(_, p) => [p.conversationId], (conversationId): string => conversationId],
 
         effectiveApprovalStatuses: [
             (s) => [s.resolvedApprovalStatuses, s.pendingApprovalsData],

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -162,6 +162,10 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             ['featureFlags'],
             sceneLogic,
             ['sceneId'],
+            // Mounts the sandbox attachment store so its `attachments` are readable at send time
+            // even when no context-chip UI is rendered (a fresh conversation never mounts it itself).
+            posthogAiContextLogic,
+            ['attachments as sandboxAttachments'],
         ],
         actions: [
             maxLogic({ panelId }),
@@ -178,6 +182,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             ],
             maxGlobalLogic,
             ['loadConversation'],
+            // Pulling the action in (rather than calling sandboxStreamLogic.actions.* directly) mounts
+            // the logic as a dependency, so its listeners actually run. SandboxThread only mounts it
+            // while a sandbox conversation is rendered — too late for the first message of a new one.
+            sandboxStreamLogic,
+            ['openSseForRun as openSandboxSse'],
         ],
     })),
 
@@ -629,19 +638,33 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.addMessage(message)
             }
 
-            // Sandbox runtime: POST the non-streaming /sandbox/ routing endpoint, then hand the SSE
-            // connection off to sandboxStreamLogic. The LangGraph EventSource loop below is never
-            // entered for sandbox conversations. See 02_CORE.md § 7.1.
-            if (values.conversation?.agent_runtime === 'sandbox') {
+            // Sandbox runtime: route the message to a non-streaming products/tasks Run, then hand the
+            // SSE connection off to sandboxStreamLogic. The LangGraph EventSource loop below is never
+            // entered for sandbox conversations. See 02_CORE.md §§ 4, 7.1.
+            //
+            // An *existing* sandbox conversation (`agent_runtime === 'sandbox'`) uses the dedicated
+            // `/sandbox/` routing endpoint. A *brand-new* conversation has no row yet — it's created
+            // lazily on the first message — so `agent_runtime` isn't known here; we detect the
+            // `is_sandbox` flag and let the conversation-create endpoint create it + return the run
+            // IDs as JSON (both endpoints return the identical { task_id, run_id, just_created_run }).
+            const isExistingSandboxConversation = values.conversation?.agent_runtime === 'sandbox'
+            if (isExistingSandboxConversation || isSandbox) {
                 try {
                     const conversationId = values.conversation?.id || values.conversationId
                     if (conversationId && streamData.content) {
-                        const { task_id, run_id, just_created_run } = await api.conversations.sandbox(conversationId, {
-                            content: streamData.content,
-                            trace_id: traceId,
-                            attached_context: posthogAiContextLogic.values.attachments,
-                        })
-                        sandboxStreamLogic.actions.openSseForRun({
+                        const { task_id, run_id, just_created_run } = isExistingSandboxConversation
+                            ? await api.conversations.sandbox(conversationId, {
+                                  content: streamData.content,
+                                  trace_id: traceId,
+                                  attached_context: values.sandboxAttachments,
+                              })
+                            : await api.conversations.sandboxCreate({
+                                  conversation: conversationId,
+                                  content: streamData.content,
+                                  trace_id: traceId,
+                                  attached_context: values.sandboxAttachments,
+                              })
+                        actions.openSandboxSse({
                             taskId: task_id,
                             runId: run_id,
                             // Fresh runs need everything from the top; follow-ups resume from latest.

--- a/frontend/src/scenes/max/maxTypes.ts
+++ b/frontend/src/scenes/max/maxTypes.ts
@@ -237,3 +237,47 @@ export const createMaxContextHelpers = {
 export function isAgentMode(mode: unknown): mode is AgentMode {
     return typeof mode === 'string' && Object.values(AgentMode).includes(mode as AgentMode)
 }
+
+/**
+ * The shape `mcpToolRegistry` renderers receive — a merged `ToolInvocation` flattened with the
+ * fields the renderer adapters read. Built by `sandboxStreamLogic` from ACP frames. See
+ * docs/internal/posthog-ai-migration/03_RICH_UI.md §§ 2.1, 3.1.
+ */
+export interface McpToolCallMessage {
+    /** Stable id — the tool call id. */
+    id: string
+    /** Registry lookup key — see 03_RICH_UI.md § 2.2. */
+    resolvedKey: string
+    rawServerName: string
+    rawToolName: string
+    innerToolName?: string
+    /** rawInput at `tool_call` (for `exec`, includes the wrapper `{ command }`). */
+    rawInput: Record<string, unknown>
+    /** JSON-parsed inner args when `innerToolName` is set. */
+    innerInput?: Record<string, unknown>
+    rawOutput?: unknown
+    /** Accumulated ACP `content[]`. */
+    content: unknown[]
+    status: 'pending' | 'in_progress' | 'completed' | 'failed'
+    title?: string
+    kind?: string
+    error?: { message?: string } | null
+}
+
+/**
+ * Flat context attachment sent to the sandbox agent runtime (`agent_runtime === 'sandbox'`).
+ *
+ * Unlike the rich `MaxUIContext` payloads used by the LangGraph runtime, the sandbox runtime
+ * carries only typed references the agent fetches on demand via its read tools. See
+ * docs/internal/posthog-ai-migration/01_CONTEXT.md § 1. This is a new export added alongside
+ * the existing context types during the coexistence window — existing types are untouched.
+ */
+export interface AttachedContext {
+    type: 'dashboard' | 'insight' | 'event' | 'action' | 'error_tracking_issue' | 'evaluation' | 'notebook' | 'text'
+    /** Entity id — int for dashboards/actions, short_id for insights/notebooks, UUID for error tracking issues. */
+    id?: string | number
+    /** Optional human-readable label for entity types. */
+    name?: string
+    /** Free-text value — only set when `type === 'text'`. */
+    value?: string
+}

--- a/frontend/src/scenes/max/maxTypes.ts
+++ b/frontend/src/scenes/max/maxTypes.ts
@@ -240,13 +240,12 @@ export function isAgentMode(mode: unknown): mode is AgentMode {
 
 /**
  * The shape `mcpToolRegistry` renderers receive — a merged `ToolInvocation` flattened with the
- * fields the renderer adapters read. Built by `sandboxStreamLogic` from ACP frames. See
- * docs/internal/posthog-ai-migration/03_RICH_UI.md §§ 2.1, 3.1.
+ * fields the renderer adapters read. Built by `sandboxStreamLogic` from ACP frames.
  */
 export interface McpToolCallMessage {
     /** Stable id — the tool call id. */
     id: string
-    /** Registry lookup key — see 03_RICH_UI.md § 2.2. */
+    /** Registry lookup key — the inner tool name for single-exec calls, otherwise the wire tool name. */
     resolvedKey: string
     rawServerName: string
     rawToolName: string
@@ -268,9 +267,9 @@ export interface McpToolCallMessage {
  * Flat context attachment sent to the sandbox agent runtime (`agent_runtime === 'sandbox'`).
  *
  * Unlike the rich `MaxUIContext` payloads used by the LangGraph runtime, the sandbox runtime
- * carries only typed references the agent fetches on demand via its read tools. See
- * docs/internal/posthog-ai-migration/01_CONTEXT.md § 1. This is a new export added alongside
- * the existing context types during the coexistence window — existing types are untouched.
+ * carries only typed references the agent fetches on demand via its read tools. This is a new
+ * export added alongside the existing context types during the coexistence window — existing
+ * types are untouched.
  */
 export interface AttachedContext {
     type: 'dashboard' | 'insight' | 'event' | 'action' | 'error_tracking_issue' | 'evaluation' | 'notebook' | 'text'

--- a/frontend/src/scenes/max/mcpToolRegistry.tsx
+++ b/frontend/src/scenes/max/mcpToolRegistry.tsx
@@ -1,0 +1,65 @@
+import type { ComponentType } from 'react'
+
+import { IconWrench } from '@posthog/icons'
+
+import type { McpToolCallMessage } from './maxTypes'
+import { FallbackMcpToolRenderer } from './messages/FallbackMcpToolRenderer'
+
+export interface McpToolRendererProps {
+    message: McpToolCallMessage
+    isLastInGroup: boolean
+}
+
+export interface McpToolRegistryEntry {
+    /**
+     * Registry key. For single-exec PostHog tools, this is the **inner** tool name parsed from
+     * `rawInput.command` (e.g. "execute-sql", "insight-create"); for `exec`'s discovery verbs,
+     * the sentinel "__posthog_exec_tools__" etc.; for non-exec MCP tools and Claude built-ins,
+     * the wire `toolName` directly (e.g. "TodoWrite", "WebSearch"). See 03_RICH_UI.md § 2.2.
+     */
+    key: string
+    /** Display name / icon for fallback rendering and for the tool-call header line. */
+    displayName: string
+    icon: JSX.Element
+    Renderer: ComponentType<McpToolRendererProps>
+}
+
+export interface McpToolRegistry {
+    register: (entry: McpToolRegistryEntry) => void
+    lookup: (toolName: string) => McpToolRegistryEntry | null
+}
+
+class MapBackedRegistry implements McpToolRegistry {
+    private entries = new Map<string, McpToolRegistryEntry>()
+
+    register(entry: McpToolRegistryEntry): void {
+        this.entries.set(entry.key, entry)
+    }
+
+    lookup(toolName: string): McpToolRegistryEntry | null {
+        return this.entries.get(toolName) ?? null
+    }
+}
+
+/**
+ * Single module-level registry of MCP tool-name → renderer. All entries are registered at module
+ * load — no dynamic registration, no hooks, no scene callbacks. Custom adapters land per-tool
+ * (behind `phai-sandbox-tool-{slug}`) in follow-up PRs (UI-A / UI-B / UI-C); until then every tool
+ * falls through to `FallbackMcpToolRenderer`. See docs/internal/posthog-ai-migration/03_RICH_UI.md
+ * §§ 3.1–3.2.
+ */
+export const mcpToolRegistry: McpToolRegistry = new MapBackedRegistry()
+
+// Custom adapters are registered here as they land. The skeleton ships with the fallback only.
+
+/** Looks up the renderer entry for a resolved tool key, falling back to the generic card. */
+export function lookupMcpToolRenderer(resolvedKey: string): McpToolRegistryEntry {
+    return (
+        mcpToolRegistry.lookup(resolvedKey) ?? {
+            key: resolvedKey,
+            displayName: resolvedKey,
+            icon: <IconWrench />,
+            Renderer: FallbackMcpToolRenderer,
+        }
+    )
+}

--- a/frontend/src/scenes/max/mcpToolRegistry.tsx
+++ b/frontend/src/scenes/max/mcpToolRegistry.tsx
@@ -15,7 +15,7 @@ export interface McpToolRegistryEntry {
      * Registry key. For single-exec PostHog tools, this is the **inner** tool name parsed from
      * `rawInput.command` (e.g. "execute-sql", "insight-create"); for `exec`'s discovery verbs,
      * the sentinel "__posthog_exec_tools__" etc.; for non-exec MCP tools and Claude built-ins,
-     * the wire `toolName` directly (e.g. "TodoWrite", "WebSearch"). See 03_RICH_UI.md § 2.2.
+     * the wire `toolName` directly (e.g. "TodoWrite", "WebSearch").
      */
     key: string
     /** Display name / icon for fallback rendering and for the tool-call header line. */
@@ -43,10 +43,9 @@ class MapBackedRegistry implements McpToolRegistry {
 
 /**
  * Single module-level registry of MCP tool-name → renderer. All entries are registered at module
- * load — no dynamic registration, no hooks, no scene callbacks. Custom adapters land per-tool
- * (behind `phai-sandbox-tool-{slug}`) in follow-up PRs (UI-A / UI-B / UI-C); until then every tool
- * falls through to `FallbackMcpToolRenderer`. See docs/internal/posthog-ai-migration/03_RICH_UI.md
- * §§ 3.1–3.2.
+ * load — no dynamic registration, no hooks, no scene callbacks. Custom adapters are registered
+ * per tool (behind `phai-sandbox-tool-{slug}` flags); any tool without one falls through to
+ * `FallbackMcpToolRenderer`.
  */
 export const mcpToolRegistry: McpToolRegistry = new MapBackedRegistry()
 

--- a/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
+++ b/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
@@ -1,0 +1,96 @@
+import { IconCheck, IconWarning, IconWrench } from '@posthog/icons'
+import { LemonCollapse, Spinner } from '@posthog/lemon-ui'
+
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+
+import type { McpToolRendererProps } from '../mcpToolRegistry'
+import { MessageTemplate } from './MessageTemplate'
+
+/** Pretty-prints accumulated ACP `content[]` — text frames inline, everything else as JSON. */
+function renderContentBlocks(content: unknown[]): string {
+    return content
+        .map((block) => {
+            if (block && typeof block === 'object' && 'text' in block) {
+                return String((block as { text: unknown }).text)
+            }
+            return JSON.stringify(block, null, 2)
+        })
+        .join('\n')
+}
+
+function statusBadge(status: McpToolRendererProps['message']['status']): JSX.Element {
+    if (status === 'in_progress' || status === 'pending') {
+        return <Spinner className="text-sm" />
+    }
+    if (status === 'failed') {
+        return <IconWarning className="text-danger text-sm" />
+    }
+    return <IconCheck className="text-success text-sm" />
+}
+
+/**
+ * Catch-all renderer for any MCP tool call not yet wired through a custom adapter — user-installed
+ * MCPs, unknown inner tools, malformed `exec` commands. Renders a generic, greppable tool card so
+ * the registry can ship incrementally. See docs/internal/posthog-ai-migration/03_RICH_UI.md § 3.4.
+ */
+export function FallbackMcpToolRenderer({ message }: McpToolRendererProps): JSX.Element {
+    const headerLabel = message.title || message.innerToolName || message.rawToolName || 'Tool call'
+    const contentText = message.content.length > 0 ? renderContentBlocks(message.content) : ''
+    const outputText =
+        message.rawOutput !== undefined && message.rawOutput !== null ? JSON.stringify(message.rawOutput, null, 2) : ''
+
+    return (
+        <MessageTemplate
+            type="ai"
+            header={
+                <div className="flex items-center gap-1.5 text-sm text-secondary mb-1">
+                    <IconWrench className="text-base" />
+                    <span className="font-medium text-default">{headerLabel}</span>
+                    {statusBadge(message.status)}
+                </div>
+            }
+        >
+            <div className="flex flex-col gap-2">
+                {message.status === 'failed' && message.error?.message && (
+                    <div className="text-danger text-sm">{message.error.message}</div>
+                )}
+                <LemonCollapse
+                    size="small"
+                    panels={[
+                        {
+                            key: 'input',
+                            header: 'Input',
+                            content: (
+                                <CodeSnippet language={Language.JSON} compact>
+                                    {JSON.stringify(message.innerInput ?? message.rawInput, null, 2)}
+                                </CodeSnippet>
+                            ),
+                        },
+                        contentText
+                            ? {
+                                  key: 'content',
+                                  header: 'Output',
+                                  content: (
+                                      <CodeSnippet language={Language.Text} compact>
+                                          {contentText}
+                                      </CodeSnippet>
+                                  ),
+                              }
+                            : null,
+                        outputText
+                            ? {
+                                  key: 'raw-output',
+                                  header: 'Raw output',
+                                  content: (
+                                      <CodeSnippet language={Language.JSON} compact>
+                                          {outputText}
+                                      </CodeSnippet>
+                                  ),
+                              }
+                            : null,
+                    ]}
+                />
+            </div>
+        </MessageTemplate>
+    )
+}

--- a/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
+++ b/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
@@ -31,7 +31,7 @@ function statusBadge(status: McpToolRendererProps['message']['status']): JSX.Ele
 /**
  * Catch-all renderer for any MCP tool call not yet wired through a custom adapter — user-installed
  * MCPs, unknown inner tools, malformed `exec` commands. Renders a generic, greppable tool card so
- * the registry can ship incrementally. See docs/internal/posthog-ai-migration/03_RICH_UI.md § 3.4.
+ * the registry can ship incrementally.
  */
 export function FallbackMcpToolRenderer({ message }: McpToolRendererProps): JSX.Element {
     const headerLabel = message.title || message.innerToolName || message.rawToolName || 'Tool call'

--- a/frontend/src/scenes/max/posthogAiContextLogic.tsx
+++ b/frontend/src/scenes/max/posthogAiContextLogic.tsx
@@ -1,0 +1,147 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import type { ReactNode } from 'react'
+
+import { IconDashboard, IconGraph, IconNotebook } from '@posthog/icons'
+
+import { IconAction, IconEvent } from 'lib/lemon-ui/icons'
+import { sceneLogic } from 'scenes/sceneLogic'
+
+import { AttachedContext, MaxContextInput, MaxContextType } from './maxTypes'
+import type { posthogAiContextLogicType } from './posthogAiContextLogicType'
+
+/** Stable dedupe + chip key for an attachment: `${type}:${id ?? value}`. */
+export function attachedContextKey(item: AttachedContext): string {
+    return `${item.type}:${item.id ?? item.value ?? ''}`
+}
+
+/**
+ * Projects a rich scene `MaxContextInput` down to the flat `AttachedContext` shape the sandbox
+ * runtime sends. Strips nested entity data — the agent fetches details via its read tools.
+ * Returns null for inputs that have no flat representation.
+ */
+export function projectToAttachedContext(item: MaxContextInput): AttachedContext | null {
+    switch (item.type) {
+        case MaxContextType.DASHBOARD:
+            return { type: 'dashboard', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.INSIGHT:
+            return { type: 'insight', id: item.data.short_id, name: item.data.name ?? undefined }
+        case MaxContextType.EVENT:
+            return { type: 'event', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.ACTION:
+            return { type: 'action', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.ERROR_TRACKING_ISSUE:
+            return { type: 'error_tracking_issue', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.EVALUATION:
+            return { type: 'evaluation', id: item.data.id, name: item.data.name ?? undefined }
+        case MaxContextType.NOTEBOOK:
+            return { type: 'notebook', id: item.data.short_id, name: item.data.title ?? undefined }
+        default:
+            return null
+    }
+}
+
+function iconForType(type: AttachedContext['type']): ReactNode {
+    switch (type) {
+        case 'dashboard':
+            return <IconDashboard />
+        case 'insight':
+            return <IconGraph />
+        case 'event':
+            return <IconEvent />
+        case 'action':
+            return <IconAction />
+        case 'notebook':
+            return <IconNotebook />
+        default:
+            return <IconGraph />
+    }
+}
+
+function labelForItem(item: AttachedContext): string {
+    if (item.type === 'text') {
+        return item.value ?? 'Text'
+    }
+    if (item.name) {
+        return item.name
+    }
+    return `${item.type} ${item.id ?? ''}`.trim()
+}
+
+/**
+ * Sandbox-runtime context store. Holds one flat `attachments` reducer plus a scene-pull
+ * listener that reads the existing scenes' `maxContext` selectors and projects their rich
+ * items down to `AttachedContext` at consumption time — zero scene-side edits.
+ *
+ * Coexistence sibling to `maxContextLogic.ts`; used only when `agent_runtime === 'sandbox'`.
+ * See docs/internal/posthog-ai-migration/01_CONTEXT.md § 3.
+ */
+export const posthogAiContextLogic = kea<posthogAiContextLogicType>([
+    path(['scenes', 'max', 'posthogAiContextLogic']),
+    connect(() => ({
+        values: [sceneLogic, ['activeSceneLogic']],
+    })),
+    actions({
+        /** Dedup-add. Called by scene sync AND by the TaxonomicFilter affordance. */
+        attach: (item: AttachedContext) => ({ item }),
+        /** Remove by `${type}:${id ?? value}` key. */
+        detach: (key: string) => ({ key }),
+        /** Convenience reset, e.g. on a new conversation. */
+        clearAttachments: true,
+        /** Router/scene listener — projects every current-scene item and attaches it. */
+        syncSceneAttachments: true,
+    }),
+    reducers({
+        attachments: [
+            [] as AttachedContext[],
+            {
+                attach: (state, { item }) => {
+                    const key = attachedContextKey(item)
+                    // Text items are never deduped — repeated text is intentional.
+                    if (item.type !== 'text' && state.some((existing) => attachedContextKey(existing) === key)) {
+                        return state
+                    }
+                    return [...state, item]
+                },
+                detach: (state, { key }) => state.filter((item) => attachedContextKey(item) !== key),
+                clearAttachments: () => [],
+            },
+        ],
+    }),
+    selectors({
+        chipsForDisplay: [
+            (s) => [s.attachments],
+            (attachments): { key: string; label: string; icon: ReactNode; onRemove: () => void }[] =>
+                attachments.map((item) => {
+                    const key = attachedContextKey(item)
+                    return {
+                        key,
+                        label: labelForItem(item),
+                        icon: iconForType(item.type),
+                        onRemove: () => posthogAiContextLogic.actions.detach(key),
+                    }
+                }),
+        ],
+    }),
+    listeners(({ values, actions }) => ({
+        syncSceneAttachments: () => {
+            const activeSceneLogic = values.activeSceneLogic
+            if (!activeSceneLogic || !('maxContext' in activeSceneLogic.selectors)) {
+                return
+            }
+            let sceneItems: MaxContextInput[] = []
+            try {
+                // BuiltLogic exposes selector results on `.values`; props are already bound.
+                sceneItems = (activeSceneLogic.values as { maxContext?: MaxContextInput[] }).maxContext ?? []
+            } catch {
+                // If the scene's maxContext selector throws, skip — nothing to attach.
+                return
+            }
+            for (const item of sceneItems) {
+                const projected = projectToAttachedContext(item)
+                if (projected) {
+                    actions.attach(projected)
+                }
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/max/posthogAiContextLogic.tsx
+++ b/frontend/src/scenes/max/posthogAiContextLogic.tsx
@@ -73,7 +73,6 @@ function labelForItem(item: AttachedContext): string {
  * items down to `AttachedContext` at consumption time — zero scene-side edits.
  *
  * Coexistence sibling to `maxContextLogic.ts`; used only when `agent_runtime === 'sandbox'`.
- * See docs/internal/posthog-ai-migration/01_CONTEXT.md § 3.
  */
 export const posthogAiContextLogic = kea<posthogAiContextLogicType>([
     path(['scenes', 'max', 'posthogAiContextLogic']),

--- a/frontend/src/scenes/max/posthogAiContextLogic.tsx
+++ b/frontend/src/scenes/max/posthogAiContextLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import type { ReactNode } from 'react'
 
 import { IconDashboard, IconGraph, IconNotebook } from '@posthog/icons'
@@ -8,6 +8,10 @@ import { sceneLogic } from 'scenes/sceneLogic'
 
 import { AttachedContext, MaxContextInput, MaxContextType } from './maxTypes'
 import type { posthogAiContextLogicType } from './posthogAiContextLogicType'
+
+export interface PosthogAiContextLogicProps {
+    conversationId: string
+}
 
 /** Stable dedupe + chip key for an attachment: `${type}:${id ?? value}`. */
 export function attachedContextKey(item: AttachedContext): string {
@@ -73,9 +77,13 @@ function labelForItem(item: AttachedContext): string {
  * items down to `AttachedContext` at consumption time — zero scene-side edits.
  *
  * Coexistence sibling to `maxContextLogic.ts`; used only when `agent_runtime === 'sandbox'`.
+ *
+ * Keyed by conversation id so each conversation keeps its own attachment set.
  */
 export const posthogAiContextLogic = kea<posthogAiContextLogicType>([
-    path(['scenes', 'max', 'posthogAiContextLogic']),
+    props({} as PosthogAiContextLogicProps),
+    key((props) => props.conversationId),
+    path((key) => ['scenes', 'max', 'posthogAiContextLogic', key]),
     connect(() => ({
         values: [sceneLogic, ['activeSceneLogic']],
     })),
@@ -109,16 +117,14 @@ export const posthogAiContextLogic = kea<posthogAiContextLogicType>([
     selectors({
         chipsForDisplay: [
             (s) => [s.attachments],
-            (attachments): { key: string; label: string; icon: ReactNode; onRemove: () => void }[] =>
-                attachments.map((item) => {
-                    const key = attachedContextKey(item)
-                    return {
-                        key,
-                        label: labelForItem(item),
-                        icon: iconForType(item.type),
-                        onRemove: () => posthogAiContextLogic.actions.detach(key),
-                    }
-                }),
+            // No onRemove closures here — removal dispatches `detach(key)` on the consumer's
+            // bound instance, so chips stay instance-agnostic data.
+            (attachments): { key: string; label: string; icon: ReactNode }[] =>
+                attachments.map((item) => ({
+                    key: attachedContextKey(item),
+                    label: labelForItem(item),
+                    icon: iconForType(item.type),
+                })),
         ],
     }),
     listeners(({ values, actions }) => ({

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -1,0 +1,124 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { resolveToolKey, sandboxStreamLogic } from './sandboxStreamLogic'
+import type { StoredLogEntry } from './types/sandboxStreamTypes'
+
+function notification(method: string, params: Record<string, unknown>): StoredLogEntry {
+    return { type: 'notification', notification: { method, params } }
+}
+
+function sessionUpdate(update: Record<string, unknown>): StoredLogEntry {
+    return notification('session/update', { update })
+}
+
+describe('sandboxStreamLogic', () => {
+    let logic: ReturnType<typeof sandboxStreamLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = sandboxStreamLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    describe('resolveToolKey', () => {
+        it('parses the inner tool name out of a single-exec call command', () => {
+            const resolved = resolveToolKey('posthog', 'exec', { command: 'call insight-create {"name":"Signups"}' })
+            expect(resolved.resolvedKey).toEqual('insight-create')
+            expect(resolved.innerToolName).toEqual('insight-create')
+            expect(resolved.innerInput).toEqual({ name: 'Signups' })
+        })
+
+        it('maps discovery verbs to sentinels', () => {
+            expect(resolveToolKey('posthog', 'exec', { command: 'tools' }).resolvedKey).toEqual(
+                '__posthog_exec_tools__'
+            )
+            expect(resolveToolKey('posthog', 'exec', { command: 'search recordings' }).resolvedKey).toEqual(
+                '__posthog_exec_search__'
+            )
+        })
+
+        it('falls back to unknown sentinel for malformed commands', () => {
+            expect(resolveToolKey('posthog', 'exec', { command: '!!!' }).resolvedKey).toEqual(
+                '__posthog_exec_unknown__'
+            )
+        })
+
+        it('returns the wire name for non-exec MCP tools and built-ins', () => {
+            expect(resolveToolKey('user-mcp', 'do_thing', {}).resolvedKey).toEqual('do_thing')
+            expect(resolveToolKey('claude', 'TodoWrite', {}).resolvedKey).toEqual('TodoWrite')
+        })
+    })
+
+    describe('ingestAcpFrame replay', () => {
+        it('folds a stream of StoredLogEntry frames into thread items', async () => {
+            const frames: StoredLogEntry[] = [
+                notification('_posthog/run_started', {}),
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', messageId: 'm1', content: { text: 'Hel' } }),
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', messageId: 'm1', content: { text: 'lo' } }),
+                sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'Hello' } }),
+                sessionUpdate({
+                    sessionUpdate: 'tool_call',
+                    toolCallId: 't1',
+                    serverName: 'posthog',
+                    toolName: 'exec',
+                    rawInput: { command: 'call execute-sql {"query":"select 1"}' },
+                    status: 'in_progress',
+                }),
+                sessionUpdate({
+                    sessionUpdate: 'tool_call_update',
+                    toolCallId: 't1',
+                    status: 'completed',
+                    rawOutput: { rows: 1 },
+                    content: [{ type: 'text', text: 'done' }],
+                }),
+                notification('_posthog/turn_complete', {}),
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            expect(logic.values.runStarted).toEqual(true)
+            expect(logic.values.turnComplete).toEqual(true)
+
+            const assistantItem = logic.values.threadItems.find((item) => item.type === 'assistant_message')
+            expect(assistantItem?.text).toEqual('Hello')
+            expect(assistantItem?.complete).toEqual(true)
+
+            const toolItem = logic.values.threadItems.find((item) => item.type === 'tool_invocation')
+            expect(toolItem?.toolCallId).toEqual('t1')
+
+            const invocation = logic.values.toolInvocations.get('t1')
+            expect(invocation?.resolvedKey).toEqual('execute-sql')
+            expect(invocation?.status).toEqual('completed')
+            expect(invocation?.output).toEqual({ rows: 1 })
+            expect(invocation?.contentBlocks).toEqual([{ type: 'text', text: 'done' }])
+
+            expect(logic.values.threadItems.some((item) => item.type === 'turn_separator')).toEqual(true)
+        })
+
+        it('sets currentMode on a current_mode_update frame', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({ sessionUpdate: 'current_mode_update', currentModeId: 'plan' })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentMode).toEqual('plan')
+        })
+
+        it('drives terminal status off handleTerminalStatus', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.handleTerminalStatus({ status: 'completed' })
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentRunStatus).toEqual('completed')
+        })
+    })
+})

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -18,7 +18,7 @@ describe('sandboxStreamLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        logic = sandboxStreamLogic()
+        logic = sandboxStreamLogic({ conversationId: 'test-conversation' })
         logic.mount()
     })
 
@@ -184,6 +184,25 @@ describe('sandboxStreamLogic', () => {
                 complete: true,
             })
             expect(logic.values.threadItems[1].type).toEqual('assistant_message')
+        })
+    })
+
+    describe('per-conversation isolation', () => {
+        it('keeps thread state independent between two mounted conversations', async () => {
+            const otherLogic = sandboxStreamLogic({ conversationId: 'other-conversation' })
+            otherLogic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.pushHumanMessage('hello agent')
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'Hi!' } })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems).toHaveLength(2)
+            expect(otherLogic.values.threadItems).toHaveLength(0)
+
+            otherLogic.unmount()
         })
     })
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -121,4 +121,125 @@ describe('sandboxStreamLogic', () => {
             expect(logic.values.currentRunStatus).toEqual('completed')
         })
     })
+
+    describe('assistant message buffering without messageId', () => {
+        it('keeps two consecutive turns without a messageId in separate thread items', async () => {
+            const frames: StoredLogEntry[] = [
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', content: { text: 'One' } }),
+                sessionUpdate({ sessionUpdate: 'agent_message', content: { text: 'One' } }),
+                notification('_posthog/turn_complete', {}),
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', content: { text: 'Tw' } }),
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', content: { text: 'o' } }),
+                sessionUpdate({ sessionUpdate: 'agent_message', content: { text: 'Two' } }),
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            const assistantItems = logic.values.threadItems.filter((item) => item.type === 'assistant_message')
+            expect(assistantItems).toHaveLength(2)
+            expect(assistantItems[0].text).toEqual('One')
+            expect(assistantItems[0].complete).toEqual(true)
+            expect(assistantItems[1].text).toEqual('Two')
+            expect(assistantItems[1].complete).toEqual(true)
+            expect(assistantItems[0].id).not.toEqual(assistantItems[1].id)
+        })
+
+        it('starts a new bubble for a chunk arriving after finalize instead of mutating the finalized one', async () => {
+            const frames: StoredLogEntry[] = [
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', messageId: 'm1', content: { text: 'Done' } }),
+                sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'Done' } }),
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', messageId: 'm1', content: { text: 'More' } }),
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            const assistantItems = logic.values.threadItems.filter((item) => item.type === 'assistant_message')
+            expect(assistantItems).toHaveLength(2)
+            expect(assistantItems[0].text).toEqual('Done')
+            expect(assistantItems[0].complete).toEqual(true)
+            expect(assistantItems[1].text).toEqual('More')
+            expect(assistantItems[1].complete).toEqual(false)
+            expect(assistantItems[0].id).not.toEqual(assistantItems[1].id)
+        })
+    })
+
+    describe('pushHumanMessage', () => {
+        it('appends a human_message item ordered before subsequently ingested assistant frames', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.pushHumanMessage('hello agent')
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'Hi!' } })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems).toHaveLength(2)
+            expect(logic.values.threadItems[0]).toEqual({
+                id: 'human-0',
+                type: 'human_message',
+                text: 'hello agent',
+                complete: true,
+            })
+            expect(logic.values.threadItems[1].type).toEqual('assistant_message')
+        })
+    })
+
+    describe('tool call errors', () => {
+        it('populates error from a failed tool_call_update carrying an error message', async () => {
+            const frames: StoredLogEntry[] = [
+                sessionUpdate({
+                    sessionUpdate: 'tool_call',
+                    toolCallId: 't1',
+                    serverName: 'posthog',
+                    toolName: 'exec',
+                    rawInput: { command: 'tools' },
+                    status: 'in_progress',
+                }),
+                sessionUpdate({
+                    sessionUpdate: 'tool_call_update',
+                    toolCallId: 't1',
+                    status: 'failed',
+                    error: { message: 'command exploded' },
+                }),
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            const invocation = logic.values.toolInvocations.get('t1')
+            expect(invocation?.status).toEqual('failed')
+            expect(invocation?.error?.message).toEqual('command exploded')
+        })
+
+        it('falls back to the notification-level error when a failed update has none', async () => {
+            const frames: StoredLogEntry[] = [
+                sessionUpdate({
+                    sessionUpdate: 'tool_call',
+                    toolCallId: 't2',
+                    serverName: 'posthog',
+                    toolName: 'exec',
+                    rawInput: { command: 'tools' },
+                    status: 'in_progress',
+                }),
+                {
+                    type: 'notification',
+                    notification: {
+                        method: 'session/update',
+                        params: { update: { sessionUpdate: 'tool_call_update', toolCallId: 't2', status: 'failed' } },
+                        error: { message: 'sandbox crashed' },
+                    },
+                },
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            expect(logic.values.toolInvocations.get('t2')?.error?.message).toEqual('sandbox crashed')
+        })
+    })
 })

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -1,0 +1,406 @@
+import { actions, connect, kea, listeners, path, reducers } from 'kea'
+
+import { projectLogic } from 'scenes/projectLogic'
+
+import type { sandboxStreamLogicType } from './sandboxStreamLogicType'
+import type {
+    PermissionRequestRecord,
+    StoredLogEntry,
+    ThreadItem,
+    ToolInvocation,
+    ToolInvocationStatus,
+} from './types/sandboxStreamTypes'
+
+export type SandboxSseStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed' | 'error'
+export type SandboxRunStatus = 'queued' | 'in_progress' | 'completed' | 'failed' | 'cancelled'
+
+/** Matches `mcp__posthog__exec` (and plugin/regional variants). Ported from Twig posthog-exec-display.ts. */
+const POSTHOG_EXEC_TOOL_RE = /^mcp__(?:plugin_)?posthog(?:_[^_]+)*__exec$/
+
+interface ResolvedToolKey {
+    resolvedKey: string
+    innerToolName?: string
+    innerInput?: Record<string, unknown>
+}
+
+/**
+ * Resolves the registry key for a tool call. The single-exec `posthog` MCP server exposes one
+ * outer `exec` tool; the inner tool name is parsed out of `rawInput.command`. Non-exec MCP tools
+ * and Claude built-ins look up by their wire name directly. See 03_RICH_UI.md § 2.2.
+ */
+export function resolveToolKey(serverName: string, toolName: string, input: Record<string, unknown>): ResolvedToolKey {
+    const fullName = `mcp__${serverName}__${toolName}`
+
+    if (POSTHOG_EXEC_TOOL_RE.test(fullName) && typeof input.command === 'string') {
+        const verbMatch = input.command.match(/^\s*(tools|search|info|schema|call)(?:\s+([\s\S]*))?\s*$/)
+        if (!verbMatch) {
+            return { resolvedKey: '__posthog_exec_unknown__' }
+        }
+
+        const verb = verbMatch[1] as 'tools' | 'search' | 'info' | 'schema' | 'call'
+        const rest = (verbMatch[2] ?? '').trim()
+
+        if (verb !== 'call') {
+            return { resolvedKey: `__posthog_exec_${verb}__` }
+        }
+
+        const callMatch = rest.match(/^(?:--json\s+)?([a-zA-Z0-9_-]+)\s*([\s\S]*)$/)
+        if (!callMatch) {
+            return { resolvedKey: '__posthog_exec_unknown__' }
+        }
+
+        const innerToolName = callMatch[1]
+        const jsonBody = (callMatch[2] ?? '').trim()
+        let innerInput: Record<string, unknown> = {}
+        if (jsonBody) {
+            try {
+                innerInput = JSON.parse(jsonBody)
+            } catch {
+                // leave empty
+            }
+        }
+        return { resolvedKey: innerToolName, innerToolName, innerInput }
+    }
+
+    return { resolvedKey: toolName }
+}
+
+function mapAcpStatus(status: unknown): ToolInvocationStatus {
+    switch (status) {
+        case 'in_progress':
+            return 'in_progress'
+        case 'completed':
+            return 'completed'
+        case 'failed':
+            return 'failed'
+        default:
+            return 'pending'
+    }
+}
+
+/**
+ * Owns the `EventSource` to the products/tasks stream endpoint, parses the ACP wire format, and
+ * produces thread-shaped state the renderer consumes. Coexistence sibling to `maxThreadLogic`'s
+ * SSE loop — the sandbox path never enters the LangGraph EventSource loop.
+ *
+ * I1 skeleton: open/close, `data.type === 'notification'` → `ingestAcpFrame`, the § 6.3 dispatch
+ * table, terminal status, and stream-error surfacing. Reconnect/backoff and content dedup land in
+ * I2.6 (02_CORE.md §§ 4.3, 4.4, 6). See 02_CORE.md § 6.
+ */
+export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
+    path(['scenes', 'max', 'sandboxStreamLogic']),
+    connect(() => ({
+        values: [projectLogic, ['currentProjectId']],
+    })),
+    actions({
+        openSseForRun: (payload: { taskId: string; runId: string; startLatest?: boolean }) => payload,
+        closeSse: true,
+        sseConnecting: true,
+        sseOpened: true,
+        /** Frame ingestion — called by the SSE listener and by products/tasks `logs/` replay. */
+        ingestAcpFrame: (entry: StoredLogEntry) => ({ entry }),
+        ingestPermissionRequest: (record: PermissionRequestRecord) => ({ record }),
+        handleTerminalStatus: (status: { status: SandboxRunStatus; errorMessage?: string | null }) => status,
+        handleStreamError: (envelope: { errorTitle: string; errorMessage?: string; retryable: boolean }) => envelope,
+        // Internal state-folding actions emitted by ingestAcpFrame.
+        appendAssistantChunk: (id: string, delta: string) => ({ id, delta }),
+        finalizeAssistantMessage: (id: string, text: string) => ({ id, text }),
+        upsertToolInvocation: (invocation: ToolInvocation) => ({ invocation }),
+        updateToolInvocation: (toolCallId: string, patch: Partial<ToolInvocation>) => ({ toolCallId, patch }),
+        setCurrentMode: (mode: string) => ({ mode }),
+        setCurrentProgress: (progress: string) => ({ progress }),
+        markRunStarted: true,
+        markTurnComplete: true,
+        pushErrorItem: (errorMessage: string) => ({ errorMessage }),
+        reset: true,
+    }),
+    reducers({
+        sseStatus: [
+            'idle' as SandboxSseStatus,
+            {
+                sseConnecting: () => 'connecting',
+                sseOpened: () => 'open',
+                closeSse: () => 'closed',
+                handleStreamError: () => 'error',
+                reset: () => 'idle',
+            },
+        ],
+        currentRunStatus: [
+            null as SandboxRunStatus | null,
+            {
+                openSseForRun: () => 'queued',
+                handleTerminalStatus: (_, { status }) => status,
+                reset: () => null,
+            },
+        ],
+        toolInvocations: [
+            new Map<string, ToolInvocation>(),
+            {
+                upsertToolInvocation: (state, { invocation }) => {
+                    const next = new Map(state)
+                    next.set(invocation.toolCallId, invocation)
+                    return next
+                },
+                updateToolInvocation: (state, { toolCallId, patch }) => {
+                    const existing = state.get(toolCallId)
+                    if (!existing) {
+                        return state
+                    }
+                    const next = new Map(state)
+                    next.set(toolCallId, { ...existing, ...patch })
+                    return next
+                },
+                reset: () => new Map(),
+            },
+        ],
+        threadItems: [
+            [] as ThreadItem[],
+            {
+                appendAssistantChunk: (state, { id, delta }) => {
+                    const idx = state.findIndex((item) => item.type === 'assistant_message' && item.id === id)
+                    if (idx === -1) {
+                        return [...state, { id, type: 'assistant_message', text: delta, complete: false }]
+                    }
+                    const next = [...state]
+                    next[idx] = { ...next[idx], text: (next[idx].text ?? '') + delta }
+                    return next
+                },
+                finalizeAssistantMessage: (state, { id, text }) => {
+                    const idx = state.findIndex((item) => item.type === 'assistant_message' && item.id === id)
+                    if (idx === -1) {
+                        return [...state, { id, type: 'assistant_message', text, complete: true }]
+                    }
+                    const next = [...state]
+                    next[idx] = { ...next[idx], text, complete: true }
+                    return next
+                },
+                upsertToolInvocation: (state, { invocation }) => {
+                    if (
+                        state.some(
+                            (item) => item.type === 'tool_invocation' && item.toolCallId === invocation.toolCallId
+                        )
+                    ) {
+                        return state
+                    }
+                    return [
+                        ...state,
+                        { id: invocation.toolCallId, type: 'tool_invocation', toolCallId: invocation.toolCallId },
+                    ]
+                },
+                markTurnComplete: (state) => [...state, { id: `turn-${state.length}`, type: 'turn_separator' }],
+                pushErrorItem: (state, { errorMessage }) => [
+                    ...state,
+                    { id: `error-${state.length}`, type: 'error', errorMessage },
+                ],
+                reset: () => [],
+            },
+        ],
+        pendingPermissionRequest: [
+            null as PermissionRequestRecord | null,
+            {
+                ingestPermissionRequest: (_, { record }) => record,
+                reset: () => null,
+            },
+        ],
+        currentMode: [
+            null as string | null,
+            {
+                setCurrentMode: (_, { mode }) => mode,
+                reset: () => null,
+            },
+        ],
+        currentProgress: [
+            null as string | null,
+            {
+                setCurrentProgress: (_, { progress }) => progress,
+                markTurnComplete: () => null,
+                reset: () => null,
+            },
+        ],
+        runStarted: [
+            false,
+            {
+                markRunStarted: () => true,
+                reset: () => false,
+            },
+        ],
+        turnComplete: [
+            false,
+            {
+                markTurnComplete: () => true,
+                markRunStarted: () => false,
+                reset: () => false,
+            },
+        ],
+    }),
+    listeners(({ values, actions, cache }) => ({
+        openSseForRun: ({ taskId, runId, startLatest }) => {
+            const projectId = values.currentProjectId
+            if (projectId === null) {
+                actions.handleStreamError({ errorTitle: 'No current project', retryable: false })
+                return
+            }
+
+            actions.sseConnecting()
+
+            // Replace any prior connection — I2.6 layers reconnect/backoff on top of this.
+            cache.disposables.dispose('event-source')
+            cache.disposables.add((): (() => void) => {
+                const start = startLatest ? '?start=latest' : ''
+                const url = `/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/stream/${start}`
+                const eventSource = new EventSource(url, { withCredentials: true })
+
+                eventSource.onopen = (): void => actions.sseOpened()
+                eventSource.onmessage = (event: MessageEvent<string>): void => {
+                    let data: { type?: string } & Record<string, unknown>
+                    try {
+                        data = JSON.parse(event.data)
+                    } catch {
+                        return
+                    }
+                    switch (data.type) {
+                        case 'notification':
+                            actions.ingestAcpFrame(data as unknown as StoredLogEntry)
+                            break
+                        case 'task_run_state':
+                            actions.handleTerminalStatus({
+                                status: data.status as SandboxRunStatus,
+                                errorMessage: (data.errorMessage as string | null) ?? null,
+                            })
+                            break
+                        case 'keepalive':
+                            break
+                        default:
+                            break
+                    }
+                }
+                // Named `event: error` frames (02_CORE.md § 4.1).
+                eventSource.addEventListener('error', (event: MessageEvent<string>): void => {
+                    if (typeof event.data === 'string' && event.data.length > 0) {
+                        try {
+                            const envelope = JSON.parse(event.data)
+                            actions.handleStreamError({
+                                errorTitle: envelope.errorTitle ?? 'Cloud stream failed',
+                                errorMessage: envelope.errorMessage,
+                                retryable: envelope.retryable ?? true,
+                            })
+                        } catch {
+                            actions.handleStreamError({ errorTitle: 'Cloud stream failed', retryable: true })
+                        }
+                    }
+                })
+
+                return () => eventSource.close()
+            }, 'event-source')
+        },
+        closeSse: () => {
+            cache.disposables.dispose('event-source')
+        },
+        reset: () => {
+            cache.disposables.dispose('event-source')
+        },
+        ingestAcpFrame: ({ entry }) => {
+            const notification = entry?.notification
+            if (!notification) {
+                return
+            }
+            const method = notification.method
+            const params = (notification.params ?? {}) as Record<string, any>
+
+            // Custom `_posthog/*` namespace — § 6.3.
+            if (method === '_posthog/run_started') {
+                actions.markRunStarted()
+                return
+            }
+            if (method === '_posthog/turn_complete') {
+                actions.markTurnComplete()
+                return
+            }
+            if (method === '_posthog/progress') {
+                actions.setCurrentProgress(String(params.message ?? params.progress ?? ''))
+                return
+            }
+            if (method === '_posthog/error') {
+                actions.pushErrorItem(String(params.message ?? notification.error?.message ?? 'Agent error'))
+                return
+            }
+            if (method?.startsWith('_posthog/')) {
+                // _posthog/usage_update, _posthog/console, _posthog/sdk_session, _posthog/git_checkpoint, ...
+                return
+            }
+
+            if (method !== 'session/update') {
+                return
+            }
+
+            const update = (params.update ?? {}) as Record<string, any>
+            const sessionUpdate = update.sessionUpdate as string | undefined
+
+            switch (sessionUpdate) {
+                case 'agent_message_chunk': {
+                    const id = String(update.messageId ?? 'current')
+                    actions.appendAssistantChunk(id, String(update.content?.text ?? update.text ?? ''))
+                    break
+                }
+                case 'agent_message': {
+                    const id = String(update.messageId ?? 'current')
+                    actions.finalizeAssistantMessage(id, String(update.content?.text ?? update.text ?? ''))
+                    break
+                }
+                case 'tool_call': {
+                    const toolCallId = String(update.toolCallId ?? '')
+                    if (!toolCallId) {
+                        break
+                    }
+                    const rawServerName = String(update.serverName ?? 'posthog')
+                    const rawToolName = String(update.toolName ?? update.title ?? '')
+                    const input = (update.rawInput ?? update.input ?? {}) as Record<string, unknown>
+                    const { resolvedKey, innerToolName, innerInput } = resolveToolKey(rawServerName, rawToolName, input)
+                    actions.upsertToolInvocation({
+                        toolCallId,
+                        rawServerName,
+                        rawToolName,
+                        innerToolName,
+                        resolvedKey,
+                        input,
+                        innerInput,
+                        status: mapAcpStatus(update.status),
+                        title: update.title as string | undefined,
+                        kind: update.kind as string | undefined,
+                        locations: update.locations as { path: string; line?: number }[] | undefined,
+                        contentBlocks: Array.isArray(update.content) ? update.content : [],
+                    })
+                    break
+                }
+                case 'tool_call_update': {
+                    const toolCallId = String(update.toolCallId ?? '')
+                    if (!toolCallId) {
+                        break
+                    }
+                    const existing = values.toolInvocations.get(toolCallId)
+                    const mergedContent = existing
+                        ? [...existing.contentBlocks, ...(Array.isArray(update.content) ? update.content : [])]
+                        : Array.isArray(update.content)
+                          ? update.content
+                          : []
+                    actions.updateToolInvocation(toolCallId, {
+                        status: mapAcpStatus(update.status ?? existing?.status),
+                        title: (update.title as string | undefined) ?? existing?.title,
+                        progress: update.progress ?? existing?.progress,
+                        output: update.rawOutput ?? existing?.output,
+                        locations:
+                            (update.locations as { path: string; line?: number }[] | undefined) ?? existing?.locations,
+                        contentBlocks: mergedContent,
+                    })
+                    break
+                }
+                case 'current_mode_update': {
+                    actions.setCurrentMode(String(update.currentModeId ?? update.mode ?? ''))
+                    break
+                }
+                default:
+                    break
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -26,7 +26,7 @@ interface ResolvedToolKey {
 /**
  * Resolves the registry key for a tool call. The single-exec `posthog` MCP server exposes one
  * outer `exec` tool; the inner tool name is parsed out of `rawInput.command`. Non-exec MCP tools
- * and Claude built-ins look up by their wire name directly. See 03_RICH_UI.md § 2.2.
+ * and Claude built-ins look up by their wire name directly.
  */
 export function resolveToolKey(serverName: string, toolName: string, input: Record<string, unknown>): ResolvedToolKey {
     const fullName = `mcp__${serverName}__${toolName}`
@@ -101,9 +101,9 @@ function mapAcpStatus(status: unknown): ToolInvocationStatus {
  * produces thread-shaped state the renderer consumes. Coexistence sibling to `maxThreadLogic`'s
  * SSE loop — the sandbox path never enters the LangGraph EventSource loop.
  *
- * I1 skeleton: open/close, `data.type === 'notification'` → `ingestAcpFrame`, the § 6.3 dispatch
- * table, terminal status, and stream-error surfacing. Reconnect/backoff and content dedup land in
- * I2.6 (02_CORE.md §§ 4.3, 4.4, 6). See 02_CORE.md § 6.
+ * Covers open/close, `data.type === 'notification'` → `ingestAcpFrame` dispatch, terminal status,
+ * and stream-error capture. Reconnect/backoff and content dedup are intentionally not implemented
+ * here yet.
  */
 export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
     path(['scenes', 'max', 'sandboxStreamLogic']),
@@ -275,7 +275,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
 
             actions.sseConnecting()
 
-            // Replace any prior connection — I2.6 layers reconnect/backoff on top of this.
+            // Replace any prior connection — reconnect/backoff layers on top of this later.
             cache.disposables.dispose('event-source')
             // pauseOnPageHidden: false — a live SSE connection must survive tab hides; re-running
             // setup on show would replay the stream from the top and duplicate thread state.
@@ -309,7 +309,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                                 break
                         }
                     }
-                    // Named `event: error` frames (02_CORE.md § 4.1).
+                    // Named `event: error` frames sent by the stream endpoint.
                     eventSource.addEventListener('error', (event: MessageEvent<string>): void => {
                         if (typeof event.data === 'string' && event.data.length > 0) {
                             try {
@@ -345,7 +345,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             const method = notification.method
             const params = (notification.params ?? {}) as Record<string, any>
 
-            // Custom `_posthog/*` namespace — § 6.3.
+            // Custom `_posthog/*` notification namespace emitted by the agent-server.
             if (method === '_posthog/run_started') {
                 actions.markRunStarted()
                 return

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -65,6 +65,24 @@ export function resolveToolKey(serverName: string, toolName: string, input: Reco
     return { resolvedKey: toolName }
 }
 
+/**
+ * Finds the last assistant-message buffer for a wire message id, also matching the derived
+ * `${id}@<n>` ids minted when the wire omits `messageId` and every message shares the fallback id.
+ */
+function findLastAssistantMessageIndex(state: ThreadItem[], id: string, incompleteOnly: boolean): number {
+    for (let i = state.length - 1; i >= 0; i--) {
+        const item = state[i]
+        if (
+            item.type === 'assistant_message' &&
+            (item.id === id || item.id.startsWith(`${id}@`)) &&
+            (!incompleteOnly || !item.complete)
+        ) {
+            return i
+        }
+    }
+    return -1
+}
+
 function mapAcpStatus(status: unknown): ToolInvocationStatus {
     switch (status) {
         case 'in_progress':
@@ -111,6 +129,8 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         setCurrentProgress: (progress: string) => ({ progress }),
         markRunStarted: true,
         markTurnComplete: true,
+        /** Echoes the user's own message into the thread — the sandbox wire never replays it. */
+        pushHumanMessage: (content: string) => ({ content }),
         pushErrorItem: (errorMessage: string) => ({ errorMessage }),
         reset: true,
     }),
@@ -157,16 +177,24 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             [] as ThreadItem[],
             {
                 appendAssistantChunk: (state, { id, delta }) => {
-                    const idx = state.findIndex((item) => item.type === 'assistant_message' && item.id === id)
+                    const idx = findLastAssistantMessageIndex(state, id, false)
                     if (idx === -1) {
                         return [...state, { id, type: 'assistant_message', text: delta, complete: false }]
+                    }
+                    if (state[idx].complete) {
+                        // Never reopen a finalized buffer — a post-finalize chunk is a new message
+                        // (the wire may omit messageId), so start a fresh bubble with a unique id.
+                        return [
+                            ...state,
+                            { id: `${id}@${state.length}`, type: 'assistant_message', text: delta, complete: false },
+                        ]
                     }
                     const next = [...state]
                     next[idx] = { ...next[idx], text: (next[idx].text ?? '') + delta }
                     return next
                 },
                 finalizeAssistantMessage: (state, { id, text }) => {
-                    const idx = state.findIndex((item) => item.type === 'assistant_message' && item.id === id)
+                    const idx = findLastAssistantMessageIndex(state, id, true)
                     if (idx === -1) {
                         return [...state, { id, type: 'assistant_message', text, complete: true }]
                     }
@@ -187,6 +215,10 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         { id: invocation.toolCallId, type: 'tool_invocation', toolCallId: invocation.toolCallId },
                     ]
                 },
+                pushHumanMessage: (state, { content }) => [
+                    ...state,
+                    { id: `human-${state.length}`, type: 'human_message', text: content, complete: true },
+                ],
                 markTurnComplete: (state) => [...state, { id: `turn-${state.length}`, type: 'turn_separator' }],
                 pushErrorItem: (state, { errorMessage }) => [
                     ...state,
@@ -245,53 +277,59 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
 
             // Replace any prior connection — I2.6 layers reconnect/backoff on top of this.
             cache.disposables.dispose('event-source')
-            cache.disposables.add((): (() => void) => {
-                const start = startLatest ? '?start=latest' : ''
-                const url = `/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/stream/${start}`
-                const eventSource = new EventSource(url, { withCredentials: true })
+            // pauseOnPageHidden: false — a live SSE connection must survive tab hides; re-running
+            // setup on show would replay the stream from the top and duplicate thread state.
+            cache.disposables.add(
+                (): (() => void) => {
+                    const start = startLatest ? '?start=latest' : ''
+                    const url = `/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/stream/${start}`
+                    const eventSource = new EventSource(url, { withCredentials: true })
 
-                eventSource.onopen = (): void => actions.sseOpened()
-                eventSource.onmessage = (event: MessageEvent<string>): void => {
-                    let data: { type?: string } & Record<string, unknown>
-                    try {
-                        data = JSON.parse(event.data)
-                    } catch {
-                        return
-                    }
-                    switch (data.type) {
-                        case 'notification':
-                            actions.ingestAcpFrame(data as unknown as StoredLogEntry)
-                            break
-                        case 'task_run_state':
-                            actions.handleTerminalStatus({
-                                status: data.status as SandboxRunStatus,
-                                errorMessage: (data.errorMessage as string | null) ?? null,
-                            })
-                            break
-                        case 'keepalive':
-                            break
-                        default:
-                            break
-                    }
-                }
-                // Named `event: error` frames (02_CORE.md § 4.1).
-                eventSource.addEventListener('error', (event: MessageEvent<string>): void => {
-                    if (typeof event.data === 'string' && event.data.length > 0) {
+                    eventSource.onopen = (): void => actions.sseOpened()
+                    eventSource.onmessage = (event: MessageEvent<string>): void => {
+                        let data: { type?: string } & Record<string, unknown>
                         try {
-                            const envelope = JSON.parse(event.data)
-                            actions.handleStreamError({
-                                errorTitle: envelope.errorTitle ?? 'Cloud stream failed',
-                                errorMessage: envelope.errorMessage,
-                                retryable: envelope.retryable ?? true,
-                            })
+                            data = JSON.parse(event.data)
                         } catch {
-                            actions.handleStreamError({ errorTitle: 'Cloud stream failed', retryable: true })
+                            return
+                        }
+                        switch (data.type) {
+                            case 'notification':
+                                actions.ingestAcpFrame(data as unknown as StoredLogEntry)
+                                break
+                            case 'task_run_state':
+                                actions.handleTerminalStatus({
+                                    status: data.status as SandboxRunStatus,
+                                    errorMessage: (data.errorMessage as string | null) ?? null,
+                                })
+                                break
+                            case 'keepalive':
+                                break
+                            default:
+                                break
                         }
                     }
-                })
+                    // Named `event: error` frames (02_CORE.md § 4.1).
+                    eventSource.addEventListener('error', (event: MessageEvent<string>): void => {
+                        if (typeof event.data === 'string' && event.data.length > 0) {
+                            try {
+                                const envelope = JSON.parse(event.data)
+                                actions.handleStreamError({
+                                    errorTitle: envelope.errorTitle ?? 'Cloud stream failed',
+                                    errorMessage: envelope.errorMessage,
+                                    retryable: envelope.retryable ?? true,
+                                })
+                            } catch {
+                                actions.handleStreamError({ errorTitle: 'Cloud stream failed', retryable: true })
+                            }
+                        }
+                    })
 
-                return () => eventSource.close()
-            }, 'event-source')
+                    return () => eventSource.close()
+                },
+                'event-source',
+                { pauseOnPageHidden: false }
+            )
         },
         closeSse: () => {
             cache.disposables.dispose('event-source')
@@ -383,14 +421,19 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         : Array.isArray(update.content)
                           ? update.content
                           : []
+                    const status = mapAcpStatus(update.status ?? existing?.status)
+                    const errorMessage =
+                        (update.error?.message as string | undefined) ??
+                        (status === 'failed' ? notification.error?.message : undefined)
                     actions.updateToolInvocation(toolCallId, {
-                        status: mapAcpStatus(update.status ?? existing?.status),
+                        status,
                         title: (update.title as string | undefined) ?? existing?.title,
                         progress: update.progress ?? existing?.progress,
                         output: update.rawOutput ?? existing?.output,
                         locations:
                             (update.locations as { path: string; line?: number }[] | undefined) ?? existing?.locations,
                         contentBlocks: mergedContent,
+                        error: errorMessage !== undefined ? { message: errorMessage } : existing?.error,
                     })
                     break
                 }

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, reducers } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
 
 import { projectLogic } from 'scenes/projectLogic'
 
@@ -13,6 +13,10 @@ import type {
 
 export type SandboxSseStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed' | 'error'
 export type SandboxRunStatus = 'queued' | 'in_progress' | 'completed' | 'failed' | 'cancelled'
+
+export interface SandboxStreamLogicProps {
+    conversationId: string
+}
 
 /** Matches `mcp__posthog__exec` (and plugin/regional variants). Ported from Twig posthog-exec-display.ts. */
 const POSTHOG_EXEC_TOOL_RE = /^mcp__(?:plugin_)?posthog(?:_[^_]+)*__exec$/
@@ -104,9 +108,14 @@ function mapAcpStatus(status: unknown): ToolInvocationStatus {
  * Covers open/close, `data.type === 'notification'` → `ingestAcpFrame` dispatch, terminal status,
  * and stream-error capture. Reconnect/backoff and content dedup are intentionally not implemented
  * here yet.
+ *
+ * Keyed by conversation id so concurrent conversations keep independent stream state and
+ * EventSource connections.
  */
 export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
-    path(['scenes', 'max', 'sandboxStreamLogic']),
+    props({} as SandboxStreamLogicProps),
+    key((props) => props.conversationId),
+    path((key) => ['scenes', 'max', 'sandboxStreamLogic', key]),
     connect(() => ({
         values: [projectLogic, ['currentProjectId']],
     })),

--- a/frontend/src/scenes/max/types/sandboxStreamTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxStreamTypes.ts
@@ -1,0 +1,100 @@
+/**
+ * Wire + thread shapes for the sandbox agent runtime (`agent_runtime === 'sandbox'`).
+ *
+ * The sandbox path consumes the products/tasks SSE endpoint directly (the same endpoint
+ * PostHog Code uses). `sandboxStreamLogic` parses the raw ACP frames carried inside
+ * `StoredLogEntry` envelopes into the `ToolInvocation` / `ThreadItem` state the renderer
+ * consumes. See docs/internal/posthog-ai-migration/02_CORE.md §§ 4.1, 6.2 and
+ * 03_RICH_UI.md §§ 2.1, 2.2.
+ */
+
+/** ACP notification body — the JSON-RPC payload carried inside a `StoredLogEntry`. */
+export interface AcpNotification {
+    method?: string
+    params?: Record<string, unknown>
+    result?: unknown
+    error?: { message?: string; code?: number } | null
+}
+
+/**
+ * Wire envelope around a single ACP notification. The products/tasks stream emits these as
+ * the bulk of `data.type === 'notification'` traffic. See 02_CORE.md glossary.
+ */
+export interface StoredLogEntry {
+    type: 'notification'
+    timestamp?: string
+    notification: AcpNotification
+}
+
+export type ToolInvocationStatus = 'pending' | 'in_progress' | 'completed' | 'failed'
+
+/**
+ * One merged tool call: a `tool_call` creation plus N × `tool_call_update`s folded into a
+ * single record keyed on `toolCallId`. The single-exec `posthog` MCP server runs one outer
+ * `exec` tool; the inner tool name is what the renderer keys on (`resolvedKey`).
+ */
+export interface ToolInvocation {
+    toolCallId: string
+    /** ACP-reported MCP server, e.g. 'posthog' or '<user-installed>'. */
+    rawServerName: string
+    /** ACP-reported tool, e.g. 'exec', 'TodoWrite', '<user-tool>'. */
+    rawToolName: string
+    /** Parsed inner tool name when `rawToolName === 'exec'` — e.g. 'insight-create'. */
+    innerToolName?: string
+    /** Registry lookup key — see 03_RICH_UI.md § 2.2 resolution table. */
+    resolvedKey: string
+    /** rawInput at `tool_call` time (for `exec`, includes the wrapper `{ command }`). */
+    input: Record<string, unknown>
+    /** JSON-parsed inner args when `innerToolName` is set. */
+    innerInput?: Record<string, unknown>
+    /** rawOutput on the final `tool_call_update`. */
+    output?: unknown
+    /** Partial result from intermediate updates. */
+    progress?: unknown
+    status: ToolInvocationStatus
+    title?: string
+    /** ACP `toolCall.kind`. */
+    kind?: string
+    locations?: { path: string; line?: number }[]
+    /** Accumulated ACP `content[]` from updates. */
+    contentBlocks: unknown[]
+}
+
+export type ThreadItemType = 'assistant_message' | 'tool_invocation' | 'turn_separator' | 'error'
+
+/**
+ * An ordered, append-only entry the renderer consumes. Text chunks, tool-invocation
+ * references, run-lifecycle markers, and inline errors all flow through this list.
+ */
+export interface ThreadItem {
+    /** Stable id — message buffer id, tool call id, or a generated separator/error id. */
+    id: string
+    type: ThreadItemType
+    /** For `assistant_message` items. */
+    text?: string
+    /** Whether the assistant message buffer is finalized. */
+    complete?: boolean
+    /** For `tool_invocation` items — the keyed tool call id (look up in `toolInvocations`). */
+    toolCallId?: string
+    /** For `error` items. */
+    errorMessage?: string
+}
+
+export interface PermissionOption {
+    optionId: string
+    name: string
+    kind: 'allow_once' | 'allow_always' | 'reject' | 'reject_with_feedback'
+}
+
+/**
+ * A pending ACP `permission_request` surfaced by the products/tasks stream. Ingested in I3
+ * (`02_CORE.md` § 5.5) and bound to `DangerousOperationApprovalCard`.
+ */
+export interface PermissionRequestRecord {
+    requestId: string
+    toolCallId: string
+    options: PermissionOption[]
+    title?: string
+    description?: string
+    rawToolCall: ToolInvocation
+}

--- a/frontend/src/scenes/max/types/sandboxStreamTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxStreamTypes.ts
@@ -4,8 +4,7 @@
  * The sandbox path consumes the products/tasks SSE endpoint directly (the same endpoint
  * PostHog Code uses). `sandboxStreamLogic` parses the raw ACP frames carried inside
  * `StoredLogEntry` envelopes into the `ToolInvocation` / `ThreadItem` state the renderer
- * consumes. See docs/internal/posthog-ai-migration/02_CORE.md §§ 4.1, 6.2 and
- * 03_RICH_UI.md §§ 2.1, 2.2.
+ * consumes.
  */
 
 /** ACP notification body — the JSON-RPC payload carried inside a `StoredLogEntry`. */
@@ -18,7 +17,7 @@ export interface AcpNotification {
 
 /**
  * Wire envelope around a single ACP notification. The products/tasks stream emits these as
- * the bulk of `data.type === 'notification'` traffic. See 02_CORE.md glossary.
+ * the bulk of `data.type === 'notification'` traffic.
  */
 export interface StoredLogEntry {
     type: 'notification'
@@ -41,7 +40,10 @@ export interface ToolInvocation {
     rawToolName: string
     /** Parsed inner tool name when `rawToolName === 'exec'` — e.g. 'insight-create'. */
     innerToolName?: string
-    /** Registry lookup key — see 03_RICH_UI.md § 2.2 resolution table. */
+    /**
+     * Registry lookup key — the inner tool name for single-exec `call` commands, a
+     * `__posthog_exec_*__` sentinel for discovery verbs, or the wire tool name otherwise.
+     */
     resolvedKey: string
     /** rawInput at `tool_call` time (for `exec`, includes the wrapper `{ command }`). */
     input: Record<string, unknown>
@@ -89,8 +91,8 @@ export interface PermissionOption {
 }
 
 /**
- * A pending ACP `permission_request` surfaced by the products/tasks stream. Ingested in I3
- * (`02_CORE.md` § 5.5) and bound to `DangerousOperationApprovalCard`.
+ * A pending ACP `permission_request` surfaced by the products/tasks stream, to be bound to
+ * `DangerousOperationApprovalCard` by the approval flow.
  */
 export interface PermissionRequestRecord {
     requestId: string

--- a/frontend/src/scenes/max/types/sandboxStreamTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxStreamTypes.ts
@@ -49,6 +49,8 @@ export interface ToolInvocation {
     innerInput?: Record<string, unknown>
     /** rawOutput on the final `tool_call_update`. */
     output?: unknown
+    /** Error carried by a failed `tool_call_update` (from the update or its notification envelope). */
+    error?: { message?: string } | null
     /** Partial result from intermediate updates. */
     progress?: unknown
     status: ToolInvocationStatus
@@ -60,17 +62,17 @@ export interface ToolInvocation {
     contentBlocks: unknown[]
 }
 
-export type ThreadItemType = 'assistant_message' | 'tool_invocation' | 'turn_separator' | 'error'
+export type ThreadItemType = 'human_message' | 'assistant_message' | 'tool_invocation' | 'turn_separator' | 'error'
 
 /**
- * An ordered, append-only entry the renderer consumes. Text chunks, tool-invocation
- * references, run-lifecycle markers, and inline errors all flow through this list.
+ * An ordered, append-only entry the renderer consumes. Human messages, text chunks,
+ * tool-invocation references, run-lifecycle markers, and inline errors all flow through this list.
  */
 export interface ThreadItem {
     /** Stable id — message buffer id, tool call id, or a generated separator/error id. */
     id: string
     type: ThreadItemType
-    /** For `assistant_message` items. */
+    /** For `human_message` and `assistant_message` items. */
     text?: string
     /** Whether the assistant message buffer is finalized. */
     complete?: boolean

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7049,8 +7049,7 @@ export interface Conversation {
     is_sandbox?: boolean
     /**
      * Runtime the conversation was created on. Stamped at create-time from the `phai-sandbox-mode`
-     * flag and never re-read. Existing rows default to `'langgraph'`. See
-     * docs/internal/posthog-ai-migration/02_CORE.md § 2.
+     * flag and never re-read. Existing rows default to `'langgraph'`.
      */
     agent_runtime?: 'langgraph' | 'sandbox'
     /** Backing products/tasks Task for sandbox conversations. Null until the first message creates it. */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7047,6 +7047,14 @@ export interface Conversation {
     is_internal?: boolean
     pending_approvals?: PendingApproval[]
     is_sandbox?: boolean
+    /**
+     * Runtime the conversation was created on. Stamped at create-time from the `phai-sandbox-mode`
+     * flag and never re-read. Existing rows default to `'langgraph'`. See
+     * docs/internal/posthog-ai-migration/02_CORE.md § 2.
+     */
+    agent_runtime?: 'langgraph' | 'sandbox'
+    /** Backing products/tasks Task for sandbox conversations. Null until the first message creates it. */
+    task?: { id: string; current_run_id: string | null } | null
 }
 
 export interface ConversationDetail extends Conversation {


### PR DESCRIPTION
## Problem

PR **I1.3** of the PostHog AI → sandbox-agent migration (`docs/internal/posthog-ai-migration/00_OVERVIEW.md` § 10). The frontend needs the foundational sandbox-runtime surfaces — a context-attachment logic, an ACP stream processor, and a tool-renderer registry — so that sandbox conversations can send a message, open SSE against the `products/tasks` stream endpoint, and render results. Runs in parallel with the backend foundations (I1.2).

## Changes

All additive and gated on `conversation.agent_runtime === 'sandbox'`; no existing LangGraph code path (`maxContextLogic.ts`, `MaxTool.tsx`, `useMaxTool.ts`, existing renderers/SSE handlers) is modified — per `BACKWARD_COMPAT.md`.

New files in `frontend/src/scenes/max/`:

- `posthogAiContextLogic.tsx` (`01_CONTEXT` § 3) — flat `attachments` reducer with dedup on `(type, id ?? value)`, `attach`/`detach`/`clearAttachments`/`syncSceneAttachments`, the `projectToAttachedContext` helper, and a `chipsForDisplay` selector. Reads the existing scenes' `maxContext` selector with zero scene edits.
- `sandboxStreamLogic.ts` (`02_CORE` §§ 6.1–6.3) — **skeleton** owning the `EventSource` against `GET /api/projects/{tid}/tasks/{taskId}/runs/{runId}/stream/`, with the full § 6.3 ACP dispatch table (`session/update` chunks/tool calls/mode + `_posthog/*`). No reconnect/backoff/dedup yet (that's I2.6).
- `types/sandboxStreamTypes.ts`, `mcpToolRegistry.tsx` (skeleton), `messages/FallbackMcpToolRenderer.tsx` (generic tool card per `03_RICH_UI` § 3.4).
- `sandboxStreamLogic.test.ts` — `resolveToolKey` unit tests + a `StoredLogEntry` fixture-replay test through `ingestAcpFrame`.

Additive edits: `AttachedContext` export in `maxTypes.ts`; runtime branches in `Context.tsx` and `Thread.tsx`; sandbox branch in `maxThreadLogic.sendMessage` (POST `/sandbox/` → `openSseForRun`); `api.conversations.sandbox()` in `lib/api.ts`; optional `agent_runtime`/`task` on the frontend `Conversation` type.

## How did you test this code?

Automated only (I'm an agent):

- `pnpm --filter=@posthog/frontend format` — clean.
- `tsc --noEmit` (kea typegen regenerated first) — **0 errors in the 12 changed files**. The 69 pre-existing repo errors all stem from an unbuilt `@posthog/quill` workspace dependency in the worktree and touch none of this PR's files.
- `hogli test sandboxStreamLogic.test.ts` — 7/7 pass.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) via a multi-agent workflow (implement → independent verify), one branch per PR-to-spec row, in an isolated git worktree.

`posthogAiContextLogic` uses `.tsx` (not the spec's `.ts`) because `chipsForDisplay` emits JSX icons — matches the repo convention for JSX-bearing logics. The optional `agent_runtime`/`task` fields were added to the frontend `Conversation` type by hand so the runtime branches typecheck; these should be reconciled with the serializer-driven shape after `hogli build:openapi` once the backend PRs land. ACP wire-field extraction is inferred from the spec § 6.3 table and Twig references and should be validated against a real `products/tasks` trace when wire-format validation lands in I2.6. Per-conversation mount/unmount lifecycle for these logics is deferred to I2.6/I2.7.

Requires human review; not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
