### PR TITLE
fix(modeling): fix hung temporal workers

### DIFF
--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -1,15 +1,12 @@
 import uuid
-import queue
 import typing
 import asyncio
-import threading
 import dataclasses
 
 from django.conf import settings
 
 import pyarrow as pa
 import deltalake
-import asyncstdlib
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
 from structlog.contextvars import bind_contextvars
@@ -533,113 +530,44 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
         row_count = 0
         storage_options = _get_aws_storage_options()
         delta_table: deltalake.DeltaTable | None = None
-        # cache the schema of the first written batch so we can synthesize an empty
-        # parquet for zero-row results without going through delta-rs (whose Schema
-        # is arro3, not pyarrow).
+        # cache the schema of the first batch so we can synthesize an empty parquet for
+        # zero-row results without going through delta-rs (whose Schema is arro3, not
+        # pyarrow).
         pa_schema: pa.Schema | None = None
 
-        # we stream every batch through a single deltalake write transaction.
-        # writing per-batch with mode="append" routes through delta-rs's
-        # DataFusion-backed writer, which lowercases identifiers and breaks
-        # columns with uppercase characters (`personId`, `Event`, ...) with
-        # errors like "Generic DeltaTable error: Schema error: No field named
-        # personid. ... Did you mean 'personId'?".
-        SENTINEL: typing.Any = object()
-        batch_queue: queue.Queue[pa.RecordBatch] = queue.Queue(maxsize=2)
-        producer_error: list[BaseException] = []
+        # buffer every batch, then write them all through a single deltalake transaction.
+        # writing per-batch with mode="append" routes through delta-rs's DataFusion-backed
+        # writer, which lowercases identifiers and breaks columns with uppercase characters
+        # (`personId`, `Event`, ...) with errors like "Generic DeltaTable error: Schema
+        # error: No field named personid. ... Did you mean 'personId'?". one overwrite of
+        # the full result takes the case-safe create path. note this holds the whole result
+        # in memory; hogql_table yields ~100MB combined batches, so peak ≈ result size.
+        batches: list[pa.RecordBatch] = []
+        async for batch, ch_types in hogql_table(hogql_query, team, logger):
+            batch = _transform_unsupported_decimals(batch)
+            batch = _transform_date_and_datetimes(batch, ch_types)
+            batches.append(batch)
+            row_count = row_count + batch.num_rows
+            job.rows_materialized = row_count
+            await database_sync_to_async(job.save)()
 
