### PR TITLE
fix(data-warehouse): bound delta merge writer and source memory

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/consts.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/consts.py
@@ -1,3 +1,8 @@
 DEFAULT_CHUNK_SIZE = 20_000
 DEFAULT_TABLE_SIZE_BYTES = 150 * 1024 * 1024  # 150 MB
 PARTITION_KEY = "_ph_partition_key"
+
+# Delta Lake writer tuning: bounds writer + source memory during merges/writes.
+MERGE_WRITE_BATCH_SIZE = 8_192
+MERGE_MAX_ROW_GROUP_SIZE = 131_072
+MERGE_SOURCE_CHUNK_SIZE = 10_000

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -16,7 +16,12 @@ from structlog.types import FilteringBoundLogger
 from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.data_imports.naming_convention import NamingConvention
-from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
+from posthog.temporal.data_imports.pipelines.pipeline.consts import (
+    MERGE_MAX_ROW_GROUP_SIZE,
+    MERGE_SOURCE_CHUNK_SIZE,
+    MERGE_WRITE_BATCH_SIZE,
+    PARTITION_KEY,
+)
 from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     conditional_lru_cache_async,
     normalize_column_name,
@@ -26,6 +31,11 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
 from products.data_warehouse.backend.s3 import aget_s3_client, ensure_bucket_exists
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 
+_WRITER_PROPERTIES = deltalake.WriterProperties(
+    write_batch_size=MERGE_WRITE_BATCH_SIZE,
+    max_row_group_size=MERGE_MAX_ROW_GROUP_SIZE,
+)
+
 
 def _write_deltalake(
     table_or_uri: str | deltalake.DeltaTable,
@@ -34,6 +44,7 @@ def _write_deltalake(
     mode: Literal["error", "append", "overwrite", "ignore"],
     schema_mode: Literal["merge", "overwrite"] | None,
     commit_properties: deltalake.CommitProperties | None = None,
+    writer_properties: deltalake.WriterProperties | None = None,
 ) -> None:
     deltalake.write_deltalake(
         table_or_uri=table_or_uri,
@@ -42,6 +53,7 @@ def _write_deltalake(
         mode=mode,
         schema_mode=schema_mode,
         commit_properties=commit_properties,
+        writer_properties=writer_properties,
     )
 
 
@@ -268,14 +280,16 @@ class DeltaTableHelper:
                         predicate: str,
                         merge_commit_properties: deltalake.CommitProperties | None,
                     ):
+                        # Reader is single-use; built here right before its one execute.
                         return (
                             existing_delta_table.merge(
-                                source=filtered_table,
+                                source=filtered_table.to_reader(max_chunksize=MERGE_SOURCE_CHUNK_SIZE),
                                 source_alias="source",
                                 target_alias="target",
                                 predicate=predicate,
                                 streamed_exec=True,
                                 commit_properties=merge_commit_properties,
+                                writer_properties=_WRITER_PROPERTIES,
                             )
                             .when_matched_update_all()
                             .when_not_matched_insert_all()
@@ -291,14 +305,16 @@ class DeltaTableHelper:
             else:
                 # Single merge call → safe to tag directly; this is the terminal commit.
                 def _do_merge_unpartitioned(data: pa.Table, predicate_ops: list[str]):
+                    # Reader is single-use; built here right before its one execute.
                     return (
                         existing_delta_table.merge(
-                            source=data,
+                            source=data.to_reader(max_chunksize=MERGE_SOURCE_CHUNK_SIZE),
                             source_alias="source",
                             target_alias="target",
                             predicate=" AND ".join(predicate_ops),
                             streamed_exec=False,
                             commit_properties=commit_properties,
+                            writer_properties=_WRITER_PROPERTIES,
                         )
                         .when_matched_update_all()
                         .when_not_matched_insert_all()
@@ -340,6 +356,7 @@ class DeltaTableHelper:
                     mode=mode,
                     schema_mode=schema_mode,
                     commit_properties=commit_properties,
+                    writer_properties=_WRITER_PROPERTIES,
                 )
             except deltalake.exceptions.SchemaMismatchError as e:
                 await self._logger.adebug("SchemaMismatchError: attempting to overwrite schema instead", exc_info=e)
@@ -353,6 +370,7 @@ class DeltaTableHelper:
                     mode=mode,
                     schema_mode="overwrite",
                     commit_properties=commit_properties,
+                    writer_properties=_WRITER_PROPERTIES,
                 )
         elif write_type == "append":
             if delta_table is None:
@@ -376,6 +394,7 @@ class DeltaTableHelper:
                 mode="append",
                 schema_mode="merge",
                 commit_properties=commit_properties,
+                writer_properties=_WRITER_PROPERTIES,
             )
 
         delta_table = await self.get_delta_table()
