### PR TITLE
fix(logs): stop closed modals leaking react-modal portals on unmount

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogsViewerModal/LogsViewerModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerModal/LogsViewerModal.tsx
@@ -7,6 +7,7 @@ import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 import { FloatingContainerContext } from 'lib/hooks/useFloatingContainerContext'
 
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
+import { useKeepMountedWhileOpen } from 'products/logs/frontend/hooks/useKeepMountedWhileOpen'
 
 import { logsViewerModalLogic } from './logsViewerModalLogic'
 
@@ -15,6 +16,11 @@ export function LogsViewerModal(): JSX.Element | null {
     const { closeLogsViewerModal } = useActions(logsViewerModalLogic)
     const [floatingContainer, setFloatingContainer] = useState<HTMLDivElement | null>(null)
     const floatingContainerRef = useCallback((el: HTMLDivElement | null) => setFloatingContainer(el), [])
+    const shouldRender = useKeepMountedWhileOpen(isOpen)
+
+    if (!shouldRender) {
+        return null
+    }
 
     return (
         <LemonModal

--- a/products/logs/frontend/components/LogsViews/SavedViewsModal.tsx
+++ b/products/logs/frontend/components/LogsViews/SavedViewsModal.tsx
@@ -6,6 +6,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 
+import { useKeepMountedWhileOpen } from 'products/logs/frontend/hooks/useKeepMountedWhileOpen'
 import { getFiltersSummaryLines } from 'products/logs/frontend/utils'
 
 import { logsViewsListLogic } from './logsViewsListLogic'
@@ -27,9 +28,14 @@ function FiltersSummaryDisplay({ filters }: { filters: Record<string, any> }): J
     )
 }
 
-function SaveViewModal({ id }: LogsViewsLogicProps): JSX.Element {
+function SaveViewModal({ id }: LogsViewsLogicProps): JSX.Element | null {
     const { isSaveModalOpen, viewName, filters } = useValues(logsViewsListLogic({ id }))
     const { closeSaveModal, setViewName, saveView } = useActions(logsViewsListLogic({ id }))
+    const shouldRender = useKeepMountedWhileOpen(isSaveModalOpen)
+
+    if (!shouldRender) {
+        return null
+    }
 
     return (
         <LemonModal
@@ -70,6 +76,7 @@ export function SavedViewsModal({ id }: LogsViewsLogicProps): JSX.Element {
     const { closeModal, openSaveModal } = useActions(logsViewsListLogic({ id }))
     const { views, viewsLoading } = useValues(logsViewsLogic({ id }))
     const { deleteView, loadView } = useActions(logsViewsLogic({ id }))
+    const shouldRenderList = useKeepMountedWhileOpen(isModalOpen)
 
     const columns: LemonTableColumns<LogsView> = [
         {
@@ -137,31 +144,33 @@ export function SavedViewsModal({ id }: LogsViewsLogicProps): JSX.Element {
 
     return (
         <>
-            <LemonModal
-                isOpen={isModalOpen}
-                onClose={closeModal}
-                title="Saved views"
-                width={720}
-                footer={
-                    <div className="flex justify-between w-full">
-                        <LemonButton type="primary" onClick={openSaveModal}>
-                            Save current view
-                        </LemonButton>
-                        <LemonButton type="secondary" onClick={closeModal}>
-                            Close
-                        </LemonButton>
-                    </div>
-                }
-            >
-                <LemonTable
-                    columns={columns}
-                    dataSource={views}
-                    rowKey="id"
-                    loading={viewsLoading}
-                    emptyState="No saved views yet."
-                    size="small"
-                />
-            </LemonModal>
+            {shouldRenderList && (
+                <LemonModal
+                    isOpen={isModalOpen}
+                    onClose={closeModal}
+                    title="Saved views"
+                    width={720}
+                    footer={
+                        <div className="flex justify-between w-full">
+                            <LemonButton type="primary" onClick={openSaveModal}>
+                                Save current view
+                            </LemonButton>
+                            <LemonButton type="secondary" onClick={closeModal}>
+                                Close
+                            </LemonButton>
+                        </div>
+                    }
+                >
+                    <LemonTable
+                        columns={columns}
+                        dataSource={views}
+                        rowKey="id"
+                        loading={viewsLoading}
+                        emptyState="No saved views yet."
+                        size="small"
+                    />
+                </LemonModal>
+            )}
             <SaveViewModal id={id} />
         </>
     )

--- a/products/logs/frontend/hooks/useKeepMountedWhileOpen.ts
+++ b/products/logs/frontend/hooks/useKeepMountedWhileOpen.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from 'react'
+
+// react-modal (under LemonModal/LemonDrawer) mounts a portal container the moment it
+// renders, even when closed, and React 18 binds its full delegated event surface to that
+// container. A modal that's rendered-but-closed therefore leaks that container + listeners
+// every time it mounts/unmounts (e.g. on navigation). Gate the modal on this so a
+// never-opened modal mounts no portal at all. Keep it mounted for `graceMs` after close so
+// react-modal's closeTimeoutMS exit animation can finish before we unmount. Same approach as
+// the Popover/Radix portal gating in PR #54126.
+export function useKeepMountedWhileOpen(isOpen: boolean, graceMs = 300): boolean {
+    const [shouldRender, setShouldRender] = useState(isOpen)
+    const timeoutRef = useRef<number | null>(null)
+
+    useEffect(() => {
+        if (timeoutRef.current !== null) {
+            clearTimeout(timeoutRef.current)
+            timeoutRef.current = null
+        }
+        if (isOpen) {
+            setShouldRender(true)
+            return
+        }
+        timeoutRef.current = window.setTimeout(() => {
+            setShouldRender(false)
+            timeoutRef.current = null
+        }, graceMs)
+        return () => {
+            if (timeoutRef.current !== null) {
+                clearTimeout(timeoutRef.current)
+                timeoutRef.current = null
+            }
+        }
+    }, [isOpen, graceMs])
+
+    return shouldRender
+}


### PR DESCRIPTION
## Problem

`react-modal` (used under `LemonModal`/`LemonDrawer`) mounts a portal container the moment it renders, even when the modal is closed. React 18 binds its full delegated event surface to that container, meaning any modal that is rendered-but-closed leaks that container and its listeners on every mount/unmount (e.g. during navigation). The logs viewer and saved views modals were both affected by this.

## Changes

Introduces a `useKeepMountedWhileOpen` hook that gates whether a modal component renders at all:

- Returns `false` (preventing render) until the modal is opened for the first time, so a never-opened modal mounts no portal.
- Returns `true` immediately when opened.
- Stays `true` for a 300 ms grace period after close, allowing `react-modal`'s `closeTimeoutMS` exit animation to complete before unmounting.

The hook is applied to `LogsViewerModal`, `SaveViewModal`, and `SavedViewsModal`.

This follows the same portal-gating approach used for Popover/Radix in #54126.

## How did you test this code?

Open and close the logs viewer modal and saved views modal and verify that animations complete correctly and no console errors appear. Confirm that modals that are never opened do not mount any portal containers.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update