### PR TITLE
fix(ws): decouple loader liveness heartbeat from batch processing

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -44,6 +44,7 @@ POLL_INTERVAL_SECONDS = 2.0
 
 RECOVERY_INTERVAL_SECONDS = 30.0
 RETRY_BACKOFF_BASE_SECONDS = 15
+HEARTBEAT_INTERVAL_SECONDS = 5.0
 
 
 @dataclass
@@ -57,6 +58,7 @@ class ConsumerConfig:
     poll_limit: int = 50
     health_port: int = 8080
     health_timeout_seconds: float = 60.0
+    heartbeat_interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS
     recovery_interval_seconds: float = RECOVERY_INTERVAL_SECONDS
     retry_backoff_base_seconds: int = RETRY_BACKOFF_BASE_SECONDS
     recovery_grace_seconds: int | None = None
@@ -88,6 +90,7 @@ class BatchConsumer:
         self._conn: psycopg.AsyncConnection[Any] | None = None
         self._recovery_conn: psycopg.AsyncConnection[Any] | None = None
         self._recovery_task: asyncio.Task[None] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
 
     async def run(self) -> None:
         """Main loop: poll → group → process → unlock → repeat."""
@@ -112,6 +115,7 @@ class BatchConsumer:
         try:
             await self._recovery_sweep()
             self._recovery_task = asyncio.create_task(self._recovery_loop())
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
 
             while not self._shutdown.is_set():
                 if self._health_reporter:
@@ -372,6 +376,19 @@ class BatchConsumer:
             except Exception:
                 logger.exception("recovery_sweep_error")
 
+    async def _heartbeat_loop(self) -> None:
+        """Report liveness on a fixed cadence, independent of batch processing."""
+        while not self._shutdown.is_set():
+            if self._health_reporter:
+                self._health_reporter()
+            try:
+                await asyncio.wait_for(
+                    self._shutdown.wait(),
+                    timeout=self._config.heartbeat_interval_seconds,
+                )
+            except TimeoutError:
+                pass
+
     async def _recovery_sweep(self) -> None:
         """Recover batches left in 'executing' by a crashed pod."""
         conn = self._recovery_conn or self._conn
@@ -443,13 +460,14 @@ class BatchConsumer:
             loop.add_signal_handler(sig, self._shutdown.set)
 
     async def _close(self) -> None:
-        """Cancel the recovery task, release all advisory locks, and close both connections."""
-        if self._recovery_task is not None:
-            self._recovery_task.cancel()
-            try:
-                await self._recovery_task
-            except asyncio.CancelledError:
-                pass
+        """Cancel the recovery and heartbeat tasks, release all advisory locks, and close both connections."""
+        for task in (self._recovery_task, self._heartbeat_task):
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
         if self._recovery_conn is not None and not self._recovery_conn.closed:
             await self._recovery_conn.close()

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 
 import pytest
@@ -5,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import structlog
 
+from posthog.temporal.data_imports.pipelines.pipeline_v3.load.health import HealthState
 from posthog.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer import (
     BatchConsumer,
     ConsumerConfig,
@@ -399,3 +401,43 @@ class TestLogContextBinding:
 
         assert "batch_id" not in structlog.contextvars.get_contextvars()
         assert "workflow_run_id" not in structlog.contextvars.get_contextvars()
+
+
+class TestHeartbeatLoop:
+    @pytest.mark.asyncio
+    async def test_reports_until_shutdown(self):
+        consumer = _make_consumer(heartbeat_interval_seconds=0.01)
+        calls = 0
+
+        def reporter():
+            nonlocal calls
+            calls += 1
+
+        consumer._health_reporter = reporter
+
+        task = asyncio.create_task(consumer._heartbeat_loop())
+        await asyncio.sleep(0.05)
+        consumer._shutdown.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert calls >= 2
+
+    @pytest.mark.asyncio
+    async def test_keeps_liveness_healthy_through_long_batch(self):
+        # A poll cycle (large final-batch compaction) can run far longer than the
+        # health timeout; the dedicated heartbeat must keep liveness green so
+        # kubelet doesn't SIGTERM the pod mid-batch.
+        health = HealthState(timeout_seconds=0.1)
+        consumer = _make_consumer(heartbeat_interval_seconds=0.02)
+        consumer._health_reporter = health.report_healthy
+
+        task = asyncio.create_task(consumer._heartbeat_loop())
+        await asyncio.sleep(0.3)  # simulate a batch ~3x the health timeout
+        assert health.is_healthy() is True
+
+        consumer._shutdown.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        # Once the heartbeat stops, liveness correctly goes stale again.
+        await asyncio.sleep(0.2)
+        assert health.is_healthy() is False

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1015,7 +1015,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1031,7 +1031,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,


### PR DESCRIPTION
## Problem

The loader consumer refreshes its liveness heartbeat only at the top of each poll cycle, *before* it awaits batch processing. When a large final-batch Delta compaction makes a cycle exceed the 60s liveness timeout, the heartbeat goes stale, `/_liveness` returns 503, and Kubernetes restarts the pod mid-batch. The consumer handles `SIGTERM` gracefully (exit 0), so this looks like benign `Completed` restarts, but each one abandons the in-flight batch, and enough repeats exhaust `max_attempts` and fail the run. Under load it becomes a self-reinforcing restart loop.

## Changes

- Add a dedicated `_heartbeat_loop()` task that reports liveness every 5s, independent of batch processing (started in `run()`, cancelled in `_close()`).
- Compaction runs in a thread, so the event loop — and the heartbeat — stays responsive through long batches, while still going stale if the loop genuinely wedges.

## How did you test this code?

Test pass and new tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

NO

## 🤖 Agent context

Co-Authored with PostHog Code (Claude Code). The diagnosis used the team's `investigating-warehouse-sources-load` skill 
