### PR TITLE
chore: use ReleaseStatus enum for warehouse source release status

### DIFF
--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -77,7 +77,7 @@ Follow this order. Each step maps to TODOs in `source.template`.
 10. **Add icon.** Place at `frontend/public/services/{source}.svg` (prefer SVG). If the logo isn't already committed, fetch from [Logo.dev](https://docs.logo.dev/introduction) — **ask the user for the Logo.dev API key**; do not hardcode one. Keep file size reasonable.
 11. **Run migrations.** `DEBUG=1 python manage.py makemigrations && DEBUG=1 ./bin/migrate` (only needed if a new enum value triggers a Django migration).
 12. **Rebuild schema types**: `pnpm run schema:build`. This updates `posthog/schema.py` from `schema-general.ts` and makes the source appear in frontend dropdowns. Re-run whenever `schema-general.ts` changes.
-13. **Release status.** For unfinished work, set `unreleasedSource=True`. Set `releaseStatus="alpha"` for new sources that haven't been extensively tested, `releaseStatus="beta"` once most rough edges are ironed out, and leave `releaseStatus` unset for general availability. For controlled rollout, set `featureFlag="dwh-{source_name}"` (kebab-case). When fully releasing, remove `unreleasedSource`, set `releaseStatus` to the appropriate stage (or omit for GA), and optionally drop the feature flag.
+13. **Release status.** Always set `releaseStatus` via the `ReleaseStatus` enum from `posthog.schema` — never a bare string literal. Import it (`from posthog.schema import ..., ReleaseStatus, ...`) and use `releaseStatus=ReleaseStatus.ALPHA` for new sources that haven't been extensively tested, `releaseStatus=ReleaseStatus.BETA` once most rough edges are ironed out, and `releaseStatus=ReleaseStatus.GA` (or leave it unset) for general availability. For unfinished work, set `unreleasedSource=True`. For controlled rollout, set `featureFlag="dwh-{source_name}"` (kebab-case). When fully releasing, remove `unreleasedSource`, set `releaseStatus` to the appropriate stage (`ReleaseStatus.GA` or omit), and optionally drop the feature flag.
 14. **Delete the template TODO comments** before PR.
 
 ## Source architecture contract
@@ -413,9 +413,10 @@ Tooling & assets:
 
 Release status:
 - [ ] unreleasedSource=True while WIP
-- [ ] releaseStatus="alpha" for new sources not yet extensively tested
-- [ ] releaseStatus="beta" when most rough edges have been ironed out
-- [ ] Omit releaseStatus (or set to "ga") on full release
+- [ ] releaseStatus set via the `ReleaseStatus` enum, never a string literal
+- [ ] releaseStatus=ReleaseStatus.ALPHA for new sources not yet extensively tested
+- [ ] releaseStatus=ReleaseStatus.BETA when most rough edges have been ironed out
+- [ ] releaseStatus=ReleaseStatus.GA (or omit) on full release
 - [ ] featureFlag="dwh-{source_name}" for controlled rollout
 - [ ] Flag removed / unreleasedSource removed on full release
 

--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -77,7 +77,7 @@ Follow this order. Each step maps to TODOs in `source.template`.
 10. **Add icon.** Place at `frontend/public/services/{source}.svg` (prefer SVG). If the logo isn't already committed, fetch from [Logo.dev](https://docs.logo.dev/introduction) — **ask the user for the Logo.dev API key**; do not hardcode one. Keep file size reasonable.
 11. **Run migrations.** `DEBUG=1 python manage.py makemigrations && DEBUG=1 ./bin/migrate` (only needed if a new enum value triggers a Django migration).
 12. **Rebuild schema types**: `pnpm run schema:build`. This updates `posthog/schema.py` from `schema-general.ts` and makes the source appear in frontend dropdowns. Re-run whenever `schema-general.ts` changes.
