### PR TITLE
feat(posthog-ai): sandbox history-load and telemetry parity

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -108,6 +108,10 @@ class PermissionResponseSerializer(serializers.Serializer):
         max_length=10000,
         help_text="Optional feedback text sent with a 'reject_with_feedback' decision.",
     )
+    traceId = serializers.UUIDField(
+        required=False,
+        help_text="Trace id the client associated with the run, for PERMISSION_RESPONDED telemetry correlation.",
+    )
 
 
 class PermissionResponseResultSerializer(serializers.Serializer):
@@ -262,6 +266,14 @@ class SandboxMessageResponseSerializer(serializers.Serializer):
     just_created_run = serializers.BooleanField(
         help_text="True when a new Run was created (first message or terminal resume); false for an in-progress follow-up."
     )
+
+
+class SandboxCancelResponseSerializer(serializers.Serializer):
+    """Response for `PATCH /conversations/{id}/cancel/` on a sandbox-runtime conversation."""
+
+    task_id = serializers.CharField(help_text="The products/tasks Task backing the conversation.")
+    run_id = serializers.CharField(help_text="The Run that was targeted for cancellation.")
+    run_status = serializers.CharField(help_text="Status of the Run after the cancel command was issued.")
 
 
 @extend_schema(tags=["max"])
@@ -685,13 +697,27 @@ class ConversationViewSet(
                 "trace_id": result.trace_id,
                 "conversation_id": str(conversation.id),
                 "execution_type": "sandbox",
+                "agent_runtime": "sandbox",
                 "just_created_run": result.just_created_run,
+                "has_attached_context": result.attached_context_count > 0,
+                "attached_context_count": result.attached_context_count,
             },
             team=self.team,
             request=request,
         )
-        return Response(result.model_dump(), status=status.HTTP_200_OK)
+        # attached_context_count is internal telemetry plumbing — keep it out of the response body.
+        return Response(result.model_dump(exclude={"attached_context_count"}), status=status.HTTP_200_OK)
 
+    @extend_schema(
+        description="Cancel the conversation's in-progress run (sandbox or LangGraph).",
+        responses={
+            200: SandboxCancelResponseSerializer,
+            204: OpenApiResponse(description="LangGraph cancellation accepted, or already cancelling."),
+            400: OpenApiResponse(description="Sandbox conversation has no backing task or active run."),
+            422: OpenApiResponse(description="Failed to cancel the LangGraph conversation."),
+            502: OpenApiResponse(description="Sandbox agent unreachable or rejected the cancel command."),
+        },
+    )
     @action(detail=True, methods=["PATCH"])
     def cancel(self, request: Request, *args, **kwargs):
         conversation = self.get_object()
