### PR TITLE
chore(hog-charts): break BarChart into focused modules

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -1,25 +1,12 @@
-import * as d3 from 'd3'
 import React, { useCallback, useMemo, useRef } from 'react'
 
-import { type BarChartPrivate, computeBarTrackRect, computeSeriesBars } from '../../core/bar-layout'
-import {
-    BAR_TRACK_HOVER_ALPHA,
-    type BarRect,
-    type BarShadow,
-    drawBarHighlight,
-    drawBars,
-    drawBarTracks,
-    drawGrid,
-    type DrawContext,
-} from '../../core/canvas-renderer'
+import { type BarChartPrivate, bandCenter, groupedBarCenter } from '../../core/bar-layout'
 import { Chart } from '../../core/Chart'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
-import { DEFAULT_MARGINS, X_AXIS_TITLE_MARGIN } from '../../core/hooks/useChartMargins'
 import { useLatest } from '../../core/hooks/useLatest'
 import {
     buildSegmentResolveValue,
     buildStackedPositionValue,
-    type BarScaleSet,
     computeDivergingStackData,
     computePercentStackData,
     computeStackData,
@@ -29,7 +16,6 @@ import {
 } from '../../core/scales'
 import type {
     BarChartConfig,
-    BarsConfig,
     ChartDimensions,
     ChartDrawArgs,
     ChartScales,
@@ -42,33 +28,15 @@ import type {
     TooltipContext,
 } from '../../core/types'
 import { DEFAULT_Y_AXIS_ID } from '../../core/types'
-import { computeVisibleXLabels } from '../../overlays/AxisLabels'
 import { BarTooltip } from './BarTooltip'
+import { computeWrapperMinHeight, HORIZONTAL_MIN_BAND_SIZE_DEFAULT } from './utils/bar-config'
 import {
-    type BarLayout,
-    barContainsPointOnBandAxis,
-    cursorOutsideBarFillExtent,
-    findVisibleStackedSegment,
-    iterBarsAtCursor,
-    isStackedLayout,
-} from './utils/bars-under-cursor'
-
-function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
-    const start = scales.band(label)
-    return start == null ? undefined : start + scales.band.bandwidth() / 2
-}
-
-/** Center of a specific series's bar within a band. Used by overlays (e.g. annotations)
- *  to anchor on the current-period bar in compare-against-previous grouped layouts.
- *  Returns undefined when the layout isn't grouped or the series isn't in the group scale. */
-function groupedBarCenter(scales: BarChartPrivate['__barChart'], label: string, seriesKey: string): number | undefined {
-    const start = scales.band(label)
-    const groupOffset = scales.group?.(seriesKey)
-    if (start == null || groupOffset == null) {
-        return undefined
-    }
-    return start + groupOffset + (scales.group?.bandwidth() ?? 0) / 2
-}
+    type BarChartDrawConfig,
+    drawBarChartStatic,
+    drawBarHoverItems,
+    resolveBarHoverItems,
+} from './utils/draw-bar-chart'
+import { resolveClickedBarSeries } from './utils/resolve-clicked-bar-series'
 
 export interface BarChartProps<Meta = unknown> {
     series: Series<Meta>[]
@@ -82,24 +50,6 @@ export interface BarChartProps<Meta = unknown> {
     dataAttr?: string
     children?: React.ReactNode
     onError?: (error: Error, info: React.ErrorInfo) => void
-}
-
-// Negative offsetY casts the shadow upward onto the visible track above the bar.
-const DEFAULT_BAR_SHADOW: BarShadow = { color: 'rgba(0,0,0,0.30)', blur: 12, offsetY: -4 }
-
-// Horizontal floor: each row gets at least this much px so tick labels don't crush; wrapper scrolls.
-const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
-// Reserve room for chart-edge margins + worst-case x-axis title margin (matches useChartMargins).
-const HORIZONTAL_CHART_MARGIN_PX = DEFAULT_MARGINS.top + DEFAULT_MARGINS.bottom + X_AXIS_TITLE_MARGIN
-
-function resolveBarShadow(barShadow: BarsConfig['shadow']): BarShadow | undefined {
-    if (barShadow === true) {
-        return DEFAULT_BAR_SHADOW
-    }
-    if (barShadow === false || barShadow == null) {
-        return undefined
-    }
-    return barShadow
 }
 
 export function BarChart<Meta = unknown>({ onError, ...rest }: BarChartProps<Meta>): React.ReactElement {
@@ -140,16 +90,10 @@ function BarChartInner<Meta = unknown>({
     const isHorizontal = axisOrientation === 'horizontal'
 
     const resolvedMinBandSize = minBandSize ?? (isHorizontal ? HORIZONTAL_MIN_BAND_SIZE_DEFAULT : 0)
-    const wrapperMinHeight = useMemo(() => {
-        if (!isHorizontal || resolvedMinBandSize <= 0) {
-            return undefined
-        }
-        const uniqueBands = new Set(labels).size
-        if (uniqueBands === 0) {
-            return undefined
-        }
-        return uniqueBands * resolvedMinBandSize + HORIZONTAL_CHART_MARGIN_PX
-    }, [isHorizontal, resolvedMinBandSize, labels])
+    const wrapperMinHeight = useMemo(
+        () => computeWrapperMinHeight({ isHorizontal, resolvedMinBandSize, labels }),
+        [isHorizontal, resolvedMinBandSize, labels]
+    )
 
     const stackedData = useMemo((): Map<string, StackedBand> | undefined => {
         if (barLayout === 'percent') {
@@ -273,219 +217,57 @@ function BarChartInner<Meta = unknown>({
         [yScaleType, barLayout, axisOrientation, stackedData, isHorizontal, divergingStack, maxBandRange, bandPadding]
     )
 
-    const drawStatic = useCallback(
-        ({ ctx, dimensions, scales, series: coloredSeries, labels: drawLabels, theme }: ChartDrawArgs) => {
-            const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
-            if (!d3Scales) {
-                return
-            }
-
-            const baseDrawCtx: DrawContext = {
-                ctx,
-                dimensions,
-                xScale: (label: string) => bandCenter(d3Scales, label),
-                yScale: d3Scales.value,
-                labels: drawLabels,
-            }
-
-            if (showGrid) {
-                // Align cross-axis grid with visible category labels, not every band.
-                let categoryTicks: number[] = []
-                if (isHorizontal) {
-                    for (const label of drawLabels) {
-                        const coord = bandCenter(d3Scales, label)
-                        if (coord != null && isFinite(coord)) {
-                            categoryTicks.push(coord)
-                        }
-                    }
-                } else {
-                    categoryTicks = computeVisibleXLabels(
-                        drawLabels,
-                        (label) => bandCenter(d3Scales, label),
-                        xTickFormatter
-                    ).map((entry) => entry.x)
-                }
-                drawGrid(baseDrawCtx, {
-                    gridColor: theme.gridColor,
-                    orientation: isHorizontal ? 'horizontal' : 'vertical',
-                    categoryTicks,
-                })
-            }
-
-            const seriesBars = coloredSeries
-                .filter((s) => !s.visibility?.excluded)
-                .map((s) => {
-                    const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
-                    const bars = computeSeriesBars({
-                        series: s,
-                        labels: drawLabels,
-                        scales: d3Scales,
-                        layout: barLayout,
-                        isHorizontal,
-                        stackedBand: stackedData?.get(s.key),
-                        isTopOfStack: topStackedKeyByAxis.get(axisId) === s.key,
-                    }).filter((b): b is BarRect => b !== null)
-                    return { series: s, bars }
-                })
-
-            // Tracks are a separate pass so a later series' full-height track can't paint
-            // over an earlier series' bar. Track is "share of a whole" semantics — only
-            // meaningful for grouped layouts; in stacked/percent every layer would paint
-            // a full-height track over the same band with the wrong corners.
-            if (barTrack && barLayout === 'grouped') {
-                const [axisStart = 0, axisEnd = 0] = d3Scales.value.range()
-                for (const { series: s, bars } of seriesBars) {
-                    const tracks = bars.map((b) => computeBarTrackRect(b, axisStart, axisEnd, isHorizontal))
-                    drawBarTracks(baseDrawCtx, s, tracks, barCornerRadius)
-                }
-            }
-
-            const resolvedShadow = resolveBarShadow(barShadow)
-            // Clip to plot area so a 100% bar's upward shadow doesn't bleed past the chart edge.
-            if (resolvedShadow) {
-                ctx.save()
-                ctx.beginPath()
-                ctx.rect(dimensions.plotLeft, dimensions.plotTop, dimensions.plotWidth, dimensions.plotHeight)
-                ctx.clip()
-                ctx.shadowColor = resolvedShadow.color
-                ctx.shadowBlur = resolvedShadow.blur
-                ctx.shadowOffsetX = resolvedShadow.offsetX ?? 0
-                ctx.shadowOffsetY = resolvedShadow.offsetY ?? 0
-            }
-            for (const { series: s, bars } of seriesBars) {
-                drawBars(baseDrawCtx, s, bars, barCornerRadius)
-            }
-            if (resolvedShadow) {
-                ctx.restore()
-            }
-        },
-        [
-            showGrid,
-            stackedData,
+    const drawConfig = useMemo<BarChartDrawConfig>(
+        () => ({
             barLayout,
             isHorizontal,
+            stackedData,
             topStackedKeyByAxis,
             barCornerRadius,
             barTrack,
+            showGrid,
+            xTickFormatter,
+            barShadow,
+        }),
+        [
+            barLayout,
+            isHorizontal,
+            stackedData,
+            topStackedKeyByAxis,
+            barCornerRadius,
+            barTrack,
+            showGrid,
             xTickFormatter,
             barShadow,
         ]
     )
 
+    const drawStatic = useCallback((args: ChartDrawArgs) => drawBarChartStatic(args, drawConfig), [drawConfig])
+
     // Restart the fade on bar → track moves (same hoverIndex, different visible state).
     const lastHoverKeyRef = useRef<string | null>(null)
 
     const drawHover = useCallback(
-        ({
-            ctx,
-            scales,
-            series: coloredSeries,
-            labels: drawLabels,
-            hoverIndex,
-            hoverPosition,
-            hoverProgress,
-            resetHoverFade,
-        }: ChartDrawArgs): DrawHoverResult => {
-            const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
-            if (!d3Scales || hoverIndex < 0) {
+        (args: ChartDrawArgs): DrawHoverResult => {
+            const resolved = resolveBarHoverItems(args, drawConfig)
+            if (!resolved) {
                 lastHoverKeyRef.current = null
                 return false
             }
-            const hoveredLabel = drawLabels[hoverIndex]
-            const [trackAxisStart = 0, trackAxisEnd = 0] = barTrack ? d3Scales.value.range() : []
-            // Key includes bar-vs-track per series so bar → track moves at the same
-            // hoverIndex still trigger a fade restart.
-            type DrawItem = { series: ResolvedSeries; bar: BarRect; isTrackHighlight: boolean }
-            const items: DrawItem[] = []
-            let composition = ''
-            // Stacked: clip the highlight to the visible slice so hover only changes shade,
-            // never z-order. Grouped keeps band-axis containment for cursor-above-bar.
-            const stackedHighlight = isStackedLayout(barLayout)
-            if (stackedHighlight && hoverPosition) {
-                const visible = findVisibleStackedSegment({
-                    series: coloredSeries,
-                    labels: drawLabels,
-                    hoveredLabel,
-                    cursor: hoverPosition,
-                    scales: d3Scales,
-                    layout: barLayout,
-                    isHorizontal,
-                    stackedData,
-                    topStackedKeyByAxis,
-                })
-                if (visible) {
-                    const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
-                    const { nextSmallerExtent } = visible
-                    const baselinePx = isHorizontal ? visible.bar.x : visible.bar.y + visible.bar.height
-                    const clippedExtent = Math.max(0, visibleExtent - nextSmallerExtent)
-                    const clipped: BarRect = isHorizontal
-                        ? { ...visible.bar, x: baselinePx + nextSmallerExtent, width: clippedExtent }
-                        : { ...visible.bar, y: baselinePx - visibleExtent, height: clippedExtent }
-                    items.push({ series: visible.series, bar: clipped, isTrackHighlight: false })
-                    composition += 'b'
-                }
-            } else {
-                for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
-                    series: coloredSeries,
-                    label: hoveredLabel,
-                    dataIndex: hoverIndex,
-                    scales: d3Scales,
-                    layout: barLayout,
-                    isHorizontal,
-                    stackedData,
-                    topStackedKeyByAxis,
-                })) {
-                    if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
-                        continue
-                    }
-                    const isTrackHighlight =
-                        barTrack === true &&
-                        barLayout === 'grouped' &&
-                        hoverPosition != null &&
-                        cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal)
-                    items.push({ series: s, bar, isTrackHighlight })
-                    composition += isTrackHighlight ? 't' : 'b'
-                }
-            }
-            if (items.length === 0) {
-                lastHoverKeyRef.current = null
-                return false
-            }
-            const currentKey = `${hoverIndex}:${composition}`
-            let alpha = hoverProgress
+            const { items, composition, trackAxisRange } = resolved
+            const currentKey = `${args.hoverIndex}:${composition}`
+            let alpha = args.hoverProgress
             if (currentKey !== lastHoverKeyRef.current) {
-                alpha = resetHoverFade()
+                alpha = args.resetHoverFade()
                 lastHoverKeyRef.current = currentKey
             }
-            ctx.save()
-            ctx.globalAlpha = alpha
-            for (const { series: s, bar, isTrackHighlight } of items) {
-                if (isTrackHighlight) {
-                    const parsed = d3.color(s.color)
-                    // Always translucent — `s.color` direct would paint an opaque full-height
-                    // block if d3 can't parse the color.
-                    let trackColor: string
-                    if (parsed) {
-                        parsed.opacity = BAR_TRACK_HOVER_ALPHA
-                        trackColor = parsed.toString()
-                    } else {
-                        trackColor = `rgba(0,0,0,${BAR_TRACK_HOVER_ALPHA})`
-                    }
-                    drawBarHighlight(
-                        ctx,
-                        computeBarTrackRect(bar, trackAxisStart, trackAxisEnd, isHorizontal),
-                        trackColor,
-                        barCornerRadius
-                    )
-                } else {
-                    const highlightColor = d3.color(s.color)?.darker(0.6).toString() ?? s.color
-                    drawBarHighlight(ctx, bar, highlightColor, barCornerRadius)
-                }
-            }
-            ctx.restore()
+            args.ctx.save()
+            args.ctx.globalAlpha = alpha
+            drawBarHoverItems(args.ctx, items, { barCornerRadius, isHorizontal, trackAxisRange })
+            args.ctx.restore()
             return true
         },
-        [stackedData, barLayout, isHorizontal, topStackedKeyByAxis, barCornerRadius, barTrack]
+        [drawConfig, barCornerRadius, isHorizontal]
     )
 
     // Show each series's own segment value (resolveValue) but anchor the tooltip/value labels
@@ -557,87 +339,4 @@ function BarChartInner<Meta = unknown>({
             {chart}
         </div>
     )
-}
-
-/** Rewrites the click payload to the bar series actually under the cursor. The base payload
- *  always points at the first series in the band; this picks the right one per layout:
- *   - grouped: the series whose sub-band column the cursor is over — band axis only, so a
- *     click above a short bar (or on its track) still resolves to that column.
- *   - stacked/percent: the segment whose rect contains the cursor on the value axis, walking
- *     every dataIndex in the band so sparse-overlap segments route correctly, and re-reading
- *     the value at that segment's own dataIndex.
- *  Pure so the routing is unit-testable; returns `null` to pass `clickData` through unchanged. */
-export function resolveClickedBarSeries<Meta>({
-    clickData,
-    d3Scales,
-    barLayout,
-    isHorizontal,
-    stackedData,
-    topStackedKeyByAxis,
-    series,
-    labels,
-}: {
-    clickData: PointClickData<Meta>
-    d3Scales: BarScaleSet
-    barLayout: BarLayout
-    isHorizontal: boolean
-    stackedData: Map<string, StackedBand> | undefined
-    topStackedKeyByAxis: Map<string, string>
-    series: Series<Meta>[]
-    labels: readonly string[]
-}): PointClickData<Meta> | null {
-    const { cursor, label, dataIndex, crossSeriesData } = clickData
-    if (!cursor) {
-        return null
-    }
-    const rewrite = (hitSeries: Series<Meta>, value: number, hitDataIndex: number): PointClickData<Meta> => ({
-        ...clickData,
-        dataIndex: hitDataIndex,
-        series: hitSeries,
-        value,
-        seriesIndex: series.findIndex((s) => s.key === hitSeries.key),
-    })
-
-    if (barLayout === 'grouped') {
-        for (const { series: s, bar } of iterBarsAtCursor({
-            series: crossSeriesData.map((d) => d.series),
-            label,
-            dataIndex,
-            scales: d3Scales,
-            layout: barLayout,
-            isHorizontal,
-            topStackedKeyByAxis,
-        })) {
-            if (!barContainsPointOnBandAxis(bar, cursor, isHorizontal)) {
-                continue
-            }
-            const hit = crossSeriesData.find((d) => d.series.key === s.key)
-            return hit ? rewrite(hit.series, hit.value, dataIndex) : null
-        }
-        return null
-    }
-
-    const visible = findVisibleStackedSegment({
-        series: crossSeriesData.map((d) => d.series),
-        labels,
-        hoveredLabel: label,
-        cursor,
-        scales: d3Scales,
-        layout: barLayout,
-        isHorizontal,
-        stackedData,
-        topStackedKeyByAxis,
-    })
-    if (!visible) {
-        return null
-    }
-    const hit = crossSeriesData.find((d) => d.series.key === visible.series.key)
-    if (!hit) {
-        return null
-    }
-    // Re-read value at the visible segment's own dataIndex — `hit.value` was resolved at the
-    // band's dataIndex, which is a sparse-zero cell for the visible series.
-    const raw = hit.series.data[visible.dataIndex]
-    const resolvedValue = typeof raw === 'number' && Number.isFinite(raw) ? raw : hit.value
-    return rewrite(hit.series, resolvedValue, visible.dataIndex)
 }

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bar-config.test.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bar-config.test.ts
@@ -1,0 +1,60 @@
+import {
+    computeWrapperMinHeight,
+    DEFAULT_BAR_SHADOW,
+    HORIZONTAL_CHART_MARGIN_PX,
+    HORIZONTAL_MIN_BAND_SIZE_DEFAULT,
+    resolveBarShadow,
+} from './bar-config'
+
+describe('resolveBarShadow', () => {
+    it('maps `true` to the default shadow', () => {
+        expect(resolveBarShadow(true)).toBe(DEFAULT_BAR_SHADOW)
+    })
+
+    it.each([
+        ['false', false],
+        ['undefined', undefined],
+    ])('maps `%s` to no shadow', (_desc, input) => {
+        expect(resolveBarShadow(input as boolean | undefined)).toBeUndefined()
+    })
+
+    it('passes an explicit shadow config through untouched', () => {
+        const shadow = { color: 'red', blur: 4, offsetX: 1, offsetY: 2 }
+        expect(resolveBarShadow(shadow)).toBe(shadow)
+    })
+})
+
+describe('computeWrapperMinHeight', () => {
+    it('returns undefined for vertical charts', () => {
+        expect(
+            computeWrapperMinHeight({ isHorizontal: false, resolvedMinBandSize: 24, labels: ['a', 'b'] })
+        ).toBeUndefined()
+    })
+
+    it('returns undefined when there is no band floor', () => {
+        expect(
+            computeWrapperMinHeight({ isHorizontal: true, resolvedMinBandSize: 0, labels: ['a', 'b'] })
+        ).toBeUndefined()
+    })
+
+    it('returns undefined when there are no bands', () => {
+        expect(computeWrapperMinHeight({ isHorizontal: true, resolvedMinBandSize: 24, labels: [] })).toBeUndefined()
+    })
+
+    it('reserves one band slot per unique label plus chart margins', () => {
+        const labels = ['a', 'b', 'c']
+        expect(
+            computeWrapperMinHeight({
+                isHorizontal: true,
+                resolvedMinBandSize: HORIZONTAL_MIN_BAND_SIZE_DEFAULT,
+                labels,
+            })
+        ).toBe(labels.length * HORIZONTAL_MIN_BAND_SIZE_DEFAULT + HORIZONTAL_CHART_MARGIN_PX)
+    })
+
+    it('counts unique bands only when labels repeat', () => {
+        expect(computeWrapperMinHeight({ isHorizontal: true, resolvedMinBandSize: 10, labels: ['a', 'a', 'b'] })).toBe(
+            2 * 10 + HORIZONTAL_CHART_MARGIN_PX
+        )
+    })
+})

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bar-config.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bar-config.ts
@@ -1,0 +1,43 @@
+import type { BarShadow } from '../../../core/canvas-renderer'
+import { DEFAULT_MARGINS, X_AXIS_TITLE_MARGIN } from '../../../core/hooks/useChartMargins'
+import type { BarsConfig } from '../../../core/types'
+
+// Negative offsetY casts the shadow upward onto the visible track above the bar.
+export const DEFAULT_BAR_SHADOW: BarShadow = { color: 'rgba(0,0,0,0.30)', blur: 12, offsetY: -4 }
+
+// Horizontal floor: each row gets at least this much px so tick labels don't crush; wrapper scrolls.
+export const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
+// Reserve room for chart-edge margins + worst-case x-axis title margin (matches useChartMargins).
+export const HORIZONTAL_CHART_MARGIN_PX = DEFAULT_MARGINS.top + DEFAULT_MARGINS.bottom + X_AXIS_TITLE_MARGIN
+
+export function resolveBarShadow(barShadow: BarsConfig['shadow']): BarShadow | undefined {
+    if (barShadow === true) {
+        return DEFAULT_BAR_SHADOW
+    }
+    if (barShadow === false || barShadow == null) {
+        return undefined
+    }
+    return barShadow
+}
+
+/** Minimum wrapper height for a horizontal bar chart so each band keeps `resolvedMinBandSize`
+ *  px and tick labels don't crush — the wrapper scrolls past this. Returns `undefined` when
+ *  the floor doesn't apply (vertical, no floor, or no bands). */
+export function computeWrapperMinHeight({
+    isHorizontal,
+    resolvedMinBandSize,
+    labels,
+}: {
+    isHorizontal: boolean
+    resolvedMinBandSize: number
+    labels: string[]
+}): number | undefined {
+    if (!isHorizontal || resolvedMinBandSize <= 0) {
+        return undefined
+    }
+    const uniqueBands = new Set(labels).size
+    if (uniqueBands === 0) {
+        return undefined
+    }
+    return uniqueBands * resolvedMinBandSize + HORIZONTAL_CHART_MARGIN_PX
+}

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/draw-bar-chart.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/draw-bar-chart.ts
@@ -1,0 +1,252 @@
+import * as d3 from 'd3'
+
+import { type BarChartPrivate, bandCenter, computeBarTrackRect, computeSeriesBars } from '../../../core/bar-layout'
+import {
+    BAR_TRACK_HOVER_ALPHA,
+    type BarRect,
+    drawBarHighlight,
+    drawBars,
+    drawBarTracks,
+    drawGrid,
+    type DrawContext,
+} from '../../../core/canvas-renderer'
+import type { StackedBand } from '../../../core/scales'
+import type { BarsConfig, ChartDrawArgs, ResolvedSeries } from '../../../core/types'
+import { DEFAULT_Y_AXIS_ID } from '../../../core/types'
+import { computeVisibleXLabels } from '../../../overlays/AxisLabels'
+import { resolveBarShadow } from './bar-config'
+import {
+    type BarLayout,
+    barContainsPointOnBandAxis,
+    cursorOutsideBarFillExtent,
+    findVisibleStackedSegment,
+    isStackedLayout,
+    iterBarsAtCursor,
+} from './bars-under-cursor'
+
+/** Bar-specific draw inputs threaded from `BarChart` config into the canvas passes. */
+export interface BarChartDrawConfig {
+    barLayout: BarLayout
+    isHorizontal: boolean
+    stackedData: Map<string, StackedBand> | undefined
+    topStackedKeyByAxis: Map<string, string>
+    barCornerRadius: number
+    barTrack: boolean
+    showGrid: boolean
+    xTickFormatter?: (value: string, index: number) => string | null
+    barShadow: BarsConfig['shadow']
+}
+
+/** Static (non-hover) bar layer: optional grid, per-series bars, tracks, and drop shadow.
+ *  Pure canvas work — all React state arrives via `args` and `config`. */
+export function drawBarChartStatic(args: ChartDrawArgs, config: BarChartDrawConfig): void {
+    const { ctx, dimensions, scales, series: coloredSeries, labels: drawLabels, theme } = args
+    const { showGrid, isHorizontal, xTickFormatter, barLayout, stackedData, topStackedKeyByAxis } = config
+    const { barTrack, barCornerRadius, barShadow } = config
+
+    const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
+    if (!d3Scales) {
+        return
+    }
+
+    const baseDrawCtx: DrawContext = {
+        ctx,
+        dimensions,
+        xScale: (label: string) => bandCenter(d3Scales, label),
+        yScale: d3Scales.value,
+        labels: drawLabels,
+    }
+
+    if (showGrid) {
+        // Align cross-axis grid with visible category labels, not every band.
+        let categoryTicks: number[] = []
+        if (isHorizontal) {
+            for (const label of drawLabels) {
+                const coord = bandCenter(d3Scales, label)
+                if (coord != null && isFinite(coord)) {
+                    categoryTicks.push(coord)
+                }
+            }
+        } else {
+            categoryTicks = computeVisibleXLabels(
+                drawLabels,
+                (label) => bandCenter(d3Scales, label),
+                xTickFormatter
+            ).map((entry) => entry.x)
+        }
+        drawGrid(baseDrawCtx, {
+            gridColor: theme.gridColor,
+            orientation: isHorizontal ? 'horizontal' : 'vertical',
+            categoryTicks,
+        })
+    }
+
+    const seriesBars = coloredSeries
+        .filter((s) => !s.visibility?.excluded)
+        .map((s) => {
+            const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
+            const bars = computeSeriesBars({
+                series: s,
+                labels: drawLabels,
+                scales: d3Scales,
+                layout: barLayout,
+                isHorizontal,
+                stackedBand: stackedData?.get(s.key),
+                isTopOfStack: topStackedKeyByAxis.get(axisId) === s.key,
+            }).filter((b): b is BarRect => b !== null)
+            return { series: s, bars }
+        })
+
+    // Tracks are a separate pass so a later series' full-height track can't paint
+    // over an earlier series' bar. Track is "share of a whole" semantics — only
+    // meaningful for grouped layouts; in stacked/percent every layer would paint
+    // a full-height track over the same band with the wrong corners.
+    if (barTrack && barLayout === 'grouped') {
+        const [axisStart = 0, axisEnd = 0] = d3Scales.value.range()
+        for (const { series: s, bars } of seriesBars) {
+            const tracks = bars.map((b) => computeBarTrackRect(b, axisStart, axisEnd, isHorizontal))
+            drawBarTracks(baseDrawCtx, s, tracks, barCornerRadius)
+        }
+    }
+
+    const resolvedShadow = resolveBarShadow(barShadow)
+    // Clip to plot area so a 100% bar's upward shadow doesn't bleed past the chart edge.
+    if (resolvedShadow) {
+        ctx.save()
+        ctx.beginPath()
+        ctx.rect(dimensions.plotLeft, dimensions.plotTop, dimensions.plotWidth, dimensions.plotHeight)
+        ctx.clip()
+        ctx.shadowColor = resolvedShadow.color
+        ctx.shadowBlur = resolvedShadow.blur
+        ctx.shadowOffsetX = resolvedShadow.offsetX ?? 0
+        ctx.shadowOffsetY = resolvedShadow.offsetY ?? 0
+    }
+    for (const { series: s, bars } of seriesBars) {
+        drawBars(baseDrawCtx, s, bars, barCornerRadius)
+    }
+    if (resolvedShadow) {
+        ctx.restore()
+    }
+}
+
+export interface BarHoverItem {
+    series: ResolvedSeries
+    bar: BarRect
+    isTrackHighlight: boolean
+}
+
+export interface BarHoverResolution {
+    items: BarHoverItem[]
+    /** Per-series bar-vs-track marker (`b`/`t`) — distinguishes a bar → track move at the same
+     *  hoverIndex so the caller can restart the fade. */
+    composition: string
+    /** Value-axis pixel range used to size track highlights; `[0, 0]` when tracks are off. */
+    trackAxisRange: [number, number]
+}
+
+/** Resolves which bars/tracks to highlight under the cursor. Pure — returns `null` when there's
+ *  nothing to highlight (no scales, no hover, or the cursor missed every bar). Drawing is left to
+ *  {@link drawBarHoverItems} so the caller can own the hover-fade alpha between resolve and draw. */
+export function resolveBarHoverItems(args: ChartDrawArgs, config: BarChartDrawConfig): BarHoverResolution | null {
+    const { scales, series: coloredSeries, labels: drawLabels, hoverIndex, hoverPosition } = args
+    const { barLayout, isHorizontal, stackedData, topStackedKeyByAxis, barTrack } = config
+
+    const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
+    if (!d3Scales || hoverIndex < 0) {
+        return null
+    }
+    const hoveredLabel = drawLabels[hoverIndex]
+    const [trackAxisStart = 0, trackAxisEnd = 0] = barTrack ? d3Scales.value.range() : []
+    const items: BarHoverItem[] = []
+    let composition = ''
+    // Stacked: clip the highlight to the visible slice so hover only changes shade,
+    // never z-order. Grouped keeps band-axis containment for cursor-above-bar.
+    const stackedHighlight = isStackedLayout(barLayout)
+    if (stackedHighlight && hoverPosition) {
+        const visible = findVisibleStackedSegment({
+            series: coloredSeries,
+            labels: drawLabels,
+            hoveredLabel,
+            cursor: hoverPosition,
+            scales: d3Scales,
+            layout: barLayout,
+            isHorizontal,
+            stackedData,
+            topStackedKeyByAxis,
+        })
+        if (visible) {
+            const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
+            const { nextSmallerExtent } = visible
+            const baselinePx = isHorizontal ? visible.bar.x : visible.bar.y + visible.bar.height
+            const clippedExtent = Math.max(0, visibleExtent - nextSmallerExtent)
+            const clipped: BarRect = isHorizontal
+                ? { ...visible.bar, x: baselinePx + nextSmallerExtent, width: clippedExtent }
+                : { ...visible.bar, y: baselinePx - visibleExtent, height: clippedExtent }
+            items.push({ series: visible.series, bar: clipped, isTrackHighlight: false })
+            composition += 'b'
+        }
+    } else {
+        for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
+            series: coloredSeries,
+            label: hoveredLabel,
+            dataIndex: hoverIndex,
+            scales: d3Scales,
+            layout: barLayout,
+            isHorizontal,
+            stackedData,
+            topStackedKeyByAxis,
+        })) {
+            if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
+                continue
+            }
+            const isTrackHighlight =
+                barTrack === true &&
+                barLayout === 'grouped' &&
+                hoverPosition != null &&
+                cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal)
+            items.push({ series: s, bar, isTrackHighlight })
+            composition += isTrackHighlight ? 't' : 'b'
+        }
+    }
+    if (items.length === 0) {
+        return null
+    }
+    return { items, composition, trackAxisRange: [trackAxisStart, trackAxisEnd] }
+}
+
+/** Paints the highlights resolved by {@link resolveBarHoverItems}. The caller sets
+ *  `ctx.globalAlpha` (the hover-fade) and wraps in save/restore. */
+export function drawBarHoverItems(
+    ctx: CanvasRenderingContext2D,
+    items: BarHoverItem[],
+    {
+        barCornerRadius,
+        isHorizontal,
+        trackAxisRange,
+    }: { barCornerRadius: number; isHorizontal: boolean; trackAxisRange: [number, number] }
+): void {
+    const [trackAxisStart, trackAxisEnd] = trackAxisRange
+    for (const { series: s, bar, isTrackHighlight } of items) {
+        if (isTrackHighlight) {
+            const parsed = d3.color(s.color)
+            // Always translucent — `s.color` direct would paint an opaque full-height
+            // block if d3 can't parse the color.
+            let trackColor: string
+            if (parsed) {
+                parsed.opacity = BAR_TRACK_HOVER_ALPHA
+                trackColor = parsed.toString()
+            } else {
+                trackColor = `rgba(0,0,0,${BAR_TRACK_HOVER_ALPHA})`
+            }
+            drawBarHighlight(
+                ctx,
+                computeBarTrackRect(bar, trackAxisStart, trackAxisEnd, isHorizontal),
+                trackColor,
+                barCornerRadius
+            )
+        } else {
+            const highlightColor = d3.color(s.color)?.darker(0.6).toString() ?? s.color
+            drawBarHighlight(ctx, bar, highlightColor, barCornerRadius)
+        }
+    }
+}

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/resolve-clicked-bar-series.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/resolve-clicked-bar-series.ts
@@ -1,0 +1,91 @@
+import type { BarScaleSet, StackedBand } from '../../../core/scales'
+import type { PointClickData, Series } from '../../../core/types'
+import {
+    type BarLayout,
+    barContainsPointOnBandAxis,
+    findVisibleStackedSegment,
+    iterBarsAtCursor,
+} from './bars-under-cursor'
+
+/** Rewrites the click payload to the bar series actually under the cursor. The base payload
+ *  always points at the first series in the band; this picks the right one per layout:
+ *   - grouped: the series whose sub-band column the cursor is over — band axis only, so a
+ *     click above a short bar (or on its track) still resolves to that column.
+ *   - stacked/percent: the segment whose rect contains the cursor on the value axis, walking
+ *     every dataIndex in the band so sparse-overlap segments route correctly, and re-reading
+ *     the value at that segment's own dataIndex.
+ *  Pure so the routing is unit-testable; returns `null` to pass `clickData` through unchanged. */
+export function resolveClickedBarSeries<Meta>({
+    clickData,
+    d3Scales,
+    barLayout,
+    isHorizontal,
+    stackedData,
+    topStackedKeyByAxis,
+    series,
+    labels,
+}: {
+    clickData: PointClickData<Meta>
+    d3Scales: BarScaleSet
+    barLayout: BarLayout
+    isHorizontal: boolean
+    stackedData: Map<string, StackedBand> | undefined
+    topStackedKeyByAxis: Map<string, string>
+    series: Series<Meta>[]
+    labels: readonly string[]
+}): PointClickData<Meta> | null {
+    const { cursor, label, dataIndex, crossSeriesData } = clickData
+    if (!cursor) {
+        return null
+    }
+    const rewrite = (hitSeries: Series<Meta>, value: number, hitDataIndex: number): PointClickData<Meta> => ({
+        ...clickData,
+        dataIndex: hitDataIndex,
+        series: hitSeries,
+        value,
+        seriesIndex: series.findIndex((s) => s.key === hitSeries.key),
+    })
+
+    if (barLayout === 'grouped') {
+        for (const { series: s, bar } of iterBarsAtCursor({
+            series: crossSeriesData.map((d) => d.series),
+            label,
+            dataIndex,
+            scales: d3Scales,
+            layout: barLayout,
+            isHorizontal,
+            topStackedKeyByAxis,
+        })) {
+            if (!barContainsPointOnBandAxis(bar, cursor, isHorizontal)) {
+                continue
+            }
+            const hit = crossSeriesData.find((d) => d.series.key === s.key)
+            return hit ? rewrite(hit.series, hit.value, dataIndex) : null
+        }
+        return null
+    }
+
+    const visible = findVisibleStackedSegment({
+        series: crossSeriesData.map((d) => d.series),
+        labels,
+        hoveredLabel: label,
+        cursor,
+        scales: d3Scales,
+        layout: barLayout,
+        isHorizontal,
+        stackedData,
+        topStackedKeyByAxis,
+    })
+    if (!visible) {
+        return null
+    }
+    const hit = crossSeriesData.find((d) => d.series.key === visible.series.key)
+    if (!hit) {
+        return null
+    }
+    // Re-read value at the visible segment's own dataIndex — `hit.value` was resolved at the
+    // band's dataIndex, which is a sparse-zero cell for the visible series.
+    const raw = hit.series.data[visible.dataIndex]
+    const resolvedValue = typeof raw === 'number' && Number.isFinite(raw) ? raw : hit.value
+    return rewrite(hit.series, resolvedValue, visible.dataIndex)
+}

--- a/frontend/src/lib/hog-charts/core/bar-layout.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.ts
@@ -10,6 +10,24 @@ export interface BarChartPrivate {
 
 export type SeriesBarLayout = (BarRect | null)[]
 
+/** Pixel center of a band slot, or `undefined` when the label isn't in the band scale. */
+export function bandCenter(scales: BarScaleSet, label: string): number | undefined {
+    const start = scales.band(label)
+    return start == null ? undefined : start + scales.band.bandwidth() / 2
+}
+
+/** Center of a specific series's bar within a band. Used by overlays (e.g. annotations)
+ *  to anchor on the current-period bar in compare-against-previous grouped layouts.
+ *  Returns `undefined` when the layout isn't grouped or the series isn't in the group scale. */
+export function groupedBarCenter(scales: BarScaleSet, label: string, seriesKey: string): number | undefined {
+    const start = scales.band(label)
+    const groupOffset = scales.group?.(seriesKey)
+    if (start == null || groupOffset == null) {
+        return undefined
+    }
+    return start + groupOffset + (scales.group?.bandwidth() ?? 0) / 2
+}
+
 /** Cap is the side away from the value-axis baseline; pass `shouldRoundCap: false` for stacked
  *  layers below the topmost. `shouldRoundBaseline` rounds the side *towards* the baseline — used
  *  for the bottom-of-stack layer so a funnel-style bar reads as one rounded pill on both ends. */


### PR DESCRIPTION
## Problem

`BarChart.tsx` in `lib/hog-charts` had grown to **643 lines** — more than 2× its `LineChart` sibling. A single file held the React component orchestration, the static + hover canvas-drawing passes, config resolution (shadow, min-band-height), band-center geometry, and the pure click-routing function. That made the hot drawing logic hard to read in isolation and hard to test directly, and it had drifted away from the conventions the rest of the library follows.

This is a pure refactor — no behavior change, no public API change.

## Changes

Followed the pattern the `LineChart` / `TimeSeriesLineChart` family already uses (extract pure logic into `utils/` siblings with co-located tests) and the layering guidance in [`docs/CONTRIBUTING.md`](https://github.com/PostHog/posthog/blob/master/frontend/src/lib/hog-charts/docs/CONTRIBUTING.md) ("Pure geometry → `core/`", "Drawing code is stateless", "Pure logic is tested at the lower layer").

| New / moved | What |
| --- | --- |
| `core/bar-layout.ts` | `bandCenter` + `groupedBarCenter` band geometry helpers — the documented home for bar geometry, sitting beside `computeSeriesBars` / `computeBarTrackRect`. |
| `charts/BarChart/utils/bar-config.ts` | `resolveBarShadow`, `computeWrapperMinHeight`, and the shadow/band-size constants — pure config resolution, with a new co-located `bar-config.test.ts`. |
| `charts/BarChart/utils/draw-bar-chart.ts` | `drawBarChartStatic` (the full static pass) and `resolveBarHoverItems` / `drawBarHoverItems` (hover resolution split from drawing). The component keeps only the `useRef` hover-fade bookkeeping, since that's the genuinely stateful part. |
| `charts/BarChart/utils/resolve-clicked-bar-series.ts` | The pure `resolveClickedBarSeries` click-routing function (was an internal export at the bottom of `BarChart.tsx`). |

Result: `BarChart.tsx` drops from **643 → 342 lines** and now reads as a thin orchestration layer — config destructuring, the memoized scale builder, and thin `useCallback` wrappers that delegate to the extracted draw functions — matching `LineChart`'s altitude.

No new public exports were added to the library `index.ts`; everything moved stays internal to the `BarChart` directory or `core/`.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated suites — no manual UI testing was performed:

- `jest src/lib/hog-charts/charts/BarChart` → **84 passed** (existing BarChart tests + new `bar-config` tests).
- `jest src/lib/hog-charts` → **1112 passed / 39 suites** (covers `TimeSeriesBarChart`, which composes `BarChart`).
- `tsc --noEmit` → **0 errors**.
- `oxlint` / `oxfmt` via the frontend `format` script → clean.

Because the extracted functions are byte-for-byte the same logic with parameters threaded through explicitly, the existing DOM-level BarChart tests exercise every drawing path unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed — internal library refactor. Suggest adding the `skip-inkeep-docs` label.

## 🤖 Agent context

Authored by Claude Code at a maintainer's request to break up the oversized `BarChart` component, using `LineChart` as the reference for "good" altitude and the hog-charts library docs for where each kind of logic belongs.

Approach: read `BarChart.tsx`, `LineChart.tsx`, and the `CONTRIBUTING.md` layering table; identified four extractable concerns (geometry, config, drawing, click-routing) and moved each to the layer the docs prescribe. Kept the hover-fade `useRef` logic in the component on purpose — it's the one genuinely stateful piece, so `resolveBarHoverItems` (pure, testable) is split from `drawBarHoverItems` (the paint loop) and the caller owns the fade alpha in between. Verified behavior preservation by relying on the existing DOM-level test suite plus a new pure-unit test for the config helpers.

Reviewers: the highest-value thing to sanity-check is `draw-bar-chart.ts` against the original `drawStatic`/`drawHover` bodies — the extraction is intended to be mechanical.
