### PR TITLE
fix(oauth): point proxy landing page to OAuth docs

### DIFF
--- a/services/oauth-proxy/src/index.ts
+++ b/services/oauth-proxy/src/index.ts
@@ -89,7 +89,7 @@ export default {
             }
 
             if (normalized === '') {
-                return new Response('PostHog OAuth Proxy — https://posthog.com/docs/model-context-protocol', {
+                return new Response('PostHog OAuth Proxy - https://posthog.com/docs/api/oauth', {
                     headers: { 'Content-Type': 'text/plain' },
                 })
             }


### PR DESCRIPTION
## Problem

The OAuth proxy's root route returns a plain-text landing message, but it linked to the MCP docs (`https://posthog.com/docs/model-context-protocol`). This is the OAuth proxy, so the link should point to PostHog's OAuth integration docs. The message also used an em-dash, which rendered as mojibake under the `text/plain` response.

## Changes

- Point the landing page link to `https://posthog.com/docs/api/oauth`.
- Replace the em-dash with a plain hyphen so the text renders cleanly.

## How did you test this code?

I'm an agent. The existing `tests/router.test.ts` assertions (`content-type` contains `text/plain`, body contains `PostHog OAuth Proxy`) remain satisfied by inspection. I was unable to execute the vitest suite in this environment because the service's `node_modules` are not installed here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored with Claude Code. The task was to repoint the OAuth proxy landing route from MCP docs to OAuth docs and fix the em-dash. I located the correct OAuth docs URL (`/docs/api/oauth`) via the PostHog docs search, then switched the em-dash to a plain hyphen at the user's request. Left the genuinely MCP-related references in `services/mcp/` and the OAuth metadata `service_documentation` field untouched, since those are not the landing route in question.
