### PR TITLE
fix(ci): deploy cymbal resolution image

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -85,6 +85,9 @@ jobs:
                     - release: cymbal
                       digest_key: cymbal
                       values_key: image
+                    - release: cymbal-resolution
+                      digest_key: cymbal-resolution
+                      values_key: image
                     - release: embedding-worker
                       digest_key: embedding-worker
                       values_key: image


### PR DESCRIPTION
## Problem

The `cymbal-resolution` Rust image is built, but it is not included in the deploy matrix that dispatches chart state updates. As a result, new image digests are not written to charts state and deployments can render without a valid image digest.

## Changes

- Add `cymbal-resolution` to the Rust image deploy matrix.
- Map the release name and digest key to `cymbal-resolution` so the charts repo receives `commit_state_update` for the matching state entry.

## How did you test this code?

As an agent, I validated that the workflow YAML parses with:

```bash
yq e '.' .github/workflows/rust-docker-build.yml
```

Commit hooks also ran successfully.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this is a CI deploy-matrix fix.

## 🤖 Agent context

This PR was authored with pi using shell, file-read, and edit tools. The change follows the existing Rust image deployment pattern: the image already exists in `.github/rust-images.yml`, and this adds the corresponding deploy-matrix entry so charts state updates use the same `cymbal-resolution` key.
