### PR TITLE
feat: seed deterministic project token for demo data

### DIFF
--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -55,6 +55,7 @@ class MatrixManager:
         password: str | None = None,
         is_staff: bool = False,
         email_collision_handling: Literal["log_in", "disambiguate"] = "log_in",
+        api_token: str | None = None,
     ) -> tuple[Organization, Team, User]:
         """If there's an email collision in signup in the demo environment, we treat it as a login."""
         existing_user: User | None = User.objects.filter(email=email).first()
@@ -90,7 +91,7 @@ class MatrixManager:
                     theme_mode="system",
                     role_at_organization="engineering",
                 )
-                team = self.create_team(organization)
+                team = self.create_team(organization, **({"api_token": api_token} if api_token else {}))
             self.run_on_team(team, new_user)
             return (organization, team, new_user)
         elif existing_user.is_staff:

--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -22,7 +22,7 @@ from posthog.models import (
     Team,
     User,
 )
-from posthog.models.utils import UUIDT
+from posthog.models.utils import UUIDT, generate_random_token_project
 
 from .matrix import Matrix
 from .models import SimEvent, SimPerson
@@ -91,6 +91,10 @@ class MatrixManager:
                     theme_mode="system",
                     role_at_organization="engineering",
                 )
+                if api_token:
+                    # api_token is unique, so release it from any team that claimed it on a previous run
+                    # before the new team claims it. Kept in the same transaction so a failure can't orphan it.
+                    Team.objects.filter(api_token=api_token).update(api_token=generate_random_token_project())
                 team = self.create_team(organization, **({"api_token": api_token} if api_token else {}))
             self.run_on_team(team, new_user)
             return (organization, team, new_user)

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -22,12 +22,17 @@ from posthog.models.file_system.user_product_list import UserProductList
 from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.team.setup_tasks import SetupTaskId
 from posthog.models.team.team import Team
+from posthog.models.utils import generate_random_token_project
 from posthog.products import Products
 from posthog.taxonomy.taxonomy import PERSON_PROPERTIES_ADAPTED_FROM_EVENT
 
 from ee.clickhouse.materialized_columns.analyze import materialize_properties_task
 
 logging.getLogger("kafka").setLevel(logging.ERROR)  # Hide kafka-python's logspam
+
+# Deterministic project token for the locally seeded demo team, so SDKs/tools can target it without
+# looking up the random token. Only used for the freshly created demo account (not existing projects).
+DEMO_PROJECT_API_TOKEN = "phc_localposthogprojecttoken"
 
 
 class Command(BaseCommand):
@@ -170,6 +175,11 @@ class Command(BaseCommand):
                             raise ValueError(f"Project {existing_team_id} has no organization members")
                         matrix_manager.run_on_team(team, user)
                 else:
+                    # Hand the deterministic token to the new demo team. It's unique, so release it from
+                    # any team that claimed it on a previous run first.
+                    Team.objects.filter(api_token=DEMO_PROJECT_API_TOKEN).update(
+                        api_token=generate_random_token_project()
+                    )
                     _organization, team, user = matrix_manager.ensure_account_and_save(
                         email,
                         "Employee 427",
@@ -177,6 +187,7 @@ class Command(BaseCommand):
                         is_staff=bool(options.get("staff")),
                         password=password,
                         email_collision_handling="disambiguate",
+                        api_token=DEMO_PROJECT_API_TOKEN,
                     )
 
                     # Optionally generate demo issues for issue tracker if extension is available
@@ -233,6 +244,7 @@ class Command(BaseCommand):
                     "Pre-fill the login form with this link:\n"
                     f"http://localhost:8010/login?email={quote(user.email if user is not None else '')}\n"
                     f"The password is:\n{password}\n\n"
+                    f"The project API token is:\n{DEMO_PROJECT_API_TOKEN}\n\n"
                     "If running demo mode (DEMO=1), log in instantly with this link:\n"
                     f"http://localhost:8010/signup?email={quote(user.email if user is not None else '')}\n"
                 )

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -8,6 +8,7 @@ from time import monotonic
 from typing import Optional
 from urllib.parse import quote
 
+from django.conf import settings
 from django.core import exceptions
 from django.core.management.base import BaseCommand
 
