### PR TITLE
fix(ci): skip hogql-parser pin guard on workflow-only edits

### DIFF
--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -21,6 +21,7 @@ jobs:
         timeout-minutes: 5
         outputs:
             parser-release-needed: ${{ steps.version.outputs.parser-release-needed }}
+            version-release-needed: ${{ steps.version.outputs.version-release-needed }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -72,6 +73,10 @@ jobs:
                       parser_release_needed='true'
                     fi
                   fi
+                  # A genuinely new version (the 404/unknown cases above) — not a workflow-only
+                  # exercise — is what must move the pyproject/uv.lock pin. Emit it now, before
+                  # the workflow-only override below raises parser-release-needed on its own.
+                  echo "version-release-needed=$parser_release_needed" >> $GITHUB_OUTPUT
                   # Exercise the release pipeline on workflow-only edits; skip-existing makes publish a no-op.
                   if [[ "$WORKFLOW_CHANGED" == 'true' ]]; then
                     parser_release_needed='true'
@@ -137,7 +142,7 @@ jobs:
 
     publish:
         name: Publish on PyPI
-        needs: build-wheels
+        needs: [check-version, build-wheels]
         environment: pypi-hogql-parser
         permissions:
             id-token: write
@@ -245,6 +250,10 @@ jobs:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
             - name: Fail if pin update produced no commit
+              # Only a real version release must move the pin. Workflow-only edits
+              # exercise the pipeline as a skip-existing no-op and legitimately leave
+              # the pin untouched, so the guard must not fire for them.
+              if: needs.check-version.outputs.version-release-needed == 'true'
               shell: bash
               env:
                   CHANGED: ${{ steps.check-pin.outputs.changed }}


### PR DESCRIPTION
Note: **This PR is blocking https://github.com/PostHog/posthog/pull/59440** (Python 3.13.13 cutover): that PR's `Release hogql-parser` check fails until this merges. Land this, then rebase the cutover onto it.

## Problem

The `Release hogql-parser` workflow runs on workflow-only edits as a dry run (`skip-existing` makes publish a no-op, no new version released). But the "Fail if pin update produced no commit" guard (https://github.com/PostHog/posthog/pull/55106) fires whenever the pin didn't move — which it can't when there's no new version. Result: a false failure on every Python bump (they edit this workflow's `python-version` without touching the parser version). Surfaced on the 3.13.13 cutover (https://github.com/PostHog/posthog/pull/59440).

## Changes

Gate the guard on a new `version-release-needed` output that's true only for a real release (PyPI 404). Real version bumps are unchanged; workflow-only edits skip the guard.

## How did you test this code?

Agent (Claude Code); not run end-to-end. YAML parses; change is additive/backwards-compatible. This PR edits the workflow, so its own `Release hogql-parser` run exercises the fixed path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — CI-only change.

## 🤖 Agent context

Authored with Claude Code while merging master into https://github.com/PostHog/posthog/pull/59440 and debugging its red `Release hogql-parser` check. Root cause: contradiction between the workflow-only "exercise the pipeline" path (https://github.com/PostHog/posthog/pull/18244) and the pin guard (https://github.com/PostHog/posthog/pull/55106). Split off master so the cutover can rebase onto it. Longer-term fix remains https://github.com/PostHog/posthog/pull/55799.
