### PR TITLE
fix(data-stack): disable hive partitioning in iceberg dual-write read_parquet

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1391,6 +1391,13 @@ def write_partition_to_iceberg(
     writes Iceberg data + metadata itself. `BY NAME` matches on column name so we
     don't depend on column ordering.
 
+    `hive_partitioning=false` is required: the S3 keys carry year=/month=/day=
+    (events) or year=/month= (persons) parts, and read_parquet would otherwise
+    synthesize those as columns. `BY NAME` then fails to map them into a table
+    that has no such columns ("does not have a column with name day"). The
+    real data columns already live in the Parquet (ClickHouse exports with
+    use_hive_partitioning=0).
+
     Idempotency is best-effort: we attempt a partition-scoped DELETE first, but
     DuckDB's Iceberg extension may not support DELETE, so a failure there is
     logged and the INSERT proceeds. Re-running a partition can therefore leave

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1445,7 +1445,9 @@ def write_partition_to_iceberg(
 
     try:
         conn.execute(
-            psql.SQL("INSERT INTO {}.posthog.{} BY NAME SELECT * FROM read_parquet({})").format(
+            psql.SQL(
+                "INSERT INTO {}.posthog.{} BY NAME SELECT * FROM read_parquet({}, hive_partitioning=false)"
+            ).format(
                 psql.Identifier(ICEBERG_ALIAS),
                 psql.Identifier(table),
                 psql.Literal(s3_path),

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -879,3 +879,29 @@ class TestIcebergInsertByNameHivePartitioning:
         )
         result = conn.execute("SELECT count(*) FROM test_lake.posthog.events").fetchone()
         assert result[0] == 1
+
+    def test_write_partition_emits_hive_partitioning_false(self):
+        # Guards the production code path itself (the tests above only exercise
+        # hand-written SQL): write_partition_to_iceberg must emit a read_parquet
+        # that disables Hive inference, or BY NAME breaks on the path's
+        # year/month/day keys again.
+        executed: list[str] = []
+        conn = MagicMock()
+        conn.execute.side_effect = lambda stmt, *a, **k: executed.append(
+            stmt.as_string(None) if hasattr(stmt, "as_string") else str(stmt)
+        )
+
+        result = write_partition_to_iceberg(
+            MagicMock(),
+            conn,
+            "events",
+            "s3://bucket/backfill/events/2/year=2026/month=05/day=31/run.parquet",
+            2,
+            "timestamp",
+            datetime(2026, 5, 31),
+        )
+
+        assert result is True
+        insert_sql = next(s for s in executed if "read_parquet" in s)
+        assert "BY NAME" in insert_sql
+        assert "hive_partitioning=false" in insert_sql

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -842,3 +842,40 @@ class TestDuckLakeAddDataFilesPartitioning:
                 f"CALL ducklake_add_data_files('test_lake', 'events', '{path}',"
                 f" schema => 'posthog', hive_partitioning => false)"
             )
+
+
+class TestIcebergInsertByNameHivePartitioning:
+    """Regression tests for the Iceberg dual-write INSERT ... BY NAME.
+
+    read_parquet() auto-detects the Hive year=/month=/day= keys in the S3 path
+    and synthesizes year/month/day columns. INSERT ... BY NAME then tries to map
+    those into the events table, which has no such columns, producing a binder
+    error. Disabling hive_partitioning keeps read_parquet to the real data
+    columns. These reuse TestDuckLakeAddDataFilesPartitioning's catalog fixture.
+    """
+
+    ducklake_env = TestDuckLakeAddDataFilesPartitioning.ducklake_env
+
+    def _hive_partitioned_parquet(self, parquet_dir):
+        dest = os.path.join(parquet_dir, "2", "year=2026", "month=03", "day=30")
+        os.makedirs(dest, exist_ok=True)
+        path = os.path.join(dest, "run.parquet")
+        os.link(os.path.join(parquet_dir, "events.parquet"), path)
+        return path
+
+    def test_insert_by_name_default_hive_partitioning_fails(self, ducklake_env):
+        # Reproduces the production error: BY NAME can't map the inferred day column.
+        conn, parquet_dir = ducklake_env
+        path = self._hive_partitioned_parquet(parquet_dir)
+        with pytest.raises(duckdb.BinderException, match='column with name "day"'):
+            conn.execute(f"INSERT INTO test_lake.posthog.events BY NAME SELECT * FROM read_parquet('{path}')")
+
+    def test_insert_by_name_hive_partitioning_false_succeeds(self, ducklake_env):
+        conn, parquet_dir = ducklake_env
+        path = self._hive_partitioned_parquet(parquet_dir)
+        conn.execute(
+            f"INSERT INTO test_lake.posthog.events BY NAME "
+            f"SELECT * FROM read_parquet('{path}', hive_partitioning=false)"
+        )
+        result = conn.execute("SELECT count(*) FROM test_lake.posthog.events").fetchone()
+        assert result[0] == 1


### PR DESCRIPTION
## Problem

The `duckling_events_backfill` (and persons backfill) Dagster assets dual-write exported records into an Iceberg table after registering them with DuckLake. In production this dual-write was failing for every partition with:

```
Iceberg dual-write failed for events team_id=2 ...:
Binder Error: Table "events" does not have a column with name "day"
Did you mean: "distinct_id", "team_id"
```

Records are exported to S3 paths carrying Hive-style partition keys (`.../events/2/year=2026/month=05/day=31/<run>.parquet`), but the actual data columns live *inside* the Parquet — ClickHouse exports with `use_hive_partitioning=0`, so `year`/`month`/`day` are only encoded in the path. When the Iceberg write read the file with `read_parquet(...)`, DuckDB auto-detected those path keys and synthesized `year`/`month`/`day` columns. `INSERT ... BY NAME` then tried to map them into a table that has no such columns, and the write failed.

The dual-write is intentionally non-fatal (logs a warning, returns `False`), so the DuckLake backfill itself completed — but the Iceberg copy never landed.

## Changes

Pass `hive_partitioning=false` to `read_parquet` in `write_partition_to_iceberg` so it reads only the real data columns and `INSERT ... BY NAME` maps cleanly. Documented why the flag is required in the function docstring.

This is a one-line behavioral change at the single shared INSERT, so it fixes **all three** dual-write call sites: events, full-persons, and dated-persons.

## Review notes (verified before merge)

- **Schema alignment** — confirmed the ClickHouse export column lists match their Iceberg table DDLs exactly (events: 25 columns name-for-name; persons: 10), so with the phantom partition columns gone, `BY NAME` has nothing left unmapped. The fix is complete, not a swap for a different missing-column error.
- **Persons had the same latent bug** — persons paths also use Hive keys (`year=`/`month=`, plus the `year=0/month=0` full-export variant). They route through the same `write_partition_to_iceberg` INSERT, so this fixes them too.
- **Production execution path** — `conn` is a `psycopg` pgwire connection to duckgres and the INSERT runs remotely over Arrow Flight. The original failure was a DuckDB `Binder Error`, confirming the remote engine is DuckDB-based; `hive_partitioning` is a long-standing `read_parquet` parameter honored by that same binder. (Unit tests can't stand up the full duckgres+Flight+Lakekeeper stack — the existing suite has the same limitation and relies on integration coverage for the round trip.)

## How did you test this code?

I'm an agent. I added automated regression tests and did not perform manual testing against production.

Added `TestIcebergInsertByNameHivePartitioning` (reusing the existing real-DuckLake-catalog fixture):

- `test_insert_by_name_default_hive_partitioning_fails` — reproduces the exact production binder error (`column with name "day"`) against a Hive-partitioned path.
- `test_insert_by_name_hive_partitioning_false_succeeds` — proves the fix inserts the row.
- `test_write_partition_emits_hive_partitioning_false` — calls `write_partition_to_iceberg` with a mock connection and asserts the emitted SQL contains `BY NAME` and `hive_partitioning=false`. **Mutation-tested**: reverting the production line makes this test fail, confirming it genuinely guards the fix (the two SQL-level tests do not, since they don't call the function).

Full file passes locally: `100 passed`. `ruff format` + `ruff check` clean.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). Diagnosed from the production warning logs the user shared. Traced the dual-write to `write_partition_to_iceberg`, confirmed DuckDB's `read_parquet` Hive auto-detection synthesized the phantom `year`/`month`/`day` columns, and chose `hive_partitioning=false` over an explicit column projection because the Parquet schema already matches the table by name — keeping `BY NAME` + `SELECT *` is the smallest robust change. On a follow-up "110% confidence" review pass: verified export/DDL column alignment for both events and persons, confirmed all three call sites share the fixed INSERT, reasoned through the pgwire→Flight→DuckDB execution path for the `hive_partitioning` syntax, found that the initial SQL-level tests didn't actually exercise the production function, and added + mutation-tested a guard test to close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
