### PR TITLE
fix(logs): import emit_signal from signals facade

### DIFF
--- a/products/logs/backend/alert_signal_emitter.py
+++ b/products/logs/backend/alert_signal_emitter.py
@@ -9,7 +9,7 @@ import structlog
 from posthog.models import Team
 
 from products.logs.backend.alert_state_machine import NotificationAction
-from products.signals.backend.api import emit_signal
+from products.signals.backend.facade.api import emit_signal
 
 logger = structlog.get_logger(__name__)
 


### PR DESCRIPTION
## Problem

Every Temporal worker crash-loops at import time on prod-eu and prod-us with:

```
ModuleNotFoundError: No module named 'products.signals.backend.api'
```

The signals facade refactor (#60848) moved `products/signals/backend/api.py` to `products/signals/backend/facade/api.py` and updated every caller it knew about. It branched before #60637 added `products/logs/backend/alert_signal_emitter.py`, so that one caller was missed and still imported the old `products.signals.backend.api` path.

The old module no longer exists on master. `posthog/temporal/common/worker.py` imports `products.logs.backend.temporal` unconditionally at module level, and that package pulls in the alert signal emitter — so **any** worker started via `start_temporal_worker` (session replay, video export, batch exports, data modeling, tasks, …) fails to import and crash-loops. Not session-replay specific.

## Changes

One-line import fix in `alert_signal_emitter.py`, pointing at the new facade path — matching what #60848 did for every other caller, and routing through the signals product's public facade as the isolation boundary expects.

```diff
-from products.signals.backend.api import emit_signal
+from products.signals.backend.facade.api import emit_signal
```

## How did you test this code?

Agent-authored. No manual testing. Automated checks run:

- Imported the failing worker chain under Django (`django.setup()` → `import products.logs.backend.temporal` → `from products.logs.backend.alert_signal_emitter import emit_signal`) — resolves cleanly, `emit_signal.__module__` is now `products.signals.backend.facade.api`.
- lint-staged on commit: ruff fix/format + `ty check` passed.
- Confirmed via `git grep` this was the only stale importer of the old path on master (the remaining hit is a frontend doc comment).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at the user's direction, triggered by a worker crash-loop alert. The agent read the alert traceback, traced the import chain, and used `git` history to identify that #60848 (the facade move) predated the #60637 caller — a stale-merge miss rather than a logic bug. Verified the fix by reproducing the worker import chain under Django rather than relying on static reasoning, since the failure was import-time. Chose the facade path over re-adding the old module to stay consistent with the isolation boundary.
