### PR TITLE
feat(posthog-ai): sandbox approval UI, mode badge, live progress

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -150,11 +150,9 @@ function toolInvocationToMessage(
  * `conversation.agent_runtime === 'sandbox'`.
  */
 function SandboxThread(): JSX.Element {
-    const { threadItems, toolInvocations, currentProgress, runStarted, turnComplete } = useValues(sandboxStreamLogic)
-
     // Drive the thinking indicator from real agent progress: show the latest `_posthog/progress`
     // message while the run is active, falling back to the canned rotation.
-    const isThinking = runStarted && !turnComplete
+    const { threadItems, toolInvocations, currentProgress, isThinking } = useValues(sandboxStreamLogic)
 
     return (
         <>
@@ -200,7 +198,9 @@ function SandboxThread(): JSX.Element {
  * `_posthog/progress` message when present, otherwise the canned thinking rotation.
  */
 function SandboxThinkingIndicator({ progress }: { progress: string | null }): JSX.Element {
-    const message = useMemo(() => (progress?.trim() ? progress : getRandomThinkingMessage()), [progress])
+    // One roll per mount — re-rolling on every progress transition would visibly swap the verb.
+    const fallbackMessage = useMemo(() => getRandomThinkingMessage(), [])
+    const message = progress?.trim() ? progress : fallbackMessage
     return (
         <MessageTemplate type="ai">
             <div className="flex items-center gap-2 text-muted">

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -29,6 +29,7 @@ import {
     LemonDialog,
     LemonInput,
     LemonSkeleton,
+    Spinner,
     Tooltip,
 } from '@posthog/lemon-ui'
 
@@ -111,7 +112,7 @@ import {
     isVisualizationArtifactContent,
     visualizationTypeToQuery,
 } from './utils'
-import { getThinkingMessageFromResponse } from './utils/thinkingMessages'
+import { getRandomThinkingMessage, getThinkingMessageFromResponse } from './utils/thinkingMessages'
 
 // Helper function to check if a message is an error or failure
 function isErrorMessage(message: ThreadMessage): boolean {
@@ -149,7 +150,11 @@ function toolInvocationToMessage(
  * `conversation.agent_runtime === 'sandbox'`.
  */
 function SandboxThread(): JSX.Element {
-    const { threadItems, toolInvocations } = useValues(sandboxStreamLogic)
+    const { threadItems, toolInvocations, currentProgress, runStarted, turnComplete } = useValues(sandboxStreamLogic)
+
+    // Drive the thinking indicator from real agent progress: show the latest `_posthog/progress`
+    // message while the run is active, falling back to the canned rotation.
+    const isThinking = runStarted && !turnComplete
 
     return (
         <>
@@ -185,7 +190,24 @@ function SandboxThread(): JSX.Element {
                 }
                 return null
             })}
+            {isThinking && <SandboxThinkingIndicator progress={currentProgress} />}
         </>
+    )
+}
+
+/**
+ * Bottom-of-thread "what's it doing right now" line for sandbox conversations. Reflects the latest
+ * `_posthog/progress` message when present, otherwise the canned thinking rotation.
+ */
+function SandboxThinkingIndicator({ progress }: { progress: string | null }): JSX.Element {
+    const message = useMemo(() => (progress?.trim() ? progress : getRandomThinkingMessage()), [progress])
+    return (
+        <MessageTemplate type="ai">
+            <div className="flex items-center gap-2 text-muted">
+                <Spinner className="size-4" />
+                <span>{message}</span>
+            </div>
+        </MessageTemplate>
     )
 }
 

--- a/frontend/src/scenes/max/components/InputFormArea.tsx
+++ b/frontend/src/scenes/max/components/InputFormArea.tsx
@@ -517,7 +517,6 @@ export function InputFormArea(): JSX.Element | null {
         pendingApprovalProposalId,
         pendingApprovalsData,
         resolvedApprovalStatuses,
-        conversation,
         conversationId,
         pendingSandboxPermissionRequest,
     } = useValues(maxThreadLogic)
@@ -546,8 +545,10 @@ export function InputFormArea(): JSX.Element | null {
     }, [pendingApprovalProposalId, pendingApprovalsData, resolvedApprovalStatuses])
 
     // Sandbox permission requests take precedence in the input area, mirroring the LangGraph
-    // dangerous-operation flow but driven by sandboxStreamLogic.
-    if (conversation?.agent_runtime === 'sandbox' && pendingSandboxPermissionRequest) {
+    // dangerous-operation flow but driven by sandboxStreamLogic. A pending request only ever
+    // originates from the sandbox stream, so its presence is sufficient — gating on `agent_runtime`
+    // would strand approvals on new conversations whose runtime isn't resolved yet.
+    if (pendingSandboxPermissionRequest) {
         return (
             <SandboxPermissionInput
                 key={pendingSandboxPermissionRequest.requestId}

--- a/frontend/src/scenes/max/components/InputFormArea.tsx
+++ b/frontend/src/scenes/max/components/InputFormArea.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useRef, useState } from 'react'
 import useResizeObserver from 'use-resize-observer'
 
 import { IconCheck, IconWarning, IconX } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonTabs, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonTabs, LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import {
     DangerousOperationResponse,
@@ -11,8 +11,11 @@ import {
     MultiQuestionFormQuestion,
 } from '~/queries/schema/schema-assistant-messages'
 
+import { mapPermissionOptions } from '../approvalOperationUtils'
 import { MarkdownMessage } from '../MarkdownMessage'
 import { maxThreadLogic } from '../maxThreadLogic'
+import { sandboxStreamLogic } from '../sandboxStreamLogic'
+import type { PermissionRequestRecord } from '../types/sandboxStreamTypes'
 import { Option, OptionSelector } from './OptionSelector'
 import { MultiFieldQuestion, QuestionField, isFieldValid } from './QuestionField'
 
@@ -402,10 +405,117 @@ function DangerousOperationInput({ operation }: DangerousOperationInputProps): J
     )
 }
 
+interface SandboxPermissionInputProps {
+    conversationId: string
+    request: PermissionRequestRecord
+}
+
+/**
+ * Input-area renderer for an ACP `permission_request` on a sandbox conversation.
+ * `mapPermissionOptions` owns the kind → affordance mapping: one button per option,
+ * `reject_with_feedback` rides the OptionSelector custom input, and `allow_always` stays hidden
+ * until a tool preview opts into rememberable decisions. Submitting POSTs through
+ * `sandboxStreamLogic.respondToPermission`; the logic's `respondingToPermission` drives the
+ * loading/double-submit guard and re-enables the buttons when the POST fails (the pending
+ * request only clears on success).
+ */
+export function SandboxPermissionInput({ conversationId, request }: SandboxPermissionInputProps): JSX.Element {
+    const boundLogic = sandboxStreamLogic({ conversationId })
+    const { respondToPermission } = useActions(boundLogic)
+    const { respondingToPermission } = useValues(boundLogic)
+
+    const mappedOptions = mapPermissionOptions(request.options)
+    const feedbackOption = mappedOptions.find((o) => o.requiresFeedback)
+    const buttonOptions = mappedOptions.filter((o) => !o.requiresFeedback)
+
+    const options: Option[] = buttonOptions.map((o) => ({
+        label: o.label,
+        value: o.optionId,
+        icon: o.decision === 'approved' ? <IconCheck /> : <IconX />,
+    }))
+
+    const isPlan = request.rawToolCall.kind === 'plan' || request.title?.toLowerCase().includes('plan')
+
+    const handleSelect = (value: string | null): void => {
+        if (!value || respondingToPermission) {
+            return
+        }
+        respondToPermission({ conversationId, requestId: request.requestId, optionId: value })
+    }
+
+    const handleCustomSubmit = (customInput: string): void => {
+        if (!feedbackOption || respondingToPermission) {
+            return
+        }
+        respondToPermission({
+            conversationId,
+            requestId: request.requestId,
+            optionId: feedbackOption.optionId,
+            customInput,
+        })
+    }
+
+    return (
+        <div className="flex flex-col gap-2 p-3">
+            <div className="flex items-center gap-2 text-sm">
+                <IconWarning className="text-warning size-4" />
+                <span className="font-medium">{isPlan ? 'Approve this plan?' : 'Approval required'}</span>
+            </div>
+            {(request.title || request.description) && (
+                <div className="max-h-60 overflow-y-auto">
+                    <MarkdownMessage
+                        content={request.description ?? request.title ?? ''}
+                        id={`permission-${request.requestId}`}
+                    />
+                </div>
+            )}
+            <LemonDivider className="my-0 -mx-3 w-[calc(100%+var(--spacing)*6)]" />
+            <OptionSelector
+                options={options}
+                onSelect={handleSelect}
+                allowCustom={!!feedbackOption}
+                customPlaceholder="Explain what you'd like instead..."
+                onCustomSubmit={handleCustomSubmit}
+                loading={respondingToPermission}
+                loadingMessage="Sending response..."
+                submitLabel="Send"
+            />
+        </div>
+    )
+}
+
+/**
+ * Compact badge showing the active ACP permission mode (e.g. plan vs default) for sandbox
+ * conversations. Hidden when no mode has been reported. Reads the mode via `maxThreadLogic`'s
+ * alias — this renders outside SandboxThread's BindLogic subtree, so it cannot bind the keyed
+ * stream logic itself.
+ */
+export function SandboxModeBadge(): JSX.Element | null {
+    const { conversation, sandboxCurrentMode } = useValues(maxThreadLogic)
+
+    if (conversation?.agent_runtime !== 'sandbox' || !sandboxCurrentMode) {
+        return null
+    }
+
+    const isPlan = sandboxCurrentMode === 'plan'
+    return (
+        <LemonTag size="small" type={isPlan ? 'highlight' : 'muted'}>
+            {isPlan ? 'Plan mode' : 'Default mode'}
+        </LemonTag>
+    )
+}
+
 export function InputFormArea(): JSX.Element | null {
     // Use raw state values instead of selector to ensure re-renders on state changes
-    const { activeMultiQuestionForm, pendingApprovalProposalId, pendingApprovalsData, resolvedApprovalStatuses } =
-        useValues(maxThreadLogic)
+    const {
+        activeMultiQuestionForm,
+        pendingApprovalProposalId,
+        pendingApprovalsData,
+        resolvedApprovalStatuses,
+        conversation,
+        conversationId,
+        pendingSandboxPermissionRequest,
+    } = useValues(maxThreadLogic)
 
     // Build the approval object to display - only show if not yet resolved
     // Resolved approvals are shown as summaries in the chat thread, not in the input area
@@ -429,6 +539,18 @@ export function InputFormArea(): JSX.Element | null {
             payload: approval.payload as Record<string, unknown>,
         }
     }, [pendingApprovalProposalId, pendingApprovalsData, resolvedApprovalStatuses])
+
+    // Sandbox permission requests take precedence in the input area, mirroring the LangGraph
+    // dangerous-operation flow but driven by sandboxStreamLogic.
+    if (conversation?.agent_runtime === 'sandbox' && pendingSandboxPermissionRequest) {
+        return (
+            <SandboxPermissionInput
+                key={pendingSandboxPermissionRequest.requestId}
+                conversationId={conversationId}
+                request={pendingSandboxPermissionRequest}
+            />
+        )
+    }
 
     if (activeDangerousOperationApproval) {
         return (

--- a/frontend/src/scenes/max/components/InputFormArea.tsx
+++ b/frontend/src/scenes/max/components/InputFormArea.tsx
@@ -422,9 +422,12 @@ interface SandboxPermissionInputProps {
 export function SandboxPermissionInput({ conversationId, request }: SandboxPermissionInputProps): JSX.Element {
     const boundLogic = sandboxStreamLogic({ conversationId })
     const { respondToPermission } = useActions(boundLogic)
-    const { respondingToPermission } = useValues(boundLogic)
+    const { respondingToPermission, currentMode } = useValues(boundLogic)
 
-    const mappedOptions = mapPermissionOptions(request.options)
+    // A request whose every option was filtered out (e.g. only `allow_always` without a
+    // rememberable preview) must still be answerable — fall back to showing everything.
+    const defaultOptions = mapPermissionOptions(request.options)
+    const mappedOptions = defaultOptions.length > 0 ? defaultOptions : mapPermissionOptions(request.options, true)
     const feedbackOption = mappedOptions.find((o) => o.requiresFeedback)
     const buttonOptions = mappedOptions.filter((o) => !o.requiresFeedback)
 
@@ -434,7 +437,9 @@ export function SandboxPermissionInput({ conversationId, request }: SandboxPermi
         icon: o.decision === 'approved' ? <IconCheck /> : <IconX />,
     }))
 
-    const isPlan = request.rawToolCall.kind === 'plan' || request.title?.toLowerCase().includes('plan')
+    // Plan approvals are raised while the agent is in plan mode — the mode is the grounded
+    // signal; `toolCall.kind === 'plan'` covers adapters that tag the request directly.
+    const isPlan = currentMode === 'plan' || request.rawToolCall.kind === 'plan'
 
     const handleSelect = (value: string | null): void => {
         if (!value || respondingToPermission) {

--- a/frontend/src/scenes/max/components/SandboxApproval.test.tsx
+++ b/frontend/src/scenes/max/components/SandboxApproval.test.tsx
@@ -1,0 +1,180 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useActions, useValues } from 'kea'
+
+import type { PermissionRequestRecord, ToolInvocation } from '../types/sandboxStreamTypes'
+import { SandboxModeBadge, SandboxPermissionInput } from './InputFormArea'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useActions: jest.fn(),
+    useValues: jest.fn(),
+}))
+
+jest.mock('use-resize-observer', () => () => ({
+    height: 160,
+    ref: { current: null },
+}))
+
+jest.mock('../maxThreadLogic', () => ({
+    maxThreadLogic: { __mock: 'maxThreadLogic' },
+}))
+
+jest.mock('../sandboxStreamLogic', () => ({
+    // Keyed logic — the component binds it with `sandboxStreamLogic({ conversationId })`.
+    sandboxStreamLogic: jest.fn(() => ({ __mock: 'sandboxStreamLogicInstance' })),
+}))
+
+jest.mock('../MarkdownMessage', () => ({
+    MarkdownMessage: ({ content }: { content: string }) => <div data-attr="markdown">{content}</div>,
+}))
+
+const rawToolCall: ToolInvocation = {
+    toolCallId: 'tc-1',
+    rawServerName: 'posthog',
+    rawToolName: 'exec',
+    resolvedKey: 'insight-create',
+    input: {},
+    status: 'pending',
+    contentBlocks: [],
+}
+
+function makeRequest(overrides: Partial<PermissionRequestRecord> = {}): PermissionRequestRecord {
+    return {
+        requestId: 'req-1',
+        toolCallId: 'tc-1',
+        title: 'Create insight',
+        description: 'The agent wants to create an insight.',
+        options: [
+            { optionId: 'opt-allow', name: 'Approve', kind: 'allow_once' },
+            { optionId: 'opt-reject', name: 'Decline', kind: 'reject' },
+            { optionId: 'opt-feedback', name: 'Decline with feedback', kind: 'reject_with_feedback' },
+        ],
+        rawToolCall,
+        ...overrides,
+    }
+}
+
+describe('Sandbox approval input area', () => {
+    const respondToPermission = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(useActions as jest.Mock).mockReturnValue({ respondToPermission })
+        ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: false })
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    describe('SandboxPermissionInput', () => {
+        it('renders one button per non-feedback option plus the feedback custom input', () => {
+            render(<SandboxPermissionInput conversationId="conv-1" request={makeRequest()} />)
+
+            expect(screen.getByText('Approval required')).toBeInTheDocument()
+            expect(screen.getByText('Approve')).toBeInTheDocument()
+            expect(screen.getByText('Decline')).toBeInTheDocument()
+            // reject_with_feedback rides the OptionSelector custom input, not a plain button.
+            expect(screen.getByText("Explain what you'd like instead..")).toBeInTheDocument()
+        })
+
+        it('posts the chosen optionId on click', () => {
+            render(<SandboxPermissionInput conversationId="conv-1" request={makeRequest()} />)
+
+            fireEvent.click(screen.getByText('Approve'))
+
+            expect(respondToPermission).toHaveBeenCalledWith({
+                conversationId: 'conv-1',
+                requestId: 'req-1',
+                optionId: 'opt-allow',
+            })
+        })
+
+        it('guards against double-submit while the reply POST is in flight', () => {
+            // The logic's respondingToPermission flag drives the loading state — it flips
+            // synchronously on dispatch and resets on success and on failure alike.
+            ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: true })
+            render(<SandboxPermissionInput conversationId="conv-1" request={makeRequest()} />)
+
+            // Loading message replaces the option list, so nothing can be clicked.
+            expect(screen.getByText('Sending response...')).toBeInTheDocument()
+            expect(screen.queryByText('Approve')).not.toBeInTheDocument()
+            expect(screen.queryByText('Decline')).not.toBeInTheDocument()
+            expect(respondToPermission).not.toHaveBeenCalled()
+        })
+
+        it('sends feedback text through the reject_with_feedback option', () => {
+            render(<SandboxPermissionInput conversationId="conv-1" request={makeRequest()} />)
+
+            // Open the custom feedback input.
+            fireEvent.click(screen.getByText("Explain what you'd like instead.."))
+            const input = screen.getByPlaceholderText("Explain what you'd like instead...")
+            fireEvent.change(input, { target: { value: 'Use a funnel instead' } })
+            fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+            expect(respondToPermission).toHaveBeenCalledWith({
+                conversationId: 'conv-1',
+                requestId: 'req-1',
+                optionId: 'opt-feedback',
+                customInput: 'Use a funnel instead',
+            })
+        })
+
+        it('shows plan copy when the request is a plan approval', () => {
+            render(
+                <SandboxPermissionInput
+                    conversationId="conv-1"
+                    request={makeRequest({ title: 'Approve the plan', rawToolCall: { ...rawToolCall, kind: 'plan' } })}
+                />
+            )
+
+            expect(screen.getByText('Approve this plan?')).toBeInTheDocument()
+        })
+    })
+
+    describe('SandboxModeBadge', () => {
+        it('reflects plan mode for a sandbox conversation', () => {
+            ;(useValues as jest.Mock).mockReturnValue({
+                conversation: { agent_runtime: 'sandbox' },
+                sandboxCurrentMode: 'plan',
+            })
+
+            render(<SandboxModeBadge />)
+
+            expect(screen.getByText('Plan mode')).toBeInTheDocument()
+        })
+
+        it('reflects default mode for a sandbox conversation', () => {
+            ;(useValues as jest.Mock).mockReturnValue({
+                conversation: { agent_runtime: 'sandbox' },
+                sandboxCurrentMode: 'default',
+            })
+
+            render(<SandboxModeBadge />)
+
+            expect(screen.getByText('Default mode')).toBeInTheDocument()
+        })
+
+        it('renders nothing when there is no current mode', () => {
+            ;(useValues as jest.Mock).mockReturnValue({
+                conversation: { agent_runtime: 'sandbox' },
+                sandboxCurrentMode: null,
+            })
+
+            const { container } = render(<SandboxModeBadge />)
+            expect(container).toBeEmptyDOMElement()
+        })
+
+        it('renders nothing for a non-sandbox conversation', () => {
+            ;(useValues as jest.Mock).mockReturnValue({
+                conversation: { agent_runtime: 'langgraph' },
+                sandboxCurrentMode: 'plan',
+            })
+
+            const { container } = render(<SandboxModeBadge />)
+            expect(container).toBeEmptyDOMElement()
+        })
+    })
+})