@@ -433,13 +452,15 @@ class DeltaTableHelper:
                 # redelivery would see the tagged commit, treat the batch as already done, and
                 # silently skip the append → data loss. Tag only the terminal commit (step 2).
                 def _do_scd2_close(first_per_pk: pa.Table, predicate: str) -> dict:
+                    # Reader is single-use; built here right before its one execute.
                     return (
                         existing_delta_table.merge(
-                            source=first_per_pk,
+                            source=first_per_pk.to_reader(max_chunksize=MERGE_SOURCE_CHUNK_SIZE),
                             source_alias="source",
                             target_alias="target",
                             predicate=predicate,
                             streamed_exec=False,
+                            writer_properties=_WRITER_PROPERTIES,
                         )
                         .when_matched_update(updates={"valid_to": "source.valid_from"})
                         .execute()
@@ -466,6 +487,7 @@ class DeltaTableHelper:
             mode="append",
             schema_mode="merge",
             commit_properties=commit_properties,
+            writer_properties=_WRITER_PROPERTIES,
         )
 
         delta_table = await self.get_delta_table()

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -3,10 +3,13 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pyarrow as pa
 import deltalake
+import deltalake.exceptions
 from parameterized import parameterized
 
-from posthog.temporal.data_imports.pipelines.pipeline.delta_table_helper import DeltaTableHelper
+from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
+from posthog.temporal.data_imports.pipelines.pipeline.delta_table_helper import _WRITER_PROPERTIES, DeltaTableHelper
 
 
 def _make_logger():
@@ -152,8 +155,6 @@ class TestWriteToDeltalakeCommitMetadataPassThrough:
         commit_metadata: dict[str, str] | None,
         expected_custom_metadata: dict[str, str] | None,
     ):
-        import pyarrow as pa
-
         helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
         data = pa.table({"id": [1, 2, 3]})
         mock_delta = MagicMock()
@@ -180,3 +181,139 @@ class TestWriteToDeltalakeCommitMetadataPassThrough:
             else:
                 assert isinstance(commit_properties, deltalake.CommitProperties)
                 assert commit_properties.custom_metadata == expected_custom_metadata
