### PR TITLE
fix(data-stack): retry duckgres connection with long jittered backoff

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -64,7 +64,7 @@ from dagster import (
     sensor,
 )
 from psycopg import sql as psql
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_fixed
+from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_fixed
 
 from posthog.clickhouse.client.connection import NodeRole, Workload
 from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
@@ -126,6 +126,27 @@ def _get_cluster() -> ClickhouseCluster:
     return get_cluster()
 
 
+def _log_duckgres_connect_retry(retry_state: RetryCallState) -> None:
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    logger.warning(
+        "duckling_duckgres_connect_retry",
+        attempt=retry_state.attempt_number,
+        error=str(exc) if exc else None,
+        error_type=type(exc).__name__ if exc else None,
+    )
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    # ConnectionTimeout and other transient connection failures (server still
+    # starting up, reset peer) all surface as OperationalError. A bounded retry
+    # keeps a cold duckgres or a network blip from failing the whole backfill;
+    # genuinely-down duckgres still reraises after the attempts are exhausted.
+    retry=retry_if_exception_type(psycopg.OperationalError),
+    before_sleep=_log_duckgres_connect_retry,
+    reraise=True,
+)
 def _connect_duckgres(catalog: DuckLakeCatalog) -> psycopg.Connection[Any]:
     """Open a psycopg connection to the org's duckgres server.
 
@@ -135,6 +156,10 @@ def _connect_duckgres(catalog: DuckLakeCatalog) -> psycopg.Connection[Any]:
 
     Cross-account S3 credentials are configured server-side via IRSA on the
     duckling, so the DAG no longer calls `configure_cross_account_connection`.
+
+    Transient connection failures are retried (see decorator) — duckgres can be
+    momentarily unreachable during cold start or a network blip, and a single
+    `connect_timeout` expiry should not abort the backfill.
     """
     if catalog.team_id is None:
         raise ValueError(

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -64,7 +64,15 @@ from dagster import (
     sensor,
 )
 from psycopg import sql as psql
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_fixed
+from tenacity import (
+    RetryCallState,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    wait_fixed,
+    wait_random_exponential,
+)
 
 from posthog.clickhouse.client.connection import NodeRole, Workload
 from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
@@ -109,6 +117,17 @@ def iceberg_enabled_for_team(team_id: int) -> bool:
 DUCKGRES_CONNECT_TIMEOUT = 10  # seconds
 DUCKGRES_STATEMENT_TIMEOUT_MS = 300_000  # 5 minutes
 
+# Duckgres connect retry: a per-org duckgres can be unreachable for a long time
+# during a cold start, restart, or scale-up, so back off generously rather than
+# fail the partition early. Exponential with jitter (avoids partitions
+# reconnecting in lockstep), each sleep capped at MAX_WAIT. With these defaults
+# the per-sleep ceiling climbs ~2s → 10min, giving a worst-case total wait of
+# ~37 min across all attempts (~18 min on average) — long enough to ride out a
+# duckgres that is coming back, while still bounded so a truly-dead instance
+# eventually reraises. Tune these to trade patience against worker-slot holding.
+DUCKGRES_CONNECT_RETRY_ATTEMPTS = 12
+DUCKGRES_CONNECT_RETRY_MAX_WAIT = 600  # seconds (per-attempt backoff ceiling)
+
 
 @retry(
     stop=stop_after_attempt(3),
@@ -137,12 +156,12 @@ def _log_duckgres_connect_retry(retry_state: RetryCallState) -> None:
 
 
 @retry(
-    stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=1, min=2, max=10),
+    stop=stop_after_attempt(DUCKGRES_CONNECT_RETRY_ATTEMPTS),
+    wait=wait_random_exponential(multiplier=2, max=DUCKGRES_CONNECT_RETRY_MAX_WAIT),
     # ConnectionTimeout and other transient connection failures (server still
-    # starting up, reset peer) all surface as OperationalError. A bounded retry
-    # keeps a cold duckgres or a network blip from failing the whole backfill;
-    # genuinely-down duckgres still reraises after the attempts are exhausted.
+    # starting up, reset peer) all surface as OperationalError. A long, jittered
+    # backoff keeps a cold or restarting duckgres from failing the whole
+    # backfill; a genuinely-down duckgres still reraises once attempts run out.
     retry=retry_if_exception_type(psycopg.OperationalError),
     before_sleep=_log_duckgres_connect_retry,
     reraise=True,
@@ -157,9 +176,10 @@ def _connect_duckgres(catalog: DuckLakeCatalog) -> psycopg.Connection[Any]:
     Cross-account S3 credentials are configured server-side via IRSA on the
     duckling, so the DAG no longer calls `configure_cross_account_connection`.
 
-    Transient connection failures are retried (see decorator) — duckgres can be
-    momentarily unreachable during cold start or a network blip, and a single
-    `connect_timeout` expiry should not abort the backfill.
+    Transient connection failures are retried with a long, jittered backoff (see
+    decorator) — a per-org duckgres can be unreachable for minutes during a cold
+    start or restart, and a single `connect_timeout` expiry should not abort the
+    backfill.
     """
     if catalog.team_id is None:
         raise ValueError(

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -9,6 +9,7 @@ import psycopg
 from parameterized import parameterized
 
 from posthog.dags.events_backfill_to_duckling import (
+    DUCKGRES_CONNECT_RETRY_ATTEMPTS,
     EARLIEST_BACKFILL_DATE,
     EVENTS_COLUMNS,
     EVENTS_TABLE_DDL,
@@ -751,13 +752,13 @@ class TestConnectDuckgresRetry:
     @patch("posthog.dags.events_backfill_to_duckling.psycopg.connect")
     def test_reraises_after_max_retries_exhausted(self, mock_connect, _mock_conninfo, _mock_sleep):
         # Persistently-unreachable duckgres reraises the original error after
-        # the bounded attempts — a retry does not mask a real outage.
+        # the bounded attempts — a long backoff does not mask a real outage.
         mock_connect.side_effect = psycopg.errors.ConnectionTimeout("connection timeout expired")
 
         with pytest.raises(psycopg.errors.ConnectionTimeout):
             _connect_duckgres(self._catalog())
 
-        assert mock_connect.call_count == 3
+        assert mock_connect.call_count == DUCKGRES_CONNECT_RETRY_ATTEMPTS
 
 
 class TestDuckLakeAddDataFilesPartitioning:

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -20,6 +20,7 @@ from posthog.dags.events_backfill_to_duckling import (
     ICEBERG_PERSONS_TABLE_DDL,
     PERSONS_COLUMNS,
     PERSONS_TABLE_DDL,
+    _connect_duckgres,
     _get_cluster,
     _set_iceberg_table_partitioning,
     _set_table_partitioning,
@@ -708,6 +709,55 @@ class TestGetClusterRetry:
             _get_cluster()
 
         assert mock_get_cluster.call_count == 3
+
+
+class TestConnectDuckgresRetry:
+    def _catalog(self):
+        catalog = MagicMock()
+        catalog.team_id = 2
+        catalog.organization_id = "org-123"
+        return catalog
+
+    @patch("tenacity.nap.time.sleep")
+    @patch("posthog.dags.events_backfill_to_duckling.make_duckgres_conninfo", return_value="postgresql://x")
+    @patch("posthog.dags.events_backfill_to_duckling.psycopg.connect")
+    def test_retries_on_connection_timeout_then_succeeds(self, mock_connect, _mock_conninfo, _mock_sleep):
+        mock_conn = MagicMock()
+        mock_connect.side_effect = [
+            psycopg.errors.ConnectionTimeout("connection timeout expired"),
+            psycopg.errors.ConnectionTimeout("connection timeout expired"),
+            mock_conn,
+        ]
+
+        result = _connect_duckgres(self._catalog())
+
+        assert result is mock_conn
+        assert mock_connect.call_count == 3
+
+    @patch("tenacity.nap.time.sleep")
+    @patch("posthog.dags.events_backfill_to_duckling.make_duckgres_conninfo", return_value="postgresql://x")
+    @patch("posthog.dags.events_backfill_to_duckling.psycopg.connect")
+    def test_raises_non_operational_error_immediately(self, mock_connect, _mock_conninfo, _mock_sleep):
+        # A non-connection error (e.g. bad config) is not transient — fail fast.
+        mock_connect.side_effect = ValueError("bad config")
+
+        with pytest.raises(ValueError, match="bad config"):
+            _connect_duckgres(self._catalog())
+
+        assert mock_connect.call_count == 1
+
+    @patch("tenacity.nap.time.sleep")
+    @patch("posthog.dags.events_backfill_to_duckling.make_duckgres_conninfo", return_value="postgresql://x")
+    @patch("posthog.dags.events_backfill_to_duckling.psycopg.connect")
+    def test_reraises_after_max_retries_exhausted(self, mock_connect, _mock_conninfo, _mock_sleep):
+        # Persistently-unreachable duckgres reraises the original error after
+        # the bounded attempts — a retry does not mask a real outage.
+        mock_connect.side_effect = psycopg.errors.ConnectionTimeout("connection timeout expired")
+
+        with pytest.raises(psycopg.errors.ConnectionTimeout):
+            _connect_duckgres(self._catalog())
+
+        assert mock_connect.call_count == 3
 
 
 class TestDuckLakeAddDataFilesPartitioning:


### PR DESCRIPTION
## Problem

The `duckling_events_backfill` (and persons backfill) op opens a psycopg connection to the org's duckgres server via `_connect_duckgres`, which had **no retry**. A single transient connection failure aborted the entire backfill op:

```
psycopg.errors.ConnectionTimeout: connection timeout expired
  File ".../events_backfill_to_duckling.py", line 149, in _connect_duckgres
    return psycopg.connect(...)
```

ClickHouse cluster discovery (`_get_cluster`) and the exports (`_execute_export_with_retry`) are already retried — the duckgres connect was the one unguarded transient path. `ConnectionTimeout` is a `psycopg.OperationalError`, not a builtin `TimeoutError`/`OSError`, so the existing retry predicates wouldn't have caught it anyway.

A per-org duckgres can be unreachable for **minutes** during a cold start, restart, or scale-up — so a short retry isn't enough; we want to wait it out.

## Changes

Add a long, jittered exponential backoff to `_connect_duckgres`:

- Retries on `psycopg.OperationalError` (covers `ConnectionTimeout` + server-starting-up / reset-peer).
- `wait_random_exponential(multiplier=2, max=600)` — exponential **with jitter** so partitions don't reconnect in lockstep; per-sleep ceiling climbs ~2s → 10min.
- `DUCKGRES_CONNECT_RETRY_ATTEMPTS = 12` → worst-case total wait ≈ **37 min** (~18 min on average) before giving up.
- Attempts and max-wait are **module constants** for easy tuning (trade patience vs. holding a worker slot).
- `before_sleep` structlog line (`duckling_duckgres_connect_retry`) so retries are visible.
- `reraise=True`: a genuinely-dead duckgres still surfaces the original error after attempts are exhausted — the backoff does **not** mask a real outage.

Covers both call sites (events + persons) since both go through `_connect_duckgres`.

## Scope note

This rides out a duckgres that is *coming back*. It is not a fix for an instance that is *persistently down* — that still fails (after the full backoff) and needs infra attention. Parallelism is tuned separately via the `duckling_events_backfill_concurrency` tag's limit in the deployment `dagster.yaml` (charts repo), not in this PR.

## How did you test this code?

I'm an agent; automated tests only, no manual run against production.

Added `TestConnectDuckgresRetry` (mirrors the existing `TestGetClusterRetry`, with `tenacity.nap.time.sleep` patched so the long backoff doesn't slow the suite):

- `test_retries_on_connection_timeout_then_succeeds` — two `ConnectionTimeout`s then success; asserts recovery.
- `test_raises_non_operational_error_immediately` — a non-connection error fails fast (1 call, no retry).
- `test_reraises_after_max_retries_exhausted` — persistent `ConnectionTimeout` reraises after exactly `DUCKGRES_CONNECT_RETRY_ATTEMPTS` attempts (proves a real outage isn't masked).

Worst-case backoff math verified numerically (~37 min). Full file: `103 passed`. `ruff format` + `ruff check` clean.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) from a production traceback hit during a backfill. Verified via the psycopg class hierarchy that `ConnectionTimeout` is an `OperationalError`. Chose a long jittered backoff (per request to wait out a slow/restarting duckgres) with tunable constants and `reraise=True` so persistent outages still surface. Pattern mirrors the existing `_get_cluster` retry in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
