### PR TITLE
fix(data-deletion): relaunch retried requests, lock approved edits

### DIFF
--- a/posthog/admin/admins/data_deletion_request_admin.py
+++ b/posthog/admin/admins/data_deletion_request_admin.py
@@ -39,6 +39,31 @@ CRITERIA_FIELDS = {
 }
 CLICKHOUSE_TEAM_GROUP = "ClickHouse Team"
 
+# Requests can only be edited while draft or pending. Once approved (or later), the
+# criteria are locked — operators must explicitly "revert to draft" to change them.
+EDITABLE_STATUSES = {RequestStatus.DRAFT, RequestStatus.PENDING}
+
+# The non-readonly fields rendered in the fieldsets. When a request is locked these are
+# added to readonly_fields so the whole form becomes read-only.
+EDITABLE_FIELDS = (
+    "team_id",
+    "request_type",
+    "start_time",
+    "end_time",
+    "events",
+    "delete_all_events",
+    "properties",
+    "person_properties",
+    "hogql_predicate",
+    "notes",
+    "requires_approval",
+    "person_uuids",
+    "person_distinct_ids",
+    "person_drop_profiles",
+    "person_drop_events",
+    "person_drop_recordings",
+)
+
 
 # ---------------------------------------------------------------------------
 # Custom widget + field for ArrayField editing
@@ -517,6 +542,16 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
             rendered,
         )
 
+    def _is_locked(self, obj: DataDeletionRequest | None) -> bool:
+        """Approved and later requests are locked — only draft/pending are editable."""
+        return obj is not None and obj.pk is not None and obj.status not in EDITABLE_STATUSES
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly = super().get_readonly_fields(request, obj)
+        if self._is_locked(obj):
+            return tuple(readonly) + EDITABLE_FIELDS
+        return readonly
+
     def save_model(self, request, obj, form, change):
         if not change:
             obj.created_by = request.user
@@ -594,6 +629,24 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
                 obj.status == RequestStatus.FAILED and request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists()
             )
             extra_context["retry_url"] = reverse("admin:posthog_datadeletionrequest_retry", args=[obj.pk])
+
+            # ClickHouse stats are calculated from this page (works for any status).
+            extra_context["fetch_stats_url"] = reverse("admin:posthog_datadeletionrequest_fetch_stats", args=[obj.pk])
+            extra_context["preview_stats_url"] = reverse(
+                "admin:posthog_datadeletionrequest_preview_stats", args=[obj.pk]
+            )
+            extra_context["is_clickhouse_team"] = request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists()
+            preview_stats = request.session.pop("data_deletion_preview_stats", None)
+            if preview_stats and str(preview_stats.get("obj_pk")) != str(obj.pk):
+                # Belongs to a different request — drop it rather than mislead the operator.
+                preview_stats = None
+            extra_context["preview_stats"] = preview_stats
+
+            if self._is_locked(obj):
+                # Locked requests have no editable fields — hide the misleading Save row.
+                extra_context["show_save"] = False
+                extra_context["show_save_and_continue"] = False
+                extra_context["show_save_and_add_another"] = False
         return super().change_view(request, object_id, form_url, extra_context)
 
     def get_urls(self):
@@ -686,12 +739,6 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
             messages.success(request, "Request submitted and is now pending.")
             return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
-        is_clickhouse_team = request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists()
-        preview_stats = request.session.pop("data_deletion_preview_stats", None)
-        if preview_stats and str(preview_stats.get("obj_pk")) != str(obj.pk):
-            # Belongs to a different request — drop it rather than mislead the operator.
-            preview_stats = None
-
         context = {
             **self.admin_site.each_context(request),
             "obj": obj,
@@ -700,10 +747,6 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
             "missing_person_drop_flag": missing_person_drop_flag,
             "is_person_removal": obj.request_type == RequestType.PERSON_REMOVAL,
             "can_submit": can_submit,
-            "fetch_stats_url": reverse("admin:posthog_datadeletionrequest_fetch_stats", args=[obj.pk]),
-            "preview_stats_url": reverse("admin:posthog_datadeletionrequest_preview_stats", args=[obj.pk]),
-            "is_clickhouse_team": is_clickhouse_team,
-            "preview_stats": preview_stats,
             "opts": self.model._meta,
             "title": f"Submit deletion request {obj.pk}",
         }
