### PR TITLE
feat(devbox): auth gh CLI via GH_TOKEN secret

### DIFF
--- a/.agents/skills/setting-up-devbox/SKILL.md
+++ b/.agents/skills/setting-up-devbox/SKILL.md
@@ -25,7 +25,7 @@ A safe probe — it never prompts or mutates host config (unlike `devbox:setup`)
 
 ### 2. One-time local setup — `hogli devbox:setup`
 
-Interactive: checks Tailscale + Coder reachability, installs and authenticates the `coder` CLI, and writes the SSH host entries that `devbox:ssh`/`devbox:exec` rely on. It then _offers_ git identity, git signing, a dotfiles repo, and your Claude token — all optional; `--skip-*` anything you don't want. Re-run one step with its flag, e.g. `hogli devbox:setup --configure-git-signing`.
+Interactive: checks Tailscale + Coder reachability, installs and authenticates the `coder` CLI, and writes the SSH host entries that `devbox:ssh`/`devbox:exec` rely on. It then _offers_ git identity, git signing, a dotfiles repo, your Claude token, and your GitHub token (from local `gh auth token`, so `gh` is authed on every box) — all optional; `--skip-*` anything you don't want. Re-run one step with its flag, e.g. `hogli devbox:setup --configure-git-signing`.
 
 ### 3. Start and connect — `hogli devbox:start`
 

--- a/docs/internal/coder-workspaces.md
+++ b/docs/internal/coder-workspaces.md
@@ -80,11 +80,11 @@ This does the host-side setup only:
 - logs you into the Coder deployment
 - configures `~/.ssh/config` with Coder workspace entries (use `--skip-configure-ssh` to skip)
 - shows a compact "Currently configured:" status block with your saved settings
-- prompts for Git identity, an optional dotfiles repo, a preferred region, and an optional Claude OAuth token (stored as a Coder user secret)
+- prompts for Git identity, an optional dotfiles repo, a preferred region, an optional Claude OAuth token, and an optional GitHub token (both stored as Coder user secrets)
 
 A Y/n confirmation gate appears before the configuration prompts. It is automatically bypassed when stdin is non-TTY (scripts/CI) or when any explicit `--configure-*` or `--skip-configure-*` flag is passed.
 
-To reconfigure individual settings later, pass `--configure-git-identity`, `--configure-dotfiles`, `--configure-region`, or `--configure-claude`. The `--configure-claude` flag manages the `CLAUDE_CODE_OAUTH_TOKEN` Coder user secret and will offer to migrate any existing macOS Keychain token.
+To reconfigure individual settings later, pass `--configure-git-identity`, `--configure-dotfiles`, `--configure-region`, `--configure-claude`, or `--configure-gh`. The `--configure-claude` flag manages the `CLAUDE_CODE_OAUTH_TOKEN` Coder user secret and will offer to migrate any existing macOS Keychain token. The `--configure-gh` flag populates the `GH_TOKEN` Coder user secret from your local `gh auth token`, so the pre-installed `gh` CLI is authenticated on every workspace (including prebuilt ones) with zero per-box setup.
 
 ## Managing devbox configuration
 
@@ -101,6 +101,7 @@ hogli devbox:config:rm git-identity   # clear saved Git name/email
 hogli devbox:config:rm git-signing    # remove Git signing key from Coder user secrets
 hogli devbox:config:rm dotfiles       # clear dotfiles URI (also pushes empty parameter to existing workspaces)
 hogli devbox:config:rm claude         # remove Claude OAuth token from Coder user secrets
