### PR TITLE
fix(sharing): give share preview iframe an explicit background

### DIFF
--- a/frontend/src/lib/components/Sharing/SharingModal.test.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.test.tsx
@@ -193,4 +193,12 @@ describe('SharingModal (insight)', () => {
 
         expect(within(modal as HTMLElement).queryByText(/Show insight details/i)).toBeNull()
     })
+
+    it('gives the preview iframe an explicit background so it does not fall back to the browser backdrop', async () => {
+        render(<InsightSharingModalWrapper />)
+
+        // Without an explicit surface, a loading/errored iframe paints the UA color-scheme backdrop (light or dark by browser version)
+        const iframe = await screen.findByTitle('Shared insight preview')
+        expect(iframe).toHaveClass('bg-primary')
+    })
 })

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -453,7 +453,8 @@ export function SharingModalContent({
                                                     {showPreview && (
                                                         <div className="SharingPreview border-t">
                                                             <iframe
-                                                                className="block"
+                                                                // Explicit surface so the load/error state matches the embedded page, not the UA color-scheme backdrop
+                                                                className="block bg-primary"
                                                                 {...iframeProperties}
                                                                 title="Shared insight preview"
                                                                 onLoad={() => setIframeLoaded(true)}


### PR DESCRIPTION
## Problem

The share-preview iframe in `SharingModal` (the recording, insight, and dashboard share dialogs) had no explicit background. Before the embedded document paints, during the load window and persistently on a hard load error or blocked content, the iframe falls back to the browser's default `color-scheme: light dark` backdrop (`body` sets `color-scheme: light dark` in `base.scss`). Newer Chromium renders that backdrop light; older Chromium rendered it dark, so the preview area's appearance was undefined and browser-version-dependent rather than intentional.

This surfaced while bumping `@playwright/test` (#60771), where the newer bundled Chromium flipped this preview area from dark to light in Storybook snapshots. That bump is correct; this is a separate, pre-existing robustness gap.

## Changes

- Give the preview `<iframe>` an explicit `bg-primary` surface so the load/error state matches the embedded shared page's own body background (`--color-bg-primary`) in both light and dark themes, instead of the UA `color-scheme` backdrop.
- Applied to the iframe element rather than just the `.SharingPreview` container, because the iframe is the element that inherits `color-scheme` and paints the version-dependent backdrop, and it fully covers the container; a background on the container alone could be painted over by the iframe's UA canvas.
- Added a regression test asserting the preview iframe carries an explicit background utility.

No manual screenshots are attached (see testing note). The pixel before/after is best seen in this PR's visual-regression diff for the four `previewIframe` stories, light and dark: `components-sharing--insight-sharing`, `components-sharing--insight-sharing-licensed`, `components-sharing--recording-sharing-licensed`, and `replay-sharing--public-link`. Those stories intentionally do not mock the embed URL, so the iframe stays blank and shows the backdrop, which is exactly the state this fix makes deterministic.

## How did you test this code?

I'm an agent and ran only automated checks (no manual or browser testing):

- Added a red-green regression test in `SharingModal.test.tsx`: it fails on the pre-fix markup (`className="block"`, received `block`) and passes with `bg-primary`. Verified by temporarily reverting the fix and watching it fail.
- Ran the full `SharingModal.test.tsx` suite: 5/5 pass.
- `oxlint` clean on both changed files; `oxfmt` applied.

I did not run the Storybook visual-regression suite locally: its baseline lives in the remote Visual Review service (`snapshots.yml` hashes), CI deletes committed PNGs and re-captures fresh screenshots, and `snapshots.yml` is updated automatically only after human review and approval. The eight affected snapshots listed above should show as changed in CI and need approval in the Visual Review UI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change needed.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Tools: file read/edit, Bash, and grep for navigation; `hogli` to run Jest; `oxlint`/`oxfmt` for lint and format.

Decisions:
- `bg-primary` over `bg-surface-primary`: the embedded shared page's `body` background is `--color-bg-primary`, so the placeholder matches the eventual content exactly; both tokens are defined for light and dark, so either is theme-safe.
- iframe element over `.SharingPreview` container: the explicit background must override the UA `color-scheme` canvas the iframe itself paints, and the container has no padding so the iframe covers it fully.
- Confirmed the snapshots cannot be updated locally (remote Visual Review baseline plus human approval), so this PR relies on CI to surface the diff.

Agent-authored; requires human review, do not self-merge.