@@ -715,7 +758,7 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
             return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_changelist"))
 
         if request.method != "POST":
-            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_submit", args=[obj.pk]))
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
         if obj.request_type == RequestType.PERSON_REMOVAL:
             # No ClickHouse query yet for person_removal — just count selectors.
@@ -724,7 +767,7 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
             obj.save(update_fields=["count", "stats_calculated_at", "updated_at"])
             self.log_change(request, obj, "Counted person_removal selectors.")
             messages.success(request, f"Selector count: {obj.count} person target(s).")
-            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_submit", args=[obj.pk]))
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
         try:
             stats = fetch_deletion_stats(obj, user_id=request.user.id)
@@ -752,14 +795,14 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
         except Exception as e:
             messages.error(request, f"Failed to fetch stats: {e}")
 
-        return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_submit", args=[obj.pk]))
+        return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
     def preview_stats_view(self, request, object_id):
         """ClickHouse-Team-only ephemeral stats run.
 
         Runs the same ClickHouse queries as ``fetch_stats_view`` but does **not**
         persist anything to the model — useful while iterating on a predicate.
-        Results are stashed in the session and rendered on the next submit page
+        Results are stashed in the session and rendered on the next change page
         render under a separate "Preview (not saved)" block.
         """
         obj = self.get_object(request, object_id)
@@ -768,10 +811,10 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
 
         if not request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists():
             messages.error(request, "Only ClickHouse Team members can preview stats.")
-            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_submit", args=[obj.pk]))
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
         if request.method != "POST":
-            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_submit", args=[obj.pk]))
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
         if obj.request_type == RequestType.PERSON_REMOVAL:
             count = len(obj.person_uuids) + len(obj.person_distinct_ids)
@@ -781,7 +824,7 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
                 "calculated_at": timezone.now().isoformat(),
             }
             messages.info(request, f"Preview selector count: {count} person target(s). Not saved.")
-            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_submit", args=[obj.pk]))
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
         try:
             stats = fetch_deletion_stats(obj, user_id=request.user.id)
@@ -802,7 +845,7 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
         except Exception as e:
             messages.error(request, f"Failed to preview stats: {e}")
 
-        return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_submit", args=[obj.pk]))
+        return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
     def approve_view(self, request, object_id):
         obj = self.get_object(request, object_id)

--- a/posthog/admin/test_data_deletion_request_admin.py
+++ b/posthog/admin/test_data_deletion_request_admin.py
@@ -11,7 +11,7 @@ from django.test import RequestFactory, override_settings
 
 from parameterized import parameterized
 
-from posthog.admin.admins.data_deletion_request_admin import DataDeletionRequestAdmin
+from posthog.admin.admins.data_deletion_request_admin import EDITABLE_FIELDS, DataDeletionRequestAdmin
 from posthog.models.data_deletion_request import DataDeletionRequest, ExecutionMode, RequestStatus, RequestType
 
 
@@ -504,3 +504,206 @@ class TestDataDeletionRequestModelValidation(BaseTest):
             msg_dict = exc.message_dict if hasattr(exc, "message_dict") else {}
             self.assertNotIn("properties", msg_dict)
             self.assertNotIn("person_properties", msg_dict)
