### PR TITLE
feat(tracing): add feedback button to TracingScene actions

### DIFF
--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -92,6 +92,10 @@ function TracingSceneContents(): JSX.Element {
         })
     }
 
+    const onFeedbackClick = (): void => {
+        posthog.displaySurvey(TRACING_FEEDBACK_SURVEY_ID)
+    }
+
     // Anchor the overlay's coordinate space to the *fetched* sparkline data so overlay
     // drags never shift the canvas underfoot. The sparkline only refetches when dateRange
     // changes (via the DateFilter), never via overlay interaction.
@@ -118,15 +122,20 @@ function TracingSceneContents(): JSX.Element {
                     type: 'tracing',
                 }}
                 actions={
-                    <LemonButton
-                        to={TRACING_DOCS_URL}
-                        onClick={onDocsLinkClick}
-                        type="secondary"
-                        size="small"
-                        targetBlank
-                    >
-                        Documentation
-                    </LemonButton>
+                    <>
+                        <LemonButton size="small" type="secondary" icon={<IconFeedback />} onClick={onFeedbackClick}>
+                            Feedback
+                        </LemonButton>
+                        <LemonButton
+                            to={TRACING_DOCS_URL}
+                            onClick={onDocsLinkClick}
+                            type="secondary"
+                            size="small"
+                            targetBlank
+                        >
+                            Documentation
+                        </LemonButton>
+                    </>
                 }
             />
             <LemonBanner
@@ -135,7 +144,7 @@ function TracingSceneContents(): JSX.Element {
                 action={{
                     icon: <IconFeedback />,
                     children: 'Share feedback',
-                    onClick: () => posthog.displaySurvey(TRACING_FEEDBACK_SURVEY_ID),
+                    onClick: onFeedbackClick,
                 }}
             >
                 Tracing is in alpha. Expect bugs, missing features, and breaking changes.


### PR DESCRIPTION
## Problem

Users viewing the Tracing scene had no quick way to share feedback about the feature directly from the UI.

## Changes

A **Feedback** button has been added to the Tracing scene header alongside the existing Documentation button. Clicking it triggers a PostHog survey using `TRACING_FEEDBACK_SURVEY_ID`.

## How did you test this code?

Manually verified the Feedback button appears in the Tracing scene header and that clicking it displays the survey. The Documentation button continues to function as before.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update