@@ -22,7 +23,6 @@ from posthog.models.file_system.user_product_list import UserProductList
 from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.team.setup_tasks import SetupTaskId
 from posthog.models.team.team import Team
-from posthog.models.utils import generate_random_token_project
 from posthog.products import Products
 from posthog.taxonomy.taxonomy import PERSON_PROPERTIES_ADAPTED_FROM_EVENT
 
@@ -175,11 +175,10 @@ class Command(BaseCommand):
                             raise ValueError(f"Project {existing_team_id} has no organization members")
                         matrix_manager.run_on_team(team, user)
                 else:
-                    # Hand the deterministic token to the new demo team. It's unique, so release it from
-                    # any team that claimed it on a previous run first.
-                    Team.objects.filter(api_token=DEMO_PROJECT_API_TOKEN).update(
-                        api_token=generate_random_token_project()
-                    )
+                    # Hand the demo team a deterministic token in local dev only. In tests (e.g. Playwright
+                    # setup, which seeds many workspaces) and shared/cloud environments, keep random tokens
+                    # so runs don't fight over the unique token or mutate unrelated projects.
+                    demo_api_token = DEMO_PROJECT_API_TOKEN if (settings.DEBUG and not settings.TEST) else None
                     _organization, team, user = matrix_manager.ensure_account_and_save(
                         email,
                         "Employee 427",
@@ -187,7 +186,7 @@ class Command(BaseCommand):
                         is_staff=bool(options.get("staff")),
                         password=password,
                         email_collision_handling="disambiguate",
-                        api_token=DEMO_PROJECT_API_TOKEN,
+                        api_token=demo_api_token,
                     )
 
                     # Optionally generate demo issues for issue tracker if extension is available
@@ -244,7 +243,7 @@ class Command(BaseCommand):
                     "Pre-fill the login form with this link:\n"
                     f"http://localhost:8010/login?email={quote(user.email if user is not None else '')}\n"
                     f"The password is:\n{password}\n\n"
-                    f"The project API token is:\n{DEMO_PROJECT_API_TOKEN}\n\n"
+                    f"The project API token is:\n{team.api_token if team is not None else 'unknown'}\n\n"
                     "If running demo mode (DEMO=1), log in instantly with this link:\n"
                     f"http://localhost:8010/signup?email={quote(user.email if user is not None else '')}\n"
                 )


### PR DESCRIPTION
## Problem

When you run `generate_demo_data` locally we seed the Hedgebox demo team and a fixed personal API key (`DEV_API_KEY`), but the project's API token (`api_token`, the `phc_...` value) is random on every run. That means anything that wants to send events into the demo project — local SDK setups, the `hedgebox-dummy` app, scripts — has to look up the freshly generated token each time instead of hardcoding a known value.

## Changes

- `generate_demo_data` now assigns the demo team a deterministic project API token, `phc_localposthogprojecttoken`, but only on the fresh-account path (not when targeting an existing `--team-id` or resetting the master project).
- Because `api_token` is unique, the token is first released from any team that claimed it on a previous run (reassigned a random token), so re-running the command always hands the predictable token to the latest demo team.
- Threaded an optional `api_token` argument through `MatrixManager.ensure_account_and_save` → `create_team`; it defaults to `None`, so the signup and eval-data-setup callers are unaffected.
- The completion output now prints the project API token alongside the login link and password.

## How did you test this code?

I'm an agent. I syntax-checked the changed files; `ruff` and the app runtime aren't available in this environment, so I did not run the command or the test suite. The change is additive and gated behind the new-account branch — existing callers pass no `api_token` and keep the random default.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by PostHog Code (Claude) at the request of the repo owner. The ask was to make the demo project token deterministic (`phc_localposthogprojecttoken`) only for `generate_demo_data`, mirroring how `DEV_API_KEY` is fixed locally.

Key decisions:
- Scoped the deterministic token to the new-account branch only, leaving `--team-id` / master-project flows and the `signup`/eval callers on the random default by making the new `api_token` parameter optional.
- Handled the unique-constraint collision on re-runs by releasing the token from the prior holder before creating the new team, rather than catching `IntegrityError`, so the freshest demo team always owns the predictable token.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
