### PR TITLE
feat(posthog-ai): runtime-dependent conversation history

### DIFF
--- a/ee/hogai/api/serializers.py
+++ b/ee/hogai/api/serializers.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pydantic
 from asgiref.sync import async_to_sync
+from drf_spectacular.utils import extend_schema_field
 from langgraph.graph.state import CompiledStateGraph
 from rest_framework import serializers
 
@@ -42,6 +43,20 @@ CONVERSATION_TYPE_MAP: dict[
 }
 
 
+class ConversationSandboxTaskSerializer(serializers.Serializer):
+    """The products/tasks Task backing a sandbox conversation.
+
+    Carries the IDs the frontend's `sandboxStreamLogic.bootstrapRun` opens SSE / replays
+    the `logs/` history against. Null for LangGraph conversations.
+    """
+
+    id = serializers.UUIDField(help_text="The backing products/tasks Task id.")
+    current_run_id = serializers.UUIDField(
+        allow_null=True,
+        help_text="Current (latest) TaskRun id the frontend bootstraps against; null when the Task has no runs yet.",
+    )
+
+
 class ConversationMinimalSerializer(serializers.ModelSerializer):
     class Meta:
         model = Conversation
@@ -62,6 +77,7 @@ class ConversationSerializer(ConversationMinimalSerializer):
             "agent_runtime",
             "is_sandbox",
             "pending_approvals",
+            "task",
         ]
         read_only_fields = fields
 
@@ -79,6 +95,7 @@ class ConversationSerializer(ConversationMinimalSerializer):
     agent_mode = serializers.SerializerMethodField()
     is_sandbox = serializers.SerializerMethodField()
     pending_approvals = serializers.SerializerMethodField()
+    task = serializers.SerializerMethodField()
 
     def get_messages(self, conversation: Conversation) -> list[dict[str, Any]]:
         # Sandbox conversations don't persist messages Django-side — history lives in S3
@@ -117,7 +134,20 @@ class ConversationSerializer(ConversationMinimalSerializer):
         return None
 
     def get_is_sandbox(self, conversation: Conversation) -> bool:
-        return conversation.sandbox_task_id is not None
+        return conversation.agent_runtime == Conversation.AgentRuntime.SANDBOX
+
+    @extend_schema_field(ConversationSandboxTaskSerializer(allow_null=True))
+    def get_task(self, conversation: Conversation) -> dict[str, Any] | None:
+        # The backing Task + current Run let the frontend bootstrap the sandbox stream on
+        # open. `current_run` is derived (latest Run on the Task), so this costs one extra
+        # query — acceptable on single retrieve, never hit on `list`.
+        if conversation.task_id is None:
+            return None
+        current_run = conversation.current_run
+        return {
+            "id": str(conversation.task_id),
+            "current_run_id": str(current_run.id) if current_run else None,
+        }
 
     def get_pending_approvals(self, conversation: Conversation) -> list[dict[str, Any]]:
         """

--- a/ee/hogai/api/serializers.py
+++ b/ee/hogai/api/serializers.py
@@ -59,11 +59,21 @@ class ConversationSerializer(ConversationMinimalSerializer):
             "messages",
             "has_unsupported_content",
             "agent_mode",
+            "agent_runtime",
             "is_sandbox",
             "pending_approvals",
         ]
         read_only_fields = fields
 
+    agent_runtime = serializers.ChoiceField(
+        choices=Conversation.AgentRuntime.choices,
+        read_only=True,
+        help_text=(
+            "Runtime that owns this conversation. 'langgraph' conversations return their messages "
+            "in the `messages` field; 'sandbox' conversations return an empty `messages` array and "
+            "load history from the products/tasks logs endpoint instead."
+        ),
+    )
     messages = serializers.SerializerMethodField()
     has_unsupported_content = serializers.SerializerMethodField()
     agent_mode = serializers.SerializerMethodField()
@@ -71,6 +81,11 @@ class ConversationSerializer(ConversationMinimalSerializer):
     pending_approvals = serializers.SerializerMethodField()
 
     def get_messages(self, conversation: Conversation) -> list[dict[str, Any]]:
+        # Sandbox conversations don't persist messages Django-side — history lives in S3
+        # ACP logs, fetched via the products/tasks `logs/` endpoint.
+        if conversation.agent_runtime == Conversation.AgentRuntime.SANDBOX:
+            return []
+
         if conversation.messages_json is not None:
             return conversation.messages_json
 
@@ -162,6 +177,10 @@ class ConversationSerializer(ConversationMinimalSerializer):
             Tuple of (state, has_unsupported_content, interrupt_payloads).
             interrupt_payloads is a dict mapping proposal_id to the interrupt value (including payload).
         """
