### PR TITLE
fix(persons): open merge restrictions docs link in new tab

### DIFF
--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -102,7 +102,10 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
             </div>
             <div className="flex items-center gap-1">
                 <span className="text-secondary">Merge restrictions:</span> {person.is_identified ? 'applied' : 'none'}
-                <Link to="https://posthog.com/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user">
+                <Link
+                    to="https://posthog.com/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user"
+                    target="_blank"
+                >
                     <Tooltip
                         title={
                             <>


### PR DESCRIPTION
## Problem

On the person scene, the info icon next to "Merge restrictions" links to the [identify docs](https://posthog.com/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) but opened in the **same tab**, navigating the user away from PostHog and losing their place on the person page.

## Changes

Added `target="_blank"` to the `Link` wrapping the info icon so the docs open in a new tab. No `rel` work needed — the `Link` component already applies the appropriate `rel` (`noopener` for posthog.com domains) when `target="_blank"`. No visual change: the auto "open in new" icon only renders when the link's children are a plain string, and here the child is the `Tooltip`/`IconInfo`.

## How did you test this code?

I'm an agent. I made a one-line prop change and verified against the `Link` component implementation (`frontend/src/lib/lemon-ui/Link/Link.tsx`) that `target="_blank"` is supported, sets `rel` automatically, and does not add an extra icon for non-string children. I did not run the app or add automated tests for this trivial change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by an agent (Claude Code via PostHog Code) at Ben Lea's request to make the "Merge restrictions" docs link open in a new tab. Single-line change adding `target="_blank"`; verified the `Link` component handles `rel` and the new-tab icon correctly so no further changes were required.