+
+
+@override_settings(STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}})
+class TestDataDeletionRequestAdminEditLock(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.factory = RequestFactory()
+        self.admin = DataDeletionRequestAdmin(DataDeletionRequest, AdminSite())
+
+    def _make_request(self, status: str):
+        return DataDeletionRequest.objects.create(
+            team_id=self.team.id,
+            request_type=RequestType.EVENT_REMOVAL,
+            events=["$pageview"],
+            start_time=datetime.now() - timedelta(days=7),
+            end_time=datetime.now(),
+            status=status,
+        )
+
+    def _readonly_fields(self, obj):
+        http_request = self.factory.get("/admin/posthog/datadeletionrequest/")
+        http_request.user = self.user
+        return self.admin.get_readonly_fields(http_request, obj)
+
+    @parameterized.expand(
+        [
+            ("approved", RequestStatus.APPROVED),
+            ("in_progress", RequestStatus.IN_PROGRESS),
+            ("queued", RequestStatus.QUEUED),
+            ("completed", RequestStatus.COMPLETED),
+            ("failed", RequestStatus.FAILED),
+        ]
+    )
+    def test_locked_statuses_make_all_fields_readonly(self, _name, status):
+        obj = self._make_request(status)
+        readonly = self._readonly_fields(obj)
+        for field in EDITABLE_FIELDS:
+            self.assertIn(field, readonly)
+
+    @parameterized.expand(
+        [
+            ("draft", RequestStatus.DRAFT),
+            ("pending", RequestStatus.PENDING),
+        ]
+    )
+    def test_editable_statuses_keep_fields_editable(self, _name, status):
+        obj = self._make_request(status)
+        readonly = self._readonly_fields(obj)
+        for field in EDITABLE_FIELDS:
+            self.assertNotIn(field, readonly)
+
+    def test_add_view_fields_editable(self):
+        readonly = self._readonly_fields(None)
+        for field in EDITABLE_FIELDS:
+            self.assertNotIn(field, readonly)
+
+
+@override_settings(STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}})
+class TestDataDeletionRequestAdminChangeViewStatsAndLock(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.factory = RequestFactory()
+        self.admin = DataDeletionRequestAdmin(DataDeletionRequest, AdminSite())
+
+    def _make_request(self, status: str = RequestStatus.DRAFT):
+        return DataDeletionRequest.objects.create(
+            team_id=self.team.id,
+            request_type=RequestType.EVENT_REMOVAL,
+            events=["$pageview"],
+            start_time=datetime.now() - timedelta(days=7),
+            end_time=datetime.now(),
+            status=status,
+        )
+
+    def _change_context(
+        self, request: DataDeletionRequest, in_clickhouse_team: bool = False, session: dict | None = None
+    ):
+        if in_clickhouse_team:
+            clickhouse_team, _ = Group.objects.get_or_create(name="ClickHouse Team")
+            self.user.groups.add(clickhouse_team)
+        else:
+            self.user.groups.clear()
+
+        http_request = self.factory.get(f"/admin/posthog/datadeletionrequest/{request.pk}/change/")
+        http_request.user = self.user
+        _attach_messages(http_request)
+        if session:
+            http_request.session.update(session)
+
+        captured: dict = {}
+
+        def _capture_super(self_admin, http_req, object_id, form_url, extra_context):
+            captured.update(extra_context)
+            from django.http import HttpResponse
+
+            return HttpResponse(status=200)
+
+        with (
+            patch("posthog.admin.admins.data_deletion_request_admin.reverse", side_effect=_fake_reverse),
+            patch("django.contrib.admin.ModelAdmin.change_view", _capture_super),
+        ):
+            self.admin.change_view(http_request, str(request.pk))
+        return captured
+
+    def test_change_view_exposes_stats_urls(self):
+        request = self._make_request()
+        ctx = self._change_context(request)
+        self.assertIn("fetch_stats_url", ctx)
+        self.assertIn("preview_stats_url", ctx)
+
+    def test_change_view_is_clickhouse_team_flag(self):
+        request = self._make_request()
+        self.assertTrue(self._change_context(request, in_clickhouse_team=True)["is_clickhouse_team"])
+        self.assertFalse(self._change_context(request, in_clickhouse_team=False)["is_clickhouse_team"])
+
+    def test_change_view_pops_matching_preview_stats(self):
+        request = self._make_request()
+        preview = {"obj_pk": str(request.pk), "count": 42, "calculated_at": "2025-01-15T12:00:00"}
+        ctx = self._change_context(request, session={"data_deletion_preview_stats": preview})
+        self.assertEqual(ctx["preview_stats"], preview)
+
+    def test_change_view_drops_mismatched_preview_stats(self):
+        request = self._make_request()
+        preview = {"obj_pk": "999999", "count": 42, "calculated_at": "2025-01-15T12:00:00"}
+        ctx = self._change_context(request, session={"data_deletion_preview_stats": preview})
+        self.assertIsNone(ctx["preview_stats"])
+
+    @parameterized.expand(
+        [
+            ("approved", RequestStatus.APPROVED),
+            ("in_progress", RequestStatus.IN_PROGRESS),
+            ("queued", RequestStatus.QUEUED),
+            ("completed", RequestStatus.COMPLETED),
+            ("failed", RequestStatus.FAILED),
+        ]
+    )
+    def test_change_view_hides_save_for_locked(self, _name, status):
+        ctx = self._change_context(self._make_request(status))
+        self.assertFalse(ctx.get("show_save", True))
+
+    @parameterized.expand(
+        [
+            ("draft", RequestStatus.DRAFT),
+            ("pending", RequestStatus.PENDING),
+        ]
+    )
+    def test_change_view_shows_save_for_editable(self, _name, status):
+        ctx = self._change_context(self._make_request(status))
+        self.assertTrue(ctx.get("show_save", True))
+
+
+@override_settings(STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}})
+class TestDataDeletionRequestAdminStatsViewRedirects(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        clickhouse_team, _ = Group.objects.get_or_create(name="ClickHouse Team")
+        self.user.groups.add(clickhouse_team)
+        self.factory = RequestFactory()
+        self.admin = DataDeletionRequestAdmin(DataDeletionRequest, AdminSite())
+
+    def _person_request(self):
+        return DataDeletionRequest.objects.create(
+            team_id=self.team.id,
+            request_type=RequestType.PERSON_REMOVAL,
+            person_uuids=["00000000-0000-0000-0000-000000000001"],
+            person_drop_profiles=True,
+            status=RequestStatus.APPROVED,
+            approved_at=datetime.now(),
+        )
+
+    def _call(self, view, request: DataDeletionRequest, user=None):
+        http_request = self.factory.post(f"/admin/posthog/datadeletionrequest/{request.pk}/x/")
+        http_request.user = user or self.user
+        _attach_messages(http_request)
+        with patch("posthog.admin.admins.data_deletion_request_admin.reverse", side_effect=_fake_reverse):
+            return view(http_request, str(request.pk))
+
+    def test_fetch_stats_redirects_to_change_page(self):
+        request = self._person_request()
+        response = self._call(self.admin.fetch_stats_view, request)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("posthog_datadeletionrequest_change", response.url)
+        request.refresh_from_db()
+        self.assertIsNotNone(request.stats_calculated_at)
+
+    def test_preview_stats_redirects_to_change_page(self):
+        request = self._person_request()
+        response = self._call(self.admin.preview_stats_view, request)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("posthog_datadeletionrequest_change", response.url)
+
+    def test_preview_stats_rejects_non_clickhouse_team(self):
+        request = self._person_request()
+        self.user.groups.clear()
+        response = self._call(self.admin.preview_stats_view, request)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("posthog_datadeletionrequest_change", response.url)

--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -1130,7 +1130,11 @@ def data_deletion_request_pickup_sensor(context: dagster.SensorEvaluationContext
     )
 
     return dagster.RunRequest(
-        run_key=str(next_request.pk),
+        # Include attempt_count so retries / re-approvals of the same request get a
+        # distinct run_key. Dagster dedupes by run_key, so a bare pk would make every
+        # relaunch after the first a silent no-op. attempt_count is bumped exactly once
+        # per APPROVED → IN_PROGRESS transition (see _mark_in_progress).
+        run_key=f"{next_request.pk}:{next_request.attempt_count}",
         job_name=job.name,
         run_config={
             "ops": {

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -1675,4 +1675,32 @@ def test_pickup_sensor_routes_person_removal_request():
     assert isinstance(result, dagster.RunRequest)
     assert result.job_name == "data_deletion_request_person_removal"
     assert "load_person_removal_request" in result.run_config["ops"]
-    assert str(request.pk) == result.run_key
+    assert result.run_key == f"{request.pk}:{request.attempt_count}"
+
+
+@pytest.mark.django_db
+def test_pickup_sensor_run_key_changes_across_attempts():
+    # A re-approved/retried request keeps its pk but has a higher attempt_count, so
+    # the run_key must differ — otherwise Dagster dedupes and silently never relaunches.
+    request = DataDeletionRequest.objects.create(
+        team_id=TEAM_ID,
+        request_type=RequestType.EVENT_REMOVAL,
+        events=["$pageview"],
+        start_time=datetime.now() - timedelta(days=7),
+        end_time=datetime.now(),
+        status=RequestStatus.APPROVED,
+        approved_at=datetime.now(),
+        attempt_count=0,
+    )
+    instance = dagster.DagsterInstance.ephemeral()
+
+    first = data_deletion_request_pickup_sensor(dagster.build_sensor_context(instance=instance))
+    assert isinstance(first, dagster.RunRequest)
+    assert first.run_key == f"{request.pk}:0"
+
+    # Simulate the load op having run once, then a retry re-approving the same request.
+    DataDeletionRequest.objects.filter(pk=request.pk).update(attempt_count=1)
+    second = data_deletion_request_pickup_sensor(dagster.build_sensor_context(instance=instance))
+    assert isinstance(second, dagster.RunRequest)
+    assert second.run_key == f"{request.pk}:1"
+    assert second.run_key != first.run_key

--- a/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
+++ b/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
@@ -61,7 +61,10 @@
     {% endif %}
 
     {# Stats are calculated from this page (works for any status). These buttons use
-       formaction= to post the surrounding admin <form> to the stats views. #}
+       formaction= to post the surrounding admin <form> to the stats views.
+       Guarded on `original` — the stats URLs only exist for a saved object, and on the
+       add view an empty formaction would post back and create a record. #}
+    {% if original %}
     <fieldset style="margin: 20px 0; padding: 16px; border: 1px solid #ccc; border-radius: 4px;">
         <h2>ClickHouse stats</h2>
         {% if original.stats_calculated_at %}
@@ -84,6 +87,7 @@
             {% endif %}
         </div>
     </fieldset>
+    {% endif %}
 
     {% if preview_stats %}
     <fieldset style="margin: 20px 0; padding: 16px; border: 1px dashed #0c5460; border-radius: 4px; background: #d1ecf1; color: #0c5460;">

--- a/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
+++ b/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
@@ -60,6 +60,48 @@
     </fieldset>
     {% endif %}
 
+    {# Stats are calculated from this page (works for any status). These buttons use
+       formaction= to post the surrounding admin <form> to the stats views. #}
+    <fieldset style="margin: 20px 0; padding: 16px; border: 1px solid #ccc; border-radius: 4px;">
+        <h2>ClickHouse stats</h2>
+        {% if original.stats_calculated_at %}
+            <table style="border-collapse: collapse; width: 100%;">
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Matching events</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ original.count|default:"0" }}</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Min timestamp</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ original.min_timestamp|default:"—" }}</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Max timestamp</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ original.max_timestamp|default:"—" }}</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Part count</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ original.part_count|default:"0" }}</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Parts size</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ original.parts_size|default:"0" }} bytes</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Total rows in affected parts</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ original.parts_row_count|default:"0" }}</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px;">Calculated at</th><td style="padding: 6px 8px;">{{ original.stats_calculated_at }}</td></tr>
+            </table>
+        {% else %}
+            <p style="color: #666; margin: 4px 0;">No stats have been fetched yet.</p>
+        {% endif %}
+        <div style="margin-top: 12px; display: flex; gap: 8px; align-items: center;">
+            <button type="submit" formaction="{{ fetch_stats_url }}" formmethod="post" formnovalidate class="button" style="padding: 8px 14px;">{% if original.stats_calculated_at %}Refresh stats{% else %}Fetch stats{% endif %}</button>
+            {% if is_clickhouse_team %}
+                <button type="submit" formaction="{{ preview_stats_url }}" formmethod="post" formnovalidate class="button" style="padding: 8px 14px;">Show stats now (don't save)</button>
+            {% endif %}
+        </div>
+    </fieldset>
+
+    {% if preview_stats %}
+    <fieldset style="margin: 20px 0; padding: 16px; border: 1px dashed #0c5460; border-radius: 4px; background: #d1ecf1; color: #0c5460;">
+        <h2 style="color: #0c5460;">Preview (not saved)</h2>
+        <table style="border-collapse: collapse; width: 100%;">
+            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Matching events</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.count|default:"0" }}</td></tr>
+            {% if preview_stats.min_timestamp is not None %}
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Min timestamp</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.min_timestamp|default:"—" }}</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Max timestamp</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.max_timestamp|default:"—" }}</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Part count</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.part_count|default:"0" }}</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Parts size</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.parts_size|default:"0" }} bytes</td></tr>
+                <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Total rows in affected parts</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.parts_row_count|default:"0" }}</td></tr>
+            {% endif %}
+            <tr><th style="text-align: left; padding: 6px 8px;">Previewed at</th><td style="padding: 6px 8px;">{{ preview_stats.calculated_at }}</td></tr>
+        </table>
+    </fieldset>
+    {% endif %}
+
     {% if is_draft %}
     <div class="submit-row" style="margin-top: 20px; padding: 20px; border-radius: 5px; border: 1px solid #417690; display: flex; align-items: center; gap: 10px;">
         <div class="info">This request is a <strong>draft</strong>. When ready, submit it for review.</div>