+        # Sandbox conversations have no LangGraph checkpoint — their state lives in S3 ACP logs.
+        if conversation.agent_runtime == Conversation.AgentRuntime.SANDBOX:
+            return None, False, {}
+
         try:
             team = self.context["team"]
             user = self.context["user"]

--- a/ee/hogai/api/test/test_serializers.py
+++ b/ee/hogai/api/test/test_serializers.py
@@ -13,6 +13,7 @@ from posthog.schema import (
 )
 
 from products.posthog_ai.backend.models.assistant import AgentArtifact, Conversation
+from products.tasks.backend.models import Task
 
 from ee.hogai.api.serializers import ConversationSerializer
 from ee.hogai.chat_agent import AssistantGraph
@@ -285,6 +286,65 @@ class TestConversationSerializerRuntimeMessages(APIBaseTest):
         self.assertEqual(data["agent_runtime"], Conversation.AgentRuntime.LANGGRAPH.value)
         self.assertEqual(len(data["messages"]), 1)
         self.assertEqual(data["messages"][0]["content"], "Hello from LangGraph")
+
+
+class TestConversationSerializerTaskField(APIBaseTest):
+    def _serialize(self, conversation: Conversation) -> dict:
+        return ConversationSerializer(conversation, context={"team": self.team, "user": self.user}).data
+
+    def _sandbox_conversation(self, task: Task | None = None) -> Conversation:
+        return Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            type=Conversation.Type.ASSISTANT,
+            agent_runtime=Conversation.AgentRuntime.SANDBOX,
+            task=task,
+        )
+
+    def _task(self) -> Task:
+        return Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=self.user,
+        )
+
+    def test_task_is_null_before_first_message(self):
+        # A sandbox conversation gets its Task FK on the first message, not at creation.
+        data = self._serialize(self._sandbox_conversation())
+        self.assertIsNone(data["task"])
+        self.assertTrue(data["is_sandbox"])
+
+    def test_langgraph_conversation_has_null_task_and_is_not_sandbox(self):
+        conversation = Conversation.objects.create(user=self.user, team=self.team, type=Conversation.Type.ASSISTANT)
+
+        with patch("langgraph.graph.state.CompiledStateGraph.aget_state", new_callable=AsyncMock) as mock_get_state:
+
+            class MockSnapshot:
+                values = AssistantState(messages=[]).model_dump()
+                tasks = []
+
+            mock_get_state.return_value = MockSnapshot()
+            data = self._serialize(conversation)
+
+        self.assertIsNone(data["task"])
+        self.assertFalse(data["is_sandbox"])
+
+    def test_task_current_run_id_null_when_task_has_no_runs(self):
+        task = self._task()
+        data = self._serialize(self._sandbox_conversation(task))
+        self.assertEqual(data["task"], {"id": str(task.id), "current_run_id": None})
+
+    def test_task_reports_latest_run(self):
+        task = self._task()
+        first = task.create_run(mode="interactive")
+        latest = task.create_run(mode="interactive")
+
+        data = self._serialize(self._sandbox_conversation(task))
+
+        self.assertEqual(data["task"], {"id": str(task.id), "current_run_id": str(latest.id)})
+        self.assertNotEqual(data["task"]["current_run_id"], str(first.id))
 
 
 class TestConversationSerializerArtifactEnrichment(APIBaseTest):

--- a/ee/hogai/api/test/test_serializers.py
+++ b/ee/hogai/api/test/test_serializers.py
@@ -234,6 +234,59 @@ class TestConversationSerializers(APIBaseTest):
         self.assertEqual(mock_get_state.call_count, 1)
 
 
