### PR TITLE
fix(logs): dual-register logs_config under /api/projects/ and /api/environments/

### DIFF
--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -844,6 +844,52 @@ export const organizationsProjectsIsGeneratingDemoDataRetrieve = async (
     )
 }
 
+export const getOrganizationsProjectsLogsConfigRetrieveUrl = (organizationId: string, id: number) => {
+    return `/api/organizations/${organizationId}/projects/${id}/logs_config/`
+}
+
+/**
+ * Manage logs product configuration for this project's canonical environment.
+Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
+alongside the legacy /api/environments/:id/logs_config/ alias.
+ */
+export const organizationsProjectsLogsConfigRetrieve = async (
+    organizationId: string,
+    id: number,
+    options?: RequestInit
+): Promise<ProjectBackwardCompatApi> => {
+    return apiMutator<ProjectBackwardCompatApi>(getOrganizationsProjectsLogsConfigRetrieveUrl(organizationId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getOrganizationsProjectsLogsConfigPartialUpdateUrl = (organizationId: string, id: number) => {
+    return `/api/organizations/${organizationId}/projects/${id}/logs_config/`
+}
+
+/**
+ * Manage logs product configuration for this project's canonical environment.
+Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
+alongside the legacy /api/environments/:id/logs_config/ alias.
+ */
+export const organizationsProjectsLogsConfigPartialUpdate = async (
+    organizationId: string,
+    id: number,
+    patchedProjectBackwardCompatApi?: NonReadonly<PatchedProjectBackwardCompatApi>,
+    options?: RequestInit
+): Promise<ProjectBackwardCompatApi> => {
+    return apiMutator<ProjectBackwardCompatApi>(
+        getOrganizationsProjectsLogsConfigPartialUpdateUrl(organizationId, id),
+        {
+            ...options,
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(patchedProjectBackwardCompatApi),
+        }
+    )
+}
+
 export const getOrganizationsProjectsResetTokenPartialUpdateUrl = (organizationId: string, id: number) => {
     return `/api/organizations/${organizationId}/projects/${id}/reset_token/`
 }

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -1807,6 +1807,200 @@ export const OrganizationsProjectsGenerateConversationsPublicTokenCreateBody = /
     .describe('Mixin for serializers to add user access control fields')
 
 /**
+ * Manage logs product configuration for this project's canonical environment.
+Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
+alongside the legacy /api/environments/:id/logs_config/ alias.
+ */
+export const organizationsProjectsLogsConfigPartialUpdateBodyNameMax = 200
+
+export const organizationsProjectsLogsConfigPartialUpdateBodyProductDescriptionMax = 1000
+
+export const organizationsProjectsLogsConfigPartialUpdateBodyAppUrlsItemMax = 200
+
+export const organizationsProjectsLogsConfigPartialUpdateBodyPersonDisplayNamePropertiesItemMax = 400
+
+export const organizationsProjectsLogsConfigPartialUpdateBodySessionRecordingSampleRateRegExp = new RegExp(
+    '^-?\\d{0,1}(?:\\.\\d{0,2})?$'
+)
+export const organizationsProjectsLogsConfigPartialUpdateBodySessionRecordingMinimumDurationMillisecondsMin = 0
+export const organizationsProjectsLogsConfigPartialUpdateBodySessionRecordingMinimumDurationMillisecondsMax = 30000
+
+export const organizationsProjectsLogsConfigPartialUpdateBodySessionRecordingTriggerMatchTypeConfigMax = 24
+
+export const organizationsProjectsLogsConfigPartialUpdateBodyRecordingDomainsItemMax = 200
+
+export const OrganizationsProjectsLogsConfigPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .min(1)
+            .max(organizationsProjectsLogsConfigPartialUpdateBodyNameMax)
+            .optional()
+            .describe('Human-readable project name.'),
+        product_description: zod
+            .string()
+            .max(organizationsProjectsLogsConfigPartialUpdateBodyProductDescriptionMax)
+            .nullish()
+            .describe(
+                'Short description of what the project is about. This is helpful to give our AI agents context about your project.'
+            ),
+        app_urls: zod
+            .array(zod.string().max(organizationsProjectsLogsConfigPartialUpdateBodyAppUrlsItemMax).nullable())
+            .optional(),
+        anonymize_ips: zod
+            .boolean()
+            .optional()
+            .describe('When true, PostHog drops the IP address from every ingested event.'),
+        completed_snippet_onboarding: zod.boolean().optional(),
+        test_account_filters: zod
+            .unknown()
+            .optional()
+            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+        test_account_filters_default_checked: zod
+            .boolean()
+            .nullish()
+            .describe('When true, new insights default to excluding internal\/test users.'),
+        path_cleaning_filters: zod
+            .unknown()
+            .optional()
+            .describe(
+                'Regex rewrite rules that collapse dynamic path segments (e.g. user IDs) before displaying URLs in paths.'
+            ),
+        is_demo: zod.boolean().optional(),
+        timezone: zod
+            .string()
+            .optional()
+            .describe(
+                'IANA timezone used for date-based filters and reporting (e.g. `America\/Los_Angeles`).\n\n\* `Africa\/Abidjan` - Africa\/Abidjan\n\* `Africa\/Accra` - Africa\/Accra\n\* `Africa\/Addis_Ababa` - Africa\/Addis_Ababa\n\* `Africa\/Algiers` - Africa\/Algiers\n\* `Africa\/Asmara` - Africa\/Asmara\n\* `Africa\/Asmera` - Africa\/Asmera\n\* `Africa\/Bamako` - Africa\/Bamako\n\* `Africa\/Bangui` - Africa\/Bangui\n\* `Africa\/Banjul` - Africa\/Banjul\n\* `Africa\/Bissau` - Africa\/Bissau\n\* `Africa\/Blantyre` - Africa\/Blantyre\n\* `Africa\/Brazzaville` - Africa\/Brazzaville\n\* `Africa\/Bujumbura` - Africa\/Bujumbura\n\* `Africa\/Cairo` - Africa\/Cairo\n\* `Africa\/Casablanca` - Africa\/Casablanca\n\* `Africa\/Ceuta` - Africa\/Ceuta\n\* `Africa\/Conakry` - Africa\/Conakry\n\* `Africa\/Dakar` - Africa\/Dakar\n\* `Africa\/Dar_es_Salaam` - Africa\/Dar_es_Salaam\n\* `Africa\/Djibouti` - Africa\/Djibouti\n\* `Africa\/Douala` - Africa\/Douala\n\* `Africa\/El_Aaiun` - Africa\/El_Aaiun\n\* `Africa\/Freetown` - Africa\/Freetown\n\* `Africa\/Gaborone` - Africa\/Gaborone\n\* `Africa\/Harare` - Africa\/Harare\n\* `Africa\/Johannesburg` - Africa\/Johannesburg\n\* `Africa\/Juba` - Africa\/Juba\n\* `Africa\/Kampala` - Africa\/Kampala\n\* `Africa\/Khartoum` - Africa\/Khartoum\n\* `Africa\/Kigali` - Africa\/Kigali\n\* `Africa\/Kinshasa` - Africa\/Kinshasa\n\* `Africa\/Lagos` - Africa\/Lagos\n\* `Africa\/Libreville` - Africa\/Libreville\n\* `Africa\/Lome` - Africa\/Lome\n\* `Africa\/Luanda` - Africa\/Luanda\n\* `Africa\/Lubumbashi` - Africa\/Lubumbashi\n\* `Africa\/Lusaka` - Africa\/Lusaka\n\* `Africa\/Malabo` - Africa\/Malabo\n\* `Africa\/Maputo` - Africa\/Maputo\n\* `Africa\/Maseru` - Africa\/Maseru\n\* `Africa\/Mbabane` - Africa\/Mbabane\n\* `Africa\/Mogadishu` - Africa\/Mogadishu\n\* `Africa\/Monrovia` - Africa\/Monrovia\n\* `Africa\/Nairobi` - Africa\/Nairobi\n\* `Africa\/Ndjamena` - Africa\/Ndjamena\n\* `Africa\/Niamey` - Africa\/Niamey\n\* `Africa\/Nouakchott` - Africa\/Nouakchott\n\* `Africa\/Ouagadougou` - Africa\/Ouagadougou\n\* `Africa\/Porto-Novo` - Africa\/Porto-Novo\n\* `Africa\/Sao_Tome` - Africa\/Sao_Tome\n\* `Africa\/Timbuktu` - Africa\/Timbuktu\n\* `Africa\/Tripoli` - Africa\/Tripoli\n\* `Africa\/Tunis` - Africa\/Tunis\n\* `Africa\/Windhoek` - Africa\/Windhoek\n\* `America\/Adak` - America\/Adak\n\* `America\/Anchorage` - America\/Anchorage\n\* `America\/Anguilla` - America\/Anguilla\n\* `America\/Antigua` - America\/Antigua\n\* `America\/Araguaina` - America\/Araguaina\n\* `America\/Argentina\/Buenos_Aires` - America\/Argentina\/Buenos_Aires\n\* `America\/Argentina\/Catamarca` - America\/Argentina\/Catamarca\n\* `America\/Argentina\/ComodRivadavia` - America\/Argentina\/ComodRivadavia\n\* `America\/Argentina\/Cordoba` - America\/Argentina\/Cordoba\n\* `America\/Argentina\/Jujuy` - America\/Argentina\/Jujuy\n\* `America\/Argentina\/La_Rioja` - America\/Argentina\/La_Rioja\n\* `America\/Argentina\/Mendoza` - America\/Argentina\/Mendoza\n\* `America\/Argentina\/Rio_Gallegos` - America\/Argentina\/Rio_Gallegos\n\* `America\/Argentina\/Salta` - America\/Argentina\/Salta\n\* `America\/Argentina\/San_Juan` - America\/Argentina\/San_Juan\n\* `America\/Argentina\/San_Luis` - America\/Argentina\/San_Luis\n\* `America\/Argentina\/Tucuman` - America\/Argentina\/Tucuman\n\* `America\/Argentina\/Ushuaia` - America\/Argentina\/Ushuaia\n\* `America\/Aruba` - America\/Aruba\n\* `America\/Asuncion` - America\/Asuncion\n\* `America\/Atikokan` - America\/Atikokan\n\* `America\/Atka` - America\/Atka\n\* `America\/Bahia` - America\/Bahia\n\* `America\/Bahia_Banderas` - America\/Bahia_Banderas\n\* `America\/Barbados` - America\/Barbados\n\* `America\/Belem` - America\/Belem\n\* `America\/Belize` - America\/Belize\n\* `America\/Blanc-Sablon` - America\/Blanc-Sablon\n\* `America\/Boa_Vista` - America\/Boa_Vista\n\* `America\/Bogota` - America\/Bogota\n\* `America\/Boise` - America\/Boise\n\* `America\/Buenos_Aires` - America\/Buenos_Aires\n\* `America\/Cambridge_Bay` - America\/Cambridge_Bay\n\* `America\/Campo_Grande` - America\/Campo_Grande\n\* `America\/Cancun` - America\/Cancun\n\* `America\/Caracas` - America\/Caracas\n\* `America\/Catamarca` - America\/Catamarca\n\* `America\/Cayenne` - America\/Cayenne\n\* `America\/Cayman` - America\/Cayman\n\* `America\/Chicago` - America\/Chicago\n\* `America\/Chihuahua` - America\/Chihuahua\n\* `America\/Ciudad_Juarez` - America\/Ciudad_Juarez\n\* `America\/Coral_Harbour` - America\/Coral_Harbour\n\* `America\/Cordoba` - America\/Cordoba\n\* `America\/Costa_Rica` - America\/Costa_Rica\n\* `America\/Creston` - America\/Creston\n\* `America\/Cuiaba` - America\/Cuiaba\n\* `America\/Curacao` - America\/Curacao\n\* `America\/Danmarkshavn` - America\/Danmarkshavn\n\* `America\/Dawson` - America\/Dawson\n\* `America\/Dawson_Creek` - America\/Dawson_Creek\n\* `America\/Denver` - America\/Denver\n\* `America\/Detroit` - America\/Detroit\n\* `America\/Dominica` - America\/Dominica\n\* `America\/Edmonton` - America\/Edmonton\n\* `America\/Eirunepe` - America\/Eirunepe\n\* `America\/El_Salvador` - America\/El_Salvador\n\* `America\/Ensenada` - America\/Ensenada\n\* `America\/Fort_Nelson` - America\/Fort_Nelson\n\* `America\/Fort_Wayne` - America\/Fort_Wayne\n\* `America\/Fortaleza` - America\/Fortaleza\n\* `America\/Glace_Bay` - America\/Glace_Bay\n\* `America\/Godthab` - America\/Godthab\n\* `America\/Goose_Bay` - America\/Goose_Bay\n\* `America\/Grand_Turk` - America\/Grand_Turk\n\* `America\/Grenada` - America\/Grenada\n\* `America\/Guadeloupe` - America\/Guadeloupe\n\* `America\/Guatemala` - America\/Guatemala\n\* `America\/Guayaquil` - America\/Guayaquil\n\* `America\/Guyana` - America\/Guyana\n\* `America\/Halifax` - America\/Halifax\n\* `America\/Havana` - America\/Havana\n\* `America\/Hermosillo` - America\/Hermosillo\n\* `America\/Indiana\/Indianapolis` - America\/Indiana\/Indianapolis\n\* `America\/Indiana\/Knox` - America\/Indiana\/Knox\n\* `America\/Indiana\/Marengo` - America\/Indiana\/Marengo\n\* `America\/Indiana\/Petersburg` - America\/Indiana\/Petersburg\n\* `America\/Indiana\/Tell_City` - America\/Indiana\/Tell_City\n\* `America\/Indiana\/Vevay` - America\/Indiana\/Vevay\n\* `America\/Indiana\/Vincennes` - America\/Indiana\/Vincennes\n\* `America\/Indiana\/Winamac` - America\/Indiana\/Winamac\n\* `America\/Indianapolis` - America\/Indianapolis\n\* `America\/Inuvik` - America\/Inuvik\n\* `America\/Iqaluit` - America\/Iqaluit\n\* `America\/Jamaica` - America\/Jamaica\n\* `America\/Jujuy` - America\/Jujuy\n\* `America\/Juneau` - America\/Juneau\n\* `America\/Kentucky\/Louisville` - America\/Kentucky\/Louisville\n\* `America\/Kentucky\/Monticello` - America\/Kentucky\/Monticello\n\* `America\/Knox_IN` - America\/Knox_IN\n\* `America\/Kralendijk` - America\/Kralendijk\n\* `America\/La_Paz` - America\/La_Paz\n\* `America\/Lima` - America\/Lima\n\* `America\/Los_Angeles` - America\/Los_Angeles\n\* `America\/Louisville` - America\/Louisville\n\* `America\/Lower_Princes` - America\/Lower_Princes\n\* `America\/Maceio` - America\/Maceio\n\* `America\/Managua` - America\/Managua\n\* `America\/Manaus` - America\/Manaus\n\* `America\/Marigot` - America\/Marigot\n\* `America\/Martinique` - America\/Martinique\n\* `America\/Matamoros` - America\/Matamoros\n\* `America\/Mazatlan` - America\/Mazatlan\n\* `America\/Mendoza` - America\/Mendoza\n\* `America\/Menominee` - America\/Menominee\n\* `America\/Merida` - America\/Merida\n\* `America\/Metlakatla` - America\/Metlakatla\n\* `America\/Mexico_City` - America\/Mexico_City\n\* `America\/Miquelon` - America\/Miquelon\n\* `America\/Moncton` - America\/Moncton\n\* `America\/Monterrey` - America\/Monterrey\n\* `America\/Montevideo` - America\/Montevideo\n\* `America\/Montreal` - America\/Montreal\n\* `America\/Montserrat` - America\/Montserrat\n\* `America\/Nassau` - America\/Nassau\n\* `America\/New_York` - America\/New_York\n\* `America\/Nipigon` - America\/Nipigon\n\* `America\/Nome` - America\/Nome\n\* `America\/Noronha` - America\/Noronha\n\* `America\/North_Dakota\/Beulah` - America\/North_Dakota\/Beulah\n\* `America\/North_Dakota\/Center` - America\/North_Dakota\/Center\n\* `America\/North_Dakota\/New_Salem` - America\/North_Dakota\/New_Salem\n\* `America\/Nuuk` - America\/Nuuk\n\* `America\/Ojinaga` - America\/Ojinaga\n\* `America\/Panama` - America\/Panama\n\* `America\/Pangnirtung` - America\/Pangnirtung\n\* `America\/Paramaribo` - America\/Paramaribo\n\* `America\/Phoenix` - America\/Phoenix\n\* `America\/Port-au-Prince` - America\/Port-au-Prince\n\* `America\/Port_of_Spain` - America\/Port_of_Spain\n\* `America\/Porto_Acre` - America\/Porto_Acre\n\* `America\/Porto_Velho` - America\/Porto_Velho\n\* `America\/Puerto_Rico` - America\/Puerto_Rico\n\* `America\/Punta_Arenas` - America\/Punta_Arenas\n\* `America\/Rainy_River` - America\/Rainy_River\n\* `America\/Rankin_Inlet` - America\/Rankin_Inlet\n\* `America\/Recife` - America\/Recife\n\* `America\/Regina` - America\/Regina\n\* `America\/Resolute` - America\/Resolute\n\* `America\/Rio_Branco` - America\/Rio_Branco\n\* `America\/Rosario` - America\/Rosario\n\* `America\/Santa_Isabel` - America\/Santa_Isabel\n\* `America\/Santarem` - America\/Santarem\n\* `America\/Santiago` - America\/Santiago\n\* `America\/Santo_Domingo` - America\/Santo_Domingo\n\* `America\/Sao_Paulo` - America\/Sao_Paulo\n\* `America\/Scoresbysund` - America\/Scoresbysund\n\* `America\/Shiprock` - America\/Shiprock\n\* `America\/Sitka` - America\/Sitka\n\* `America\/St_Barthelemy` - America\/St_Barthelemy\n\* `America\/St_Johns` - America\/St_Johns\n\* `America\/St_Kitts` - America\/St_Kitts\n\* `America\/St_Lucia` - America\/St_Lucia\n\* `America\/St_Thomas` - America\/St_Thomas\n\* `America\/St_Vincent` - America\/St_Vincent\n\* `America\/Swift_Current` - America\/Swift_Current\n\* `America\/Tegucigalpa` - America\/Tegucigalpa\n\* `America\/Thule` - America\/Thule\n\* `America\/Thunder_Bay` - America\/Thunder_Bay\n\* `America\/Tijuana` - America\/Tijuana\n\* `America\/Toronto` - America\/Toronto\n\* `America\/Tortola` - America\/Tortola\n\* `America\/Vancouver` - America\/Vancouver\n\* `America\/Virgin` - America\/Virgin\n\* `America\/Whitehorse` - America\/Whitehorse\n\* `America\/Winnipeg` - America\/Winnipeg\n\* `America\/Yakutat` - America\/Yakutat\n\* `America\/Yellowknife` - America\/Yellowknife\n\* `Antarctica\/Casey` - Antarctica\/Casey\n\* `Antarctica\/Davis` - Antarctica\/Davis\n\* `Antarctica\/DumontDUrville` - Antarctica\/DumontDUrville\n\* `Antarctica\/Macquarie` - Antarctica\/Macquarie\n\* `Antarctica\/Mawson` - Antarctica\/Mawson\n\* `Antarctica\/McMurdo` - Antarctica\/McMurdo\n\* `Antarctica\/Palmer` - Antarctica\/Palmer\n\* `Antarctica\/Rothera` - Antarctica\/Rothera\n\* `Antarctica\/South_Pole` - Antarctica\/South_Pole\n\* `Antarctica\/Syowa` - Antarctica\/Syowa\n\* `Antarctica\/Troll` - Antarctica\/Troll\n\* `Antarctica\/Vostok` - Antarctica\/Vostok\n\* `Arctic\/Longyearbyen` - Arctic\/Longyearbyen\n\* `Asia\/Aden` - Asia\/Aden\n\* `Asia\/Almaty` - Asia\/Almaty\n\* `Asia\/Amman` - Asia\/Amman\n\* `Asia\/Anadyr` - Asia\/Anadyr\n\* `Asia\/Aqtau` - Asia\/Aqtau\n\* `Asia\/Aqtobe` - Asia\/Aqtobe\n\* `Asia\/Ashgabat` - Asia\/Ashgabat\n\* `Asia\/Ashkhabad` - Asia\/Ashkhabad\n\* `Asia\/Atyrau` - Asia\/Atyrau\n\* `Asia\/Baghdad` - Asia\/Baghdad\n\* `Asia\/Bahrain` - Asia\/Bahrain\n\* `Asia\/Baku` - Asia\/Baku\n\* `Asia\/Bangkok` - Asia\/Bangkok\n\* `Asia\/Barnaul` - Asia\/Barnaul\n\* `Asia\/Beirut` - Asia\/Beirut\n\* `Asia\/Bishkek` - Asia\/Bishkek\n\* `Asia\/Brunei` - Asia\/Brunei\n\* `Asia\/Calcutta` - Asia\/Calcutta\n\* `Asia\/Chita` - Asia\/Chita\n\* `Asia\/Choibalsan` - Asia\/Choibalsan\n\* `Asia\/Chongqing` - Asia\/Chongqing\n\* `Asia\/Chungking` - Asia\/Chungking\n\* `Asia\/Colombo` - Asia\/Colombo\n\* `Asia\/Dacca` - Asia\/Dacca\n\* `Asia\/Damascus` - Asia\/Damascus\n\* `Asia\/Dhaka` - Asia\/Dhaka\n\* `Asia\/Dili` - Asia\/Dili\n\* `Asia\/Dubai` - Asia\/Dubai\n\* `Asia\/Dushanbe` - Asia\/Dushanbe\n\* `Asia\/Famagusta` - Asia\/Famagusta\n\* `Asia\/Gaza` - Asia\/Gaza\n\* `Asia\/Harbin` - Asia\/Harbin\n\* `Asia\/Hebron` - Asia\/Hebron\n\* `Asia\/Ho_Chi_Minh` - Asia\/Ho_Chi_Minh\n\* `Asia\/Hong_Kong` - Asia\/Hong_Kong\n\* `Asia\/Hovd` - Asia\/Hovd\n\* `Asia\/Irkutsk` - Asia\/Irkutsk\n\* `Asia\/Istanbul` - Asia\/Istanbul\n\* `Asia\/Jakarta` - Asia\/Jakarta\n\* `Asia\/Jayapura` - Asia\/Jayapura\n\* `Asia\/Jerusalem` - Asia\/Jerusalem\n\* `Asia\/Kabul` - Asia\/Kabul\n\* `Asia\/Kamchatka` - Asia\/Kamchatka\n\* `Asia\/Karachi` - Asia\/Karachi\n\* `Asia\/Kashgar` - Asia\/Kashgar\n\* `Asia\/Kathmandu` - Asia\/Kathmandu\n\* `Asia\/Katmandu` - Asia\/Katmandu\n\* `Asia\/Khandyga` - Asia\/Khandyga\n\* `Asia\/Kolkata` - Asia\/Kolkata\n\* `Asia\/Krasnoyarsk` - Asia\/Krasnoyarsk\n\* `Asia\/Kuala_Lumpur` - Asia\/Kuala_Lumpur\n\* `Asia\/Kuching` - Asia\/Kuching\n\* `Asia\/Kuwait` - Asia\/Kuwait\n\* `Asia\/Macao` - Asia\/Macao\n\* `Asia\/Macau` - Asia\/Macau\n\* `Asia\/Magadan` - Asia\/Magadan\n\* `Asia\/Makassar` - Asia\/Makassar\n\* `Asia\/Manila` - Asia\/Manila\n\* `Asia\/Muscat` - Asia\/Muscat\n\* `Asia\/Nicosia` - Asia\/Nicosia\n\* `Asia\/Novokuznetsk` - Asia\/Novokuznetsk\n\* `Asia\/Novosibirsk` - Asia\/Novosibirsk\n\* `Asia\/Omsk` - Asia\/Omsk\n\* `Asia\/Oral` - Asia\/Oral\n\* `Asia\/Phnom_Penh` - Asia\/Phnom_Penh\n\* `Asia\/Pontianak` - Asia\/Pontianak\n\* `Asia\/Pyongyang` - Asia\/Pyongyang\n\* `Asia\/Qatar` - Asia\/Qatar\n\* `Asia\/Qostanay` - Asia\/Qostanay\n\* `Asia\/Qyzylorda` - Asia\/Qyzylorda\n\* `Asia\/Rangoon` - Asia\/Rangoon\n\* `Asia\/Riyadh` - Asia\/Riyadh\n\* `Asia\/Saigon` - Asia\/Saigon\n\* `Asia\/Sakhalin` - Asia\/Sakhalin\n\* `Asia\/Samarkand` - Asia\/Samarkand\n\* `Asia\/Seoul` - Asia\/Seoul\n\* `Asia\/Shanghai` - Asia\/Shanghai\n\* `Asia\/Singapore` - Asia\/Singapore\n\* `Asia\/Srednekolymsk` - Asia\/Srednekolymsk\n\* `Asia\/Taipei` - Asia\/Taipei\n\* `Asia\/Tashkent` - Asia\/Tashkent\n\* `Asia\/Tbilisi` - Asia\/Tbilisi\n\* `Asia\/Tehran` - Asia\/Tehran\n\* `Asia\/Tel_Aviv` - Asia\/Tel_Aviv\n\* `Asia\/Thimbu` - Asia\/Thimbu\n\* `Asia\/Thimphu` - Asia\/Thimphu\n\* `Asia\/Tokyo` - Asia\/Tokyo\n\* `Asia\/Tomsk` - Asia\/Tomsk\n\* `Asia\/Ujung_Pandang` - Asia\/Ujung_Pandang\n\* `Asia\/Ulaanbaatar` - Asia\/Ulaanbaatar\n\* `Asia\/Ulan_Bator` - Asia\/Ulan_Bator\n\* `Asia\/Urumqi` - Asia\/Urumqi\n\* `Asia\/Ust-Nera` - Asia\/Ust-Nera\n\* `Asia\/Vientiane` - Asia\/Vientiane\n\* `Asia\/Vladivostok` - Asia\/Vladivostok\n\* `Asia\/Yakutsk` - Asia\/Yakutsk\n\* `Asia\/Yangon` - Asia\/Yangon\n\* `Asia\/Yekaterinburg` - Asia\/Yekaterinburg\n\* `Asia\/Yerevan` - Asia\/Yerevan\n\* `Atlantic\/Azores` - Atlantic\/Azores\n\* `Atlantic\/Bermuda` - Atlantic\/Bermuda\n\* `Atlantic\/Canary` - Atlantic\/Canary\n\* `Atlantic\/Cape_Verde` - Atlantic\/Cape_Verde\n\* `Atlantic\/Faeroe` - Atlantic\/Faeroe\n\* `Atlantic\/Faroe` - Atlantic\/Faroe\n\* `Atlantic\/Jan_Mayen` - Atlantic\/Jan_Mayen\n\* `Atlantic\/Madeira` - Atlantic\/Madeira\n\* `Atlantic\/Reykjavik` - Atlantic\/Reykjavik\n\* `Atlantic\/South_Georgia` - Atlantic\/South_Georgia\n\* `Atlantic\/St_Helena` - Atlantic\/St_Helena\n\* `Atlantic\/Stanley` - Atlantic\/Stanley\n\* `Australia\/ACT` - Australia\/ACT\n\* `Australia\/Adelaide` - Australia\/Adelaide\n\* `Australia\/Brisbane` - Australia\/Brisbane\n\* `Australia\/Broken_Hill` - Australia\/Broken_Hill\n\* `Australia\/Canberra` - Australia\/Canberra\n\* `Australia\/Currie` - Australia\/Currie\n\* `Australia\/Darwin` - Australia\/Darwin\n\* `Australia\/Eucla` - Australia\/Eucla\n\* `Australia\/Hobart` - Australia\/Hobart\n\* `Australia\/LHI` - Australia\/LHI\n\* `Australia\/Lindeman` - Australia\/Lindeman\n\* `Australia\/Lord_Howe` - Australia\/Lord_Howe\n\* `Australia\/Melbourne` - Australia\/Melbourne\n\* `Australia\/NSW` - Australia\/NSW\n\* `Australia\/North` - Australia\/North\n\* `Australia\/Perth` - Australia\/Perth\n\* `Australia\/Queensland` - Australia\/Queensland\n\* `Australia\/South` - Australia\/South\n\* `Australia\/Sydney` - Australia\/Sydney\n\* `Australia\/Tasmania` - Australia\/Tasmania\n\* `Australia\/Victoria` - Australia\/Victoria\n\* `Australia\/West` - Australia\/West\n\* `Australia\/Yancowinna` - Australia\/Yancowinna\n\* `Brazil\/Acre` - Brazil\/Acre\n\* `Brazil\/DeNoronha` - Brazil\/DeNoronha\n\* `Brazil\/East` - Brazil\/East\n\* `Brazil\/West` - Brazil\/West\n\* `CET` - CET\n\* `CST6CDT` - CST6CDT\n\* `Canada\/Atlantic` - Canada\/Atlantic\n\* `Canada\/Central` - Canada\/Central\n\* `Canada\/Eastern` - Canada\/Eastern\n\* `Canada\/Mountain` - Canada\/Mountain\n\* `Canada\/Newfoundland` - Canada\/Newfoundland\n\* `Canada\/Pacific` - Canada\/Pacific\n\* `Canada\/Saskatchewan` - Canada\/Saskatchewan\n\* `Canada\/Yukon` - Canada\/Yukon\n\* `Chile\/Continental` - Chile\/Continental\n\* `Chile\/EasterIsland` - Chile\/EasterIsland\n\* `Cuba` - Cuba\n\* `EET` - EET\n\* `EST` - EST\n\* `EST5EDT` - EST5EDT\n\* `Egypt` - Egypt\n\* `Eire` - Eire\n\* `Etc\/GMT` - Etc\/GMT\n\* `Etc\/GMT+0` - Etc\/GMT+0\n\* `Etc\/GMT+1` - Etc\/GMT+1\n\* `Etc\/GMT+10` - Etc\/GMT+10\n\* `Etc\/GMT+11` - Etc\/GMT+11\n\* `Etc\/GMT+12` - Etc\/GMT+12\n\* `Etc\/GMT+2` - Etc\/GMT+2\n\* `Etc\/GMT+3` - Etc\/GMT+3\n\* `Etc\/GMT+4` - Etc\/GMT+4\n\* `Etc\/GMT+5` - Etc\/GMT+5\n\* `Etc\/GMT+6` - Etc\/GMT+6\n\* `Etc\/GMT+7` - Etc\/GMT+7\n\* `Etc\/GMT+8` - Etc\/GMT+8\n\* `Etc\/GMT+9` - Etc\/GMT+9\n\* `Etc\/GMT-0` - Etc\/GMT-0\n\* `Etc\/GMT-1` - Etc\/GMT-1\n\* `Etc\/GMT-10` - Etc\/GMT-10\n\* `Etc\/GMT-11` - Etc\/GMT-11\n\* `Etc\/GMT-12` - Etc\/GMT-12\n\* `Etc\/GMT-13` - Etc\/GMT-13\n\* `Etc\/GMT-14` - Etc\/GMT-14\n\* `Etc\/GMT-2` - Etc\/GMT-2\n\* `Etc\/GMT-3` - Etc\/GMT-3\n\* `Etc\/GMT-4` - Etc\/GMT-4\n\* `Etc\/GMT-5` - Etc\/GMT-5\n\* `Etc\/GMT-6` - Etc\/GMT-6\n\* `Etc\/GMT-7` - Etc\/GMT-7\n\* `Etc\/GMT-8` - Etc\/GMT-8\n\* `Etc\/GMT-9` - Etc\/GMT-9\n\* `Etc\/GMT0` - Etc\/GMT0\n\* `Etc\/Greenwich` - Etc\/Greenwich\n\* `Etc\/UCT` - Etc\/UCT\n\* `Etc\/UTC` - Etc\/UTC\n\* `Etc\/Universal` - Etc\/Universal\n\* `Etc\/Zulu` - Etc\/Zulu\n\* `Europe\/Amsterdam` - Europe\/Amsterdam\n\* `Europe\/Andorra` - Europe\/Andorra\n\* `Europe\/Astrakhan` - Europe\/Astrakhan\n\* `Europe\/Athens` - Europe\/Athens\n\* `Europe\/Belfast` - Europe\/Belfast\n\* `Europe\/Belgrade` - Europe\/Belgrade\n\* `Europe\/Berlin` - Europe\/Berlin\n\* `Europe\/Bratislava` - Europe\/Bratislava\n\* `Europe\/Brussels` - Europe\/Brussels\n\* `Europe\/Bucharest` - Europe\/Bucharest\n\* `Europe\/Budapest` - Europe\/Budapest\n\* `Europe\/Busingen` - Europe\/Busingen\n\* `Europe\/Chisinau` - Europe\/Chisinau\n\* `Europe\/Copenhagen` - Europe\/Copenhagen\n\* `Europe\/Dublin` - Europe\/Dublin\n\* `Europe\/Gibraltar` - Europe\/Gibraltar\n\* `Europe\/Guernsey` - Europe\/Guernsey\n\* `Europe\/Helsinki` - Europe\/Helsinki\n\* `Europe\/Isle_of_Man` - Europe\/Isle_of_Man\n\* `Europe\/Istanbul` - Europe\/Istanbul\n\* `Europe\/Jersey` - Europe\/Jersey\n\* `Europe\/Kaliningrad` - Europe\/Kaliningrad\n\* `Europe\/Kiev` - Europe\/Kiev\n\* `Europe\/Kirov` - Europe\/Kirov\n\* `Europe\/Kyiv` - Europe\/Kyiv\n\* `Europe\/Lisbon` - Europe\/Lisbon\n\* `Europe\/Ljubljana` - Europe\/Ljubljana\n\* `Europe\/London` - Europe\/London\n\* `Europe\/Luxembourg` - Europe\/Luxembourg\n\* `Europe\/Madrid` - Europe\/Madrid\n\* `Europe\/Malta` - Europe\/Malta\n\* `Europe\/Mariehamn` - Europe\/Mariehamn\n\* `Europe\/Minsk` - Europe\/Minsk\n\* `Europe\/Monaco` - Europe\/Monaco\n\* `Europe\/Moscow` - Europe\/Moscow\n\* `Europe\/Nicosia` - Europe\/Nicosia\n\* `Europe\/Oslo` - Europe\/Oslo\n\* `Europe\/Paris` - Europe\/Paris\n\* `Europe\/Podgorica` - Europe\/Podgorica\n\* `Europe\/Prague` - Europe\/Prague\n\* `Europe\/Riga` - Europe\/Riga\n\* `Europe\/Rome` - Europe\/Rome\n\* `Europe\/Samara` - Europe\/Samara\n\* `Europe\/San_Marino` - Europe\/San_Marino\n\* `Europe\/Sarajevo` - Europe\/Sarajevo\n\* `Europe\/Saratov` - Europe\/Saratov\n\* `Europe\/Simferopol` - Europe\/Simferopol\n\* `Europe\/Skopje` - Europe\/Skopje\n\* `Europe\/Sofia` - Europe\/Sofia\n\* `Europe\/Stockholm` - Europe\/Stockholm\n\* `Europe\/Tallinn` - Europe\/Tallinn\n\* `Europe\/Tirane` - Europe\/Tirane\n\* `Europe\/Tiraspol` - Europe\/Tiraspol\n\* `Europe\/Ulyanovsk` - Europe\/Ulyanovsk\n\* `Europe\/Uzhgorod` - Europe\/Uzhgorod\n\* `Europe\/Vaduz` - Europe\/Vaduz\n\* `Europe\/Vatican` - Europe\/Vatican\n\* `Europe\/Vienna` - Europe\/Vienna\n\* `Europe\/Vilnius` - Europe\/Vilnius\n\* `Europe\/Volgograd` - Europe\/Volgograd\n\* `Europe\/Warsaw` - Europe\/Warsaw\n\* `Europe\/Zagreb` - Europe\/Zagreb\n\* `Europe\/Zaporozhye` - Europe\/Zaporozhye\n\* `Europe\/Zurich` - Europe\/Zurich\n\* `GB` - GB\n\* `GB-Eire` - GB-Eire\n\* `GMT` - GMT\n\* `GMT+0` - GMT+0\n\* `GMT-0` - GMT-0\n\* `GMT0` - GMT0\n\* `Greenwich` - Greenwich\n\* `HST` - HST\n\* `Hongkong` - Hongkong\n\* `Iceland` - Iceland\n\* `Indian\/Antananarivo` - Indian\/Antananarivo\n\* `Indian\/Chagos` - Indian\/Chagos\n\* `Indian\/Christmas` - Indian\/Christmas\n\* `Indian\/Cocos` - Indian\/Cocos\n\* `Indian\/Comoro` - Indian\/Comoro\n\* `Indian\/Kerguelen` - Indian\/Kerguelen\n\* `Indian\/Mahe` - Indian\/Mahe\n\* `Indian\/Maldives` - Indian\/Maldives\n\* `Indian\/Mauritius` - Indian\/Mauritius\n\* `Indian\/Mayotte` - Indian\/Mayotte\n\* `Indian\/Reunion` - Indian\/Reunion\n\* `Iran` - Iran\n\* `Israel` - Israel\n\* `Jamaica` - Jamaica\n\* `Japan` - Japan\n\* `Kwajalein` - Kwajalein\n\* `Libya` - Libya\n\* `MET` - MET\n\* `MST` - MST\n\* `MST7MDT` - MST7MDT\n\* `Mexico\/BajaNorte` - Mexico\/BajaNorte\n\* `Mexico\/BajaSur` - Mexico\/BajaSur\n\* `Mexico\/General` - Mexico\/General\n\* `NZ` - NZ\n\* `NZ-CHAT` - NZ-CHAT\n\* `Navajo` - Navajo\n\* `PRC` - PRC\n\* `PST8PDT` - PST8PDT\n\* `Pacific\/Apia` - Pacific\/Apia\n\* `Pacific\/Auckland` - Pacific\/Auckland\n\* `Pacific\/Bougainville` - Pacific\/Bougainville\n\* `Pacific\/Chatham` - Pacific\/Chatham\n\* `Pacific\/Chuuk` - Pacific\/Chuuk\n\* `Pacific\/Easter` - Pacific\/Easter\n\* `Pacific\/Efate` - Pacific\/Efate\n\* `Pacific\/Enderbury` - Pacific\/Enderbury\n\* `Pacific\/Fakaofo` - Pacific\/Fakaofo\n\* `Pacific\/Fiji` - Pacific\/Fiji\n\* `Pacific\/Funafuti` - Pacific\/Funafuti\n\* `Pacific\/Galapagos` - Pacific\/Galapagos\n\* `Pacific\/Gambier` - Pacific\/Gambier\n\* `Pacific\/Guadalcanal` - Pacific\/Guadalcanal\n\* `Pacific\/Guam` - Pacific\/Guam\n\* `Pacific\/Honolulu` - Pacific\/Honolulu\n\* `Pacific\/Johnston` - Pacific\/Johnston\n\* `Pacific\/Kanton` - Pacific\/Kanton\n\* `Pacific\/Kiritimati` - Pacific\/Kiritimati\n\* `Pacific\/Kosrae` - Pacific\/Kosrae\n\* `Pacific\/Kwajalein` - Pacific\/Kwajalein\n\* `Pacific\/Majuro` - Pacific\/Majuro\n\* `Pacific\/Marquesas` - Pacific\/Marquesas\n\* `Pacific\/Midway` - Pacific\/Midway\n\* `Pacific\/Nauru` - Pacific\/Nauru\n\* `Pacific\/Niue` - Pacific\/Niue\n\* `Pacific\/Norfolk` - Pacific\/Norfolk\n\* `Pacific\/Noumea` - Pacific\/Noumea\n\* `Pacific\/Pago_Pago` - Pacific\/Pago_Pago\n\* `Pacific\/Palau` - Pacific\/Palau\n\* `Pacific\/Pitcairn` - Pacific\/Pitcairn\n\* `Pacific\/Pohnpei` - Pacific\/Pohnpei\n\* `Pacific\/Ponape` - Pacific\/Ponape\n\* `Pacific\/Port_Moresby` - Pacific\/Port_Moresby\n\* `Pacific\/Rarotonga` - Pacific\/Rarotonga\n\* `Pacific\/Saipan` - Pacific\/Saipan\n\* `Pacific\/Samoa` - Pacific\/Samoa\n\* `Pacific\/Tahiti` - Pacific\/Tahiti\n\* `Pacific\/Tarawa` - Pacific\/Tarawa\n\* `Pacific\/Tongatapu` - Pacific\/Tongatapu\n\* `Pacific\/Truk` - Pacific\/Truk\n\* `Pacific\/Wake` - Pacific\/Wake\n\* `Pacific\/Wallis` - Pacific\/Wallis\n\* `Pacific\/Yap` - Pacific\/Yap\n\* `Poland` - Poland\n\* `Portugal` - Portugal\n\* `ROC` - ROC\n\* `ROK` - ROK\n\* `Singapore` - Singapore\n\* `Turkey` - Turkey\n\* `UCT` - UCT\n\* `US\/Alaska` - US\/Alaska\n\* `US\/Aleutian` - US\/Aleutian\n\* `US\/Arizona` - US\/Arizona\n\* `US\/Central` - US\/Central\n\* `US\/East-Indiana` - US\/East-Indiana\n\* `US\/Eastern` - US\/Eastern\n\* `US\/Hawaii` - US\/Hawaii\n\* `US\/Indiana-Starke` - US\/Indiana-Starke\n\* `US\/Michigan` - US\/Michigan\n\* `US\/Mountain` - US\/Mountain\n\* `US\/Pacific` - US\/Pacific\n\* `US\/Samoa` - US\/Samoa\n\* `UTC` - UTC\n\* `Universal` - Universal\n\* `W-SU` - W-SU\n\* `WET` - WET\n\* `Zulu` - Zulu'
+            ),
+        data_attributes: zod
+            .unknown()
+            .optional()
+            .describe(
+                "Element attributes that posthog-js should capture as action identifiers (e.g. `['data-attr']`)."
+            ),
+        person_display_name_properties: zod
+            .array(zod.string().max(organizationsProjectsLogsConfigPartialUpdateBodyPersonDisplayNamePropertiesItemMax))
+            .nullish()
+            .describe('Ordered list of person properties used to render a human-friendly display name in the UI.'),
+        correlation_config: zod.unknown().optional(),
+        autocapture_opt_out: zod
+            .boolean()
+            .nullish()
+            .describe('Disables posthog-js autocapture (clicks, page views) when true.'),
+        autocapture_exceptions_opt_in: zod
+            .boolean()
+            .nullish()
+            .describe('Enables automatic capture of JavaScript exceptions via the SDK.'),
+        autocapture_web_vitals_opt_in: zod
+            .boolean()
+            .nullish()
+            .describe('Enables automatic capture of Core Web Vitals performance metrics.'),
+        autocapture_web_vitals_allowed_metrics: zod.unknown().optional(),
+        autocapture_exceptions_errors_to_ignore: zod.unknown().optional(),
+        capture_console_log_opt_in: zod
+            .boolean()
+            .nullish()
+            .describe('Enables capturing browser console logs alongside session replays.'),
+        capture_performance_opt_in: zod
+            .boolean()
+            .nullish()
+            .describe('Enables capturing performance timing and network requests.'),
+        session_recording_opt_in: zod
+            .boolean()
+            .optional()
+            .describe('Enables session replay recording for this project.'),
+        session_recording_sample_rate: zod
+            .stringFormat('decimal', organizationsProjectsLogsConfigPartialUpdateBodySessionRecordingSampleRateRegExp)
+            .nullish()
+            .describe(
+                'Fraction of sessions to record, as a decimal string between `0.00` and `1.00` (e.g. `0.1` = 10%).'
+            ),
+        session_recording_minimum_duration_milliseconds: zod
+            .number()
+            .min(organizationsProjectsLogsConfigPartialUpdateBodySessionRecordingMinimumDurationMillisecondsMin)
+            .max(organizationsProjectsLogsConfigPartialUpdateBodySessionRecordingMinimumDurationMillisecondsMax)
+            .nullish()
+            .describe('Skip saving sessions shorter than this many milliseconds.'),
+        session_recording_linked_flag: zod.unknown().optional(),
+        session_recording_network_payload_capture_config: zod.unknown().optional(),
+        session_recording_masking_config: zod.unknown().optional(),
+        session_recording_url_trigger_config: zod.array(zod.unknown()).nullish(),
+        session_recording_url_blocklist_config: zod.array(zod.unknown()).nullish(),
+        session_recording_event_trigger_config: zod.array(zod.string().nullable()).nullish(),
+        session_recording_trigger_match_type_config: zod
+            .string()
+            .max(organizationsProjectsLogsConfigPartialUpdateBodySessionRecordingTriggerMatchTypeConfigMax)
+            .nullish(),
+        session_recording_trigger_groups: zod
+            .unknown()
+            .optional()
+            .describe(
+                'V2 trigger groups configuration for session recording. If present, takes precedence over legacy trigger fields.'
+            ),
+        session_recording_retention_period: zod
+            .enum(['30d', '90d', '1y', '5y'])
+            .describe('\* `30d` - 30 Days\n\* `90d` - 90 Days\n\* `1y` - 1 Year\n\* `5y` - 5 Years')
+            .optional()
+            .describe(
+                'How long to retain new session recordings. One of `30d`, `90d`, `1y`, or `5y` (availability depends on plan).\n\n\* `30d` - 30 Days\n\* `90d` - 90 Days\n\* `1y` - 1 Year\n\* `5y` - 5 Years'
+            ),
+        session_replay_config: zod.unknown().optional(),
+        survey_config: zod.unknown().optional(),
+        access_control: zod.boolean().optional(),
+        week_start_day: zod
+            .union([
+                zod.union([zod.literal(0), zod.literal(1)]).describe('\* `0` - Sunday\n\* `1` - Monday'),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                'First day of the week for date range filters. 0 = Sunday, 1 = Monday.\n\n\* `0` - Sunday\n\* `1` - Monday'
+            ),
+        primary_dashboard: zod
+            .number()
+            .nullish()
+            .describe("ID of the dashboard shown as the project's default landing dashboard."),
+        live_events_columns: zod.array(zod.string()).nullish(),
+        recording_domains: zod
+            .array(zod.string().max(organizationsProjectsLogsConfigPartialUpdateBodyRecordingDomainsItemMax).nullable())
+            .nullish()
+            .describe('Origins permitted to record session replays and heatmaps. Empty list allows all origins.'),
+        inject_web_apps: zod.boolean().nullish(),
+        extra_settings: zod.unknown().optional(),
+        modifiers: zod.unknown().optional(),
+        has_completed_onboarding_for: zod.unknown().optional(),
+        surveys_opt_in: zod
+            .boolean()
+            .nullish()
+            .describe('Enables displaying surveys via posthog-js on allowed origins.'),
+        heatmaps_opt_in: zod.boolean().nullish().describe('Enables heatmap recording on pages that host posthog-js.'),
+        flags_persistence_default: zod
+            .boolean()
+            .nullish()
+            .describe('Default value for the `persist` option on newly created feature flags.'),
+        receive_org_level_activity_logs: zod.boolean().nullish(),
+        business_model: zod
+            .union([
+                zod.enum(['b2b', 'b2c', 'other']).describe('\* `b2b` - B2B\n\* `b2c` - B2C\n\* `other` - Other'),
+                zod.enum(['']),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                'Whether this project serves B2B or B2C customers. Used to optimize default UI layouts.\n\n\* `b2b` - B2B\n\* `b2c` - B2C\n\* `other` - Other'
+            ),
+        conversations_enabled: zod
+            .boolean()
+            .nullish()
+            .describe('Enables the customer conversations \/ live chat product for this project.'),
+        conversations_settings: zod.unknown().optional(),
+        logs_settings: zod.unknown().optional(),
+        proactive_tasks_enabled: zod.boolean().nullish(),
+    })
+    .describe('Mixin for serializers to add user access control fields')
+
+/**
  * Projects for the current organization.
  */
 export const organizationsProjectsResetTokenPartialUpdateBodyNameMax = 200

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -21,6 +21,7 @@ from posthog.api.team import (
     TeamSerializer,
     get_or_mint_live_events_token,
     handle_conversations_token_on_update,
+    handle_logs_config,
     validate_team_attrs,
 )
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
@@ -911,6 +912,19 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
     def is_generating_demo_data(self, request: request.Request, id: str, **kwargs) -> response.Response:
         project = self.get_object()
         return response.Response({"is_generating_demo_data": project.passthrough_team.get_is_generating_demo_data()})
+
+    @action(
+        methods=["GET", "PATCH"],
+        detail=True,
+        permission_classes=[TeamMemberLightManagementPermission],
+        url_path="logs_config",
+    )
+    def logs_config(self, request: request.Request, id: str, **kwargs) -> response.Response:
+        """Manage logs product configuration for this project's canonical environment.
+        Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
+        alongside the legacy /api/environments/:id/logs_config/ alias."""
+        project = self.get_object()
+        return handle_logs_config(request, project.passthrough_team)
 
     @action(methods=["GET"], detail=True)
     def activity(self, request: request.Request, **kwargs):

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -99,6 +99,40 @@ from products.signals.backend.models import SignalSourceConfig
 tracer = trace.get_tracer(__name__)
 
 
+class TeamLogsConfigSerializer(serializers.ModelSerializer):
+    logs_distinct_id_attribute_key = serializers.CharField(
+        max_length=200,
+        help_text=(
+            "Log attribute key whose value should match a person's distinct_id. "
+            "Used by the person profile Logs tab and the `query-logs` MCP tool. "
+            "Defaults to 'posthogDistinctId' — the convention documented at "
+            "https://posthog.com/docs/logs/link-session-replay and the key the "
+            "posthog-js / posthog-react-native SDKs auto-attach. Override only if "
+            "your pipeline emits a different attribute."
+        ),
+    )
+
+    class Meta:
+        model = TeamLogsConfig
+        fields = ["logs_distinct_id_attribute_key"]
+
+
+def handle_logs_config(request: request.Request, team: Team) -> response.Response:
+    """Shared handler for the logs_config action — exposed under both the team/environment
+    and project routers so the canonical /api/projects/ URL resolves alongside the legacy
+    /api/environments/ alias. Both endpoints operate on the env-scoped TeamLogsConfig
+    keyed by team_id."""
+    config = get_or_create_team_extension(team, TeamLogsConfig)
+
+    if request.method == "PATCH":
+        serializer = TeamLogsConfigSerializer(config, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return response.Response(serializer.data)
+
+    return response.Response(TeamLogsConfigSerializer(config).data)
+
+
 def _format_serializer_errors(serializer_errors: dict) -> str:
     """Formats DRF serializer errors into a human readable string."""
     error_messages: list[str] = []
@@ -1712,35 +1746,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
     )
     def logs_config(self, request: request.Request, id: str, **kwargs) -> response.Response:
         """Manage logs product configuration for this environment."""
-        from rest_framework import serializers
-
-        class TeamLogsConfigSerializer(serializers.ModelSerializer):
-            logs_distinct_id_attribute_key = serializers.CharField(
-                max_length=200,
-                help_text=(
-                    "Log attribute key whose value should match a person's distinct_id. "
-                    "Used by the person profile Logs tab and the `query-logs` MCP tool. "
-                    "Defaults to 'posthogDistinctId' — the convention documented at "
-                    "https://posthog.com/docs/logs/link-session-replay and the key the "
-                    "posthog-js / posthog-react-native SDKs auto-attach. Override only if "
-                    "your pipeline emits a different attribute."
-                ),
-            )
-
-            class Meta:
-                model = TeamLogsConfig
-                fields = ["logs_distinct_id_attribute_key"]
-
-        team = self.get_object()
-        config = get_or_create_team_extension(team, TeamLogsConfig)
-
-        if request.method == "PATCH":
-            serializer = TeamLogsConfigSerializer(config, data=request.data, partial=True)
-            serializer.is_valid(raise_exception=True)
-            serializer.save()
-            return response.Response(serializer.data)
-
-        return response.Response(TeamLogsConfigSerializer(config).data)
+        return handle_logs_config(request, self.get_object())
 
     @action(
         methods=["GET", "PATCH"],

--- a/posthog/api/test/test_team_logs_config.py
+++ b/posthog/api/test/test_team_logs_config.py
@@ -1,5 +1,6 @@
 from posthog.test.base import APIBaseTest
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import OrganizationMembership, Team
@@ -7,23 +8,31 @@ from posthog.models.team.extensions import get_or_create_team_extension
 
 from products.logs.backend.models import TeamLogsConfig
 
+# Both routes resolve to the same handler — /api/projects/ is canonical, /api/environments/
+# remains as the back-compat alias. See `handle_logs_config` in posthog/api/team.py.
+URL_PREFIXES = [("projects", "api/projects"), ("environments", "api/environments")]
+
 
 class TestTeamLogsConfig(APIBaseTest):
     def setUp(self):
         super().setUp()
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
-        self.url = f"/api/environments/{self.team.id}/logs_config/"
 
-    def test_get_returns_default_attribute_key(self):
-        response = self.client.get(self.url)
+    def _url(self, prefix: str) -> str:
+        return f"/{prefix}/{self.team.id}/logs_config/"
+
+    @parameterized.expand(URL_PREFIXES)
+    def test_get_returns_default_attribute_key(self, _name: str, prefix: str):
+        response = self.client.get(self._url(prefix))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {"logs_distinct_id_attribute_key": "posthogDistinctId"})
 
-    def test_patch_updates_attribute_key(self):
+    @parameterized.expand(URL_PREFIXES)
+    def test_patch_updates_attribute_key(self, _name: str, prefix: str):
         response = self.client.patch(
-            self.url,
+            self._url(prefix),
             {"logs_distinct_id_attribute_key": "user.id"},
             format="json",
         )
@@ -34,37 +43,41 @@ class TestTeamLogsConfig(APIBaseTest):
         config = get_or_create_team_extension(self.team, TeamLogsConfig)
         self.assertEqual(config.logs_distinct_id_attribute_key, "user.id")
 
-    def test_patch_persists_across_requests(self):
+    @parameterized.expand(URL_PREFIXES)
+    def test_patch_persists_across_requests(self, _name: str, prefix: str):
         self.client.patch(
-            self.url,
+            self._url(prefix),
             {"logs_distinct_id_attribute_key": "posthog.distinct_id"},
             format="json",
         )
 
-        response = self.client.get(self.url)
+        response = self.client.get(self._url(prefix))
         self.assertEqual(response.json(), {"logs_distinct_id_attribute_key": "posthog.distinct_id"})
 
-    def test_patch_rejects_key_over_max_length(self):
+    @parameterized.expand(URL_PREFIXES)
+    def test_patch_rejects_key_over_max_length(self, _name: str, prefix: str):
         response = self.client.patch(
-            self.url,
+            self._url(prefix),
             {"logs_distinct_id_attribute_key": "x" * 201},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_regular_member_can_patch(self):
+    @parameterized.expand(URL_PREFIXES)
+    def test_regular_member_can_patch(self, _name: str, prefix: str):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
         response = self.client.patch(
-            self.url,
+            self._url(prefix),
             {"logs_distinct_id_attribute_key": "user.id"},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {"logs_distinct_id_attribute_key": "user.id"})
 
-    def test_config_is_scoped_per_environment(self):
+    @parameterized.expand(URL_PREFIXES)
+    def test_config_is_scoped_per_environment(self, _name: str, prefix: str):
         # Each environment under a project must keep its own config. A write on this
         # environment must not leak to a sibling environment that shares its project.
         sibling = Team.objects.create(
@@ -74,13 +87,25 @@ class TestTeamLogsConfig(APIBaseTest):
         )
 
         self.client.patch(
-            self.url,
+            self._url(prefix),
             {"logs_distinct_id_attribute_key": "user.id"},
             format="json",
         )
 
-        sibling_response = self.client.get(f"/api/environments/{sibling.id}/logs_config/")
+        sibling_response = self.client.get(f"/{prefix}/{sibling.id}/logs_config/")
         self.assertEqual(
             sibling_response.json(),
             {"logs_distinct_id_attribute_key": "posthogDistinctId"},
         )
+
+    def test_project_and_environment_share_same_config(self):
+        # Writes via the canonical /api/projects/ URL must be visible via the
+        # /api/environments/ alias and vice versa — both routes operate on the
+        # same env-scoped TeamLogsConfig keyed by team_id.
+        self.client.patch(
+            f"/api/projects/{self.team.id}/logs_config/",
+            {"logs_distinct_id_attribute_key": "user.id"},
+            format="json",
+        )
+        env_response = self.client.get(f"/api/environments/{self.team.id}/logs_config/")
+        self.assertEqual(env_response.json(), {"logs_distinct_id_attribute_key": "user.id"})

--- a/products/logs/frontend/logsConfigLogic.ts
+++ b/products/logs/frontend/logsConfigLogic.ts
@@ -24,10 +24,6 @@ export const logsConfigLogic = kea<logsConfigLogicType>([
             null as LogsConfig | null,
             {
                 loadLogsConfig: async (): Promise<LogsConfig> => {
-                    // The `logs_config` sub-endpoint is a `@action` on TeamViewSet without
-                    // `@extend_schema`, so it isn't in the generated client (same as
-                    // `experiments_config`). The codegen path opens up when the action
-                    // gets a proper request/response schema annotation.
                     // nosemgrep: prefer-codegen-api
                     return await api.get(`api/projects/${values.currentTeamId}/logs_config/`)
                 },

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -185,6 +185,12 @@ tools:
     oauth-applications-list:
         operation: oauth_applications_list
         enabled: false
+    organizations-projects-logs-config-partial-update:
+        operation: organizations_projects_logs_config_partial_update
+        enabled: false
+    organizations-projects-logs-config-retrieve:
+        operation: organizations_projects_logs_config_retrieve
+        enabled: false
     project-get:
         operation: organizations_projects_retrieve
         enabled: true


### PR DESCRIPTION
## Problem

Production `Load logs config failed: Endpoint not found.` on the person profile Logs tab. The frontend calls `/api/projects/:team_id/logs_config/` which 404s because the backend `@action` only exists under `/api/environments/`.

## Root cause

PR #60407 (the sweep that makes `/api/projects/` canonical for env-only endpoints) mechanically rewrote URL strings in `logsConfigLogic.ts` from `api/environments/` to `api/projects/`. But `logs_config` is an `@action(detail=True)` on `TeamViewSet`, not a `router.register(...)` call — the sweep's script only converted env-router `register(...)` calls, so the backend was never dual-registered. The projects router uses `RootProjectViewSet(ProjectViewSet)`, a different class that doesn't carry the `@action`.

The sibling `experiments_config` action has the same gap; it still works only because its frontend file wasn't swept by #60407.

## Fix

Align with #60407's canonical-`/api/projects/` direction by mirroring `logs_config` on `ProjectViewSet`:

- Extract the action body into `handle_logs_config(request, team)` in `posthog/api/team.py` so both viewsets share one implementation.
- Add a matching `@action` to `ProjectViewSet` that looks up `project.passthrough_team` (the same pattern `reset_token`, `rotate_secret_token`, and other project-side actions use to operate on team-scoped state).
- Restore the frontend URL to `api/projects/...` per the canonical direction.

Both routes operate on the same env-scoped `TeamLogsConfig` keyed by `team_id`.

## Tests

Existing `test_team_logs_config.py` tests are parameterized across both URL prefixes (`/api/projects/` and `/api/environments/`), plus a new cross-route consistency test confirms a write through one prefix is visible via the other. 13/13 passing locally.

## Agent context

Authored by PostHog Code (Opus 4.7).

Discovery flow:

1. Browser-console fetch interceptor on the affected person profile revealed the call to `/api/projects/2/logs_config/` returning 404, while `/api/environments/2/logs_config/` returned 200.
2. Backend audit confirmed `logs_config` lives on `TeamViewSet` as an `@action`, registered only via `environments_router` → `RootTeamViewSet(TeamViewSet)`. The projects router uses `RootProjectViewSet(ProjectViewSet)`, which doesn't inherit the action.
3. `git blame` traced the frontend URL change to commit `7ce43b8f9d` (PR #60407 — "register canonical /api/projects/ route for env-only endpoints"). Its mechanical script only converted `environments_router.register(...)` calls; it did not inspect `@action` decorators on `TeamViewSet`/`ProjectViewSet`.
4. Verified `experimentsConfigLogic.ts` (sibling endpoint, same shape) was NOT swept by that PR. Confirms our backend implementation followed the existing convention.

Decisions:
- **Add the project-side action over reverting the frontend URL.** Reverting matches the still-working `experiments_config` precedent but moves us back toward `/api/environments/` for a team-scoped endpoint — against #60407's stated direction. Adding the project-side action fixes prod *and* aligns with the canonical-`/api/projects/` direction the codebase is moving toward.
- **Use `project.passthrough_team` rather than introducing a new resolution path.** Matches existing project-side actions (`reset_token`, `rotate_secret_token`, `delete_secret_token_backup`, `generate_conversations_public_token`).
- **Parameterize the existing tests rather than duplicate them.** Per repo convention; also catches future regressions on either route.

Out of scope (potential follow-ups):
- `experiments_config` has the same gap; it just hasn't been swept yet on the frontend. Same fix pattern would apply if/when needed.
- Adding `@extend_schema` to surface these endpoints in the generated OpenAPI client would let frontend code drop the hand-rolled `api.get()` and remove the `// nosemgrep: prefer-codegen-api` marker.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*