### PR TITLE
fix(web-analytics): hide editor filter bar on dashboard tiles

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/WebAnalyticsEditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/WebAnalyticsEditorFilters.tsx
@@ -24,6 +24,13 @@ export function WebAnalyticsEditorFilters({ query, embedded }: WebAnalyticsEdito
     const { insightProps } = useValues(insightLogic)
     const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
 
+    // Dashboard tiles render a readOnly snapshot. The Query component ignores
+    // updateQuerySource changes here (see Query.tsx — `query = readOnly ? propsQuery : localQuery`),
+    // so the toggle/filters never reflect the new state and clicks have no useful effect.
+    if (insightProps.dashboardId != null) {
+        return null
+    }
+
     const isStatsTable = isWebStatsTableQuery(query)
     const isPathBased =
         isStatsTable &&


### PR DESCRIPTION
## Problem

When a Web Analytics insight is pinned to a dashboard, the per-tile filter bar (conversion goal, "Filter out internal and test users", property filters) still renders. The tile's `Query` is `readOnly`, so `updateQuerySource` updates kea state but the rendered query never picks it up — the toggle never reflects state and clicks trigger a runaway loop that mints fresh `queryId`s until the page is refreshed.

`EditorFilters.tsx` short-circuits to `WebAnalyticsEditorFilters` before `EditorFiltersShell`'s `showing` collapse runs, so the dashboard tile case wasn't getting hidden the way other filter panels are.

## Changes

`WebAnalyticsEditorFilters` returns `null` when `insightProps.dashboardId != null`. The insight scene (edit + view) is unchanged. Doesn't fix the underlying readOnly `setQuery` loop — only removes the entry point.

## How did you test this code?

Tested locally

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Claude Code (Opus 4.7). Considered gating the early return in `EditorFilters.tsx` on `showing`, but `showing` is also false in insight-scene view mode — that would over-hide. `insightProps.dashboardId != null` targets the actual dashboard-tile case.
