### PR TITLE
feat(posthog-ai): sandbox follow-up routing and /sandbox/ route

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -286,8 +286,8 @@ class ConversationViewSet(
         return queryset
 
     def get_throttles(self):
-        # For create action, throttling is handled in check_throttles() for conditional logic
-        if self.action == "create":
+        # For message-sending actions, throttling is handled in check_throttles() for conditional logic
+        if self.action in ("create", "sandbox"):
             return []
         return super().get_throttles()
 
@@ -312,8 +312,8 @@ class ConversationViewSet(
         return False
 
     def check_throttles(self, request: Request):
-        # Only apply custom throttling for create action
-        if self.action != "create":
+        # Only apply custom throttling for message-sending actions
+        if self.action not in ("create", "sandbox"):
             return super().check_throttles(request)
 
         # Skip throttling in local development
@@ -633,6 +633,14 @@ class ConversationViewSet(
     )
     @action(detail=True, methods=["POST"], url_path="sandbox")
     def sandbox(self, request: Request, *args, **kwargs):
+        # Same billing gate as `create` — this is the follow-up path, so skipping it
+        # would let quota-limited teams keep launching runs.
+        if is_team_limited(self.team.api_token, QuotaResource.AI_CREDITS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY):
+            raise QuotaLimitExceeded(
+                "Your organization reached its AI credit usage limit. Increase the limits in Billing settings, or ask an org admin to do so."
+            )
+        serializer = SandboxMessageSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
         conversation = self.get_object()
         if conversation.agent_runtime != Conversation.AgentRuntime.SANDBOX:
             raise exceptions.ValidationError("This conversation is not on the sandbox runtime.")

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -27,6 +27,7 @@ from rest_framework.viewsets import GenericViewSet
 from posthog.schema import AgentMode, AssistantMessage, HumanMessage, MaxBillingContext
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import report_user_action
 from posthog.exceptions import Conflict, QuotaLimitExceeded
 from posthog.exceptions_capture import capture_exception
 from posthog.models.user import User
@@ -50,6 +51,7 @@ from posthog.temporal.ai.research_agent import (
     ResearchAgentWorkflowInputs,
 )
 
+from products.posthog_ai.backend.context_wrapper import ALLOWED_TYPES as ALLOWED_ATTACHED_CONTEXT_TYPES
 from products.posthog_ai.backend.message_routing import MessageRoutingService
 from products.posthog_ai.backend.models.assistant import Conversation
 
@@ -186,6 +188,51 @@ class QueueMessageSerializer(serializers.Serializer):
 
 class QueueMessageUpdateSerializer(serializers.Serializer):
     content = serializers.CharField(required=True, allow_blank=False, max_length=40000)
+
+
+class SandboxAttachedContextItemSerializer(serializers.Serializer):
+    """One typed attachment carried by a sandbox message."""
+
+    type = serializers.ChoiceField(
+        choices=sorted(ALLOWED_ATTACHED_CONTEXT_TYPES),
+        help_text="Attachment kind. Entity types carry `id` (+ optional `name`); `text` carries `value`.",
+    )
+    id = serializers.JSONField(
+        required=False,
+        help_text="Entity identifier — integer for `dashboard`/`action`, string short_id/UUID otherwise. Absent for `text`.",
+    )
+    name = serializers.CharField(
+        required=False, help_text="Optional human-readable label rendered in the context block."
+    )
+    value = serializers.CharField(required=False, help_text="Free-text content. Only for `text` attachments.")
+
+
+class SandboxMessageSerializer(serializers.Serializer):
+    """Request body for the non-streaming `POST /conversations/{id}/sandbox/` route."""
+
+    content = serializers.CharField(
+        required=True, allow_blank=False, max_length=40000, help_text="The user's message text."
+    )
+    trace_id = serializers.UUIDField(
+        required=False, help_text="Client-generated trace id correlated with the resulting Run's SSE stream."
+    )
+    attached_context = serializers.ListField(
+        required=False,
+        child=SandboxAttachedContextItemSerializer(),
+        help_text="Typed PostHog entities (and free text) attached to this message.",
+    )
+
+
+class SandboxMessageResponseSerializer(serializers.Serializer):
+    """Response for `POST /conversations/{id}/sandbox/` — the IDs the frontend opens SSE against."""
+
+    task_id = serializers.CharField(help_text="The products/tasks Task backing the conversation.")
+    run_id = serializers.CharField(help_text="The Run the frontend opens SSE against.")
+    trace_id = serializers.CharField(allow_null=True, help_text="Echo of the request trace id, if provided.")
+    run_status = serializers.CharField(help_text="Current status of the targeted Run (e.g. `queued`, `in_progress`).")
+    just_created_run = serializers.BooleanField(
+        help_text="True when a new Run was created (first message or terminal resume); false for an in-progress follow-up."
+    )
 
 
 @extend_schema(tags=["max"])
@@ -411,7 +458,7 @@ class ConversationViewSet(
             if is_new_conversation:
                 conversation.title = serializer.validated_data["content"][:80]
                 conversation.save(update_fields=["title"])
-            return MessageRoutingService(request, conversation).handle()
+            return self._route_sandbox_message(request, conversation)
 
         workflow_inputs: ChatAgentWorkflowInputs | ResearchAgentWorkflowInputs
         workflow_class: type[ChatAgentWorkflow] | type[ResearchAgentWorkflow]
@@ -574,9 +621,49 @@ class ConversationViewSet(
         queue_store = ConversationQueueStore(conversation_id)
         return self._queue_response(queue_store, queue_store.clear())
 
+    @extend_schema(
+        request=SandboxMessageSerializer,
+        responses={200: SandboxMessageResponseSerializer},
+        description=(
+            "Non-streaming routing endpoint for sandbox-runtime conversations. Wraps + dedupes the "
+            "message, then starts a Run / signals a follow-up / resumes via in-process products/tasks calls and "
+            "returns the IDs the frontend opens SSE against. Sandbox runtime only — LangGraph conversations stream "
+            "via the unchanged `/stream/` path."
+        ),
+    )
+    @action(detail=True, methods=["POST"], url_path="sandbox")
+    def sandbox(self, request: Request, *args, **kwargs):
+        conversation = self.get_object()
+        if conversation.agent_runtime != Conversation.AgentRuntime.SANDBOX:
+            raise exceptions.ValidationError("This conversation is not on the sandbox runtime.")
+        return self._route_sandbox_message(request, conversation)
+
+    def _route_sandbox_message(self, request: Request, conversation: Conversation) -> Response:
+        user = cast(User, request.user)
+        result = MessageRoutingService(conversation, user).handle(request.data)
+        report_user_action(
+            user,
+            "prompt sent",
+            {
+                "trace_id": result["trace_id"],
+                "conversation_id": str(conversation.id),
+                "execution_type": "sandbox",
+                "just_created_run": result["just_created_run"],
+            },
+            team=self.team,
+            request=request,
+        )
+        return Response(result, status=status.HTTP_200_OK)
+
     @action(detail=True, methods=["PATCH"])
     def cancel(self, request: Request, *args, **kwargs):
         conversation = self.get_object()
+
+        if conversation.agent_runtime == Conversation.AgentRuntime.SANDBOX:
+            # Sandbox runs are cancelled in-process via the products/tasks command
+            # path; no LangGraph workflow is involved.
+            result = MessageRoutingService(conversation, cast(User, request.user)).cancel()
+            return Response(result, status=status.HTTP_200_OK)
 
         # IDLE is intentionally not short-circuited: during the handoff between the main
         # workflow completing and a queued workflow starting, the status is briefly IDLE

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -653,15 +653,15 @@ class ConversationViewSet(
             user,
             "prompt sent",
             {
-                "trace_id": result["trace_id"],
+                "trace_id": result.trace_id,
                 "conversation_id": str(conversation.id),
                 "execution_type": "sandbox",
-                "just_created_run": result["just_created_run"],
+                "just_created_run": result.just_created_run,
             },
             team=self.team,
             request=request,
         )
-        return Response(result, status=status.HTTP_200_OK)
+        return Response(result.model_dump(), status=status.HTTP_200_OK)
 
     @action(detail=True, methods=["PATCH"])
     def cancel(self, request: Request, *args, **kwargs):
@@ -671,7 +671,7 @@ class ConversationViewSet(
             # Sandbox runs are cancelled in-process via the products/tasks command
             # path; no LangGraph workflow is involved.
             result = MessageRoutingService(conversation, cast(User, request.user)).cancel()
-            return Response(result, status=status.HTTP_200_OK)
+            return Response(result.model_dump(), status=status.HTTP_200_OK)
 
         # IDLE is intentionally not short-circuited: during the handoff between the main
         # workflow completing and a queued workflow starting, the status is briefly IDLE

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -1246,3 +1246,64 @@ class TestConversationSoftDelete(APIBaseTest):
         still_deleted = Conversation.objects.get(pk=conversation.pk)
         self.assertTrue(still_deleted.deleted)
         self.assertEqual(Conversation.objects.filter(pk=conversation.pk).count(), 1)
+
+
+class TestConversationSandboxRoute(APIBaseTest):
+    def _sandbox_conversation(self) -> Conversation:
+        return Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            title="A chat",
+            type=Conversation.Type.ASSISTANT,
+            agent_runtime=Conversation.AgentRuntime.SANDBOX,
+        )
+
+    def test_sandbox_route_reachable_and_delegates_to_handler(self):
+        conversation = self._sandbox_conversation()
+        sentinel = {"task_id": "t", "run_id": "r", "trace_id": None, "run_status": "queued", "just_created_run": True}
+        with (
+            patch("ee.api.conversation.MessageRoutingService") as m_service,
+            patch("ee.api.conversation.report_user_action") as m_telemetry,
+        ):
+            m_service.return_value.handle.return_value = sentinel
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/sandbox/",
+                {"content": "hello", "trace_id": str(uuid.uuid4())},
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), sentinel)
+        m_service.return_value.handle.assert_called_once()
+        # The service receives the resolved conversation, not just an id.
+        passed_conversation = m_service.call_args[0][0]
+        self.assertEqual(passed_conversation.id, conversation.id)
+        # Telemetry fires at the API boundary, after the service returns.
+        m_telemetry.assert_called_once()
+
+    def test_sandbox_route_rejects_langgraph_conversation(self):
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            title="A chat",
+            type=Conversation.Type.ASSISTANT,
+            agent_runtime=Conversation.AgentRuntime.LANGGRAPH,
+        )
+        with patch("ee.api.conversation.MessageRoutingService") as m_service:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/sandbox/",
+                {"content": "hello"},
+            )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        m_service.assert_not_called()
+
+    def test_cancel_sandbox_conversation_delegates_to_sandbox_handler(self):
+        conversation = self._sandbox_conversation()
+        sentinel = {"task_id": "t", "run_id": "r", "run_status": "cancelled"}
+        with patch("ee.api.conversation.MessageRoutingService") as m_service:
+            m_service.return_value.cancel.return_value = sentinel
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/cancel/",
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), sentinel)
+        m_service.return_value.cancel.assert_called_once()

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -30,6 +30,7 @@ from posthog.models.user import User
 from posthog.temporal.ai.chat_agent import ChatAgentWorkflow, ChatAgentWorkflowInputs
 from posthog.temporal.ai.research_agent import ResearchAgentWorkflow, ResearchAgentWorkflowInputs
 