@@ -699,8 +725,26 @@ class ConversationViewSet(
         if conversation.agent_runtime == Conversation.AgentRuntime.SANDBOX:
             # Sandbox runs are cancelled in-process via the products/tasks command
             # path; no LangGraph workflow is involved.
-            result = MessageRoutingService(conversation, cast(User, request.user)).cancel()
-            return Response(result.model_dump(), status=status.HTTP_200_OK)
+            user = cast(User, request.user)
+            result = MessageRoutingService(conversation, user).cancel()
+            if result.cancel_requested:
+                # Only when a live run was actually signalled — an already-terminal no-op
+                # cancelled nothing. The endpoint is always user-initiated; sandbox idle
+                # shutdowns surface separately as a terminal task_run_state.
+                report_user_action(
+                    user,
+                    "task_run_cancelled",
+                    {
+                        "conversation_id": str(conversation.id),
+                        "run_id": result.run_id,
+                        "execution_type": "sandbox",
+                        "cancel_source": "user",
+                    },
+                    team=self.team,
+                    request=request,
+                )
+            # cancel_requested only gates the telemetry above — keep it out of the response body.
+            return Response(result.model_dump(exclude={"cancel_requested"}), status=status.HTTP_200_OK)
 
         # IDLE is intentionally not short-circuited: during the handoff between the main
         # workflow completing and a queued workflow starting, the status is briefly IDLE
@@ -748,6 +792,9 @@ class ConversationViewSet(
         request_id = serializer.validated_data["requestId"]
         option_id = serializer.validated_data["optionId"]
         custom_input = serializer.validated_data.get("customInput")
+        # UUIDField yields a UUID instance; stringify for the analytics payload.
+        trace_id = serializer.validated_data.get("traceId")
+        trace_id = str(trace_id) if trace_id else None
 
         result = send_permission_response(
             task_run,
@@ -763,6 +810,7 @@ class ConversationViewSet(
                 event="permission_responded",
                 properties={
                     "conversation_id": str(conversation.id),
+                    "trace_id": trace_id,
                     "request_id": request_id,
                     "option_id": option_id,
                     "execution_type": "sandbox",

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -1262,7 +1262,12 @@ class TestConversationSandboxRoute(APIBaseTest):
     def test_sandbox_route_reachable_and_delegates_to_handler(self):
         conversation = self._sandbox_conversation()
         sentinel = SandboxRouteResult(
-            task_id="t", run_id="r", trace_id=None, run_status="queued", just_created_run=True
+            task_id="t",
+            run_id="r",
+            trace_id=None,
+            run_status="queued",
+            just_created_run=True,
+            attached_context_count=2,
         )
         with (
             patch("ee.api.conversation.MessageRoutingService") as m_service,
@@ -1275,13 +1280,20 @@ class TestConversationSandboxRoute(APIBaseTest):
             )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), sentinel.model_dump())
+        # attached_context_count is internal telemetry plumbing, excluded from the response body.
+        self.assertEqual(response.json(), sentinel.model_dump(exclude={"attached_context_count"}))
         m_service.return_value.handle.assert_called_once()
         # The service receives the resolved conversation, not just an id.
         passed_conversation = m_service.call_args[0][0]
         self.assertEqual(passed_conversation.id, conversation.id)
-        # Telemetry fires at the API boundary, after the service returns.
+        # Telemetry fires once at the API boundary with sandbox-path field parity, derived
+        # from the routing result.
         m_telemetry.assert_called_once()
+        props = m_telemetry.call_args[0][2]
+        self.assertEqual(props["execution_type"], "sandbox")
+        self.assertEqual(props["agent_runtime"], "sandbox")
+        self.assertTrue(props["has_attached_context"])
+        self.assertEqual(props["attached_context_count"], 2)
 
     def test_sandbox_route_blocked_when_quota_limited(self):
         conversation = self._sandbox_conversation()
@@ -1339,12 +1351,38 @@ class TestConversationSandboxRoute(APIBaseTest):
 
     def test_cancel_sandbox_conversation_delegates_to_sandbox_handler(self):
         conversation = self._sandbox_conversation()
-        sentinel = SandboxCancelResult(task_id="t", run_id="r", run_status="cancelled")
-        with patch("ee.api.conversation.MessageRoutingService") as m_service:
+        sentinel = SandboxCancelResult(task_id="t", run_id="r", run_status="cancelled", cancel_requested=True)
+        with (
+            patch("ee.api.conversation.MessageRoutingService") as m_service,
+            patch("ee.api.conversation.report_user_action") as m_telemetry,
+        ):
             m_service.return_value.cancel.return_value = sentinel
             response = self.client.patch(
                 f"/api/environments/{self.team.id}/conversations/{conversation.id}/cancel/",
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), sentinel.model_dump())
+        # cancel_requested only gates telemetry; it's excluded from the response body.
+        self.assertEqual(response.json(), sentinel.model_dump(exclude={"cancel_requested"}))
         m_service.return_value.cancel.assert_called_once()
+        # A real cancel fires task_run_cancelled with the user source.
+        m_telemetry.assert_called_once()
+        self.assertEqual(m_telemetry.call_args[0][1], "task_run_cancelled")
+        props = m_telemetry.call_args[0][2]
+        self.assertEqual(props["execution_type"], "sandbox")
+        self.assertEqual(props["cancel_source"], "user")
+        self.assertEqual(props["run_id"], "r")
+
+    def test_cancel_sandbox_conversation_skips_telemetry_for_terminal_noop(self):
+        conversation = self._sandbox_conversation()
+        # cancel_requested defaults False — an already-terminal run was a no-op.
+        sentinel = SandboxCancelResult(task_id="t", run_id="r", run_status="completed")
+        with (
+            patch("ee.api.conversation.MessageRoutingService") as m_service,
+            patch("ee.api.conversation.report_user_action") as m_telemetry,
+        ):
+            m_service.return_value.cancel.return_value = sentinel
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/cancel/",
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        m_telemetry.assert_not_called()

--- a/ee/api/test/test_conversation_permission.py
+++ b/ee/api/test/test_conversation_permission.py
@@ -57,6 +57,33 @@ class TestConversationPermission(APIBaseTest):
         _, kwargs = mock_send.call_args
         self.assertEqual(kwargs["custom_input"], "try harder")
 
+    def test_permission_responded_telemetry_includes_trace_id(self):
+        run = self._create_run()
+        conversation = Conversation.objects.create(user=self.user, team=self.team, task=run.task)
+        trace_id = "123e4567-e89b-12d3-a456-426614174000"
+
+        with (
+            patch(
+                "ee.api.conversation.send_permission_response",
+                return_value=CommandResult(success=True, status_code=200, data={}),
+            ),
+            patch("ee.api.conversation.posthoganalytics.capture") as mock_capture,
+        ):
+            self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/permission/",
+                {"requestId": "req-3", "optionId": "allow_once", "traceId": trace_id},
+                format="json",
+            )
+
+        mock_capture.assert_called_once()
+        self.assertEqual(mock_capture.call_args.kwargs["event"], "permission_responded")
+        props = mock_capture.call_args.kwargs["properties"]
+        self.assertEqual(props["trace_id"], trace_id)
+        self.assertEqual(props["request_id"], "req-3")
+        self.assertEqual(props["option_id"], "allow_once")
+        self.assertEqual(props["execution_type"], "sandbox")
+        self.assertEqual(props["conversation_id"], str(conversation.id))
+
     def test_permission_400_when_no_sandbox_run(self):
         conversation = Conversation.objects.create(user=self.user, team=self.team)
         response = self.client.post(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6684,6 +6684,7 @@ const api = {
                 requestId: string
                 optionId: string
                 customInput?: string
+                traceId?: string
             }
         ): Promise<{ status: string }> {
             return new ApiRequest().conversation(conversationId).withAction('permission').create({ data })

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -1330,6 +1330,68 @@ describe('maxThreadLogic', () => {
         })
     })
 
