### PR TITLE
feat(replay-vision): add banners for when quota is approaching

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,7 +445,7 @@ importers:
         version: 0.19.1(storybook@8.6.18(prettier@3.8.2))
       '@storybook/theming':
         specifier: ^8.6.14
-        version: 8.6.14(storybook@8.6.18(prettier@3.8.2))
+        version: 8.6.18(storybook@8.6.18(prettier@3.8.2))
       '@storybook/types':
         specifier: 'catalog:'
         version: 8.6.14(storybook@8.6.18(prettier@3.8.2))
@@ -1806,7 +1806,7 @@ importers:
         version: 0.19.1(@types/node@25.8.0)(storybook@8.6.18(prettier@3.8.2))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@storybook/theming':
         specifier: ^8.6.14
-        version: 8.6.14(storybook@8.6.18(prettier@3.8.2))
+        version: 8.6.18(storybook@8.6.18(prettier@3.8.2))
       '@tailwindcss/vite':
         specifier: ^4.1.17
         version: 4.2.2(vite@5.4.21(@types/node@25.8.0)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
@@ -3288,6 +3288,9 @@ importers:
       kea-forms:
         specifier: 'catalog:'
         version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
+      kea-loaders:
+        specifier: 'catalog:'
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
@@ -10460,11 +10463,6 @@ packages:
       typescript:
         optional: true
 
-  '@storybook/components@8.6.14':
-    resolution: {integrity: sha512-HNR2mC5I4Z5ek8kTrVZlIY/B8gJGs5b3XdZPBPBopTIN6U/YHXiDyOjY3JlaS4fSG1fVhp/Qp1TpMn1w/9m1pw==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
   '@storybook/components@8.6.18':
     resolution: {integrity: sha512-55yViiZzPS/cPBuOeW4QGxGqrusjXVyxuknmbYCIwDtFyyvI/CgbjXRHdxNBaIjz+IlftxvBmmSaOqFG5+/dkA==}
     peerDependencies:
@@ -10526,11 +10524,6 @@ packages:
     peerDependencies:
       storybook: ^8.6.18
 
-  '@storybook/manager-api@8.6.14':
-    resolution: {integrity: sha512-ez0Zihuy17udLbfHZQXkGqwtep0mSGgHcNzGN7iZrMP1m+VmNo+7aGCJJdvXi7+iU3yq8weXSQFWg5DqWgLS7g==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
   '@storybook/manager-api@8.6.18':
     resolution: {integrity: sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==}
     peerDependencies:
@@ -10547,11 +10540,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  '@storybook/preview-api@8.6.14':
-    resolution: {integrity: sha512-2GhcCd4dNMrnD7eooEfvbfL4I83qAqEyO0CO7JQAmIO6Rxb9BsOLLI/GD5HkvQB73ArTJ+PT50rfaO820IExOQ==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
   '@storybook/preview-api@8.6.18':
     resolution: {integrity: sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==}
@@ -10632,11 +10620,6 @@ packages:
     resolution: {integrity: sha512-u/RwfWMyHcH0N2hqfMTw2CoZ58IXdeED3b8NmcHc8bmERB3byI5vVAkwYbcD7+WeRHIiym38ZHi0SRn+IpkO3Q==}
     peerDependencies:
       storybook: ^8.6.18
-
-  '@storybook/theming@8.6.14':
-    resolution: {integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
   '@storybook/theming@8.6.18':
     resolution: {integrity: sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==}
@@ -22762,6 +22745,11 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -32018,10 +32006,6 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/components@8.6.14(storybook@8.6.18(prettier@3.8.2))':
-    dependencies:
-      storybook: 8.6.18(prettier@3.8.2)
-
   '@storybook/components@8.6.18(storybook@8.6.18(prettier@3.8.2))':
     dependencies:
       storybook: 8.6.18(prettier@3.8.2)
@@ -32091,10 +32075,6 @@ snapshots:
       '@vitest/utils': 2.1.9
       storybook: 8.6.18(prettier@3.8.2)
 
-  '@storybook/manager-api@8.6.14(storybook@8.6.18(prettier@3.8.2))':
-    dependencies:
-      storybook: 8.6.18(prettier@3.8.2)
-
   '@storybook/manager-api@8.6.18(storybook@8.6.18(prettier@3.8.2))':
     dependencies:
       storybook: 8.6.18(prettier@3.8.2)
@@ -32133,10 +32113,6 @@ snapshots:
       - supports-color
       - uglify-js
       - webpack-cli
-
-  '@storybook/preview-api@8.6.14(storybook@8.6.18(prettier@3.8.2))':
-    dependencies:
-      storybook: 8.6.18(prettier@3.8.2)
 
   '@storybook/preview-api@8.6.18(storybook@8.6.18(prettier@3.8.2))':
     dependencies:
@@ -32249,7 +32225,7 @@ snapshots:
       '@storybook/core-common': 8.6.14(storybook@8.6.18(prettier@3.8.2))
       '@storybook/csf': 0.1.13
       '@storybook/csf-tools': 8.6.14(storybook@8.6.18(prettier@3.8.2))
-      '@storybook/preview-api': 8.6.14(storybook@8.6.18(prettier@3.8.2))
+      '@storybook/preview-api': 8.6.18(storybook@8.6.18(prettier@3.8.2))
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.37(@swc/core@1.15.18)
       expect-playwright: 0.8.0
@@ -32283,7 +32259,7 @@ snapshots:
       '@storybook/core-common': 8.6.14(storybook@8.6.18(prettier@3.8.2))
       '@storybook/csf': 0.1.13
       '@storybook/csf-tools': 8.6.14(storybook@8.6.18(prettier@3.8.2))
-      '@storybook/preview-api': 8.6.14(storybook@8.6.18(prettier@3.8.2))
+      '@storybook/preview-api': 8.6.18(storybook@8.6.18(prettier@3.8.2))
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.37(@swc/core@1.15.18)
       expect-playwright: 0.8.0
@@ -32316,10 +32292,6 @@ snapshots:
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.6.18(prettier@3.8.2)
-
-  '@storybook/theming@8.6.14(storybook@8.6.18(prettier@3.8.2))':
-    dependencies:
       storybook: 8.6.18(prettier@3.8.2)
 
   '@storybook/theming@8.6.18(storybook@8.6.18(prettier@3.8.2))':
@@ -41030,7 +41002,7 @@ snapshots:
       micromatch: 4.0.8
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.9.0
+      yaml: 2.8.4
     transitivePeerDependencies:
       - supports-color
 
@@ -45482,12 +45454,12 @@ snapshots:
 
   storybook-dark-mode@4.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2)):
     dependencies:
-      '@storybook/components': 8.6.14(storybook@8.6.18(prettier@3.8.2))
+      '@storybook/components': 8.6.18(storybook@8.6.18(prettier@3.8.2))
       '@storybook/core-events': 8.6.14(storybook@8.6.18(prettier@3.8.2))
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/manager-api': 8.6.14(storybook@8.6.18(prettier@3.8.2))
-      '@storybook/theming': 8.6.14(storybook@8.6.18(prettier@3.8.2))
+      '@storybook/manager-api': 8.6.18(storybook@8.6.18(prettier@3.8.2))
+      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@3.8.2))
       fast-deep-equal: 3.1.3
       memoizerific: 1.11.3
     transitivePeerDependencies:
@@ -47651,6 +47623,8 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@1.10.2: {}
+
+  yaml@2.8.4: {}
 
   yaml@2.9.0: {}
 

--- a/products/replay_vision/frontend/components/ObservationsDock.tsx
+++ b/products/replay_vision/frontend/components/ObservationsDock.tsx
@@ -6,18 +6,38 @@ import { LemonButton, LemonInput, Link, Spinner } from '@posthog/lemon-ui'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
+import { dayjs } from 'lib/dayjs'
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown/LemonDropdown'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { urls } from 'scenes/urls'
 
-import type { ReplayScannerApi } from '../generated/api.schemas'
+import type { ReplayScannerApi, VisionQuotaApi } from '../generated/api.schemas'
 import { observationsDockLogic } from '../logics/observationsDockLogic'
+import { visionQuotaLogic } from '../logics/visionQuotaLogic'
 import { ObservationDockCard } from './ObservationCard'
 
 const COLLAPSED_HEIGHT = 44
 const DEFAULT_EXPANDED_HEIGHT = 480
 const MIN_EXPANDED_HEIGHT = 120
 const MAX_EXPANDED_HEIGHT = 800
+const QUOTA_WARN_THRESHOLD = 0.8
+
+// Assumes block-only overage policy; revisit when `usage_based` lands so we don't disable buttons on metered orgs.
+function quotaUx(quota: VisionQuotaApi | null): { disabledReason?: string; tooltip?: string } {
+    if (!quota || quota.monthly_quota <= 0) {
+        return {}
+    }
+    const resetsOn = dayjs(quota.period_end).format('MMM D')
+    if (quota.exhausted) {
+        return { disabledReason: `Monthly Vision quota reached. Resets ${resetsOn}.` }
+    }
+    if (quota.usage_this_month / quota.monthly_quota >= QUOTA_WARN_THRESHOLD) {
+        return {
+            tooltip: `${quota.remaining.toLocaleString()} Vision observations left this month (resets ${resetsOn})`,
+        }
+    }
+    return {}
+}
 
 export function ObservationsDock(): JSX.Element | null {
     const { sessionRecordingId } = useValues(sessionRecordingPlayerLogic)
@@ -33,6 +53,8 @@ function ScannerPicker({ sessionId }: { sessionId: string }): JSX.Element {
     const logic = observationsDockLogic({ sessionId })
     const { scanners, filteredScanners, scannerSearch, scannerPickerOpen, observing } = useValues(logic)
     const { observe, setScannerSearch, setScannerPickerOpen } = useActions(logic)
+    const { quota } = useValues(visionQuotaLogic)
+    const { disabledReason: quotaDisabledReason, tooltip: quotaTooltip } = quotaUx(quota)
 
     return (
         <LemonDropdown
@@ -84,6 +106,8 @@ function ScannerPicker({ sessionId }: { sessionId: string }): JSX.Element {
                 icon={<IconEye />}
                 sideIcon={<IconChevronDown />}
                 loading={observing}
+                disabledReason={quotaDisabledReason}
+                tooltip={quotaTooltip}
                 data-attr="vision-observe-recording"
             >
                 Scan this recording

--- a/products/replay_vision/frontend/logics/visionQuotaLogic.ts
+++ b/products/replay_vision/frontend/logics/visionQuotaLogic.ts
@@ -1,4 +1,5 @@
-import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
+import { afterMount, kea, path } from 'kea'
+import { loaders } from 'kea-loaders'
 
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -9,35 +10,24 @@ import type { visionQuotaLogicType } from './visionQuotaLogicType'
 export const visionQuotaLogic = kea<visionQuotaLogicType>([
     path(['products', 'replay_vision', 'frontend', 'logics', 'visionQuotaLogic']),
 
-    actions({
-        loadQuota: true,
-        loadQuotaSuccess: (quota: VisionQuotaApi | null) => ({ quota }),
-        loadQuotaFailure: true,
-    }),
-
-    reducers({
+    loaders({
         quota: [
             null as VisionQuotaApi | null,
             {
-                loadQuotaSuccess: (_, { quota }) => quota,
+                loadQuota: async () => {
+                    const teamId = teamLogic.values.currentTeamId
+                    if (!teamId) {
+                        return null
+                    }
+                    try {
+                        return await environmentVisionQuotaRetrieve(String(teamId))
+                    } catch {
+                        return null
+                    }
+                },
             },
         ],
     }),
-
-    listeners(({ actions }) => ({
-        loadQuota: async () => {
-            const teamId = teamLogic.values.currentTeamId
-            if (!teamId) {
-                return
-            }
-            try {
-                const response = await environmentVisionQuotaRetrieve(String(teamId))
-                actions.loadQuotaSuccess(response)
-            } catch {
-                actions.loadQuotaFailure()
-            }
-        },
-    })),
 
     afterMount(({ actions }) => {
         actions.loadQuota()

--- a/products/replay_vision/frontend/logics/visionQuotaLogic.ts
+++ b/products/replay_vision/frontend/logics/visionQuotaLogic.ts
@@ -1,0 +1,45 @@
+import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { environmentVisionQuotaRetrieve } from '../generated/api'
+import type { VisionQuotaApi } from '../generated/api.schemas'
+import type { visionQuotaLogicType } from './visionQuotaLogicType'
+
+export const visionQuotaLogic = kea<visionQuotaLogicType>([
+    path(['products', 'replay_vision', 'frontend', 'logics', 'visionQuotaLogic']),
+
+    actions({
+        loadQuota: true,
+        loadQuotaSuccess: (quota: VisionQuotaApi | null) => ({ quota }),
+        loadQuotaFailure: true,
+    }),
+
+    reducers({
+        quota: [
+            null as VisionQuotaApi | null,
+            {
+                loadQuotaSuccess: (_, { quota }) => quota,
+            },
+        ],
+    }),
+
+    listeners(({ actions }) => ({
+        loadQuota: async () => {
+            const teamId = teamLogic.values.currentTeamId
+            if (!teamId) {
+                return
+            }
+            try {
+                const response = await environmentVisionQuotaRetrieve(String(teamId))
+                actions.loadQuotaSuccess(response)
+            } catch {
+                actions.loadQuotaFailure()
+            }
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadQuota()
+    }),
+])

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -15,6 +15,7 @@ import {
 } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { dayjs } from 'lib/dayjs'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
@@ -25,6 +26,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
+import { visionQuotaLogic } from '../logics/visionQuotaLogic'
 import { ScannerObservationsTable } from './components/ScannerObservationsTable'
 import { ScannerTriggers } from './components/ScannerTriggers'
 import { ScannerTypeConfigEditor } from './components/ScannerTypeConfigEditor'
@@ -206,6 +208,8 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
 
             {hasUnsavedChanges && !isNew && <LemonBanner type="info">You have unsaved changes.</LemonBanner>}
 
+            <QuotaBanner />
+
             <Form logic={replayScannerLogic} props={{ id: scannerId, tabId }} formKey="scanner" enableFormOnSubmit>
                 <LemonTabs
                     activeKey={activeTab}
@@ -215,6 +219,34 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
             </Form>
         </SceneContent>
     )
+}
+
+const QUOTA_WARN_THRESHOLD = 0.8
+
+// Assumes block-only overage policy; revisit when `usage_based` ships so we don't scare metered orgs.
+function QuotaBanner(): JSX.Element | null {
+    const { quota } = useValues(visionQuotaLogic)
+    if (!quota || quota.monthly_quota <= 0) {
+        return null
+    }
+    const resetsOn = dayjs(quota.period_end).format('MMM D')
+    if (quota.exhausted) {
+        return (
+            <LemonBanner type="warning">
+                Monthly Vision quota reached ({quota.usage_this_month.toLocaleString()} /{' '}
+                {quota.monthly_quota.toLocaleString()}). Scheduled scans are paused until {resetsOn}.
+            </LemonBanner>
+        )
+    }
+    if (quota.usage_this_month / quota.monthly_quota >= QUOTA_WARN_THRESHOLD) {
+        return (
+            <LemonBanner type="warning">
+                Approaching monthly Vision quota: {quota.usage_this_month.toLocaleString()} of{' '}
+                {quota.monthly_quota.toLocaleString()} used. Schedules will pause once the cap is reached on {resetsOn}.
+            </LemonBanner>
+        )
+    }
+    return null
 }
 
 export default ReplayScannerSceneComponent

--- a/products/replay_vision/frontend/replay_scanners/components/VisionQuotaMeter.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionQuotaMeter.tsx
@@ -3,13 +3,26 @@ import { useValues } from 'kea'
 import { Tooltip } from '@posthog/lemon-ui'
 
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 
-import { replayScannersLogic } from '../replayScannersLogic'
+import { visionQuotaLogic } from '../../logics/visionQuotaLogic'
 
 export function VisionQuotaMeter(): JSX.Element | null {
-    const { quota } = useValues(replayScannersLogic)
+    const { quota, quotaLoading } = useValues(visionQuotaLogic)
 
     if (!quota) {
+        if (quotaLoading) {
+            return (
+                <div className="border rounded p-3 bg-bg-light space-y-2">
+                    <div className="flex items-center justify-between">
+                        <LemonSkeleton className="h-4 w-48" />
+                        <LemonSkeleton className="h-4 w-20" />
+                    </div>
+                    <LemonSkeleton className="h-2 w-full" />
+                    <LemonSkeleton className="h-3 w-24" />
+                </div>
+            )
+        }
         return null
     }
 

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
@@ -49,7 +49,6 @@ describe('replayScannersLogic', () => {
         useMocks({
             get: {
                 '/api/projects/:team/vision/scanners/': { results: [] },
-                '/api/projects/:team/vision/quota/': () => [404, {}],
             },
         })
         initKeaTests()

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
@@ -9,7 +9,6 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import {
-    environmentVisionQuotaRetrieve,
     visionScannersCreate,
     visionScannersDestroy,
     visionScannersList,
@@ -22,7 +21,6 @@ import {
     SCANNER_TYPE_OPTIONS,
     ScannerType,
     ReplayScanner,
-    VisionQuota,
     scannerFromApi,
     scannerToApiBody,
     scannersFromApi,
@@ -55,8 +53,6 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
         loadScanners: true,
         loadScannersSuccess: (scanners: ReplayScanner[]) => ({ scanners }),
         loadScannersFailure: (error: string) => ({ error }),
-        loadQuota: true,
-        loadQuotaSuccess: (quota: VisionQuota | null) => ({ quota }),
         deleteScanner: (id: string) => ({ id }),
         deleteScannerSuccess: (id: string) => ({ id }),
         duplicateScanner: (id: string) => ({ id }),
@@ -86,12 +82,6 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
                 loadScanners: () => true,
                 loadScannersSuccess: () => false,
                 loadScannersFailure: () => false,
-            },
-        ],
-        quota: [
-            null as VisionQuota | null,
-            {
-                loadQuotaSuccess: (_, { quota }) => quota,
             },
         ],
         search: [
@@ -129,19 +119,6 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
             } catch (error) {
                 lemonToast.error(`Failed to load scanners: ${String(error)}`)
                 actions.loadScannersFailure(String(error))
-            }
-        },
-
-        loadQuota: async () => {
-            const teamId = teamLogic.values.currentTeamId
-            if (!teamId) {
-                return
-            }
-            try {
-                const response = await environmentVisionQuotaRetrieve(String(teamId))
-                actions.loadQuotaSuccess(response)
-            } catch {
-                actions.loadQuotaSuccess(null)
             }
         },
 
@@ -284,6 +261,5 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
 
     afterMount(({ actions }) => {
         actions.loadScanners()
-        actions.loadQuota()
     }),
 ])

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -205,8 +205,6 @@ export interface ScorerScanner extends BaseReplayScanner {
 
 export type ReplayScanner = MonitorScanner | SummarizerScanner | ClassifierScanner | ScorerScanner
 
-export type { VisionQuotaApi as VisionQuota } from '../generated/api.schemas'
-
 // The API exposes scanner_config and query as `unknown`. The client narrows them via
 // the scanner_type discriminator, so conversion is contained to this single boundary.
 export function scannerFromApi(api: ReplayScannerApi): ReplayScanner {

--- a/products/replay_vision/package.json
+++ b/products/replay_vision/package.json
@@ -6,6 +6,7 @@
     "dependencies": {
         "kea": "catalog:",
         "kea-forms": "catalog:",
+        "kea-loaders": "catalog:",
         "kea-router": "catalog:"
     },
     "devDependencies": {


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Users should be notified when quota for replay vision is approaching + triggering observation should be disabled when the quota is reached

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- show notification banner when quota is 80% reached
- disable scan this recording button when the quota has reached

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
no

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