+from products.posthog_ai.backend.message_routing import SandboxCancelResult, SandboxRouteResult
 from products.posthog_ai.backend.models.assistant import Conversation
 
 from ee.api.conversation import ConversationViewSet
@@ -1260,7 +1261,9 @@ class TestConversationSandboxRoute(APIBaseTest):
 
     def test_sandbox_route_reachable_and_delegates_to_handler(self):
         conversation = self._sandbox_conversation()
-        sentinel = {"task_id": "t", "run_id": "r", "trace_id": None, "run_status": "queued", "just_created_run": True}
+        sentinel = SandboxRouteResult(
+            task_id="t", run_id="r", trace_id=None, run_status="queued", just_created_run=True
+        )
         with (
             patch("ee.api.conversation.MessageRoutingService") as m_service,
             patch("ee.api.conversation.report_user_action") as m_telemetry,
@@ -1272,7 +1275,7 @@ class TestConversationSandboxRoute(APIBaseTest):
             )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), sentinel)
+        self.assertEqual(response.json(), sentinel.model_dump())
         m_service.return_value.handle.assert_called_once()
         # The service receives the resolved conversation, not just an id.
         passed_conversation = m_service.call_args[0][0]
@@ -1336,12 +1339,12 @@ class TestConversationSandboxRoute(APIBaseTest):
 
     def test_cancel_sandbox_conversation_delegates_to_sandbox_handler(self):
         conversation = self._sandbox_conversation()
-        sentinel = {"task_id": "t", "run_id": "r", "run_status": "cancelled"}
+        sentinel = SandboxCancelResult(task_id="t", run_id="r", run_status="cancelled")
         with patch("ee.api.conversation.MessageRoutingService") as m_service:
             m_service.return_value.cancel.return_value = sentinel
             response = self.client.patch(
                 f"/api/environments/{self.team.id}/conversations/{conversation.id}/cancel/",
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), sentinel)
+        self.assertEqual(response.json(), sentinel.model_dump())
         m_service.return_value.cancel.assert_called_once()

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -1280,6 +1280,44 @@ class TestConversationSandboxRoute(APIBaseTest):
         # Telemetry fires at the API boundary, after the service returns.
         m_telemetry.assert_called_once()
 
