### PR TITLE
fix(replay): load org members so @-mentions resolve in player comments

### DIFF
--- a/frontend/src/lib/components/RichContentEditor/MentionsExtension.test.tsx
+++ b/frontend/src/lib/components/RichContentEditor/MentionsExtension.test.tsx
@@ -1,0 +1,157 @@
+import { MOCK_DEFAULT_BASIC_USER, MOCK_SECOND_BASIC_USER } from 'lib/api.mock'
+
+import '@testing-library/jest-dom'
+
+import { act, render } from '@testing-library/react'
+import { Editor } from '@tiptap/react'
+import { Provider } from 'kea'
+import { expectLogic } from 'kea-test-utils'
+import { createRef } from 'react'
+
+import { membersLogic } from 'scenes/organization/membersLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { Mentions } from './MentionsExtension'
+
+type MentionsHandle = { onKeyDown: (event: KeyboardEvent) => boolean }
+
+const mockMembers = [
+    {
+        id: '1',
+        user: MOCK_DEFAULT_BASIC_USER,
+        level: 8,
+        joined_at: '2020-09-24T15:05:26.758796Z',
+        updated_at: '2020-09-24T15:05:26.758837Z',
+        is_2fa_enabled: false,
+        has_social_auth: false,
+        last_login: '2020-09-24T15:05:26.758796Z',
+    },
+    {
+        id: '2',
+        user: MOCK_SECOND_BASIC_USER,
+        level: 1,
+        joined_at: '2021-03-11T19:11:11Z',
+        updated_at: '2021-03-11T19:11:11Z',
+        is_2fa_enabled: false,
+        has_social_auth: false,
+        last_login: '2021-03-11T19:11:11Z',
+    },
+]
+
+function createMockEditor(): { editor: Editor; run: jest.Mock; insertContentAt: jest.Mock } {
+    const run = jest.fn()
+    const insertContentAt = jest.fn(() => ({ run }))
+    const deleteRange = jest.fn(() => ({ insertContentAt }))
+    const focus = jest.fn(() => ({ deleteRange }))
+    const chain = jest.fn(() => ({ focus }))
+    return { editor: { chain } as unknown as Editor, run, insertContentAt }
+}
+
+function renderMentions(editor: Editor, onClose: () => void): React.RefObject<MentionsHandle> {
+    const ref = createRef<MentionsHandle>()
+    render(
+        <Provider>
+            <Mentions
+                ref={ref as React.Ref<any>}
+                editor={editor}
+                range={{ from: 0, to: 1 }}
+                query=""
+                onClose={onClose}
+            />
+        </Provider>
+    )
+    return ref
+}
+
+describe('Mentions', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/organizations/:organization_id/members/': { results: mockMembers },
+            },
+        })
+        initKeaTests()
+    })
+
+    it('does not swallow Enter when there is no matching member', () => {
+        // members never loaded -> meFirstMembers is empty -> no selectable member
+        const { editor, run } = createMockEditor()
+        const onClose = jest.fn()
+
+        const ref = renderMentions(editor, onClose)
+        const handled = ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }))
+
+        expect(handled).toBe(false)
+        expect(editor.chain).not.toHaveBeenCalled()
+        expect(run).not.toHaveBeenCalled()
+        expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('inserts the selected member and closes on Enter when a match exists', async () => {
+        await expectLogic(membersLogic, () => {
+            membersLogic.mount()
+            membersLogic.actions.loadAllMembers()
+        }).toDispatchActions(['loadAllMembersSuccess'])
+
+        const { editor, run, insertContentAt } = createMockEditor()
+        const onClose = jest.fn()
+
+        const ref = renderMentions(editor, onClose)
+        const handled = ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }))
+
+        expect(handled).toBe(true)
+        expect(editor.chain).toHaveBeenCalledTimes(1)
+        expect(run).toHaveBeenCalledTimes(1)
+        expect(insertContentAt).toHaveBeenCalledWith(0, [
+            expect.objectContaining({ attrs: { id: membersLogic.values.meFirstMembers[0].user.id } }),
+        ])
+        expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('wraps selection around with ArrowUp/ArrowDown', async () => {
+        await expectLogic(membersLogic, () => {
+            membersLogic.mount()
+            membersLogic.actions.loadAllMembers()
+        }).toDispatchActions(['loadAllMembersSuccess'])
+
+        const members = membersLogic.values.meFirstMembers
+        expect(members.length).toBe(mockMembers.length)
+
+        const { editor, insertContentAt } = createMockEditor()
+        const onClose = jest.fn()
+        const ref = renderMentions(editor, onClose)
+
+        // ArrowUp from the first item wraps to the last.
+        act(() => {
+            ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
+        })
+        act(() => {
+            ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }))
+        })
+        expect(insertContentAt).toHaveBeenLastCalledWith(0, [
+            expect.objectContaining({ attrs: { id: members[members.length - 1].user.id } }),
+        ])
+
+        // From the last item, ArrowDown wraps back to the first.
+        act(() => {
+            ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+        })
+        act(() => {
+            ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }))
+        })
+        expect(insertContentAt).toHaveBeenLastCalledWith(0, [
+            expect.objectContaining({ attrs: { id: members[0].user.id } }),
+        ])
+    })
+
+    it('arrow keys are handled even when the list is empty', () => {
+        const { editor } = createMockEditor()
+        const ref = renderMentions(editor, jest.fn())
+
+        expect(ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp' }))).toBe(true)
+        expect(ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }))).toBe(true)
+        expect(editor.chain).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/lib/components/RichContentEditor/MentionsExtension.test.tsx
+++ b/frontend/src/lib/components/RichContentEditor/MentionsExtension.test.tsx
@@ -146,12 +146,11 @@ describe('Mentions', () => {
         ])
     })
 
