### PR TITLE
feat(data-warehouse): log view deletions and name views in activity feed

### DIFF
--- a/frontend/src/scenes/data-warehouse/saved_queries/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-warehouse/saved_queries/activityDescriptions.tsx
@@ -60,10 +60,11 @@ export function dataWarehouseSavedQueryActivityDescriber(
     }
 
     const user = <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong>
+    const viewName = logItem.detail?.name ? <strong>{logItem.detail.name}</strong> : <i>a view</i>
 
     if (logItem.activity === 'created') {
         return {
-            description: <SentenceList listParts={[<>created a new view</>]} prefix={user} />,
+            description: <SentenceList listParts={[<>created view {viewName}</>]} prefix={user} />,
         }
     }
 
@@ -71,22 +72,32 @@ export function dataWarehouseSavedQueryActivityDescriber(
         const changes = logItem.detail?.changes ?? []
         const parts = changes.map(describeChange).filter((p): p is JSX.Element => p !== null)
         return {
-            description: <SentenceList listParts={parts.length > 0 ? parts : [<>updated the view</>]} prefix={user} />,
+            description: (
+                <SentenceList
+                    listParts={parts.length > 0 ? parts : [<>updated the view</>]}
+                    prefix={user}
+                    suffix={<>on {viewName}</>}
+                />
+            ),
         }
     }
 
     if (logItem.activity === 'sync_triggered') {
-        return { description: <SentenceList listParts={[<>triggered an ad-hoc sync</>]} prefix={user} /> }
+        return {
+            description: <SentenceList listParts={[<>triggered an ad-hoc sync on {viewName}</>]} prefix={user} />,
+        }
     }
 
     if (logItem.activity === 'sync_cancelled') {
-        return { description: <SentenceList listParts={[<>cancelled a running sync</>]} prefix={user} /> }
+        return {
+            description: <SentenceList listParts={[<>cancelled a running sync on {viewName}</>]} prefix={user} />,
+        }
     }
 
     if (logItem.activity === 'materialization_enabled') {
         const changes = logItem.detail?.changes ?? []
         const freqChange = changes.find((c) => c.field === 'sync_frequency_interval')
-        const parts: JSX.Element[] = [<>enabled materialization</>]
+        const parts: JSX.Element[] = [<>enabled materialization for {viewName}</>]
         if (freqChange) {
             const after = humanizeInterval(freqChange.after as string | null)
             parts.push(
@@ -99,7 +110,9 @@ export function dataWarehouseSavedQueryActivityDescriber(
     }
 
     if (logItem.activity === 'materialization_disabled') {
-        return { description: <SentenceList listParts={[<>disabled materialization</>]} prefix={user} /> }
+        return {
+            description: <SentenceList listParts={[<>disabled materialization for {viewName}</>]} prefix={user} />,
+        }
     }
 
     if (logItem.activity === 'sync_frequency_reset') {
@@ -111,7 +124,7 @@ export function dataWarehouseSavedQueryActivityDescriber(
                 <SentenceList
                     listParts={[
                         <>
-                            auto-reset sync frequency to <strong>{after}</strong>
+                            auto-reset sync frequency to <strong>{after}</strong> for {viewName}
                         </>,
                     ]}
                     prefix={user}
@@ -120,5 +133,11 @@ export function dataWarehouseSavedQueryActivityDescriber(
         }
     }
 
-    return defaultDescriber(logItem, asNotification)
+    if (logItem.activity === 'deleted') {
+        return {
+            description: <SentenceList listParts={[<>deleted view {viewName}</>]} prefix={user} />,
+        }
+    }
+
+    return defaultDescriber(logItem, asNotification, viewName)
 }

--- a/frontend/src/scenes/data-warehouse/saved_queries/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-warehouse/saved_queries/activityDescriptions.tsx
@@ -64,7 +64,7 @@ export function dataWarehouseSavedQueryActivityDescriber(
 
     if (logItem.activity === 'created') {
         return {
-            description: <SentenceList listParts={[<>created view {viewName}</>]} prefix={user} />,
+            description: <SentenceList listParts={[<>created {viewName}</>]} prefix={user} />,
         }
     }
 
@@ -135,7 +135,7 @@ export function dataWarehouseSavedQueryActivityDescriber(
 
     if (logItem.activity === 'deleted') {
         return {
-            description: <SentenceList listParts={[<>deleted view {viewName}</>]} prefix={user} />,
+            description: <SentenceList listParts={[<>deleted {viewName}</>]} prefix={user} />,
         }
     }
 

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -809,12 +809,25 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
         from products.data_modeling.backend.services.saved_query_dag_sync import HasDependentsError
 
         instance: DataWarehouseSavedQuery = self.get_object()
+        # Capture the name before deletion; the soft-delete path scrambles `name`.
+        name = instance.name
         try:
             delete_saved_query(instance)
         except HasDependentsError:
             raise serializers.ValidationError(
                 "Cannot delete this view because other views depend on it. Delete or update those views first."
             )
+
+        log_activity(
+            organization_id=self.team.organization_id,
+            team_id=self.team_id,
+            user=cast(User, request.user),
+            was_impersonated=is_impersonated_session(request),
+            item_id=instance.id,
+            scope="DataWarehouseSavedQuery",
+            activity="deleted",
+            detail=Detail(name=name),
+        )
 
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -809,7 +809,6 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
         from products.data_modeling.backend.services.saved_query_dag_sync import HasDependentsError
 
         instance: DataWarehouseSavedQuery = self.get_object()
-        # Capture the name before deletion; the soft-delete path scrambles `name`.
         name = instance.name
         try:
             delete_saved_query(instance)

--- a/products/data_warehouse/backend/api/test/test_saved_query.py
+++ b/products/data_warehouse/backend/api/test/test_saved_query.py
@@ -389,6 +389,11 @@ class TestSavedQuery(APIBaseTest):
         assert saved_query.deleted_name == query_name
         assert saved_query.name.startswith("POSTHOG_DELETED_")
 
+        delete_activity = ActivityLog.objects.get(
+            item_id=str(saved_query.id), scope="DataWarehouseSavedQuery", activity="deleted"
+        )
+        assert cast(dict[str, Any], delete_activity.detail)["name"] == query_name
+
     def test_update_folder_assignment(self):
         folder = DataWarehouseSavedQueryFolder.objects.create(
             team=self.team, name="Warehouse ops", created_by=self.user


### PR DESCRIPTION
## Problem

The data warehouse saved query activity feed had two gaps:

- Deleting a view produced no activity log entry at all, so there was no audit trail for deletions.
- Existing activity entries (created, updated, sync triggered/cancelled, materialization toggled, sync frequency reset) never said *which* view they referred to, making the feed hard to read when a project has many views.

## Changes

- **Backend:** Log a `deleted` activity entry in the saved query viewset's destroy path. The view name is captured *before* `delete_saved_query` runs, because the soft-delete path scrambles `name` (it gets prefixed with `POSTHOG_DELETED_` and the real name moves to `deleted_name`).
- **Frontend:** The saved query activity describers now include the view name across every activity type, falling back to *a view* when the name isn't present. Added a `deleted` branch and threaded the view name into the `defaultDescriber` fallback.

## How did you test this code?

I'm an agent. I added an automated assertion to `test_delete` verifying that a `deleted` activity log with the correct view name is recorded after deletion. I was not able to run the Python test suite in this environment because the dev environment (flox/venv) was not bootstrapped, so the test has not been executed locally — CI will run it. The frontend change was checked against the `defaultDescriber` signature, which already accepts the optional `resource` argument being passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The non-obvious decision was capturing `instance.name` before calling `delete_saved_query`: the soft-delete moves the real name to `deleted_name` and overwrites `name` with a `POSTHOG_DELETED_` placeholder, so logging after deletion would record the placeholder. The activity describer reuses the existing `defaultDescriber` resource fallback rather than duplicating the rendering logic.