+class TestConversationSerializerRuntimeMessages(APIBaseTest):
+    def test_sandbox_conversation_returns_empty_messages(self):
+        """Sandbox conversations don't persist messages Django-side — `messages` is always empty."""
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            title="Sandbox conversation",
+            type=Conversation.Type.ASSISTANT,
+            agent_runtime=Conversation.AgentRuntime.SANDBOX,
+            messages_json=[{"type": "ai", "content": "should be ignored on the sandbox path"}],
+        )
+
+        # aget_state must never be invoked for a sandbox conversation — the guard short-circuits first.
+        with patch("langgraph.graph.state.CompiledStateGraph.aget_state", new_callable=AsyncMock) as mock_get_state:
+            data = ConversationSerializer(
+                conversation,
+                context={"team": self.team, "user": self.user},
+            ).data
+
+        self.assertEqual(data["messages"], [])
+        self.assertEqual(data["agent_runtime"], Conversation.AgentRuntime.SANDBOX.value)
+        mock_get_state.assert_not_called()
+
+    def test_langgraph_conversation_returns_populated_messages(self):
+        """LangGraph conversations keep today's behavior — messages come from the graph state."""
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            title="LangGraph conversation",
+            type=Conversation.Type.ASSISTANT,
+            agent_runtime=Conversation.AgentRuntime.LANGGRAPH,
+        )
+
+        state = AssistantState(messages=[AssistantMessage(content="Hello from LangGraph", type="ai")])
+
+        with patch("langgraph.graph.state.CompiledStateGraph.aget_state", new_callable=AsyncMock) as mock_get_state:
+
+            class MockSnapshot:
+                values = state.model_dump()
+                tasks = []
+
+            mock_get_state.return_value = MockSnapshot()
+
+            data = ConversationSerializer(
+                conversation,
+                context={"team": self.team, "user": self.user},
+            ).data
+
+        self.assertEqual(data["agent_runtime"], Conversation.AgentRuntime.LANGGRAPH.value)
+        self.assertEqual(len(data["messages"]), 1)
+        self.assertEqual(data["messages"][0]["content"], "Hello from LangGraph")
+
+
 class TestConversationSerializerArtifactEnrichment(APIBaseTest):
     """Test artifact enrichment functionality in the serializer."""
 

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -187,6 +187,33 @@ export type ConversationApiMessagesItem = { [key: string]: unknown }
 
 export type ConversationApiPendingApprovalsItem = { [key: string]: unknown }
 
