### PR TITLE
feat(max): open a new chat when selecting the Chat nav tab

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from '@base-ui/react/tabs'
 import { cva } from 'cva'
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import posthog from 'posthog-js'
 import { lazy, Suspense, useRef } from 'react'
 
@@ -18,6 +19,7 @@ import { Label } from 'lib/ui/Label/Label'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { cn } from 'lib/utils/css-classes'
 import { sceneLogic } from 'scenes/sceneLogic'
+import { urls } from 'scenes/urls'
 
 import { NavExperimentTab, PanelLayoutNavIdentifier, panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 
@@ -173,10 +175,14 @@ export function Nav(): JSX.Element {
                                 tooltipPlacement="right"
                                 active={activePanelIdentifier === 'Chat'}
                                 onClick={() => {
+                                    const isOpening = activePanelIdentifier !== 'Chat'
                                     posthog.capture('nav chat panel toggled', {
-                                        is_open: activePanelIdentifier !== 'Chat',
+                                        is_open: isOpening,
                                     })
                                     handlePanelTriggerClick('Chat')
+                                    if (isOpening) {
+                                        router.actions.push(urls.ai())
+                                    }
                                 }}
                             >
                                 <span
@@ -205,6 +211,9 @@ export function Nav(): JSX.Element {
                     onValueChange={(value) => {
                         posthog.capture('nav tab clicked', { tab: value })
                         setNavExperimentTab(value as NavExperimentTab)
+                        if (value === 'chat') {
+                            router.actions.push(urls.ai())
+                        }
                     }}
                     orientation={isLayoutNavCollapsed ? 'vertical' : 'horizontal'}
                 >

--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabChat.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabChat.tsx
@@ -118,6 +118,7 @@ export function NavTabChat({
                         </label>
                         <Link
                             to={urls.ai()}
+                            data-attr="nav-chat-new"
                             buttonProps={{ iconOnly: true, variant: 'outline', className: 'text-ai' }}
                             tooltip="New chat"
                         >
@@ -178,6 +179,7 @@ export function NavTabChat({
                                                                                     to={AiChatListItem.getHref(
                                                                                         conversation.id
                                                                                     )}
+                                                                                    data-attr="nav-chat-history-conversation"
                                                                                     buttonProps={{
                                                                                         active:
                                                                                             conversation.id ===


### PR DESCRIPTION
## Problem

Reaching the full AI chat interface takes two clicks today: selecting the "Chat" tab in the nav sidebar only swaps the panel to show chat history, so users then have to click again (the `+` button or a conversation) to actually start chatting. Data showed that ~64% of users who click the Chat tab click `+` to start a new chat within 10 seconds — so the common intent is "start a new chat", and the extra click is pure friction.

## Changes

- Selecting the **Chat** tab (`data-attr="nav-tab-chat"`) now navigates to a fresh chat at `/ai` while still showing the chat history panel, so a single click lands you in the AI chat ready to type — and you can still switch to a past conversation from the panel.
- The collapsed-nav Chat button behaves the same: opening the chat panel also starts a new chat.
- Added `data-attr="nav-chat-history-conversation"` to the past-conversation links so autocapture can distinguish "started a new chat" from "loaded an old conversation".

## How did you test this code?

I'm an agent and did not perform manual testing. There were no existing tests covering this nav behavior, and the frontend toolchain (oxlint/oxfmt) was not installed in this environment. The change is a small, self-contained navigation tweak in `Nav.tsx` plus a `data-attr` addition in `NavTabChat.tsx`; edits were hand-formatted to match the surrounding style. Recommend a quick manual smoke test: click the Chat tab from the Browse tab and confirm it lands on a new chat with history still visible.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by PostHog Code (Claude). The request originated from a Slack discussion about reducing friction to reach the AI chat interface. Explored the nav under `frontend/src/layout/panel-layout/ai-first/` to locate the `nav-tab-chat` Tabs control and its `onValueChange` handler. Chose to push `urls.ai()` (a new chat) on selecting the Chat tab rather than adding a separate `+` entry point, since the panel already keeps history visible for switching. Applied the same behavior to the collapsed-nav Chat button for consistency, and added a `data-attr` on history links so autocapture can measure the new-chat-vs-resume-old split going forward.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
