### PR TITLE
fix(tasks): gate dropped slack post behind temporal patch

### DIFF
--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -442,11 +442,70 @@ class TestProcessTaskWorkflowUnit:
             workflow, "_wait_for_event", AsyncMock(return_value=process_task_workflow_module.TaskEvent.TIMEOUT_REACHED)
         )
         monkeypatch.setattr(workflow, "_relay_sandbox_events", relay_sandbox_events_mock)
+        monkeypatch.setattr(process_task_workflow_module.workflow, "patched", Mock(return_value=True))
 
         result = await workflow.run(ProcessTaskInput(run_id="run-id"))
 
         assert result.success is True
         relay_sandbox_events_mock.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "patched, expected_post_slack_calls",
+        [
+            (True, 2),  # post-rollout: the provisioning post is skipped (initial + completion remain)
+            (False, 3),  # pre-rollout replay: provisioning post is still scheduled to match history
+        ],
+    )
+    async def test_run_gates_slack_post_after_provisioning_on_patch(
+        self, monkeypatch, patched, expected_post_slack_calls
+    ):
+        workflow = ProcessTaskWorkflow()
+        post_slack_update_mock = AsyncMock()
+
+        monkeypatch.setattr(
+            workflow, "_get_task_processing_context", AsyncMock(return_value=_build_context(github_integration_id=123))
+        )
+        monkeypatch.setattr(workflow, "_update_task_run_status", AsyncMock())
+        monkeypatch.setattr(workflow, "_track_workflow_event", AsyncMock())
+        monkeypatch.setattr(workflow, "_post_slack_update", post_slack_update_mock)
+        monkeypatch.setattr(workflow, "_emit_progress", AsyncMock())
+        monkeypatch.setattr(workflow, "_read_sandbox_logs", AsyncMock())
+        monkeypatch.setattr(workflow, "_cleanup_sandbox", AsyncMock())
+        monkeypatch.setattr(workflow, "_create_resume_snapshot", AsyncMock())
+        monkeypatch.setattr(workflow, "_forward_pending_user_message", AsyncMock())
+        monkeypatch.setattr(
+            workflow,
+            "_get_sandbox_for_repository",
+            AsyncMock(
+                return_value=GetSandboxForRepositoryOutput(
+                    sandbox_id="sandbox-123",
+                    sandbox_url="https://sandbox.example",
+                    connect_token="connect-token",
+                    used_snapshot=False,
+                    should_create_snapshot=False,
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            workflow,
+            "_start_agent_server",
+            AsyncMock(
+                return_value=StartAgentServerOutput(
+                    sandbox_url="https://sandbox.example",
+                    connect_token="connect-token",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            workflow, "_wait_for_event", AsyncMock(return_value=process_task_workflow_module.TaskEvent.TIMEOUT_REACHED)
+        )
+        monkeypatch.setattr(workflow, "_relay_sandbox_events", AsyncMock())
+        monkeypatch.setattr(process_task_workflow_module.workflow, "patched", Mock(return_value=patched))
+
+        result = await workflow.run(ProcessTaskInput(run_id="run-id"))
+
+        assert result.success is True
+        assert post_slack_update_mock.await_count == expected_post_slack_calls
 
     async def test_get_sandbox_for_repository_skips_clone_and_checkout_for_private_repo_without_github_integration(
         self, monkeypatch

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -121,6 +121,16 @@ _PATCH_ID_CI_FOLLOW_UP_PR_CONTEXT = "tasks-ci-follow-up-pr-context"
 # which workflow task records it. Same two-step lifecycle as above.
 _PATCH_ID_FOLLOWUP_QUEUE = "tasks-follow-up-message-queue"
 
+# #60923 dropped the redundant slack post that ran immediately after sandbox
+# provisioning — between `_get_sandbox_for_repository` and the agent-start
+# progress emit. Pre-rollout histories scheduled a `post_slack_update` activity
+# at that point, so removing it unconditionally broke replay of in-flight
+# workflows with TMPRL1100: the next command (`emit_progress_activity`) no
+# longer matched the recorded `post_slack_update` event. Gate the removal —
+# post-rollout executions skip the call, replays of older histories still
+# schedule it. Same two-step cleanup lifecycle as the patches above.
+_PATCH_ID_DROP_SLACK_POST_AFTER_PROVISIONING = "tasks-drop-slack-post-after-provisioning"
+
 
 def _deprecate_ci_follow_up_pr_context_patch() -> None:
     workflow.deprecate_patch(_PATCH_ID_CI_FOLLOW_UP_PR_CONTEXT)
@@ -386,6 +396,12 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             # TODO(tasks): Re-enable snapshot creation
             # if sandbox_output.should_create_snapshot and self.context.repository and self.context.github_integration_id:
             #     await self._trigger_snapshot_workflow()
+
+            # See `_PATCH_ID_DROP_SLACK_POST_AFTER_PROVISIONING`: only replays of
+            # pre-rollout histories still post here; new executions skip the
+            # redundant update to keep determinism for in-flight workflows.
+            if not workflow.patched(_PATCH_ID_DROP_SLACK_POST_AFTER_PROVISIONING):
+                await self._post_slack_update()
 
             # Start agent-server for direct connection from PostHog Code
             await self._emit_progress("agent", "in_progress", "Starting agent", "setup")


### PR DESCRIPTION
## Problem

Production is throwing `[TMPRL1100] Nondeterminism error: Activity type of scheduled event 'post_slack_update' does not match activity type of activity command 'emit_progress_activity'` 

#60923 ("drop duplicate slack progress post after sandbox provisioning") removed an `await self._post_slack_update()` call that sat between sandbox provisioning and the agent-start progress emit. Removing an activity call from a workflow is a backwards-incompatible change