+hogli devbox:config:rm gh             # remove GitHub token from Coder user secrets
 hogli devbox:config:rm region          # clear saved region preference (new workspaces use the built-in default)
 hogli devbox:config:rm --all          # clear everything
 ```
@@ -135,5 +136,6 @@ Common secrets include `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, and `OP_SERVICE_AC
 - Laptop to workspace access uses `coder ssh` and `coder config-ssh` (configured automatically during setup)
 - Git inside the workspace should use HTTPS via Coder external auth — do not set up SSH Git inside the workspace
 - Claude auth is stored as a Coder user secret named `CLAUDE_CODE_OAUTH_TOKEN` (requires Coder 2.33+). Run `hogli devbox:setup --configure-claude` to set or replace it. `devbox:task` warns when the secret is unset.
+- `gh` CLI auth is stored as a Coder user secret named `GH_TOKEN` (requires Coder 2.33+). Run `hogli devbox:setup --configure-gh` to populate it from your local `gh auth token`; `gh` reads `GH_TOKEN` natively, so every workspace is authenticated without per-box `gh auth login`.
 
 `go/coder` is a convenient shortcut for humans, but the canonical deployment URL is `https://coder.dev.posthog.dev`.

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -27,6 +27,7 @@ from .coder import (
     DEFAULT_REGION,
     DEFAULT_TEMPLATE,
     DOTFILES_URI_PARAMETER,
+    GH_TOKEN_SECRET,
     GIT_EMAIL_PARAMETER,
     GIT_NAME_PARAMETER,
     GIT_SIGNING_KEY_SECRET,
@@ -781,6 +782,67 @@ def maybe_configure_claude_secret(configure_claude: bool | None, *, known_secret
     click.echo(f"Saved Claude token as Coder user secret '{CLAUDE_CODE_OAUTH_ENV}'.")
 
 
+def _read_local_gh_token() -> str | None:
+    """Return the engineer's local GitHub token from ``gh auth token``, or ``None``.
+
+    Reads whatever the laptop's ``gh`` CLI is authenticated with so the same
+    token propagates into devboxes. Returns ``None`` when ``gh`` is missing or
+    not logged in (non-zero exit) or prints nothing. Never raises.
+    """
+    try:
+        result = subprocess.run(["gh", "auth", "token"], capture_output=True, text=True)
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def maybe_configure_gh_token(configure_gh: bool | None, *, known_secret_names: set[str] | None = None) -> None:
+    """Propagate the engineer's local ``gh auth token`` into devboxes as the GH_TOKEN secret.
+
+    The pre-installed ``gh`` CLI in every workspace reads ``GH_TOKEN`` natively,
+    so populating this per-user Coder secret authenticates ``gh`` on every box --
+    including prebuilt/prewarm ones, since the Coder agent re-injects the secret
+    on each start. Mirrors ``maybe_configure_git_signing``'s resolution order.
+    """
+    if not server_supports_user_secrets():
+        click.echo("GitHub token: skipping (Coder server is older than 2.33; user secrets unavailable).")
+        return
+
+    already_set = (
+        GH_TOKEN_SECRET in known_secret_names if known_secret_names is not None else user_secret_exists(GH_TOKEN_SECRET)
+    )
+
+    if configure_gh is False:
+        if not already_set:
+            click.echo("Skipping GitHub token setup.")
+        return
+
+    if configure_gh is None and already_set:
+        return
+
+    token = _read_local_gh_token()
+    if not token:
+        click.echo()
+        click.echo(click.style("GitHub token (skipped)", bold=True))
+        click.echo("  `gh auth token` returned nothing -- `gh` is not installed or not logged in.")
+        click.echo("  Run `gh auth login`, then re-run `hogli devbox:setup --configure-gh`.")
+        return
+
+    upsert_user_secret(
+        GH_TOKEN_SECRET,
+        token,
+        env_name=GH_TOKEN_SECRET,
+        description="GitHub token for gh CLI (managed by hogli)",
+    )
+
+    click.echo()
+    click.echo(click.style("GitHub token", bold=True))
+    click.echo(f"  Pushed your local `gh auth token` as Coder user secret '{GH_TOKEN_SECRET}'.")
+    click.echo(f"  Injected as ${GH_TOKEN_SECRET} into every workspace, so `gh` is authenticated automatically.")
+
+
 def _reset_user_secret(secret_name: str) -> bool:
     """Delete a Coder user secret. Returns True iff something was actually removed."""
     if delete_user_secret(secret_name).returncode == 0:
@@ -905,6 +967,13 @@ _CONFIG_ITEMS: tuple[_ConfigItem, ...] = (
         status=_secret_status(CLAUDE_CODE_OAUTH_ENV),
         reset=lambda: _reset_user_secret(CLAUDE_CODE_OAUTH_ENV),
     ),
+    _ConfigItem(
+        cli_key="gh",
+        label="GitHub token",
+        needs_secrets=True,
+        status=_secret_status(GH_TOKEN_SECRET),
+        reset=lambda: _reset_user_secret(GH_TOKEN_SECRET),
+    ),
 )
 
 
@@ -975,6 +1044,7 @@ def _confirm_run_setup() -> bool:
     click.echo("  - Preferred region for new workspaces (optional)")
     click.echo("  - Dotfiles repo for new workspaces (optional)")
     click.echo("  - Claude OAuth token as a Coder user secret (optional)")
+    click.echo("  - GitHub token (from `gh auth token`) as a Coder user secret (optional)")
     click.echo()
     return click.confirm("Proceed?", default=True)
 
@@ -1011,6 +1081,12 @@ def _confirm_run_setup() -> bool:
     default=None,
     help="Manage the CLAUDE_CODE_OAUTH_TOKEN Coder user secret for this user",
 )