-        # the producer's queue ops run in a thread via asyncio.to_thread, which is not
-        # cancellable: once a blocking queue.put/get is in flight, cancelling the
-        # awaiting coroutine does nothing to the thread. a plain blocking put against a
-        # full queue would therefore park its thread forever if the consumer stops
-        # draining (e.g. the write aborts, or the activity is cancelled), orphaning the
-        # thread and the producer task. so every blocking queue op below is a bounded
-        # poll on stop_event instead — when stop is requested, the in-flight op returns
-        # within QUEUE_POLL_SECONDS no matter what. safety is a property of the queue
-        # primitives, not of how carefully cleanup is sequenced.
-        stop_event = threading.Event()
-
-        def _put(item: typing.Any) -> None:
-            while not stop_event.is_set():
-                try:
-                    batch_queue.put(item, timeout=QUEUE_POLL_SECONDS)
-                    return
-                except queue.Full:
-                    continue
-
-        def _get() -> typing.Any:
-            while not stop_event.is_set():
-                try:
-                    return batch_queue.get(timeout=QUEUE_POLL_SECONDS)
-                except queue.Empty:
-                    continue
-            return SENTINEL
-
-        # a producer error is recorded in producer_error and then signalled to the
-        # consumer as a SENTINEL — i.e. the same clean end-of-stream as success. the
-        # consumer therefore commits whatever batches it received (a partial overwrite)
-        # before we re-raise below. that partial commit is harmless: the activity raises,
-        # Temporal retries, and the retry's delete-first wipes table_uri before rewriting.
-        async def _produce_batches() -> None:
-            nonlocal row_count
-            try:
-                async for _, res in asyncstdlib.enumerate(hogql_table(hogql_query, team, logger)):
-                    if stop_event.is_set():
-                        break
-                    batch, ch_types = res
-                    batch = _transform_unsupported_decimals(batch)
-                    batch = _transform_date_and_datetimes(batch, ch_types)
-                    num_rows = batch.num_rows
-                    await asyncio.to_thread(_put, batch)
-                    # local reference dropped immediately; the queue (and later
-                    # the consumer) holds the only remaining reference.
-                    del batch, ch_types
-                    row_count = row_count + num_rows
-                    job.rows_materialized = row_count
-                    await database_sync_to_async(job.save)()
-            except BaseException as e:
-                producer_error.append(e)
-            finally:
-                await asyncio.to_thread(_put, SENTINEL)
-
-        producer_task = asyncio.create_task(_produce_batches())
-        try:
-            first_batch = await asyncio.to_thread(_get)
-            if first_batch is not SENTINEL:
-                pa_schema = first_batch.schema
-
-                def _batch_iter() -> typing.Iterator[pa.RecordBatch]:
-                    yield first_batch
-                    while True:
-                        item = _get()
-                        if item is SENTINEL:
-                            return
-                        yield item
-
-                reader = pa.RecordBatchReader.from_batches(pa_schema, _batch_iter())
-                await logger.adebug(
-                    f"Writing batches to delta table in a single transaction: mode=overwrite schema_mode=overwrite first_batch_rows={first_batch.num_rows}"
-                )
-                await asyncio.to_thread(
-                    deltalake.write_deltalake,
-                    table_or_uri=table_uri,
-                    data=reader,
-                    mode="overwrite",
-                    schema_mode="overwrite",
-                    storage_options=storage_options,
-                )
-                delta_table = deltalake.DeltaTable(table_uri, storage_options=storage_options)
-        finally:
-            # request the producer stop and reap it. stop_event is set synchronously,
-            # before any await, so even a cancellation delivered at the await below
-            # cannot leave the producer parked on a queue op — its bounded _put/_get
-            # observe the flag and return promptly, the producer breaks its loop, and
-            # the task completes on its own. awaiting it here simply joins that exit.
-            stop_event.set()
-            await producer_task
-
-        if producer_error:
-            raise producer_error[0]
+        # hogql_table always yields at least one batch (an empty one carrying the schema for
+        # zero-row results), so batches is non-empty whenever the query ran to completion.
+        if batches:
+            pa_schema = batches[0].schema
+            await logger.adebug(
+                f"Writing {len(batches)} batches to delta table in a single transaction: "
+                f"mode=overwrite schema_mode=overwrite row_count={row_count}"
+            )
+            await asyncio.to_thread(
+                deltalake.write_deltalake,
+                table_or_uri=table_uri,
+                data=pa.RecordBatchReader.from_batches(pa_schema, batches),
+                mode="overwrite",
+                schema_mode="overwrite",
+                storage_options=storage_options,
+            )
+            delta_table = deltalake.DeltaTable(table_uri, storage_options=storage_options)
 
         await logger.ainfo(f"Finished writing to delta table. row_count={row_count}")
         # row count validation warning

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -558,7 +558,7 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
                 delta_table = deltalake.DeltaTable(table_uri, storage_options=storage_options)
             else:
                 await asyncio.to_thread(
-                    deltalake.write_deltalake,  # type: ignore[arg-type]
+                    deltalake.write_deltalake,
                     table_or_uri=delta_table,
                     data=batch,
                     mode="append",

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -535,39 +535,39 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
         # pyarrow).
         pa_schema: pa.Schema | None = None
 
-        # buffer every batch, then write them all through a single deltalake transaction.
-        # writing per-batch with mode="append" routes through delta-rs's DataFusion-backed
-        # writer, which lowercases identifiers and breaks columns with uppercase characters
-        # (`personId`, `Event`, ...) with errors like "Generic DeltaTable error: Schema
-        # error: No field named personid. ... Did you mean 'personId'?". one overwrite of
-        # the full result takes the case-safe create path. note this holds the whole result
-        # in memory; hogql_table yields ~100MB combined batches, so peak ≈ result size.
-        batches: list[pa.RecordBatch] = []
+        # write each batch as its own delta commit, imitating the data_imports pipeline
+        # (DeltaTableHelper.write_to_deltalake): the first batch overwrites — creating the
+        # table from the exact arrow schema, which pins column case like `personId` — and
+        # later batches append with schema_mode="merge". this keeps peak memory at ~one
+        # batch (hogql_table yields ~100MB combined batches) and, because each write is a
+        # brief to_thread released between batches, never pins a worker thread for the whole
+        # read — which is what starved the shared executor that heartbeats/db/logging use.
         async for batch, ch_types in hogql_table(hogql_query, team, logger):
             batch = _transform_unsupported_decimals(batch)
             batch = _transform_date_and_datetimes(batch, ch_types)
-            batches.append(batch)
+            if delta_table is None:
+                pa_schema = batch.schema
+                await asyncio.to_thread(
+                    deltalake.write_deltalake,
+                    table_or_uri=table_uri,
+                    data=batch,
+                    mode="overwrite",
+                    schema_mode="overwrite",
+                    storage_options=storage_options,
+                )
+                delta_table = deltalake.DeltaTable(table_uri, storage_options=storage_options)
+            else:
+                await asyncio.to_thread(
+                    deltalake.write_deltalake,  # type: ignore[arg-type]
+                    table_or_uri=delta_table,
+                    data=batch,
+                    mode="append",
+                    schema_mode="merge",
+                    storage_options=storage_options,
+                )
             row_count = row_count + batch.num_rows
             job.rows_materialized = row_count
             await database_sync_to_async(job.save)()
-
-        # hogql_table always yields at least one batch (an empty one carrying the schema for
-        # zero-row results), so batches is non-empty whenever the query ran to completion.
-        if batches:
-            pa_schema = batches[0].schema
-            await logger.adebug(
-                f"Writing {len(batches)} batches to delta table in a single transaction: "
-                f"mode=overwrite schema_mode=overwrite row_count={row_count}"
-            )
-            await asyncio.to_thread(
-                deltalake.write_deltalake,
-                table_or_uri=table_uri,
-                data=pa.RecordBatchReader.from_batches(pa_schema, batches),
-                mode="overwrite",
-                schema_mode="overwrite",
-                storage_options=storage_options,
-            )
-            delta_table = deltalake.DeltaTable(table_uri, storage_options=storage_options)
 
         await logger.ainfo(f"Finished writing to delta table. row_count={row_count}")
         # row count validation warning

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -597,15 +597,13 @@ class TestMaterializeViewActivity:
     ):
         # regression: multiple batches with case-sensitive columns must materialize cleanly.
         #
