### PR TITLE
fix(taxonomic-filter): reduce fetch-on-mount flake in headless stories

### DIFF
--- a/common/storybook/.storybook/preview.tsx
+++ b/common/storybook/.storybook/preview.tsx
@@ -16,9 +16,16 @@ import { withMockDate } from './decorators/withMockDate'
 import { withPageUrl } from './decorators/withPageUrl'
 import { withTheme } from './decorators/withTheme'
 
+// `worker.start()` is async (it registers a service worker). Capture the
+// promise so stories can await it before rendering. Otherwise a story that
+// fetches on mount can fire its request before MSW is intercepting, hit the
+// real network, resolve empty, and (because the data layer caches by staleTime)
+// render that empty result for the rest of the session. This raced
+// non-deterministically and produced flaky snapshots (e.g. the headless
+// TaxonomicFilter tabs intermittently showing 0 results).
+let mswReady: Promise<unknown> = Promise.resolve()
 const setupMsw = (): void => {
-    // Make sure the msw worker is started
-    worker.start({
+    mswReady = worker.start({
         quiet: true,
         onUnhandledRequest(request, print) {
             // MSW warns on all unhandled requests, but we don't necessarily care
@@ -80,6 +87,11 @@ export const parameters: Parameters = {
         mocks: defaultMocks,
     },
 }
+
+// Block every story's render until the MSW service worker is actually
+// intercepting, so fetch-on-mount stories never race a real (empty) network
+// response. Loaders run and resolve before the story renders.
+export const loaders = [async (): Promise<Record<string, never>> => (await mswReady, {})]
 
 // Setup storybook global decorators. See https://storybook.js.org/docs/react/writing-stories/decorators#global-decorators
 export const decorators: Meta['decorators'] = [

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
@@ -36,7 +36,7 @@ import { createFuse } from 'lib/utils/fuseSearch'
 import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 
 import { fetchTaxonomicListPage } from './fetchTaxonomicListPage'
-import { useTaxonomicResource } from './useTaxonomicResource'
+import { peekTaxonomicResource, useTaxonomicResource } from './useTaxonomicResource'
 
 export const NO_ITEM_SELECTED = -1
 
@@ -213,6 +213,15 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
         ]
     )
 
+    // Don't pin an empty unsearched result for the full staleTime. An empty
+    // base list almost always means the request resolved before its data was
+    // available (e.g. a fetch that raced mock/worker setup in stories, or an
+    // in-flight dependency), not that the group is genuinely empty; caching
+    // it for 60s left tabs stuck at 0. Empty results for an actual search term
+    // are legitimate and stay cached. Peek the existing cache entry (we can't
+    // read `remote` before it's assigned) to decide.
+    const cachedRemote = peekTaxonomicResource<ListStorage>(remoteKey)
+    const cachedEmptyUnsearched = !!cachedRemote && cachedRemote.count === 0 && !trimmedSearch
     const remote = useTaxonomicResource<ListStorage>(
         remoteKey,
         ({ signal }) =>
@@ -230,9 +239,12 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
         // is the single source of truth for the whole typing session.
         // Cohort create/update should invalidate via `invalidateTaxonomicResource`
         // (TODO) so a fresh fetch picks up the new item.
+        //
+        // Exception: never pin an empty unsearched result (see comment above) —
+        // re-fetch it on the next mount regardless of group kind.
         {
             enabled: remoteEnabled,
-            staleTime: clientFilter ? 5 * 60_000 : 60_000,
+            staleTime: cachedEmptyUnsearched ? 0 : clientFilter ? 5 * 60_000 : 60_000,
             keepPreviousData: true,
         }
     )


### PR DESCRIPTION
## Problem

The headless TaxonomicFilter (`Filters/Taxonomic Filter (Headless)` stories) produces non-deterministic visual-regression snapshots: per-tab result counts flip between runs (e.g. **Event properties 6 vs 0**, **Events 4 vs 1**). This was the source of recurring snapshot flakiness in CI.

Root cause: the headless filter fetches its list data on mount, and the resource layer caches by `staleTime` (60s). If a fetch resolves **empty** once, that empty result is pinned for the whole session and the tab stays at 0. Two timing windows let an early fetch resolve empty:

1. Storybook called `worker.start()` (MSW service worker) **without awaiting it**, so a fetch-on-mount could fire before MSW was intercepting, hit the real (empty) network, and cache empty.
2. `useGroupList` cached an empty **unsearched** base list for the full `staleTime`, so even a transient premature resolve stuck.

## Changes

- **`preview.tsx`**: capture the `worker.start()` promise and gate every story's render on it via a Storybook `loader`, so fetch-on-mount can't race MSW readiness. This is a general correctness fix for any fetch-on-mount story.
- **`useGroupList.ts`**: don't pin an empty *unsearched* base list — use `staleTime: 0` for that case so the next mount re-fetches. Empty results for an actual search term remain legitimately cached. Composes with the existing `clientFilter` staleTime logic.

## Honest scope note

This **measurably reduces** the flake (verified by repeated local Storybook loads: stories that were flipping went stable across many runs), but I want to be straight that it may not be a **complete** fix. The flake is load/timing-dependent, and at the sample sizes practical for local probing the measurement is noisy — identical code gave somewhat different flake rates between dev-server instances. A residual race remains under heavy mount churn (React 18 double-invoke can supersede the in-flight fetch), which is better closed in the resource hook itself. I deliberately avoided changing the hook's public contract here (an earlier attempt to do so broke a documented `staleTime: 0` unit test), keeping this PR to the two safe, contract-preserving mitigations.

## How did you test this code?

I am an agent (Claude Code).

- Full TaxonomicFilter jest suite passes: **17 suites, 367 tests**.
- `oxlint` clean on both changed files.
- Diagnosed and measured the flake by serving Storybook locally and loading the affected stories many times via Playwright (Chromium), capturing the per-tab counters and the underlying network/cache transitions before and after. The two mitigations each removed a class of premature-empty-resolve; together they took the previously-flaky `events-and-actions` and `suggested-filters-with-recents` stories to stable across repeated runs and substantially reduced `properties`.

The real arbiter is the visual-regression job in CI across many runs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes (story/test-infra determinism fix).

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) on Robbie's behalf. Follow-up to #60831 (which merged the story-determinism groundwork); these two mitigations were developed afterward and so land separately.

cc @adamleith — you own the headless `useTaxonomicFilter` rewrite. This is an FYI, not a handoff: sharing in case the residual hook-level race (an empty/superseded fetch caching under `staleTime` during React 18 mount churn) is interesting to fold into the hook itself. Happy to pair on it.

Key decisions: kept the fix to MSW-readiness gating + a targeted `staleTime` exception for empty-unsearched results; reverted exploratory hook changes (removing the unmount-abort, removing `resetHandlers`, and a fetch-guard tweak) after live testing showed they either didn't help or broke a documented unit test.
