### PR TITLE
chore(ci): add trigger context to rate-limit monitor

### DIFF
--- a/.github/scripts/monitor-github-rate-limit.js
+++ b/.github/scripts/monitor-github-rate-limit.js
@@ -29,7 +29,27 @@ async function captureEvent({ fetchImpl, posthogToken, event, distinctId, proper
     }
 }
 
-function buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId }) {
+// The workflow runs on every PR open/synchronize and master push, so each sample
+// can be attributed to the event that triggered it. Capturing that context turns
+// the aggregate /rate_limit series into a per-trigger breakdown downstream in
+// PostHog — which event types and PR sizes precede the steepest core burn.
+function buildTrigger(context) {
+    const payload = context.payload || {}
+    const pr = payload.pull_request || null
+    const num = (value) => (typeof value === 'number' ? value : null)
+    return {
+        trigger_event: context.eventName || null,
+        trigger_action: payload.action || null,
+        head_ref: (pr && pr.head && pr.head.ref) || payload.ref || null,
+        pr_number: pr ? pr.number : null,
+        pr_author: (pr && pr.user && pr.user.login) || null,
+        pr_changed_files: pr ? num(pr.changed_files) : null,
+        pr_additions: pr ? num(pr.additions) : null,
+        pr_deletions: pr ? num(pr.deletions) : null,
+    }
+}
+
+function buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId, trigger }) {
     const used = typeof snapshot.used === 'number' ? snapshot.used : snapshot.limit - snapshot.remaining
     const utilization = snapshot.limit > 0 ? used / snapshot.limit : 0
     return {
@@ -44,6 +64,7 @@ function buildProperties({ resource, snapshot, observedAt, observedAtSeconds, re
         source: 'github_token',
         observed_at: observedAt,
         workflow_run_id: runId || null,
+        ...(trigger || {}),
     }
 }
 
@@ -54,6 +75,7 @@ module.exports = async ({ github, context, core }, { now: _now, fetch: _fetch } 
     const observedAtSeconds = Math.floor(observedAtDate.getTime() / 1000)
     const repo = `${context.repo.owner}/${context.repo.repo}`
     const runId = process.env.GITHUB_RUN_ID || null
+    const trigger = buildTrigger(context)
 
     const posthogToken = process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN
     if (!posthogToken) {
@@ -70,7 +92,7 @@ module.exports = async ({ github, context, core }, { now: _now, fetch: _fetch } 
     let failures = 0
     for (const [resource, snapshot] of Object.entries(resources)) {
         if (!snapshot || typeof snapshot.limit !== 'number' || typeof snapshot.remaining !== 'number') continue
-        const properties = buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId })
+        const properties = buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId, trigger })
         core.info(`${resource}: ${properties.remaining}/${properties.limit} remaining (resets ${properties.reset_at})`)
         try {
             await captureEvent({
@@ -94,4 +116,5 @@ module.exports = async ({ github, context, core }, { now: _now, fetch: _fetch } 
 }
 
 module.exports.buildProperties = buildProperties
+module.exports.buildTrigger = buildTrigger
 module.exports.captureEvent = captureEvent

--- a/.github/scripts/monitor-github-rate-limit.js
+++ b/.github/scripts/monitor-github-rate-limit.js
@@ -41,7 +41,7 @@ function buildTrigger(context) {
         trigger_event: context.eventName || null,
         trigger_action: payload.action || null,
         head_ref: (pr && pr.head && pr.head.ref) || payload.ref || null,
-        pr_number: pr ? pr.number : null,
+        pr_number: pr ? num(pr.number) : null,
         pr_author: (pr && pr.user && pr.user.login) || null,
         pr_changed_files: pr ? num(pr.changed_files) : null,
         pr_additions: pr ? num(pr.additions) : null,

--- a/.github/scripts/monitor-github-rate-limit.js
+++ b/.github/scripts/monitor-github-rate-limit.js
@@ -37,15 +37,18 @@ function buildTrigger(context) {
     const payload = context.payload || {}
     const pr = payload.pull_request || null
     const num = (value) => (typeof value === 'number' ? value : null)
+    // PR head refs are short (`feature/foo`); push refs are qualified
+    // (`refs/heads/master`). Normalize to the short form so the column is uniform.
+    const ref = pr?.head?.ref ?? payload.ref ?? null
     return {
         trigger_event: context.eventName || null,
         trigger_action: payload.action || null,
-        head_ref: (pr && pr.head && pr.head.ref) || payload.ref || null,
-        pr_number: pr ? num(pr.number) : null,
-        pr_author: (pr && pr.user && pr.user.login) || null,
-        pr_changed_files: pr ? num(pr.changed_files) : null,
-        pr_additions: pr ? num(pr.additions) : null,
-        pr_deletions: pr ? num(pr.deletions) : null,
+        head_ref: ref ? ref.replace(/^refs\/heads\//, '') : null,
+        pr_number: num(pr?.number),
+        pr_author: pr?.user?.login ?? null,
+        pr_changed_files: num(pr?.changed_files),
+        pr_additions: num(pr?.additions),
+        pr_deletions: num(pr?.deletions),
     }
 }
 
@@ -64,7 +67,7 @@ function buildProperties({ resource, snapshot, observedAt, observedAtSeconds, re
         source: 'github_token',
         observed_at: observedAt,
         workflow_run_id: runId || null,
-        ...(trigger || {}),
+        ...trigger,
     }
 }
 

--- a/.github/scripts/monitor-github-rate-limit.test.js
+++ b/.github/scripts/monitor-github-rate-limit.test.js
@@ -126,7 +126,7 @@ describe('monitor-github-rate-limit', () => {
     })
 
     test.each([
-        ['push', { ref: 'refs/heads/master' }, 'refs/heads/master'],
+        ['push', { ref: 'refs/heads/master' }, 'master'],
         ['schedule', {}, null],
         ['workflow_dispatch', {}, null],
     ])('buildTrigger nulls PR fields and resolves head_ref for non-PR event %s', (eventName, payload, expectedRef) => {

--- a/.github/scripts/monitor-github-rate-limit.test.js
+++ b/.github/scripts/monitor-github-rate-limit.test.js
@@ -125,14 +125,20 @@ describe('monitor-github-rate-limit', () => {
         })
     })
 
-    test('buildTrigger falls back to ref and nulls PR fields for non-PR events', () => {
-        expect(monitor.buildTrigger({ eventName: 'push', payload: { ref: 'refs/heads/master' } })).toMatchObject({
-            trigger_event: 'push',
+    test.each([
+        ['push', { ref: 'refs/heads/master' }, 'refs/heads/master'],
+        ['schedule', {}, null],
+        ['workflow_dispatch', {}, null],
+    ])('buildTrigger nulls PR fields and resolves head_ref for non-PR event %s', (eventName, payload, expectedRef) => {
+        expect(monitor.buildTrigger({ eventName, payload })).toMatchObject({
+            trigger_event: eventName,
             trigger_action: null,
-            head_ref: 'refs/heads/master',
+            head_ref: expectedRef,
             pr_number: null,
             pr_author: null,
             pr_changed_files: null,
+            pr_additions: null,
+            pr_deletions: null,
         })
     })
 

--- a/.github/scripts/monitor-github-rate-limit.test.js
+++ b/.github/scripts/monitor-github-rate-limit.test.js
@@ -86,6 +86,56 @@ describe('monitor-github-rate-limit', () => {
         expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('capture 500'))
     })
 
+    test('captures the triggering event context on each sample', async () => {
+        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+        const captured = []
+        const fetchMock = jest.fn((_url, opts) => {
+            captured.push(JSON.parse(opts.body))
+            return fetchOk()
+        })
+        const github = createGithubMock({ core: snapshot({ remaining: 3000, limit: 15000 }) })
+        const core = createCore()
+        const prContext = {
+            repo: { owner: 'PostHog', repo: 'posthog' },
+            eventName: 'pull_request',
+            payload: {
+                action: 'synchronize',
+                pull_request: {
+                    number: 12345,
+                    head: { ref: 'feature/foo' },
+                    user: { login: 'octocat' },
+                    changed_files: 7,
+                    additions: 120,
+                    deletions: 4,
+                },
+            },
+        }
+
+        await monitor({ github, context: prContext, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        expect(captured[0].properties).toMatchObject({
+            trigger_event: 'pull_request',
+            trigger_action: 'synchronize',
+            head_ref: 'feature/foo',
+            pr_number: 12345,
+            pr_author: 'octocat',
+            pr_changed_files: 7,
+            pr_additions: 120,
+            pr_deletions: 4,
+        })
+    })
+
+    test('buildTrigger falls back to ref and nulls PR fields for non-PR events', () => {
+        expect(monitor.buildTrigger({ eventName: 'push', payload: { ref: 'refs/heads/master' } })).toMatchObject({
+            trigger_event: 'push',
+            trigger_action: null,
+            head_ref: 'refs/heads/master',
+            pr_number: null,
+            pr_author: null,
+            pr_changed_files: null,
+        })
+    })
+
     test('skips emission when devex token is not configured', async () => {
         const fetchMock = jest.fn(fetchOk)
         const github = createGithubMock({ core: snapshot({ remaining: 1, limit: 15000 }) })


### PR DESCRIPTION
## Problem

The `Monitor GitHub Rate Limit` workflow records the repo's `/rate_limit` snapshot to PostHog on every PR open/synchronize and master push, but each sample only carries the aggregate per-resource numbers (`used`, `remaining`, `limit`). Nothing records *what triggered* the sample, so the time series can't be broken down by event type or PR characteristics — which makes it hard to see which kinds of CI activity drive `core` (GITHUB_TOKEN) consumption.

## Changes

Adds a `buildTrigger(context)` helper that tags every emitted sample with the triggering event context:

- `trigger_event` / `trigger_action` — e.g. `pull_request` / `synchronize`, or `push`
- `head_ref`, `pr_number`, `pr_author`
- `pr_changed_files`, `pr_additions`, `pr_deletions`

These merge into each `github_rate_limit_observed` event's properties. Non-PR events (push, schedule) fall back to `ref` and leave the PR fields null. No change to triggers, cadence, permissions, or the measured bucket — purely additive instrumentation.

Downstream in PostHog this enables breakdowns the aggregate series alone can't answer — burn rate by event type, and whether larger PRs correlate with higher per-event consumption.

## How did you test this code?

I'm an agent (Claude Code) — automated tests only, no manual/live testing:

- Extended `monitor-github-rate-limit.test.js` with two cases: one asserting the PR trigger fields are captured on each sample, one asserting `buildTrigger` falls back to `ref` and nulls PR fields for non-PR events.
- `npx jest .github/scripts/monitor-github-rate-limit.test.js` → 5/5 passing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal CI/observability tooling.

## 🤖 Agent context

Authored with Claude Code while investigating `core` GITHUB_TOKEN rate-limit pressure. The monitor measures the aggregate per-repo bucket but can't attribute consumption to a workflow or event type; this is the first, lowest-effort ("event-level") attribution layer, reusing the existing high-frequency sample stream. A complementary per-workflow approach (snapshot `used` delta regressed against job elapsed time to cancel the shared-bucket background) was considered for finer attribution and deferred as a heavier follow-up. The PR-size fields are included deliberately to test whether large diffs correlate with higher per-event burn. Field set kept minimal and additive.
