### PR TITLE
fix(data-warehouse): restore sync method column for non-SQL sources

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
@@ -85,7 +85,8 @@ export default function SchemaForm(): JSX.Element {
         toggleSchemaShouldSync(schema, checked)
     }
 
-    const shouldShowSyncColumns = !isDirectQueryMode && !!selectedConnector?.supportsColumnSelection
+    const shouldShowSyncColumns = !isDirectQueryMode
+    const shouldShowColumnSelection = !isDirectQueryMode && !!selectedConnector?.supportsColumnSelection
 
     // scroll to top of container
     useEffect(() => {
@@ -317,7 +318,7 @@ export default function SchemaForm(): JSX.Element {
             key: 'columns',
             title: 'Columns',
             align: 'right' as const,
-            isHidden: !shouldShowSyncColumns,
+            isHidden: !shouldShowColumnSelection,
             tooltip:
                 'Pick a subset of columns to sync. Primary keys and the active incremental field are always retained.',
             render: function RenderColumns(_: unknown, schema: ExternalDataSourceSyncSchema) {


### PR DESCRIPTION
## Problem

In the new source wizard's "Select tables to import" step, the **Sync method** column disappeared for non-SQL sources (Stripe, Hubspot, and any REST-based source). Users could no longer choose the sync method (full refresh vs incremental) per table during source setup.

This was a regression from #60155, which added per-table column selection for SQL sources (MySQL, MSSQL, BigQuery, Snowflake, Redshift, Postgres).

## Changes

The column-selection PR tightened the existing `shouldShowSyncColumns` gate to `!isDirectQueryMode && !!selectedConnector?.supportsColumnSelection`. That variable also controls the **Sync field**, **Primary key**, and **Sync method** columns — so gating it behind `supportsColumnSelection` (which is `false` for all non-SQL sources) hid those columns everywhere except SQL sources.

This splits the gate into two:

- `shouldShowSyncColumns = !isDirectQueryMode` — restores the original behavior for **Sync field**, **Primary key**, and **Sync method** (shown for all non-direct-query sources).
- `shouldShowColumnSelection = !isDirectQueryMode && !!selectedConnector?.supportsColumnSelection` — keeps the new **Columns** column correctly scoped to SQL sources, which was the intent of #60155.

## How did you test this code?

I'm an agent (Claude Code). I traced the regression to the gating change in `SchemaForm.tsx`, confirmed via `git show` that #60155 was the source, and verified `supports_column_selection` defaults to `False` in the source base config (only SQL sources set it `True`). I did not run the wizard manually — a quick manual check that the Sync method picker renders and works for a Stripe source would be worth doing before merge. No automated tests cover this column-gating logic.

## 🤖 Agent context

Authored with Claude Code. The user reported the missing sync method picker for Stripe; I located the table-selection step (`SchemaForm`), bisected the cause to the over-broad `shouldShowSyncColumns` gate introduced in #60155, and decoupled the column-selection gate from the sync-method/sync-field/primary-key gate rather than reverting the column-selection feature.