+@click.option(
+    "--configure-gh/--skip-configure-gh",
+    "configure_gh",
+    default=None,
+    help="Manage the GH_TOKEN Coder user secret from your local `gh auth token`",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Show full Coder/Terraform build output")
 def devbox_setup(
     configure_ssh: bool | None,
@@ -1019,6 +1095,7 @@ def devbox_setup(
     configure_region: bool | None,
     configure_dotfiles: bool | None,
     configure_claude_setup: bool | None,
+    configure_gh: bool | None,
     verbose: bool,
 ) -> None:
     """Prepare this machine for Coder workspaces."""
@@ -1030,6 +1107,7 @@ def devbox_setup(
             configure_region,
             configure_dotfiles,
             configure_claude_setup,
+            configure_gh,
         ],
     )
 
@@ -1063,6 +1141,7 @@ def devbox_setup(
     maybe_configure_region(configure_region)
     maybe_configure_dotfiles(configure_dotfiles)
     maybe_configure_claude_secret(configure_claude_setup, known_secret_names=secret_names)
+    maybe_configure_gh_token(configure_gh, known_secret_names=secret_names)
     print_setup_summary()
 
 

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -80,6 +80,13 @@ _RESERVED_LABEL_SUFFIXES: tuple[str, ...] = tuple(s for s in REGION_NAME_SUFFIXE
 # it.
 GIT_SIGNING_KEY_SECRET = "POSTHOG_GIT_SIGNING_KEY"
 
+# Per-user Coder secret holding a GitHub token. Injected as the GH_TOKEN env
+# var on every workspace start (including coder task runs and prebuilt boxes);
+# the pre-installed `gh` CLI reads GH_TOKEN natively and prefers it over stored
+# credentials, so the box is authenticated with zero per-workspace setup.
+# Populated from the engineer's local `gh auth token` by `hogli devbox:setup`.
+GH_TOKEN_SECRET = "GH_TOKEN"
+
 
 # Coder rejects --parameter values for keys the chosen template does not
 # define, with this exact message: `parameter "X" is not present in the

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -1350,6 +1350,11 @@ class TestDevboxCommands:
             "maybe_configure_claude_secret",
             lambda configure_claude, **kw: calls.append(f"claude:{configure_claude}"),
         )
+        monkeypatch.setattr(
+            devbox_cli,
+            "maybe_configure_gh_token",
+            lambda configure_gh, **kw: calls.append(f"gh:{configure_gh}"),
+        )
         monkeypatch.setattr(devbox_cli, "print_setup_summary", lambda: calls.append("summary"))
 
         result = runner.invoke(
@@ -1362,6 +1367,7 @@ class TestDevboxCommands:
                 "--skip-configure-region",
                 "--skip-configure-dotfiles",
                 "--skip-configure-claude",
+                "--skip-configure-gh",
             ],
         )
 
@@ -1378,6 +1384,7 @@ class TestDevboxCommands:
             "region:False",
             "dotfiles:False",
             "claude:False",
+            "gh:False",
             "summary",
         ]
 
@@ -1398,6 +1405,7 @@ class TestDevboxCommands:
         monkeypatch.setattr(devbox_cli, "maybe_configure_region", lambda *a, **kw: None)
         monkeypatch.setattr(devbox_cli, "maybe_configure_dotfiles", lambda *a, **kw: None)
         monkeypatch.setattr(devbox_cli, "maybe_configure_claude_secret", lambda *a, **kw: None)