-        # per-batch mode="append" writes route through delta-rs's DataFusion-backed
-        # writer, which lowercases identifiers and fails with
-        # "Generic DeltaTable error: Schema error: No field named personid. ...
-        # Did you mean 'personId'?" on tables whose column names contain uppercase
-        # characters. the activity streams every batch through a single mode="overwrite"
-        # transaction to take the case-safe create path; this test guards both invariants:
-        #   - all rows from every batch are written and column casing is preserved;
-        #   - the delta history contains a single version (i.e. one commit), which would
-        #     regress to N versions if someone reintroduced per-batch append.
+        # delta-rs's DataFusion-backed append writer can lowercase identifiers and fail with
+        # "Generic DeltaTable error: Schema error: No field named personid. ... Did you mean
+        # 'personId'?" on tables whose column names contain uppercase characters. the activity
+        # writes the first batch with mode="overwrite" (creating the table from the exact arrow
+        # schema, pinning case) and appends later batches with schema_mode="merge" — the
+        # data_imports write path. this asserts every batch's rows land and casing survives
+        # across the overwrite + append commits.
         camel_case_names = ["Event", "DistinctId", "personId", "CamelCaseColumn"]
 
         def mock_hogql_table(*args, **kwargs):
@@ -652,10 +650,6 @@ class TestMaterializeViewActivity:
             materialized = delta_table.to_pyarrow_table()
             assert materialized.column_names == camel_case_names
             assert materialized.num_rows == 6
