### PR TITLE
perf(tasks): add an index on pr url for task run output

### DIFF
--- a/products/tasks/backend/migrations/0036_taskrun_output_pr_url_idx.py
+++ b/products/tasks/backend/migrations/0036_taskrun_output_pr_url_idx.py
@@ -16,6 +16,7 @@ class Migration(migrations.Migration):
             index=models.Index(
                 django.db.models.fields.json.KeyTransform("pr_url", "output"),
                 name="task_run_output_pr_url_idx",
+                condition=models.Q(output__pr_url__isnull=False),
             ),
         ),
     ]

--- a/products/tasks/backend/migrations/0036_taskrun_output_pr_url_idx.py
+++ b/products/tasks/backend/migrations/0036_taskrun_output_pr_url_idx.py
@@ -1,0 +1,21 @@
+import django.db.models.fields.json
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("tasks", "0035_task_origin_product_signals_scout"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="taskrun",
+            index=models.Index(
+                django.db.models.fields.json.KeyTransform("pr_url", "output"),
+                name="task_run_output_pr_url_idx",
+            ),
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0035_task_origin_product_signals_scout
+0036_taskrun_output_pr_url_idx

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -20,6 +20,7 @@ from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, models, transaction
+from django.db.models.fields.json import KeyTransform
 from django.utils import timezone as django_timezone
 
 import structlog
@@ -593,6 +594,9 @@ class TaskRun(models.Model):
     class Meta:
         db_table = "posthog_task_run"
         ordering = ["-created_at"]
+        indexes = [
+            models.Index(KeyTransform("pr_url", "output"), name="task_run_output_pr_url_idx"),
+        ]
 
     def __str__(self):
         return f"Run for {self.task.title} - {self.get_status_display()}"

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -595,7 +595,16 @@ class TaskRun(models.Model):
         db_table = "posthog_task_run"
         ordering = ["-created_at"]
         indexes = [
-            models.Index(KeyTransform("pr_url", "output"), name="task_run_output_pr_url_idx"),
+            # Partial functional index backing the per-PR-webhook lookup
+            # `filter(output__pr_url=...)`. The equality lookup implies the key is
+            # present, so the `IS NOT NULL` condition keeps the index off the many
+            # runs without a PR URL (queued/in-progress/failed) while still serving
+            # the query.
+            models.Index(
+                KeyTransform("pr_url", "output"),
+                name="task_run_output_pr_url_idx",
+                condition=models.Q(output__pr_url__isnull=False),
+            ),
         ]
 
     def __str__(self):

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1015,7 +1015,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1031,7 +1031,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-delete-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-delete-tile.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A unique integer value identifying this dashboard.",
+            "type": "number"
+        },
+        "tile_id": {
+            "description": "ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs.",
+            "type": "number"
+        }
+    },
+    "required": ["id", "tile_id"],
+    "type": "object"
+}


### PR DESCRIPTION
This query is very slow in our pr analytics webhooks without this, adds a partial index for non-null values of pr url