--- a/frontend/src/scenes/max/components/SandboxApproval.test.tsx
+++ b/frontend/src/scenes/max/components/SandboxApproval.test.tsx
@@ -62,7 +62,7 @@ describe('Sandbox approval input area', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         ;(useActions as jest.Mock).mockReturnValue({ respondToPermission })
-        ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: false })
+        ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: false, currentMode: null })
     })
 
     afterEach(() => {
@@ -122,55 +122,73 @@ describe('Sandbox approval input area', () => {
             })
         })
 
-        it('shows plan copy when the request is a plan approval', () => {
+        it.each([
+            [
+                'the agent is in plan mode',
+                (): void => {
+                    ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: false, currentMode: 'plan' })
+                },
+                makeRequest(),
+            ],
+            [
+                'the tool call is tagged as a plan',
+                (): void => {},
+                makeRequest({ rawToolCall: { ...rawToolCall, kind: 'plan' } }),
+            ],
+        ])('shows plan copy when %s', (_case, arrange, request) => {
+            arrange()
+            render(<SandboxPermissionInput conversationId="conv-1" request={request} />)
+
+            expect(screen.getByText('Approve this plan?')).toBeInTheDocument()
+        })
+
+        it('does not show plan copy just because the title mentions a plan', () => {
             render(
                 <SandboxPermissionInput
                     conversationId="conv-1"
-                    request={makeRequest({ title: 'Approve the plan', rawToolCall: { ...rawToolCall, kind: 'plan' } })}
+                    request={makeRequest({ title: 'Create a data retention plan' })}
                 />
             )
 
-            expect(screen.getByText('Approve this plan?')).toBeInTheDocument()
+            expect(screen.getByText('Approval required')).toBeInTheDocument()
+        })
+
+        it('falls back to showing every option when filtering would leave none', () => {
+            render(
+                <SandboxPermissionInput
+                    conversationId="conv-1"
+                    request={makeRequest({
+                        options: [{ optionId: 'opt-always', name: '', kind: 'allow_always' }],
+                    })}
+                />
+            )
+
+            expect(screen.getByText('Approve always')).toBeInTheDocument()
         })
     })
 
     describe('SandboxModeBadge', () => {
-        it('reflects plan mode for a sandbox conversation', () => {
+        it.each([
+            ['sandbox', 'plan', 'Plan mode'],
+            ['sandbox', 'default', 'Default mode'],
+        ])('renders the %s runtime in %s mode as a badge', (runtime, mode, label) => {
             ;(useValues as jest.Mock).mockReturnValue({
-                conversation: { agent_runtime: 'sandbox' },
-                sandboxCurrentMode: 'plan',
+                conversation: { agent_runtime: runtime },
+                sandboxCurrentMode: mode,
             })
 
             render(<SandboxModeBadge />)
 
-            expect(screen.getByText('Plan mode')).toBeInTheDocument()
+            expect(screen.getByText(label)).toBeInTheDocument()
         })
 
-        it('reflects default mode for a sandbox conversation', () => {
+        it.each([
+            ['no mode has been reported', 'sandbox', null],
+            ['the conversation is not sandbox-runtime', 'langgraph', 'plan'],
+        ])('renders nothing when %s', (_case, runtime, mode) => {
             ;(useValues as jest.Mock).mockReturnValue({
-                conversation: { agent_runtime: 'sandbox' },
-                sandboxCurrentMode: 'default',
-            })
-
-            render(<SandboxModeBadge />)
-
-            expect(screen.getByText('Default mode')).toBeInTheDocument()
-        })
-
-        it('renders nothing when there is no current mode', () => {
-            ;(useValues as jest.Mock).mockReturnValue({
-                conversation: { agent_runtime: 'sandbox' },
-                sandboxCurrentMode: null,
-            })
-
-            const { container } = render(<SandboxModeBadge />)
-            expect(container).toBeEmptyDOMElement()
-        })
-
-        it('renders nothing for a non-sandbox conversation', () => {
-            ;(useValues as jest.Mock).mockReturnValue({
-                conversation: { agent_runtime: 'langgraph' },
-                sandboxCurrentMode: 'plan',
+                conversation: { agent_runtime: runtime },
+                sandboxCurrentMode: mode,
             })
 
             const { container } = render(<SandboxModeBadge />)

--- a/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
+++ b/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
@@ -12,7 +12,7 @@ import { cn } from 'lib/utils/css-classes'
 
 import { SuggestionGroup, maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
-import { InputFormArea } from './InputFormArea'
+import { InputFormArea, SandboxModeBadge } from './InputFormArea'
 import { QuestionInput } from './QuestionInput'
 
 export function SidebarQuestionInput({
@@ -31,7 +31,10 @@ export function SidebarQuestionInput({
         pendingApprovalProposalId,
         pendingApprovalsData,
         resolvedApprovalStatuses,
+        conversation,
+        pendingSandboxPermissionRequest,
     } = useValues(maxThreadLogic)
+    const hasSandboxPermissionToShow = conversation?.agent_runtime === 'sandbox' && !!pendingSandboxPermissionRequest
 
     // Check if there's a pending (not yet resolved) approval to show
     const hasApprovalToShow = useMemo(() => {
@@ -61,7 +64,7 @@ export function SidebarQuestionInput({
     }, [focusCounter]) // Update focus when focusCounter changes
 
     // Show form area directly when there's a pending form/approval (even if showInput is false)
-    if (activeMultiQuestionForm || hasApprovalToShow) {
+    if (activeMultiQuestionForm || hasApprovalToShow || hasSandboxPermissionToShow) {
         return (
             <div className="w-full max-w-180 self-center px-3 mx-auto bg-[var(--scene-layout-background)]/50 backdrop-blur-sm">
                 <div className="border border-primary rounded-lg bg-surface-primary">
@@ -78,6 +81,7 @@ export function SidebarQuestionInput({
             containerClassName={cn('mx-auto self-center backdrop-blur-sm z-50', sidePanel && 'px-0')}
             isThreadVisible={threadVisible}
         >
+            <SandboxModeBadge />
             <SuggestionsList />
         </QuestionInput>
     )

--- a/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
+++ b/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
@@ -31,10 +31,11 @@ export function SidebarQuestionInput({
         pendingApprovalProposalId,
         pendingApprovalsData,
         resolvedApprovalStatuses,
-        conversation,
         pendingSandboxPermissionRequest,
     } = useValues(maxThreadLogic)
-    const hasSandboxPermissionToShow = conversation?.agent_runtime === 'sandbox' && !!pendingSandboxPermissionRequest
+    // A pending sandbox request only originates from the sandbox stream, so its presence alone is
+    // enough — gating on `agent_runtime` would strand approvals on as-yet-unresolved conversations.
+    const hasSandboxPermissionToShow = !!pendingSandboxPermissionRequest
 
     // Check if there's a pending (not yet resolved) approval to show
     const hasApprovalToShow = useMemo(() => {

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -167,6 +167,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             // mounts it itself).
             posthogAiContextLogic({ conversationId }),
             ['attachments as sandboxAttachments'],
+            // Surfaces the sandbox stream's input-area state to components outside SandboxThread's
+            // BindLogic subtree (the input area renders for LangGraph conversations too, so they
+            // can't bind the keyed stream logic themselves).
+            sandboxStreamLogic({ conversationId }),
+            ['pendingPermissionRequest as pendingSandboxPermissionRequest', 'currentMode as sandboxCurrentMode'],
         ],
         actions: [
             maxLogic({ panelId }),

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -183,6 +183,20 @@ describe('sandboxStreamLogic', () => {
             expect(logic.values.currentMode).toEqual('plan')
         })
 
+        it('sets currentProgress on a _posthog/progress frame and clears it on turn complete', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(notification('_posthog/progress', { label: 'Querying events' }))
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentProgress).toEqual('Querying events')
+
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(notification('_posthog/turn_complete', {}))
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentProgress).toBeNull()
+        })
+
         it('drives terminal status off handleTerminalStatus', async () => {
             await expectLogic(logic, () => {
                 logic.actions.handleTerminalStatus({ status: 'completed' })
@@ -848,6 +862,7 @@ describe('sandboxStreamLogic', () => {
             }).toFinishAllListeners()
 
             expect(logic.values.pendingPermissionRequest).toBeNull()
+            expect(logic.values.respondingToPermission).toEqual(false)
             expect(permissionSpy).toHaveBeenCalledWith('conv-1', {
                 requestId: 'req-1',
                 optionId: 'allow_once',
@@ -870,6 +885,8 @@ describe('sandboxStreamLogic', () => {
 
             expect(logic.values.pendingPermissionRequest?.requestId).toEqual('req-1')
             expect(logic.values.sseStatus).toEqual('error')
+            // The in-flight flag resets so the surviving card's buttons re-enable for a retry.
+            expect(logic.values.respondingToPermission).toEqual(false)
             expect(exceptionSpy).toHaveBeenCalled()
         })
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -535,6 +535,32 @@ describe('sandboxStreamLogic', () => {
         })
     })
 
+    describe('isThinking', () => {
+        it('is on only while a started turn is incomplete, surviving non-terminal status updates', () => {
+            expect(logic.values.isThinking).toEqual(false)
+
+            logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
+            expect(logic.values.isThinking).toEqual(true)
+
+            logic.actions.handleTerminalStatus({ status: 'queued' })
+            expect(logic.values.isThinking).toEqual(true)
+
+            logic.actions.ingestAcpFrame(notification('_posthog/turn_complete', {}))
+            expect(logic.values.isThinking).toEqual(false)
+        })
+
+        it.each([
+            ['a terminal run status', (): void => logic.actions.handleTerminalStatus({ status: 'failed' })],
+            ['a stream error', (): void => logic.actions.handleStreamError({ errorTitle: 'x', retryable: true })],
+        ])('turns off on %s even when turn_complete never arrives', (_case, act) => {
+            logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
+            expect(logic.values.isThinking).toEqual(true)
+
+            act()
+            expect(logic.values.isThinking).toEqual(false)
+        })
+    })
+
     describe('terminal-status handling', () => {
         it('closes the SSE and stops reconnects on a terminal task_run_state', async () => {
             await expectLogic(logic, () => {

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -2,6 +2,7 @@ import { expectLogic } from 'kea-test-utils'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { projectLogic } from 'scenes/projectLogic'
 
 import { initKeaTests } from '~/test/init'
@@ -899,6 +900,7 @@ describe('sandboxStreamLogic', () => {
         it('keeps the card pending and surfaces an error when the reply POST fails', async () => {
             jest.spyOn(api.conversations, 'permission').mockRejectedValue({ status: 502 })
             const exceptionSpy = jest.spyOn(posthog, 'captureException').mockImplementation(() => undefined as any)
+            const toastSpy = jest.spyOn(lemonToast, 'error').mockImplementation(() => undefined as any)
             logic.actions.ingestPermissionRequest(parsePermissionRequestFrame(permissionFrame)!)
 
             await expectLogic(logic, () => {
@@ -910,10 +912,12 @@ describe('sandboxStreamLogic', () => {
             }).toFinishAllListeners()
 
             expect(logic.values.pendingPermissionRequest?.requestId).toEqual('req-1')
-            expect(logic.values.sseStatus).toEqual('error')
-            // The in-flight flag resets so the surviving card's buttons re-enable for a retry.
+            // A failed reply POST must not tear down the live stream — the run is still alive and
+            // blocked on this approval; only the card's buttons re-enable for a retry.
+            expect(logic.values.sseStatus).not.toEqual('error')
             expect(logic.values.respondingToPermission).toEqual(false)
             expect(exceptionSpy).toHaveBeenCalled()
+            expect(toastSpy).toHaveBeenCalled()
         })
 
         it('ignores a replayed permission_request envelope once the request is resolved', async () => {

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
@@ -322,6 +322,11 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             customInput?: string
         }) => payload,
         clearPermissionRequest: true,
+        /**
+         * Internal: the reply POST failed. Resets the in-flight flag (so the surviving card's
+         * buttons re-enable for retry) without coupling that reset to unrelated stream errors.
+         */
+        permissionResponseFailed: true,
         handleTerminalStatus: (status: { status: SandboxRunStatus; errorMessage?: string | null }) => status,
         handleStreamError: (envelope: { errorTitle: string; errorMessage?: string; retryable: boolean }) => envelope,
         // Internal state-folding actions emitted by ingestAcpFrame.
@@ -501,7 +506,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             },
         ],
         // In-flight state for the approval reply POST — drives the input card's loading/disabled
-        // props. Cleared on resolution (success) and on stream error (a failure keeps the card
+        // props. Cleared on resolution (success) and on the POST's own failure (the card stays
         // pending, so the buttons must re-enable for retry).
         respondingToPermission: [
             false,
@@ -509,7 +514,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 respondToPermission: () => true,
                 markPermissionRequestResolved: () => false,
                 clearPermissionRequest: () => false,
-                handleStreamError: () => false,
+                permissionResponseFailed: () => false,
                 reset: () => false,
             },
         ],
@@ -542,6 +547,18 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 markRunStarted: () => false,
                 reset: () => false,
             },
+        ],
+    }),
+    selectors({
+        /**
+         * Whether the agent is actively working a turn — drives the thread's thinking indicator.
+         * Off once the turn completes, the run reaches a terminal status (a failed or cancelled
+         * run may never emit `_posthog/turn_complete`), or the stream errors out.
+         */
+        isThinking: [
+            (s) => [s.runStarted, s.turnComplete, s.currentRunStatus, s.sseStatus],
+            (runStarted, turnComplete, currentRunStatus, sseStatus): boolean =>
+                runStarted && !turnComplete && !isTerminalRunStatus(currentRunStatus) && sseStatus !== 'error',
         ],
     }),
     listeners(({ values, actions, cache }) => ({
@@ -746,6 +763,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 actions.markPermissionRequestResolved(requestId)
             } catch (error) {
                 posthog.captureException(error)
+                actions.permissionResponseFailed()
                 actions.handleStreamError({ errorTitle: 'Failed to send approval', retryable: true })
             }
         },

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -2,6 +2,7 @@ import { actions, connect, kea, key, listeners, path, props, reducers, selectors
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { projectLogic } from 'scenes/projectLogic'
 
 import type { sandboxStreamLogicType } from './sandboxStreamLogicType'
@@ -762,9 +763,13 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 })
                 actions.markPermissionRequestResolved(requestId)
             } catch (error) {
+                // A failed reply POST does not mean the run died — the agent is still alive and
+                // blocked on this same approval. Keep the failure local to the card (re-enable its
+                // buttons for a retry) instead of tearing down the stream, which would release the
+                // chat lock and hide the still-pending request behind the normal input.
                 posthog.captureException(error)
                 actions.permissionResponseFailed()
-                actions.handleStreamError({ errorTitle: 'Failed to send approval', retryable: true })
+                lemonToast.error('Failed to send approval. Please try again.')
             }
         },
         handleTerminalStatus: ({ status }) => {

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -500,6 +500,19 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 reset: () => new Set<string>(),
             },
         ],
+        // In-flight state for the approval reply POST — drives the input card's loading/disabled
+        // props. Cleared on resolution (success) and on stream error (a failure keeps the card
+        // pending, so the buttons must re-enable for retry).
+        respondingToPermission: [
+            false,
+            {
+                respondToPermission: () => true,
+                markPermissionRequestResolved: () => false,
+                clearPermissionRequest: () => false,
+                handleStreamError: () => false,
+                reset: () => false,
+            },
+        ],
         currentMode: [
             null as string | null,
             {


### PR DESCRIPTION
## Problem

PR **UI-C** of the PostHog AI → sandbox-agent migration (`docs/internal/posthog-ai-migration/00_OVERVIEW.md` § 10). I3.8 wired the approval data path but deferred the actual UI; this renders the approval prompt in the input area, surfaces the current permission mode, and drives the thinking indicator from real agent progress.

> Stacked on **`feat/phai-sandbox-integration`** (contains I1.1–I3.8 + UI-A/B).

## Changes

Per `03_RICH_UI` §§ 5, 6 (coexistence — sandbox-only):

- **Approval card in the input area:** when `sandboxStreamLogic.pendingPermissionRequest` is set, renders the I3.8 `DangerousOperationApprovalCard` sandbox variant; clicking an option posts to `POST /permission/` with a double-submit-guarded loading state and clears on success; `reject_with_feedback` opens the feedback input.
- **Mode badge** near the input (`Plan mode` / `Default mode` from `currentMode`).
- **Progress-driven thinking:** the existing `thinkingMessages` indicator is fed from `_posthog/progress` → `currentProgress` for sandbox conversations; LangGraph thinking unchanged.

## How did you test this code?

Automated only (I'm an agent): format clean; scoped `tsc` 0 errors in changed files; jest suite (approval render + option post + loading/clear, mode badge, progress) passes.

## 🤖 Agent context

Built by Claude Code (Opus 4.8) via a multi-agent workflow (implement → verify) in an isolated worktree off the integration branch. Plan-mode detection uses a `kind === 'plan'`/title heuristic — swap if the backend emits a distinct discriminator; unknown ACP modes currently display as `Default mode`. Touches `Thread.tsx` + `sandboxStreamLogic.test.ts` (shared with I2.7 — trivial union when both land). Requires human review; not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
