### PR TITLE
feat(posthog-ai): sandbox stream SSE resilience

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5082,6 +5082,29 @@ const api = {
                 }
                 return ''
             },
+            /**
+             * Fetch the assembled resume-chain ACP log for a run (the products/tasks `logs/`
+             * endpoint returns JSONL — one `StoredLogEntry` per line, concatenated server-side
+             * across the entire resume chain). Used to bootstrap the sandbox stream before
+             * opening SSE.
+             */
+            async getLogEntries(taskId: Task['id'], runId: TaskRun['id']): Promise<Record<string, any>[]> {
+                const response = await new ApiRequest().taskRun(taskId, runId).withAction('logs').getResponse()
+                const text = await response.text()
+                const entries: Record<string, any>[] = []
+                for (const line of text.split('\n')) {
+                    const trimmed = line.trim()
+                    if (!trimmed) {
+                        continue
+                    }
+                    try {
+                        entries.push(JSON.parse(trimmed))
+                    } catch {
+                        // Skip unparseable lines — the stream is best-effort historical replay.
+                    }
+                }
+                return entries
+            },
         },
     },
 
@@ -6599,7 +6622,6 @@ const api = {
          * Sandbox-runtime message routing endpoint (`agent_runtime === 'sandbox'`). Non-streaming:
          * wraps + dedupes context, creates/continues the backing products/tasks Run, and returns the
          * IDs the frontend needs to open SSE directly against the products/tasks stream endpoint.
-         * See docs/internal/posthog-ai-migration/02_CORE.md § 4.
          */
         sandbox(
             conversationId: string,
@@ -6624,7 +6646,7 @@ const api = {
          * so the first turn goes through the conversation-create endpoint with `is_sandbox: true`,
          * which creates the conversation and routes to `handle_sandbox_message`, returning the same
          * run IDs (not an SSE stream). Read them directly so the frontend can bootstrap the sandbox
-         * stream. Follow-ups use `sandbox()`. See 02_CORE.md §§ 3, 4.
+         * stream. Follow-ups use `sandbox()`.
          */
         async sandboxCreate(data: {
             content: string

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -1,8 +1,18 @@
 import { expectLogic } from 'kea-test-utils'
 
+import api from 'lib/api'
+import { projectLogic } from 'scenes/projectLogic'
+
 import { initKeaTests } from '~/test/init'
 
-import { resolveToolKey, sandboxStreamLogic } from './sandboxStreamLogic'
+import {
+    mapHttpStatusToStreamError,
+    MAX_SSE_RECONNECT_ATTEMPTS,
+    reconnectDelayMs,
+    resolveToolKey,
+    sandboxStreamLogic,
+    SSE_RECONNECT_MAX_DELAY_MS,
+} from './sandboxStreamLogic'
 import type { StoredLogEntry } from './types/sandboxStreamTypes'
 
 function notification(method: string, params: Record<string, unknown>): StoredLogEntry {
@@ -13,17 +23,69 @@ function sessionUpdate(update: Record<string, unknown>): StoredLogEntry {
     return notification('session/update', { update })
 }
 
+/** Minimal `EventSource` stand-in so the logic can open/drop a connection under test control. */
+class MockEventSource {
+    static instances: MockEventSource[] = []
+    url: string
+    onopen: (() => void) | null = null
+    onmessage: ((event: MessageEvent<string>) => void) | null = null
+    closed = false
+    private errorListeners: ((event: MessageEvent<string>) => void)[] = []
+
+    constructor(url: string) {
+        this.url = url
+        MockEventSource.instances.push(this)
+    }
+
+    addEventListener(type: string, listener: (event: MessageEvent<string>) => void): void {
+        if (type === 'error') {
+            this.errorListeners.push(listener)
+        }
+    }
+
+    close(): void {
+        this.closed = true
+    }
+
+    emitOpen(): void {
+        this.onopen?.()
+    }
+
+    /** Simulate a transient connection drop (no `data`). */
+    emitDrop(): void {
+        this.errorListeners.forEach((l) => l({ data: '' } as MessageEvent<string>))
+    }
+
+    /** Simulate a named `event: error` envelope frame. */
+    emitErrorFrame(envelope: Record<string, unknown>): void {
+        this.errorListeners.forEach((l) => l({ data: JSON.stringify(envelope) } as MessageEvent<string>))
+    }
+
+    static latest(): MockEventSource {
+        return MockEventSource.instances[MockEventSource.instances.length - 1]
+    }
+
+    static reset(): void {
+        MockEventSource.instances = []
+    }
+}
+
 describe('sandboxStreamLogic', () => {
     let logic: ReturnType<typeof sandboxStreamLogic.build>
 
     beforeEach(() => {
         initKeaTests()
+        MockEventSource.reset()
+        ;(global as any).EventSource = MockEventSource
+        projectLogic.mount()
+        projectLogic.actions.loadCurrentProjectSuccess({ id: 997 } as any)
         logic = sandboxStreamLogic({ conversationId: 'test-conversation' })
         logic.mount()
     })
 
     afterEach(() => {
         logic.unmount()
+        jest.restoreAllMocks()
     })
 
     describe('resolveToolKey', () => {
@@ -261,4 +323,201 @@ describe('sandboxStreamLogic', () => {
             expect(logic.values.toolInvocations.get('t2')?.error?.message).toEqual('sandbox crashed')
         })
     })
+
+    describe('content dedup', () => {
+        it('folds an entry once and drops an identical replay', async () => {
+            const frame = sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'Hi' } })
+
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(frame)
+                logic.actions.ingestAcpFrame(frame)
+            }).toFinishAllListeners()
+
+            const assistantItems = logic.values.threadItems.filter((item) => item.type === 'assistant_message')
+            expect(assistantItems).toHaveLength(1)
+            expect(assistantItems[0].text).toEqual('Hi')
+            expect(logic.values.ingestedEntryHashes.size).toEqual(1)
+        })
+
+        it('does not dedup distinct chunks of the same message', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({ sessionUpdate: 'agent_message_chunk', messageId: 'm1', content: { text: 'A' } })
+                )
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({ sessionUpdate: 'agent_message_chunk', messageId: 'm1', content: { text: 'B' } })
+                )
+            }).toFinishAllListeners()
+
+            const assistantItem = logic.values.threadItems.find((item) => item.type === 'assistant_message')
+            expect(assistantItem?.text).toEqual('AB')
+        })
+    })
+
+    describe('error mapping', () => {
+        it('maps HTTP statuses to error envelopes', () => {
+            expect(mapHttpStatusToStreamError(401)).toEqual({
+                errorTitle: 'Cloud authentication expired',
+                retryable: true,
+            })
+            expect(mapHttpStatusToStreamError(403)).toEqual({ errorTitle: 'Cloud access denied', retryable: true })
+            expect(mapHttpStatusToStreamError(404)).toEqual({
+                errorTitle: 'Conversation backing run not found',
+                retryable: false,
+            })
+            expect(mapHttpStatusToStreamError(406)).toEqual({
+                errorTitle: 'Cloud stream unavailable',
+                retryable: true,
+            })
+            expect(mapHttpStatusToStreamError(500)).toEqual({ errorTitle: 'Cloud stream failed', retryable: true })
+            expect(mapHttpStatusToStreamError(undefined)).toEqual({
+                errorTitle: 'Cloud stream failed',
+                retryable: true,
+            })
+        })
+
+        it('caps the backoff schedule at 2s/4s/8s/16s/30s', () => {
+            expect([1, 2, 3, 4, 5].map(reconnectDelayMs)).toEqual([2000, 4000, 8000, 16000, 30000])
+            expect(reconnectDelayMs(6)).toEqual(SSE_RECONNECT_MAX_DELAY_MS)
+        })
+
+        it('surfaces a named event:error frame verbatim', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                MockEventSource.latest().emitErrorFrame({
+                    errorTitle: 'Sandbox crashed',
+                    errorMessage: 'boom',
+                    retryable: false,
+                })
+            }).toMatchValues({ sseStatus: 'error' })
+        })
+    })
+
+    describe('terminal-status handling', () => {
+        it('closes the SSE and stops reconnects on a terminal task_run_state', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+            const source = MockEventSource.latest()
+            source.emitOpen()
+
+            await expectLogic(logic, () => {
+                logic.actions.handleTerminalStatus({ status: 'completed' })
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentRunStatus).toEqual('completed')
+            expect(source.closed).toEqual(true)
+        })
+    })
+
+    describe('reconnect / backoff', () => {
+        it('refetches and surfaces terminal status on a drop, without reopening', async () => {
+            const getSpy = jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'completed' } as any)
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            MockEventSource.latest().emitOpen()
+
+            const beforeDrop = MockEventSource.instances.length
+            logic.actions.sseDropped()
+            await flushPromises()
+
+            expect(getSpy).toHaveBeenCalledWith('task-1', 'run-1')
+            expect(logic.values.currentRunStatus).toEqual('completed')
+            // No new EventSource was created (terminal → no reconnect).
+            expect(MockEventSource.instances.length).toEqual(beforeDrop)
+        })
+
+        it('backs off and reopens on a drop while the run is non-terminal', async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            MockEventSource.latest().emitOpen()
+            const beforeDrop = MockEventSource.instances.length
+
+            jest.useFakeTimers()
+            logic.actions.sseDropped()
+            await flushPromises()
+
+            expect(logic.values.sseStatus).toEqual('reconnecting')
+            expect(logic.values.reconnectAttempt).toEqual(1)
+
+            jest.advanceTimersByTime(2000)
+            expect(MockEventSource.instances.length).toEqual(beforeDrop + 1)
+            jest.useRealTimers()
+        })
+
+        it('surfaces a retryable error after exhausting the attempt cap', async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            // Drive the attempt counter to the cap without an intervening successful open.
+            logic.actions.sseReconnecting(MAX_SSE_RECONNECT_ATTEMPTS)
+
+            logic.actions.sseDropped()
+            await flushPromises()
+
+            expect(logic.values.sseStatus).toEqual('error')
+        })
+
+        it('maps a refetch failure through the HTTP-status table', async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockRejectedValue({ status: 404 })
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            logic.actions.sseDropped()
+            await flushPromises()
+
+            expect(logic.values.sseStatus).toEqual('error')
+        })
+    })
+
+    describe('bootstrapRun', () => {
+        it('skips logs/ and opens SSE directly on the fresh-run fast path', async () => {
+            const logsSpy = jest.spyOn(api.tasks.runs, 'getLogEntries')
+
+            logic.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-1', justCreatedRun: true })
+            await flushPromises()
+
+            expect(logsSpy).not.toHaveBeenCalled()
+            expect(MockEventSource.instances.length).toEqual(1)
+            expect(MockEventSource.latest().url).not.toContain('start=latest')
+        })
+
+        it('replays logs/ then opens SSE with start=latest for a non-terminal run', async () => {
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([
+                notification('_posthog/run_started', {}) as any,
+                sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'history' } }) as any,
+            ])
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+
+            logic.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-1' })
+            await flushPromises()
+
+            expect(logic.values.runStarted).toEqual(true)
+            const assistantItem = logic.values.threadItems.find((item) => item.type === 'assistant_message')
+            expect(assistantItem?.text).toEqual('history')
+            expect(MockEventSource.latest().url).toContain('start=latest')
+        })
+
+        it('replays logs/ and stays read-only for a terminal run', async () => {
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([])
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'completed' } as any)
+
+            logic.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-1' })
+            await flushPromises()
+
+            expect(logic.values.currentRunStatus).toEqual('completed')
+            expect(MockEventSource.instances.length).toEqual(0)
+        })
+    })
 })
