### PR TITLE
fix(mcp): use public app URL for user-facing links, not the API base

### DIFF
--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -89,6 +89,12 @@ export interface QueryEndpointResponse {
 export interface ApiConfig {
     apiToken: string
     baseUrl: string
+    /**
+     * Public, user-facing base URL for links surfaced to people (insights, dashboards, flags).
+     * Separate from `baseUrl`, which is the server-to-server API host and may be an in-cluster
+     * address on Cloud. Defaults to `baseUrl` when not provided.
+     */
+    appBaseUrl?: string | undefined
     clientUserAgent?: string | undefined
     mcpClientName?: string | undefined
     mcpClientVersion?: string | undefined
@@ -104,18 +110,20 @@ type Endpoint = Record<string, any>
 export class ApiClient {
     public config: ApiConfig
     public baseUrl: string
+    public appBaseUrl: string
 
     constructor(config: ApiConfig) {
         this.config = config
         this.baseUrl = config.baseUrl
+        this.appBaseUrl = config.appBaseUrl ?? config.baseUrl
     }
 
     getProjectBaseUrl(projectId: string): string {
         if (projectId === '@current') {
-            return this.baseUrl
+            return this.appBaseUrl
         }
 
-        return `${this.baseUrl}/project/${projectId}`
+        return `${this.appBaseUrl}/project/${projectId}`
     }
 
     private async fetch(url: string, options?: RequestInit): Promise<Response> {

--- a/services/mcp/src/hono/constants.ts
+++ b/services/mcp/src/hono/constants.ts
@@ -9,6 +9,7 @@ export {
     toCloudRegion,
     getBaseUrlForRegion,
     getCustomApiBaseUrl,
+    getPublicAppBaseUrl,
     getAuthorizationServerUrl,
     MCP_DOCS_URL,
     OAUTH_PROXY_URL,
@@ -22,6 +23,7 @@ export function getEnv(): Env {
     }
     return {
         POSTHOG_API_BASE_URL: process.env.POSTHOG_API_BASE_URL || undefined,
+        SITE_URL: process.env.SITE_URL || undefined,
         MCP_APPS_BASE_URL: process.env.MCP_APPS_BASE_URL || undefined,
         POSTHOG_MCP_APPS_ANALYTICS_BASE_URL: process.env.POSTHOG_MCP_APPS_ANALYTICS_BASE_URL || undefined,
         POSTHOG_UI_APPS_TOKEN: process.env.POSTHOG_UI_APPS_TOKEN || undefined,

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -15,7 +15,7 @@ import { hash } from '@/lib/utils'
 import type { Context, Env, State } from '@/tools/types'
 
 import { RedisCache, type RedisLike } from './cache/RedisCache'
-import { getCustomApiBaseUrl } from './constants'
+import { getCustomApiBaseUrl, getPublicAppBaseUrl, toCloudRegion } from './constants'
 import {
     buildMCPRequestContext,
     buildMCPSessionAnalyticsProperties,
@@ -92,9 +92,11 @@ export class RequestContext {
             } else {
                 baseUrl = 'http://localhost:8010'
             }
+            const region = this.props.region ? toCloudRegion(this.props.region) : undefined
             this.apiInstance = new ApiClient({
                 apiToken: this.props.apiToken,
                 baseUrl,
+                appBaseUrl: getPublicAppBaseUrl(region),
                 clientUserAgent: this.props.clientUserAgent,
                 mcpClientName: this.props.mcpClientName,
                 mcpClientVersion: this.props.mcpClientVersion,

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -7,6 +7,7 @@ export {
     toCloudRegion,
     getBaseUrlForRegion,
     getCustomApiBaseUrl,
+    getPublicAppBaseUrl,
     isCloudApi,
     isLocalApi,
     MCP_DOCS_URL,

--- a/services/mcp/src/lib/oauth-constants.ts
+++ b/services/mcp/src/lib/oauth-constants.ts
@@ -79,6 +79,36 @@ export const isCloudApi = (): boolean => {
 
 export const isLocalApi = (): boolean => !!getCustomApiBaseUrl()?.includes('localhost')
 
+// In-cluster Service addresses are reachable for server-to-server API calls but must never
+// appear in user-facing links (e.g. http://posthog-web-django.posthog.svc.cluster.local:8000).
+const isInternalClusterUrl = (url: string): boolean => {
+    try {
+        return new URL(url).hostname.endsWith('.svc.cluster.local')
+    } catch {
+        return false
+    }
+}
+
+// Public, user-facing base URL for links we surface to people (insight/dashboard/flag URLs).
+// Deliberately separate from the API base URL: on Cloud the server reaches the PostHog API over
+// an in-cluster address that must not leak into links. Resolution order:
+//   1. SITE_URL — the public app URL, same convention as the rest of PostHog (set per deployment)
+//   2. the API base URL — when it's already user-reachable (public cloud, self-hosted, local dev)
+//   3. the region's public URL — when the API base is an in-cluster address (or unset)
+export const getPublicAppBaseUrl = (region?: CloudRegion): string => {
+    const siteUrl = env.SITE_URL
+    if (siteUrl) {
+        return siteUrl
+    }
+
+    const apiBaseUrl = getCustomApiBaseUrl()
+    if (apiBaseUrl && !isInternalClusterUrl(apiBaseUrl)) {
+        return apiBaseUrl
+    }
+
+    return getBaseUrlForRegion(region ?? 'us')
+}
+
 export const resolveAuthorizationServerUrl = (): string => {
     if (isCloudApi()) {
         return OAUTH_PROXY_URL

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -11,6 +11,7 @@ import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
 import { MCPClientProfile } from '@/lib/client-detection'
 import {
     getCustomApiBaseUrl,
+    getPublicAppBaseUrl,
     MCP_SERVER_NAME,
     MCP_SERVER_VERSION,
     POSTHOG_EU_BASE_URL,
@@ -218,25 +219,27 @@ export class MCP extends McpAgent<Env> {
         return undefined
     }
 
-    async getBaseUrl(): Promise<string> {
+    async getBaseUrl(): Promise<{ baseUrl: string; region: CloudRegion | undefined }> {
+        // Region from request props first (passed via URL param); it also refines the public
+        // app URL used for user-facing links even when the API base is a custom/in-cluster address.
+        const propsRegion = this.requestProperties.region
+        const region: CloudRegion | undefined = propsRegion ? toCloudRegion(propsRegion) : undefined
+
         const customBaseUrl = getCustomApiBaseUrl()
         if (customBaseUrl) {
-            return customBaseUrl
+            return { baseUrl: customBaseUrl, region }
         }
 
-        // Check region from request props first (passed via URL param), then cache, then detect
-        const propsRegion = this.requestProperties.region
-        if (propsRegion) {
-            const region = toCloudRegion(propsRegion)
+        if (region) {
             // Cache it for future requests
             await this.cache.set('region', region)
-            return getBaseUrlForRegion(region)
+            return { baseUrl: getBaseUrlForRegion(region), region }
         }
 
         const cachedRegion = await this.cache.get('region')
-        const region = cachedRegion ? toCloudRegion(cachedRegion) : await this.detectRegion()
+        const resolved = cachedRegion ? toCloudRegion(cachedRegion) : await this.detectRegion()
 
-        return getBaseUrlForRegion(region || 'us')
+        return { baseUrl: getBaseUrlForRegion(resolved || 'us'), region: resolved ?? undefined }
     }
 
     async api(): Promise<ApiClient> {
@@ -245,11 +248,13 @@ export class MCP extends McpAgent<Env> {
         // during init() — e.g. the `context.api` passed to every tool handler
         // in getContext() — seeing the latest token on subsequent fetches.
         if (!this._api) {
-            const baseUrl = await this.getBaseUrl()
+            const { baseUrl, region } = await this.getBaseUrl()
             await this.resolveClientInfo()
             this._api = new ApiClient({
                 apiToken: this.requestProperties.apiToken,
                 baseUrl,
+                // User-facing links must use the public app URL, never the in-cluster API base.
+                appBaseUrl: getPublicAppBaseUrl(region),
                 clientUserAgent: this.requestProperties.clientUserAgent,
                 mcpClientName: this.mcpClientName,
                 mcpClientVersion: this.mcpClientVersion,

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -51,6 +51,17 @@ export type Env = {
      */
     POSTHOG_API_BASE_URL: string | undefined
     /**
+     * Public, user-facing PostHog app URL for links we surface to people
+     * (insight/dashboard/flag URLs, etc). Same meaning as Django's SITE_URL — set it to the
+     * public app URL for this deployment.
+     *
+     * Set this when POSTHOG_API_BASE_URL points at an in-cluster address that must not
+     * leak into links — e.g. on Cloud, set it per region to https://us.posthog.com or
+     * https://eu.posthog.com. When unset, links fall back to the API base URL (correct
+     * for public-cloud, self-hosted, and local deployments).
+     */
+    SITE_URL?: string | undefined
+    /**
      * Base URL for serving MCP UI app static assets.
      * When using Workers Static Assets, this is the Worker's own public URL.
      * Example: https://mcp.posthog.com

--- a/services/mcp/tests/unit/api-client.test.ts
+++ b/services/mcp/tests/unit/api-client.test.ts
@@ -24,6 +24,28 @@ describe('ApiClient', () => {
         expect(baseUrl).toBe(customUrl)
     })
 
+    describe('getProjectBaseUrl', () => {
+        it('uses appBaseUrl for user-facing project links, not the API baseUrl', () => {
+            const client = new ApiClient({
+                apiToken: 'test-token',
+                baseUrl: 'http://posthog-web-django.posthog.svc.cluster.local:8000',
+                appBaseUrl: 'https://us.posthog.com',
+            })
+
+            expect(client.getProjectBaseUrl('123')).toBe('https://us.posthog.com/project/123')
+            expect(client.getProjectBaseUrl('@current')).toBe('https://us.posthog.com')
+        })
+
+        it('falls back to baseUrl when appBaseUrl is not provided', () => {
+            const client = new ApiClient({
+                apiToken: 'test-token',
+                baseUrl: 'https://us.posthog.com',
+            })
+
+            expect(client.getProjectBaseUrl('123')).toBe('https://us.posthog.com/project/123')
+        })
+    })
+
     it('should send correct headers on fetch', async () => {
         const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
         vi.stubGlobal('fetch', mockFetch)

--- a/services/mcp/tests/unit/mcp-api-caching.test.ts
+++ b/services/mcp/tests/unit/mcp-api-caching.test.ts
@@ -64,7 +64,7 @@ function buildMcp(initialToken: string): MCP {
             },
         },
     }
-    ;(mcp as any).getBaseUrl = async () => 'https://us.posthog.com'
+    ;(mcp as any).getBaseUrl = async () => ({ baseUrl: 'https://us.posthog.com', region: 'us' })
     ;(mcp as any).resolveClientInfo = async () => {}
     return mcp
 }

--- a/services/mcp/tests/unit/oauth-region.test.ts
+++ b/services/mcp/tests/unit/oauth-region.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { getAuthorizationServerUrl, getBaseUrlForRegion, isCloudApi, isLocalApi, toCloudRegion } from '@/lib/constants'
+import {
+    getAuthorizationServerUrl,
+    getBaseUrlForRegion,
+    getPublicAppBaseUrl,
+    isCloudApi,
+    isLocalApi,
+    toCloudRegion,
+} from '@/lib/constants'
+import type { CloudRegion } from '@/tools/types'
 
 describe('OAuth Region Routing', () => {
     const originalEnv = { ...process.env }
@@ -81,6 +89,69 @@ describe('OAuth Region Routing', () => {
 
         it('returns US URL for us region', () => {
             expect(getBaseUrlForRegion('us')).toBe('https://us.posthog.com')
+        })
+    })
+
+    describe('getPublicAppBaseUrl', () => {
+        const INTERNAL = 'http://posthog-web-django.posthog.svc.cluster.local:8000'
+
+        it('prefers SITE_URL when set, even over an internal API base', () => {
+            process.env.POSTHOG_API_BASE_URL = INTERNAL
+            process.env.SITE_URL = 'https://eu.posthog.com'
+            expect(getPublicAppBaseUrl('us')).toBe('https://eu.posthog.com')
+        })
+
+        it.each<{ name: string; apiBaseUrl: string | undefined; region: CloudRegion | undefined; expected: string }>([
+            {
+                name: 'internal cluster API base, eu region -> public EU',
+                apiBaseUrl: INTERNAL,
+                region: 'eu',
+                expected: 'https://eu.posthog.com',
+            },
+            {
+                name: 'internal cluster API base, us region -> public US',
+                apiBaseUrl: INTERNAL,
+                region: 'us',
+                expected: 'https://us.posthog.com',
+            },
+            {
+                name: 'internal cluster API base, unknown region -> defaults to public US',
+                apiBaseUrl: INTERNAL,
+                region: undefined,
+                expected: 'https://us.posthog.com',
+            },
+            {
+                name: 'public cloud API base is already user-reachable -> used as-is',
+                apiBaseUrl: 'https://eu.posthog.com',
+                region: undefined,
+                expected: 'https://eu.posthog.com',
+            },
+            {
+                name: 'self-hosted API base is the public URL -> used as-is',
+                apiBaseUrl: 'https://posthog.example.com',
+                region: undefined,
+                expected: 'https://posthog.example.com',
+            },
+            {
+                name: 'local dev API base -> used as-is',
+                apiBaseUrl: 'http://localhost:8010',
+                region: undefined,
+                expected: 'http://localhost:8010',
+            },
+            {
+                name: 'unset API base, eu region -> public EU',
+                apiBaseUrl: undefined,
+                region: 'eu',
+                expected: 'https://eu.posthog.com',
+            },
+        ])('$name', ({ apiBaseUrl, region, expected }) => {
+            delete process.env.SITE_URL
+            if (apiBaseUrl === undefined) {
+                delete process.env.POSTHOG_API_BASE_URL
+            } else {
+                process.env.POSTHOG_API_BASE_URL = apiBaseUrl
+            }
+            expect(getPublicAppBaseUrl(region)).toBe(expected)
         })
     })
 


### PR DESCRIPTION
## Problem

The PostHog AI assistant (Max) replying in Slack returned an insight link pointing at an internal cluster address (`http://posthog-web-django.posthog.svc.cluster.local:8000/project/2/insights/...`) instead of the public app URL.

Root cause: the MCP server (`services/mcp`) backs that assistant and reuses a **single** base URL for two different jobs. `POSTHOG_API_BASE_URL` is set to the in-cluster Service address so the server can reach the PostHog API server-to-server (correct), but `ApiClient.getProjectBaseUrl()` also builds **user-facing links** (insight, dashboard, flag, entity-search URLs) from that same base — so the internal host leaks into every link the server shows people. Because `POSTHOG_API_BASE_URL` is the internal address on the hosted `mcp.us`/`mcp.eu` deployments too, this affects all MCP link output, not just Slack.

(Originally misdiagnosed as a Django `SITE_URL`/exporter issue — see closed #60846. `SITE_URL` is public on all Cloud environments and was never the source.)

## Changes

- Add `ApiConfig.appBaseUrl` — the public, user-facing base URL — separate from `baseUrl` (the server-to-server API host). `getProjectBaseUrl()` now uses `appBaseUrl`, so every link builder is fixed at one chokepoint. `appBaseUrl` defaults to `baseUrl` when unset, so nothing changes for callers that don't set it.
- Add `getPublicAppBaseUrl(region)` resolving, in order:
  1. `SITE_URL` when set — the public app URL, using the **same convention as the rest of PostHog** (Django reads `SITE_URL` for the same purpose);
  2. the API base URL when it's already user-reachable (public cloud, self-hosted, local dev);
  3. the region's public URL (`us`/`eu.posthog.com`) when the API base is an in-cluster `*.svc.cluster.local` address (or unset).
- Wire `appBaseUrl` at the two real client construction sites (`mcp.ts` Durable Object path and `hono/request-context.ts` Node path), threading the known region. The server-to-server API base URL is unchanged, so fetches keep using the reachable address.

> **Companion charts change required** to fully fix the in-cluster deployment: set `SITE_URL` per region on the `mcp-server` deployment (`values.prod-us.yaml` → `https://us.posthog.com`, `values.prod-eu.yaml` → `https://eu.posthog.com`) — the same public value Django pods already receive. Until then, the region-derived fallback applies (defaulting to US when region is unknown for an internal API base).

## How did you test this code?

I'm an agent. I added and ran automated unit tests; I did not perform manual testing.

- `tests/unit/oauth-region.test.ts`: parameterized coverage of `getPublicAppBaseUrl` — `SITE_URL` wins; internal cluster base maps to the region's public URL (US/EU/unknown→US); public-cloud / self-hosted / localhost bases are used as-is; unset base is region-derived.
- `tests/unit/api-client.test.ts`: `getProjectBaseUrl` uses `appBaseUrl` (not the API `baseUrl`), and falls back to `baseUrl` when `appBaseUrl` is absent.
- Full unit suite green (the unrelated `exec.test.ts`/`@posthog/quill` failures are a local unbuilt-workspace-dep env issue, not touched here). `tsc --noEmit` clean for the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — `SITE_URL` for the MCP server is an internal deployment setting matching the existing convention.

## 🤖 Agent context

Authored by PostHog Code (Opus 4.8) at the request of @pauldambra.

Investigation started from a report that a Slack assistant reply contained an internal-host link. A first hypothesis (Django `SITE_URL`/image-exporter, PR #60846) was investigated and **rejected**: the charts show `SITE_URL` is public on all Cloud environments, and no Django link-builder produces the internal host. Querying the actual artifact (the leaked link was `/project/2/insights/<id>`, generated by the MCP-backed assistant) traced it to `services/mcp`: `ApiClient.getProjectBaseUrl()` building links from `POSTHOG_API_BASE_URL`, which `apps/mcp-server` sets to the in-cluster address. The fix decouples the public link URL from the internal API base, reading `SITE_URL` like the rest of the system rather than inventing a new env var.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
