### PR TITLE
chore(ci): gate prod deploy dispatch on backend tests

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -23,11 +23,14 @@ jobs:
         name: Build and push PostHog
         if: github.repository == 'PostHog/posthog'
         runs-on: depot-ubuntu-latest
-        timeout-minutes: 30
+        # Bumped from 30: the deploy dispatch now waits for backend CI on this commit
+        # before firing, so the job stays alive through the build + the wait window.
+        timeout-minutes: 75
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
             packages: write # allow push to ghcr.io
+            checks: read # allow reading backend CI check results to gate the deploy
 
         steps:
             - name: Check out
@@ -86,6 +89,43 @@ jobs:
                   posthog-token: ${{secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN}}
                   event: 'posthog-image-build'
                   properties: '{"status": "failure", "commit_hash": "${{ github.sha }}"}'
+
+            # Gate the deploy on backend CI. The image is already built and pushed above
+            # (ci-backend.yml runs in parallel on the same commit) — we only hold the
+            # deploy *dispatch* to Charts until this commit's backend suite is green.
+            # A stale merge once shipped a red master commit to prod because the dispatch
+            # fired regardless of test results; this is the backstop. Cross-workflow
+            # check-waiting on the same SHA mirrors the pattern in ci-hobby.yml.
+            - name: Wait for backend tests to pass
+              # Only gate automatic master pushes. A manual workflow_dispatch is the
+              # break-glass: it skips the wait so an operator can force a deploy.
+              if: github.event_name == 'push'
+              id: wait-for-backend
+              uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  checkName: Django Tests Pass
+                  ref: ${{ github.sha }}
+                  timeoutSeconds: 2700
+                  intervalSeconds: 30
+
+            - name: Block deploy if backend tests did not pass
+              if: github.event_name == 'push'
+              env:
+                  BACKEND_CONCLUSION: ${{ steps.wait-for-backend.outputs.conclusion }}
+              run: |
+                  conclusion="$BACKEND_CONCLUSION"
+                  # `skipped` = the backend suite didn't run for this commit; nothing to gate on.
+                  if [ "$conclusion" = "skipped" ]; then
+                    echo "Backend tests skipped for this commit — proceeding with deploy."
+                    exit 0
+                  fi
+                  if [ "$conclusion" != "success" ]; then
+                    echo "::error::Backend CI for this commit is '${conclusion:-incomplete/timed out}'. Not deploying."
+                    echo "Fix CI and re-run, or trigger this workflow via workflow_dispatch to override."
+                    exit 1
+                  fi
+                  echo "Backend tests passed — proceeding with deploy."
 
             - name: get deployer token
               id: deployer


### PR DESCRIPTION
## Problem

`container-images-cd.yml` builds and pushes the image, then immediately fires the `repository_dispatch` to Charts — with no dependency on whether this commit's backend tests passed. The build job is green even when pytest is red (a Docker build doesn't run tests), and the deploy keys off the build. So a commit whose backend suite is fully red can ship straight to prod.

That happened recently: a stale merge left a relocated module imported from its old path, every Temporal worker crash-looped at startup, and the deploy rolled out unblocked even though `Django Tests Pass` was red on that exact commit. CI caught it loudly; nothing consulted the result.

## Changes

Hold the deploy dispatch until this commit's `Django Tests Pass` check succeeds, reusing the cross-workflow `fountainhead/action-wait-for-check` pattern already used in `ci-hobby.yml`.

- Image still builds + pushes **in parallel** with CI; only the dispatch to Charts waits.
- **Fail-closed:** `failure` / timed-out / missing check → deploy blocked. `skipped` (backend didn't run for this commit) → allowed through.
- **Break-glass:** the gate runs only on automatic `push`; a manual `workflow_dispatch` skips it so an operator can force a deploy. The manual Charts deploy path is also unaffected.
- Adds `checks: read` to the job and bumps its timeout to cover the wait window.

Known tradeoff: the wait holds the build runner idle during the wait window (~20–30 min typical). A follow-up can split build / wait / dispatch into separate jobs so the wait runs on a cheap `ubuntu-latest` runner — left out here to keep the diff small and avoid moving the large dispatch block without a way to exercise it.

## How did you test this code?

Agent-assisted; **no live workflow run** — the prod CD path can't be safely exercised from a branch. Static validation only:

- YAML parses; both gate steps present; `checks: read` set on the job.
- `actionlint` clean on the new steps (the `SC2086` infos it reports are all in pre-existing change-detection `run` blocks, untouched here).
- Confirmed `Django Tests Pass` runs on `push: master` and was the check that went red on the commit behind the recent worker crash-loop — so this gate would have blocked that deploy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — infra/CI only. Add `skip-inkeep-docs`.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8), prompted by a Temporal-worker crash-loop incident. We traced it to a deploy that shipped a red-CI commit, then debated gating in the app repo (the CD dispatch) vs the deploy repo (Charts). Chose the CD-dispatch gate: the test signal is local to the commit, a same-repo `GITHUB_TOKEN` is enough, the build stays parallel, and it leaves the manual Charts deploy open as break-glass (the route the incident fix actually used). Mirrored the existing `ci-hobby.yml` wait-for-check rather than introduce a new action or SHA. The job-split optimization was deliberately deferred to avoid relocating the large dispatch block without being able to run it.
