### PR TITLE
feat(tracing): add documentation links to scene header and empty state

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -28935,7 +28935,8 @@
                 "vercel_integration",
                 "endpoint_created",
                 "endpoint_created_from_insight",
-                "endpoint_created_from_sql_editor"
+                "endpoint_created_from_sql_editor",
+                "tracing_docs_viewed"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -6764,6 +6764,9 @@ export enum ProductIntentContext {
     ENDPOINT_CREATED = 'endpoint_created',
     ENDPOINT_CREATED_FROM_INSIGHT = 'endpoint_created_from_insight',
     ENDPOINT_CREATED_FROM_SQL_EDITOR = 'endpoint_created_from_sql_editor',
+
+    // Tracing
+    TRACING_DOCS_VIEWED = 'tracing_docs_viewed',
 }
 
 // Known prod_interest values from posthog.com

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3990,6 +3990,7 @@ class ProductIntentContext(StrEnum):
     ENDPOINT_CREATED = "endpoint_created"
     ENDPOINT_CREATED_FROM_INSIGHT = "endpoint_created_from_insight"
     ENDPOINT_CREATED_FROM_SQL_EDITOR = "endpoint_created_from_sql_editor"
+    TRACING_DOCS_VIEWED = "tracing_docs_viewed"
 
 
 class ProductItemCategory(StrEnum):

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -1,17 +1,18 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { LemonBanner, LemonModal } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonModal, Link } from '@posthog/lemon-ui'
 
 import { IconFeedback } from 'lib/lemon-ui/icons'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { ProductKey } from '~/queries/schema/schema-general'
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import { VirtualizedSpanList } from './components/VirtualizedSpanList/VirtualizedSpanList'
 import { TraceCompareFlame } from './TraceCompareFlame'
@@ -26,6 +27,7 @@ import { TracingTabIdProvider, useTracingTabId } from './TracingTabContext'
 import type { Span } from './types'
 
 const TRACING_FEEDBACK_SURVEY_ID = '019e6a26-4943-0000-24a0-dc46310f6b7c'
+const TRACING_DOCS_URL = 'https://posthog.com/docs/tracing'
 
 export const scene: SceneExport<TracingSceneLogicProps> = {
     component: TracingScene,
@@ -80,7 +82,15 @@ function TracingSceneContents(): JSX.Element {
         fetchNextPage,
         setVisibleRowRange,
     } = useActions(tracingSceneLogic({ tabId }))
+    const { addProductIntent } = useActions(teamLogic)
     const compareMode = filters.compareMode
+
+    const onDocsLinkClick = (): void => {
+        addProductIntent({
+            product_type: ProductKey.TRACING,
+            intent_context: ProductIntentContext.TRACING_DOCS_VIEWED,
+        })
+    }
 
     // Anchor the overlay's coordinate space to the *fetched* sparkline data so overlay
     // drags never shift the canvas underfoot. The sparkline only refetches when dateRange
@@ -107,6 +117,17 @@ function TracingSceneContents(): JSX.Element {
                 resourceType={{
                     type: 'tracing',
                 }}
+                actions={
+                    <LemonButton
+                        to={TRACING_DOCS_URL}
+                        onClick={onDocsLinkClick}
+                        type="secondary"
+                        size="small"
+                        targetBlank
+                    >
+                        Documentation
+                    </LemonButton>
+                }
             />
             <LemonBanner
                 type="warning"
@@ -150,6 +171,14 @@ function TracingSceneContents(): JSX.Element {
                     hasMoreToLoad={hasMoreToLoad}
                     onLoadMore={fetchNextPage}
                     onVisibleRowRangeChange={setVisibleRowRange}
+                    emptyState={
+                        <div className="flex flex-col items-center gap-1">
+                            <span>No spans found</span>
+                            <Link to={TRACING_DOCS_URL} onClick={onDocsLinkClick} target="_blank">
+                                Learn how to send traces
+                            </Link>
+                        </div>
+                    }
                     onRowClick={(span: Span) => {
                         // Clicking a row leaves the scrollable <main tabIndex="0"> as the active
                         // element; react-modal then scrolls it back into view when restoring focus

--- a/products/tracing/frontend/components/VirtualizedSpanList/VirtualizedSpanList.tsx
+++ b/products/tracing/frontend/components/VirtualizedSpanList/VirtualizedSpanList.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useCallback, useMemo, useRef } from 'react'
+import { CSSProperties, ReactNode, useCallback, useMemo, useRef } from 'react'
 import { List } from 'react-window'
 
 import { LemonTag } from '@posthog/lemon-ui'
@@ -40,6 +40,7 @@ interface VirtualizedSpanListProps {
     onVisibleRowRangeChange: (startIndex: number, stopIndex: number) => void
     hasMoreToLoad?: boolean
     onLoadMore?: () => void
+    emptyState?: ReactNode
 }
 
 interface SpanRowProps {
@@ -146,6 +147,7 @@ export function VirtualizedSpanList({
     onVisibleRowRangeChange,
     hasMoreToLoad = false,
     onLoadMore,
+    emptyState = 'No spans found',
 }: VirtualizedSpanListProps): JSX.Element {
     // Tracks the last range we dispatched so we don't fire on every overscan tick.
     const lastVisibleRangeRef = useRef<{ startIndex: number; stopIndex: number } | null>(null)
@@ -178,7 +180,7 @@ export function VirtualizedSpanList({
     if (dataSource.length === 0 && !loading) {
         return (
             <div className="flex items-center justify-center p-8 text-muted border rounded bg-bg-light">
-                No spans found
+                {emptyState}
             </div>
         )
     }


### PR DESCRIPTION
## Problem

When users land on the Tracing scene with no data, there's no clear guidance on how to get started. Additionally, there's no easy way to access the tracing documentation from the scene itself.

## Changes

- Adds a "Documentation" button to the Tracing scene header that links to the PostHog tracing docs
- Adds a contextual empty state to the span list that includes a "Learn how to send traces" link when no spans are found
- Introduces a new `TRACING_DOCS_VIEWED` product intent context that is captured when either the header docs button or the empty state link is clicked, allowing us to track interest in tracing onboarding

## How did you test this code?

Verified the new `TRACING_DOCS_VIEWED` enum value is consistent across `schema-general.ts`, `schema.json`, and `posthog/schema.py`. The intent is fired via the existing `addProductIntent` action in `teamLogic`, which is already tested elsewhere.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update