### PR TITLE
fix(toolbar): match authorized URLs by exact origin

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.test.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.test.ts
@@ -14,6 +14,7 @@ import {
     SuggestedDomain,
     appEditorUrl,
     authorizedUrlListLogic,
+    checkUrlIsAuthorized,
     directToolbarUrl,
     filterNotAuthorizedUrls,
     validateProposedUrl,
@@ -114,6 +115,38 @@ describe('the authorized urls list logic', () => {
                 proposedUrlChanged: true,
                 proposedUrlHasErrors: true,
                 proposedUrlValidationErrors: { url: 'Please enter a valid URL' },
+            })
+        })
+    })
+
+    describe('checkUrlIsAuthorized', () => {
+        const testCases: { url: string; authorized: string[]; expected: boolean }[] = [
+            // Legitimate matches
+            { url: 'https://example.com', authorized: ['https://example.com'], expected: true },
+            { url: 'https://example.com/some/path?q=1', authorized: ['https://example.com'], expected: true },
+            { url: 'https://example.com', authorized: ['https://example.com/already/has/a/path'], expected: true },
+            // www-equivalence both directions
+            { url: 'https://example.com', authorized: ['https://www.example.com'], expected: true },
+            { url: 'https://www.example.com', authorized: ['https://example.com'], expected: true },
+            // wildcard subdomains and ports
+            { url: 'https://app.example.com', authorized: ['https://*.example.com'], expected: true },
+            { url: 'https://a.b.example.com', authorized: ['https://*.example.com'], expected: true },
+            { url: 'http://localhost:3000', authorized: ['http://localhost:*'], expected: true },
+            // Suffix bypass: an attacker domain that merely ends with the authorized origin string
+            { url: 'https://example.com.evil.com', authorized: ['https://example.com'], expected: false },
+            { url: 'https://app.example.com.evil.com', authorized: ['https://*.example.com'], expected: false },
+            // Prefix/substring bypass: a different registrable domain that is a substring of the entry
+            { url: 'https://example.co', authorized: ['https://example.com'], expected: false },
+            // Plain unrelated origin
+            { url: 'https://evil.com', authorized: ['https://example.com'], expected: false },
+            { url: 'https://example.org', authorized: ['https://example.com'], expected: false },
+            // Nothing authorized
+            { url: 'https://example.com', authorized: [], expected: false },
+        ]
+
+        testCases.forEach(({ url, authorized, expected }) => {
+            it(`"${url}" against [${authorized.join(', ')}] is ${expected ? 'authorized' : 'not authorized'}`, () => {
+                expect(checkUrlIsAuthorized(url, authorized)).toBe(expected)
             })
         })
     })

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -198,32 +198,33 @@ export const checkUrlIsAuthorized = (url: string | URL, authorizedUrls: string[]
         const urlWithoutPath = parsedUrl.protocol + '//' + parsedUrl.host
         const hostNormalized = stripWww(parsedUrl.hostname)
 
-        const exactMatch = authorizedUrls.some((authorizedUrl) => {
-            if (authorizedUrl.indexOf(urlWithoutPath) > -1) {
-                return true
+        return authorizedUrls.some((authorizedUrl) => {
+            // Wildcard entries (subdomain or port wildcards, e.g. `https://*.example.com`). Anchor the
+            // pattern with ^…$ so a `*` cannot match a suffix of an unrelated origin such as
+            // `https://app.example.com.evil.com`.
+            if (authorizedUrl.includes('*')) {
+                try {
+                    const regex = new RegExp('^' + authorizedUrl.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$')
+                    return regex.test(urlWithoutPath)
+                } catch {
+                    return false
+                }
             }
-            // www-equivalence: compare hostnames with www. stripped
+
+            // Exact entries: compare by origin (protocol + host) instead of a substring check, so a
+            // different domain cannot be authorized merely by being a prefix/substring of an entry
+            // (e.g. `https://example.co` against `https://example.com`).
             try {
-                const authorizedHost = sanitizePossibleWildCardedURL(authorizedUrl).hostname
-                return stripWww(authorizedHost) === hostNormalized
+                const authorizedUrlParsed = sanitizePossibleWildCardedURL(authorizedUrl)
+                if (authorizedUrlParsed.protocol + '//' + authorizedUrlParsed.host === urlWithoutPath) {
+                    return true
+                }
+                // www-equivalence: compare hostnames with www. stripped
+                return stripWww(authorizedUrlParsed.hostname) === hostNormalized
             } catch {
                 return false
             }
         })
-
-        if (exactMatch) {
-            return true
-        }
-
-        const wildcardMatch = !!authorizedUrls.find((authorizedUrl) => {
-            // Matches something like `https://*.example.com` against the urlWithoutPath
-            const regex = new RegExp(authorizedUrl.replace(/\./g, '\\.').replace(/\*/g, '.*'))
-            return urlWithoutPath.match(regex)
-        })
-
-        if (wildcardMatch) {
-            return true
-        }
     } catch {
         // Ignore invalid URLs
     }


### PR DESCRIPTION
## Problem

`checkUrlIsAuthorized` (shared by the toolbar, heatmaps, web analytics, and the postMessage origin check in the iframed toolbar browser) decided whether a URL belongs to a project's authorized list using a loose substring check plus an **unanchored** wildcard regex. As a result a URL could be considered authorized just by overlapping an authorized entry's string:

- `https://example.com.evil.com` matched `https://example.com` (suffix)
- `https://app.example.com.evil.com` matched `https://*.example.com` (the wildcard regex had no end anchor)
- `https://example.co` matched `https://example.com` (prefix/substring)

In each case the actual registrable domain is different from — and not controlled by the owner of — the authorized one.

## Changes

Rewrite the matching so each authorized entry is evaluated exactly once:

- **Wildcard entries** (`https://*.example.com`, `http://localhost:*`) are compiled to a regex anchored with `^…$`, so a `*` can no longer match a suffix of an unrelated origin.
- **Non-wildcard entries** are compared by origin (`protocol://host`) instead of substring, so a different domain can't be authorized by being a prefix/substring of an entry.

Existing behavior is preserved: path is ignored, `www.` equivalence still holds in both directions, and subdomain/port wildcards still match as before.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual QA:

- Added a parameterized `checkUrlIsAuthorized` test block in `authorizedUrlListLogic.test.ts` covering the legitimate matches (exact, path, `www.` both directions, subdomain wildcard, multi-level subdomain, port wildcard) and the suffix / prefix / unanchored-wildcard cases that must be rejected. Written test-first: the rejection cases failed against the old implementation and pass after the change.
- Ran the full `authorizedUrlListLogic` suite (55 tests, incl. existing `filterNotAuthorizedUrls` coverage) and the heatmaps logic suite — all green.

## 🤖 Agent context

Authored by Claude Code as a follow-up to a separate change that hardened the site-preview iframe. While verifying that the site-preview authorization gate was sound, the underlying `checkUrlIsAuthorized` matcher was found to accept origins that overlap an authorized entry's string. This PR tightens the matcher itself, which also benefits the other callers (notably the `postMessage` event-origin check in `iframedToolbarBrowserLogic`). Approach: kept the wildcard pattern construction identical and only added anchoring, and replaced the substring comparison with an origin comparison while preserving the existing `www.`-equivalence semantics to avoid regressing legitimate matches.