-    it('arrow keys are handled even when the list is empty', () => {
+    it.each(['ArrowUp', 'ArrowDown'])('%s is handled even when the list is empty', (key) => {
         const { editor } = createMockEditor()
         const ref = renderMentions(editor, jest.fn())
 
-        expect(ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp' }))).toBe(true)
-        expect(ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }))).toBe(true)
+        expect(ref.current?.onKeyDown(new KeyboardEvent('keydown', { key }))).toBe(true)
         expect(editor.chain).not.toHaveBeenCalled()
     })
 })

--- a/frontend/src/lib/components/RichContentEditor/MentionsExtension.tsx
+++ b/frontend/src/lib/components/RichContentEditor/MentionsExtension.tsx
@@ -60,8 +60,8 @@ export const Mentions = forwardRef<MentionsRef, MentionsProps>(function SlashCom
         setSelectedHorizontalIndex(0)
     }, [query])
 
-    const execute = async (member: OrganizationMemberType): Promise<void> => {
-        if (editor) {
+    const execute = async (member: OrganizationMemberType | undefined): Promise<void> => {
+        if (editor && member) {
             editor
                 .chain()
                 .focus()
@@ -80,15 +80,31 @@ export const Mentions = forwardRef<MentionsRef, MentionsProps>(function SlashCom
         }
     }
 
-    const onPressEnter = async (): Promise<void> => {
+    const onPressEnter = (): boolean => {
         const member = filteredMembers[selectedIndex]
-        await execute(member)
+        // No match (e.g. members still loading or no results) — let the editor
+        // handle Enter normally instead of swallowing it.
+        if (!member) {
+            return false
+        }
+        void execute(member)
+        return true
     }
-    const onPressUp = (): void => {
-        setSelectedIndex(Math.max(selectedIndex - 1, -1))
+    const onPressUp = (): boolean => {
+        const count = filteredMembers.length
+        if (count === 0) {
+            return true
+        }
+        setSelectedIndex((selectedIndex - 1 + count) % count)
+        return true
     }
-    const onPressDown = (): void => {
-        setSelectedIndex(Math.min(selectedIndex + 1, filteredMembers.length - 1))
+    const onPressDown = (): boolean => {
+        const count = filteredMembers.length
+        if (count === 0) {
+            return true
+        }
+        setSelectedIndex((selectedIndex + 1) % count)
+        return true
     }
 
     const onKeyDown = useCallback(
@@ -100,8 +116,7 @@ export const Mentions = forwardRef<MentionsRef, MentionsProps>(function SlashCom
             }
 
             if (isKeyOf(event.key, keyMappings)) {
-                keyMappings[event.key]()
-                return true
+                return keyMappings[event.key]()
             }
 
             return false

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.test.ts
@@ -1,0 +1,78 @@
+import { MOCK_DEFAULT_BASIC_USER, MOCK_SECOND_BASIC_USER } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { membersLogic } from 'scenes/organization/membersLogic'
+import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
+
+import { setupSessionRecordingTest } from '../__mocks__/test-setup'
+import { playerCommentOverlayLogic } from './playerFrameCommentOverlayLogic'
+
+jest.mock('../snapshot-processing/DecompressionWorkerManager')
+
+const playerLogicProps = { sessionRecordingId: '1', playerKey: 'playlist', recordingId: '1' }
+
+const mockMembers = [
+    {
+        id: '1',
+        user: MOCK_DEFAULT_BASIC_USER,
+        level: 8,
+        joined_at: '2020-09-24T15:05:26.758796Z',
+        updated_at: '2020-09-24T15:05:26.758837Z',
+        is_2fa_enabled: false,
+        has_social_auth: false,
+        last_login: '2020-09-24T15:05:26.758796Z',
+    },
+    {
+        id: '2',
+        user: MOCK_SECOND_BASIC_USER,
+        level: 1,
+        joined_at: '2021-03-11T19:11:11Z',
+        updated_at: '2021-03-11T19:11:11Z',
+        is_2fa_enabled: false,
+        has_social_auth: false,
+        last_login: '2021-03-11T19:11:11Z',
+    },
+]
+
+describe('playerFrameCommentOverlayLogic', () => {
+    let logic: ReturnType<typeof playerCommentOverlayLogic.build>
+
+    beforeEach(() => {
+        setupSessionRecordingTest({
+            getMocks: {
+                '/api/organizations/:organization_id/members/': { results: mockMembers },
+            },
+        })
+        featureFlagLogic.mount()
+
+        sessionRecordingPlayerLogic(playerLogicProps).mount()
+
+        logic = playerCommentOverlayLogic(playerLogicProps)
+        logic.mount()
+    })
+
+    // Regression test: opening the in-player comment box must populate the org
+    // members list so the @-mention autocomplete can resolve teammates. Without
+    // this, deep-linking straight to the player and commenting showed an empty
+    // "No member matching @" list because nothing else had loaded members yet.
+    it('loads org members when the comment overlay opens', async () => {
+        await expectLogic(membersLogic, () => {
+            logic.actions.setIsCommenting(true)
+        }).toDispatchActions(['ensureAllMembersLoaded', 'loadAllMembers', 'loadAllMembersSuccess'])
+
+        expect(membersLogic.values.meFirstMembers).toHaveLength(mockMembers.length)
+    })
+
+    it('does not load all members again when the overlay closes', async () => {
+        // Prime the loaded state first so the close path is exercised in isolation.
+        await expectLogic(membersLogic, () => {
+            logic.actions.setIsCommenting(true)
+        }).toDispatchActions(['loadAllMembersSuccess'])
+
+        await expectLogic(membersLogic, () => {
+            logic.actions.setIsCommenting(false)
+        }).toNotHaveDispatchedActions(['loadAllMembers'])
+    })
+})

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
@@ -7,6 +7,7 @@ import { JSONContent, RichContentEditorType } from 'lib/components/RichContentEd
 import { Dayjs, dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { colonDelimitedDuration } from 'lib/utils'
+import { membersLogic } from 'scenes/organization/membersLogic'
 import { playerCommentModel } from 'scenes/session-recordings/player/commenting/playerCommentModel'
 import { isSingleEmoji } from 'scenes/session-recordings/utils'
 
@@ -39,7 +40,7 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
     props({} as PlayerCommentOverlayLogicProps),
     connect((props: PlayerCommentOverlayLogicProps) => ({
         values: [sessionRecordingPlayerLogic(props), ['currentPlayerTime', 'currentTimestamp', 'sessionPlayerData']],
-        actions: [sessionRecordingPlayerLogic(props), ['setIsCommenting']],
+        actions: [sessionRecordingPlayerLogic(props), ['setIsCommenting'], membersLogic, ['ensureAllMembersLoaded']],
     })),
     actions({
         editComment: (comment: RecordingCommentForm) => ({ comment }),
@@ -125,7 +126,10 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
             }
         },
         setIsCommenting: ({ isCommenting }) => {
-            if (!isCommenting) {
+            if (isCommenting) {
+                // Load org members so @-mentions in the comment editor can resolve.
+                actions.ensureAllMembersLoaded()
+            } else {
                 actions.resetRecordingComment()
                 // Don't let "Add as task" leak into the next overlay session.
                 actions.setAsTask(false)


### PR DESCRIPTION
## Problem

A logged-in user opening the in-player comment box on a session recording and typing `@` saw **"No member matching @"** — they couldn't mention any teammates.

Root cause is a load-order bug, not permissions. The `@`-mention autocomplete (`Mentions` in `MentionsExtension.tsx`) reads the org member list from `membersLogic` but never triggers a load. `membersLogic` only fetches members when some consumer dispatches `ensureAllMembersLoaded`/`loadAllMembers`. The session-replay player comment overlay (`playerCommentOverlayLogic`) never did this, unlike the discussion side panel (`commentsLogic`). Because `membersLogic` is permanently mounted, mentions silently "worked" only if an earlier page in the session had already populated it — so anyone deep-linking straight to the player and commenting hit the empty list.

While there, the mention popover had a couple of sharp edges: pressing Enter with an empty list threw on `member.user.id`, and ArrowUp dead-ended at a "nothing selected" slot.

## Changes

- **`playerFrameCommentOverlayLogic.ts`**: connect `membersLogic` and fire `ensureAllMembersLoaded` when the comment overlay opens (`setIsCommenting(true)`, which also covers the edit path). `ensureAllMembersLoaded` is idempotent — full load on first use, cheap `updated_after` delta afterwards, no-op while in flight.
- **`MentionsExtension.tsx`** key-handling hardening:
  - `execute` is null-safe; the empty-list Enter path no longer throws.
  - `onPressEnter` returns `false` when there's no match, so Enter falls through to the editor (newline) instead of being swallowed.
  - ArrowUp/ArrowDown now **wrap around** instead of dead-ending, and are safe when the list is empty.

Scoped the load trigger to the authed in-player overlay (rather than the shared `Mentions` component) so shared/embedded replay doesn't fire an org-members request that would 401/403, and so we don't refetch on every `@` keystroke.

## How did you test this code?

I'm an agent (Cursor). I did **not** manually test in a browser. Automated tests I wrote and ran locally (`hogli test`, all passing):

- `playerFrameCommentOverlayLogic.test.ts` — opening the overlay dispatches `ensureAllMembersLoaded → loadAllMembers → loadAllMembersSuccess` and populates `meFirstMembers`; closing it does not refetch.
- `MentionsExtension.test.tsx` — Enter with no match returns `false` and never touches the editor (regression for the NPE); Enter with a match inserts the mention chip and closes; ArrowUp/ArrowDown wrap around; arrow keys are safe on an empty list.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by an agent (Cursor) with human oversight from @ahillen, who triaged the bug and chose the approach.

Investigation traced the empty list to `membersLogic` never being loaded on the replay player path. Two fixes were considered:

- **Option A (chosen)**: trigger the load from `playerCommentOverlayLogic` when the overlay opens. Narrow blast radius, only runs in the authed in-app path.
- **Option B (rejected)**: make the shared `Mentions` component self-load via `ensureAllMembersLoaded` on mount. Rejected because it would fire org-members requests in shared/embedded replay (401/403 + error toast where there's currently none) and refetch a delta on every `@` trigger.

The mention key-handling hardening (null-safe Enter, fall-through, wrap-around navigation) was added in the same change since it's the same surface and the loading-flash window makes the empty-list Enter path reachable.

Agent-authored — requires human review, no self-merge.
