### PR TITLE
feat(navigation): link status indicators to region-specific status page

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
@@ -37,7 +37,7 @@ const Section = ({ title, children }: { title: string; children: React.ReactNode
 }
 
 const StatusPageAlert = (): JSX.Element | null => {
-    const { status, statusDescription } = useValues(incidentStatusLogic)
+    const { status, statusDescription, statusPageUrl } = useValues(incidentStatusLogic)
 
     if (status === 'operational') {
         return null
@@ -55,7 +55,7 @@ const StatusPageAlert = (): JSX.Element | null => {
                 <IconWarning className="text-warning w-5 h-5 shrink-0 mt-0.5" />
                 <div className="flex-1">
                     <p className="font-semibold mb-1">
-                        <Link to="https://posthogstatus.com" target="_blank">
+                        <Link to={statusPageUrl} target="_blank">
                             {description}
                         </Link>
                     </p>
@@ -63,7 +63,7 @@ const StatusPageAlert = (): JSX.Element | null => {
                         <p className="mb-1">We're aware of an issue that may be affecting your PostHog experience.</p>
                         <p className="mb-0">
                             You may wish to check our{' '}
-                            <Link to="https://posthogstatus.com" target="_blank">
+                            <Link to={statusPageUrl} target="_blank">
                                 current status
                             </Link>{' '}
                             before contacting support.

--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -60,7 +60,8 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
     const { isCloudOrDev, preflight } = useValues(preflightLogic)
     const { reportAccountOwnerClicked } = useActions(eventUsageLogic)
     const { billing } = useValues(billingLogic)
-    const { postHogStatusTooltip, postHogStatusBadgeStatus, postHogStatusBadgeContent } = useValues(posthogStatusLogic)
+    const { postHogStatusTooltip, postHogStatusBadgeStatus, postHogStatusBadgeContent, statusPageUrl } =
+        useValues(posthogStatusLogic)
     const { totalIssues } = useValues(healthSummaryLogic)
 
     return (
@@ -197,7 +198,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             targetBlankIcon
                                             target="_blank"
                                             buttonProps={{ menuItem: true }}
-                                            to="https://posthogstatus.com"
+                                            to={statusPageUrl}
                                             tooltip={postHogStatusTooltip}
                                             tooltipPlacement="right"
                                             tooltipCloseDelayMs={0}

--- a/frontend/src/lib/components/HelpMenu/incidentStatusLogic.tsx
+++ b/frontend/src/lib/components/HelpMenu/incidentStatusLogic.tsx
@@ -79,8 +79,21 @@ const RELEVANT_GROUP_NAME_MAP: Record<string, string> = {
     '127.0.0.1': 'US Cloud 🇺🇸', // Storybook CI runs at 127.0.0.1:6006
 }
 
+// Map hostname to the region-specific status page path (incident.io sub-pages)
+const REGION_PATH_MAP: Record<string, string> = {
+    'us.posthog.com': '/us',
+    'eu.posthog.com': '/eu',
+    localhost: '/us', // Default to US for local dev
+    '127.0.0.1': '/us', // Storybook CI runs at 127.0.0.1:6006
+}
+
 function getRelevantGroupName(): string | null {
     return RELEVANT_GROUP_NAME_MAP[window.location.hostname] || null
+}
+
+// Region-specific status page URL, falling back to the root page for unknown (self-hosted) hosts
+export function getStatusPageUrl(): string {
+    return `${STATUS_PAGE_BASE}${REGION_PATH_MAP[window.location.hostname] ?? ''}`
 }
 
 function hasRelevantComponents(affectedComponents: AffectedComponent[]): boolean {
@@ -180,6 +193,7 @@ export const incidentStatusLogic = kea<incidentStatusLogicType>([
     })),
 
     selectors({
+        statusPageUrl: [() => [], (): string => getStatusPageUrl()],
         rawStatus: [
             (s) => [s.summary],
             (summary: Summary | null): NormalizedStatus => {

--- a/frontend/src/lib/components/HelpMenu/posthogStatusLogic.tsx
+++ b/frontend/src/lib/components/HelpMenu/posthogStatusLogic.tsx
@@ -14,7 +14,7 @@ export const posthogStatusLogic = kea<posthogStatusLogicType>([
     connect({
         values: [
             incidentStatusLogic,
-            ['status', 'statusDescription'],
+            ['status', 'statusDescription', 'statusPageUrl'],
             superpowersLogic,
             ['fakeStatusOverride', 'superpowersEnabled'],
         ],

--- a/frontend/src/lib/components/PosthogStatus/PosthogStatusShownOnlyIfNotOperational.tsx
+++ b/frontend/src/lib/components/PosthogStatus/PosthogStatusShownOnlyIfNotOperational.tsx
@@ -11,7 +11,8 @@ export function PosthogStatusShownOnlyIfNotOperational({
 }: {
     iconOnly?: boolean
 }): JSX.Element | null {
-    const { postHogStatus, postHogStatusTooltip, postHogStatusBadgeStatus } = useValues(posthogStatusLogic)
+    const { postHogStatus, postHogStatusTooltip, postHogStatusBadgeStatus, statusPageUrl } =
+        useValues(posthogStatusLogic)
 
     if (postHogStatus === 'operational') {
         return null
@@ -31,7 +32,7 @@ export function PosthogStatusShownOnlyIfNotOperational({
                     iconOnly: iconOnly,
                     menuItem: !iconOnly,
                 }}
-                to="https://posthogstatus.com"
+                to={statusPageUrl}
                 tooltip={!iconOnly ? tooltipText : undefined}
                 tooltipCloseDelayMs={0}
                 target="_blank"

--- a/frontend/src/scenes/health/components/PlatformStatusBanner.tsx
+++ b/frontend/src/scenes/health/components/PlatformStatusBanner.tsx
@@ -4,7 +4,6 @@ import { LemonBanner } from '@posthog/lemon-ui'
 import type { LemonBannerProps } from '@posthog/lemon-ui'
 
 import { HeartHog, SleepingHog, WarningHog } from 'lib/components/hedgehogs'
-import { STATUS_PAGE_BASE } from 'lib/components/HelpMenu/incidentStatusLogic'
 import { posthogStatusLogic } from 'lib/components/HelpMenu/posthogStatusLogic'
 import type { PostHogStatusBadgeStatus, PostHogStatusType } from 'lib/components/HelpMenu/posthogStatusLogic'
 
@@ -28,7 +27,8 @@ const STATUS_LABELS: Record<PostHogStatusType, string> = {
 }
 
 export const PlatformStatusBanner = (): JSX.Element => {
-    const { postHogStatusTooltip, postHogStatusBadgeStatus, postHogStatus } = useValues(posthogStatusLogic)
+    const { postHogStatusTooltip, postHogStatusBadgeStatus, postHogStatus, statusPageUrl } =
+        useValues(posthogStatusLogic)
     const { bannerType, Hog } = STATUS_CONFIG[postHogStatusBadgeStatus]
     const statusLabel = STATUS_LABELS[postHogStatus]
     const statusMessage = postHogStatusTooltip ?? 'Checking for active incidents...'
@@ -40,7 +40,7 @@ export const PlatformStatusBanner = (): JSX.Element => {
             hideIcon={false}
             action={{
                 children: 'View status page',
-                to: STATUS_PAGE_BASE,
+                to: statusPageUrl,
                 targetBlank: true,
             }}
         >


### PR DESCRIPTION
## Problem

When PostHog is showing a degraded/incident status in the app, the status indicators all linked to the root `posthogstatus.com` page, which doesn't preselect the user's cloud region. Users had to pick their region manually to see whether the incident actually affects them.

We already determine the relevant region internally (by hostname → incident.io `group_name`) to decide *whether* to show a status — this reuses that mapping to send users straight to the region-specific status page so they can understand the issue without extra clicks.

## Changes

- Added `getStatusPageUrl()` and a `statusPageUrl` selector in `incidentStatusLogic`, mapping the hostname to the region-specific incident.io sub-page (`us.posthog.com` → `/us`, `eu.posthog.com` → `/eu`, local dev → `/us`). Unknown/self-hosted hosts fall back to the root `posthogstatus.com` page.
- Re-exposed `statusPageUrl` through `posthogStatusLogic`.
- Pointed every status link at the region-specific URL, all opening in a new tab:
  - Nav footer indicator (`PosthogStatusShownOnlyIfNotOperational`)
  - Help menu "PostHog status" item
  - Support side panel incident banner
  - Health scene `PlatformStatusBanner`

No visual change beyond the link target; the indicators already opened in a new tab.

## How did you test this code?

I'm an agent. The frontend toolchain (node_modules) wasn't installed in my environment, so I could not run the formatter, type check, or Jest. Changes are mechanical: a new pure helper + selector reused across four existing call sites, following the surrounding kea/TS conventions. Reviewer should run `pnpm --filter=@posthog/frontend typescript:check` and confirm the links resolve to `/us` and `/eu` in the respective clouds.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code (PostHog Code) at a maintainer's request from a Slack thread.

The status feature has two distinct concerns; this change only touches the cloud incident-status display (the internal self-hosted system-status admin panel is unrelated and untouched). I considered hardcoding `/us` per the original request but instead reused the existing hostname→region mapping that already gates *whether* the indicator shows, so EU users get `/eu` and self-hosted instances still fall back gracefully. The region URL is computed from `window.location.hostname` once via a dependency-free kea selector, matching the existing `getRelevantGroupName()` pattern in the same logic file.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*