### PR TITLE
chore(ci): gate depot ci-backend shadow behind toggle variable

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -25,11 +25,11 @@
 # If these tests get too slow, look at increasing concurrency and re-timing the tests by manually dispatching
 # .depot/workflows/ci-backend-update-test-timing.yml action
 name: Backend CI
-# Every job is gated on the ENABLE_DEPOT_SHADOW Depot CI variable (see the `changes`
+# Every job is gated on the CI_ENABLE_DEPOT_SHADOW Depot CI variable (see the `changes`
 # job): `true` runs the shadow, anything else (incl. unset) skips it. This is a Depot
 # variable, NOT a GitHub one — Depot CI reads its own `vars` store. Toggle with:
-#   depot ci vars add ENABLE_DEPOT_SHADOW=true --repo PostHog/posthog    (enable)
-#   depot ci vars remove ENABLE_DEPOT_SHADOW --repo PostHog/posthog      (disable)
+#   depot ci vars add CI_ENABLE_DEPOT_SHADOW=true --repo PostHog/posthog    (enable)
+#   depot ci vars remove CI_ENABLE_DEPOT_SHADOW --repo PostHog/posthog      (disable)
 # The companion drift check (.github/workflows/ci-backend-shadow-drift.yml) runs on
 # GitHub Actions and reads a same-named GitHub repository variable — set both.
 on:
@@ -98,7 +98,7 @@ jobs:
         # Shadow on/off switch. `changes` is the root of the `needs` graph, so gating
         # it skips every downstream job. `django_tests` repeats the gate because its
         # `always()` would otherwise survive the skip cascade.
-        if: vars.ENABLE_DEPOT_SHADOW == 'true'
+        if: vars.CI_ENABLE_DEPOT_SHADOW == 'true'
         runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
         timeout-minutes: 5
         name: Determine need to run backend and migration checks
@@ -1159,7 +1159,7 @@ jobs:
         timeout-minutes: 5
         # always() collates skipped/failed matrix jobs; gated so it doesn't spin up a
         # lone runner when the shadow is off.
-        if: always() && vars.ENABLE_DEPOT_SHADOW == 'true'
+        if: always() && vars.CI_ENABLE_DEPOT_SHADOW == 'true'
         steps:
             - name: Check matrix outcome
               run: |

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -25,14 +25,24 @@
 # If these tests get too slow, look at increasing concurrency and re-timing the tests by manually dispatching
 # .depot/workflows/ci-backend-update-test-timing.yml action
 name: Backend CI
-# Shadow disabled — reduced to manual workflow_dispatch only (no auto-runs on
-# push/pull_request/merge_group). Restore those triggers to re-enable.
+# Every job is gated on the DEPOT_CI_SHADOW_ENABLED repository variable (see the
+# `changes` job): `true` runs the shadow, anything else (incl. unset) skips it.
+# Toggle in GitHub → Settings → Secrets and variables → Actions → Variables.
 on:
+    push:
+        branches:
+            - master
     workflow_dispatch:
         inputs:
             clickhouseServerVersion:
                 description: ClickHouse server version. Leave blank for default
                 type: string
+    pull_request:
+        # Heavy test matrices (django, turbo-tests) skip drafts; ready_for_review
+        # re-triggers them when a PR leaves draft. Add the `run-ci-backend` label
+        # (labeled/unlabeled re-trigger) to force them on a draft. Mirrors canonical.
+        types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    merge_group:
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -81,6 +91,10 @@ jobs:
     # Job to decide if we should run backend ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
     changes:
+        # Shadow on/off switch. `changes` is the root of the `needs` graph, so gating
+        # it skips every downstream job. `django_tests` repeats the gate because its
+        # `always()` would otherwise survive the skip cascade.
+        if: vars.DEPOT_CI_SHADOW_ENABLED == 'true'
         runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
         timeout-minutes: 5
         name: Determine need to run backend and migration checks