--- a/posthog/templates/admin/posthog/datadeletionrequest/submit.html
+++ b/posthog/templates/admin/posthog/datadeletionrequest/submit.html
@@ -78,50 +78,6 @@
     <tr><th style="text-align: left; padding: 8px;">Requires approval</th><td style="padding: 8px;">{{ obj.requires_approval|yesno:"Yes,No" }}</td></tr>
 </table>
 
-<fieldset style="margin: 20px 0; padding: 16px; border: 1px solid #ccc; border-radius: 4px;">
-    <legend style="font-weight: bold; padding: 0 8px;">ClickHouse stats</legend>
-    {% if obj.stats_calculated_at %}
-        <table style="border-collapse: collapse; width: 100%;">
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Matching events</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ obj.count|default:"0" }}</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Min timestamp</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ obj.min_timestamp|default:"—" }}</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Max timestamp</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ obj.max_timestamp|default:"—" }}</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Part count</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ obj.part_count|default:"0" }}</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Parts size</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ obj.parts_size|default:"0" }} bytes</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #eee;">Total rows in affected parts</th><td style="padding: 6px 8px; border-bottom: 1px solid #eee;">{{ obj.parts_row_count|default:"0" }}</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px;">Calculated at</th><td style="padding: 6px 8px;">{{ obj.stats_calculated_at }}</td></tr>
-        </table>
-    {% else %}
-        <p style="color: #666; margin: 4px 0;">No stats have been fetched yet.</p>
-    {% endif %}
-    <form method="post" action="{{ fetch_stats_url }}" style="margin-top: 12px; display: inline-block;">
-        {% csrf_token %}
-        <input type="submit" value="{% if obj.stats_calculated_at %}Refresh stats{% else %}Fetch stats{% endif %}" style="padding: 8px 14px;" />
-    </form>
-    {% if is_clickhouse_team %}
-        <form method="post" action="{{ preview_stats_url }}" style="margin-top: 12px; display: inline-block; margin-left: 8px;">
-            {% csrf_token %}
-            <input type="submit" value="Show stats now (don't save)" style="padding: 8px 14px;" />
-        </form>
-    {% endif %}
-</fieldset>
-
-{% if preview_stats %}
-<fieldset style="margin: 20px 0; padding: 16px; border: 1px dashed #0c5460; border-radius: 4px; background: #d1ecf1; color: #0c5460;">
-    <legend style="font-weight: bold; padding: 0 8px;">Preview (not saved)</legend>
-    <table style="border-collapse: collapse; width: 100%;">
-        <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Matching events</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.count|default:"0" }}</td></tr>
-        {% if preview_stats.min_timestamp is not None %}
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Min timestamp</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.min_timestamp|default:"—" }}</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Max timestamp</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.max_timestamp|default:"—" }}</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Part count</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.part_count|default:"0" }}</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Parts size</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.parts_size|default:"0" }} bytes</td></tr>
-            <tr><th style="text-align: left; padding: 6px 8px; border-bottom: 1px solid #bee5eb;">Total rows in affected parts</th><td style="padding: 6px 8px; border-bottom: 1px solid #bee5eb;">{{ preview_stats.parts_row_count|default:"0" }}</td></tr>
-        {% endif %}
-        <tr><th style="text-align: left; padding: 6px 8px;">Previewed at</th><td style="padding: 6px 8px;">{{ preview_stats.calculated_at }}</td></tr>
-    </table>
-</fieldset>
-{% endif %}
-
 {% if missing_properties %}
 <div style="margin: 16px 0; padding: 12px 16px; border: 1px solid #dc3545; border-radius: 4px; background: #f8d7da; color: #721c24;">
     <strong>Cannot submit:</strong> This is a property removal request but no properties are specified. Go back and add properties before submitting.

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1015,7 +1015,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1031,7 +1031,6 @@
         "summary": "Delete dashboard tile",
         "title": "Delete dashboard tile",
         "required_scopes": ["dashboard:write"],
