### PR TITLE
feat(taxonomic-filter): verified badges, telemetry, and cohort search fix

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -42,6 +42,7 @@ import { TaxonomicDefinitionTypes, TaxonomicFilterGroup, TaxonomicFilterGroupTyp
 import { MenuFilterHeader } from './Header'
 import { PreviewPane } from './PreviewPane'
 import { CommitFn, DrillCategory, MenuFilterEntry } from './types'
+import { VerificationBadge } from './VerificationBadge'
 
 // `threshold` + `ignoreDiacritics` come from `createFuse` defaults; we
 // only override what's specific to the menu (keys + the
@@ -612,6 +613,7 @@ function Row({ entry, showCategory, opensSubmenu, selectedRowId, onCommit }: Row
                 </span>
                 {showCategory && <MenuLabel className="text-tertiary/50 text-xxs p-0 mt-px">{category}</MenuLabel>}
             </div>
+            <VerificationBadge entry={entry} />
             {isSelected && <IconCheck className="size-3.5 text-foreground shrink-0" />}
             {opensSubmenu && <IconChevronRight className="size-3.5 text-tertiary shrink-0" />}
         </Autocomplete.Item>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -279,11 +279,30 @@ export function MenuFilterCombobox({
 
     const filtered = useMemo<MenuFilterEntry[]>(() => {
         const q = searchQuery.trim()
-        const base = q
-            ? createFuse(indexed, FUSE_OPTIONS as Parameters<typeof createFuse<MenuFilterEntry>>[1])
-                  .search(q)
-                  .map((r) => r.item)
-            : indexed
+        let base: MenuFilterEntry[]
+        if (!q) {
+            base = indexed
+        } else {
+            // The endpoint is the search authority for endpoint-backed
+            // groups (e.g. Cohorts use `name__icontains` server-side, plus
+            // server-side behavioral-cohort exclusion). Re-running the
+            // client Fuse over already-server-searched results filters them
+            // a *second*, fuzzier time — and Fuse scoring isn't monotonic as
+            // the query grows, so a valid match shown for "posthog te" can
+            // vanish at "posthog team". So only Fuse locally-sourced groups
+            // (Actions, etc., which load their full list client-side); pass
+            // server-searched entries through untouched, preserving order.
+            const localSourced = indexed.filter((e) => !e.group.endpoint)
+            const localMatches =
+                localSourced.length > 0
+                    ? new Set(
+                          createFuse(localSourced, FUSE_OPTIONS as Parameters<typeof createFuse<MenuFilterEntry>>[1])
+                              .search(q)
+                              .map((r) => r.item)
+                      )
+                    : null
+            base = indexed.filter((e) => !!e.group.endpoint || (localMatches?.has(e) ?? false))
+        }
         // Promote the committed selection to index 0 so base-ui's
         // `autoHighlight="always"` lands on it the moment the list
         // mounts — keyboard nav starts on the selected row, the

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -12,6 +12,7 @@
  */
 import { Autocomplete } from '@base-ui/react/autocomplete'
 import { useValues } from 'kea'
+import posthog from 'posthog-js'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { IconCheck, IconChevronRight } from '@posthog/icons'
@@ -395,6 +396,12 @@ export function MenuFilterCombobox({
             const idx = ordered.indexOf(activeChip)
             const dir = e.shiftKey ? -1 : 1
             const next = ordered[(idx + dir + ordered.length) % ordered.length]
+            posthog.capture('taxonomic filter menu category changed', {
+                fromChip: activeChip,
+                toChip: next,
+                via: 'tab',
+                direction: e.shiftKey ? 'backward' : 'forward',
+            })
             setActiveChip(next)
             e.preventDefault()
             e.stopPropagation()
@@ -456,6 +463,11 @@ export function MenuFilterCombobox({
                                         <Select<DrillCategory>
                                             value={activeChip}
                                             onValueChange={(value) => {
+                                                posthog.capture('taxonomic filter menu category changed', {
+                                                    fromChip: activeChip,
+                                                    toChip: value ?? 'all',
+                                                    via: 'dropdown',
+                                                })
                                                 setActiveChip(value ?? 'all')
                                                 inputRef.current?.focus()
                                             }}

--- a/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
@@ -9,6 +9,8 @@
  * Properties / events / actions render specific extras; everything else
  * falls back to the shared header + description.
  */
+import posthog from 'posthog-js'
+
 import { IconPin } from '@posthog/icons'
 import { Button, cn, ScrollArea, Separator } from '@posthog/quill'
 
@@ -111,7 +113,15 @@ function PreviewHeader({ details, viewUrl, entry }: PreviewHeaderProps): JSX.Ele
                     size="sm"
                     disabled={!details.isPinnable}
                     aria-pressed={details.isPinned}
-                    onClick={details.togglePin}
+                    onClick={() => {
+                        posthog.capture('taxonomic filter menu pin toggled', {
+                            groupType: entry.group.type,
+                            // Intended next state — `isPinned` still reads
+                            // the pre-toggle value here.
+                            pinned: !details.isPinned,
+                        })
+                        details.togglePin()
+                    }}
                 >
                     <IconPin className="size-3.5" />
                     {details.isPinned ? 'Pinned' : 'Pin'}

--- a/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
@@ -21,6 +21,7 @@ import { useTaxonomicAutocompleteItemDetails } from '../headless'
 import { TaxonomicFilterGroupType } from '../types'
 import { ActionMatchGroups } from './preview/ActionMatchGroups'
 import { MenuFilterEntry } from './types'
+import { VerificationBadge } from './VerificationBadge'
 
 export interface PreviewPaneProps {
     /** Highlighted entry, or `null` when nothing is highlighted. */
@@ -59,7 +60,7 @@ function PreviewBody({ entry }: { entry: MenuFilterEntry }): JSX.Element | null 
     return (
         <ScrollArea className="flex-1 min-h-0">
             <div className="flex flex-col gap-3 p-3 text-sm">
-                <PreviewHeader details={details} viewUrl={viewUrl} />
+                <PreviewHeader details={details} viewUrl={viewUrl} entry={entry} />
 
                 {details.description ? (
                     <p className="text-xs leading-relaxed text-secondary">{details.description}</p>
@@ -93,9 +94,11 @@ interface PreviewHeaderProps {
     details: ReturnType<typeof useTaxonomicAutocompleteItemDetails>
     /** Data management URL for the definition, or `undefined` to hide. */
     viewUrl: string | undefined
+    /** Highlighted entry — drives the verification badge. */
+    entry: MenuFilterEntry
 }
 
-function PreviewHeader({ details, viewUrl }: PreviewHeaderProps): JSX.Element | null {
+function PreviewHeader({ details, viewUrl, entry }: PreviewHeaderProps): JSX.Element | null {
     if (!details) {
         return null
     }
@@ -127,6 +130,7 @@ function PreviewHeader({ details, viewUrl }: PreviewHeaderProps): JSX.Element | 
             <div className="flex flex-col gap-1">
                 <div className="text-xxs uppercase tracking-wide text-secondary">{details.groupLabel}</div>
                 <div className="text-base font-semibold leading-tight break-words">{details.title}</div>
+                <VerificationBadge entry={entry} className="mt-1 self-start" />
             </div>
             <Separator />
         </div>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -101,6 +101,15 @@ export interface TriggerState {
     open: boolean
 }
 
+/** Dropdown-menu options users can pick, for the option-click event. */
+type MenuOption = 'new' | 'recent' | 'pinned' | 'dwh' | 'hogql'
+
+// Module-level so a quick close→reopen is detectable even though the
+// component unmounts between opens (consumers lazily mount it on the
+// first trigger click). Heuristic only — shared across all triggers.
+let lastMenuClosedAtMs: number | null = null
+const QUICK_REOPEN_MS = 3000
+
 export function TaxonomicFilterMenu({
     triggerLabel,
     selected,
@@ -127,12 +136,18 @@ export function TaxonomicFilterMenu({
         const previous = lastStateKindRef.current
         const next = state.kind
         if (previous === 'closed' && next !== 'closed') {
-            openedAtRef.current = Date.now()
+            const now = Date.now()
+            const msSinceLastClose = lastMenuClosedAtMs != null ? now - lastMenuClosedAtMs : null
+            openedAtRef.current = now
             hadCommitRef.current = false
             posthog.capture('taxonomic filter menu opened', {
                 openedTo: next,
                 hadSelection: !!selected,
                 triggerLabel,
+                // Reopen funnel — `null` on the first open of the session;
+                // a small value means the user bounced and came right back.
+                msSinceLastClose,
+                reopenedQuickly: msSinceLastClose != null && msSinceLastClose < QUICK_REOPEN_MS,
             })
         } else if (previous !== 'closed' && next !== 'closed' && previous !== next) {
             posthog.capture('taxonomic filter menu drilled', {
@@ -140,11 +155,13 @@ export function TaxonomicFilterMenu({
                 toState: next,
             })
         } else if (previous !== 'closed' && next === 'closed') {
+            const closedAt = Date.now()
             posthog.capture('taxonomic filter menu closed', {
-                dwellMs: openedAtRef.current ? Date.now() - openedAtRef.current : null,
+                dwellMs: openedAtRef.current ? closedAt - openedAtRef.current : null,
                 hadCommit: hadCommitRef.current,
                 lastState: previous,
             })
+            lastMenuClosedAtMs = closedAt
             openedAtRef.current = null
         }
         lastStateKindRef.current = next
@@ -166,6 +183,14 @@ export function TaxonomicFilterMenu({
         []
     )
     const openHogql = useCallback(() => setState({ kind: 'hogql-edit' }), [])
+
+    // Capture which dropdown-menu option the user picked, then run its
+    // transition. Lets us see the relative pull of New / Recent / Pinned /
+    // DWH / HogQL rather than just a generic menu→panel `drilled` event.
+    const selectMenuOption = useCallback((option: MenuOption, action: () => void): void => {
+        posthog.capture('taxonomic filter menu option clicked', { option })
+        action()
+    }, [])
 
     /**
      * Resolve the initial state when the trigger opens. If `selected` is
@@ -259,6 +284,9 @@ export function TaxonomicFilterMenu({
                 query: searchQuery || undefined,
                 hadExtras: !!extra,
                 fromState: lastStateKindRef.current,
+                // Time-to-select — how long from opening the menu to
+                // committing this item.
+                msSinceOpen: openedAtRef.current ? Date.now() - openedAtRef.current : null,
             })
             selectItem(entry.group, itemValue, mergedItem)
             onCommit?.({ ...entry, item: mergedItem }, extra)
@@ -531,34 +559,43 @@ export function TaxonomicFilterMenu({
                 />
             )}
             <DropdownMenuContent align="start" className="min-w-[240px]">
-                <DropdownMenuItem onClick={() => openCombobox('all')} data-attr="taxonomic-filter-menu-new">
+                <DropdownMenuItem
+                    onClick={() => selectMenuOption('new', () => openCombobox('all'))}
+                    data-attr="taxonomic-filter-menu-new"
+                >
                     New filter…
                     <IconChevronRight className="ml-auto size-3.5 text-tertiary" />
                 </DropdownMenuItem>
                 {recentEntries.length > 0 && (
                     <>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem onClick={() => openCombobox('recent')}>
+                        <DropdownMenuItem onClick={() => selectMenuOption('recent', () => openCombobox('recent'))}>
                             Recent
                             <IconChevronRight className="ml-auto size-3.5 text-tertiary" />
                         </DropdownMenuItem>
                     </>
                 )}
                 {pinnedEntries.length > 0 && (
-                    <DropdownMenuItem onClick={() => openCombobox('pinned')}>
+                    <DropdownMenuItem onClick={() => selectMenuOption('pinned', () => openCombobox('pinned'))}>
                         Pinned
                         <IconChevronRight className="ml-auto size-3.5 text-tertiary" />
                     </DropdownMenuItem>
                 )}
                 {(hasDwh || hasHogql) && <DropdownMenuSeparator />}
                 {hasDwh && (
-                    <DropdownMenuItem onClick={openDwhPick} data-attr="taxonomic-filter-menu-dwh">
+                    <DropdownMenuItem
+                        onClick={() => selectMenuOption('dwh', openDwhPick)}
+                        data-attr="taxonomic-filter-menu-dwh"
+                    >
                         Data warehouse tables
                         <IconChevronRight className="ml-auto size-3.5 text-tertiary" />
                     </DropdownMenuItem>
                 )}
                 {hasHogql && (
-                    <DropdownMenuItem onClick={openHogql} data-attr="taxonomic-filter-menu-hogql">
+                    <DropdownMenuItem
+                        onClick={() => selectMenuOption('hogql', openHogql)}
+                        data-attr="taxonomic-filter-menu-hogql"
+                    >
                         HogQL expression
                         <IconChevronRight className="ml-auto size-3.5 text-tertiary" />
                     </DropdownMenuItem>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/VerificationBadge.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/VerificationBadge.tsx
@@ -1,0 +1,79 @@
+/**
+ * Verification badge for taxonomic filter rows + preview pane.
+ *
+ * Two mutually-exclusive states (core defs can't be team-verified — see
+ * `DefinitionPopoverContents`'s `allowVerification`):
+ *   - `core`     — a built-in PostHog definition (`isCoreFilter`). Badge
+ *                  reads "By PostHog" with the logomark.
+ *   - `verified` — a custom definition a team explicitly marked verified
+ *                  (`item.verified`). Badge reads "Verified".
+ */
+import { IconBadge, IconLogomark } from '@posthog/icons'
+import { Badge, cn, Tooltip, TooltipContent, TooltipTrigger } from '@posthog/quill'
+
+import { isCoreFilter } from '~/taxonomy/helpers'
+
+import { MenuFilterEntry } from './types'
+
+type Verification = { kind: 'core' } | { kind: 'verified' }
+
+export function getVerification(entry: MenuFilterEntry): Verification | null {
+    // Core PostHog definitions ($pageview, $browser, …) are inherently
+    // verified — surfaced as "By PostHog" rather than a team flag.
+    if (isCoreFilter(entry.name)) {
+        return { kind: 'core' }
+    }
+    if ((entry.item as { verified?: boolean })?.verified) {
+        return { kind: 'verified' }
+    }
+    return null
+}
+
+export function VerificationBadge({
+    entry,
+    className,
+}: {
+    entry: MenuFilterEntry
+    className?: string
+}): JSX.Element | null {
+    const verification = getVerification(entry)
+    if (!verification) {
+        return null
+    }
+    const isCore = verification.kind === 'core'
+    return (
+        <Tooltip>
+            {/* The trigger must render a host element (a `<span>`) so
+                base-ui's ref + hover handlers actually attach — `Badge` is
+                a plain function component (not `forwardRef`), so spreading
+                the trigger's `ref` onto it gets dropped and the tooltip
+                never anchors/opens. The Badge is plain visual content
+                inside the trigger span. */}
+            <TooltipTrigger
+                delay={300}
+                render={(triggerProps) => (
+                    <span {...triggerProps} className={cn('inline-flex', className)}>
+                        <Badge variant={isCore ? 'default' : 'success'} className="gap-1 shrink-0">
+                            {isCore ? <IconLogomark className="size-3" /> : <IconBadge className="size-3" />}
+                            {isCore ? 'PostHog' : 'Verified'}
+                        </Badge>
+                    </span>
+                )}
+            />
+            <TooltipContent className="max-w-64 flex-col items-start">
+                {isCore ? (
+                    <>
+                        <strong>Built into PostHog.</strong> A core definition PostHog ships, maintains, and documents.
+                        Its name, type, and description are managed for you, so you don't need to verify it.
+                    </>
+                ) : (
+                    <>
+                        <strong>Verified by your team.</strong> Someone marked this definition as the right one to use.
+                        Verified items are prioritized in filters so collaborators reach for them over similar,
+                        unverified ones.
+                    </>
+                )}
+            </TooltipContent>
+        </Tooltip>
+    )
+}


### PR DESCRIPTION
## Problem

Three related improvements to the rebuilt taxonomic filter menu:

1. The rebuild dropped the verification signal — users couldn't tell core PostHog built-ins from team-verified custom definitions.
2. The menu's telemetry had gaps (no per-option clicks, no Tab/category switches, no pin/unpin, no time-to-select or quick-reopen signal).
3. Cohort search was broken: a cohort visible while typing a partial query ("posthog te") would vanish once the full query was typed ("posthog team").

## Changes

**Verified / PostHog badges**
- New shared `menu/VerificationBadge.tsx`. Core PostHog definitions (`isCoreFilter`) get a **PostHog** badge; team-verified definitions (`item.verified`) get a **Verified** badge. Mutually exclusive, mirroring `DefinitionPopover`'s `allowVerification`.
- Rendered in the combobox rows (left of the selected check) and in the preview pane, each with a quill tooltip explaining the status.

**Telemetry coverage**
- `taxonomic filter menu option clicked` (New / Recent / Pinned / DWH / HogQL)
- `taxonomic filter menu category changed` (`via: tab | dropdown`) — covers both Tab-cycling and the category dropdown
- `taxonomic filter menu pin toggled`
- `msSinceOpen` (time-to-select) on item selection
- `msSinceLastClose` / `reopenedQuickly` on open (quick-reopen funnel)
- All additive — existing event/property shapes unchanged.

**Cohort search fix**
- The combobox was running its own Fuse pass on top of already-server-searched results. The cohort endpoint is the search authority (`name__icontains` plus server-side behavioral-cohort exclusion). Fuse scoring isn't monotonic as the candidate set shifts per keystroke, so a valid server match could drop out as the query grew.
- Now endpoint-backed groups (Cohorts, events, properties) pass through untouched; only locally-sourced groups (Actions, etc., which load their full list client-side) are Fused. Behavioral-cohort exclusion stays server-side, where it must — it depends on server feature-flag config and cohort dependency resolution that can't be reproduced on the client.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run locally:

- `pnpm --filter=@posthog/frontend typescript:check` — clean on touched files
- `pnpm --filter=@posthog/frontend format` — clean

Manual verification by the human author against the live app: badges + tooltips render in rows and preview pane; the cohort search regression ("posthog team" disappearing) is resolved. I did not run the full visual-regression suite.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8).

Notable decisions:
- **Tooltip not opening:** quill `Badge` is a plain function component (not `forwardRef`), so passing it directly as a `TooltipTrigger render={<Badge/>}` dropped base-ui's ref and the tooltip never anchored. Fixed by rendering the trigger as a host `<span>` with the Badge as content.
- **Cohort search:** considered moving cohorts to a fully client-side list (like Actions/DWH) but rejected it — the endpoint's behavioral-cohort exclusion can't be faithfully reproduced client-side, so the endpoint must stay the search authority. The fix instead removes the redundant client-side re-filter of server-searched groups.

Reviewer note: the **PostHog** badge shows on every core `$`-prefixed definition, so high-traffic categories (events, properties) display many badges. That matches the requested behavior; flag if it reads as too noisy.