@@ -1139,7 +1153,9 @@ jobs:
         name: Django Tests Pass
         runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
         timeout-minutes: 5
-        if: always()
+        # always() collates skipped/failed matrix jobs; gated so it doesn't spin up a
+        # lone runner when the shadow is off.
+        if: always() && vars.DEPOT_CI_SHADOW_ENABLED == 'true'
         steps:
             - name: Check matrix outcome
               run: |

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -25,9 +25,13 @@
 # If these tests get too slow, look at increasing concurrency and re-timing the tests by manually dispatching
 # .depot/workflows/ci-backend-update-test-timing.yml action
 name: Backend CI
-# Every job is gated on the DEPOT_CI_SHADOW_ENABLED repository variable (see the
-# `changes` job): `true` runs the shadow, anything else (incl. unset) skips it.
-# Toggle in GitHub → Settings → Secrets and variables → Actions → Variables.
+# Every job is gated on the ENABLE_DEPOT_SHADOW Depot CI variable (see the `changes`
+# job): `true` runs the shadow, anything else (incl. unset) skips it. This is a Depot
+# variable, NOT a GitHub one — Depot CI reads its own `vars` store. Toggle with:
+#   depot ci vars add ENABLE_DEPOT_SHADOW=true --repo PostHog/posthog    (enable)
+#   depot ci vars remove ENABLE_DEPOT_SHADOW --repo PostHog/posthog      (disable)
+# The companion drift check (.github/workflows/ci-backend-shadow-drift.yml) runs on
+# GitHub Actions and reads a same-named GitHub repository variable — set both.
 on:
     push:
         branches:
@@ -94,7 +98,7 @@ jobs:
         # Shadow on/off switch. `changes` is the root of the `needs` graph, so gating
         # it skips every downstream job. `django_tests` repeats the gate because its
         # `always()` would otherwise survive the skip cascade.
-        if: vars.DEPOT_CI_SHADOW_ENABLED == 'true'
+        if: vars.ENABLE_DEPOT_SHADOW == 'true'
         runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
         timeout-minutes: 5
         name: Determine need to run backend and migration checks
@@ -1155,7 +1159,7 @@ jobs:
         timeout-minutes: 5
         # always() collates skipped/failed matrix jobs; gated so it doesn't spin up a
         # lone runner when the shadow is off.
-        if: always() && vars.DEPOT_CI_SHADOW_ENABLED == 'true'
+        if: always() && vars.ENABLE_DEPOT_SHADOW == 'true'
         steps:
             - name: Check matrix outcome
               run: |

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -25,17 +25,14 @@
 # If these tests get too slow, look at increasing concurrency and re-timing the tests by manually dispatching
 # .depot/workflows/ci-backend-update-test-timing.yml action
 name: Backend CI
+# Shadow disabled — reduced to manual workflow_dispatch only (no auto-runs on
+# push/pull_request/merge_group). Restore those triggers to re-enable.
 on:
-    push:
-        branches:
-            - master
     workflow_dispatch:
         inputs:
             clickhouseServerVersion:
                 description: ClickHouse server version. Leave blank for default
                 type: string
-    pull_request:
-    merge_group:
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci-backend-shadow-drift.yml
+++ b/.github/workflows/ci-backend-shadow-drift.yml
@@ -7,8 +7,11 @@ name: Backend CI shadow drift check
 # measuring the same work.
 #
 # Cheap to run — only triggers when one of the two files changes. Gated on the
-# DEPOT_CI_SHADOW_ENABLED repository variable so drift enforcement tracks the
-# shadow itself: no point keeping the shadow in sync while it is switched off.
+# ENABLE_DEPOT_SHADOW GitHub repository variable so drift enforcement tracks the
+# shadow's on/off state — no point keeping the shadow in sync while it is off. This
+# workflow runs on GitHub Actions, so its `vars` come from GitHub (Settings →
+# Secrets and variables → Actions → Variables), separate from the same-named Depot
+# CI variable that gates the shadow itself.
 
 on:
     pull_request:
@@ -26,7 +29,7 @@ concurrency:
 jobs:
     check:
         name: Both ci-backend files updated together
-        if: vars.DEPOT_CI_SHADOW_ENABLED == 'true'
+        if: vars.ENABLE_DEPOT_SHADOW == 'true'
         runs-on: ubuntu-latest
         # 5 min absorbs cold-runner startup + the explicit depth=100 fetch of BASE_SHA below.
         # `actions/checkout` defaults to depth=1 (HEAD only); a full-history clone is unnecessary

--- a/.github/workflows/ci-backend-shadow-drift.yml
+++ b/.github/workflows/ci-backend-shadow-drift.yml
@@ -6,11 +6,15 @@ name: Backend CI shadow drift check
 # without this check, canonical drifts silently and the depot timing trial stops
 # measuring the same work.
 #
-# Disabled alongside the shadow — reduced to manual workflow_dispatch. Restore
-# the pull_request paths trigger to re-enable.
+# Cheap to run — only triggers when one of the two files changes. Gated on the
+# DEPOT_CI_SHADOW_ENABLED repository variable so drift enforcement tracks the
+# shadow itself: no point keeping the shadow in sync while it is switched off.
 
 on:
-    workflow_dispatch:
+    pull_request:
+        paths:
+            - .github/workflows/ci-backend.yml
+            - .depot/workflows/ci-backend.yml
 
 permissions:
     contents: read
@@ -22,6 +26,7 @@ concurrency:
 jobs:
     check:
         name: Both ci-backend files updated together
+        if: vars.DEPOT_CI_SHADOW_ENABLED == 'true'
         runs-on: ubuntu-latest
         # 5 min absorbs cold-runner startup + the explicit depth=100 fetch of BASE_SHA below.
         # `actions/checkout` defaults to depth=1 (HEAD only); a full-history clone is unnecessary

--- a/.github/workflows/ci-backend-shadow-drift.yml
+++ b/.github/workflows/ci-backend-shadow-drift.yml
@@ -6,13 +6,11 @@ name: Backend CI shadow drift check
 # without this check, canonical drifts silently and the depot timing trial stops
 # measuring the same work.
 #
-# Cheap to run — only triggers when one of the two files changes.
+# Disabled alongside the shadow — reduced to manual workflow_dispatch. Restore
+# the pull_request paths trigger to re-enable.
 
 on:
-    pull_request:
-        paths:
-            - .github/workflows/ci-backend.yml
-            - .depot/workflows/ci-backend.yml
+    workflow_dispatch:
 
 permissions:
     contents: read

--- a/.github/workflows/ci-backend-shadow-drift.yml
+++ b/.github/workflows/ci-backend-shadow-drift.yml
@@ -7,7 +7,7 @@ name: Backend CI shadow drift check
 # measuring the same work.
 #
 # Cheap to run — only triggers when one of the two files changes. Gated on the
-# ENABLE_DEPOT_SHADOW GitHub repository variable so drift enforcement tracks the
+# CI_ENABLE_DEPOT_SHADOW GitHub repository variable so drift enforcement tracks the
 # shadow's on/off state — no point keeping the shadow in sync while it is off. This
 # workflow runs on GitHub Actions, so its `vars` come from GitHub (Settings →
 # Secrets and variables → Actions → Variables), separate from the same-named Depot
@@ -29,7 +29,7 @@ concurrency:
 jobs:
     check:
         name: Both ci-backend files updated together
-        if: vars.ENABLE_DEPOT_SHADOW == 'true'
+        if: vars.CI_ENABLE_DEPOT_SHADOW == 'true'
         runs-on: ubuntu-latest
         # 5 min absorbs cold-runner startup + the explicit depth=100 fetch of BASE_SHA below.
         # `actions/checkout` defaults to depth=1 (HEAD only); a full-history clone is unnecessary