+    describe('sandbox history-load branch', () => {
+        const SANDBOX_TASK_ID = 'task-abc'
+        const SANDBOX_RUN_ID = 'run-abc'
+
+        function sandboxConversation(currentRunId: string | null): ConversationDetail {
+            return {
+                id: MOCK_CONVERSATION_ID,
+                status: ConversationStatus.InProgress,
+                title: 'Sandbox chat',
+                user: MOCK_DEFAULT_BASIC_USER,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                type: ConversationType.Assistant,
+                agent_runtime: 'sandbox',
+                task: { id: SANDBOX_TASK_ID, current_run_id: currentRunId },
+                messages: [],
+            }
+        }
+
+        it('replays logs/ then opens SSE for a non-terminal sandbox run, never reconnecting LangGraph', async () => {
+            logic.unmount()
+            jest.spyOn(api.conversations, 'get').mockResolvedValue(sandboxConversation(SANDBOX_RUN_ID))
+            const logsSpy = jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([])
+            const runSpy = jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+            const streamSpy = mockStream()
+
+            logic = maxThreadLogic({
+                conversationId: MOCK_CONVERSATION_ID,
+                panelId: 'test',
+                conversation: sandboxConversation(SANDBOX_RUN_ID),
+            })
+            logic.mount()
+            // Drain the async afterMount (loadConversation → bootstrapRun → logs/ replay → run refetch).
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            await new Promise((resolve) => setTimeout(resolve, 0))
+
+            // bootstrapRun replayed logs/ and refetched the run, then opened SSE — and the LangGraph
+            // stream was never touched (coexistence).
+            expect(logsSpy).toHaveBeenCalledWith(SANDBOX_TASK_ID, SANDBOX_RUN_ID)
+            expect(runSpy).toHaveBeenCalledWith(SANDBOX_TASK_ID, SANDBOX_RUN_ID)
+            expect(streamSpy).not.toHaveBeenCalled()
+        })
+
+        it('does not bootstrap a sandbox run without a current_run_id', async () => {
+            logic.unmount()
+            jest.spyOn(api.conversations, 'get').mockResolvedValue(sandboxConversation(null))
+            const logsSpy = jest.spyOn(api.tasks.runs, 'getLogEntries')
+            const streamSpy = mockStream()
+
+            logic = maxThreadLogic({
+                conversationId: MOCK_CONVERSATION_ID,
+                panelId: 'test',
+                conversation: sandboxConversation(null),
+            })
+            logic.mount()
+            await new Promise((resolve) => setTimeout(resolve, 0))
+
+            expect(logsSpy).not.toHaveBeenCalled()
+            expect(streamSpy).not.toHaveBeenCalled()
+        })
+    })
+
     describe('command selection and activation', () => {
         beforeEach(() => {
             logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -197,7 +197,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 'openSseForRun as openSandboxSse',
                 'pushHumanMessage as pushSandboxHumanMessage',
                 'pushErrorItem as pushSandboxError',
+                'bootstrapRun as bootstrapSandboxRun',
+                'reset as resetSandboxStream',
             ],
+            posthogAiContextLogic({ conversationId }),
+            ['clearAttachments as clearSandboxAttachments'],
         ],
     })),
 
@@ -685,6 +689,8 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                             runId: run_id,
                             // Fresh runs need everything from the top; follow-ups resume from latest.
                             startLatest: !just_created_run,
+                            // Correlate SSE-side telemetry with the trace this run was sent under.
+                            traceId,
                         })
                         // The streaming lock must span the whole SSE stream so the input stays
                         // guarded until `_posthog/turn_complete` or a terminal/error event —
@@ -1923,6 +1929,27 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         // Grab freshly loaded conversation from cache; if missing, the load failed, so skip reconnect
         const conversation = maxGlobalLogic.values.conversationHistory.find((c) => c.id === parentConversationId)
         if (!conversation || conversation.messages === undefined) {
+            return
+        }
+
+        // Sandbox history-load branch. Sandbox conversations don't persist messages Django-side —
+        // history lives in S3 ACP logs, read via the products/tasks logs/ endpoint. Hand off to
+        // sandboxStreamLogic, which replays logs/ then opens SSE if non-terminal. The LangGraph
+        // reconnect path below is never entered for sandbox runtimes (coexistence).
+        if (conversation.agent_runtime === 'sandbox') {
+            // sandboxStreamLogic and posthogAiContextLogic are connected (so already mounted) for this
+            // conversation. Reset their per-conversation state before replaying this run's history.
+            actions.resetSandboxStream()
+            actions.clearSandboxAttachments()
+            if (conversation.task) {
+                const runId = conversation.task.current_run_id
+                if (runId) {
+                    actions.bootstrapSandboxRun({
+                        taskId: conversation.task.id,
+                        runId,
+                    })
+                }
+            }
             return
         }
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -946,6 +946,33 @@ describe('sandboxStreamLogic', () => {
                 expect.objectContaining({ requestId: 'req-1', optionId: 'allow_once', traceId: 'trace-1' })
             )
         })