+        monkeypatch.setattr(devbox_cli, "maybe_configure_gh_token", lambda *a, **kw: None)
         monkeypatch.setattr(devbox_cli, "print_setup_summary", lambda: None)
         monkeypatch.setattr(
             devbox_cli,
@@ -1429,6 +1437,7 @@ class TestDevboxCommands:
         monkeypatch.setattr(devbox_cli, "maybe_configure_region", lambda configure_region: None)
         monkeypatch.setattr(devbox_cli, "maybe_configure_dotfiles", lambda configure_dotfiles: None)
         monkeypatch.setattr(devbox_cli, "maybe_configure_claude_secret", lambda configure_claude, **kw: None)
+        monkeypatch.setattr(devbox_cli, "maybe_configure_gh_token", lambda configure_gh, **kw: None)
         monkeypatch.setattr(devbox_cli, "print_setup_summary", lambda: None)
         monkeypatch.setattr(devbox_cli, "get_default_git_identity", lambda: ("Coder User", "coder@example.com"))
 
@@ -1465,6 +1474,7 @@ class TestDevboxCommands:
         monkeypatch.setattr(devbox_cli, "maybe_configure_region", lambda configure_region: None)
         monkeypatch.setattr(devbox_cli, "maybe_configure_dotfiles", lambda configure_dotfiles: None)
         monkeypatch.setattr(devbox_cli, "maybe_configure_claude_secret", lambda configure_claude, **kw: None)
+        monkeypatch.setattr(devbox_cli, "maybe_configure_gh_token", lambda configure_gh, **kw: None)
         monkeypatch.setattr(devbox_cli, "print_setup_summary", lambda: None)
 
         result = runner.invoke(cli, ["devbox:setup", "--skip-configure-ssh"])
@@ -1833,6 +1843,7 @@ def stub_setup_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(devbox_cli, "maybe_configure_region", lambda *a, **kw: None)
     monkeypatch.setattr(devbox_cli, "maybe_configure_dotfiles", lambda *a, **kw: None)
     monkeypatch.setattr(devbox_cli, "maybe_configure_claude_secret", lambda *a, **kw: None)
+    monkeypatch.setattr(devbox_cli, "maybe_configure_gh_token", lambda *a, **kw: None)
     monkeypatch.setattr(devbox_cli, "print_setup_summary", lambda: None)
     monkeypatch.setattr(devbox_cli, "list_user_secrets", lambda: [])
     monkeypatch.setattr(devbox_cli, "list_user_workspaces", lambda: [])
@@ -1962,8 +1973,9 @@ class TestDevboxConfigCommands:
         [
             ("git-signing", coder.GIT_SIGNING_KEY_SECRET),
             ("claude", coder.CLAUDE_CODE_OAUTH_ENV),
+            ("gh", coder.GH_TOKEN_SECRET),
         ],
-        ids=["git-signing", "claude"],
+        ids=["git-signing", "claude", "gh"],
     )
     def test_rm_secret_keys_delete_the_right_coder_secret(
         self,
@@ -2024,7 +2036,7 @@ class TestDevboxConfigCommands:
 
         assert result.exit_code == 0, result.output
         assert devbox_config.load_config() == {}
-        assert deleted == [coder.GIT_SIGNING_KEY_SECRET, coder.CLAUDE_CODE_OAUTH_ENV]
+        assert deleted == [coder.GIT_SIGNING_KEY_SECRET, coder.CLAUDE_CODE_OAUTH_ENV, coder.GH_TOKEN_SECRET]
 
     def test_rm_with_no_args_fails_with_valid_keys_hint(self, stub_config_runtime: None) -> None:
         result = runner.invoke(cli, ["devbox:config:rm"])
@@ -2035,6 +2047,7 @@ class TestDevboxConfigCommands:
         assert "region" in result.output
         assert "dotfiles" in result.output
         assert "claude" in result.output
+        assert "gh" in result.output
 
     def test_rm_with_unknown_key_fails_with_valid_keys_hint(self, stub_config_runtime: None) -> None:
         result = runner.invoke(cli, ["devbox:config:rm", "bogus"])
@@ -2686,6 +2699,139 @@ class TestSetupClaudeSecret:
 
         devbox_cli.maybe_configure_claude_secret(None)
         assert called == []
+
+
+class TestReadLocalGhToken:
+    """Test reading the GitHub token from the engineer's local `gh auth token`."""
+
+    def test_returns_trimmed_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            devbox_cli.subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, "gho_abc123\n", ""),
+        )
+        assert devbox_cli._read_local_gh_token() == "gho_abc123"
+
+    def test_returns_none_when_not_logged_in(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli.subprocess, "run", lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, "", ""))
+        assert devbox_cli._read_local_gh_token() is None
+
+    def test_returns_none_when_output_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            devbox_cli.subprocess, "run", lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, "  \n", "")
+        )
+        assert devbox_cli._read_local_gh_token() is None
+
+    def test_returns_none_when_gh_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+            raise FileNotFoundError("gh")
+
+        monkeypatch.setattr(devbox_cli.subprocess, "run", _raise)
+        assert devbox_cli._read_local_gh_token() is None
+
+
+class TestSetupGhToken:
+    """Test the GitHub-token user-secret step in devbox:setup."""
+
+    TOKEN = "gho_token123"
+
+    def test_pushes_local_gh_token_to_user_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli, "server_supports_user_secrets", lambda: True)
+        monkeypatch.setattr(devbox_cli, "user_secret_exists", lambda name: False)
+        monkeypatch.setattr(devbox_cli, "_read_local_gh_token", lambda: self.TOKEN)
+        upserts: list[tuple[str, str, str | None]] = []
+        monkeypatch.setattr(
+            devbox_cli,
+            "upsert_user_secret",
+            lambda name, value, env_name=None, description=None: upserts.append((name, value, env_name)),
+        )
+
+        devbox_cli.maybe_configure_gh_token(None)
+
+        assert upserts == [(coder.GH_TOKEN_SECRET, self.TOKEN, coder.GH_TOKEN_SECRET)]
+
+    def test_not_logged_in_prints_guidance_and_upserts_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli, "server_supports_user_secrets", lambda: True)
+        monkeypatch.setattr(devbox_cli, "user_secret_exists", lambda name: False)
+        monkeypatch.setattr(devbox_cli, "_read_local_gh_token", lambda: None)
+        upserts: list[str] = []
+        monkeypatch.setattr(devbox_cli, "upsert_user_secret", lambda *a, **kw: upserts.append("upsert"))
+        echoed: list[str] = []
+        monkeypatch.setattr(devbox_cli.click, "echo", lambda msg="", **kw: echoed.append(str(msg)))
+
+        devbox_cli.maybe_configure_gh_token(None)
+
+        assert upserts == []
+        assert any("gh auth login" in line for line in echoed)
+
+    def test_skip_flag_short_circuits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli, "server_supports_user_secrets", lambda: True)
+        monkeypatch.setattr(devbox_cli, "user_secret_exists", lambda name: False)
+        reads: list[str] = []
+        monkeypatch.setattr(devbox_cli, "_read_local_gh_token", lambda: reads.append("read") or self.TOKEN)
+        upserts: list[str] = []
+        monkeypatch.setattr(devbox_cli, "upsert_user_secret", lambda *a, **kw: upserts.append("upsert"))
+        echoed: list[str] = []
+        monkeypatch.setattr(devbox_cli.click, "echo", lambda msg="", **kw: echoed.append(str(msg)))
+
+        devbox_cli.maybe_configure_gh_token(False)
+
+        assert upserts == []
+        assert reads == []
+        assert any("Skipping" in line for line in echoed)
+
+    def test_already_set_without_flag_is_a_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli, "server_supports_user_secrets", lambda: True)
+        monkeypatch.setattr(devbox_cli, "user_secret_exists", lambda name: True)
+        reads: list[str] = []
+        monkeypatch.setattr(devbox_cli, "_read_local_gh_token", lambda: reads.append("read") or self.TOKEN)
+        upserts: list[str] = []
+        monkeypatch.setattr(devbox_cli, "upsert_user_secret", lambda *a, **kw: upserts.append("upsert"))
+        echoed: list[str] = []
+        monkeypatch.setattr(devbox_cli.click, "echo", lambda msg="", **kw: echoed.append(str(msg)))
+
+        devbox_cli.maybe_configure_gh_token(None)
+
+        assert upserts == []
+        assert reads == []
+        assert echoed == []
+
+    def test_explicit_reconfigure_overrides_existing_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli, "server_supports_user_secrets", lambda: True)
+        monkeypatch.setattr(devbox_cli, "user_secret_exists", lambda name: True)
+        monkeypatch.setattr(devbox_cli, "_read_local_gh_token", lambda: self.TOKEN)
+        upserts: list[tuple[str, str, str | None]] = []
+        monkeypatch.setattr(
+            devbox_cli,
+            "upsert_user_secret",
+            lambda name, value, env_name=None, description=None: upserts.append((name, value, env_name)),
+        )
+
+        devbox_cli.maybe_configure_gh_token(True)
+
+        assert upserts == [(coder.GH_TOKEN_SECRET, self.TOKEN, coder.GH_TOKEN_SECRET)]
+
+    def test_known_secret_names_short_circuits_user_secret_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli, "server_supports_user_secrets", lambda: True)
+        monkeypatch.setattr(
+            devbox_cli, "user_secret_exists", lambda name: pytest.fail("must use known_secret_names, not a CLI call")
+        )
+        monkeypatch.setattr(devbox_cli, "_read_local_gh_token", lambda: self.TOKEN)
+        upserts: list[str] = []
+        monkeypatch.setattr(devbox_cli, "upsert_user_secret", lambda *a, **kw: upserts.append("upsert"))
+
+        devbox_cli.maybe_configure_gh_token(None, known_secret_names={coder.GH_TOKEN_SECRET})
+
+        assert upserts == []
+
+    def test_skips_when_server_does_not_support_user_secrets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli, "server_supports_user_secrets", lambda: False)
+        echoed: list[str] = []
+        monkeypatch.setattr(devbox_cli.click, "echo", lambda msg="", **kw: echoed.append(str(msg)))
+
+        devbox_cli.maybe_configure_gh_token(None)
+
+        assert any("older than 2.33" in line for line in echoed)
 
 
 class TestDevboxTaskClaudeWarning:


### PR DESCRIPTION
Problem

The pre-installed gh CLI in Coder devboxes starts out unauthenticated, so every engineer has to run gh auth login per workspace — and that doesn't survive on prebuilt/prewarm boxes, which are claimed already-built.

Changes

Adds a GitHub-token step to hogli devbox:setup that populates a per-user Coder secret named GH_TOKEN from the engineer's local gh auth token. The Coder agent re-injects user secrets as env vars on every workspace start/rebuild/claim (the same mechanism CLAUDE_CODE_OAUTH_TOKEN already uses), and gh reads GH_TOKEN natively, so gh is authenticated on every box — including prebuilt ones — with zero per-workspace setup.

- coder.py: new GH_TOKEN_SECRET = "GH_TOKEN" constant.
- cli.py: _read_local_gh_token() (runs gh auth token, returns None if gh is missing/not-logged-in, never raises) and maybe_configure_gh_token(), mirroring maybe_configure_git_signing's resolution order and gated on server_supports_user_secrets() like the Claude helper. Token is piped via stdin (upsert_user_secret), never argv.
- New --configure-gh/--skip-configure-gh flag, wired into the setup flow right after the Claude step, the explicit-flag gate, and the _CONFIG_ITEMS registry (so devbox:config:rm gh, --all, and the status block include it).
- Docs: coder-workspaces.md and the setting-up-devbox skill updated where they enumerate configured secrets.

How did you test this code?

I'm an agent. Automated only — extended test_devbox.py and ran the full hogli suite (uv run pytest hogli_commands/tests/test_devbox.py, 253 passed), plus ruff check/ruff format and the pre-commit ty type check. New tests cover: token read → upsert with env_name=GH_TOKEN; not-logged-in prints guidance and upserts nothing; --skip-configure-gh; already-set + no flag is a no-op; server-unsupported skip; and the new _CONFIG_ITEMS entry in the reconfigure/status output. No manual devbox run performed.

Docs update

Updated docs/internal/coder-workspaces.md and .agents/skills/setting-up-devbox/SKILL.md.

🤖 Agent context

Authored by Claude Code (Opus 4.8) via the /wt worktree skill. The design — a per-user GH_TOKEN Coder secret populated from the laptop's gh auth token — was specified up front because it reuses the exact secret-injection path that already makes CLAUDE_CODE_OAUTH_TOKEN work on prebuilt workspaces. Implementation mirrors the existing maybe_configure_git_signing / maybe_configure_claude_secret helpers (resolution order, echo conventions, _CONFIG_ITEMS registration) rather than introducing a new pattern. Requires human review; not self-merged.