+    def test_sandbox_route_blocked_when_quota_limited(self):
+        conversation = self._sandbox_conversation()
+        with (
+            patch("ee.api.conversation.is_team_limited", return_value=True),
+            patch("ee.api.conversation.MessageRoutingService") as m_service,
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/sandbox/",
+                {"content": "hello"},
+            )
+        self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
+        m_service.assert_not_called()
+
+    def test_sandbox_route_validates_request_body(self):
+        conversation = self._sandbox_conversation()
+        bad_payloads = [
+            {"content": "x" * 40001},  # over the content length cap
+            {"content": "hello", "trace_id": "not-a-uuid"},  # malformed trace id
+            {"trace_id": str(uuid.uuid4())},  # missing content
+        ]
+        for payload in bad_payloads:
+            with patch("ee.api.conversation.MessageRoutingService") as m_service:
+                response = self.client.post(
+                    f"/api/environments/{self.team.id}/conversations/{conversation.id}/sandbox/",
+                    payload,
+                )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, payload)
+            m_service.assert_not_called()
+
+    @override_settings(DEBUG=False)
+    def test_get_throttles_returns_empty_for_sandbox_action(self):
+        # Like create, the sandbox action's AI throttles are applied conditionally in check_throttles().
+        viewset = ConversationViewSet()
+        viewset.action = "sandbox"
+        viewset.team_id = self.team.id
+        viewset.organization = self.organization
+        self.assertEqual(viewset.get_throttles(), [])
+
     def test_sandbox_route_rejects_langgraph_conversation(self):
         conversation = Conversation.objects.create(
             user=self.user,

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -384,6 +384,87 @@ export interface PatchedConversationApi {
 }
 
 /**
+ * * `action` - action
+ * * `dashboard` - dashboard
+ * * `error_tracking_issue` - error_tracking_issue
+ * * `evaluation` - evaluation
+ * * `event` - event
+ * * `insight` - insight
+ * * `notebook` - notebook
+ * * `text` - text
+ */
+export type SandboxAttachedContextItemTypeEnumApi =
+    (typeof SandboxAttachedContextItemTypeEnumApi)[keyof typeof SandboxAttachedContextItemTypeEnumApi]
+
+export const SandboxAttachedContextItemTypeEnumApi = {
+    Action: 'action',
+    Dashboard: 'dashboard',
+    ErrorTrackingIssue: 'error_tracking_issue',
+    Evaluation: 'evaluation',
+    Event: 'event',
+    Insight: 'insight',
+    Notebook: 'notebook',
+    Text: 'text',
+} as const
+
+/**
+ * One typed attachment carried by a sandbox message.
+ */
+export interface SandboxAttachedContextItemApi {
+    /** Attachment kind. Entity types carry `id` (+ optional `name`); `text` carries `value`.
+     *
+     * * `action` - action
+     * * `dashboard` - dashboard
+     * * `error_tracking_issue` - error_tracking_issue
+     * * `evaluation` - evaluation
+     * * `event` - event
+     * * `insight` - insight
+     * * `notebook` - notebook
+     * * `text` - text */
+    type: SandboxAttachedContextItemTypeEnumApi
+    /** Entity identifier — integer for `dashboard`/`action`, string short_id/UUID otherwise. Absent for `text`. */
+    id?: unknown
+    /** Optional human-readable label rendered in the context block. */
+    name?: string
+    /** Free-text content. Only for `text` attachments. */
+    value?: string
+}
+
+/**
+ * Request body for the non-streaming `POST /conversations/{id}/sandbox/` route.
+ */
+export interface SandboxMessageApi {
+    /**
+     * The user's message text.
+     * @maxLength 40000
+     */
+    content: string
+    /** Client-generated trace id correlated with the resulting Run's SSE stream. */
+    trace_id?: string
+    /** Typed PostHog entities (and free text) attached to this message. */
+    attached_context?: SandboxAttachedContextItemApi[]
+}
+
+/**
+ * Response for `POST /conversations/{id}/sandbox/` — the IDs the frontend opens SSE against.
+ */
+export interface SandboxMessageResponseApi {
+    /** The products/tasks Task backing the conversation. */
+    task_id: string
+    /** The Run the frontend opens SSE against. */
+    run_id: string
+    /**
+     * Echo of the request trace id, if provided.
+     * @nullable
+     */
+    trace_id: string | null
+    /** Current status of the targeted Run (e.g. `queued`, `in_progress`). */
+    run_status: string
+    /** True when a new Run was created (first message or terminal resume); false for an in-progress follow-up. */
+    just_created_run: boolean
+}
+
+/**
  * * `widget` - Widget
  * * `email` - Email
  * * `slack` - Slack

--- a/products/conversations/frontend/generated/api.ts
+++ b/products/conversations/frontend/generated/api.ts
@@ -28,6 +28,8 @@ import type {
     PaginatedTicketViewListApi,
     PatchedConversationApi,
     PatchedTicketApi,
+    SandboxMessageApi,
+    SandboxMessageResponseApi,
     SuggestReplyResponseApi,
     TicketApi,
     TicketMessageApi,
@@ -259,6 +261,27 @@ export const conversationsQueueClearCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(conversationApi),
+    })
+}
+
+export const getConversationsSandboxCreateUrl = (projectId: string, conversation: string) => {
+    return `/api/environments/${projectId}/conversations/${conversation}/sandbox/`
+}
+
+/**
+ * Non-streaming routing endpoint for sandbox-runtime conversations. Wraps + dedupes the message, then starts a Run / signals a follow-up / resumes via in-process products/tasks calls and returns the IDs the frontend opens SSE against. Sandbox runtime only — LangGraph conversations stream via the unchanged `/stream/` path.
+ */
+export const conversationsSandboxCreate = async (
+    projectId: string,
+    conversation: string,
+    sandboxMessageApi: SandboxMessageApi,
+    options?: RequestInit
+): Promise<SandboxMessageResponseApi> => {
+    return apiMutator<SandboxMessageResponseApi>(getConversationsSandboxCreateUrl(projectId, conversation), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(sandboxMessageApi),
     })
 }
 

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -74,6 +74,58 @@ export const ConversationsQueuePartialUpdateBody = /* @__PURE__ */ zod.looseObje
 
 export const ConversationsQueueClearCreateBody = /* @__PURE__ */ zod.looseObject({})
 
