### PR TITLE
fix(tasks): drop duplicate slack progress post after sandbox provisioning

### DIFF
--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -385,8 +385,6 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             # if sandbox_output.should_create_snapshot and self.context.repository and self.context.github_integration_id:
             #     await self._trigger_snapshot_workflow()
 
-            await self._post_slack_update()
-
             # Start agent-server for direct connection from PostHog Code
             await self._emit_progress("agent", "in_progress", "Starting agent", "setup")
             agent_server_output = await self._start_agent_server(sandbox_output)


### PR DESCRIPTION
## Problem

`@PostHog`-mentions in Slack were leaving stray `Working on task…` placeholders behind — sometimes two of them, and the final reply didn't clean them up.

Root cause: `ProcessTaskWorkflow.run` calls `_post_slack_update()` twice during startup, bracketing `_get_sandbox_for_repository()`. Both read the same `task_run` state with no stage write between them, so the second call is redundant — it renders the exact same text as the first. The intent was that it would find the first message via `conversations_replies` and `chat_update` it in place, but as latency in the activity grew and the gap between the two calls shrank, the second lookup started racing with Slack's read-after-write — the first `chat_postMessage` hadn't been indexed yet, so the second call missed it and posted a duplicate.

## Changes

Drop the post-provisioning `_post_slack_update()` call — it doesn't add any new information, so it's safe to remove. The pre-provisioning one stays so users see the placeholder immediately at task start. Subsequent updates throughout the workflow still find that one message and `chat_update` it in place.

## How did you test this code?

Authored as an agent. Verified locally with a parallel logging branch — added structured logs around the lookup / post / delete path and reproduced the original behaviour against a local dev stack, confirming the second call correctly updates in place when only one writer exists. Existing `test_workflow.py` does not assert on `_post_slack_update` call count and passes unchanged.

## 🤖 Agent context

Claude Code session. Diagnosis confirmed by inspecting reproducing Slack threads via the Slack MCP and a logging branch run locally.