### PR DESCRIPTION
## Problem

The Depot CI-backend shadow (added in the [depot ci-backend shadow timing-trial PR (#53803)](https://github.com/PostHog/posthog/pull/53803)) auto-runs on every `pull_request`, `merge_group`, and `master` push, consuming Depot CI on each. We want it dormant now, but with an easy on/off switch — re-enabling shouldn't require another PR.

## Changes

Instead of stripping the triggers, the workflows keep their canonical triggers and gate execution on a `CI_ENABLE_DEPOT_SHADOW` variable. The two files run on **different** CI systems and therefore read the variable from **different stores**:

| File | Runs on | Reads `vars.*` from | Set the toggle via |
| --- | --- | --- | --- |
| `.depot/workflows/ci-backend.yml` | Depot CI | Depot's own variable store | `depot ci vars add CI_ENABLE_DEPOT_SHADOW=true --repo PostHog/posthog` |
| `.github/workflows/ci-backend-shadow-drift.yml` | GitHub Actions | GitHub repo variables | GitHub → Settings → Secrets and variables → Actions → Variables |

- **`.depot/workflows/ci-backend.yml`**: triggers restored to match canonical (`push: master`, `pull_request`, `merge_group`, `workflow_dispatch`). Gated on `vars.CI_ENABLE_DEPOT_SHADOW == 'true'` at two jobs — `changes` (the root of the `needs` graph, so gating it short-circuits every downstream job via the existing `needs.changes.outputs.*` cascade) and `django_tests` (runs with `always()`, so it would otherwise survive the skip cascade). All job logic is otherwise untouched.
- **`.github/workflows/ci-backend-shadow-drift.yml`**: `pull_request: paths` trigger restored and the `check` job gated on the same-named GitHub variable, so drift enforcement tracks the shadow's on/off state.

The variable is currently unset in both stores, so merging this leaves the shadow **off** — same end state as a hard disable. Re-enabling is a variable flip in both stores, no code change.

### On the name

`CI_ENABLE_DEPOT_SHADOW` is valid in both stores: Depot reserves the `DEPOT_` prefix (an earlier `DEPOT_CI_SHADOW_ENABLED` was rejected by `depot ci vars`), and GitHub only reserves the `GITHUB_` prefix. `CI` is a default *environment* variable on runners, but that namespace is separate from the `vars.*` context, so there's no collision.

## How did you test this code?

I'm an agent. No automated tests apply to a CI trigger/gating change. Verified:
- Both YAML files parse (`yaml.safe_load`) and the three `if:` gates resolve to the expected jobs (`changes`, `django_tests`, `check`).
- The depot shadow's triggers again match canonical and the net diff vs `master` is additive (comments + gates).
- Via the `depot` CLI that the variable store is Depot-side and repo-scoped: `depot ci vars list --repo PostHog/posthog` shows the existing `OIDC_RSA_FAKE_PRIVATE_KEY`, confirming `.depot/` workflows read Depot variables (not GitHub).

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Raúl's direction. The first revision disabled the shadow by reducing both workflows to `workflow_dispatch`; the ask was a variable-gated toggle so the shadow flips on/off without editing files.

Key decisions and corrections:
- Gated only the root `changes` job and the `always()` `django_tests` collator rather than annotating all ~10 jobs, since every other job already short-circuits through the `needs.changes.outputs.*` cascade.
- Initially assumed the depot shadow read `vars` from GitHub repository variables. That was wrong — `depot ci vars` is a **separate Depot store** (repo-scoped to `PostHog/posthog`), and the `.github/` drift check reads GitHub variables. The toggle therefore lives in two stores under the same name.
- Variable named `CI_ENABLE_DEPOT_SHADOW` to clear Depot's reserved `DEPOT_` prefix while staying valid on GitHub.
