### PR TITLE
fix(signals): Send inbox Slack notifications once per channel

### DIFF
--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -392,8 +392,6 @@ def dispatch_inbox_item_notifications(
         # All configs in a group share the same integration and resolved channel id.
         integration = configs[0].slack_notification_integration
         channel = configs[0].slack_notification_channel
-        if integration is None or not channel:
-            continue
 
         try:
             slack = SlackIntegration(integration)

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -397,7 +397,9 @@ def dispatch_inbox_item_notifications(
 
         try:
             slack = SlackIntegration(integration)
-            recipients = [_recipient_presentation(users_by_id[config.user_id], slack, integration) for config in configs]
+            recipients = [
+                _recipient_presentation(users_by_id[config.user_id], slack, integration) for config in configs
+            ]
             blocks, text = _build_message_blocks(
                 report,
                 priority=priority,

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -2,15 +2,19 @@
 
 When a report transitions to READY (a new inbox item lands), we look up the
 suggested reviewers from its `suggested_reviewers` artefact, resolve them to
-PostHog users, and dispatch a Slack message to each user that has configured a
+PostHog users, and dispatch a Slack message for each user that has configured a
 Slack channel and integration in their `SignalUserAutonomyConfig`.
+
+Reviewers are grouped by their resolved Slack channel so each channel receives a
+single message — when several reviewers point at the same channel, that one
+message tags all of them rather than posting once per reviewer.
 
 Each user's `slack_notification_min_priority` filters out reports below the
 configured threshold (P0 is highest). When the report has no priority
 judgement, we notify regardless of the user's threshold — the inbox should
 not silently swallow these.
 
-Messages are framed for public channels: each post names the suggested reviewer
+Messages are framed for public channels: each post names the suggested reviewers
 (Slack @mention when email matches the workspace, otherwise their PostHog name).
 """
 
@@ -242,6 +246,13 @@ def _recipient_presentation(
     return _RecipientPresentation(slack_mention=slack_mention, plain_name=plain_name)
 
 
+def _recipient_label(recipient: _RecipientPresentation) -> str:
+    # Mention pings the user inside mrkdwn; otherwise escape the plain name so it renders literally.
+    return recipient.slack_mention or recipient.plain_name.replace("&", "&amp;").replace("<", "&lt;").replace(
+        ">", "&gt;"
+    )
+
+
 def _format_source_product_labels(source_products: list[str]) -> str:
     if not source_products:
         return ""
@@ -267,7 +278,7 @@ def _build_message_blocks(
     *,
     priority: str | None,
     source_products: list[str],
-    recipient: _RecipientPresentation,
+    recipients: list[_RecipientPresentation],
     implementation_pr_url: str | None = None,
 ) -> tuple[list[dict], str]:
     title_line = report.title or "New signals inbox item"
@@ -275,9 +286,7 @@ def _build_message_blocks(
     if len(header_text) > _SLACK_HEADER_MAX_LEN:
         header_text = header_text[: _SLACK_HEADER_MAX_LEN - 3] + "..."
 
-    recipient_label = recipient.slack_mention or recipient.plain_name.replace("&", "&amp;").replace(
-        "<", "&lt;"
-    ).replace(">", "&gt;")
+    recipient_label = ", ".join(_recipient_label(recipient) for recipient in recipients)
     metadata_parts = [f"Matched to {recipient_label} per code"]
     if priority:
         metadata_parts.insert(0, _slack_priority_label(priority))
@@ -325,7 +334,8 @@ def _build_message_blocks(
     blocks.append({"type": "actions", "elements": action_elements})
 
     priority_suffix = f" ({priority})" if priority else ""
-    fallback_text = f"Inbox for {recipient.plain_name}{priority_suffix}: {title_line}"
+    recipient_names = ", ".join(recipient.plain_name for recipient in recipients)
+    fallback_text = f"Inbox for {recipient_names}{priority_suffix}: {title_line}"
     return blocks, fallback_text
 
 
@@ -358,39 +368,41 @@ def dispatch_inbox_item_notifications(
     implementation_pr_url = fetch_implementation_pr_urls_for_reports([str(report.id)]).get(str(report.id))
     users_by_id = {user.id: user for user in User.objects.filter(id__in=[config.user_id for config in targets])}
 
-    sent = 0
-    notified_channels: set[tuple[int, str]] = set()
+    # Several reviewers can resolve to the same channel — group them so each channel gets a
+    # single message that still tags every matched reviewer. Keyed by integration + channel id,
+    # since the same channel id under a different integration is a distinct destination.
+    channels: dict[tuple[int, str], list[SignalUserAutonomyConfig]] = {}
     for config in targets:
         if not _meets_min_priority(priority, config.slack_notification_min_priority):
             continue
-
-        user = users_by_id.get(config.user_id)
-        if user is None:
+        if config.user_id not in users_by_id:
             logger.warning(
                 "signals_inbox_slack_notification_missing_user",
                 extra={"report_id": report_id, "team_id": team_id, "user_id": config.user_id},
             )
             continue
-
         integration = config.slack_notification_integration
         channel = config.slack_notification_channel
         if integration is None or not channel:
             continue
+        channels.setdefault((integration.id, _channel_id_from_target(channel)), []).append(config)
 
-        # Several reviewers can resolve to the same channel — only notify each channel once.
-        channel_key = (integration.id, _channel_id_from_target(channel))
-        if channel_key in notified_channels:
+    sent = 0
+    for configs in channels.values():
+        # All configs in a group share the same integration and resolved channel id.
+        integration = configs[0].slack_notification_integration
+        channel = configs[0].slack_notification_channel
+        if integration is None or not channel:
             continue
-        notified_channels.add(channel_key)
 
         try:
             slack = SlackIntegration(integration)
-            recipient = _recipient_presentation(user, slack, integration)
+            recipients = [_recipient_presentation(users_by_id[config.user_id], slack, integration) for config in configs]
             blocks, text = _build_message_blocks(
                 report,
                 priority=priority,
                 source_products=sources,
-                recipient=recipient,
+                recipients=recipients,
                 implementation_pr_url=implementation_pr_url,
             )
             slack.client.chat_postMessage(
@@ -405,7 +417,7 @@ def dispatch_inbox_item_notifications(
                 extra={
                     "report_id": report_id,
                     "team_id": team_id,
-                    "user_id": config.user_id,
+                    "user_ids": [config.user_id for config in configs],
                     "channel": _channel_display_name(channel),
                 },
             )

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -392,6 +392,8 @@ def dispatch_inbox_item_notifications(
         # All configs in a group share the same integration and resolved channel id.
         integration = configs[0].slack_notification_integration
         channel = configs[0].slack_notification_channel
+        if integration is None or not channel:
+            continue  # Needed to satisfy mypy
 
         try:
             slack = SlackIntegration(integration)

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -2,19 +2,15 @@
 
 When a report transitions to READY (a new inbox item lands), we look up the
 suggested reviewers from its `suggested_reviewers` artefact, resolve them to
-PostHog users, and dispatch a Slack message for each user that has configured a
+PostHog users, and dispatch a Slack message to each user that has configured a
 Slack channel and integration in their `SignalUserAutonomyConfig`.
-
-Reviewers are grouped by their resolved Slack channel so each channel receives a
-single message — when several reviewers point at the same channel, the message
-names all of them rather than posting once per reviewer.
 
 Each user's `slack_notification_min_priority` filters out reports below the
 configured threshold (P0 is highest). When the report has no priority
 judgement, we notify regardless of the user's threshold — the inbox should
 not silently swallow these.
 
-Messages are framed for public channels: each post names the suggested reviewers
+Messages are framed for public channels: each post names the suggested reviewer
 (Slack @mention when email matches the workspace, otherwise their PostHog name).
 """
 
@@ -246,13 +242,6 @@ def _recipient_presentation(
     return _RecipientPresentation(slack_mention=slack_mention, plain_name=plain_name)
 
 
-def _recipient_label(recipient: _RecipientPresentation) -> str:
-    # Mention pings the user inside mrkdwn; otherwise escape the plain name so it renders literally.
-    return recipient.slack_mention or recipient.plain_name.replace("&", "&amp;").replace("<", "&lt;").replace(
-        ">", "&gt;"
-    )
-
-
 def _format_source_product_labels(source_products: list[str]) -> str:
     if not source_products:
         return ""
@@ -278,7 +267,7 @@ def _build_message_blocks(
     *,
     priority: str | None,
     source_products: list[str],
-    recipients: list[_RecipientPresentation],
+    recipient: _RecipientPresentation,
     implementation_pr_url: str | None = None,
 ) -> tuple[list[dict], str]:
     title_line = report.title or "New signals inbox item"
@@ -286,7 +275,9 @@ def _build_message_blocks(
     if len(header_text) > _SLACK_HEADER_MAX_LEN:
         header_text = header_text[: _SLACK_HEADER_MAX_LEN - 3] + "..."
 
-    recipient_label = ", ".join(_recipient_label(recipient) for recipient in recipients)
+    recipient_label = recipient.slack_mention or recipient.plain_name.replace("&", "&amp;").replace(
+        "<", "&lt;"
+    ).replace(">", "&gt;")
     metadata_parts = [f"Matched to {recipient_label} per code"]
     if priority:
         metadata_parts.insert(0, _slack_priority_label(priority))
@@ -334,8 +325,7 @@ def _build_message_blocks(
     blocks.append({"type": "actions", "elements": action_elements})
 
     priority_suffix = f" ({priority})" if priority else ""
-    recipient_names = ", ".join(recipient.plain_name for recipient in recipients)
-    fallback_text = f"Inbox for {recipient_names}{priority_suffix}: {title_line}"
+    fallback_text = f"Inbox for {recipient.plain_name}{priority_suffix}: {title_line}"
     return blocks, fallback_text
 
 
@@ -368,50 +358,39 @@ def dispatch_inbox_item_notifications(
     implementation_pr_url = fetch_implementation_pr_urls_for_reports([str(report.id)]).get(str(report.id))
     users_by_id = {user.id: user for user in User.objects.filter(id__in=[config.user_id for config in targets])}
 
-    # Group qualifying targets by destination channel so each Slack channel gets a single
-    # message — multiple suggested reviewers can resolve to the same channel, and we don't
-    # want to post one notification per reviewer there. The key pairs the integration with the
-    # resolved channel id, since the same channel id under different integrations is a distinct
-    # destination.
-    groups: dict[tuple[int, str], list[SignalUserAutonomyConfig]] = {}
+    sent = 0
+    notified_channels: set[tuple[int, str]] = set()
     for config in targets:
         if not _meets_min_priority(priority, config.slack_notification_min_priority):
             continue
+
+        user = users_by_id.get(config.user_id)
+        if user is None:
+            logger.warning(
+                "signals_inbox_slack_notification_missing_user",
+                extra={"report_id": report_id, "team_id": team_id, "user_id": config.user_id},
+            )
+            continue
+
         integration = config.slack_notification_integration
         channel = config.slack_notification_channel
         if integration is None or not channel:
             continue
-        groups.setdefault((integration.id, _channel_id_from_target(channel)), []).append(config)
 
-    sent = 0
-    for configs in groups.values():
-        # All configs in a group share the same integration and resolved channel id.
-        integration = configs[0].slack_notification_integration
-        channel = configs[0].slack_notification_channel
-        if integration is None or not channel:
+        # Several reviewers can resolve to the same channel — only notify each channel once.
+        channel_key = (integration.id, _channel_id_from_target(channel))
+        if channel_key in notified_channels:
             continue
+        notified_channels.add(channel_key)
 
         try:
             slack = SlackIntegration(integration)
-
-            recipients: list[_RecipientPresentation] = []
-            for config in configs:
-                user = users_by_id.get(config.user_id)
-                if user is None:
-                    logger.warning(
-                        "signals_inbox_slack_notification_missing_user",
-                        extra={"report_id": report_id, "team_id": team_id, "user_id": config.user_id},
-                    )
-                    continue
-                recipients.append(_recipient_presentation(user, slack, integration))
-            if not recipients:
-                continue
-
+            recipient = _recipient_presentation(user, slack, integration)
             blocks, text = _build_message_blocks(
                 report,
                 priority=priority,
                 source_products=sources,
-                recipients=recipients,
+                recipient=recipient,
                 implementation_pr_url=implementation_pr_url,
             )
             slack.client.chat_postMessage(
@@ -426,7 +405,7 @@ def dispatch_inbox_item_notifications(
                 extra={
                     "report_id": report_id,
                     "team_id": team_id,
-                    "user_ids": [config.user_id for config in configs],
+                    "user_id": config.user_id,
                     "channel": _channel_display_name(channel),
                 },
             )

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -2,15 +2,19 @@
 
 When a report transitions to READY (a new inbox item lands), we look up the
 suggested reviewers from its `suggested_reviewers` artefact, resolve them to
-PostHog users, and dispatch a Slack message to each user that has configured a
+PostHog users, and dispatch a Slack message for each user that has configured a
 Slack channel and integration in their `SignalUserAutonomyConfig`.
+
+Reviewers are grouped by their resolved Slack channel so each channel receives a
+single message — when several reviewers point at the same channel, the message
+names all of them rather than posting once per reviewer.
 
 Each user's `slack_notification_min_priority` filters out reports below the
 configured threshold (P0 is highest). When the report has no priority
 judgement, we notify regardless of the user's threshold — the inbox should
 not silently swallow these.
 
-Messages are framed for public channels: each post names the suggested reviewer
+Messages are framed for public channels: each post names the suggested reviewers
 (Slack @mention when email matches the workspace, otherwise their PostHog name).
 """
 
@@ -242,6 +246,13 @@ def _recipient_presentation(
     return _RecipientPresentation(slack_mention=slack_mention, plain_name=plain_name)
 
 
+def _recipient_label(recipient: _RecipientPresentation) -> str:
+    # Mention pings the user inside mrkdwn; otherwise escape the plain name so it renders literally.
+    return recipient.slack_mention or recipient.plain_name.replace("&", "&amp;").replace("<", "&lt;").replace(
+        ">", "&gt;"
+    )
+
+
 def _format_source_product_labels(source_products: list[str]) -> str:
     if not source_products:
         return ""
@@ -267,7 +278,7 @@ def _build_message_blocks(
     *,
     priority: str | None,
     source_products: list[str],
-    recipient: _RecipientPresentation,
+    recipients: list[_RecipientPresentation],
     implementation_pr_url: str | None = None,
 ) -> tuple[list[dict], str]:
     title_line = report.title or "New signals inbox item"
@@ -275,9 +286,7 @@ def _build_message_blocks(
     if len(header_text) > _SLACK_HEADER_MAX_LEN:
         header_text = header_text[: _SLACK_HEADER_MAX_LEN - 3] + "..."
 
-    recipient_label = recipient.slack_mention or recipient.plain_name.replace("&", "&amp;").replace(
-        "<", "&lt;"
-    ).replace(">", "&gt;")
+    recipient_label = ", ".join(_recipient_label(recipient) for recipient in recipients)
     metadata_parts = [f"Matched to {recipient_label} per code"]
     if priority:
         metadata_parts.insert(0, _slack_priority_label(priority))
@@ -325,7 +334,8 @@ def _build_message_blocks(
     blocks.append({"type": "actions", "elements": action_elements})
 
     priority_suffix = f" ({priority})" if priority else ""
-    fallback_text = f"Inbox for {recipient.plain_name}{priority_suffix}: {title_line}"
+    recipient_names = ", ".join(recipient.plain_name for recipient in recipients)
+    fallback_text = f"Inbox for {recipient_names}{priority_suffix}: {title_line}"
     return blocks, fallback_text
 
 
@@ -358,32 +368,50 @@ def dispatch_inbox_item_notifications(
     implementation_pr_url = fetch_implementation_pr_urls_for_reports([str(report.id)]).get(str(report.id))
     users_by_id = {user.id: user for user in User.objects.filter(id__in=[config.user_id for config in targets])}
 
-    sent = 0
+    # Group qualifying targets by destination channel so each Slack channel gets a single
+    # message — multiple suggested reviewers can resolve to the same channel, and we don't
+    # want to post one notification per reviewer there. The key pairs the integration with the
+    # resolved channel id, since the same channel id under different integrations is a distinct
+    # destination.
+    groups: dict[tuple[int, str], list[SignalUserAutonomyConfig]] = {}
     for config in targets:
         if not _meets_min_priority(priority, config.slack_notification_min_priority):
             continue
-
-        user = users_by_id.get(config.user_id)
-        if user is None:
-            logger.warning(
-                "signals_inbox_slack_notification_missing_user",
-                extra={"report_id": report_id, "team_id": team_id, "user_id": config.user_id},
-            )
-            continue
-
         integration = config.slack_notification_integration
         channel = config.slack_notification_channel
+        if integration is None or not channel:
+            continue
+        groups.setdefault((integration.id, _channel_id_from_target(channel)), []).append(config)
+
+    sent = 0
+    for configs in groups.values():
+        # All configs in a group share the same integration and resolved channel id.
+        integration = configs[0].slack_notification_integration
+        channel = configs[0].slack_notification_channel
         if integration is None or not channel:
             continue
 
         try:
             slack = SlackIntegration(integration)
-            recipient = _recipient_presentation(user, slack, integration)
+
+            recipients: list[_RecipientPresentation] = []
+            for config in configs:
+                user = users_by_id.get(config.user_id)
+                if user is None:
+                    logger.warning(
+                        "signals_inbox_slack_notification_missing_user",
+                        extra={"report_id": report_id, "team_id": team_id, "user_id": config.user_id},
+                    )
+                    continue
+                recipients.append(_recipient_presentation(user, slack, integration))
+            if not recipients:
+                continue
+
             blocks, text = _build_message_blocks(
                 report,
                 priority=priority,
                 source_products=sources,
-                recipient=recipient,
+                recipients=recipients,
                 implementation_pr_url=implementation_pr_url,
             )
             slack.client.chat_postMessage(
@@ -398,7 +426,7 @@ def dispatch_inbox_item_notifications(
                 extra={
                     "report_id": report_id,
                     "team_id": team_id,
-                    "user_id": config.user_id,
+                    "user_ids": [config.user_id for config in configs],
                     "channel": _channel_display_name(channel),
                 },
             )

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -74,7 +74,7 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
         report,
         priority="P1",
         source_products=["error_tracking"],
-        recipient=recipient,
+        recipients=[recipient],
     )
 
     assert blocks[0]["text"]["text"] == "📬 Checkout errors spiked"
@@ -95,6 +95,18 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
     assert text == "Inbox for Marcus Twix (P1): Checkout errors spiked"
 
 
+def test_build_message_blocks_tags_all_recipients() -> None:
+    report = SignalReport(id="report-uuid", title="Shared channel report")
+    recipients = [
+        _RecipientPresentation(slack_mention="<@U123>", plain_name="Marcus Twix"),
+        _RecipientPresentation(slack_mention=None, plain_name="Dana Snickers"),
+    ]
+    blocks, text = _build_message_blocks(report, priority="P2", source_products=[], recipients=recipients)
+
+    assert blocks[1]["text"]["text"].startswith("*❗ P2 • Matched to <@U123>, Dana Snickers per code*")
+    assert text == "Inbox for Marcus Twix, Dana Snickers (P2): Shared channel report"
+
+
 def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -> None:
     report = SignalReport(
         id="report-uuid",
@@ -108,7 +120,7 @@ def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -
         report,
         priority="P1",
         source_products=["error_tracking"],
-        recipient=recipient,
+        recipients=[recipient],
         implementation_pr_url=pr_url,
     )
 
@@ -126,7 +138,7 @@ def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
         report,
         priority=None,
         source_products=[],
-        recipient=recipient,
+        recipients=[recipient],
         implementation_pr_url=None,
     )
 
@@ -151,7 +163,7 @@ def test_build_message_blocks_prefixes_priority_with_emoji(priority: str, expect
         report,
         priority=priority,
         source_products=[],
-        recipient=recipient,
+        recipients=[recipient],
     )
 
     assert blocks[1]["text"]["text"] == f"*{expected_priority_label} • Matched to <@U123> per code*"
@@ -445,12 +457,14 @@ def test_dispatch_sends_once_per_channel_when_reviewers_share_channel(org_and_te
     )
     report = _make_ready_report(team, suggested_logins=["shared-login-1", "shared-login-2"])
 
+    mentions = {"shared1@example.com": "U_ONE", "shared2@example.com": "U_TWO"}
+
     fake_client = MagicMock()
     with (
         patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
         patch(
             "products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email",
-            return_value=None,
+            side_effect=lambda _slack, email: mentions.get(email),
         ),
     ):
         slack_cls.return_value.client = fake_client
@@ -458,4 +472,8 @@ def test_dispatch_sends_once_per_channel_when_reviewers_share_channel(org_and_te
 
     assert sent == 1
     assert fake_client.chat_postMessage.call_count == 1
-    assert fake_client.chat_postMessage.call_args.kwargs["channel"] == "C123"
+    call_kwargs = fake_client.chat_postMessage.call_args.kwargs
+    assert call_kwargs["channel"] == "C123"
+    # The single message still tags both reviewers that resolved to the channel.
+    section_text = call_kwargs["blocks"][1]["text"]["text"]
+    assert "Matched to <@U_ONE>, <@U_TWO> per code" in section_text

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -74,7 +74,7 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
         report,
         priority="P1",
         source_products=["error_tracking"],
-        recipient=recipient,
+        recipients=[recipient],
     )
 
     assert blocks[0]["text"]["text"] == "📬 Checkout errors spiked"
@@ -95,6 +95,23 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
     assert text == "Inbox for Marcus Twix (P1): Checkout errors spiked"
 
 
+def test_build_message_blocks_names_all_recipients_when_channel_shared() -> None:
+    report = SignalReport(id="report-uuid", title="Shared channel report")
+    recipients = [
+        _RecipientPresentation(slack_mention="<@U123>", plain_name="Marcus Twix"),
+        _RecipientPresentation(slack_mention=None, plain_name="Dana Snickers"),
+    ]
+    blocks, text = _build_message_blocks(
+        report,
+        priority="P2",
+        source_products=[],
+        recipients=recipients,
+    )
+
+    assert blocks[1]["text"]["text"].startswith("*❗ P2 • Matched to <@U123>, Dana Snickers per code*")
+    assert text == "Inbox for Marcus Twix, Dana Snickers (P2): Shared channel report"
+
+
 def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -> None:
     report = SignalReport(
         id="report-uuid",
@@ -108,7 +125,7 @@ def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -
         report,
         priority="P1",
         source_products=["error_tracking"],
-        recipient=recipient,
+        recipients=[recipient],
         implementation_pr_url=pr_url,
     )
 
@@ -126,7 +143,7 @@ def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
         report,
         priority=None,
         source_products=[],
-        recipient=recipient,
+        recipients=[recipient],
         implementation_pr_url=None,
     )
 
@@ -151,7 +168,7 @@ def test_build_message_blocks_prefixes_priority_with_emoji(priority: str, expect
         report,
         priority=priority,
         source_products=[],
-        recipient=recipient,
+        recipients=[recipient],
     )
 
     assert blocks[1]["text"]["text"] == f"*{expected_priority_label} • Matched to <@U123> per code*"
@@ -390,6 +407,80 @@ def test_dispatch_ignores_slack_config_from_another_team(org_and_team):
 
     assert sent == 0
     assert fake_client.chat_postMessage.call_count == 0
+
+
+@pytest.mark.django_db
+def test_dispatch_sends_once_per_channel_when_reviewers_share_channel(org_and_team):
+    org, team = org_and_team
+    user1 = _make_reviewer_user(org, "shared1@example.com", "shared-login-1")
+    user2 = _make_reviewer_user(org, "shared2@example.com", "shared-login-2")
+    integration = _make_slack_integration(team, user1)
+    # Both reviewers point at the same channel — the display label differs but the id is identical.
+    SignalUserAutonomyConfig.objects.create(
+        user=user1,
+        slack_notification_integration=integration,
+        slack_notification_channel="C123|#inbox",
+    )
+    SignalUserAutonomyConfig.objects.create(
+        user=user2,
+        slack_notification_integration=integration,
+        slack_notification_channel="C123|#inbox-alias",
+    )
+    report = _make_ready_report(team, suggested_logins=["shared-login-1", "shared-login-2"])
+
+    fake_client = MagicMock()
+    with (
+        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
+        patch(
+            "products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email",
+            return_value=None,
+        ),
+    ):
+        slack_cls.return_value.client = fake_client
+        sent = dispatch_inbox_item_notifications(str(report.id), team.id)
+
+    assert sent == 1
+    assert fake_client.chat_postMessage.call_count == 1
+    call_kwargs = fake_client.chat_postMessage.call_args.kwargs
+    assert call_kwargs["channel"] == "C123"
+    # Both reviewers are named in the single message that lands in the shared channel.
+    section_text = call_kwargs["blocks"][1]["text"]["text"]
+    assert "Reviewer Bot, Reviewer Bot" in section_text
+
+
+@pytest.mark.django_db
+def test_dispatch_sends_to_distinct_channels_separately(org_and_team):
+    org, team = org_and_team
+    user1 = _make_reviewer_user(org, "distinct1@example.com", "distinct-login-1")
+    user2 = _make_reviewer_user(org, "distinct2@example.com", "distinct-login-2")
+    integration = _make_slack_integration(team, user1)
+    SignalUserAutonomyConfig.objects.create(
+        user=user1,
+        slack_notification_integration=integration,
+        slack_notification_channel="C1|#a",
+    )
+    SignalUserAutonomyConfig.objects.create(
+        user=user2,
+        slack_notification_integration=integration,
+        slack_notification_channel="C2|#b",
+    )
+    report = _make_ready_report(team, suggested_logins=["distinct-login-1", "distinct-login-2"])
+
+    fake_client = MagicMock()
+    with (
+        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
+        patch(
+            "products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email",
+            return_value=None,
+        ),
+    ):
+        slack_cls.return_value.client = fake_client
+        sent = dispatch_inbox_item_notifications(str(report.id), team.id)
+
+    assert sent == 2
+    assert fake_client.chat_postMessage.call_count == 2
+    channels = {call.kwargs["channel"] for call in fake_client.chat_postMessage.call_args_list}
+    assert channels == {"C1", "C2"}
 
 
 @pytest.mark.django_db

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -74,7 +74,7 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
         report,
         priority="P1",
         source_products=["error_tracking"],
-        recipients=[recipient],
+        recipient=recipient,
     )
 
     assert blocks[0]["text"]["text"] == "📬 Checkout errors spiked"
@@ -95,23 +95,6 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
     assert text == "Inbox for Marcus Twix (P1): Checkout errors spiked"
 
 
-def test_build_message_blocks_names_all_recipients_when_channel_shared() -> None:
-    report = SignalReport(id="report-uuid", title="Shared channel report")
-    recipients = [
-        _RecipientPresentation(slack_mention="<@U123>", plain_name="Marcus Twix"),
-        _RecipientPresentation(slack_mention=None, plain_name="Dana Snickers"),
-    ]
-    blocks, text = _build_message_blocks(
-        report,
-        priority="P2",
-        source_products=[],
-        recipients=recipients,
-    )
-
-    assert blocks[1]["text"]["text"].startswith("*❗ P2 • Matched to <@U123>, Dana Snickers per code*")
-    assert text == "Inbox for Marcus Twix, Dana Snickers (P2): Shared channel report"
-
-
 def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -> None:
     report = SignalReport(
         id="report-uuid",
@@ -125,7 +108,7 @@ def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -
         report,
         priority="P1",
         source_products=["error_tracking"],
-        recipients=[recipient],
+        recipient=recipient,
         implementation_pr_url=pr_url,
     )
 
@@ -143,7 +126,7 @@ def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
         report,
         priority=None,
         source_products=[],
-        recipients=[recipient],
+        recipient=recipient,
         implementation_pr_url=None,
     )
 
@@ -168,7 +151,7 @@ def test_build_message_blocks_prefixes_priority_with_emoji(priority: str, expect
         report,
         priority=priority,
         source_products=[],
-        recipients=[recipient],
+        recipient=recipient,
     )
 
     assert blocks[1]["text"]["text"] == f"*{expected_priority_label} • Matched to <@U123> per code*"
@@ -410,80 +393,6 @@ def test_dispatch_ignores_slack_config_from_another_team(org_and_team):
 
 
 @pytest.mark.django_db
-def test_dispatch_sends_once_per_channel_when_reviewers_share_channel(org_and_team):
-    org, team = org_and_team
-    user1 = _make_reviewer_user(org, "shared1@example.com", "shared-login-1")
-    user2 = _make_reviewer_user(org, "shared2@example.com", "shared-login-2")
-    integration = _make_slack_integration(team, user1)
-    # Both reviewers point at the same channel — the display label differs but the id is identical.
-    SignalUserAutonomyConfig.objects.create(
-        user=user1,
-        slack_notification_integration=integration,
-        slack_notification_channel="C123|#inbox",
-    )
-    SignalUserAutonomyConfig.objects.create(
-        user=user2,
-        slack_notification_integration=integration,
-        slack_notification_channel="C123|#inbox-alias",
-    )
-    report = _make_ready_report(team, suggested_logins=["shared-login-1", "shared-login-2"])
-
-    fake_client = MagicMock()
-    with (
-        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
-        patch(
-            "products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email",
-            return_value=None,
-        ),
-    ):
-        slack_cls.return_value.client = fake_client
-        sent = dispatch_inbox_item_notifications(str(report.id), team.id)
-
-    assert sent == 1
-    assert fake_client.chat_postMessage.call_count == 1
-    call_kwargs = fake_client.chat_postMessage.call_args.kwargs
-    assert call_kwargs["channel"] == "C123"
-    # Both reviewers are named in the single message that lands in the shared channel.
-    section_text = call_kwargs["blocks"][1]["text"]["text"]
-    assert "Reviewer Bot, Reviewer Bot" in section_text
-
-
-@pytest.mark.django_db
-def test_dispatch_sends_to_distinct_channels_separately(org_and_team):
-    org, team = org_and_team
-    user1 = _make_reviewer_user(org, "distinct1@example.com", "distinct-login-1")
-    user2 = _make_reviewer_user(org, "distinct2@example.com", "distinct-login-2")
-    integration = _make_slack_integration(team, user1)
-    SignalUserAutonomyConfig.objects.create(
-        user=user1,
-        slack_notification_integration=integration,
-        slack_notification_channel="C1|#a",
-    )
-    SignalUserAutonomyConfig.objects.create(
-        user=user2,
-        slack_notification_integration=integration,
-        slack_notification_channel="C2|#b",
-    )
-    report = _make_ready_report(team, suggested_logins=["distinct-login-1", "distinct-login-2"])
-
-    fake_client = MagicMock()
-    with (
-        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
-        patch(
-            "products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email",
-            return_value=None,
-        ),
-    ):
-        slack_cls.return_value.client = fake_client
-        sent = dispatch_inbox_item_notifications(str(report.id), team.id)
-
-    assert sent == 2
-    assert fake_client.chat_postMessage.call_count == 2
-    channels = {call.kwargs["channel"] for call in fake_client.chat_postMessage.call_args_list}
-    assert channels == {"C1", "C2"}
-
-
-@pytest.mark.django_db
 def test_dispatch_continues_after_per_user_failure(org_and_team):
     org, team = org_and_team
     user1 = _make_reviewer_user(org, "alpha@example.com", "alpha-login")
@@ -515,3 +424,38 @@ def test_dispatch_continues_after_per_user_failure(org_and_team):
 
     assert sent == 1
     assert fake_client.chat_postMessage.call_count == 2
+
+
+@pytest.mark.django_db
+def test_dispatch_sends_once_per_channel_when_reviewers_share_channel(org_and_team):
+    org, team = org_and_team
+    user1 = _make_reviewer_user(org, "shared1@example.com", "shared-login-1")
+    user2 = _make_reviewer_user(org, "shared2@example.com", "shared-login-2")
+    integration = _make_slack_integration(team, user1)
+    # Both reviewers point at the same channel id — the display alias differs but the id matches.
+    SignalUserAutonomyConfig.objects.create(
+        user=user1,
+        slack_notification_integration=integration,
+        slack_notification_channel="C123|#inbox",
+    )
+    SignalUserAutonomyConfig.objects.create(
+        user=user2,
+        slack_notification_integration=integration,
+        slack_notification_channel="C123|#inbox-alias",
+    )
+    report = _make_ready_report(team, suggested_logins=["shared-login-1", "shared-login-2"])
+
+    fake_client = MagicMock()
+    with (
+        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
+        patch(
+            "products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email",
+            return_value=None,
+        ),
+    ):
+        slack_cls.return_value.client = fake_client
+        sent = dispatch_inbox_item_notifications(str(report.id), team.id)
+
+    assert sent == 1
+    assert fake_client.chat_postMessage.call_count == 1
+    assert fake_client.chat_postMessage.call_args.kwargs["channel"] == "C123"


### PR DESCRIPTION
## Problem

Signals inbox dispatches a Slack notification for each suggested reviewer - when several reviewers point at the same Slack channel, that channel receives one message per reviewer, i.e. duplicated.

## Changes

Let's group resolved target users by destination. Each channel receives a single message that names all matched reviewers (e.g. `Matched to <@U1>, Jane Doe per code`).


## How did you test this code?

Claude added a few tests.