-13. **Release status.** Always set `releaseStatus` via the `ReleaseStatus` enum from `posthog.schema` — never a bare string literal. Import it (`from posthog.schema import ..., ReleaseStatus, ...`) and use `releaseStatus=ReleaseStatus.ALPHA` for new sources that haven't been extensively tested, `releaseStatus=ReleaseStatus.BETA` once most rough edges are ironed out, and `releaseStatus=ReleaseStatus.GA` (or leave it unset) for general availability. For unfinished work, set `unreleasedSource=True`. For controlled rollout, set `featureFlag="dwh-{source_name}"` (kebab-case). When fully releasing, remove `unreleasedSource`, set `releaseStatus` to the appropriate stage (`ReleaseStatus.GA` or omit), and optionally drop the feature flag.
+13. **Release status.** Whenever you set `releaseStatus`, use the `ReleaseStatus` enum from `posthog.schema` — never a bare string literal. Add `ReleaseStatus` to your existing `from posthog.schema import (...)` block, then use `releaseStatus=ReleaseStatus.ALPHA` for new sources that haven't been extensively tested, `releaseStatus=ReleaseStatus.BETA` once most rough edges are ironed out, and `releaseStatus=ReleaseStatus.GA` for general availability (you may also leave `releaseStatus` unset for GA). For unfinished work, set `unreleasedSource=True`. For controlled rollout, set `featureFlag="dwh-{source_name}"` (kebab-case). When fully releasing, remove `unreleasedSource`, set `releaseStatus` to the appropriate stage (`ReleaseStatus.GA` or omit it), and optionally drop the feature flag.
 14. **Delete the template TODO comments** before PR.
 
 ## Source architecture contract
@@ -413,10 +413,10 @@ Tooling & assets:
 
 Release status:
 - [ ] unreleasedSource=True while WIP
-- [ ] releaseStatus set via the `ReleaseStatus` enum, never a string literal
+- [ ] When set, releaseStatus uses the `ReleaseStatus` enum, never a string literal
 - [ ] releaseStatus=ReleaseStatus.ALPHA for new sources not yet extensively tested
 - [ ] releaseStatus=ReleaseStatus.BETA when most rough edges have been ironed out
-- [ ] releaseStatus=ReleaseStatus.GA (or omit) on full release
+- [ ] releaseStatus=ReleaseStatus.GA (or omit it) on full release
 - [ ] featureFlag="dwh-{source_name}" for controlled rollout
 - [ ] Flag removed / unreleasedSource removed on full release
 


### PR DESCRIPTION
## Problem

The `implementing-warehouse-sources` skill documented setting `releaseStatus` with bare string literals (`"alpha"`, `"beta"`, `"ga"`). Newer sources (e.g. `resend`, `plain`, `revenuecat`, `customer_io`) already use the `ReleaseStatus` enum from `posthog.schema`, so the skill guidance had drifted from the preferred pattern and would lead agents to write string-literal release statuses.

## Changes

Updated the skill in two places to direct agents to use the `ReleaseStatus` enum instead of string literals:

- **Step 13 ("Release status")** — now instructs importing `ReleaseStatus` from `posthog.schema` and using `ReleaseStatus.ALPHA` / `ReleaseStatus.BETA` / `ReleaseStatus.GA`.
- **The "Release status" checklist** — each item references the enum members, plus a new explicit item: "releaseStatus set via the `ReleaseStatus` enum, never a string literal".

Docs/skill-only change — no production code touched.

## How did you test this code?

I'm an agent. This is a documentation-only change to a skill file (no code), so there are no automated tests to run. Verified the referenced `ReleaseStatus` enum exists in `posthog/schema.py` and matches the enum-based usage in existing sources.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Tom Owers' request. The change aligns the warehouse-sources skill with the `ReleaseStatus` enum pattern already adopted by several sources in the repo, replacing the older string-literal guidance. Confirmed the enum (`ALPHA`/`BETA`/`GA`) in `posthog/schema.py` and the existing enum-based usages before editing.