+
+        it('suppresses run lifecycle telemetry while replaying history on bootstrap', async () => {
+            const captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined as any)
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([
+                notification('_posthog/run_started', {}) as any,
+                sessionUpdate({
+                    sessionUpdate: 'tool_call',
+                    toolCallId: 't1',
+                    serverName: 'posthog',
+                    toolName: 'exec',
+                    rawInput: { command: 'call execute-sql {"query":"select 1"}' },
+                    status: 'in_progress',
+                }) as any,
+                sessionUpdate({ sessionUpdate: 'tool_call_update', toolCallId: 't1', status: 'completed' }) as any,
+            ])
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'completed' } as any)
+
+            logic.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-1' })
+            await flushPromises()
+
+            // History is folded in (run marked started, status terminal) but none of the lifecycle
+            // events re-fire — the run lived and died in a prior session.
+            expect(logic.values.runStarted).toEqual(true)
+            expect(logic.values.currentRunStatus).toEqual('completed')
+            const lifecycleEvents = ['task_run_started', 'task_run_terminated', 'tool_call_completed']
+            expect(captureSpy.mock.calls.filter((c) => lifecycleEvents.includes(c[0] as string))).toEqual([])
+        })
     })
 
     describe('permission_request ingest', () => {

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -827,6 +827,127 @@ describe('sandboxStreamLogic', () => {
         })
     })
 
+    describe('telemetry parity', () => {
+        it('emits TASK_RUN_STARTED once on the first run_started frame, always cold (wire carries no warmth)', async () => {
+            const captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined as any)
+            logic.actions.openSseForRun({
+                taskId: 'task-1',
+                runId: 'run-1',
+                traceId: 'trace-1',
+            })
+
+            await expectLogic(logic, () => {
+                // A stray cold_start hint on the wire is ignored — pre-warming isn't wired yet.
+                logic.actions.ingestAcpFrame(notification('_posthog/run_started', { cold_start: false }))
+                logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
+            }).toFinishAllListeners()
+
+            const startedCalls = captureSpy.mock.calls.filter((c) => c[0] === 'task_run_started')
+            expect(startedCalls.length).toEqual(1)
+            expect(startedCalls[0][1]).toEqual(
+                expect.objectContaining({
+                    conversation_id: 'test-conversation',
+                    trace_id: 'trace-1',
+                    run_id: 'run-1',
+                    task_id: 'task-1',
+                    execution_type: 'sandbox',
+                    cold_start: true,
+                })
+            )
+        })
+
+        it('emits TASK_RUN_TERMINATED with duration_ms measured from run start', async () => {
+            const captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined as any)
+            logic.actions.openSseForRun({
+                taskId: 'task-1',
+                runId: 'run-1',
+                traceId: 'trace-1',
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
+                logic.actions.handleTerminalStatus({ status: 'failed', errorMessage: 'boom' })
+            }).toFinishAllListeners()
+
+            const call = captureSpy.mock.calls.find((c) => c[0] === 'task_run_terminated')
+            expect(call?.[1]).toEqual(
+                expect.objectContaining({
+                    conversation_id: 'test-conversation',
+                    trace_id: 'trace-1',
+                    run_id: 'run-1',
+                    status: 'failed',
+                    error_message: 'boom',
+                    execution_type: 'sandbox',
+                })
+            )
+            expect((call![1] as any).duration_ms).toBeGreaterThanOrEqual(0)
+        })
+
+        it('emits TOOL_CALL_COMPLETED once when a tool call reaches a terminal status', async () => {
+            const captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined as any)
+            logic.actions.openSseForRun({
+                taskId: 'task-1',
+                runId: 'run-1',
+                traceId: 'trace-1',
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({
+                        sessionUpdate: 'tool_call',
+                        toolCallId: 't1',
+                        serverName: 'posthog',
+                        toolName: 'exec',
+                        rawInput: { command: 'call execute-sql {"query":"select 1"}' },
+                        status: 'in_progress',
+                    })
+                )
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({ sessionUpdate: 'tool_call_update', toolCallId: 't1', status: 'completed' })
+                )
+                // A second terminal update must not re-emit.
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({ sessionUpdate: 'tool_call_update', toolCallId: 't1', status: 'completed' })
+                )
+            }).toFinishAllListeners()
+
+            const toolCalls = captureSpy.mock.calls.filter((c) => c[0] === 'tool_call_completed')
+            expect(toolCalls.length).toEqual(1)
+            expect(toolCalls[0][1]).toEqual(
+                expect.objectContaining({
+                    conversation_id: 'test-conversation',
+                    trace_id: 'trace-1',
+                    tool_call_id: 't1',
+                    tool_qualified_name: 'execute-sql',
+                    status: 'completed',
+                    execution_type: 'sandbox',
+                })
+            )
+        })
+
+        it('forwards the trace_id to the permission endpoint for PERMISSION_RESPONDED correlation', async () => {
+            const permissionSpy = jest.spyOn(api.conversations, 'permission').mockResolvedValue({ status: 'ok' } as any)
+            logic.actions.openSseForRun({
+                taskId: 'task-1',
+                runId: 'run-1',
+                traceId: 'trace-1',
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.respondToPermission({
+                    conversationId: 'conv-1',
+                    requestId: 'req-1',
+                    optionId: 'allow_once',
+                })
+            }).toFinishAllListeners()
+
+            expect(permissionSpy).toHaveBeenCalledWith(
+                'conv-1',
+                expect.objectContaining({ requestId: 'req-1', optionId: 'allow_once', traceId: 'trace-1' })
+            )
+        })
+    })
+
     describe('permission_request ingest', () => {
         const permissionFrame: PermissionRequestFrame = {
             type: 'permission_request',

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -329,7 +329,11 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
          * buttons re-enable for retry) without coupling that reset to unrelated stream errors.
          */
         permissionResponseFailed: true,
-        handleTerminalStatus: (status: { status: SandboxRunStatus; errorMessage?: string | null }) => status,
+        handleTerminalStatus: (status: {
+            status: SandboxRunStatus
+            errorMessage?: string | null
+            replayedFromHistory?: boolean
+        }) => status,
         handleStreamError: (envelope: { errorTitle: string; errorMessage?: string; retryable: boolean }) => envelope,
         // Internal state-folding actions emitted by ingestAcpFrame.
         appendAssistantChunk: (id: string, delta: string) => ({ id, delta }),
@@ -615,8 +619,9 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 return
             }
             if (isTerminalRunStatus(result.status)) {
-                // Read-only history — surface the terminal status, do not open SSE.
-                actions.handleTerminalStatus({ status: result.status as SandboxRunStatus })
+                // Read-only history — surface the terminal status, do not open SSE. Flag the replay
+                // so the listener records the status without re-emitting termination telemetry.
+                actions.handleTerminalStatus({ status: result.status as SandboxRunStatus, replayedFromHistory: true })
                 return
             }
             // Non-terminal: open SSE from the latest point, deduping against the replayed history.
@@ -790,7 +795,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 lemonToast.error('Failed to send approval. Please try again.')
             }
         },