+
+
+def _make_merge_delta() -> MagicMock:
+    delta = MagicMock()
+    builder = MagicMock()
+    delta.merge.return_value = builder
+    builder.when_matched_update_all.return_value = builder
+    builder.when_not_matched_insert_all.return_value = builder
+    builder.when_matched_update.return_value = builder
+    builder.execute.return_value = {"num_target_rows_inserted": 0}
+    return delta
+
+
+class TestWriterPropertiesAndReaderSource:
+    """1.2 (tuned WriterProperties on every delta write) + 1.3 (merge source is a streamed RecordBatchReader)."""
+
+    @pytest.mark.asyncio
+    async def test_partitioned_merge_uses_reader_and_writer_properties(self):
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+        helper._is_first_sync = False
+        data = pa.table({"id": [1, 2, 3, 4], PARTITION_KEY: ["a", "a", "b", "b"]})
+        delta = _make_merge_delta()
+
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=delta)),
+            patch.object(helper, "_evolve_delta_schema", AsyncMock(return_value=delta)),
+        ):
+            await helper.write_to_deltalake(
+                data=data, write_type="incremental", should_overwrite_table=False, primary_keys=["id"]
+            )
+
+        assert delta.merge.call_count == 2
+        total_rows = 0
+        for call in delta.merge.call_args_list:
+            assert call.kwargs["streamed_exec"] is True
+            assert call.kwargs["writer_properties"] is _WRITER_PROPERTIES
+            source = call.kwargs["source"]
+            assert isinstance(source, pa.RecordBatchReader)
+            total_rows += pa.Table.from_batches(list(source)).num_rows
+        assert total_rows == 4
+
+    @pytest.mark.asyncio
+    async def test_unpartitioned_merge_uses_reader_and_writer_properties(self):
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+        helper._is_first_sync = False
+        data = pa.table({"id": [1, 2, 3]})
+        delta = _make_merge_delta()
+
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=delta)),
+            patch.object(helper, "_evolve_delta_schema", AsyncMock(return_value=delta)),
+        ):
+            await helper.write_to_deltalake(
+                data=data, write_type="incremental", should_overwrite_table=False, primary_keys=["id"]
+            )
+
+        assert delta.merge.call_count == 1
+        kwargs = delta.merge.call_args.kwargs
+        assert kwargs["streamed_exec"] is False
+        assert kwargs["writer_properties"] is _WRITER_PROPERTIES
+        source = kwargs["source"]
+        assert isinstance(source, pa.RecordBatchReader)
+        assert pa.Table.from_batches(list(source)).num_rows == 3
+
+    @pytest.mark.asyncio
+    async def test_full_refresh_passes_writer_properties_and_keeps_table_on_retry(self):
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+        data = pa.table({"id": [1, 2, 3]})
+        delta = _make_merge_delta()
+
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=delta)),
+            patch.object(helper, "_evolve_delta_schema", AsyncMock(return_value=delta)),
+            patch(
+                "deltalake.write_deltalake",
+                side_effect=[deltalake.exceptions.SchemaMismatchError("mismatch"), None],
+            ) as mock_write,
+        ):
+            await helper.write_to_deltalake(
+                data=data, write_type="full_refresh", should_overwrite_table=True, primary_keys=None
+            )
+
+        assert mock_write.call_count == 2
+        for call in mock_write.call_args_list:
+            assert call.kwargs["writer_properties"] is _WRITER_PROPERTIES
+            # data must stay a re-iterable Table so the retry isn't handed an exhausted reader.
+            assert isinstance(call.kwargs["data"], pa.Table)
+
+    @pytest.mark.asyncio
+    async def test_append_passes_writer_properties_with_table_source(self):
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+        data = pa.table({"id": [1, 2, 3]})
+        delta = _make_merge_delta()
+
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=delta)),
+            patch.object(helper, "_evolve_delta_schema", AsyncMock(return_value=delta)),
+            patch("deltalake.write_deltalake") as mock_write,
+        ):
+            await helper.write_to_deltalake(
+                data=data, write_type="append", should_overwrite_table=False, primary_keys=None
+            )
+
+        assert mock_write.call_args.kwargs["writer_properties"] is _WRITER_PROPERTIES
+        assert isinstance(mock_write.call_args.kwargs["data"], pa.Table)
+
+    @pytest.mark.asyncio
+    async def test_scd2_close_uses_reader_and_append_passes_writer_properties(self):
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+        data = pa.table(
+            {
+                "id": [1, 2],
+                "valid_from": [1, 2],
+                "valid_to": pa.array([None, None], type=pa.int64()),
+            }
+        )
+        delta = _make_merge_delta()
+
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=delta)),
+            patch.object(helper, "_evolve_delta_schema", AsyncMock(return_value=delta)),
+            patch("deltalake.write_deltalake") as mock_write,
+        ):
+            await helper.write_scd2_to_deltalake(data=data, primary_keys=["id"])
+
+        close_kwargs = delta.merge.call_args.kwargs
+        assert close_kwargs["streamed_exec"] is False
+        assert close_kwargs["writer_properties"] is _WRITER_PROPERTIES
+        assert isinstance(close_kwargs["source"], pa.RecordBatchReader)
+
+        assert mock_write.call_args.kwargs["writer_properties"] is _WRITER_PROPERTIES
+        assert isinstance(mock_write.call_args.kwargs["data"], pa.Table)
+
+    def test_writer_properties_values_match_rfc(self):
+        assert _WRITER_PROPERTIES.write_batch_size == 8_192
+        assert _WRITER_PROPERTIES.max_row_group_size == 131_072


