### PR TITLE
fix(ingestion): pre-create combined consumer output topics in kafka-init

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -465,7 +465,24 @@ services:
                         exit 1
                     fi
                 done
-                for topic in document_embeddings_input; do
+                # The combined analytics ingestion consumer checks topic existence at
+                # startup for every output it produces to (see analytics/outputs/registry.ts).
+                # Auto-create only fires on producer-first writes, so pre-create them here.
+                TOPICS="document_embeddings_input \
+                    clickhouse_events_json \
+                    clickhouse_ai_events_json \
+                    clickhouse_heatmap_events \
+                    clickhouse_ingestion_warnings \
+                    events_plugin_ingestion_dlq \
+                    events_plugin_ingestion_overflow \
+                    events_plugin_ingestion_async \
+                    clickhouse_groups \
+                    clickhouse_person \
+                    clickhouse_person_distinct_id \
+                    clickhouse_app_metrics2 \
+                    log_entries \
+                    clickhouse_tophog"
+                for topic in $$TOPICS; do
                     if rpk topic create "$$topic" --brokers kafka:9092 -p 1 -r 1 2>&1; then
                         echo "Topic $$topic created"
                     elif rpk topic list --brokers kafka:9092 | grep -q "$$topic"; then

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -514,9 +514,25 @@ services:
                     fi
                 done
                 echo "Kafka broker is accepting requests, creating topics..."
-                # Create topics needed by rust services
+                # Create topics needed by rust services and the combined analytics ingestion
+                # consumer, which checks topic existence at startup for every output it produces
+                # to (see analytics/outputs/registry.ts). Auto-create only fires on producer-first
+                # writes, so pre-create them here.
                 # Note: $$ escapes $ for docker-compose variable substitution
-                for topic in clickhouse_events_json; do
+                TOPICS="clickhouse_events_json \
+                    clickhouse_ai_events_json \
+                    clickhouse_heatmap_events \
+                    clickhouse_ingestion_warnings \
+                    events_plugin_ingestion_dlq \
+                    events_plugin_ingestion_overflow \
+                    events_plugin_ingestion_async \
+                    clickhouse_groups \
+                    clickhouse_person \
+                    clickhouse_person_distinct_id \
+                    clickhouse_app_metrics2 \
+                    log_entries \
+                    clickhouse_tophog"
+                for topic in $$TOPICS; do
                     if rpk topic create "$$topic" --brokers kafka:9092 -p 1 -r 1 2>&1; then
                         echo "Topic $$topic created successfully"
                     else


### PR DESCRIPTION
## Problem

On a fresh dev or hobby stack, the combined analytics ingestion consumer (`INGESTION-V2-COMBINED`) fails its startup health check with repeated errors like:

```
🔴 Topic check failed for "DEFAULT" topic "clickhouse_groups"
🔴 Topic check failed for "DEFAULT" topic "clickhouse_person_distinct_id"
🔴 Topic check failed for "DEFAULT" topic "log_entries"
🔴 Topic check failed for "DEFAULT" topic "clickhouse_tophog"
```

The consumer checks topic existence at startup for **every** output it produces to (`nodejs/src/ingestion/analytics/outputs/registry.ts`, verified in `nodejs/src/ingestion/outputs/single-ingestion-output.ts`). Redpanda's `auto_create_topics_enabled` only fires on a producer-first write, so the output topics that no other service writes to first don't exist when the check runs, and startup fails.

The `kafka-init` services pre-created only a single topic each (`document_embeddings_input` in dev, `clickhouse_events_json` in hobby), which is why most topics happened to exist (created by other producers) but these four did not.

## Changes

Expanded the `kafka-init` pre-create loop in both `docker-compose.dev.yml` and `docker-compose.hobby.yml` to cover the full set of output topics the combined consumer checks at startup:

- `clickhouse_events_json`, `clickhouse_ai_events_json`, `clickhouse_heatmap_events`
- `clickhouse_ingestion_warnings`, `clickhouse_app_metrics2`
- `events_plugin_ingestion_dlq` / `_overflow` / `_async`
- `clickhouse_groups`, `clickhouse_person`, `clickhouse_person_distinct_id`
- `log_entries`, `clickhouse_tophog`

The loop is idempotent — existing topics are skipped — so pre-creating topics that other producers normally create first is harmless.

## How did you test this code?

I'm an agent. I validated both compose files parse with `docker compose -f <file> config` after the change (and confirmed the YAML block-scalar shell loop survived `hogli format:yaml`). I did not spin up a full stack to observe the consumer starting cleanly.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Traced the failing log line to `single-ingestion-output.ts`, enumerated the required output topics from `analytics/outputs/registry.ts` and their default values in `nodejs/src/ingestion/config.ts`, then mapped them to literal topic names via `nodejs/src/config/kafka-topics.ts` (no prefix/suffix in dev/hobby). Chose to pre-create the full output set rather than only the four observed failures, since any of them can be missing depending on fresh-environment ordering.