+
+// Drain queued microtasks (chained `await`s in async listeners) without relying on timers, so it
+// works under both real and fake timers.
+async function flushPromises(): Promise<void> {
+    for (let i = 0; i < 10; i++) {
+        await Promise.resolve()
+    }
+}

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -411,6 +411,21 @@ describe('sandboxStreamLogic', () => {
             expect(logic.values.currentRunStatus).toEqual('completed')
             expect(source.closed).toEqual(true)
         })
+
+        it('keeps the stream open on a non-terminal task_run_state', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+            const source = MockEventSource.latest()
+            source.emitOpen()
+
+            await expectLogic(logic, () => {
+                logic.actions.handleTerminalStatus({ status: 'in_progress' })
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentRunStatus).toEqual('in_progress')
+            expect(source.closed).toEqual(false)
+        })
     })
 
     describe('reconnect / backoff', () => {
@@ -446,7 +461,33 @@ describe('sandboxStreamLogic', () => {
 
             jest.advanceTimersByTime(2000)
             expect(MockEventSource.instances.length).toEqual(beforeDrop + 1)
+            // The reconnect replays the full stream (no start=latest) so the content-dedup can
+            // fill in frames emitted while disconnected instead of skipping past them.
+            expect(MockEventSource.latest().url).not.toContain('start=latest')
             jest.useRealTimers()
+        })
+
+        it('preserves a known in-flight status when the reconnect reopens the stream', async () => {
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            logic.actions.handleTerminalStatus({ status: 'in_progress' })
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
+
+            expect(logic.values.currentRunStatus).toEqual('in_progress')
+        })
+
+        it('abandons the drop loop when the stream is closed mid-refetch', async () => {
+            let resolveGet: (value: unknown) => void = () => {}
+            jest.spyOn(api.tasks.runs, 'get').mockReturnValue(new Promise((resolve) => (resolveGet = resolve)) as any)
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            logic.actions.sseDropped()
+            logic.actions.closeSse()
+
+            resolveGet({ status: 'in_progress' })
+            await flushPromises()
+
+            expect(logic.values.sseStatus).toEqual('closed')
+            expect(logic.values.reconnectAttempt).toEqual(0)
         })
 
         it('surfaces a retryable error after exhausting the attempt cap', async () => {

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -1,5 +1,6 @@
 import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
 
+import api from 'lib/api'
 import { projectLogic } from 'scenes/projectLogic'
 
 import type { sandboxStreamLogicType } from './sandboxStreamLogicType'
@@ -16,6 +17,53 @@ export type SandboxRunStatus = 'queued' | 'in_progress' | 'completed' | 'failed'
 
 export interface SandboxStreamLogicProps {
     conversationId: string
+}
+
+/** Reconnect/backoff constants for the SSE drop-recovery loop. */
+export const MAX_SSE_RECONNECT_ATTEMPTS = 5
+export const SSE_RECONNECT_BASE_DELAY_MS = 2_000
+export const SSE_RECONNECT_MAX_DELAY_MS = 30_000
+
+const TERMINAL_RUN_STATUSES: ReadonlySet<SandboxRunStatus> = new Set(['completed', 'failed', 'cancelled'])
+
+function isTerminalRunStatus(status: SandboxRunStatus | null | undefined): boolean {
+    return status != null && TERMINAL_RUN_STATUSES.has(status)
+}
+
+/** Capped exponential backoff: 2s / 4s / 8s / 16s / 30s. `attempt` is 1-based. */
+export function reconnectDelayMs(attempt: number): number {
+    const delay = SSE_RECONNECT_BASE_DELAY_MS * 2 ** (attempt - 1)
+    return Math.min(delay, SSE_RECONNECT_MAX_DELAY_MS)
+}
+
+export interface StreamErrorEnvelope {
+    errorTitle: string
+    errorMessage?: string
+    retryable: boolean
+}
+
+/**
+ * HTTP status → user-visible error envelope for refetch/open failures. Cloud-agent also emits
+ * some of these as `event: error` frames; those carry their own envelope and bypass this table.
+ */
+export function mapHttpStatusToStreamError(status: number | undefined): StreamErrorEnvelope {
+    switch (status) {
+        case 401:
+            return { errorTitle: 'Cloud authentication expired', retryable: true }
+        case 403:
+            return { errorTitle: 'Cloud access denied', retryable: true }
+        case 404:
+            return { errorTitle: 'Conversation backing run not found', retryable: false }
+        case 406:
+            return { errorTitle: 'Cloud stream unavailable', retryable: true }
+        default:
+            return { errorTitle: 'Cloud stream failed', retryable: true }
+    }
+}
+
+/** Stable serialized-JSON hash of a StoredLogEntry for content-dedup. */
+function hashLogEntry(entry: StoredLogEntry): string {
+    return JSON.stringify(entry)
 }
 
 /** Matches `mcp__posthog__exec` (and plugin/regional variants). Ported from Twig posthog-exec-display.ts. */
@@ -106,8 +154,9 @@ function mapAcpStatus(status: unknown): ToolInvocationStatus {
  * SSE loop — the sandbox path never enters the LangGraph EventSource loop.
  *
  * Covers open/close, `data.type === 'notification'` → `ingestAcpFrame` dispatch, terminal status,
- * and stream-error capture. Reconnect/backoff and content dedup are intentionally not implemented
- * here yet.
+ * and stream-error capture, plus the reconnect/backoff loop on SSE drops, content-dedup against
+ * the `logs/` replay, HTTP-status error mapping, and the `bootstrapRun` history-replay-then-SSE
+ * helper.
  *
  * Keyed by conversation id so concurrent conversations keep independent stream state and
  * EventSource connections.
@@ -120,12 +169,23 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         values: [projectLogic, ['currentProjectId']],
     })),
     actions({
+        /**
+         * Bootstrap an existing run on conversation open: replay history from the products/tasks
+         * `logs/` endpoint, then open SSE if the run is non-terminal. `justCreatedRun` skips the
+         * `logs/` round-trip (fresh-run fast path — nothing historical to assemble).
+         */
+        bootstrapRun: (payload: { taskId: string; runId: string; justCreatedRun?: boolean }) => payload,
         openSseForRun: (payload: { taskId: string; runId: string; startLatest?: boolean }) => payload,
         closeSse: true,
         sseConnecting: true,
         sseOpened: true,
+        sseReconnecting: (attempt: number) => ({ attempt }),
+        /** Internal: an SSE drop initiates the refetch + backoff loop. */
+        sseDropped: true,
         /** Frame ingestion — called by the SSE listener and by products/tasks `logs/` replay. */
         ingestAcpFrame: (entry: StoredLogEntry) => ({ entry }),
+        /** Internal: records an entry's serialized hash so reconnect replay can dedup it. */
+        markEntryIngested: (hash: string) => ({ hash }),
         ingestPermissionRequest: (record: PermissionRequestRecord) => ({ record }),
         handleTerminalStatus: (status: { status: SandboxRunStatus; errorMessage?: string | null }) => status,
         handleStreamError: (envelope: { errorTitle: string; errorMessage?: string; retryable: boolean }) => envelope,
@@ -149,9 +209,33 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             {
                 sseConnecting: () => 'connecting',
                 sseOpened: () => 'open',
+                sseReconnecting: () => 'reconnecting',
                 closeSse: () => 'closed',
                 handleStreamError: () => 'error',
                 reset: () => 'idle',
+            },
+        ],
+        reconnectAttempt: [
+            0,
+            {
+                sseReconnecting: (_, { attempt }) => attempt,
+                // A successful (re)connection clears the counter; bootstrapping a run starts fresh.
+                sseOpened: () => 0,
+                bootstrapRun: () => 0,
+                reset: () => 0,
+            },
+        ],
+        // Serialized-JSON hashes of entries already ingested (from `logs/` replay or live SSE) so a
+        // reconnect with `?start=latest` doesn't double-fold history.
+        ingestedEntryHashes: [
+            new Set<string>(),
+            {
+                markEntryIngested: (state, { hash }) => {
+                    const next = new Set(state)
+                    next.add(hash)
+                    return next
+                },
+                reset: () => new Set<string>(),
             },
         ],
         currentRunStatus: [
@@ -275,6 +359,45 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         ],
     }),
     listeners(({ values, actions, cache }) => ({
+        bootstrapRun: async ({ taskId, runId, justCreatedRun }) => {
+            const projectId = values.currentProjectId
+            if (projectId === null) {
+                actions.handleStreamError({ errorTitle: 'No current project', retryable: false })
+                return
+            }
+
+            // Fresh-run fast path: nothing historical to assemble — go straight to SSE.
+            if (justCreatedRun) {
+                actions.openSseForRun({ taskId, runId, startLatest: false })
+                return
+            }
+
+            // Existing run: replay the assembled resume-chain log, then refetch the run to decide on SSE.
+            try {
+                const entries = await api.tasks.runs.getLogEntries(taskId, runId)
+                entries.forEach((entry) => actions.ingestAcpFrame(entry as unknown as StoredLogEntry))
+            } catch (error) {
+                actions.handleStreamError(mapHttpStatusToStreamError((error as { status?: number })?.status))
+                return
+            }
+
+            let run: { status?: SandboxRunStatus }
+            try {
+                run = await api.tasks.runs.get(taskId, runId)
+            } catch (error) {
+                actions.handleStreamError(mapHttpStatusToStreamError((error as { status?: number })?.status))
+                return
+            }
+
+            const status = run.status ?? null
+            if (isTerminalRunStatus(status)) {
+                // Read-only history — surface the terminal status, do not open SSE.
+                actions.handleTerminalStatus({ status: status as SandboxRunStatus })
+                return
+            }
+            // Non-terminal: open SSE from the latest point, deduping against the replayed history.
+            actions.openSseForRun({ taskId, runId, startLatest: true })
+        },
         openSseForRun: ({ taskId, runId, startLatest }) => {
             const projectId = values.currentProjectId
             if (projectId === null) {
@@ -282,9 +405,13 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 return
             }
 
-            actions.sseConnecting()
+            // Track the active run so the reconnect loop can refetch it on a drop.
+            cache.activeRun = { taskId, runId }
 
-            // Replace any prior connection — reconnect/backoff layers on top of this later.
+            actions.sseConnecting()
+            cache.disposables.dispose('reconnect-backoff')
+
+            // Replace any prior connection.
             cache.disposables.dispose('event-source')
             // pauseOnPageHidden: false — a live SSE connection must survive tab hides; re-running
             // setup on show would replay the stream from the top and duplicate thread state.
@@ -318,7 +445,9 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                                 break
                         }
                     }
-                    // Named `event: error` frames sent by the stream endpoint.
+                    // `EventSource` fires `error` both for named `event: error` envelopes (carrying
+                    // `data`) and for transient connection drops (no `data`). Surface the former
+                    // verbatim; treat the latter as a drop and run the refetch + backoff loop.
                     eventSource.addEventListener('error', (event: MessageEvent<string>): void => {
                         if (typeof event.data === 'string' && event.data.length > 0) {
                             try {
@@ -331,7 +460,11 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                             } catch {
                                 actions.handleStreamError({ errorTitle: 'Cloud stream failed', retryable: true })
                             }
+                            return
                         }
+                        // Connection drop — take over manual reconnection (the native auto-retry would
+                        // bypass our refetch + capped-backoff logic).
+                        actions.sseDropped()
                     })
 
                     return () => eventSource.close()
@@ -340,10 +473,61 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 { pauseOnPageHidden: false }
             )
         },
+        sseDropped: async () => {
+            const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
+            if (!activeRun) {
+                return
+            }
+            // Stop the native EventSource so its built-in auto-retry doesn't race our loop.
+            cache.disposables.dispose('event-source')
+
+            // First refetch the run to detect terminal state.
+            let run: { status?: SandboxRunStatus }
+            try {
+                run = await api.tasks.runs.get(activeRun.taskId, activeRun.runId)
+            } catch (error) {
+                actions.handleStreamError(mapHttpStatusToStreamError((error as { status?: number })?.status))
+                return
+            }
+
+            // Terminal → final terminal-status action + close.
+            if (isTerminalRunStatus(run.status ?? null)) {
+                actions.handleTerminalStatus({ status: (run.status ?? 'completed') as SandboxRunStatus })
+                return
+            }
+
+            // Non-terminal → capped exponential backoff; attempts exhausted surface a retryable error.
+            const attempt = values.reconnectAttempt + 1
+            if (attempt > MAX_SSE_RECONNECT_ATTEMPTS) {
+                actions.handleStreamError({ errorTitle: 'Cloud stream failed', retryable: true })
+                return
+            }
+            actions.sseReconnecting(attempt)
+            // pauseOnPageHidden: false — the SSE connection survives tab hides, so a drop in a
+            // hidden tab must also reconnect there; a paused timer would stall until refocus.
+            cache.disposables.add(
+                (): (() => void) => {
+                    const timer = window.setTimeout(() => {
+                        actions.openSseForRun({ taskId: activeRun.taskId, runId: activeRun.runId, startLatest: true })
+                    }, reconnectDelayMs(attempt))
+                    return () => clearTimeout(timer)
+                },
+                'reconnect-backoff',
+                { pauseOnPageHidden: false }
+            )
+        },
+        handleTerminalStatus: () => {
+            // A terminal run has no more frames — close the SSE and stop any pending reconnect.
+            cache.disposables.dispose('reconnect-backoff')
+            cache.disposables.dispose('event-source')
+        },
         closeSse: () => {
+            cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
         },
         reset: () => {
+            cache.activeRun = undefined
+            cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
         },
         ingestAcpFrame: ({ entry }) => {
@@ -351,6 +535,14 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             if (!notification) {
                 return
             }
+            // Content-dedup: a reconnect with `?start=latest` may replay frames already folded in from
+            // the `logs/` bootstrap (Redis-stream IDs aren't comparable to S3-log IDs). Match on
+            // serialized JSON and drop repeats before they mutate thread state.
+            const hash = hashLogEntry(entry)
+            if (values.ingestedEntryHashes.has(hash)) {
+                return
+            }
+            actions.markEntryIngested(hash)
             const method = notification.method
             const params = (notification.params ?? {}) as Record<string, any>
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -24,9 +24,9 @@ export const MAX_SSE_RECONNECT_ATTEMPTS = 5
 export const SSE_RECONNECT_BASE_DELAY_MS = 2_000
 export const SSE_RECONNECT_MAX_DELAY_MS = 30_000
 
-const TERMINAL_RUN_STATUSES: ReadonlySet<SandboxRunStatus> = new Set(['completed', 'failed', 'cancelled'])
+const TERMINAL_RUN_STATUSES: ReadonlySet<string> = new Set(['completed', 'failed', 'cancelled'])
 
-function isTerminalRunStatus(status: SandboxRunStatus | null | undefined): boolean {
+function isTerminalRunStatus(status: string | null | undefined): boolean {
     return status != null && TERMINAL_RUN_STATUSES.has(status)
 }
 
@@ -381,7 +381,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 return
             }
 
-            let run: { status?: SandboxRunStatus }
+            let run: { status?: string }
             try {
                 run = await api.tasks.runs.get(taskId, runId)
             } catch (error) {
@@ -482,7 +482,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             cache.disposables.dispose('event-source')
 
             // First refetch the run to detect terminal state.
-            let run: { status?: SandboxRunStatus }
+            let run: { status?: string }
             try {
                 run = await api.tasks.runs.get(activeRun.taskId, activeRun.runId)
             } catch (error) {

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -66,6 +66,19 @@ function hashLogEntry(entry: StoredLogEntry): string {
     return JSON.stringify(entry)
 }
 
+/** Refetch the run's status; on failure return the mapped error envelope instead. */
+async function fetchRunStatus(
+    taskId: string,
+    runId: string
+): Promise<{ status: string | null } | { error: StreamErrorEnvelope }> {
+    try {
+        const run: { status?: string } = await api.tasks.runs.get(taskId, runId)
+        return { status: run.status ?? null }
+    } catch (error) {
+        return { error: mapHttpStatusToStreamError((error as { status?: number })?.status) }
+    }
+}
+
 /** Matches `mcp__posthog__exec` (and plugin/regional variants). Ported from Twig posthog-exec-display.ts. */
 const POSTHOG_EXEC_TOOL_RE = /^mcp__(?:plugin_)?posthog(?:_[^_]+)*__exec$/
 
@@ -241,7 +254,9 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         currentRunStatus: [
             null as SandboxRunStatus | null,
             {
-                openSseForRun: () => 'queued',
+                // A reconnect reopens the same in-flight run — keep its known status rather than
+                // flickering back to queued; only a fresh open (no/terminal status) resets.
+                openSseForRun: (state) => (state && !isTerminalRunStatus(state) ? state : 'queued'),
                 handleTerminalStatus: (_, { status }) => status,
                 reset: () => null,
             },
@@ -359,7 +374,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         ],
     }),
     listeners(({ values, actions, cache }) => ({
-        bootstrapRun: async ({ taskId, runId, justCreatedRun }) => {
+        bootstrapRun: async ({ taskId, runId, justCreatedRun }, breakpoint) => {
             const projectId = values.currentProjectId
             if (projectId === null) {
                 actions.handleStreamError({ errorTitle: 'No current project', retryable: false })
@@ -373,26 +388,25 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             }
 
             // Existing run: replay the assembled resume-chain log, then refetch the run to decide on SSE.
+            let entries: Record<string, any>[]
             try {
-                const entries = await api.tasks.runs.getLogEntries(taskId, runId)
-                entries.forEach((entry) => actions.ingestAcpFrame(entry as unknown as StoredLogEntry))
+                entries = await api.tasks.runs.getLogEntries(taskId, runId)
             } catch (error) {
                 actions.handleStreamError(mapHttpStatusToStreamError((error as { status?: number })?.status))
                 return
             }
+            breakpoint()
+            entries.forEach((entry) => actions.ingestAcpFrame(entry as unknown as StoredLogEntry))
 
-            let run: { status?: string }
-            try {
-                run = await api.tasks.runs.get(taskId, runId)
-            } catch (error) {
-                actions.handleStreamError(mapHttpStatusToStreamError((error as { status?: number })?.status))
+            const result = await fetchRunStatus(taskId, runId)
+            breakpoint()
+            if ('error' in result) {
+                actions.handleStreamError(result.error)
                 return
             }
-
-            const status = run.status ?? null
-            if (isTerminalRunStatus(status)) {
+            if (isTerminalRunStatus(result.status)) {
                 // Read-only history — surface the terminal status, do not open SSE.
-                actions.handleTerminalStatus({ status: status as SandboxRunStatus })
+                actions.handleTerminalStatus({ status: result.status as SandboxRunStatus })
                 return
             }
             // Non-terminal: open SSE from the latest point, deduping against the replayed history.
@@ -473,7 +487,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 { pauseOnPageHidden: false }
             )
         },
-        sseDropped: async () => {
+        sseDropped: async (_, breakpoint) => {
             const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
             if (!activeRun) {
                 return
@@ -482,17 +496,20 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             cache.disposables.dispose('event-source')
 
             // First refetch the run to detect terminal state.
-            let run: { status?: string }
-            try {
-                run = await api.tasks.runs.get(activeRun.taskId, activeRun.runId)
-            } catch (error) {
-                actions.handleStreamError(mapHttpStatusToStreamError((error as { status?: number })?.status))
+            const result = await fetchRunStatus(activeRun.taskId, activeRun.runId)
+            breakpoint()
+            // The stream was closed or replaced while the refetch was in flight — drop this loop.
+            if (cache.activeRun !== activeRun) {
+                return
+            }
+            if ('error' in result) {
+                actions.handleStreamError(result.error)
                 return
             }
 
             // Terminal → final terminal-status action + close.
-            if (isTerminalRunStatus(run.status ?? null)) {
-                actions.handleTerminalStatus({ status: (run.status ?? 'completed') as SandboxRunStatus })
+            if (isTerminalRunStatus(result.status)) {
+                actions.handleTerminalStatus({ status: result.status as SandboxRunStatus })
                 return
             }
 
@@ -508,7 +525,10 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             cache.disposables.add(
                 (): (() => void) => {
                     const timer = window.setTimeout(() => {
-                        actions.openSseForRun({ taskId: activeRun.taskId, runId: activeRun.runId, startLatest: true })
+                        // Reopen with a full replay (no start=latest): frames emitted while
+                        // disconnected are re-delivered and the content-dedup drops the
+                        // already-ingested ones, so the gap is filled losslessly.
+                        actions.openSseForRun({ taskId: activeRun.taskId, runId: activeRun.runId, startLatest: false })
                     }, reconnectDelayMs(attempt))
                     return () => clearTimeout(timer)
                 },
@@ -516,12 +536,17 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 { pauseOnPageHidden: false }
             )
         },
-        handleTerminalStatus: () => {
-            // A terminal run has no more frames — close the SSE and stop any pending reconnect.
+        handleTerminalStatus: ({ status }) => {
+            // The wire emits task_run_state for non-terminal transitions too (e.g. queued →
+            // in_progress) — only an actually-terminal run has no more frames to stream.
+            if (!isTerminalRunStatus(status)) {
+                return
+            }
             cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
         },
         closeSse: () => {
+            cache.activeRun = undefined
             cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
         },


### PR DESCRIPTION
## Problem

PR **I2.6** of the PostHog AI → sandbox-agent migration (`docs/internal/posthog-ai-migration/00_OVERVIEW.md` § 10). The I1.3 `sandboxStreamLogic` skeleton opens an `EventSource` but has no resilience — a dropped connection ends the conversation. This adds reconnect, dedup, error mapping, and terminal-status handling so sustained sandbox conversations survive disconnects.

> Stacked on **I1.3** (`feat/phai-i1.3-frontend-foundations`). Auto-retargets to `feat/posthog-ai-sandboxes` once I1.3 merges.

## Changes

Extends `frontend/src/scenes/max/sandboxStreamLogic.ts` (additive; LangGraph handlers untouched), per `02_CORE` §§ 4.2, 4.3, 4.4, 6 — porting PostHog Code's `cloud-task/service.ts` reconnect/dedup strategy:

- **Reconnect/backoff** (§ 4.3): on drop, refetch the run; terminal → final status + close; non-terminal → capped exponential backoff `2s/4s/8s/16s/30s`, max 5 attempts, then a retryable error. Constants `MAX_SSE_RECONNECT_ATTEMPTS` / `SSE_RECONNECT_BASE_DELAY_MS` / `SSE_RECONNECT_MAX_DELAY_MS`.
- **Content-dedup** against entries already ingested from the `logs/` bootstrap (serialized-JSON match, `ingestedEntryHashes`).
- **Error class mapping** (§ 4.4): 401/403/404/406/other → `errorTitle`/`retryable`, for both `event: error` frames and HTTP-status mapping on refetch/open failure.
- **Terminal-status**: `data.type === 'task_run_state'` → Idle/Error transition + close.
- **Bootstrap** (§ 4.2): `GET .../logs/` replay → open SSE with `?start=latest` if non-terminal; fresh-run fast path skips `logs/`. Added `api.tasks.runs.*` helpers.

## How did you test this code?

Automated only (I'm an agent):

- `pnpm format` clean; jest fixtures (reconnect, dedup, terminal-status, error mapping) pass.
- Type correctness validated via scoped `kea-typegen write --show-ts-errors` (0 `error TS` in the changed file). Full-project `tsc` OOMs on the whole graph in this environment — an env limit, not a type error.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) via a multi-agent workflow (implement → verify) in an isolated worktree stacked on I1.3. Wiring `bootstrapRun`/`openSseForRun` into `maxThreadLogic`'s send/history-load branches is owned by a later PR (§ 7 / I2.7) and intentionally not done here. The session-cookie-vs-bearer auth question for the `products/tasks` stream endpoint (`02_CORE` § 4) is still open upstream; this relies on same-origin session cookies (`withCredentials`). Requires human review; not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
