### PR TITLE
chore(flags): remove dead FlagError variants

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -83,8 +83,6 @@ pub enum FlagError {
     /// not a service availability issue.
     #[error("Failed to parse flag data: {0}")]
     DataParsingErrorWithContext(String),
-    #[error("failed to deserialize filters")]
-    DeserializeFiltersError,
     #[error("redis unavailable")]
     RedisUnavailable,
     #[error("database unavailable")]
@@ -109,10 +107,6 @@ pub enum FlagError {
     /// - `None` - Timeout occurred but specific type unknown
     #[error("Timed out while fetching data")]
     TimeoutError(Option<String>),
-    #[error("No group type mappings")]
-    NoGroupTypeMappings,
-    #[error("Failed to fetch group type mappings from database")]
-    GroupTypeMappingFetchFailed,
     #[error("Dependency of type {0} with id {1} not found")]
     DependencyNotFound(DependencyType, i64),
     #[error("Failed to parse cohort filters")]
@@ -121,10 +115,6 @@ pub enum FlagError {
     DependencyCycle(DependencyType, i64),
     #[error("Person not found")]
     PersonNotFound,
-    #[error("Person properties not found")]
-    PropertiesNotInCache,
-    #[error("Static cohort matches not cached")]
-    StaticCohortMatchesNotCached,
     #[error("Cache miss - data not found in cache")]
     CacheMiss,
     #[error("Failed to parse data")]
@@ -176,10 +166,7 @@ impl FlagError {
 
             // Internal server errors (500)
             FlagError::Internal(_) => ("internal_error", 500),
-            FlagError::DeserializeFiltersError => ("deserialize_filters_error", 500),
             FlagError::DatabaseError(_, _) => ("database_error", 500),
-            FlagError::NoGroupTypeMappings => ("no_group_type_mappings", 500),
-            FlagError::GroupTypeMappingFetchFailed => ("group_type_mapping_fetch_failed", 500),
             FlagError::RowNotFound => ("row_not_found", 500),
             FlagError::DependencyNotFound(_, _) => ("dependency_not_found", 500),
             FlagError::CohortFiltersParsingError => ("cohort_filters_parsing_error", 500),
@@ -199,8 +186,6 @@ impl FlagError {
             FlagError::CacheMiss => ("cache_miss", 503),
             // Cache misses for person/cohort data - transient, data may be populated soon
             FlagError::PersonNotFound => ("person_not_found", 503),
-            FlagError::PropertiesNotInCache => ("properties_not_in_cache", 503),
-            FlagError::StaticCohortMatchesNotCached => ("static_cohort_not_cached", 503),
 
             // Cookieless errors (mixed)
             FlagError::CookielessError(err) => match err {
@@ -423,13 +408,6 @@ impl IntoResponse for FlagError {
                     "Failed to parse flag configuration data. This may indicate a misconfigured feature flag. Please check your flag definitions or contact support.".to_string(),
                 )
             }
-            FlagError::DeserializeFiltersError => {
-                tracing::error!("Failed to deserialize filters");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Failed to deserialize property filters. This is likely a temporary issue. Please try again later.".to_string(),
-                )
-            }
             FlagError::RedisUnavailable => {
                 tracing::error!("Redis unavailable: {:?}", self);
                 (
@@ -463,20 +441,6 @@ impl IntoResponse for FlagError {
                     "The request timed out. This could be due to high load or network issues. Please try again later.".to_string(),
                 )
             }
-            FlagError::NoGroupTypeMappings => {
-                tracing::error!("No group type mappings: {:?}", self);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "No group type mappings found. This is likely a configuration issue. Please contact support.".to_string(),
-                )
-            }
-            FlagError::GroupTypeMappingFetchFailed => {
-                tracing::error!("Failed to fetch group type mappings: {:?}", self);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Failed to fetch group type mappings from database.".to_string(),
-                )
-            }
             FlagError::RowNotFound => {
                 tracing::error!("Row not found in postgres: {:?}", self);
                 (
@@ -503,14 +467,6 @@ impl IntoResponse for FlagError {
             FlagError::PersonNotFound => {
                 tracing::warn!("Person not found in cache");
                 (StatusCode::SERVICE_UNAVAILABLE, "Person data not yet available. This is a temporary issue while data is being populated. Please try again.".to_string())
-            }
-            FlagError::PropertiesNotInCache => {
-                tracing::warn!("Person properties not found in cache");
-                (StatusCode::SERVICE_UNAVAILABLE, "Person properties not yet available. This is a temporary issue while data is being populated. Please try again.".to_string())
-            }
-            FlagError::StaticCohortMatchesNotCached => {
-                tracing::warn!("Static cohort matches not found in cache");
-                (StatusCode::SERVICE_UNAVAILABLE, "Cohort membership data not yet available. This is a temporary issue while data is being populated. Please try again.".to_string())
             }
             FlagError::CacheMiss => {
                 tracing::error!("Cache miss - required data not found in cache");
@@ -815,19 +771,14 @@ mod tests {
             FlagError::NoAuthenticationProvided,
             FlagError::RowNotFound,
             FlagError::DataParsingErrorWithContext("test parse error".to_string()),
-            FlagError::DeserializeFiltersError,
             FlagError::RedisUnavailable,
             FlagError::DatabaseUnavailable,
             FlagError::DatabaseError(sqlx::Error::RowNotFound, Some("test context".to_string())),
             FlagError::TimeoutError(None),
-            FlagError::NoGroupTypeMappings,
-            FlagError::GroupTypeMappingFetchFailed,
             FlagError::DependencyNotFound(DependencyType::Flag, 1),
             FlagError::DependencyCycle(DependencyType::Cohort, 2),
             FlagError::CohortFiltersParsingError,
             FlagError::PersonNotFound,
-            FlagError::PropertiesNotInCache,
-            FlagError::StaticCohortMatchesNotCached,
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
@@ -891,8 +842,6 @@ mod tests {
         assert_eq!(FlagError::RowNotFound.status_code(), 500);
         // Cache miss errors are now 503 (transient)
         assert_eq!(FlagError::PersonNotFound.status_code(), 503);
-        assert_eq!(FlagError::PropertiesNotInCache.status_code(), 503);
-        assert_eq!(FlagError::StaticCohortMatchesNotCached.status_code(), 503);
         // Semaphore timeout is 504 (gateway timeout for ingress retry)
         assert_eq!(FlagError::RayonSemaphoreTimeout(800).status_code(), 504);
     }
@@ -917,9 +866,6 @@ mod tests {
         // Server errors should be 5xx
         let server_errors = vec![
             FlagError::Internal("".into()),
-            FlagError::DeserializeFiltersError,
-            FlagError::NoGroupTypeMappings,
-            FlagError::GroupTypeMappingFetchFailed,
             FlagError::RowNotFound,
             FlagError::CohortFiltersParsingError,
             FlagError::DataParsingError,
@@ -935,10 +881,7 @@ mod tests {
         // Verify that status_code() >= 500 matches is_5xx() for ALL 5xx errors
         let errors_5xx = vec![
             FlagError::Internal("test".to_string()),
-            FlagError::DeserializeFiltersError,
             FlagError::DatabaseError(sqlx::Error::RowNotFound, None),
-            FlagError::NoGroupTypeMappings,
-            FlagError::GroupTypeMappingFetchFailed,
             FlagError::RowNotFound,
             FlagError::DependencyNotFound(DependencyType::Flag, 1),
             FlagError::CohortFiltersParsingError,
@@ -952,8 +895,6 @@ mod tests {
             FlagError::TimeoutError(None),
             FlagError::CacheMiss,
             FlagError::PersonNotFound,
-            FlagError::PropertiesNotInCache,
-            FlagError::StaticCohortMatchesNotCached,
             FlagError::ClientFacing(ClientFacingError::ServiceUnavailable),
         ];
 
@@ -1049,18 +990,14 @@ mod tests {
             FlagError::NoAuthenticationProvided,
             FlagError::RowNotFound,
             FlagError::DataParsingErrorWithContext("test parse error".to_string()),
-            FlagError::DeserializeFiltersError,
             FlagError::RedisUnavailable,
             FlagError::DatabaseUnavailable,
             FlagError::DatabaseError(sqlx::Error::RowNotFound, Some("test context".to_string())),
             FlagError::TimeoutError(None),
-            FlagError::NoGroupTypeMappings,
             FlagError::DependencyNotFound(DependencyType::Flag, 1),
             FlagError::DependencyCycle(DependencyType::Cohort, 2),
             FlagError::CohortFiltersParsingError,
             FlagError::PersonNotFound,
-            FlagError::PropertiesNotInCache,
-            FlagError::StaticCohortMatchesNotCached,
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -782,6 +782,7 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
+            FlagError::HashKeyOverrideError,
             FlagError::RayonSemaphoreTimeout(800),
             CookielessManagerError::MissingProperty("test".to_string()).into(), // CookielessError
         ];
@@ -888,6 +889,7 @@ mod tests {
             FlagError::DependencyCycle(DependencyType::Cohort, 2),
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
+            FlagError::HashKeyOverrideError,
             FlagError::RayonSemaphoreTimeout(800),
             FlagError::DataParsingErrorWithContext("test".to_string()),
             FlagError::RedisUnavailable,
@@ -1001,6 +1003,7 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
+            FlagError::HashKeyOverrideError,
             FlagError::RayonSemaphoreTimeout(800),
             CookielessManagerError::MissingProperty("test".to_string()).into(),
         ];

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -1234,6 +1234,7 @@ mod tests {
         #[case(FlagError::PersonNotFound, 503, "person_not_found")]
         #[case(FlagError::CacheMiss, 503, "cache_miss")]
         #[case(FlagError::DataParsingError, 500, "data_parsing_error")]
+        #[case(FlagError::HashKeyOverrideError, 500, "hash_key_override_error")]
         fn test_set_error_populates_fields(
             #[case] error: FlagError,
             #[case] expected_status: u16,

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -1212,12 +1212,10 @@ mod tests {
         #[case(FlagError::NoAuthenticationProvided, 401, "no_authentication")]
         #[case(FlagError::RowNotFound, 500, "row_not_found")]
         #[case(FlagError::DataParsingErrorWithContext("test".into()), 500, "flag_data_parsing_error")]
-        #[case(FlagError::DeserializeFiltersError, 500, "deserialize_filters_error")]
         #[case(FlagError::RedisUnavailable, 503, "redis_unavailable")]
         #[case(FlagError::DatabaseUnavailable, 503, "database_unavailable")]
         #[case(FlagError::TimeoutError(None), 503, "timeout")]
         #[case(FlagError::TimeoutError(Some("pool".into())), 503, "timeout")]
-        #[case(FlagError::NoGroupTypeMappings, 500, "no_group_type_mappings")]
         #[case(
             FlagError::DependencyNotFound(DependencyType::Flag, 1),
             500,
@@ -1234,12 +1232,6 @@ mod tests {
             "cohort_filters_parsing_error"
         )]
         #[case(FlagError::PersonNotFound, 503, "person_not_found")]
-        #[case(FlagError::PropertiesNotInCache, 503, "properties_not_in_cache")]
-        #[case(
-            FlagError::StaticCohortMatchesNotCached,
-            503,
-            "static_cohort_not_cached"
-        )]
         #[case(FlagError::CacheMiss, 503, "cache_miss")]
         #[case(FlagError::DataParsingError, 500, "data_parsing_error")]
         fn test_set_error_populates_fields(


### PR DESCRIPTION
## Problem

`rust/feature-flags/src/api/errors.rs` has accumulated `FlagError` variants that are never constructed anywhere in the codebase. They exist only in the enum definition, the `error_metadata()` / `is_5xx()` / `IntoResponse` arms, and test matrices. They add boilerplate flagged in #30174 without carrying any runtime meaning.

Part of #30174.

> [!NOTE]
> This re-opens @ricardothe3rd's contribution from #55115 on an internal branch. Fork PRs can't read the Depot build token, so the `build-images` jobs fail with `permission_denied` before any code is validated. Running from an internal branch lets the full CI suite execute. The change is entirely @ricardothe3rd's work and their commits are preserved unmodified.

## Changes

Removes 5 variants that a full-workspace grep and LSP check confirmed have zero construction sites outside `errors.rs` and its test modules:

- `DeserializeFiltersError`
- `NoGroupTypeMappings`
- `GroupTypeMappingFetchFailed`
- `PropertiesNotInCache`
- `StaticCohortMatchesNotCached`

Also removes each variant's arm in `error_metadata()`, `is_5xx()`, and `IntoResponse`, the `#[case]` entries in the parameterized `canonical_log.rs` test, and the test vectors in `errors.rs`.

Net 77 deletions, 1 insertion across two files. There is no behavior change because the deleted code paths were unreachable in production.

### Scoping note

This is preparatory cleanup for #30174. It does not yet introduce the `InternalError(anyhow::Error)` / `Unavailable(anyhow::Error)` buckets. That collapse is left to a follow-up so this PR stays a clean, low-risk, independently mergeable first step.

## How did you test this code?

Verification from the original contribution, covering the cargo gates rather than a running service:

- `cargo check -p feature-flags`, clean compile
- `cargo test -p feature-flags --lib api::errors`, 14/14 pass
- `cargo test -p feature-flags --lib handler::canonical_log`, 78/78 pass
- `cargo clippy -p feature-flags --all-targets`, no new warnings
- `cargo fmt -p feature-flags --check`, clean
- Workspace-wide grep for each deleted variant name and its `error_code()` string, zero references outside the two edited files

Integration tests are left to CI, which has the pre-configured Django and ClickHouse environment.

## Automatic notifications

- [ ] Publish to changelog? no
- [ ] Alert Sales and Marketing teams? no

## Docs update

No docs changes needed.

Co-authored-by: Ricardo <rarganaiii@gmail.com>

Fixes: #55115