### PR TITLE
fix(logs): keep pinned filters out of editable filterGroup

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1949,9 +1949,9 @@ snapshots:
     filters-taxonomic-filter-headless--properties--light:
         hash: v1.k794b7964.afa422fd784363e602da5668ab488a823260acba8c2b1168dc85bcbf434d3ddf.Wjl32UIE5KhBda_SpJYwXKZ2FGmnlFbtzv4uKDaJRIs
     filters-taxonomic-filter-headless--suggested-filters-with-recents--dark:
-        hash: v1.k794b7964.790efb08b3bdf38ac511b9b1d59c7b7227814bcdb8785b8a5809230680b6b417.ZIuweOHfzKGmmiyQhhfUZd9P9VKijDjyHRl3PiEbJMI
+        hash: v1.k794b7964.f524f5031bba44f2753215e83b93aa50741a3efc012fcddcc61025e4f851ba2c.sm5eih05jClMTS8zKltGelRiDYSI_2RmOFRZjjLwsAc
     filters-taxonomic-filter-headless--suggested-filters-with-recents--light:
-        hash: v1.k794b7964.d5655d5578410b405bd03d3bbcdccfdafac058bc524edb5d0ae4976d109519cf.LKBprxgu92aVJ2cJZ-RQs_ESvjYQheVBDAsrkcLq18k
+        hash: v1.k794b7964.637f0e3e35bb7c39120002127ebe7f6a7fd816894331adea79b9fa2aafd92d57.1DZDrW9fde4zlxogGxSduP4WpMW-lhoOldL3z6V9SgE
     filters-taxonomic-filter-menu-rebuild--data-warehouse-config--dark:
         hash: v1.k794b7964.c09183f21589b0f11a3013a6e359d23c8d5b17b1e6ed61476ba45da75bcdc73f.tzexSMIoGf0LgGmzdG3-O0g7vd9Isx6MRQ_TWltg4Fo
     filters-taxonomic-filter-menu-rebuild--data-warehouse-config--light:
@@ -4891,7 +4891,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
+        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.gaL7vRk-pWoOUkiPi-NGCd1W72x-M5l9jk5Qu-UcjwI
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
         hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:

--- a/frontend/src/scenes/persons/PersonLogsTab.tsx
+++ b/frontend/src/scenes/persons/PersonLogsTab.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY, logsConfigLogic } from 'product
 export function PersonLogsTab({ person }: { person: PersonType }): JSX.Element {
     const { logsConfig } = useValues(logsConfigLogic)
     const distinctIdAttributeKey = logsConfig?.logs_distinct_id_attribute_key ?? DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY
+    const isCustomizedKey = distinctIdAttributeKey !== DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY
 
     const pinnedFilters = useMemo(
         () => ({
@@ -32,6 +33,15 @@ export function PersonLogsTab({ person }: { person: PersonType }): JSX.Element {
 
     return (
         <div className="flex flex-col h-[calc(100vh-16rem)] min-h-[25rem]">
+            <p className="text-muted text-xs mb-2">
+                Scoped to this person via the <code>{distinctIdAttributeKey}</code> log attribute.
+                {isCustomizedKey && (
+                    <>
+                        {' '}
+                        Customised from default <code>{DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY}</code>.
+                    </>
+                )}
+            </p>
             <LogsViewer
                 id={`person-${person.uuid ?? person.id}`}
                 pinnedFilters={pinnedFilters}

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -1,6 +1,5 @@
 import './LogsFilterBar.scss'
 
-import equal from 'fast-deep-equal'
 import { BindLogic, useActions, useValues } from 'kea'
 import { useRef, useState } from 'react'
 
@@ -127,13 +126,17 @@ export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViews
 }
 
 const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Element => {
-    const { filters, id, utcDateRange } = useValues(logsViewerFiltersLogic)
+    const { filters, id, utcDateRange, queryFilterGroup } = useValues(logsViewerFiltersLogic)
     const { filterGroup, serviceNames } = filters
     const { setFilterGroup } = useActions(logsViewerFiltersLogic)
 
+    // Taxonomic value suggestions should respect any active scope (e.g. the person-tab
+    // distinct_id pin), so pass the combined query view rather than the user-editable
+    // filterGroup. The UniversalFilters `group` prop stays on the editable filterGroup
+    // so chips reflect what the user can actually edit.
     const endpointFilters = {
         dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
-        filterGroup,
+        filterGroup: queryFilterGroup,
         serviceNames,
     }
 
@@ -154,7 +157,7 @@ const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Eleme
 
 const LogsFilterSearch = (): JSX.Element => {
     const [visible, setVisible] = useState<boolean>(false)
-    const { utcDateRange, filters: logsFilters } = useValues(logsViewerFiltersLogic)
+    const { utcDateRange, filters: logsFilters, queryFilterGroup } = useValues(logsViewerFiltersLogic)
     const { addGroupFilter, setGroupValues } = useActions(universalFiltersLogic)
     const { filterGroup } = useValues(universalFiltersLogic)
 
@@ -171,7 +174,7 @@ const LogsFilterSearch = (): JSX.Element => {
         taxonomicGroupTypes,
         endpointFilters: {
             dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
-            filterGroup: logsFilters.filterGroup,
+            filterGroup: queryFilterGroup,
             serviceNames: logsFilters.serviceNames,
         },
         onChange: (taxonomicGroup, value, item) => {
@@ -227,7 +230,6 @@ const LogsFilterSearch = (): JSX.Element => {
 const FilterGroupValues = ({ allowInitiallyOpen }: { allowInitiallyOpen: boolean }): JSX.Element | null => {
     const { filterGroup } = useValues(universalFiltersLogic)
     const { replaceGroupValue, removeGroupValue } = useActions(universalFiltersLogic)
-    const { pinnedFilters } = useValues(logsViewerFiltersLogic)
 
     if (filterGroup.values.length === 0) {
         return null
@@ -236,14 +238,6 @@ const FilterGroupValues = ({ allowInitiallyOpen }: { allowInitiallyOpen: boolean
     return (
         <>
             {filterGroup.values.map((filterOrGroup, index) => {
-                // Pinned filters are enforced by the embedding scene (e.g. distinct_id
-                // scope on a person profile). They're applied to the query but hidden
-                // from the chip list — matching how Events / Exceptions hide their
-                // structural person scope. Without this, a user could click in and
-                // edit values that conceptually shouldn't be theirs to edit.
-                if (pinnedFilters?.values.some((pv) => equal(pv, filterOrGroup))) {
-                    return null
-                }
                 return isUniversalGroupFilterLike(filterOrGroup) ? (
                     <UniversalFilters.Group index={index} key={index} group={filterOrGroup}>
                         <FilterGroupValues allowInitiallyOpen={allowInitiallyOpen} />

--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
@@ -31,15 +31,19 @@ export const DEFAULT_SERVICE_NAMES = [] as LogsQuery['serviceNames']
 export interface LogsViewerFiltersLogicProps {
     id: string
     initialFilters?: Partial<LogsViewerFilters>
-    // Filters enforced by the embedding scene. Merged into filterGroup and rendered
-    // without an X — users can't accidentally clear the scope (e.g. the person profile
-    // Logs tab pins a distinct_id filter so the tab can't fall back to project-wide logs).
+    // Filters enforced by the embedding scene (e.g. the person profile Logs tab pins
+    // a distinct_id filter so the tab can't fall back to project-wide logs). Kept
+    // entirely separate from the user-editable `filterGroup` — combined with it only
+    // at query-build time via `queryFilterGroup` so the chips never see them and
+    // can't drift when the pinned shape changes (e.g. `logs_distinct_id_attribute_key`
+    // resolves to a non-default key after mount).
     pinnedFilters?: UniversalFiltersGroup
 }
 
-// Returns a filterGroup with pinned values prepended to the nested group, deduplicated
-// by deep equality against existing user filters.
-export function mergePinnedFilters(
+// Combines the user-editable filterGroup with pinned filters (prepended to the inner
+// AND group). Used at query-build time and for taxonomic value suggestions so the
+// query and suggestion stay scoped, without putting pinned filters into editable state.
+export function combineWithPinnedFilters(
     filterGroup: UniversalFiltersGroup,
     pinnedFilters: UniversalFiltersGroup | undefined
 ): UniversalFiltersGroup {
@@ -48,13 +52,12 @@ export function mergePinnedFilters(
     }
     const inner = filterGroup.values[0] as UniversalFiltersGroup | undefined
     const innerValues = inner?.values ?? []
-    const existingNonPinned = innerValues.filter((v) => !pinnedFilters.values.some((pv) => equal(v, pv)))
     return {
         ...filterGroup,
         values: [
             {
                 type: FilterLogicalOperator.And,
-                values: [...pinnedFilters.values, ...existingNonPinned],
+                values: [...pinnedFilters.values, ...innerValues],
             } as UniversalFiltersGroup,
             ...filterGroup.values.slice(1),
         ],
@@ -167,6 +170,15 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
                 filterGroup: UniversalFiltersGroup
             ): LogsViewerFilters => ({ dateRange, searchTerm, severityLevels, serviceNames, filterGroup }),
         ],
+        // Combined view used for query payloads and taxonomic value suggestions —
+        // user-editable `filterGroup` with pinned filters prepended. Pinned filters
+        // intentionally never enter `filterGroup` itself so chips and saved views
+        // can't pick them up.
+        queryFilterGroup: [
+            (s) => [s.filterGroup, s.pinnedFilters],
+            (filterGroup: UniversalFiltersGroup, pinnedFilters: UniversalFiltersGroup | undefined) =>
+                combineWithPinnedFilters(filterGroup, pinnedFilters),
+        ],
         utcDateRange: [
             (s) => [s.dateRange],
             (dateRange: DateRange) => ({
@@ -210,7 +222,7 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
         },
     })),
 
-    propsChanged(({ actions, values, props: logicProps }, oldProps) => {
+    propsChanged(({ actions, props: logicProps }, oldProps) => {
         if (logicProps.initialFilters && logicProps.initialFilters !== oldProps.initialFilters) {
             actions.setFilters(logicProps.initialFilters, false)
         } else if (!logicProps.initialFilters && oldProps.initialFilters) {
@@ -223,22 +235,20 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
                 false
             )
         }
-        // Re-merge pinned filters when the embedding scene changes them (e.g. switching
-        // between people on the person profile). Deep-equal check avoids re-merging on
-        // every render when the parent reconstructs the prop object identically.
+        // Mirror the prop into state when content changes (e.g. switching between
+        // people on the person profile, or the team's pinned attribute key resolving
+        // after mount). Deep-equal check avoids redundant updates on identical re-renders.
         if (!equal(logicProps.pinnedFilters, oldProps.pinnedFilters)) {
             actions.setPinnedFilters(logicProps.pinnedFilters)
-            actions.setFilterGroup(mergePinnedFilters(values.filterGroup, logicProps.pinnedFilters), false)
         }
     }),
 
-    afterMount(({ actions, values, props: logicProps }) => {
+    afterMount(({ actions, props: logicProps }) => {
         if (logicProps.initialFilters) {
             actions.setFilters(logicProps.initialFilters, false)
         }
         if (logicProps.pinnedFilters) {
             actions.setPinnedFilters(logicProps.pinnedFilters)
-            actions.setFilterGroup(mergePinnedFilters(values.filterGroup, logicProps.pinnedFilters), false)
         }
     }),
 ])

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -127,7 +127,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
         ],
         values: [
             logsViewerFiltersLogic({ id }),
-            ['filters', 'utcDateRange', 'filterGroup'],
+            ['filters', 'utcDateRange', 'filterGroup', 'queryFilterGroup'],
             logsViewerConfigLogic({ id }),
             ['sparklineBreakdownBy', 'orderBy'],
         ],
@@ -286,7 +286,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                             orderBy: values.orderBy,
                             dateRange: values.utcDateRange,
                             searchTerm: values.filters.searchTerm,
-                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            filterGroup: values.queryFilterGroup as PropertyGroupFilter,
                             severityLevels: values.filters.severityLevels,
                             serviceNames: values.filters.serviceNames,
                         },
@@ -314,7 +314,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                             orderBy: values.orderBy,
                             dateRange: values.utcDateRange,
                             searchTerm: values.filters.searchTerm,
-                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            filterGroup: values.queryFilterGroup as PropertyGroupFilter,
                             severityLevels: values.filters.severityLevels,
                             serviceNames: values.filters.serviceNames,
                             after: values.nextCursor,
@@ -342,7 +342,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                             orderBy: values.orderBy,
                             dateRange: values.utcDateRange,
                             searchTerm: values.filters.searchTerm,
-                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            filterGroup: values.queryFilterGroup as PropertyGroupFilter,
                             severityLevels: values.filters.severityLevels,
                             serviceNames: values.filters.serviceNames,
                             sparklineBreakdownBy: values.sparklineBreakdownBy,
@@ -488,7 +488,10 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
     }),
 
     subscriptions(({ actions }) => ({
-        filterGroup: (filterGroup: UniversalFiltersGroup, oldFilterGroup: UniversalFiltersGroup | undefined) => {
+        // Subscribe to the combined query view rather than the user-editable filterGroup
+        // so the query reruns when pinned filters change (e.g. team `logs_distinct_id_attribute_key`
+        // resolves after mount), not just when the user edits filters.
+        queryFilterGroup: (filterGroup: UniversalFiltersGroup, oldFilterGroup: UniversalFiltersGroup | undefined) => {
             if (shouldSkipFilterGroupChange(filterGroup, oldFilterGroup)) {
                 return
             }
@@ -644,7 +647,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                         orderBy: values.orderBy,
                         dateRange: values.utcDateRange,
                         searchTerm: values.filters.searchTerm,
-                        filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                        filterGroup: values.queryFilterGroup as PropertyGroupFilter,
                         severityLevels: values.filters.severityLevels,
                         serviceNames: values.filters.serviceNames,
                         liveLogsCheckpoint: values.liveLogsCheckpoint ?? undefined,


### PR DESCRIPTION
## Problem

The Logs tab on the person profile pins a `distinct_id` filter so the tab can't fall back to project-wide logs. Until now this was implemented by **merging the pinned filter into `filterGroup`** (the user-editable state) and then hiding the resulting chip via a deep-equal check in `LogsFilterBar`.

That broke when the pinned filter's *shape* changed after initial mount — most commonly when `logsConfig.logs_distinct_id_attribute_key` resolves to a non-default key on a team that has patched it (e.g. to `user.id` for backends that emit logs under their own identifier). On first render the pinned filter used the fallback default `posthogDistinctId`; once the team's `logs_config` resolved, a *new* pinned filter was reconstructed with the custom key. The old pinned filter sat stale inside `filterGroup`, the dedup in `mergePinnedFilters` only compared against the *new* one, and the leftover filter rendered as a chip with an X. Clicking the X removed it from `filterGroup` but the (hidden) new pinned filter still scoped the query — so the page felt like "filter is still applied but I can't see why".

## Changes

**Architectural fix — keep pinned filters entirely out of `filterGroup`.**

- `logsViewerFiltersLogic.ts` — new `queryFilterGroup` selector combines `filterGroup + pinnedFilters` on demand. The reducer stays clean; `afterMount`/`propsChanged` only mirror `pinnedFilters` into state, never touch `filterGroup`. Old `mergePinnedFilters` helper replaced with a non-deduping `combineWithPinnedFilters` since the dedup concern goes away once pinned filters never enter the editable reducer.
- `logsViewerDataLogic.ts` — query payloads (4 sites: query, fetchNextLogsPage, sparkline, liveTail) now read `values.queryFilterGroup`. Subscription switched from `filterGroup` → `queryFilterGroup` so the query reruns when pinned filters resolve.
- `LogsFilterBar.tsx` — removed the deep-equal hide-chip workaround entirely. `endpointFilters` (taxonomic value-suggestion endpoint) now passes `queryFilterGroup` so suggestions stay scoped, while the editable `filterGroup` is the source of truth for what chips render. Drops the `fast-deep-equal` import.
- `PersonLogsTab.tsx` — small muted hint above the viewer surfaces which attribute key is in use; when the team has customised the key away from `posthogDistinctId` the hint appends "Customised from default …". Pattern lifted from `frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx:70–87`.

Net diff: 4 files, +52/-35 lines.

Precedent the new shape follows: `products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts:63,84` — clean `filterGroup` reducer + derived `mergedFilterGroup` selector used only by the query layer. Counter-example we explicitly moved *away* from: `sessionRecordingsPlaylistLogic` (merges pinned into the reducer, then subtracts pinned back out in a `totalFiltersCount` selector to undo the mess — exactly the leakiness this PR removes from the logs viewer).

## How did you test this code?

I'm an agent (PostHog Code / Claude Opus 4.7). The user verified manually in the local dev stack against a person with multiple distinct_ids on a team where `logs_distinct_id_attribute_key` had been patched to `user.id`, confirming both:
- No stale chip renders for the pinned scope.
- The query is correctly scoped to the patched attribute, and emits 3/3 matching log records with no leakage from the old default key.

Automated checks:
- `tsc --noEmit` clean on all three touched files (pre-existing TS errors in unrelated files only).
- Pre-existing `logsViewerFiltersLogic.test.ts` suite fails to parse on master too (Jest/Babel config issue, not introduced here); I did not add new tests because the pre-existing harness for this logic file is broken on master and fixing it is out of scope.

The `logs_distinct_id_attribute_key` endpoint dual-registration on `/api/projects/` (which originally surfaced this bug class) lands separately via #60967 and is already on master.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change. Customer-facing doc for the team-configurable attribute key lives in `docs/internal/logs-link-person.md` and was published as part of the original feature; this PR doesn't change observable behavior for the default-config majority.

## 🤖 Agent context

PostHog Code (Claude Opus 4.7). The bug originally surfaced as a stale removable filter chip on the dev Logs tab that the local stack didn't reproduce, with the user pointing out the distinguishing variable was that they had PATCH'd `logs_distinct_id_attribute_key` on the dev team. Root-cause traced to `mergePinnedFilters` deduping only against the *new* pinned-filter content while old pinned-filter state remained in `filterGroup`. Two candidate fixes were considered: (1) tighten dedup to evict any filter matching the previous pinned key+type, (2) keep pinned filters entirely out of `filterGroup`. (2) was chosen because it makes the bug class structurally impossible, matches the existing precedent in error-tracking's `issueFiltersLogic`, and removes the hide-chip workaround that (1) would still need to retain.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*