+/**
+ * Non-streaming routing endpoint for sandbox-runtime conversations. Wraps + dedupes the message, then starts a Run / signals a follow-up / resumes via in-process products/tasks calls and returns the IDs the frontend opens SSE against. Sandbox runtime only — LangGraph conversations stream via the unchanged `/stream/` path.
+ */
+export const conversationsSandboxCreateBodyContentMax = 40000
+
+export const ConversationsSandboxCreateBody = /* @__PURE__ */ zod
+    .object({
+        content: zod.string().max(conversationsSandboxCreateBodyContentMax).describe("The user's message text."),
+        trace_id: zod
+            .uuid()
+            .optional()
+            .describe("Client-generated trace id correlated with the resulting Run's SSE stream."),
+        attached_context: zod
+            .array(
+                zod
+                    .object({
+                        type: zod
+                            .enum([
+                                'action',
+                                'dashboard',
+                                'error_tracking_issue',
+                                'evaluation',
+                                'event',
+                                'insight',
+                                'notebook',
+                                'text',
+                            ])
+                            .describe(
+                                '\* `action` - action\n\* `dashboard` - dashboard\n\* `error_tracking_issue` - error_tracking_issue\n\* `evaluation` - evaluation\n\* `event` - event\n\* `insight` - insight\n\* `notebook` - notebook\n\* `text` - text'
+                            )
+                            .describe(
+                                'Attachment kind. Entity types carry `id` (+ optional `name`); `text` carries `value`.\n\n\* `action` - action\n\* `dashboard` - dashboard\n\* `error_tracking_issue` - error_tracking_issue\n\* `evaluation` - evaluation\n\* `event` - event\n\* `insight` - insight\n\* `notebook` - notebook\n\* `text` - text'
+                            ),
+                        id: zod
+                            .unknown()
+                            .optional()
+                            .describe(
+                                'Entity identifier — integer for `dashboard`\/`action`, string short_id\/UUID otherwise. Absent for `text`.'
+                            ),
+                        name: zod
+                            .string()
+                            .optional()
+                            .describe('Optional human-readable label rendered in the context block.'),
+                        value: zod.string().optional().describe('Free-text content. Only for `text` attachments.'),
+                    })
+                    .describe('One typed attachment carried by a sandbox message.')
+            )
+            .optional()
+            .describe('Typed PostHog entities (and free text) attached to this message.'),
+    })
+    .describe('Request body for the non-streaming `POST \/conversations\/{id}\/sandbox\/` route.')
+
 export const ConversationsTicketsCreateBody = /* @__PURE__ */ zod
     .object({
         status: zod

--- a/products/conversations/mcp/tools.yaml
+++ b/products/conversations/mcp/tools.yaml
@@ -42,6 +42,9 @@ tools:
     conversations-retrieve:
         operation: conversations_retrieve
         enabled: false
+    conversations-sandbox-create:
+        operation: conversations_sandbox_create
+        enabled: false
     conversations-tickets-bulk-update-status-create:
         operation: conversations_tickets_bulk_update_status_create
         enabled: false

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -9,10 +9,11 @@ a Django SSE relay.
 
 import json
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from django.db import transaction
 
+from pydantic import BaseModel
 from rest_framework import exceptions, status
 
 from posthog.models.user import User
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
     from products.posthog_ai.backend.models.assistant import Conversation
 
 
-class SandboxRouteResult(TypedDict):
+class SandboxRouteResult(BaseModel):
     """Outcome of routing one sandbox message — the IDs the frontend opens SSE against."""
 
     task_id: str
@@ -47,7 +48,7 @@ class SandboxRouteResult(TypedDict):
     just_created_run: bool
 
 
-class SandboxCancelResult(TypedDict):
+class SandboxCancelResult(BaseModel):
     """Outcome of cancelling the conversation's current sandbox Run."""
 
     task_id: str

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -2,21 +2,21 @@
 
 Entry point for the non-streaming `POST /conversations/{id}/sandbox/` endpoint.
 Wraps + dedupes the user message, then starts a `products/tasks` Run (first
-message) via direct Python calls — never HTTP-to-self, never a Django SSE relay.
-
-Follow-up and terminal-resume branches are out of scope for this pass (I2.5).
+message), signals a follow-up on the in-progress Run, or resumes into a new Run
+after a terminal Run — all via direct Python calls, never HTTP-to-self and never
+a Django SSE relay.
 """
 
-from typing import TYPE_CHECKING, Any, cast
+import json
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from django.db import transaction
 
-from rest_framework import exceptions, status
-from rest_framework.request import Request
-from rest_framework.response import Response
+from rest_framework import exceptions
 
-from posthog.event_usage import report_user_action
 from posthog.models.user import User
+from posthog.storage import object_storage
 
 from products.posthog_ai.backend.context_wrapper import (
     ALLOWED_TYPES,
@@ -28,45 +28,118 @@ from products.posthog_ai.backend.context_wrapper import (
 from products.posthog_ai.backend.helpers import BaseSandboxService
 from products.posthog_ai.backend.run_state import PostHogAIRunState
 from products.posthog_ai.backend.system_prompt import PromptService
-from products.tasks.backend.models import Task
-from products.tasks.backend.temporal.client import execute_task_processing_workflow
+from products.posthog_ai.backend.wire_types import UnknownFrame, is_user_message_params, parse_log_entry
+from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.services.agent_command import send_cancel
+from products.tasks.backend.temporal.client import execute_task_processing_workflow, signal_task_followup_message
 
 if TYPE_CHECKING:
     from products.posthog_ai.backend.models.assistant import Conversation
 
 
+class SandboxRouteResult(TypedDict):
+    """Outcome of routing one sandbox message — the IDs the frontend opens SSE against."""
+
+    task_id: str
+    run_id: str
+    trace_id: str | None
+    run_status: str
+    just_created_run: bool
+
+
+class SandboxCancelResult(TypedDict):
+    """Outcome of cancelling the conversation's current sandbox Run."""
+
+    task_id: str
+    run_id: str
+    run_status: str
+
+
 class MessageRoutingService(BaseSandboxService):
     """Route a sandbox-runtime conversation message to a products/tasks Run, in-process.
 
-    First-message branch only (`conversation.task` is NULL). Follow-up and
-    terminal-resume branches are out of scope (I2.5).
+    Branches on the conversation's current Run:
+    - No Task yet → first message creates the Task + Run.
+    - Current Run in-progress → signal a follow-up onto the live Run.
+    - Current Run terminal → resume into a brand-new successor Run.
     """
 
     # Entity types whose id must be an integer (vs short_id / UUID strings).
     _INTEGER_ID_TYPES: frozenset[str] = frozenset({"dashboard", "action"})
 
-    def __init__(self, request: Request, conversation: "Conversation") -> None:
-        super().__init__(team=conversation.team, user=cast(User, request.user))
-        self.request = request
+    # Run statuses that accept a follow-up signal without creating a successor Run.
+    _IN_PROGRESS_STATUSES: frozenset[str] = frozenset({TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS})
+
+    def __init__(self, conversation: "Conversation", user: User) -> None:
+        super().__init__(team=conversation.team, user=user)
         self.conversation = conversation
 
-    def handle(self) -> Response:
-        content = self.request.data.get("content")
+    def handle(self, data: Mapping[str, Any]) -> SandboxRouteResult:
+        content = data.get("content")
         if not isinstance(content, str) or not content.strip():
             raise exceptions.ValidationError("`content` is required.")
 
-        trace_id = self.request.data.get("trace_id")
-        attached_context = self._validate_attached_context(self.request.data.get("attached_context"))
+        trace_id = data.get("trace_id")
+        attached_context = self._validate_attached_context(data.get("attached_context"))
 
-        if self.conversation.task_id is not None:
-            # Follow-up / terminal-resume branches land here once I2.5 implements them.
-            raise exceptions.ValidationError("Follow-up messages are not yet supported on the sandbox runtime.")
+        if self.conversation.task_id is None:
+            return self._handle_first_message(
+                content=content,
+                trace_id=trace_id,
+                attached_context=attached_context,
+            )
 
-        return self._handle_first_message(
-            content=content,
+        current_run = self.conversation.current_run
+        if current_run is None:
+            # The Task lost all of its Runs (e.g. cleanup) — there is nothing to
+            # follow up on or resume from. Surface a recoverable error.
+            raise exceptions.ValidationError("This conversation has no active run to continue.")
+
+        # Dedupe against every entity already named earlier in the conversation.
+        context_service = ContextService()
+        prior_seen = self._collect_seen_entity_refs(current_run)
+        deduped = context_service.prune_repeated_entity_refs(attached_context, prior=prior_seen)
+        wrapped = context_service.wrap_user_message(content, deduped)
+
+        if current_run.status in self._IN_PROGRESS_STATUSES:
+            return self._handle_in_progress_followup(
+                run=current_run,
+                wrapped=wrapped,
+                trace_id=trace_id,
+                attached_context=attached_context,
+            )
+
+        return self._handle_terminal_resume(
+            run=current_run,
+            wrapped=wrapped,
             trace_id=trace_id,
             attached_context=attached_context,
         )
+
+    def cancel(self) -> SandboxCancelResult:
+        """Cancel the conversation's current sandbox Run in-process.
+
+        Delegates to the products/tasks command path with `{"method": "cancel"}` —
+        the same control command PostHog Code issues. Returns the resulting
+        `run_status`; the frontend SSE then receives a terminal `task_run_state`.
+        """
+        if self.conversation.task_id is None:
+            raise exceptions.ValidationError("This conversation has no backing task to cancel.")
+
+        run = self.conversation.current_run
+        if run is None:
+            raise exceptions.ValidationError("This conversation has no active run to cancel.")
+
+        if run.is_terminal:
+            # Nothing to cancel — report the already-terminal status idempotently.
+            return SandboxCancelResult(
+                task_id=str(self.conversation.task_id), run_id=str(run.id), run_status=run.status
+            )
+
+        send_cancel(run)
+        run.refresh_from_db(fields=["status"])
+
+        return SandboxCancelResult(task_id=str(self.conversation.task_id), run_id=str(run.id), run_status=run.status)
 
     def _handle_first_message(
         self,
@@ -74,7 +147,7 @@ class MessageRoutingService(BaseSandboxService):
         content: str,
         trace_id: str | None,
         attached_context: list[AttachedContext],
-    ) -> Response:
+    ) -> SandboxRouteResult:
         context_service = ContextService()
         # First turn — the prior-seen set is empty, so dedupe is a no-op.
         deduped = context_service.prune_repeated_entity_refs(attached_context, prior=[])
@@ -124,7 +197,7 @@ class MessageRoutingService(BaseSandboxService):
         # first-message path: the agent creates insights, dashboards, and notebooks, so it
         # needs write scopes (the workflow client otherwise defaults to read-only). If the
         # start fails, un-link the conversation so the user's retry is a fresh first message
-        # rather than the not-yet-supported follow-up branch.
+        # rather than a follow-up onto a run that never started.
         try:
             execute_task_processing_workflow(
                 task_id=str(task.id),
@@ -139,29 +212,157 @@ class MessageRoutingService(BaseSandboxService):
             self.conversation.save(update_fields=["task", "updated_at"])
             raise
 
-        report_user_action(
-            self.user,
-            "prompt sent",
-            {
-                "trace_id": trace_id,
-                "conversation_id": str(self.conversation.id),
-                "execution_type": "sandbox",
-                "just_created_run": True,
-            },
-            team=self.team,
-            request=self.request,
+        return SandboxRouteResult(
+            task_id=str(task.id),
+            run_id=str(task_run.id),
+            trace_id=trace_id,
+            run_status=task_run.status,
+            just_created_run=True,
         )
 
-        return Response(
-            {
-                "task_id": str(task.id),
-                "run_id": str(task_run.id),
-                "trace_id": trace_id,
-                "run_status": task_run.status,
-                "just_created_run": True,
-            },
-            status=status.HTTP_200_OK,
+    def _handle_in_progress_followup(
+        self,
+        *,
+        run: TaskRun,
+        wrapped: str,
+        trace_id: str | None,
+        attached_context: list[AttachedContext],
+    ) -> SandboxRouteResult:
+        """Follow-up while the current Run is queued / in-progress.
+
+        Signal the live Temporal workflow in-process — no new Run, no SSE re-open.
+        The full undeduped context is recorded on the logged message's
+        `_meta.attached_context` so the persisted ACP log stays a complete record.
+        """
+        signal_task_followup_message(run.workflow_id, wrapped, artifact_ids=[])
+
+        self._log_user_message(run, wrapped, attached_context)
+
+        return SandboxRouteResult(
+            task_id=str(self.conversation.task_id),
+            run_id=str(run.id),
+            trace_id=trace_id,
+            run_status=run.status,
+            just_created_run=False,
         )
+
+    def _handle_terminal_resume(
+        self,
+        *,
+        run: TaskRun,
+        wrapped: str,
+        trace_id: str | None,
+        attached_context: list[AttachedContext],
+    ) -> SandboxRouteResult:
+        """Follow-up after the current Run reached a terminal status.
+
+        Resume into a brand-new successor Run on the same Task, then start its
+        workflow. `current_run` resolves to the new Run via the Task's reverse
+        relation — the conversation's `task` FK is unchanged.
+        """
+        task = self.conversation.task
+        if task is None:
+            raise exceptions.ValidationError("This conversation has no backing task to resume.")
+
+        system_prompt = PromptService(self.team, self.user).build()
+
+        extra_state: dict[str, Any] = {
+            "resume_from_run_id": str(run.id),
+            "pending_user_message": wrapped,
+            "systemPrompt": system_prompt,
+            # The full, undeduped list — survives for the life of the new Run.
+            "attached_context": attached_context,
+            "initial_permission_mode": "default",
+        }
+        # Carry the prior Run's snapshot forward so the resume reuses its filesystem.
+        snapshot_external_id = (run.state or {}).get("snapshot_external_id")
+        if snapshot_external_id:
+            extra_state["snapshot_external_id"] = snapshot_external_id
+
+        new_run = task.create_run(mode="interactive", extra_state=extra_state)
+
+        # Same write scopes as the first message — the resumed agent keeps creating
+        # insights/dashboards/notebooks on follow-up turns.
+        execute_task_processing_workflow(
+            task_id=str(task.id),
+            run_id=str(new_run.id),
+            team_id=self.team.id,
+            user_id=self.user.pk,
+            create_pr=False,
+            posthog_mcp_scopes="full",
+        )
+
+        return SandboxRouteResult(
+            task_id=str(task.id),
+            run_id=str(new_run.id),
+            trace_id=trace_id,
+            run_status=new_run.status,
+            just_created_run=True,
+        )
+
+    def _collect_seen_entity_refs(self, run: TaskRun) -> list[tuple[str, str | int]]:
+        """Collect `(type, id)` pairs for entities already named in the conversation.
+
+        Walks the Run's `state.attached_context` (the first message's full list) plus
+        every prior `_posthog/user_message` log entry's `_meta.attached_context`
+        across the entire resume chain. One S3 read per chain run; `text` items are
+        never deduped so they're skipped.
+        """
+        seen: list[tuple[str, str | int]] = []
+
+        def _absorb(items: Any) -> None:
+            if not isinstance(items, list):
+                return
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                item_type = item.get("type")
+                item_id = item.get("id")
+                if item_type in ALLOWED_TYPES and item_type != "text" and item_id is not None:
+                    seen.append((item_type, item_id))
+
+        for chain_run in run.get_resume_chain():
+            _absorb((chain_run.state or {}).get("attached_context"))
+            log_content = object_storage.read(chain_run.log_url, missing_ok=True) or ""
+            for line in log_content.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(data, dict):
+                    continue
+                frame = parse_log_entry(data)
+                if isinstance(frame, UnknownFrame):
+                    continue
+                notification = frame.notification
+                if not is_user_message_params(notification.params, notification.method):
+                    continue
+                meta = notification.params.get("_meta")
+                if isinstance(meta, dict):
+                    _absorb(meta.get("attached_context"))
+
+        return seen
+
+    def _log_user_message(self, run: TaskRun, wrapped: str, attached_context: list[AttachedContext]) -> None:
+        """Append a `_posthog/user_message` entry to the Run's ACP log.
+
+        Records the wrapped content plus the full undeduped `attached_context` under
+        `_meta` so the persisted log is a complete per-message record that
+        `_collect_seen_entity_refs` reads on later follow-ups.
+        """
+        entry = {
+            "notification": {
+                "method": "_posthog/user_message",
+                "params": {
+                    "content": wrapped,
+                    "_meta": {"attached_context": attached_context},
+                },
+            }
+        }
+        run.append_log([entry])
 
     def _validate_attached_context(self, raw: Any) -> list[AttachedContext]:
         """Validate user-supplied attached context at the boundary.

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from django.db import transaction
 
-from rest_framework import exceptions
+from rest_framework import exceptions, status
 
 from posthog.models.user import User
 from posthog.storage import object_storage
@@ -53,6 +53,14 @@ class SandboxCancelResult(TypedDict):
     task_id: str
     run_id: str
     run_status: str
+
+
+class SandboxCommandError(exceptions.APIException):
+    """A control command could not be delivered to the sandbox agent."""
+
+    status_code = status.HTTP_502_BAD_GATEWAY
+    default_detail = "Failed to deliver the command to the sandbox agent."
+    default_code = "sandbox_command_failed"
 
 
 class MessageRoutingService(BaseSandboxService):
@@ -136,7 +144,11 @@ class MessageRoutingService(BaseSandboxService):
                 task_id=str(self.conversation.task_id), run_id=str(run.id), run_status=run.status
             )
 
-        send_cancel(run)
+        result = send_cancel(run)
+        if not result.success:
+            # Agent unreachable (no sandbox URL, blocked URL, connection error, timeout) —
+            # the run is still live, so a 200 here would falsely tell the frontend it's cancelling.
+            raise SandboxCommandError(f"Failed to cancel the run: {result.error}")
         run.refresh_from_db(fields=["status"])
 
         return SandboxCancelResult(task_id=str(self.conversation.task_id), run_id=str(run.id), run_status=run.status)

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -55,10 +55,10 @@ class TestHandleSandboxMessage(APIBaseTest):
                 }
             )
 
-        assert result["task_id"] == str(task.id)
-        assert result["run_id"] == str(run.id)
-        assert result["just_created_run"] is True
-        assert result["trace_id"] == "trace-1"
+        assert result.task_id == str(task.id)
+        assert result.run_id == str(run.id)
+        assert result.just_created_run is True
+        assert result.trace_id == "trace-1"
 
         # Task.create_and_run called with the PostHog AI origin and no repo / no PR.
         _, kwargs = m_car.call_args
@@ -140,10 +140,10 @@ class TestHandleSandboxMessage(APIBaseTest):
                 }
             )
 
-        assert result["task_id"] == str(task.id)
-        assert result["run_id"] == str(run.id)
-        assert result["just_created_run"] is False
-        assert result["run_status"] == TaskRun.Status.IN_PROGRESS
+        assert result.task_id == str(task.id)
+        assert result.run_id == str(run.id)
+        assert result.just_created_run is False
+        assert result.run_status == TaskRun.Status.IN_PROGRESS
 
         # The live workflow is signalled, no new Run created.
         m_signal.assert_called_once()
@@ -171,12 +171,12 @@ class TestHandleSandboxMessage(APIBaseTest):
         ):
             result = self._service().handle({"content": "resume please", "trace_id": "trace-3"})
 
-        assert result["task_id"] == str(task.id)
-        assert result["just_created_run"] is True
+        assert result.task_id == str(task.id)
+        assert result.just_created_run is True
 
         new_run = task.runs.order_by("-created_at").first()
         assert new_run is not None
-        assert str(new_run.id) == result["run_id"]
+        assert str(new_run.id) == result.run_id
         assert str(new_run.id) != str(run.id)
         assert new_run.state["resume_from_run_id"] == str(run.id)
         assert new_run.state["snapshot_external_id"] == "snap-9"
@@ -268,9 +268,9 @@ class TestHandleSandboxCancel(APIBaseTest):
 
         # The command is delivered; the run stays live until the agent acts on it,
         # so the response reports the current (not yet terminal) status.
-        assert result["task_id"] == str(task.id)
-        assert result["run_id"] == str(run.id)
-        assert result["run_status"] == TaskRun.Status.IN_PROGRESS
+        assert result.task_id == str(task.id)
+        assert result.run_id == str(run.id)
+        assert result.run_status == TaskRun.Status.IN_PROGRESS
         m_cancel.assert_called_once()
 
     def test_cancel_delivery_failure_raises_502(self):
@@ -289,7 +289,7 @@ class TestHandleSandboxCancel(APIBaseTest):
         task, run = self._task_with_run(TaskRun.Status.COMPLETED)
         with patch(f"{ROUTING}.send_cancel") as m_cancel:
             result = self._service().cancel()
-        assert result["run_status"] == TaskRun.Status.COMPLETED
+        assert result.run_status == TaskRun.Status.COMPLETED
         m_cancel.assert_not_called()
 
     def test_cancel_without_task_raises(self):

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -1,12 +1,7 @@
-from typing import cast
-
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from rest_framework import exceptions
-from rest_framework.parsers import JSONParser
-from rest_framework.request import Request
-from rest_framework.test import APIRequestFactory
 
 from products.posthog_ai.backend.context_wrapper import MAX_ATTACHED_ITEMS, MAX_TEXT_LENGTH
 from products.posthog_ai.backend.message_routing import MessageRoutingService
@@ -26,12 +21,8 @@ class TestHandleSandboxMessage(APIBaseTest):
             agent_runtime=Conversation.AgentRuntime.SANDBOX,
         )
 
-    def _request(self, data: dict) -> Request:
-        factory = APIRequestFactory()
-        django_request = factory.post("/sandbox/", data, format="json")
-        request = cast(Request, Request(django_request, parsers=[JSONParser()]))
-        request.user = self.user
-        return request
+    def _service(self) -> MessageRoutingService:
+        return MessageRoutingService(self.conversation, self.user)
 
     def _stub_task(self) -> tuple[Task, TaskRun]:
         task = Task.objects.create(
@@ -49,27 +40,24 @@ class TestHandleSandboxMessage(APIBaseTest):
             patch.object(Task, "create_and_run", return_value=task),
             patch(f"{ROUTING}.execute_task_processing_workflow"),
             patch.object(PromptService, "build", return_value="SYS"),
-            patch(f"{ROUTING}.report_user_action"),
         )
 
     def test_first_message_creates_run_and_persists_task(self):
         task, run = self._stub_task()
-        car, workflow, sysprompt, telemetry = self._patches(task)
-        with car as m_car, workflow as m_workflow, sysprompt, telemetry as m_telemetry:
-            request = self._request(
+        car, workflow, sysprompt = self._patches(task)
+        with car as m_car, workflow as m_workflow, sysprompt:
+            result = self._service().handle(
                 {
                     "content": "Why did checkout drop?",
                     "trace_id": "trace-1",
                     "attached_context": [{"type": "dashboard", "id": 123, "name": "Funnel"}],
                 }
             )
-            response = MessageRoutingService(request, self.conversation).handle()
 
-        assert response.status_code == 200
-        assert response.data["task_id"] == str(task.id)
-        assert response.data["run_id"] == str(run.id)
-        assert response.data["just_created_run"] is True
-        assert response.data["trace_id"] == "trace-1"
+        assert result["task_id"] == str(task.id)
+        assert result["run_id"] == str(run.id)
+        assert result["just_created_run"] is True
+        assert result["trace_id"] == "trace-1"
 
         # Task.create_and_run called with the PostHog AI origin and no repo / no PR.
         _, kwargs = m_car.call_args
@@ -95,51 +83,203 @@ class TestHandleSandboxMessage(APIBaseTest):
         assert wf_kwargs["create_pr"] is False
         # The agent needs write scopes to create insights/dashboards/notebooks.
         assert wf_kwargs["posthog_mcp_scopes"] == "full"
-        m_telemetry.assert_called_once()
 
     def test_first_message_without_context_forwards_bare_content(self):
         task, run = self._stub_task()
-        car, workflow, sysprompt, telemetry = self._patches(task)
-        with car, workflow, sysprompt, telemetry:
-            request = self._request({"content": "Hello", "trace_id": "t"})
-            MessageRoutingService(request, self.conversation).handle()
+        car, workflow, sysprompt = self._patches(task)
+        with car, workflow, sysprompt:
+            self._service().handle({"content": "Hello", "trace_id": "t"})
 
         run.refresh_from_db()
         assert run.state["pending_user_message"] == "Hello"
         assert run.state["attached_context"] == []
 
     def test_missing_content_raises(self):
-        request = self._request({"trace_id": "t"})
         with self.assertRaises(exceptions.ValidationError):
-            MessageRoutingService(request, self.conversation).handle()
+            self._service().handle({"trace_id": "t"})
 
     def test_unknown_attached_context_type_raises(self):
-        request = self._request({"content": "x", "attached_context": [{"type": "bogus", "id": 1}]})
         with self.assertRaises(exceptions.ValidationError):
-            MessageRoutingService(request, self.conversation).handle()
+            self._service().handle({"content": "x", "attached_context": [{"type": "bogus", "id": 1}]})
 
     def test_dashboard_id_must_be_integer(self):
-        request = self._request({"content": "x", "attached_context": [{"type": "dashboard", "id": "abc"}]})
         with self.assertRaises(exceptions.ValidationError):
-            MessageRoutingService(request, self.conversation).handle()
+            self._service().handle({"content": "x", "attached_context": [{"type": "dashboard", "id": "abc"}]})
 
     def test_attached_context_item_cap(self):
         items = [{"type": "insight", "id": str(i)} for i in range(MAX_ATTACHED_ITEMS + 1)]
-        request = self._request({"content": "x", "attached_context": items})
         with self.assertRaises(exceptions.ValidationError):
-            MessageRoutingService(request, self.conversation).handle()
+            self._service().handle({"content": "x", "attached_context": items})
 
     def test_text_length_cap(self):
-        request = self._request(
-            {"content": "x", "attached_context": [{"type": "text", "value": "a" * (MAX_TEXT_LENGTH + 1)}]}
-        )
         with self.assertRaises(exceptions.ValidationError):
-            MessageRoutingService(request, self.conversation).handle()
+            self._service().handle(
+                {"content": "x", "attached_context": [{"type": "text", "value": "a" * (MAX_TEXT_LENGTH + 1)}]}
+            )
 
-    def test_followup_not_yet_supported(self):
-        task, _ = self._stub_task()
+    def _attach_task(self, task: Task) -> None:
         self.conversation.task = task
         self.conversation.save(update_fields=["task"])
-        request = self._request({"content": "follow up", "trace_id": "t"})
+
+    def test_in_progress_followup_signals_existing_run(self):
+        task, run = self._stub_task()
+        run.status = TaskRun.Status.IN_PROGRESS
+        run.save(update_fields=["status"])
+        self._attach_task(task)
+
+        with (
+            patch(f"{ROUTING}.signal_task_followup_message") as m_signal,
+            patch.object(TaskRun, "append_log") as m_append,
+        ):
+            result = self._service().handle(
+                {
+                    "content": "and the mobile funnel?",
+                    "trace_id": "trace-2",
+                    "attached_context": [{"type": "insight", "id": "abc"}],
+                }
+            )
+
+        assert result["task_id"] == str(task.id)
+        assert result["run_id"] == str(run.id)
+        assert result["just_created_run"] is False
+        assert result["run_status"] == TaskRun.Status.IN_PROGRESS
+
+        # The live workflow is signalled, no new Run created.
+        m_signal.assert_called_once()
+        signal_args, _ = m_signal.call_args
+        assert signal_args[0] == run.workflow_id
+        assert "and the mobile funnel?" in signal_args[1]
+        assert task.runs.count() == 1
+
+        # The follow-up is logged with the full undeduped attached_context on _meta.
+        m_append.assert_called_once()
+        logged_entries = m_append.call_args[0][0]
+        meta = logged_entries[0]["notification"]["params"]["_meta"]
+        assert meta["attached_context"] == [{"type": "insight", "id": "abc"}]
+
+    def test_terminal_followup_creates_new_run_with_resume(self):
+        task, run = self._stub_task()
+        run.status = TaskRun.Status.COMPLETED
+        run.state = {**(run.state or {}), "snapshot_external_id": "snap-9"}
+        run.save(update_fields=["status", "state"])
+        self._attach_task(task)
+
+        with (
+            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch.object(PromptService, "build", return_value="SYS"),
+        ):
+            result = self._service().handle({"content": "resume please", "trace_id": "trace-3"})
+
+        assert result["task_id"] == str(task.id)
+        assert result["just_created_run"] is True
+
+        new_run = task.runs.order_by("-created_at").first()
+        assert new_run is not None
+        assert str(new_run.id) == result["run_id"]
+        assert str(new_run.id) != str(run.id)
+        assert new_run.state["resume_from_run_id"] == str(run.id)
+        assert new_run.state["snapshot_external_id"] == "snap-9"
+        assert new_run.state["systemPrompt"] == "SYS"
+        assert new_run.state["initial_permission_mode"] == "default"
+        assert "resume please" in new_run.state["pending_user_message"]
+
+        m_workflow.assert_called_once()
+        assert m_workflow.call_args.kwargs["run_id"] == str(new_run.id)
+        # The resumed agent keeps the same write scopes as the first message.
+        assert m_workflow.call_args.kwargs["posthog_mcp_scopes"] == "full"
+
+    def test_dedupes_entities_named_in_prior_run_state(self):
+        task, run = self._stub_task()
+        run.status = TaskRun.Status.COMPLETED
+        run.state = {**(run.state or {}), "attached_context": [{"type": "dashboard", "id": 7}]}
+        run.save(update_fields=["status", "state"])
+        self._attach_task(task)
+
+        with (
+            patch(f"{ROUTING}.execute_task_processing_workflow"),
+            patch.object(PromptService, "build", return_value="SYS"),
+            patch(f"{ROUTING}.object_storage.read", return_value=""),
+        ):
+            self._service().handle(
+                {
+                    "content": "again",
+                    "attached_context": [{"type": "dashboard", "id": 7}, {"type": "insight", "id": "new"}],
+                }
+            )
+
+        new_run = task.runs.order_by("-created_at").first()
+        assert new_run is not None
+        wrapped = new_run.state["pending_user_message"]
+        # The already-seen dashboard is dropped from the rendered block; the new insight stays.
+        assert "Dashboard #7" not in wrapped
+        assert "Insight #new" in wrapped
+        # The structured record keeps the full undeduped list.
+        assert new_run.state["attached_context"] == [
+            {"type": "dashboard", "id": 7},
+            {"type": "insight", "id": "new"},
+        ]
+
+    def test_no_current_run_raises(self):
+        task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=self.user,
+        )
+        self._attach_task(task)
         with self.assertRaises(exceptions.ValidationError):
-            MessageRoutingService(request, self.conversation).handle()
+            self._service().handle({"content": "x"})
+
+
+class TestHandleSandboxCancel(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            agent_runtime=Conversation.AgentRuntime.SANDBOX,
+        )
+
+    def _service(self) -> MessageRoutingService:
+        return MessageRoutingService(self.conversation, self.user)
+
+    def _task_with_run(self, status: str) -> tuple[Task, TaskRun]:
+        task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=self.user,
+        )
+        run = task.create_run(mode="interactive")
+        run.status = status
+        run.save(update_fields=["status"])
+        self.conversation.task = task
+        self.conversation.save(update_fields=["task"])
+        return task, run
+
+    def test_cancel_delegates_to_command_path(self):
+        task, run = self._task_with_run(TaskRun.Status.IN_PROGRESS)
+
+        def _mark_cancelled(target_run):
+            TaskRun.objects.filter(id=target_run.id).update(status=TaskRun.Status.CANCELLED)
+
+        with patch(f"{ROUTING}.send_cancel", side_effect=_mark_cancelled) as m_cancel:
+            result = self._service().cancel()
+
+        assert result["task_id"] == str(task.id)
+        assert result["run_id"] == str(run.id)
+        assert result["run_status"] == TaskRun.Status.CANCELLED
+        m_cancel.assert_called_once()
+
+    def test_cancel_terminal_run_is_idempotent(self):
+        task, run = self._task_with_run(TaskRun.Status.COMPLETED)
+        with patch(f"{ROUTING}.send_cancel") as m_cancel:
+            result = self._service().cancel()
+        assert result["run_status"] == TaskRun.Status.COMPLETED
+        m_cancel.assert_not_called()
+
+    def test_cancel_without_task_raises(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self._service().cancel()

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -4,10 +4,11 @@ from unittest.mock import patch
 from rest_framework import exceptions
 
 from products.posthog_ai.backend.context_wrapper import MAX_ATTACHED_ITEMS, MAX_TEXT_LENGTH
-from products.posthog_ai.backend.message_routing import MessageRoutingService
+from products.posthog_ai.backend.message_routing import MessageRoutingService, SandboxCommandError
 from products.posthog_ai.backend.models.assistant import Conversation
 from products.posthog_ai.backend.system_prompt import PromptService
 from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.services.agent_command import CommandResult
 
 ROUTING = "products.posthog_ai.backend.message_routing"
 
@@ -262,16 +263,27 @@ class TestHandleSandboxCancel(APIBaseTest):
     def test_cancel_delegates_to_command_path(self):
         task, run = self._task_with_run(TaskRun.Status.IN_PROGRESS)
 
-        def _mark_cancelled(target_run):
-            TaskRun.objects.filter(id=target_run.id).update(status=TaskRun.Status.CANCELLED)
-
-        with patch(f"{ROUTING}.send_cancel", side_effect=_mark_cancelled) as m_cancel:
+        with patch(f"{ROUTING}.send_cancel", return_value=CommandResult(success=True, status_code=200)) as m_cancel:
             result = self._service().cancel()
 
+        # The command is delivered; the run stays live until the agent acts on it,
+        # so the response reports the current (not yet terminal) status.
         assert result["task_id"] == str(task.id)
         assert result["run_id"] == str(run.id)
-        assert result["run_status"] == TaskRun.Status.CANCELLED
+        assert result["run_status"] == TaskRun.Status.IN_PROGRESS
         m_cancel.assert_called_once()
+
+    def test_cancel_delivery_failure_raises_502(self):
+        self._task_with_run(TaskRun.Status.IN_PROGRESS)
+
+        with patch(
+            f"{ROUTING}.send_cancel",
+            return_value=CommandResult(success=False, status_code=0, error="connection refused"),
+        ):
+            with self.assertRaises(SandboxCommandError) as ctx:
+                self._service().cancel()
+
+        assert ctx.exception.status_code == 502
 
     def test_cancel_terminal_run_is_idempotent(self):
         task, run = self._task_with_run(TaskRun.Status.COMPLETED)

--- a/products/posthog_ai/backend/wire_types.py
+++ b/products/posthog_ai/backend/wire_types.py
@@ -71,6 +71,8 @@ class UserMessageParams(TypedDict):
     agent-server echoed it into the log (plain string or ACP content blocks)."""
 
     content: NotRequired[str | list[dict[str, Any]]]
+    # Carries `attached_context` — the full undeduped context recorded with the message.
+    _meta: NotRequired[dict[str, Any]]
 
 
 def is_user_message_params(params: object, method: str | None) -> TypeGuard[UserMessageParams]:

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39105,6 +39105,53 @@ export namespace Schemas {
       fields: S3PresignedPostFields;
     }
 
+    /**
+     * * `action` - action
+     * * `dashboard` - dashboard
+     * * `error_tracking_issue` - error_tracking_issue
+     * * `evaluation` - evaluation
+     * * `event` - event
+     * * `insight` - insight
+     * * `notebook` - notebook
+     * * `text` - text
+     */
+    export type SandboxAttachedContextItemTypeEnum = typeof SandboxAttachedContextItemTypeEnum[keyof typeof SandboxAttachedContextItemTypeEnum];
+
+
+    export const SandboxAttachedContextItemTypeEnum = {
+      Action: 'action',
+      Dashboard: 'dashboard',
+      ErrorTrackingIssue: 'error_tracking_issue',
+      Evaluation: 'evaluation',
+      Event: 'event',
+      Insight: 'insight',
+      Notebook: 'notebook',
+      Text: 'text',
+    } as const;
+
+    /**
+     * One typed attachment carried by a sandbox message.
+     */
+    export interface SandboxAttachedContextItem {
+      /** Attachment kind. Entity types carry `id` (+ optional `name`); `text` carries `value`.
+       *
+       * * `action` - action
+       * * `dashboard` - dashboard
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `evaluation` - evaluation
+       * * `event` - event
+       * * `insight` - insight
+       * * `notebook` - notebook
+       * * `text` - text */
+      type: SandboxAttachedContextItemTypeEnum;
+      /** Entity identifier — integer for `dashboard`/`action`, string short_id/UUID otherwise. Absent for `text`. */
+      id?: unknown;
+      /** Optional human-readable label rendered in the context block. */
+      name?: string;
+      /** Free-text content. Only for `text` attachments. */
+      value?: string;
+    }
+
     export interface SandboxEnvironment {
       readonly id: string;
       /** @maxLength 255 */
@@ -39135,6 +39182,40 @@ export namespace Schemas {
       readonly created_by: UserBasic;
       readonly created_at: string;
       readonly updated_at: string;
+    }
+
+    /**
+     * Request body for the non-streaming `POST /conversations/{id}/sandbox/` route.
+     */
+    export interface SandboxMessage {
+      /**
+         * The user's message text.
+         * @maxLength 40000
+         */
+      content: string;
+      /** Client-generated trace id correlated with the resulting Run's SSE stream. */
+      trace_id?: string;
+      /** Typed PostHog entities (and free text) attached to this message. */
+      attached_context?: SandboxAttachedContextItem[];
+    }
+
+    /**
+     * Response for `POST /conversations/{id}/sandbox/` — the IDs the frontend opens SSE against.
+     */
+    export interface SandboxMessageResponse {
+      /** The products/tasks Task backing the conversation. */
+      task_id: string;
+      /** The Run the frontend opens SSE against. */
+      run_id: string;
+      /**
+         * Echo of the request trace id, if provided.
+         * @nullable
+         */
+      trace_id: string | null;
+      /** Current status of the targeted Run (e.g. `queued`, `in_progress`). */
+      run_status: string;
+      /** True when a new Run was created (first message or terminal resume); false for an in-progress follow-up. */
+      just_created_run: boolean;
     }
 
     export interface SavedHeatmapListResponse {


### PR DESCRIPTION
## Problem

PR **I2.5** of the PostHog AI → sandbox-agent migration (`docs/internal/posthog-ai-migration/00_OVERVIEW.md` § 10). I1.2 implemented only the first-message branch of `handle_sandbox_message`. Sustained conversations need follow-up routing — signalling an in-progress Run, resuming after a terminal Run, and cancelling — plus the additive `POST /sandbox/` route that the frontend already calls.

> Stacked on **I1.2** (`feat/phai-i1.2-backend-foundations`). Auto-retargets to `feat/posthog-ai-sandboxes` once I1.2 merges.

## Changes

Per `02_CORE` §§ 3, 4 (follow-up), 5.2, 5.3, 5.4:

- **In-progress follow-up:** collects prior seen `(type, id)` refs across the resume chain, dedupes + wraps, calls `signal_task_followup_message(run.workflow_id, …)` in-process. Returns existing IDs, `just_created_run: false`.
- **Terminal-then-resume:** `task.create_run(extra_state={resume_from_run_id, …})` + `execute_task_processing_workflow(...)` in-process. Returns same `task_id` + new `run_id`, `just_created_run: true`.
- **Cancel:** `POST /conversations/{id}/cancel/` sandbox branch delegates in-process to the tasks command path (`method=cancel`).
- **`POST /sandbox/` route registered** as an additive DRF `@action` (with `@extend_schema`), gated to `agent_runtime === 'sandbox'`, delegating to `handle_sandbox_message` — this closes the endpoint gap so I1.3's `api.conversations.sandbox()` resolves end-to-end. LangGraph `/stream/` untouched.

## How did you test this code?

Automated only (I'm an agent):

- `ruff` clean; `makemigrations --check` no drift.
- Tests: in-progress follow-up signals; terminal follow-up creates a new Run with `resume_from_run_id`; cancel delegates; the `/sandbox/` route routes to the handler. LangGraph conversation suite still passes.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) via a multi-agent workflow (implement → verify) in an isolated worktree stacked on I1.2. `artifact_ids` to `signal_task_followup_message` is `[]` (attached-context entities ride in the prompt text, not as task artifacts). Cancel uses the in-process `agent_command.send_cancel` routine the command `@action` funnels into, rather than a synthetic DRF request. The terminal-resume race guard (`SELECT FOR UPDATE`) is added by I3.8 and wired into this branch's resume path during integration. Requires human review; not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