### PR DESCRIPTION
## Problem

Data warehouse import merges into Delta Lake can run the loader pod out of memory. delta-rs holds output row groups in memory while building the write, and the merge source is handed in fully materialized. Because many merges run concurrently on one pod, a single oversized merge can take down the others.

This implements the two lightweight mitigations the team agreed to try from the [Delta OOM RFC](https://github.com/PostHog/requests-for-comments-public/pull/552) (sections 1.2 and 1.3).

> **Note:** these are deliberately **partial** mitigations. They bound the *writer* and *source* side of a merge — they do **not** touch the dominant **target-side** partition scan that drives the worst OOMs. They mainly help the wide-row case. The structural fixes (pre-flight partition guard, partition-overwrite fallback, separate consumer pools) remain follow-ups.

## Changes

All changes live in the single chokepoint `DeltaTableHelper` (plus shared constants), so callers need no changes.

- **1.2 — tuned writer properties.** A module-level `WriterProperties(write_batch_size=8192, max_row_group_size=131072)` is now passed to every delta write the helper owns: all three `.merge()` calls, the first-sync/full-refresh write and its `SchemaMismatchError` retry, the append write, and the SCD2 step-2 append. `compression` is left unset, so delta-rs keeps its default.
- **1.3 — streamed merge source.** Each merge source is now passed as a chunked `RecordBatchReader` (`table.to_reader(max_chunksize=10000)`) instead of a fully materialized `pa.Table`, so delta-rs consumes it incrementally. The `write_deltalake` paths keep receiving the re-iterable `pa.Table` — important because the full-refresh path may call it twice (normal + schema-mismatch retry), and a `RecordBatchReader` is single-use.
- New tunable constants in `pipelines/pipeline/consts.py`: `MERGE_WRITE_BATCH_SIZE`, `MERGE_MAX_ROW_GROUP_SIZE`, `MERGE_SOURCE_CHUNK_SIZE`.

Because the helper is shared, this also covers the still-selectable v1 `PipelineNonDLT` and the CDC snapshot append path for free — desirable, just flagging it.

## How did you test this code?

I'm an agent (PostHog Code). I did not do manual UI testing. Automated checks I actually ran locally:

- **Unit tests** — extended `test_delta_table_helper.py` with cases asserting, for each path, that `writer_properties` is forwarded, that merge sources are `RecordBatchReader`s carrying the right rows, that `streamed_exec` is unchanged, and that `write_deltalake` data stays a `pa.Table` (locks in the single-use-reader invariant). `hogli test … test_delta_table_helper.py` → **20 passed**.
- **End-to-end against real delta-rs 1.4.0** — an ad-hoc script (not committed) that created a local Delta table and ran a real `.merge()` with a chunked `RecordBatchReader` source + the tuned `WriterProperties`, confirming correct upsert semantics (one row updated, one inserted, others untouched).
- `ruff check` / `ruff format` clean; pre-commit `ty` type check passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.8). Tools used: codebase exploration agents, an architecture-planning agent, and local `Bash`/`Read`/`Edit` for implementation and verification.

Key decisions:
- **Edit only `DeltaTableHelper`.** Grep confirmed it's the sole module calling `deltalake.write_deltalake` / `.merge()` in `data_imports`, so writer properties + source streaming applied there cover v1, v3, and the CDC path with no caller changes.
- **Keep `write_deltalake` sources as `pa.Table`, convert only the 3 merge sources to readers.** A `RecordBatchReader` is single-use; the full-refresh `SchemaMismatchError` retry re-uses the same `data`, so handing it a reader would feed an exhausted stream on retry.
- **Do not touch `streamed_exec`.** The reader helps most on the partitioned path (already `streamed_exec=True`); flipping the other paths to `True` would disable source-stats pruning and is out of scope.
- **`max_chunksize` is required.** Verified that tables built via `from_pydict` are a single chunk, so `to_reader()` without it yields one giant batch (no benefit).
- Chose `MERGE_SOURCE_CHUNK_SIZE = 10000` as the starting knob (per maintainer); writer values `8192` / `131072` come straight from the RFC.

Reviewers: this is partial mitigation by design — please don't read it as a full OOM fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