-        "new_mcp": true,
         "annotations": {
             "destructiveHint": true,
             "idempotentHint": false,


### PR DESCRIPTION
## Problem

The `data_deletion_request_pickup_sensor` Dagster sensor sometimes never picked up `DataDeletionRequest`s that were in `approved` status.

The root cause: the sensor emitted `RunRequest(run_key=str(request.pk))`. Dagster deduplicates run requests by `run_key`, so once a request's pk has launched a run, any *later* launch for the same pk is silently dropped. This happens on the retry path (`FAILED → APPROVED` via the admin "Retry" button) and on any revert-to-draft → re-submit → re-approve cycle after a request has already run once — the request stays `approved` forever and the sensor never relaunches it, despite the retry action telling the operator it would.

Two admin workflow gaps fed into this:
- Approved requests were still editable, and editing criteria silently resets a non-draft request back to `draft` — an operator could unknowingly demote an approved request out of the sensor's view.
- ClickHouse stats could only be calculated from the draft-only submit page, so verifying stats on an approved request forced a revert-to-draft round trip.

## Changes

- **Sensor `run_key`**: now `f"{pk}:{attempt_count}"`. `attempt_count` is incremented exactly once per `APPROVED → IN_PROGRESS` transition, so every retry/re-approval gets a distinct `run_key` and Dagster relaunches it. The existing concurrency guard still prevents double-launching a single attempt.
- **Editability lock**: approved and all later statuses (`in_progress`, `queued`, `completed`, `failed`) are now read-only in the admin, and the Save row is hidden for them. Only `draft`/`pending` stay editable; operators use "revert to draft" to change criteria.
- **Stats on the main edit page**: the "Fetch/Refresh stats" and ClickHouse-Team-only "Show stats now (preview)" actions moved from the draft-only submit page onto the change form, so they work for any status (including approved). The stats views now redirect back to the change page, and the stats block was removed from the submit page.

## How did you test this code?

Automated tests (run locally via `hogli test`):

- `posthog/admin/test_data_deletion_request_admin.py` — 60 passed, including new coverage for the read-only lock across statuses, the change-view stats context and hidden Save row, and the stats-view redirects to the change page.
- `posthog/dags/tests/test_data_deletion_requests.py` — sensor `run_key` now includes `attempt_count`, with a test asserting a re-approved/retried request (same pk, higher attempt_count) yields a distinct `run_key`.

`ruff check` and `ruff format` are clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