-            # one commit per materialization — guards against reintroducing per-batch
-            # append, which would record N+ versions and route through the broken
-            # DataFusion-backed writer.
-            assert len(delta_table.history()) == 1
 
     async def test_zero_row_materialization_writes_empty_parquet(
         self, activity_environment, ateam, anode, asaved_query, ajob, bucket_name, adag
@@ -711,11 +705,9 @@ class TestMaterializeViewActivity:
             assert pyarrow_table.num_rows == 0
             assert set(pyarrow_table.column_names) == {"id", "name"}
 
-    async def test_write_failure_surfaces_after_buffering_batches(
-        self, activity_environment, ateam, anode, ajob, bucket_name, adag
-    ):
-        # regression: a failure in the single buffered write_deltalake transaction must
-        # surface from the activity so Temporal retries, rather than being swallowed.
+    async def test_write_failure_surfaces(self, activity_environment, ateam, anode, ajob, bucket_name, adag):
+        # regression: a failure in a per-batch write_deltalake call must surface from the
+        # activity so Temporal retries, rather than being swallowed.
         names = ["a", "b"]
 
         def mock_hogql_table(*args, **kwargs):

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Collection, Iterable
 from typing import Any, cast
 
@@ -712,18 +711,11 @@ class TestMaterializeViewActivity:
             assert pyarrow_table.num_rows == 0
             assert set(pyarrow_table.column_names) == {"id", "name"}
 
-    async def test_aborted_write_releases_producer_parked_on_full_queue(
+    async def test_write_failure_surfaces_after_buffering_batches(
         self, activity_environment, ateam, anode, ajob, bucket_name, adag
     ):
-        # regression: when the consumer (write) aborts while the producer is still
-        # streaming, the producer must not be orphaned. its queue ops run in a thread
-        # via asyncio.to_thread (not cancellable), so a plain blocking put against the
-        # bounded queue would park that thread forever once the consumer stops draining,
-        # and the cleanup join (await producer_task) would hang with it. the producer's
-        # _put/_get poll a stop_event that cleanup sets, so the parked op returns and the
-        # task is reaped. we yield far more batches than the queue holds (maxsize=2) and
-        # make write_deltalake raise without draining, guaranteeing the producer parks;
-        # the activity must surface the write error promptly instead of hanging.
+        # regression: a failure in the single buffered write_deltalake transaction must
+        # surface from the activity so Temporal retries, rather than being swallowed.
         names = ["a", "b"]
 
         def mock_hogql_table(*args, **kwargs):
@@ -765,7 +757,5 @@ class TestMaterializeViewActivity:
                 node_id=str(anode.id),
                 job_id=str(ajob.id),
             )
-            # wait_for fails the test rather than hanging the suite if the producer is
-            # orphaned and the cleanup join blocks forever.
             with pytest.raises(RuntimeError, match="boom"):
-                await asyncio.wait_for(activity_environment.run(materialize_view_activity, inputs), timeout=10)
+                await activity_environment.run(materialize_view_activity, inputs)

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1015,7 +1015,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1031,7 +1031,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-delete-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-delete-tile.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A unique integer value identifying this dashboard.",
+            "type": "number"
+        },
+        "tile_id": {
+            "description": "ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs.",
+            "type": "number"
+        }
+    },
+    "required": ["id", "tile_id"],
+    "type": "object"
+}


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

hung temporal workers

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

move the logic of this to be closer to the data imports way of handling delta tables
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

unit tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->

<!-- gg:stack-start -->
## gg stack

- **#60907 `andrew/fix-hung-temporal-workers` 👈 this PR**
<!-- gg:stack-end -->
