### PR TITLE
chore(replay): demo @-mentions in comment modal story

### DIFF
--- a/frontend/src/scenes/session-recordings/player/commenting/PlayerCommentModal.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/commenting/PlayerCommentModal.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react'
-import { BindLogic } from 'kea'
+import { BindLogic, useActions } from 'kea'
 
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { PlayerCommentModal } from 'scenes/session-recordings/player/commenting/PlayerFrameCommentOverlay'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
@@ -14,11 +15,20 @@ const meta: Meta<typeof PlayerCommentModal> = {
 }
 export default meta
 
+// Opening the overlay is what triggers the org-members load (see playerCommentOverlayLogic),
+// so the @-mention autocomplete can resolve teammates. Drive it here so the story exercises
+// that path and the mention list is populated when you type `@`.
+function CommentingModal(): JSX.Element {
+    const { setIsCommenting } = useActions(sessionRecordingPlayerLogic)
+    useOnMountEffect(() => setIsCommenting(true))
+    return <PlayerCommentModal />
+}
+
 export function Default(): JSX.Element {
     return (
         <div className="min-h-80 relative">
             <BindLogic logic={sessionRecordingPlayerLogic} props={{ sessionRecordingId: '23' }}>
-                <PlayerCommentModal />
+                <CommentingModal />
             </BindLogic>
         </div>
     )


### PR DESCRIPTION
## Problem

The `Replay/Components/Comment modal` Storybook story rendered the comment editor but never opened the overlay, so org members were never loaded and the `@`-mention autocomplete showed nothing. That made the story a poor surface for working on the comment editor / mentions UX.

## Changes

Wrap the modal in a small `CommentingModal` component that fires `setIsCommenting(true)` on mount (via `useOnMountEffect`). This drives the real `playerCommentOverlayLogic` member-load path (added in #60897, now on master), so the story populates the `@`-mention list from the global Storybook member mocks (`John`, `Rose`).

Typing `@` in the story now shows the member popover:

| before | after |
| --- | --- |
| empty editor, no mention list | `@` lists `John` and `Rose` |

## How did you test this code?

I'm an agent. I ran Storybook locally (`storybook dev -p 6006`), opened `Replay → Components → Comment modal → Default`, typed `@`, and confirmed the popover lists the two mocked members and that arrow navigation highlights them. No automated tests added — this is a Storybook-only change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Cursor (Claude Opus). Split out of the mentions-fix PR (#60897) at the author's request so the Storybook demo ships independently. The story deliberately triggers the overlay-open path rather than calling `ensureAllMembersLoaded` directly, so it exercises the same wiring the fix added instead of faking the load.

Made with [Cursor](https://cursor.com)