+/**
+ * * `langgraph` - LangGraph
+ * `sandbox` - Sandbox
+ */
+export type AgentRuntimeEnumApi = (typeof AgentRuntimeEnumApi)[keyof typeof AgentRuntimeEnumApi]
+
+export const AgentRuntimeEnumApi = {
+    Langgraph: 'langgraph',
+    Sandbox: 'sandbox',
+} as const
+
+/**
+ * The products/tasks Task backing a sandbox conversation.
+
+Carries the IDs the frontend's `sandboxStreamLogic.bootstrapRun` opens SSE / replays
+the `logs/` history against. Null for LangGraph conversations.
+ */
+export interface ConversationSandboxTaskApi {
+    /** The backing products/tasks Task id. */
+    id: string
+    /**
+     * Current (latest) TaskRun id the frontend bootstraps against; null when the Task has no runs yet.
+     * @nullable
+     */
+    current_run_id: string | null
+}
+
 export interface ConversationApi {
     readonly id: string
     readonly status: ConversationStatusApi
@@ -220,12 +247,18 @@ export interface ConversationApi {
     readonly has_unsupported_content: boolean
     /** @nullable */
     readonly agent_mode: string | null
+    /** Runtime that owns this conversation. 'langgraph' conversations return their messages in the `messages` field; 'sandbox' conversations return an empty `messages` array and load history from the products/tasks logs endpoint instead.
+
+  * `langgraph` - LangGraph
+  * `sandbox` - Sandbox */
+    readonly agent_runtime: AgentRuntimeEnumApi
     readonly is_sandbox: boolean
     /** Return pending approval cards as structured data.
 
   Combines metadata from conversation.approval_decisions with payload from checkpoint
   interrupts (single source of truth for payload data). */
     readonly pending_approvals: readonly ConversationApiPendingApprovalsItem[]
+    readonly task: ConversationSandboxTaskApi | null
 }
 
 /**
@@ -273,12 +306,18 @@ export interface PatchedConversationApi {
     readonly has_unsupported_content?: boolean
     /** @nullable */
     readonly agent_mode?: string | null
+    /** Runtime that owns this conversation. 'langgraph' conversations return their messages in the `messages` field; 'sandbox' conversations return an empty `messages` array and load history from the products/tasks logs endpoint instead.
+
+  * `langgraph` - LangGraph
+  * `sandbox` - Sandbox */
+    readonly agent_runtime?: AgentRuntimeEnumApi
     readonly is_sandbox?: boolean
     /** Return pending approval cards as structured data.
 
   Combines metadata from conversation.approval_decisions with payload from checkpoint
   interrupts (single source of truth for payload data). */
     readonly pending_approvals?: readonly PatchedConversationApiPendingApprovalsItem[]
+    readonly task?: ConversationSandboxTaskApi | null
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7203,6 +7203,18 @@ export namespace Schemas {
       UserInterview: 'user_interview',
     } as const;
 
+    /**
+     * * `langgraph` - LangGraph
+    * `sandbox` - Sandbox
+     */
+    export type AgentRuntimeEnum = typeof AgentRuntimeEnum[keyof typeof AgentRuntimeEnum];
+
+
+    export const AgentRuntimeEnum = {
+      Langgraph: 'langgraph',
+      Sandbox: 'sandbox',
+    } as const;
+
     export interface AggregatedSpanRow {
       avg_duration_nano: number;
       count: number;
@@ -11568,6 +11580,22 @@ export namespace Schemas {
       Slack: 'slack',
     } as const;
 
+    /**
+     * The products/tasks Task backing a sandbox conversation.
+
+    Carries the IDs the frontend's `sandboxStreamLogic.bootstrapRun` opens SSE / replays
+    the `logs/` history against. Null for LangGraph conversations.
+     */
+    export interface ConversationSandboxTask {
+      /** The backing products/tasks Task id. */
+      id: string;
+      /**
+         * Current (latest) TaskRun id the frontend bootstraps against; null when the Task has no runs yet.
+         * @nullable
+         */
+      current_run_id: string | null;
+    }
+
     export interface Conversation {
       readonly id: string;
       readonly status: ConversationStatus;
@@ -11601,12 +11629,18 @@ export namespace Schemas {
       readonly has_unsupported_content: boolean;
       /** @nullable */
       readonly agent_mode: string | null;
+      /** Runtime that owns this conversation. 'langgraph' conversations return their messages in the `messages` field; 'sandbox' conversations return an empty `messages` array and load history from the products/tasks logs endpoint instead.
+
+      * `langgraph` - LangGraph
+      * `sandbox` - Sandbox */
+      readonly agent_runtime: AgentRuntimeEnum;
       readonly is_sandbox: boolean;
       /** Return pending approval cards as structured data.
 
       Combines metadata from conversation.approval_decisions with payload from checkpoint
       interrupts (single source of truth for payload data). */
       readonly pending_approvals: readonly ConversationPendingApprovalsItem[];
+      readonly task: ConversationSandboxTask | null;
     }
 
     export interface ConversationMinimal {
@@ -28566,12 +28600,18 @@ export namespace Schemas {
       readonly has_unsupported_content?: boolean;
       /** @nullable */
       readonly agent_mode?: string | null;
+      /** Runtime that owns this conversation. 'langgraph' conversations return their messages in the `messages` field; 'sandbox' conversations return an empty `messages` array and load history from the products/tasks logs endpoint instead.
+
+      * `langgraph` - LangGraph
+      * `sandbox` - Sandbox */
+      readonly agent_runtime?: AgentRuntimeEnum;
       readonly is_sandbox?: boolean;
       /** Return pending approval cards as structured data.
 
       Combines metadata from conversation.approval_decisions with payload from checkpoint
       interrupts (single source of truth for payload data). */
       readonly pending_approvals?: readonly PatchedConversationPendingApprovalsItem[];
+      readonly task?: ConversationSandboxTask | null;
     }
 
     export interface PatchedCoreEvent {


### PR DESCRIPTION
## Problem

PR **I2.4** of the PostHog AI → sandbox-agent migration (`docs/internal/posthog-ai-migration/00_OVERVIEW.md` § 10). Sandbox conversations don't persist messages Django-side — their history lives in S3 ACP logs. The conversation detail endpoint must reflect that without breaking the LangGraph contract, and history retrieval should reuse the existing `products/tasks` `logs/` endpoint rather than reimplementing a multi-run walker.

> Stacked on **I1.2** (`feat/phai-i1.2-backend-foundations`). Auto-retargets to `feat/posthog-ai-sandboxes` once I1.2 merges.

## Changes

Per `02_CORE` §§ 4.6, 4.7:

- `ConversationSerializer.get_messages` returns `[]` for sandbox conversations (early guard before the `messages_json` read); `_aget_state` short-circuits so the LangGraph checkpointer is never touched for sandbox rows. LangGraph output is byte-for-byte unchanged.
- Exposes `agent_runtime` as the read-only discriminator the frontend uses to pick its history-load path.
- **No** `log_assembler.py` / custom walker — history reuses `GET /api/projects/{tid}/tasks/{taskId}/runs/{runId}/logs/`, which already concatenates the full resume chain from S3. The optional `/conversations/{id}/log/` pass-through (§ 4.6) was deliberately skipped (the frontend calls the tasks endpoint directly; same-origin, session-cookie auth).

## How did you test this code?

Automated only (I'm an agent):

- `ruff` clean; `makemigrations --check` confirms serializer/view-only (no migration).
- `hogli build:openapi` — the verify stage caught that `agent_runtime`/`AgentRuntimeEnum` (and the `posthog_ai` `OriginProduct` enum) were missing from generated types and regenerated them (would otherwise fail CI drift check).
- 12 tests pass, including a sandbox test asserting `messages == []` and `aget_state` never called, and a LangGraph test confirming unchanged output.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) via a multi-agent workflow (implement → independent verify) in an isolated worktree stacked on I1.2. The `is_sandbox` serializer field still derives from the deprecated `sandbox_task_id` column (pre-existing); `agent_runtime` is the correct discriminator going forward. Requires human review; not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