-        handleTerminalStatus: ({ status, errorMessage }) => {
+        handleTerminalStatus: ({ status, errorMessage, replayedFromHistory }) => {
             // The wire emits task_run_state for non-terminal transitions too (e.g. queued →
             // in_progress) — only an actually-terminal run has no more frames to stream.
             if (!isTerminalRunStatus(status)) {
@@ -798,6 +803,13 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             }
             cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
+
+            // A run that already terminated in a prior session is surfaced read-only on reopen —
+            // the reducers still record the terminal status, but re-emitting telemetry on every
+            // page load would inflate termination counts.
+            if (replayedFromHistory) {
+                return
+            }
 
             // TASK_RUN_TERMINATED telemetry. `duration_ms` is measured from the `_posthog/run_started`
             // frame; absent if the run terminated before one was seen.
@@ -843,8 +855,10 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             // Custom `_posthog/*` notification namespace emitted by the agent-server.
             if (method === '_posthog/run_started') {
                 // TASK_RUN_STARTED telemetry — emit once per run on the first `_posthog/run_started`
-                // frame. `cold_start` is true unless the run was pre-warmed.
-                if (!values.runStarted) {
+                // frame. `cold_start` is true unless the run was pre-warmed. Suppressed while
+                // replaying history (the run started in a prior session) — `markRunStarted` below
+                // still runs so the thread's started/thinking state stays correct.
+                if (!values.runStarted && cache.bootstrapReplay !== true) {
                     const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
                     cache.runStartedAtMs = Date.now()
                     posthog.capture('task_run_started', {
@@ -994,8 +1008,10 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     })
                     // TOOL_CALL_COMPLETED telemetry (optional) — emit once when a tool call first
                     // transitions to a terminal status. `duration_ms` is measured from the run start
-                    // since per-tool start timing isn't carried on the wire.
+                    // since per-tool start timing isn't carried on the wire. Suppressed while
+                    // replaying history so a reopen doesn't re-count tool calls from a prior session.
                     if (
+                        cache.bootstrapReplay !== true &&
                         (status === 'completed' || status === 'failed') &&
                         existing?.status !== 'completed' &&
                         existing?.status !== 'failed'

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -283,8 +283,9 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
          * `logs/` endpoint, then open SSE if the run is non-terminal. `justCreatedRun` skips the
          * `logs/` round-trip (fresh-run fast path — nothing historical to assemble).
          */
-        bootstrapRun: (payload: { taskId: string; runId: string; justCreatedRun?: boolean }) => payload,
-        openSseForRun: (payload: { taskId: string; runId: string; startLatest?: boolean }) => payload,
+        bootstrapRun: (payload: { taskId: string; runId: string; justCreatedRun?: boolean; traceId?: string }) =>
+            payload,
+        openSseForRun: (payload: { taskId: string; runId: string; startLatest?: boolean; traceId?: string }) => payload,
         closeSse: true,
         sseConnecting: true,
         sseOpened: true,
@@ -386,6 +387,18 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 // flickering back to queued; only a fresh open (no/terminal status) resets.
                 openSseForRun: (state) => (state && !isTerminalRunStatus(state) ? state : 'queued'),
                 handleTerminalStatus: (_, { status }) => status,
+                reset: () => null,
+            },
+        ],
+        // Trace correlation for the telemetry inventory. The SSE bypasses Django, so the frontend
+        // supplies the trace_id it minted for POST /sandbox/ when it opened the run; conversation_id
+        // is this keyed logic's own props.conversationId. Undefined for history-loaded runs — a
+        // reload can't recover the trace_id the original run was sent under.
+        traceId: [
+            null as string | null,
+            {
+                bootstrapRun: (state, { traceId }) => traceId ?? state,
+                openSseForRun: (state, { traceId }) => traceId ?? state,
                 reset: () => null,
             },
         ],
@@ -562,7 +575,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 runStarted && !turnComplete && !isTerminalRunStatus(currentRunStatus) && sseStatus !== 'error',
         ],
     }),
-    listeners(({ values, actions, cache }) => ({
+    listeners(({ values, actions, cache, props }) => ({
         bootstrapRun: async ({ taskId, runId, justCreatedRun }, breakpoint) => {
             const projectId = values.currentProjectId
             if (projectId === null) {
@@ -746,6 +759,8 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             // emit what this logic knows.
             const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
             posthog.capture('permission_requested', {
+                conversation_id: props.conversationId,
+                trace_id: values.traceId,
                 request_id: record.requestId,
                 tool_call_name: record.rawToolCall.resolvedKey,
                 tool_call_id: record.toolCallId,
@@ -756,10 +771,13 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         },
         respondToPermission: async ({ conversationId, requestId, optionId, customInput }) => {
             try {
+                // PERMISSION_RESPONDED telemetry is emitted server-side by the /permission/ handler;
+                // forward the trace_id so it can correlate with the rest of this run's events.
                 await api.conversations.permission(conversationId, {
                     requestId,
                     optionId,
                     customInput,
+                    traceId: values.traceId ?? undefined,
                 })
                 actions.markPermissionRequestResolved(requestId)
             } catch (error) {
@@ -772,7 +790,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 lemonToast.error('Failed to send approval. Please try again.')
             }
         },
-        handleTerminalStatus: ({ status }) => {
+        handleTerminalStatus: ({ status, errorMessage }) => {
             // The wire emits task_run_state for non-terminal transitions too (e.g. queued →
             // in_progress) — only an actually-terminal run has no more frames to stream.
             if (!isTerminalRunStatus(status)) {
@@ -780,6 +798,21 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             }
             cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
+
+            // TASK_RUN_TERMINATED telemetry. `duration_ms` is measured from the `_posthog/run_started`
+            // frame; absent if the run terminated before one was seen.
+            const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
+            const startedAt = cache.runStartedAtMs as number | undefined
+            posthog.capture('task_run_terminated', {
+                conversation_id: props.conversationId,
+                trace_id: values.traceId,
+                run_id: activeRun?.runId,
+                task_id: activeRun?.taskId,
+                status,
+                error_message: errorMessage ?? undefined,
+                execution_type: 'sandbox',
+                duration_ms: startedAt !== undefined ? Date.now() - startedAt : undefined,
+            })
         },
         closeSse: () => {
             cache.activeRun = undefined
@@ -788,6 +821,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         },
         reset: () => {
             cache.activeRun = undefined
+            cache.runStartedAtMs = undefined
             cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
         },
@@ -808,6 +842,22 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
 
             // Custom `_posthog/*` notification namespace emitted by the agent-server.
             if (method === '_posthog/run_started') {
+                // TASK_RUN_STARTED telemetry — emit once per run on the first `_posthog/run_started`
+                // frame. `cold_start` is true unless the run was pre-warmed.
+                if (!values.runStarted) {
+                    const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
+                    cache.runStartedAtMs = Date.now()
+                    posthog.capture('task_run_started', {
+                        conversation_id: props.conversationId,
+                        trace_id: values.traceId,
+                        run_id: activeRun?.runId,
+                        task_id: activeRun?.taskId,
+                        execution_type: 'sandbox',
+                        // The run-started frame carries no warmth signal and pre-warming isn't wired
+                        // yet, so every run is a cold start. A later pre-warm hook flips this.
+                        cold_start: true,
+                    })
+                }
                 actions.markRunStarted()
                 return
             }
@@ -942,6 +992,25 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                               }
                             : {}),
                     })
+                    // TOOL_CALL_COMPLETED telemetry (optional) — emit once when a tool call first
+                    // transitions to a terminal status. `duration_ms` is measured from the run start
+                    // since per-tool start timing isn't carried on the wire.
+                    if (
+                        (status === 'completed' || status === 'failed') &&
+                        existing?.status !== 'completed' &&
+                        existing?.status !== 'failed'
+                    ) {
+                        const startedAt = cache.runStartedAtMs as number | undefined
+                        posthog.capture('tool_call_completed', {
+                            conversation_id: props.conversationId,
+                            trace_id: values.traceId,
+                            tool_call_id: toolCallId,
+                            tool_qualified_name: existing?.resolvedKey,
+                            status,
+                            duration_ms: startedAt !== undefined ? Date.now() - startedAt : undefined,
+                            execution_type: 'sandbox',
+                        })
+                    }
                     break
                 }
                 case 'current_mode_update': {

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -384,6 +384,18 @@ export interface PatchedConversationApi {
 }
 
 /**
+ * Response for `PATCH /conversations/{id}/cancel/` on a sandbox-runtime conversation.
+ */
+export interface SandboxCancelResponseApi {
+    /** The products/tasks Task backing the conversation. */
+    task_id: string
+    /** The Run that was targeted for cancellation. */
+    run_id: string
+    /** Status of the Run after the cancel command was issued. */
+    run_status: string
+}
+
+/**
  * Approval reply for a sandbox-runtime `permission_request`.
  */
 export interface PermissionResponseApi {
@@ -402,6 +414,8 @@ export interface PermissionResponseApi {
      * @maxLength 10000
      */
     customInput?: string
+    /** Trace id the client associated with the run, for PERMISSION_RESPONDED telemetry correlation. */
+    traceId?: string
 }
 
 /**

--- a/products/conversations/frontend/generated/api.ts
+++ b/products/conversations/frontend/generated/api.ts
@@ -30,6 +30,7 @@ import type {
     PatchedTicketApi,
     PermissionResponseApi,
     PermissionResponseResultApi,
+    SandboxCancelResponseApi,
     SandboxMessageApi,
     SandboxMessageResponseApi,
     SuggestReplyResponseApi,
@@ -166,18 +167,24 @@ export const getConversationsCancelPartialUpdateUrl = (projectId: string, conver
     return `/api/environments/${projectId}/conversations/${conversation}/cancel/`
 }
 
+/**
+ * Cancel the conversation's in-progress run (sandbox or LangGraph).
+ */
 export const conversationsCancelPartialUpdate = async (
     projectId: string,
     conversation: string,
     patchedConversationApi?: NonReadonly<PatchedConversationApi>,
     options?: RequestInit
-): Promise<ConversationApi> => {
-    return apiMutator<ConversationApi>(getConversationsCancelPartialUpdateUrl(projectId, conversation), {
-        ...options,
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(patchedConversationApi),
-    })
+): Promise<SandboxCancelResponseApi | void> => {
+    return apiMutator<SandboxCancelResponseApi | void>(
+        getConversationsCancelPartialUpdateUrl(projectId, conversation),
+        {
+            ...options,
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(patchedConversationApi),
+        }
+    )
 }
 
 export const getConversationsPermissionCreateUrl = (projectId: string, conversation: string) => {

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -66,6 +66,9 @@ export const ConversationsAppendMessageCreateBody = /* @__PURE__ */ zod
     })
     .describe('Serializer for appending a message to an existing conversation without triggering AI processing.')
 
+/**
+ * Cancel the conversation's in-progress run (sandbox or LangGraph).
+ */
 export const ConversationsCancelPartialUpdateBody = /* @__PURE__ */ zod.looseObject({})
 
 /**
@@ -92,6 +95,10 @@ export const ConversationsPermissionCreateBody = /* @__PURE__ */ zod
             .max(conversationsPermissionCreateBodyCustomInputMax)
             .optional()
             .describe("Optional feedback text sent with a 'reject_with_feedback' decision."),
+        traceId: zod
+            .uuid()
+            .optional()
+            .describe('Trace id the client associated with the run, for PERMISSION_RESPONDED telemetry correlation.'),
     })
     .describe('Approval reply for a sandbox-runtime `permission_request`.')
 

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -49,6 +49,8 @@ class SandboxRouteResult(BaseModel):
     trace_id: str | None
     run_status: str
     just_created_run: bool
+    # Count of attached context items the message carried, for the routing endpoint's telemetry.
+    attached_context_count: int = 0
 
 
 class SandboxCancelResult(BaseModel):
@@ -57,6 +59,9 @@ class SandboxCancelResult(BaseModel):
     task_id: str
     run_id: str
     run_status: str
+    # True only when a live run was actually signalled to cancel (not an already-terminal no-op),
+    # so the cancel handler emits cancellation telemetry exactly once per real cancel.
+    cancel_requested: bool = False
 
 
 class SandboxCommandError(exceptions.APIException):
@@ -169,7 +174,7 @@ class MessageRoutingService(BaseSandboxService):
             raise exceptions.ValidationError("This conversation has no active run to cancel.")
 
         if run.is_terminal:
-            # Nothing to cancel — report the already-terminal status idempotently.
+            # Nothing to cancel — report the already-terminal status idempotently, no telemetry.
             return SandboxCancelResult(
                 task_id=str(self.conversation.task_id), run_id=str(run.id), run_status=run.status
             )
@@ -181,7 +186,12 @@ class MessageRoutingService(BaseSandboxService):
             raise SandboxCommandError(f"Failed to cancel the run: {result.error}")
         run.refresh_from_db(fields=["status"])
 
-        return SandboxCancelResult(task_id=str(self.conversation.task_id), run_id=str(run.id), run_status=run.status)
+        return SandboxCancelResult(
+            task_id=str(self.conversation.task_id),
+            run_id=str(run.id),
+            run_status=run.status,
+            cancel_requested=True,
+        )
 
     def _handle_first_message(
         self,
@@ -260,6 +270,7 @@ class MessageRoutingService(BaseSandboxService):
             trace_id=trace_id,
             run_status=task_run.status,
             just_created_run=True,
+            attached_context_count=len(attached_context),
         )
 
     def _handle_in_progress_followup(
@@ -286,6 +297,7 @@ class MessageRoutingService(BaseSandboxService):
             trace_id=trace_id,
             run_status=run.status,
             just_created_run=False,
+            attached_context_count=len(attached_context),
         )
 
     def _handle_terminal_resume(
@@ -356,6 +368,7 @@ class MessageRoutingService(BaseSandboxService):
             trace_id=trace_id,
             run_status=new_run.status,
             just_created_run=True,
+            attached_context_count=len(attached_context),
         )
 
     def _collect_seen_entity_refs(self, run: TaskRun) -> list[tuple[str, str | int]]:

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -152,6 +152,8 @@ class TestHandleSandboxMessage(APIBaseTest):
         assert result.run_id == str(run.id)
         assert result.just_created_run is False
         assert result.run_status == TaskRun.Status.IN_PROGRESS
+        # The routing endpoint reads this off the result for its "prompt sent" telemetry.
+        assert result.attached_context_count == 1
 
         # The live workflow is signalled, no new Run created.
         m_signal.assert_called_once()
@@ -333,6 +335,8 @@ class TestHandleSandboxCancel(APIBaseTest):
         assert result.task_id == str(task.id)
         assert result.run_id == str(run.id)
         assert result.run_status == TaskRun.Status.IN_PROGRESS
+        # A live run was actually signalled — the routing endpoint emits cancellation telemetry.
+        assert result.cancel_requested is True
         m_cancel.assert_called_once()
 
     def test_cancel_delivery_failure_raises_502(self):
@@ -352,6 +356,8 @@ class TestHandleSandboxCancel(APIBaseTest):
         with patch(f"{ROUTING}.send_cancel") as m_cancel:
             result = self._service().cancel()
         assert result.run_status == TaskRun.Status.COMPLETED
+        # Nothing was cancelled, so no cancellation telemetry should fire.
+        assert result.cancel_requested is False
         m_cancel.assert_not_called()
 
     def test_cancel_without_task_raises(self):

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -34732,6 +34732,8 @@ export namespace Schemas {
          * @maxLength 10000
          */
       customInput?: string;
+      /** Trace id the client associated with the run, for PERMISSION_RESPONDED telemetry correlation. */
+      traceId?: string;
     }
 
     /**
@@ -39179,6 +39181,18 @@ export namespace Schemas {
       name?: string;
       /** Free-text content. Only for `text` attachments. */
       value?: string;
+    }
+
+    /**
+     * Response for `PATCH /conversations/{id}/cancel/` on a sandbox-runtime conversation.
+     */
+    export interface SandboxCancelResponse {
+      /** The products/tasks Task backing the conversation. */
+      task_id: string;
+      /** The Run that was targeted for cancellation. */
+      run_id: string;
+      /** Status of the Run after the cancel command was issued. */
+      run_status: string;
     }
 
     export interface SandboxEnvironment {


### PR DESCRIPTION
## Problem

PR **I2.7** of the PostHog AI → sandbox-agent migration (`docs/internal/posthog-ai-migration/00_OVERVIEW.md` § 10). Re-opening an existing sandbox conversation must rebuild its thread from the S3 ACP log (not Django messages), and the sandbox path must emit the same analytics events as LangGraph so existing dashboards keep working.

> Stacked on **`feat/phai-sandbox-integration`** (contains I1.1–I3.8 + UI-A/B).

## Changes

Per `02_CORE` §§ 4.7, 7.2, 10 (coexistence — sandbox branches only):

- **History-load:** a sandbox branch in `maxThreadLogic.afterMount` (the reconnect site `maxLogic` drives) calls `sandboxStreamLogic.bootstrapRun(...)` — replays the `products/tasks` `logs/` chain through `ingestAcpFrame`, refetches the run, opens SSE only when non-terminal; terminal runs stay read-only and never enter the LangGraph EventSource loop.
- **Lifecycle:** ref-counted per-conversation mount/reset of `sandboxStreamLogic` + `posthogAiContextLogic` (the deferred I1.3/I2.6 item).
- **Telemetry parity (§10):** every event carries `execution_type: 'sandbox'` — `PROMPT_SENT` (now with `agent_runtime`/`has_attached_context`/`attached_context_count`), `TASK_RUN_STARTED` (cold_start), `TASK_RUN_TERMINATED` (status/duration), `TOOL_CALL_COMPLETED`, and `conversation_id`/`trace_id` threaded into `PERMISSION_REQUESTED`/`RESPONDED`. No double-emit on the LangGraph path.

## How did you test this code?

Automated only (I'm an agent): format + ruff clean; scoped `tsc` 0 errors in changed files; 134 jest tests (history-load branch + telemetry fixtures) and 15+5 backend tests pass.

## 🤖 Agent context

Built by Claude Code (Opus 4.8) via a multi-agent workflow (implement → verify) in an isolated worktree off the integration branch. The history-load branch lives in `maxThreadLogic.afterMount` rather than `maxLogic.tsx` because that's the only coexistence-safe insertion point that can short-circuit the LangGraph reconnect (`§ 7.2` shares the control flow). The new `traceId` field on `PermissionResponseSerializer` was hand-mirrored into generated types because `build:openapi` couldn't run offline — the integration branch's verify step regenerates and confirms no drift. Requires human review; not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
